### PR TITLE
Minimized False Positives in Format String and Buffer Overflow

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
@@ -29,6 +29,8 @@ package org.zaproxy.zap.extension.ascanrules;
 
 
 
+import java.io.IOException;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -37,6 +39,8 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
 
 
 public class BufferOverflow extends AbstractAppParamPlugin  {
@@ -62,7 +66,12 @@ public class BufferOverflow extends AbstractAppParamPlugin  {
 	public String[] getDependency() {
 		return null;
 	}
-
+	
+	@Override
+	public boolean targets(TechSet technologies) { 
+		return technologies.includes(Tech.Lang.C); 
+	}
+	
 	@Override
 	public String getDescription() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
@@ -105,6 +114,10 @@ public class BufferOverflow extends AbstractAppParamPlugin  {
 			}
 			return; // Stop!
 		}
+		if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
+		{
+			return;//Stop
+		}
 		
 		try {
 			// This is where you change the 'good' request to attack the application
@@ -135,7 +148,7 @@ public class BufferOverflow extends AbstractAppParamPlugin  {
 				return;	
 
 			
-		} catch (Exception e) {
+		} catch (IOException e) {
 			log.error(e.getMessage(), e);
 		}	
 	}

--- a/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
@@ -41,6 +41,8 @@
 
 
 package org.zaproxy.zap.extension.ascanrules;
+import java.io.IOException;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -125,6 +127,11 @@ public class FormatString extends AbstractAppParamPlugin  {
 				log.debug("Scanner "+getName()+" Stopping.");
 			}
 			return; // Stop!
+		}
+		
+		if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
+		{
+			return;//Stop
 		}
 		
 		try {
@@ -251,7 +258,7 @@ public class FormatString extends AbstractAppParamPlugin  {
 
 
 			
-		} catch (Exception e) {
+		} catch (IOException e) {
 			log.error(e.getMessage(), e);
 		}	
 	}

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -6,9 +6,11 @@
 	<url/>
 	<changes>
 	<![CDATA[
-	   Change Path Traversal scanner to also check HTML responses in decoded form.<br>
+	   Change Path Traversal scanner to also check HTML responses in decoded form.<br> 
        Move Format String from Beta to Release.<br>
        Improve memory usage when scanning for persistent XSS vulnerabilities (Issue 1974).<br>
+       Fix False Positives in Buffer Overflow.<br>  
+       
 	]]>
     </changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -10,7 +10,7 @@
        Move Format String from Beta to Release.<br>
        Improve memory usage when scanning for persistent XSS vulnerabilities (Issue 1974).<br>
        Fix False Positives in Buffer Overflow.<br>  
-       
+       Fixed False Positives in Format String.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
I added code to dump out of Format String and Buffer Overflow if it detects a server error before running the scanner.  I also upgraded the exception handling.  Two commits are used.  One for each scanner.