### PR TITLE
signalr connections can use way longer URLs than 255 chars

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
@@ -88,7 +88,7 @@ public class TableWebSocket extends ParosAbstractTable {
 								+ "channel_id BIGINT PRIMARY KEY,"
 								+ "host VARCHAR(255) NOT NULL,"
 								+ "port INTEGER NOT NULL,"
-								+ "url VARCHAR(255) NOT NULL,"
+								+ "url VARCHAR(2048) NOT NULL,"
 								+ "start_timestamp TIMESTAMP NOT NULL,"
 								+ "end_timestamp TIMESTAMP NULL,"
 								+ "history_id INTEGER NULL,"


### PR DESCRIPTION
I had the problem that websocket frames would not show up in the UI because the channel record could not be inserted into the TableStorage. This fix solves the problem for my case, but URLs can be practically unlimited in length and I'm unsure whether 4096 would be a better value for the maximum URL length. An even better fix might make sure that the URL is truncated (and that fact noted) instead of the current behaviour of silently failing to show websocket frames. 