### PR TITLE
[Alpha extension] SOAP Scanner fix: operations with the same location were overwritten in the sites tree.

### DIFF
--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -4,7 +4,7 @@
 	<description>Imports and scans WSDL files containing SOAP endpoints.</description>
 	<author>Alberto (albertov91)</author>
 	<url></url>
-	<changes>Minor code changes.</changes>
+	<changes> Fixes a problem where operations under the same location were overwritten. Other minor fixes.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.soap.ExtensionImportWSDL</extension>
 	</extensions>


### PR DESCRIPTION
This is the continuation of a previous pull request: https://github.com/zaproxy/zap-extensions/pull/30
I have fixed most of the things indicated there. However, no solution comes to my mind about preserving the fix when reopening sessions without making modifications outside the plugin.