### PR TITLE
advreport: fixed string comparison

### DIFF
--- a/src/org/zaproxy/zap/extension/advreport/AlertsPanel.java
+++ b/src/org/zaproxy/zap/extension/advreport/AlertsPanel.java
@@ -108,7 +108,7 @@ public class AlertsPanel extends JPanel{
 			public void itemStateChanged(java.awt.event.ItemEvent e) {
 				boolean selected = (ItemEvent.SELECTED == e.getStateChange());
 				for (JCheckBox selection: selections ){
-					if(alertTypeRisk.get(selection.getName()) == riskLevel) {
+					if(alertTypeRisk.get(selection.getName()).equals(riskLevel)) {
 						selection.setSelected(selected);
 					}
 


### PR DESCRIPTION
Should use .equals() instead of the '==' operator when comparing strings.