### PR TITLE
Added options to select Alert Attributes for advreport alpha extension

### DIFF
--- a/src/org/zaproxy/zap/extension/advreport/AlertDetailsPanel.java
+++ b/src/org/zaproxy/zap/extension/advreport/AlertDetailsPanel.java
@@ -1,0 +1,194 @@
+package org.zaproxy.zap.extension.advreport;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.Insets;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import org.zaproxy.zap.view.LayoutHelper;
+
+
+public class AlertDetailsPanel extends JPanel{
+
+	private ExtensionAdvReport extension;
+	private JCheckBox description = null;
+	private JCheckBox otherInfo = null;
+	private JCheckBox solution = null;
+	private JCheckBox reference = null;
+	private JCheckBox cweid = null;
+	private JCheckBox wascid = null;
+	private JCheckBox requestHeader = null;
+	private JCheckBox responseHeader = null;
+	private JCheckBox requestBody = null;
+	private JCheckBox responseBody = null;
+	
+	public AlertDetailsPanel(ExtensionAdvReport extension){
+		initialize();
+		this.extension = extension;
+		description.setSelected(true);
+		otherInfo.setSelected(true);
+		solution.setSelected(true);
+		reference.setSelected(true);
+		cweid.setSelected(true);
+		wascid.setSelected(true);	
+	}
+
+	private void initialize(){
+
+		JPanel optionpanel = new JPanel();
+		optionpanel.setLayout( new GridBagLayout());
+		GridBagConstraints gbc = new GridBagConstraints();
+		
+		gbc.fill = GridBagConstraints.HORIZONTAL;
+				
+		//Include Description
+	    description = new JCheckBox();
+	    description.setText("Description");
+	    gbc.gridy = 0;
+	    gbc.gridx = 0;
+	    gbc.anchor = GridBagConstraints.WEST;
+	    gbc.insets = new Insets(2,0,2,100);
+        optionpanel.add( description, gbc );
+     
+		//Include Other Info
+		otherInfo = new JCheckBox();
+		otherInfo.setText("Other Info");
+        gbc.gridy++;
+        optionpanel.add( otherInfo, gbc );
+        
+		//Include Solution  
+	    solution = new JCheckBox();
+	    solution.setText("Solution");
+        gbc.gridy++;
+        optionpanel.add( solution, gbc );
+        
+		//Include Reference	    
+	    reference = new JCheckBox();
+	    reference.setText("Reference");
+        gbc.gridy++;
+        optionpanel.add( reference, gbc );
+        
+		//Include CWE Id
+	    cweid = new JCheckBox();
+	    cweid.setText("CWE Id");
+        gbc.gridy++;
+        optionpanel.add( cweid, gbc );
+        
+		//Include WASC ID
+	    wascid= new JCheckBox();
+	    wascid.setText("WASC Id");
+        gbc.gridy++;
+        optionpanel.add( wascid, gbc );
+
+		//Include Request Header
+	    requestHeader = new JCheckBox();
+	    requestHeader.setText("Request Header");
+        gbc.gridx = 1;
+     	gbc.gridy = 0;
+     	gbc.anchor = GridBagConstraints.EAST;
+     	gbc.insets = new Insets(2,0,2,0);
+        optionpanel.add( requestHeader, gbc );
+        
+		//Include Response Header
+	    responseHeader = new JCheckBox();
+	    responseHeader.setText("Response Header");
+        gbc.gridy++;
+        optionpanel.add( responseHeader, gbc );
+        
+		//Include Request Body
+	    requestBody = new JCheckBox();
+        requestBody.setText("Request Body");
+	    gbc.gridy++;
+        optionpanel.add( requestBody, gbc );
+        
+		//Include Response Body
+	    responseBody = new JCheckBox();
+	    responseBody.setText("Response Body");
+        gbc.gridy++;
+        optionpanel.add( responseBody, gbc );
+
+        JPanel buttonpane = new JPanel( new FlowLayout( FlowLayout.RIGHT ));
+        buttonpane.add( getCancelButton() );
+        buttonpane.add( getHTMLButton() );
+        
+		this.setLayout( new BorderLayout() );
+		this.add( new JLabel(" Alert Details in Report : " ), BorderLayout.NORTH );
+	    this.add( new JScrollPane( optionpanel ), BorderLayout.CENTER );
+        this.add(buttonpane, BorderLayout.SOUTH);
+
+	}
+	
+	public boolean description(){
+		return description.isSelected();
+	}
+	
+	public boolean otherInfo(){
+		return otherInfo.isSelected();
+	}
+	
+	public boolean solution(){
+		return solution.isSelected();
+	}
+	
+	public boolean reference(){
+		return reference.isSelected();
+	}
+	
+	public boolean cweid(){
+		return cweid.isSelected();
+	}
+	
+	public boolean wascid(){
+		return wascid.isSelected();
+	}
+	
+	public boolean requestHeader(){
+		return requestHeader.isSelected();
+	}
+	
+	public boolean responseHeader(){
+		return responseHeader.isSelected();
+	}
+	
+	public boolean requestBody(){
+		return requestBody.isSelected();
+	}
+	
+	public boolean responseBody(){
+		return responseBody.isSelected();
+	}
+	
+	private JButton getCancelButton(){
+		JButton cancelbutton = new JButton("Cancel");
+		cancelbutton.addActionListener(
+				new ActionListener() {
+		            @Override
+		            public void actionPerformed(ActionEvent e) {
+		               extension.emitFrame();
+		            }
+		        });
+		return cancelbutton;
+	}
+	
+	private JButton getHTMLButton(){
+		JButton generatebutton = new JButton("Generate HTML");
+		generatebutton.addActionListener(
+				new ActionListener() {
+		            @Override
+		            public void actionPerformed(ActionEvent e) {
+		                extension.generateReport();
+		            }
+		        });
+		return generatebutton;
+	}
+	
+}
+

--- a/src/org/zaproxy/zap/extension/advreport/AlertsPanel.java
+++ b/src/org/zaproxy/zap/extension/advreport/AlertsPanel.java
@@ -15,12 +15,12 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
 
-public class AdvancedPanel extends JPanel{
+public class AlertsPanel extends JPanel{
 
 	private List<JCheckBox> selections;
 	private ExtensionAdvReport extension;
 	
-	public AdvancedPanel(List<String> alertTypes,ExtensionAdvReport extension){
+	public AlertsPanel(List<String> alertTypes,ExtensionAdvReport extension){
 		initialize(alertTypes);
 		this.extension = extension;
 	}
@@ -29,13 +29,14 @@ public class AdvancedPanel extends JPanel{
 		
 		// generate and ad labels
         selections = new ArrayList<JCheckBox>();
-        
+        //Alert selection Panel
 		JPanel selectionPanel = new JPanel();
 		selectionPanel.setLayout( new GridBagLayout());
 		GridBagConstraints gbc = new GridBagConstraints();
 		gbc.gridx = 0;
 		gbc.gridy = 0;
 		gbc.fill = GridBagConstraints.HORIZONTAL;
+		
 		for( String alertType: alertTypes ){
 			JLabel label = new JLabel(alertType);
 		    JCheckBox selection = new JCheckBox();
@@ -53,16 +54,15 @@ public class AdvancedPanel extends JPanel{
 			
 			gbc.gridy += 1;
 		}
-		
+		 				
         JPanel buttonpane = new JPanel( new FlowLayout( FlowLayout.RIGHT ));
-        buttonpane.add( getCancleButton() );
+        buttonpane.add( getCancelButton() );
         buttonpane.add( getHTMLButton() );
         
 		this.setLayout( new BorderLayout() );
 		this.add( new JLabel(" Alerts in Report : " ), BorderLayout.NORTH );
 		this.add( new JScrollPane( selectionPanel ), BorderLayout.CENTER );
-        this.add(buttonpane, BorderLayout.SOUTH);
-		
+	    this.add(buttonpane, BorderLayout.SOUTH);
 		
 	}
 	
@@ -81,16 +81,16 @@ public class AdvancedPanel extends JPanel{
 		return selectedAlerts;
 	}
 	
-	private JButton getCancleButton(){
-		JButton canclebutton = new JButton("Cancle");
-		canclebutton.addActionListener(
+	private JButton getCancelButton(){
+		JButton cancelbutton = new JButton("Cancel");
+		cancelbutton.addActionListener(
 				new ActionListener() {
 		            @Override
 		            public void actionPerformed(ActionEvent e) {
 		               extension.emitFrame();
 		            }
 		        });
-		return canclebutton;
+		return cancelbutton;
 	}
 	
 	private JButton getHTMLButton(){
@@ -104,7 +104,6 @@ public class AdvancedPanel extends JPanel{
 		        });
 		return generatebutton;
 	}
-	
 	
 }
 

--- a/src/org/zaproxy/zap/extension/advreport/ExtensionAdvReport.java
+++ b/src/org/zaproxy/zap/extension/advreport/ExtensionAdvReport.java
@@ -37,12 +37,13 @@ import org.zaproxy.zap.view.ZapMenuItem;
  */
 public class ExtensionAdvReport extends ExtensionAdaptor {
 
-	public static final String NAME = "ExtensionNewReport";
+	public static final String NAME = "ExtensionAdvReport";
 	
-    private ZapMenuItem menuExample = null;
+    private ZapMenuItem menuCustomHtmlReport = null;
     private OptionDialog optionDialog = null;
     private ScopePanel scopetab = null;
-    private AdvancedPanel advancedtab = null;
+    private AlertsPanel alertstab = null;
+    private AlertDetailsPanel alertDetailstab = null;
     
     /**
      * 
@@ -73,16 +74,16 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
             super.hook(extensionHook);
             
             if (getView() != null) {
-                extensionHook.getHookMenu().addReportMenuItem(getMenuExample());
+                extensionHook.getHookMenu().addReportMenuItem(getMenuCustomHtmlReport());
             }
 
         }
 
-        private ZapMenuItem getMenuExample() {
-        if (menuExample == null) {
-                menuExample = new ZapMenuItem( "menu.report.html.generate" );
-                menuExample.setText("Customize HTML Report");
-                menuExample.addActionListener(new java.awt.event.ActionListener() {
+        private ZapMenuItem getMenuCustomHtmlReport() {
+        if (menuCustomHtmlReport == null) {
+                menuCustomHtmlReport = new ZapMenuItem( "menu.report.html.generate" );
+                menuCustomHtmlReport.setText("Customize HTML Report");
+                menuCustomHtmlReport.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
                 	getNewOptionFrame();
@@ -91,13 +92,13 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
                 }
             });
         }
-        return menuExample;
+        return menuCustomHtmlReport;
     }// zap menu item
         
         public void getNewOptionFrame(){
         	//optionframe.setPreferredSize( new Dimension(530,320) );
         	List<String> alertTypes= getAlertTypes();
-        	optionDialog = new OptionDialog(getScopeTab(),getAdvancedTab( alertTypes ) );
+        	optionDialog = new OptionDialog(getScopeTab(),getAlertsTab( alertTypes ), getAlertDetailsTab() );
         }
         
         private List<String> getAlertTypes() {
@@ -124,9 +125,14 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
         	return scopetab;
         }
         
-        private AdvancedPanel getAdvancedTab( List<String> alertTypes ){
-        	advancedtab = new AdvancedPanel( alertTypes, this );
-        	return advancedtab;
+        private AlertsPanel getAlertsTab( List<String> alertTypes ){
+        	alertstab = new AlertsPanel( alertTypes, this );
+        	return alertstab;
+        }
+        
+        private AlertDetailsPanel getAlertDetailsTab(){
+        	alertDetailstab = new AlertDetailsPanel( this );
+        	return alertDetailstab;
         }
         
         public String getReportName(){
@@ -138,22 +144,62 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
         }
         
         public List<String> getSelectedAlerts(){
-        	return advancedtab.getSelectedAlerts();
+        	return alertstab.getSelectedAlerts();
         }
         
         public boolean onlyInScope(){
         	return scopetab.onlyInScope();
         }
-        
+                
         public String getTemplate(){
         	return scopetab.getTemplate();
         }
+
+        public boolean alertDescription(){
+        	return alertDetailstab.description();
+        }
+
+        public boolean otherInfo(){
+        	return alertDetailstab.otherInfo();
+        }
         
+        public boolean solution(){
+        	return alertDetailstab.solution();
+        }
+        
+        public boolean reference(){
+        	return alertDetailstab.reference();
+        }
+        
+        public boolean cweid(){
+        	return alertDetailstab.cweid();
+        }
+        
+        public boolean wascid(){
+        	return alertDetailstab.wascid();
+        }
+        
+        public boolean requestHeader(){
+        	return alertDetailstab.requestHeader();
+        }
+        
+        public boolean responseHeader(){
+        	return alertDetailstab.responseHeader();
+        }
+        
+        public boolean requestBody(){
+        	return alertDetailstab.requestBody();
+        }
+
+        public boolean responseBody(){
+        	return alertDetailstab.responseBody();
+        }
+
         @Override
         public String getAuthor() {
                 return "\n Author: Chienli Ma";
         }
-
+ 
         @Override
         public URL getURL() {
                 try {

--- a/src/org/zaproxy/zap/extension/advreport/OptionDialog.java
+++ b/src/org/zaproxy/zap/extension/advreport/OptionDialog.java
@@ -6,10 +6,11 @@ import org.parosproxy.paros.view.AbstractFrame;
 
 public class OptionDialog extends AbstractFrame{
 	
-	public OptionDialog( ScopePanel scopeponel, AdvancedPanel advancedpanel){
+	public OptionDialog( ScopePanel scopepanel, AlertsPanel alertspanel, AlertDetailsPanel alertdetailspanel ){
 		JTabbedPane mainpane = new JTabbedPane();
-        mainpane.add("Scope", scopeponel );
-        mainpane.add("Advanced", advancedpanel );
+        mainpane.add("Scope", scopepanel );
+        mainpane.add("Alerts", alertspanel );
+        mainpane.add("Alert Details", alertdetailspanel );
         this.setTitle("Generate report");
         this.add(mainpane);
         this.pack();

--- a/src/org/zaproxy/zap/extension/advreport/ScopePanel.java
+++ b/src/org/zaproxy/zap/extension/advreport/ScopePanel.java
@@ -87,13 +87,13 @@ public class ScopePanel extends AbstractPanel{
         gbc.gridx++;
         gbc.anchor = GridBagConstraints.EAST;
         this.add( onlyInScope, gbc );
-	    
+  	    
 	    // button line 
         gbc.insets = new Insets(0,0,0,0);
 	    gbc.gridx = 1;
         gbc.gridy++ ;
         JPanel buttonpane = new JPanel( new FlowLayout( FlowLayout.RIGHT ));
-        buttonpane.add( getCancleButton() );
+        buttonpane.add( getCancelButton() );
         buttonpane.add( getHTMLButton() );
         this.add( buttonpane, gbc );
 	}
@@ -114,16 +114,16 @@ public class ScopePanel extends AbstractPanel{
 		return (String)template.getSelectedItem();
 	}
 	
-	private JButton getCancleButton(){
-		JButton canclebutton = new JButton("Cancle");
-		canclebutton.addActionListener(
+	private JButton getCancelButton(){
+		JButton cancelbutton = new JButton("Cancel");
+		cancelbutton.addActionListener(
 				new ActionListener() {
 		            @Override
 		            public void actionPerformed(ActionEvent e) {
 		               extension.emitFrame();
 		            }
 		        });
-		return canclebutton;
+		return cancelbutton;
 	}
 	
 	private JButton getHTMLButton(){
@@ -137,7 +137,5 @@ public class ScopePanel extends AbstractPanel{
 		        });
 		return generatebutton;
 	}
-	
-	
 	
 }

--- a/src/org/zaproxy/zap/extension/advreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/advreport/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
         <name>AdvReport</name>
-        <version>2</version>
+        <version>3</version>
         <description>New HTML report module allows users to customize report content.</description>
         <author>Chienli Ma</author>
         <url></url>

--- a/src/org/zaproxy/zap/extension/advreport/files/xml/mergeAlertitems.xml.xsl
+++ b/src/org/zaproxy/zap/extension/advreport/files/xml/mergeAlertitems.xml.xsl
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 <xsl:output method="xml" version="1.0"  encoding="utf-8" indent="yes" />
-
+<xsl:key name="k1" match="alertitem" use="concat(ancestor::site/@name, '|', alert)" />
 
 <xsl:template match="/OWASPZAPReport">
   <OWASPZAPReport><xsl:copy-of select="@*" />
+  <reportname>
+  	<xsl:value-of select="reportname"/>
+  </reportname>
+  <reportdesc>
+  	<xsl:value-of select="reportdesc"/>
+  </reportdesc>
   <xsl:for-each select="site">
     <site><xsl:copy-of select="@*" />
       <alerts>
-        <xsl:key name="alertByAlert" match="alertitem" use="concat(alert)" />
-        <xsl:for-each select="alerts/alertitem[generate-id() = generate-id(key('alertByAlert',alert))]">
+        <xsl:for-each select="alerts/alertitem[generate-id() = generate-id(key('k1', concat(ancestor::site/@name, '|', alert))[1])]">  
           <alertitem>
               <alert>
                 <xsl:value-of select="alert"/>
@@ -20,16 +25,24 @@
               <riskdesc>
                 <xsl:value-of select="riskdesc"/>
               </riskdesc>
-              <desc>
-                <xsl:value-of select="desc"/>
-              </desc>
-              <solution>
-                <xsl:value-of select="solution"/>
-              </solution>
+              <xsl:copy-of select="desc"/>
+              <xsl:copy-of select="solution"/>
+              <otherinfo>
+                <xsl:value-of select="otherinfo"/>
+              </otherinfo>
+              <reference>
+              	<xsl:value-of select="reference"/>
+              </reference>
+              <cweid>
+              	<xsl:value-of select="cweid"/>
+              </cweid>
+              <wascid>
+              	<xsl:value-of select="wascid"/>
+              </wascid>
               <br/>
 
 
-              <xsl:for-each select="key('alertByAlert', alert)">
+              <xsl:for-each select="key('k1', concat(ancestor::site/@name, '|', alert))">
                 <uri>
                   <xsl:value-of select="uri"/>
                 </uri>
@@ -38,11 +51,18 @@
                 </param>  
                 <attack>
                   <xsl:value-of select="attack"/>
-                </attack>            
+                </attack>          
                 <evidence>
                   <xsl:value-of select="evidence"/>
-                <br/>
                 </evidence>
+                <xsl:copy-of select="requestheader"/>
+                <xsl:copy-of select="responseheader"/>
+                <requestbody>
+                  <xsl:value-of select="requestbody"/>
+                </requestbody>
+                <responsebody>
+                  <xsl:value-of select="responsebody"/>
+                </responsebody>     
 
               </xsl:for-each>
             </alertitem>

--- a/src/org/zaproxy/zap/extension/advreport/files/xml/report.concise.html.xsl
+++ b/src/org/zaproxy/zap/extension/advreport/files/xml/report.concise.html.xsl
@@ -20,13 +20,13 @@
 <p><h1>ZAP Scanning Report</h1></p>
 
 <!-- Report name and desc -->
-  <p><h3>Report name: </h3></p>
-  <xsl:value-of select="name"/>
-
-  <p><h3>Report description: </h3></p>
-  <xsl:value-of select="desc"/>
-
-
+  <p><h3>Report name: </h3>
+   <xsl:value-of select="reportname"/> </p>
+  
+  <p><h3>Report description: </h3> 
+  <xsl:value-of select="reportdesc"/> </p>
+  
+  
 <!-- for each site -->
 <xsl:for-each select="site">
   
@@ -48,27 +48,27 @@
       <td width="55%" align="center"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">Number 
         of Alerts</font></strong></td>
     </tr>
-    <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#high">High</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+    <tr> 
+      <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#high">High</a></font></td>
+      <td bgcolor="red" align="center"><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='3'])"/>
       </font></td>
     </tr>
-    <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#medium">Medium</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+    <tr> 
+      <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#medium">Medium</a></font></td>
+      <td bgcolor="orange" align="center"><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='2'])"/>
       </font></td>
     </tr>
-      <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#low">Low</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+      <tr> 
+      <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#low">Low</a></font></td>
+      <td bgcolor="yellow" align="center"><font size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='1'])"/>
       </font></td>
     </tr>
-      <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#info">Informational</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+      <tr> 
+      <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#info">Informational</a></font></td>
+      <td bgcolor="green" align="center"><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='0'])"/>
       </font></td>
     </tr>
@@ -140,17 +140,17 @@
   <xsl:template match="alertitem">
 <p></p>
 <table width="100%" border="0">
-<xsl:apply-templates select="text()|alert|desc|uri|param|attack|otherinfo|solution|reference|cweid|wascid|p|br|wbr|ul|li"/>
+<xsl:apply-templates select="text()|alert|desc|uri|param|attack|otherinfo|solution|reference|cweid|wascid|requestheader|responseheader|requestbody|responsebody|p|br|wbr|ul|li"/>
 </table>
   </xsl:template>
 
   <xsl:template match="alert[following-sibling::riskcode='3']">
   <tr bgcolor="red" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="high"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
     </font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -159,11 +159,11 @@
   <xsl:template match="alert[following-sibling::riskcode='2']">
   <!-- ZAP: Changed the medium colour to orange -->
   <tr bgcolor="orange" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="medium"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -173,22 +173,22 @@
   <!-- ZAP: Changed the low colour to yellow -->
   <tr bgcolor="yellow" height="24">
     <a name="low"/>
-    <td width="20%" valign="top"><strong><font color="#000000" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#000000" size="3" face="Arial, Helvetica, sans-serif">
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#000000" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#000000" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
   </xsl:template>
   
   <xsl:template match="alert[following-sibling::riskcode='0']">
-  <tr bgcolor="blue" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+  <tr bgcolor="green" height="24">	
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="info"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -209,6 +209,7 @@
  -->
 
   <xsl:template match="desc">
+  <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
     <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>Description</p></font></td>
     <td width="80%">
@@ -216,19 +217,16 @@
     <xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
-  <TR vAlign="top"> 
-    <TD colspan="2"> </TD>
-  </TR>
-  
+  </xsl:if>
   </xsl:template>
 
   <xsl:template match="uri">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif">URL</font></blockquote></td>
-    <td width="80%">
+    <td width="20%"><strong><font size="2" face="Arial, Helvetica, sans-serif">URL</font></strong></td>
+    <td width="80%"><strong>
     <font size="2" face="Arial, Helvetica, sans-serif">
     <xsl:apply-templates select="text()|*"/>
-    </font></td>
+    </font></strong></td>
   </tr>
   </xsl:template>
 
@@ -259,20 +257,17 @@
   <xsl:template match="otherinfo">
   <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif">Other information</font></blockquote></td>
+    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif">Other Information</font></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
 	<xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
   </xsl:if>
-
-  <TR vAlign="top"> 
-    <TD colspan="2"> </TD>
-  </TR>
   </xsl:template>
 
   <xsl:template match="solution">
+  <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
     <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>Solution</p></font></td>
     <td width="80%">
@@ -280,9 +275,11 @@
 	<xsl:apply-templates select="text()|*"/>
 	</font></td>
   </tr>
+  </xsl:if>
   </xsl:template>
 
   <xsl:template match="reference">
+  <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
     <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>Reference</p></font></td>
     <td width="80%">
@@ -290,9 +287,11 @@
 	<xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
+  </xsl:if>
   </xsl:template>
   
   <xsl:template match="cweid">
+  <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
     <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>CWE Id</p></font></td>
     <td width="80%">
@@ -300,9 +299,11 @@
 	<xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
+  </xsl:if>
   </xsl:template>
   
   <xsl:template match="wascid">
+  <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
     <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>WASC Id</p></font></td>
     <td width="80%">
@@ -310,8 +311,57 @@
 	<xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
+  </xsl:if>
   </xsl:template>
   
+  <xsl:template match="requestheader">
+   <xsl:if test="text() !=''">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Request Header</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*"/>
+    </font></td>
+  </tr>
+   </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="responseheader">
+  <xsl:if test="text() !=''">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Response Header</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*"/>
+    </font></td>
+  </tr>
+  </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="requestbody">
+  <xsl:if test="text() !=''">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Request Body</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*"/>
+    </font></td>
+  </tr>
+  </xsl:if>
+  </xsl:template>
+  
+  <xsl:template match="responsebody">
+  <xsl:if test="text() !=''">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Response Body</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*"/>
+    </font></td>
+  </tr>
+  </xsl:if>
+  </xsl:template>
+    
   <xsl:template match="p">
   <p align="justify">
   <xsl:apply-templates select="text()|*"/>

--- a/src/org/zaproxy/zap/extension/advreport/files/xml/report.separated.html.xsl
+++ b/src/org/zaproxy/zap/extension/advreport/files/xml/report.separated.html.xsl
@@ -15,16 +15,17 @@
 
 </head>
 
+
 <body text="#000000">
 <!-- ZAP: rebrand -->
 <p><h1>ZAP Scanning Report</h1></p>
 
 <!-- Report name and desc -->
   <p><h3>Report name: </h3></p>
-  <xsl:value-of select="name"/>
+  <xsl:value-of select="reportname"/>
 
   <p><h3>Report description: </h3></p>
-  <xsl:value-of select="desc"/>
+  <xsl:value-of select="reportdesc"/>
 
 
 <!-- for each site -->
@@ -48,27 +49,27 @@
       <td width="55%" align="center"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">Number 
         of Alerts</font></strong></td>
     </tr>
-    <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#high">High</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+    <tr> 
+      <td  bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#high">High</a></font></td>
+      <td bgcolor="red" align="center"><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='3'])"/>
       </font></td>
     </tr>
-    <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#medium">Medium</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+    <tr> 
+      <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#medium">Medium</a></font></td>
+      <td bgcolor="orange" align="center"><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='2'])"/>
       </font></td>
     </tr>
-      <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#low">Low</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+      <tr> 
+      <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#low">Low</a></font></td>
+      <td bgcolor="yellow" align="center"><font size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='1'])"/>
       </font></td>
     </tr>
-      <tr bgcolor="#e8e8e8"> 
-      <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#info">Informational</a></font></td>
-      <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+      <tr> 
+      <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#info">Informational</a></font></td>
+      <td bgcolor="green" align="center"><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
       <xsl:value-of select="count(descendant::alertitem[riskcode='0'])"/>
       </font></td>
     </tr>
@@ -139,27 +140,21 @@
 
 
 
-
-
-
-
-
-
   <!-- Top Level Heading -->
   <xsl:template match="alertitem">
 <p></p>
 <table width="100%" border="0">
-<xsl:apply-templates select="text()|alert|desc|uri|param|attack|otherinfo|solution|reference|cweid|wascid|p|br|wbr|ul|li"/>
+<xsl:apply-templates select="text()|alert|desc|uri|param|attack|otherinfo|solution|reference|cweid|wascid|requestheader|responseheader|requestbody|responsebody|p|br|wbr|ul|li"/>
 </table>
   </xsl:template>
 
   <xsl:template match="alert[following-sibling::riskcode='3']">
   <tr bgcolor="red" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="high"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
     </font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -168,11 +163,11 @@
   <xsl:template match="alert[following-sibling::riskcode='2']">
   <!-- ZAP: Changed the medium colour to orange -->
   <tr bgcolor="orange" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="medium"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -182,22 +177,22 @@
   <!-- ZAP: Changed the low colour to yellow -->
   <tr bgcolor="yellow" height="24">
     <a name="low"/>
-    <td width="20%" valign="top"><strong><font color="#000000" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#000000" size="3" face="Arial, Helvetica, sans-serif">
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#000000" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#000000" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
   </xsl:template>
   
   <xsl:template match="alert[following-sibling::riskcode='0']">
-  <tr bgcolor="blue" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+  <tr bgcolor="green" height="24">	
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="info"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -225,19 +220,15 @@
     <xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
-  <TR vAlign="top"> 
-    <TD colspan="2"> </TD>
-  </TR>
-  
   </xsl:template>
 
   <xsl:template match="uri">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif">URL</font></blockquote></td>
-    <td width="80%">
+    <td width="20%"><strong><font size="2" face="Arial, Helvetica, sans-serif">URL</font></strong></td>
+    <td width="80%"><strong>
     <font size="2" face="Arial, Helvetica, sans-serif">
     <xsl:apply-templates select="text()|*"/>
-    </font></td>
+    </font></strong></td>
   </tr>
   </xsl:template>
 
@@ -268,17 +259,13 @@
   <xsl:template match="otherinfo">
   <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif">Other information</font></blockquote></td>
+    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif">Other information</font>></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
 	<xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
   </xsl:if>
-
-  <TR vAlign="top"> 
-    <TD colspan="2"> </TD>
-  </TR>
   </xsl:template>
 
   <xsl:template match="solution">
@@ -320,6 +307,47 @@
     </font></td>
   </tr>
   </xsl:template>
+  
+    <xsl:template match="requestheader">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Request Header</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*" />
+    </font></td>
+  </tr>
+  </xsl:template>
+  
+    <xsl:template match="responseheader">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Response Header</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*" />
+    </font></td>
+  </tr>
+  </xsl:template>
+  
+      <xsl:template match="requestbody">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Request Body</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*" />
+    </font></td>
+  </tr>
+  </xsl:template>
+  
+      <xsl:template match="responsebody">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Response Body</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*" />
+    </font></td>
+  </tr>
+  </xsl:template>
+  
   
   <xsl:template match="p">
   <p align="justify">

--- a/src/org/zaproxy/zap/extension/advreport/files/xml/report.traditional.html.xsl
+++ b/src/org/zaproxy/zap/extension/advreport/files/xml/report.traditional.html.xsl
@@ -20,12 +20,10 @@
 
 <!-- Report name and desc -->
   <p><h3>Report name: </h3></p>
-  <xsl:value-of select="name"/>
+  <xsl:value-of select="reportname"/>
 
   <p><h3>Report description: </h3></p>
-  <xsl:value-of select="desc"/>
-
-
+  <xsl:value-of select="reportdesc"/>
 
 
 <p>
@@ -39,27 +37,27 @@
     <td width="55%" align="center"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">Number 
       of Alerts</font></strong></td>
   </tr>
-  <tr bgcolor="#e8e8e8"> 
-    <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#high">High</a></font></td>
-    <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+  <tr> 
+    <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#high">High</a></font></td>
+    <td bgcolor="red" align="center"><font size="2" face="Arial, Helvetica, sans-serif">
     <xsl:value-of select="count(descendant::alertitem[riskcode='3'])"/>
     </font></td>
   </tr>
-  <tr bgcolor="#e8e8e8"> 
-    <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#medium">Medium</a></font></td>
-    <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+  <tr> 
+    <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#medium">Medium</a></font></td>
+    <td bgcolor="orange" align="center"><font size="2" face="Arial, Helvetica, sans-serif">
     <xsl:value-of select="count(descendant::alertitem[riskcode='2'])"/>
     </font></td>
   </tr>
-    <tr bgcolor="#e8e8e8"> 
-    <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#low">Low</a></font></td>
-    <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+    <tr> 
+    <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#low">Low</a></font></td>
+    <td bgcolor="yellow" align="center"><font size="2" face="Arial, Helvetica, sans-serif">
     <xsl:value-of select="count(descendant::alertitem[riskcode='1'])"/>
     </font></td>
   </tr>
-    <tr bgcolor="#e8e8e8"> 
-    <td><font size="2" face="Arial, Helvetica, sans-serif"><a href="#info">Informational</a></font></td>
-    <td align="center"><font size="2" face="Arial, Helvetica, sans-serif">
+    <tr> 
+    <td bgcolor="#e8e8e8"><font size="2" face="Arial, Helvetica, sans-serif"><a href="#info">Informational</a></font></td>
+    <td bgcolor="green" align="center"><font size="2" face="Arial, Helvetica, sans-serif">
     <xsl:value-of select="count(descendant::alertitem[riskcode='0'])"/>
     </font></td>
   </tr>
@@ -123,17 +121,17 @@
   <xsl:template match="alertitem">
 <p></p>
 <table width="100%" border="0">
-<xsl:apply-templates select="text()|alert|desc|uri|param|attack|otherinfo|solution|reference|cweid|wascid|p|br|wbr|ul|li"/>
+<xsl:apply-templates select="text()|alert|desc|uri|param|attack|otherinfo|solution|reference|cweid|wascid|requestheader|responseheader|requestbody|responsebody|p|br|wbr|ul|li"/>
 </table>
   </xsl:template>
 
   <xsl:template match="alert[following-sibling::riskcode='3']">
   <tr bgcolor="red" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="high"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
     </font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -142,36 +140,36 @@
   <xsl:template match="alert[following-sibling::riskcode='2']">
   <!-- ZAP: Changed the medium colour to orange -->
   <tr bgcolor="orange" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="medium"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
-
   </xsl:template>
+  
   <xsl:template match="alert[following-sibling::riskcode='1']">
   <!-- ZAP: Changed the low colour to yellow -->
   <tr bgcolor="yellow" height="24">
     <a name="low"/>
-    <td width="20%" valign="top"><strong><font color="#000000" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="20%" valign="top"><strong><font color="#000000" size="3" face="Arial, Helvetica, sans-serif">
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#000000" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#000000" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
   </xsl:template>
   
   <xsl:template match="alert[following-sibling::riskcode='0']">
-  <tr bgcolor="blue" height="24">	
-    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+  <tr bgcolor="green" height="24">	
+    <td width="20%" valign="top"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
     <a name="info"/>
     <xsl:value-of select="following-sibling::riskdesc"/>
 	</font></strong></td>
-    <td width="80%"><strong><font color="#FFFFFF" size="2" face="Arial, Helvetica, sans-serif">
+    <td width="80%"><strong><font color="#FFFFFF" size="3" face="Arial, Helvetica, sans-serif">
       <xsl:apply-templates select="text()"/>
 </font></strong></td>
   </tr>
@@ -199,19 +197,55 @@
     <xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
-  <TR vAlign="top"> 
-    <TD colspan="2"> </TD>
-  </TR>
-  
   </xsl:template>
-
-  <xsl:template match="uri">
+  
+  <xsl:template match="solution">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif">URL</font></blockquote></td>
+    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>Solution</p></font></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
-    <xsl:apply-templates select="text()|*"/>
+	<xsl:apply-templates select="text()|*"/>
+	</font></td>
+  </tr>
+  </xsl:template>
+  
+  <xsl:template match="reference">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>Reference</p></font></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*"/>
     </font></td>
+  </tr>
+  </xsl:template>
+  
+  <xsl:template match="cweid">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>CWE Id</p></font></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*"/>
+    </font></td>
+  </tr>
+  </xsl:template>
+  
+  <xsl:template match="wascid">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>WASC Id</p></font></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*" />
+    </font></td>
+  </tr>
+  </xsl:template>
+  
+  <xsl:template match="uri">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><strong><font size="2" face="Arial, Helvetica, sans-serif">URL</font></strong></td>
+    <td width="80%"><strong>
+    <font size="2" face="Arial, Helvetica, sans-serif">
+    <xsl:apply-templates select="text()|*"/>
+    </font></strong></td>
   </tr>
   </xsl:template>
 
@@ -238,63 +272,60 @@
   </tr>
   </xsl:if>
   </xsl:template>
-
-  <xsl:template match="otherinfo">
+ 
+ <xsl:template match="otherinfo">
   <xsl:if test="text() !=''">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif">Other information</font></blockquote></td>
+    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif">Other Information</font></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
 	<xsl:apply-templates select="text()|*"/>
     </font></td>
   </tr>
   </xsl:if>
+</xsl:template>
 
-  <TR vAlign="top"> 
-    <TD colspan="2"> </TD>
-  </TR>
-  </xsl:template>
-
-  <xsl:template match="solution">
+  <xsl:template match="requestheader">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>Solution</p></font></td>
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Request Header</p></font></blockquote></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
-	<xsl:apply-templates select="text()|*"/>
-	</font></td>
-  </tr>
-  </xsl:template>
-
-  <xsl:template match="reference">
-  <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>Reference</p></font></td>
-    <td width="80%">
-    <font size="2" face="Arial, Helvetica, sans-serif">
-	<xsl:apply-templates select="text()|*"/>
+	<xsl:apply-templates select="text()|*" />
     </font></td>
   </tr>
   </xsl:template>
   
-  <xsl:template match="cweid">
+    <xsl:template match="responseheader">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>CWE Id</p></font></td>
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Response Header</p></font></blockquote></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
-	<xsl:apply-templates select="text()|*"/>
+	<xsl:apply-templates select="text()|*" />
     </font></td>
   </tr>
   </xsl:template>
   
-  <xsl:template match="wascid">
+  <xsl:template match="requestbody">
   <tr bgcolor="#e8e8e8" valign="top"> 
-    <td width="20%"><font size="2" face="Arial, Helvetica, sans-serif"><p>WASC Id</p></font></td>
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Request Body</p></font></blockquote></td>
     <td width="80%">
     <font size="2" face="Arial, Helvetica, sans-serif">
-	<xsl:apply-templates select="text()|*"/>
+	<xsl:apply-templates select="text()|*" />
     </font></td>
   </tr>
   </xsl:template>
   
+  <xsl:template match="responsebody">
+  <tr bgcolor="#e8e8e8" valign="top"> 
+    <td width="20%"><blockquote><font size="2" face="Arial, Helvetica, sans-serif"><p>Response Body</p></font></blockquote></td>
+    <td width="80%">
+    <font size="2" face="Arial, Helvetica, sans-serif">
+	<xsl:apply-templates select="text()|*" />
+    </font></td>
+  </tr>
+  </xsl:template>
+  
+
   <xsl:template match="p">
   <p align="justify">
   <xsl:apply-templates select="text()|*"/>
@@ -324,10 +355,5 @@
   </xsl:template> 
   
 
-  
-  
-  
-  
-  
 
 </xsl:stylesheet>


### PR DESCRIPTION
Added options to include or not Description, Other Info, Solution, Reference, CWE Id, WASC Id into a report.  Now more information can be added: Request header, Request body, Response header, Response body.

Changed layout of the report and fixed some bugs in concise report xsl where description and name of report were not showing.  Fixed logic in concise reports to group by site_name+alert_name, not just alert_name.