### PR TITLE
ascanrulesBeta: remove XXE API when the add-on is uninstalled

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ExtensionAscanRulesBeta.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ExtensionAscanRulesBeta.java
@@ -20,6 +20,7 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.zaproxy.zap.extension.api.API;
 
 /**
  * A null extension just to cause the message bundle and help file to get loaded 
@@ -27,6 +28,13 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
  *
  */
 public class ExtensionAscanRulesBeta extends ExtensionAdaptor {
+
+	/**
+	 * An API end point for the specific challenge/response model of {@code XXEPlugin}.
+	 * 
+	 * @see XXEPlugin
+	 */
+	private XXEPluginAPI xxePluginApi;
 
 	public ExtensionAscanRulesBeta() {
 		super();
@@ -51,5 +59,29 @@ public class ExtensionAscanRulesBeta extends ExtensionAdaptor {
 	@Override
 	public boolean canUnload() {
 		return true;
+	}
+
+	@Override
+	public void unload() {
+		super.unload();
+
+		if (xxePluginApi != null) {
+			API.getInstance().removeApiImplementor(xxePluginApi);
+		}
+	}
+
+	XXEPluginAPI getXXEPluginAPI() {
+		if (xxePluginApi == null) {
+			createXXEPluginAPI();
+		}
+		return xxePluginApi;
+	}
+
+	private synchronized void createXXEPluginAPI() {
+		if (xxePluginApi == null) {
+			XXEPluginAPI api = new XXEPluginAPI();
+			API.getInstance().registerApiImplementor(api);
+			xxePluginApi = api;
+		}
 	}
 }

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/XXEPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/XXEPlugin.java
@@ -23,13 +23,13 @@ import java.text.MessageFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.log4j.Logger;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpStatusCode;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
 
@@ -86,10 +86,7 @@ public class XXEPlugin extends AbstractAppPlugin implements ChallengeCallbackPlu
 
     // API for the specific challenge/response model
     // Should be a common object for all this plugin instances
-    private static final XXEPluginAPI pluginApi = new XXEPluginAPI();
-    static {
-        API.getInstance().registerApiImplementor(pluginApi);
-    }
+    private static XXEPluginAPI pluginApi;
     
     // Logger instance
     private static final Logger log = Logger.getLogger(XXEPlugin.class);
@@ -207,8 +204,12 @@ public class XXEPlugin extends AbstractAppPlugin implements ChallengeCallbackPlu
 
     @Override
     public void init() {
-        // to do
-        
+        if (pluginApi == null) {
+            ExtensionAscanRulesBeta ext = Control.getSingleton()
+                    .getExtensionLoader()
+                    .getExtension(ExtensionAscanRulesBeta.class);
+            pluginApi = ext.getXXEPluginAPI();
+        }
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<changes>
 	<![CDATA[
 	Removing Format String.<br>
+	Fix unloading issue (Issue 1972).<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionAscanRulesBeta to take care to install and uninstall the
API used by XXEPlugin. The API is (created and) installed when required
by the XXEPlugin, and removed when the add-on is uninstalled.
Change XXEPlugin to no longer create and install the API but obtain it
from ExtensionAscanRulesBeta.
Update changes in ZapAddOn.xml file.
Fix zaproxy/zaproxy#1972 - Resource leak while uninstalling "Active
scanner rules (beta)" add-on