### PR TITLE
advreport: consolidated cancel and generate buttons under one class

### DIFF
--- a/src/org/zaproxy/zap/extension/advreport/AlertDetailsPanel.java
+++ b/src/org/zaproxy/zap/extension/advreport/AlertDetailsPanel.java
@@ -1,14 +1,10 @@
 package org.zaproxy.zap.extension.advreport;
 
 import java.awt.BorderLayout;
-import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.Insets;
 
-import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -19,7 +15,6 @@ import org.parosproxy.paros.Constant;
 
 public class AlertDetailsPanel extends JPanel{
 
-	private ExtensionAdvReport extension;
 	private JCheckBox description = null;
 	private JCheckBox otherInfo = null;
 	private JCheckBox solution = null;
@@ -31,9 +26,8 @@ public class AlertDetailsPanel extends JPanel{
 	private JCheckBox requestBody = null;
 	private JCheckBox responseBody = null;
 	
-	public AlertDetailsPanel(ExtensionAdvReport extension){
+	public AlertDetailsPanel(){
 		initialize();
-		this.extension = extension;
 		description.setSelected(true);
 		otherInfo.setSelected(true);
 		solution.setSelected(true);
@@ -115,15 +109,10 @@ public class AlertDetailsPanel extends JPanel{
 	    responseBody.setText(Constant.messages.getString("advreport.alertdetails.responsebody"));
         gbc.gridy++;
         optionpanel.add( responseBody, gbc );
-
-        JPanel buttonpane = new JPanel( new FlowLayout( FlowLayout.RIGHT ));
-        buttonpane.add( getCancelButton() );
-        buttonpane.add( getHTMLButton() );
         
 		this.setLayout( new BorderLayout() );
 		this.add( new JLabel(Constant.messages.getString("advreport.alertdetails.label")), BorderLayout.NORTH );
 	    this.add( new JScrollPane( optionpanel ), BorderLayout.CENTER );
-        this.add(buttonpane, BorderLayout.SOUTH);
 
 	}
 	
@@ -166,30 +155,6 @@ public class AlertDetailsPanel extends JPanel{
 	public boolean responseBody(){
 		return responseBody.isSelected();
 	}
-	
-	private JButton getCancelButton(){
-		JButton cancelbutton = new JButton(Constant.messages.getString("advreport.cancel"));
-		cancelbutton.addActionListener(
-				new ActionListener() {
-		            @Override
-		            public void actionPerformed(ActionEvent e) {
-		               extension.emitFrame();
-		            }
-		        });
-		return cancelbutton;
-	}
-	
-	private JButton getHTMLButton(){
-		JButton generatebutton = new JButton(Constant.messages.getString("advreport.generate"));
-		generatebutton.addActionListener(
-				new ActionListener() {
-		            @Override
-		            public void actionPerformed(ActionEvent e) {
-		                extension.generateReport();
-		            }
-		        });
-		return generatebutton;
-	}
-	
+
 }
 

--- a/src/org/zaproxy/zap/extension/advreport/AlertsPanel.java
+++ b/src/org/zaproxy/zap/extension/advreport/AlertsPanel.java
@@ -1,17 +1,13 @@
 package org.zaproxy.zap.extension.advreport;
 import java.awt.BorderLayout;
-import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -23,13 +19,11 @@ import org.parosproxy.paros.Constant;
 public class AlertsPanel extends JPanel{
 
 	private List<JCheckBox> selections;
-	private ExtensionAdvReport extension;
 
 	private Map<String, String> alertTypeRisk = null;
 	//Alert types with corresponding risk Levels (High, Medium, Low, Informational)
 	public AlertsPanel(List<String> alertTypes,ExtensionAdvReport extension){
 		initialize(alertTypes);
-		this.extension = extension;
 		alertTypeRisk = extension.alertTypeRisk;
 	}
 
@@ -74,15 +68,10 @@ public class AlertsPanel extends JPanel{
 			gbc.gridy += 1;
 			
 		}
-		 				
-        JPanel buttonpane = new JPanel( new FlowLayout( FlowLayout.RIGHT ));
-        buttonpane.add( getCancelButton() );
-        buttonpane.add( getHTMLButton() );
         
 		this.setLayout( new BorderLayout() );
 		this.add( new JLabel(Constant.messages.getString("advreport.alertspanel.label") ), BorderLayout.NORTH );
 		this.add( new JScrollPane( selectionPanel ), BorderLayout.CENTER );
-	    this.add(buttonpane, BorderLayout.SOUTH);
 		
 	}
 	
@@ -121,29 +110,5 @@ public class AlertsPanel extends JPanel{
 		
 		return riskChk;
 	}
-	
-	private JButton getCancelButton(){
-		JButton cancelbutton = new JButton(Constant.messages.getString("advreport.cancel"));
-		cancelbutton.addActionListener(
-				new ActionListener() {
-		            @Override
-		            public void actionPerformed(ActionEvent e) {
-		               extension.emitFrame();
-		            }
-		        });
-		return cancelbutton;
-	}
-	
-	private JButton getHTMLButton(){
-		JButton generatebutton = new JButton(Constant.messages.getString("advreport.generate"));
-		generatebutton.addActionListener(
-				new ActionListener() {
-		            @Override
-		            public void actionPerformed(ActionEvent e) {
-		                extension.generateReport();
-		            }
-		        });
-		return generatebutton;
-	}
-	
+		
 }

--- a/src/org/zaproxy/zap/extension/advreport/ExtensionAdvReport.java
+++ b/src/org/zaproxy/zap/extension/advreport/ExtensionAdvReport.java
@@ -103,7 +103,7 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
         public void getNewOptionFrame(){
         	//optionframe.setPreferredSize( new Dimension(530,320) );
         	List<String> alertTypes = getAlertTypes();
-        	optionDialog = new OptionDialog(getScopeTab(),getAlertsTab( alertTypes ), getAlertDetailsTab() );
+        	optionDialog = new OptionDialog(this, getScopeTab(),getAlertsTab( alertTypes ), getAlertDetailsTab() );
         }
         
         private List<String> getAlertTypes() {
@@ -128,7 +128,7 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
         }
 
 		private ScopePanel getScopeTab(){
-        	scopetab = new ScopePanel( this );	
+        	scopetab = new ScopePanel();	
         	return scopetab;
         }
         
@@ -138,7 +138,7 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
         }
         
         private AlertDetailsPanel getAlertDetailsTab(){
-        	alertDetailstab = new AlertDetailsPanel( this );
+        	alertDetailstab = new AlertDetailsPanel();
         	return alertDetailstab;
         }
         
@@ -219,4 +219,5 @@ public class ExtensionAdvReport extends ExtensionAdaptor {
 		public void emitFrame() {
 			optionDialog.setVisible(false);
 		}
+		
 }

--- a/src/org/zaproxy/zap/extension/advreport/OptionDialog.java
+++ b/src/org/zaproxy/zap/extension/advreport/OptionDialog.java
@@ -1,5 +1,12 @@
 package org.zaproxy.zap.extension.advreport;
 
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.JButton;
+import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 
 import org.parosproxy.paros.Constant;
@@ -7,13 +14,54 @@ import org.parosproxy.paros.view.AbstractFrame;
 
 public class OptionDialog extends AbstractFrame{
 	
-	public OptionDialog( ScopePanel scopepanel, AlertsPanel alertspanel, AlertDetailsPanel alertdetailspanel ){
+	private ExtensionAdvReport extension = null;
+	
+	public OptionDialog( ExtensionAdvReport extension, ScopePanel scopepanel, AlertsPanel alertspanel,
+						 AlertDetailsPanel alertdetailspanel ){
+		this.extension = extension;
+		JPanel optiondialog = new JPanel();
+		optiondialog.setLayout( new BorderLayout() );
+		
 		JTabbedPane mainpane = new JTabbedPane();
         mainpane.add(Constant.messages.getString("advreport.menu.scope"), scopepanel );
         mainpane.add(Constant.messages.getString("advreport.menu.alerts"), alertspanel );
         mainpane.add(Constant.messages.getString("advreport.menu.alertdetails"), alertdetailspanel );
+         
+        JPanel buttonpane = new JPanel( new FlowLayout( FlowLayout.RIGHT ));
+        buttonpane.add( getCancelButton() );
+        buttonpane.add( getHTMLButton() );
+        
+        optiondialog.add(mainpane, BorderLayout.NORTH );
+        optiondialog.add(buttonpane, BorderLayout.SOUTH );
+        
         this.setTitle(Constant.messages.getString("advreport.menu.title"));
-        this.add(mainpane);
+        this.add(optiondialog);
         this.pack();
+
 	}
+	
+	private JButton getCancelButton(){
+		JButton cancelbutton = new JButton(Constant.messages.getString("advreport.cancel"));
+		cancelbutton.addActionListener(
+				new ActionListener() {
+		            @Override
+		            public void actionPerformed(ActionEvent e) {
+		               extension.emitFrame();
+		            }
+		        });
+		return cancelbutton;
+	}
+	
+	private JButton getHTMLButton(){
+		JButton generatebutton = new JButton(Constant.messages.getString("advreport.generate"));
+		generatebutton.addActionListener(
+				new ActionListener() {
+		            @Override
+		            public void actionPerformed(ActionEvent e) {
+		                extension.generateReport();
+		            }
+		        });
+		return generatebutton;
+	}
+	
 }

--- a/src/org/zaproxy/zap/extension/advreport/ScopePanel.java
+++ b/src/org/zaproxy/zap/extension/advreport/ScopePanel.java
@@ -1,17 +1,12 @@
 package org.zaproxy.zap.extension.advreport;
 
-import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 
-import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
-import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 
@@ -26,14 +21,12 @@ public class ScopePanel extends AbstractPanel{
 	 */
 	private static final long serialVersionUID = 1L;
 	
-	private ExtensionAdvReport extension = null;
 	private JTextArea name, description;
 	private JComboBox template;
 	private JCheckBox onlyInScope;
 	
-	public ScopePanel( ExtensionAdvReport extension){
+	public ScopePanel(){
 		initialize();
-		this.extension = extension;
 	}
 	
 	private void initialize(){
@@ -90,15 +83,7 @@ public class ScopePanel extends AbstractPanel{
         gbc.gridx++;
         gbc.anchor = GridBagConstraints.EAST;
         this.add( onlyInScope, gbc );
-  	    
-	    // button line 
-        gbc.insets = new Insets(0,0,0,0);
-	    gbc.gridx = 1;
-        gbc.gridy++ ;
-        JPanel buttonpane = new JPanel( new FlowLayout( FlowLayout.RIGHT ));
-        buttonpane.add( getCancelButton() );
-        buttonpane.add( getHTMLButton() );
-        this.add( buttonpane, gbc );
+
 	}
 	
 	public String getReportName(){
@@ -116,29 +101,5 @@ public class ScopePanel extends AbstractPanel{
 	public String getTemplate(){
 		return (String)template.getSelectedItem();
 	}
-	
-	private JButton getCancelButton(){
-		JButton cancelbutton = new JButton(Constant.messages.getString("advreport.cancel"));
-		cancelbutton.addActionListener(
-				new ActionListener() {
-		            @Override
-		            public void actionPerformed(ActionEvent e) {
-		               extension.emitFrame();
-		            }
-		        });
-		return cancelbutton;
-	}
-	
-	private JButton getHTMLButton(){
-		JButton generatebutton = new JButton(Constant.messages.getString("advreport.generate"));
-		generatebutton.addActionListener(
-				new ActionListener() {
-		            @Override
-		            public void actionPerformed(ActionEvent e) {
-		                extension.generateReport();
-		            }
-		        });
-		return generatebutton;
-	}
-	
+		
 }


### PR DESCRIPTION
To avoid repetition across multiple panels, moved 'Cancel' and 'Generate HTML' buttons under the class ExtensionAdvReport.java