### PR TITLE
add plugin for codedx reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+build/build/
+build/zap-exts/

--- a/build/build.xml
+++ b/build/build.xml
@@ -239,6 +239,7 @@
 		<build-addon name="browserView" />
 		<build-addon name="callgraph" />
 		<build-addon name="cmss" />
+		<build-addon name="codedx"/>
 		<build-addon name="help_bs_BA" />
 		<build-addon name="help_es_ES" />
 		<build-addon name="help_fr_FR" />
@@ -336,6 +337,10 @@
 		<build-deploy-addon name="cmss" />
 	</target>
 
+	<target name="deploy-codedx" description="deploy the codedx extension">
+		<build-deploy-addon name="codedx" />
+	</target>
+	
 	<target name="deploy-help-fr-FR" description="deploy the help_fr_FR add-on">
 		<build-deploy-help-addon name="help_fr_FR" />
 	</target>

--- a/src/org/zaproxy/zap/extension/codedx/CodeDxExtension.java
+++ b/src/org/zaproxy/zap/extension/codedx/CodeDxExtension.java
@@ -1,0 +1,92 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.codedx;
+
+import java.net.URL;
+import java.util.List;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.report.ReportLastScan.ReportType;
+import org.zaproxy.zap.view.ZapMenuItem;
+
+/*
+ * The Code Dx ZAP extension used to include request and response data in alert reports. 
+ * 
+ */
+public class CodeDxExtension extends ExtensionAdaptor {
+
+    // The name is public so that other extensions can access it
+    public static final String NAME = "CodeDxExtension";
+
+    private ZapMenuItem menu = null;
+
+    public List<Alert> alerts;
+
+    public CodeDxExtension() {
+        super();
+        initialize();
+    }
+
+    private void initialize() {
+        this.setName(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        if (getView() != null) {
+            extensionHook.getHookMenu().addReportMenuItem(getMenu());
+        }
+
+    }
+
+    public ZapMenuItem getMenu() {
+        if (menu == null) {
+            menu = new ZapMenuItem("codedx.topmenu.report.title");
+
+            menu.addActionListener(new java.awt.event.ActionListener() {
+
+                @Override
+                public void actionPerformed(java.awt.event.ActionEvent ae) {
+                    ReportLastScanHttp saver = new ReportLastScanHttp();
+                    saver.generateReport(getView(), getModel(), ReportType.XML);
+                }
+            });
+        }
+        return menu;
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.messages.getString("codedx.author");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("codedx.desc");
+    }
+
+    @Override
+    public URL getURL() {
+        return null;
+    }
+}

--- a/src/org/zaproxy/zap/extension/codedx/ExtensionAlertHttp.java
+++ b/src/org/zaproxy/zap/extension/codedx/ExtensionAlertHttp.java
@@ -1,0 +1,79 @@
+package org.zaproxy.zap.extension.codedx;
+
+import java.util.List;
+
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.extension.report.ReportGenerator;
+import org.parosproxy.paros.model.SiteNode;
+import org.zaproxy.zap.extension.alert.ExtensionAlert;
+
+public class ExtensionAlertHttp extends ExtensionAlert {
+
+    public ExtensionAlertHttp() {
+    }
+
+    @Override
+    public String getXml(SiteNode site) {
+        StringBuilder xml = new StringBuilder();
+        xml.append("<alerts>");
+        List<Alert> alerts = site.getAlerts();
+        for (Alert alert : alerts) {
+            if (alert.getConfidence() != Alert.CONFIDENCE_FALSE_POSITIVE) {
+                String urlParamXML = getUrlParamXML(alert);
+                xml.append(alert.toPluginXML(urlParamXML));
+            }
+        }
+        xml.append("</alerts>");
+        return xml.toString();
+    }
+
+    private String getHTML(Alert alert) {
+        // gets HttpMessage request and response data from each alert and removes illegal and special characters
+        StringBuilder httpMessage = new StringBuilder();
+
+        String requestHeader = alert.getMessage().getRequestHeader().toString();
+        String requestBody = alert.getMessage().getRequestBody().toString();
+        String responseHeader = alert.getMessage().getResponseHeader().toString();
+        String responseBody = alert.getMessage().getResponseBody().toString();
+
+        httpMessage.append("<requestdata>");
+        httpMessage.append(ReportGenerator.entityEncode(requestHeader));
+        httpMessage.append(ReportGenerator.entityEncode(requestBody));
+        httpMessage.append("\n</requestdata>\n");
+        httpMessage.append("<responsedata>");
+        httpMessage.append(ReportGenerator.entityEncode(responseHeader));
+        httpMessage.append(ReportGenerator.entityEncode(responseBody));
+        httpMessage.append("\n</responsedata>\n");
+
+        return httpMessage.toString();
+    }
+
+    public String getUrlParamXML(Alert alert) {
+
+        String uri = alert.getUri();
+        String param = alert.getParam();
+        String attack = alert.getAttack();
+        String otherInfo = alert.getOtherInfo();
+        String evidence = alert.getEvidence();
+
+        StringBuilder sb = new StringBuilder(200); // ZAP: Changed the type to StringBuilder.
+        sb.append(getHTML(alert));
+        sb.append("  <uri>").append(ReportGenerator.entityEncode(uri).replaceAll("&amp;", "&amp;<wbr/>")).append("</uri>\r\n");
+        sb.append("  <param>")
+                .append(ReportGenerator.entityEncode(param).replaceAll("&amp;", "&amp;<wbr/>"))
+                .append("</param>\r\n");
+        sb.append("  <attack>")
+                .append(ReportGenerator.entityEncode(attack).replaceAll("&amp;", "&amp;<wbr/>"))
+                .append("</attack>\r\n");
+        if (evidence != null && evidence.length() > 0) {
+            sb.append("  <evidence>")
+                    .append(ReportGenerator.entityEncode(evidence).replaceAll("&amp;", "&amp;<wbr/>"))
+                    .append("</evidence>\r\n");
+        }
+        sb.append("  <otherinfo>")
+                .append(ReportGenerator.entityEncode(otherInfo).replaceAll("&amp;", "&amp;<wbr/>"))
+                .append("</otherinfo>\r\n");
+        return sb.toString();
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/codedx/ReportLastScanHttp.java
+++ b/src/org/zaproxy/zap/extension/codedx/ReportLastScanHttp.java
@@ -1,0 +1,30 @@
+package org.zaproxy.zap.extension.codedx;
+
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.extension.report.ReportLastScan;
+import org.parosproxy.paros.model.SiteNode;
+import org.zaproxy.zap.extension.XmlReporterExtension;
+
+public class ReportLastScanHttp extends ReportLastScan {
+
+    ReportLastScanHttp() {
+    }
+
+    @Override
+    public StringBuilder getExtensionsXML(SiteNode site) {
+        StringBuilder extensionXml = new StringBuilder();
+        ExtensionLoader loader = Control.getSingleton().getExtensionLoader();
+        int extensionCount = loader.getExtensionCount();
+        ExtensionAlertHttp extensionHttp = new ExtensionAlertHttp();
+        for (int i = 0; i < extensionCount; i++) {
+            Extension extension = loader.getExtension(i);
+            if (extension instanceof XmlReporterExtension) {
+                extensionXml.append(extensionHttp.getXml(site));
+            }
+        }
+        return extensionXml;
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
@@ -1,0 +1,18 @@
+<zapaddon>
+	<name>Code Dx Extension</name>
+	<version>1</version>
+	<description>includes request and response data in xml reports</description>
+	<author>Code Dx, Inc.</author>
+	<url></url>
+	<changes>First version</changes>
+	<extensions>
+		<extension>org.zaproxy.zap.extension.codedx.CodeDxExtension</extension>
+	</extensions>
+	<ascanrules/>
+	<pscanrules/>
+	<filters/>
+	<files>
+	</files>
+	<not-before-version>2.4.0</not-before-version>
+	<not-from-version></not-from-version>
+</zapaddon>

--- a/src/org/zaproxy/zap/extension/codedx/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/codedx/resources/Messages.properties
@@ -1,0 +1,7 @@
+# Used for the Report menu item 
+#
+# This file defines the default (English) variants of all of the internationalised messages
+
+codedx.topmenu.report.title = Generate XML Report for Code Dx
+codedx.author               = Code Dx, Inc.
+codedx.desc                 = Generates XML report that includes request and response data for each alert


### PR DESCRIPTION
This extension adds an alternate XML reporter to the Report dropdown that includes http request and response data, to support the data needs of [Code Dx](http://codedx.com/)