### PR TITLE
pscanrulesBeta: fix duplicated scanner ID of Weak Authentication Method

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/InsecureAuthenticationScan.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/InsecureAuthenticationScan.java
@@ -199,7 +199,7 @@ public class InsecureAuthenticationScan extends PluginPassiveScanner {
 	 */
 	@Override
 	public int getPluginId() {
-		return 40017;  
+		return 10105;  
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -1,10 +1,14 @@
 <zapaddon>
 	<name>Passive scanner rules (beta)</name>
-	<version>11</version>
+	<version>12</version>
 	<description>The beta quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
-	<changes>Minor code changes.</changes>
+	<changes>
+	<![CDATA[
+	Change (duplicated) scanner ID of Weak Authentication Method, now it's 10105.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.pscanrulesBeta.ExtensionPscanRulesBeta</extension>
 	</extensions>


### PR DESCRIPTION
Assign the new ID as specified in the alerts.xml file:
 - 40017 -> 10105, Weak Authentication Method

(reference: zaproxy/zaproxy#2006)

Update the changes and bump version in ZapAddOn.xml.