### PR TITLE
diff: automatically close the diff dialogue when uninstalling the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/diff/ExtensionDiff.java
+++ b/src/org/zaproxy/zap/extension/diff/ExtensionDiff.java
@@ -56,6 +56,17 @@ public class ExtensionDiff extends ExtensionAdaptor {
     	return true;
     }
 
+    @Override
+    public void unload() {
+        if (getView() != null) {
+            if (diffDialog != null) {
+                diffDialog.dispose();
+                diffDialog = null;
+            }
+        }
+        super.unload();
+    }
+
 	/**
 	 * This method initializes this
 	 * 

--- a/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<changes>
 	<![CDATA[
 	Do not add line break tags to resultant diff (Issue 1571)<br>
+	Automatically close the diff dialogue when uninstalling.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionDiff to close (dispose) the dialogue when unloading the
extension (done when uninstalling the add-on). Otherwise the dialogue
will remain open preventing the classes/add-on from being GC'ed, sooner.
Update the changes in ZapAddOn.xml.