### PR TITLE
Fix NullPointerException when scanning with Base64Disclosure

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -272,13 +272,13 @@ public class Base64Disclosure extends PluginPassiveScanner {
 
 						//the Base64 decoded data is not a valid ViewState (even though it may have a valid ViewStatet pre-amble) 
 						//so treat it as normal Base64 data, and raise an informational alert.
-						if ( base64evidence!=null && base64evidence.length() > 0) {
+						if ( base64evidence.length() > 0) {
 							Alert alert = new Alert(getPluginId(), Alert.RISK_INFO, Alert.CONFIDENCE_MEDIUM, getName() );
 							alert.setDetail(
 									getDescription(), 
 									msg.getRequestHeader().getURI().toString(), 
 									"", //param
-									viewstatexml.substring(0, Math.min(32000, viewstatexml.length())), //TODO: this should be the the attack (NULL).  Set this field to NULL, once Zap allows mutiple alerts on the same URL, with just different evidence 
+									null,
 									getExtraInfo(msg, base64evidence, decodeddata),  //other info
 									getSolution(), 
 									getReference(), 

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -6,7 +6,8 @@
 	<url/>
 	<changes>
 	<![CDATA[
-		ImageLocationScanner detects more GPS tag varieties, scans png & tiff files, adds i18n.
+		ImageLocationScanner detects more GPS tag varieties, scans png & tiff files, adds i18n.<br>
+		Fix exception when scanning with "Base64 Disclosure" (Issue 2037).
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change Base64Disclosure scanner to not use the variable "viewstatexml"
when raising informational alerts when a (plain) Base64 hash is found,
the variable "viewstatexml" is null in those cases (i.e. hash does not
represent a ViewState).
Also, remove redundant null check when raising the informational alert
(the variable "base64evidence" is non-null at that point).
Update changes in ZapAddOn.xml file.
Fix zaproxy/zaproxy#2037 - NullPointerException when passive scanning
with "Base64 Disclosure"