### PR TITLE
Fix duplicated IDs in active and passive scanners

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
@@ -35,7 +35,7 @@ public class TestUserAgent extends AbstractAppPlugin {
 
     private static final Logger log = Logger.getLogger(TestUserAgent.class);
 
-    private static final int PLUGIN_ID = 10050;
+    private static final int PLUGIN_ID = 10104;
     private static final String MESSAGE_PREFIX = "ascanalpha.testuseragent.";
     private static final String USER_AGENT_PARAM_NAME = Constant.messages.getString(MESSAGE_PREFIX + "useragentparmname");
 

--- a/src/org/zaproxy/zap/extension/domxss/TestDomXSS.java
+++ b/src/org/zaproxy/zap/extension/domxss/TestDomXSS.java
@@ -90,7 +90,7 @@ public class TestDomXSS extends AbstractAppPlugin {
     
     @Override
     public int getId() {
-        return 40025;
+        return 40026;
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
@@ -1,10 +1,13 @@
 <zapaddon>
 	<name>DOM XSS Active scanner rule</name>
-	<version>1</version>
+	<version>2</version>
 	<description>DOM XSS Active scanner rule</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
+	<![CDATA[
+	Change (duplicated) scanner ID, now it's 40026.<br>
+	]]>
     </changes>
 	<dependencies>
 		<addons>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
@@ -47,7 +47,7 @@ public class ImageLocationScanner extends PluginPassiveScanner {
 	private PassiveScanThread parent = null;
 	private static final Logger logger = Logger.getLogger(ImageLocationScanner.class);
 	private static final String MESSAGE_PREFIX = "pscanalpha.imagelocationscanner.";
-	private static final int PLUGIN_ID = 10049;
+	private static final int PLUGIN_ID = 10103;
 	
 	
 	@Override


### PR DESCRIPTION
Assign the new IDs as specified in the alerts.xml file:
 - 10049 -> 10103, Image Location Scanner
 - 10050 -> 10104, TestUserAgent
 - 40025 -> 40026, Cross site scripting (DOM)

(reference: zaproxy/zaproxy#2006)

Update the changes and bump version in ZapAddOn.xml, were applicable.