### PR TITLE
diff: do not add line break tags to the resultant diff

### DIFF
--- a/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
@@ -1,13 +1,12 @@
 <zapaddon>
 	<name>Diff</name>
-	<version>5</version>
+	<version>6</version>
 	<description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Added 'Lock Scrolling' checkbox so that this can be disabled if required.<br>
-	Updated for ZAP 2.4
+	Do not add line break tags to resultant diff (Issue 1571)<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
+++ b/src/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
@@ -32,7 +32,6 @@ import difflib.DiffRow.Tag;
 import difflib.DiffUtils;
 import difflib.InsertDelta;
 import difflib.Patch;
-import difflib.StringUtills;
 
 /**
  * ZAP note.
@@ -241,8 +240,9 @@ public class ZapDiffRowGenerator {
      //revised = StringUtills.normalize(revised);
 
      // wrap to the column width
-     original = StringUtills.wrapText(original, this.columnWidth);
-     revised = StringUtills.wrapText(revised, this.columnWidth);
+     // ZAP: Don't word wrap, it adds br tags. The word wrap should be done by view component.
+     // original = StringUtills.wrapText(original, this.columnWidth);
+     // revised = StringUtills.wrapText(revised, this.columnWidth);
 
      List<DiffRow> diffRows = new ArrayList<DiffRow>();
      int endPos = 0;
@@ -257,8 +257,9 @@ public class ZapDiffRowGenerator {
          //orig.setLines(StringUtills.normalize((List<String>) orig.getLines()));
          //rev.setLines(StringUtills.normalize((List<String>) rev.getLines()));
 
-         orig.setLines(StringUtills.wrapText((List<String>) orig.getLines(), this.columnWidth));
-         rev.setLines(StringUtills.wrapText((List<String>) rev.getLines(), this.columnWidth));
+         // ZAP: Don't word wrap, it adds br tags. The word wrap should be done by view component.
+         // orig.setLines(StringUtills.wrapText((List<String>) orig.getLines(), this.columnWidth));
+         // rev.setLines(StringUtills.wrapText((List<String>) rev.getLines(), this.columnWidth));
 
          // catch the equal prefix for each chunk
          for (String line : original.subList(endPos, orig.getPosition())) {


### PR DESCRIPTION
Change ZapDiffRowGenerator to not add the break line tags to the
resultant diff by disabling the word wrapping (which was not effectively
working), word wrapping should be done by the view component.
Bump version and update changes in ZapAddOn.xml file.
Fix zaproxy/zaproxy#1571 - Diffs contain superfluous "\<br>" tags.