### PR TITLE
[Alpha extension] SOAP Scanner fix: operations with the same location were overwritten in the sites tree.

### DIFF
--- a/src/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/src/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.codehaus.groovy.runtime.metaclass.MissingPropertyExceptionNoStack;
 import org.parosproxy.paros.control.Control;
@@ -223,6 +224,7 @@ public class WSDLCustomParser {
 				    
 		    	    /* Identifies operations for each endpoint.. */
 	    	        for(BindingOperation bindOp : operations){
+	    	        	String opDisplayName = "/" + bindOp.getName() + " (SOAP 1."+soapVersion+")";
 	    	        	sb.append("|\t|-- SOAP 1."+soapVersion+" Operation: "+bindOp.getName());
 	    	        	/* Adds this operation to the global operations chart. */
 	    	        	recordOperation(keyIndex, bindOp);	    	        	
@@ -239,7 +241,7 @@ public class WSDLCustomParser {
 	    	        	SOAPMsgConfig soapConfig = new SOAPMsgConfig(wsdl, soapVersion, formParams, port, bindOp);
 	    	        	lastConfig = soapConfig;
 	    	        	HttpMessage requestMessage = createSoapRequest(soapConfig);
-	    	        	if (sendMessages) sendSoapRequest(keyIndex, requestMessage, sb);
+	    	        	if (sendMessages) sendSoapRequest(keyIndex, requestMessage, opDisplayName, sb);
 	    	        } //bindingOperations loop
 		        } //Binding check if
         	}// Ports loop
@@ -449,7 +451,7 @@ public class WSDLCustomParser {
 	/* Sends a given SOAP request. File is needed to record its associated ops, and stringBuilder logs
 	 * the output message.
 	 */
-	private void sendSoapRequest(int wsdlID, HttpMessage httpRequest, StringBuilder sb){
+	private void sendSoapRequest(int wsdlID, HttpMessage httpRequest, String opDisplayName, StringBuilder sb){
 		if (httpRequest == null) return;
 		HttpRequestBody body = httpRequest.getRequestBody();
 		/* Avoids connection if message has no proper body. */
@@ -467,11 +469,11 @@ public class WSDLCustomParser {
 			if(log != null) log.debug("Trace:", e);
 		}
 		wsdlSingleton.putRequest(wsdlID, httpRequest);
-		persistMessage(httpRequest);
+		persistMessage(httpRequest, opDisplayName);
 		if (sb != null) sb.append(" (Status code: "+ httpRequest.getResponseHeader().getStatusCode() +")\n");
 	}
 	
-	private static void persistMessage(final HttpMessage message) {
+	private static void persistMessage(final HttpMessage message, final String opDisplayName) {
 		// Add the message to the history panel and sites tree
 		final HistoryReference historyRef;
 
@@ -489,6 +491,16 @@ public class WSDLCustomParser {
 				@Override
 				public void run() {
 					extHistory.addHistory(historyRef);
+					/* Modifies the URI adding the SOAP operation name to avoid overwrites. It's done after
+					 * saving it in history so that the original URI is preserved for scanning tasks.*/
+					try {
+						URI soapURI = message.getRequestHeader().getURI();
+						String soapStringURI = soapURI.getPath();
+						soapURI.setPath(soapStringURI+opDisplayName);
+						message.getRequestHeader().setURI(soapURI);
+					} catch (URIException e) {
+						e.printStackTrace();
+					}
 					Model.getSingleton().getSession().getSiteTree().addPath(historyRef, message);	
 				}
 			});

--- a/src/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/src/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -224,7 +224,7 @@ public class WSDLCustomParser {
 				    
 		    	    /* Identifies operations for each endpoint.. */
 	    	        for(BindingOperation bindOp : operations){
-	    	        	String opDisplayName = "/" + bindOp.getName() + " (SOAP 1."+soapVersion+")";
+	    	        	String opDisplayName = "/" + bindOp.getName() + " (v1."+soapVersion+")";
 	    	        	sb.append("|\t|-- SOAP 1."+soapVersion+" Operation: "+bindOp.getName());
 	    	        	/* Adds this operation to the global operations chart. */
 	    	        	recordOperation(keyIndex, bindOp);	    	        	
@@ -491,15 +491,19 @@ public class WSDLCustomParser {
 				@Override
 				public void run() {
 					extHistory.addHistory(historyRef);
+					
+					// FIXME
 					/* Modifies the URI adding the SOAP operation name to avoid overwrites. It's done after
-					 * saving it in history so that the original URI is preserved for scanning tasks.*/
+					 * saving it in history so that the original URI is preserved for scanning tasks.
+					 * 
+					 * URI modification solution is only a workaround since it has size limitations
+					 * and, anyway, it is not an elegant solution.*/
 					try {
 						URI soapURI = message.getRequestHeader().getURI();
 						String soapStringURI = soapURI.getPath();
 						soapURI.setPath(soapStringURI+opDisplayName);
-						message.getRequestHeader().setURI(soapURI);
 					} catch (URIException e) {
-						e.printStackTrace();
+						log.warn(e.getMessage(), e);
 					}
 					Model.getSingleton().getSession().getSiteTree().addPath(historyRef, message);	
 				}

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -1,10 +1,10 @@
 <zapaddon>
 	<name>SOAP Scanner</name>
-	<version>3</version>
+	<version>2</version>
 	<description>Imports and scans WSDL files containing SOAP endpoints.</description>
 	<author>Alberto (albertov91)</author>
 	<url></url>
-	<changes>Version 3 fixes a problem where operations under the same location were overwritten.</changes>
+	<changes> Fixes a problem where operations under the same location were overwritten. Other minor fixes.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.soap.ExtensionImportWSDL</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -1,10 +1,10 @@
 <zapaddon>
 	<name>SOAP Scanner</name>
-	<version>2</version>
+	<version>3</version>
 	<description>Imports and scans WSDL files containing SOAP endpoints.</description>
 	<author>Alberto (albertov91)</author>
 	<url></url>
-	<changes>Minor code changes.</changes>
+	<changes>Version 3 fixes a problem where operations under the same location were overwritten.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.soap.ExtensionImportWSDL</extension>
 	</extensions>


### PR DESCRIPTION
Hi,

I have made a fix to the SOAP scanning plugin so that operations are not overwritten anymore if they have the same location URI.

This problem was notified by a ZAP user in this post: https://groups.google.com/forum/#!topic/zaproxy-users/GuPxQ-zKh_s

Regards,
Alberto.