### PR TITLE
fuzz: correctly produce empty string payloads in fuzzer dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -8,6 +8,7 @@
     <changes>
     <![CDATA[
     Add HTTP processor for tagging fuzz results.<br>
+    Fix an error that prevented the use of empty strings as payloads (Issue 1948).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultStringPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultStringPayloadGeneratorUIHandler.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import javax.swing.GroupLayout;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
@@ -142,7 +141,7 @@ public class DefaultStringPayloadGeneratorUIHandler implements
             if (multiline) {
                 return new DefaultStringPayloadGenerator(value);
             }
-            return new DefaultStringPayloadGenerator(Arrays.asList(value.split("\r?\n")));
+            return new DefaultStringPayloadGenerator(Arrays.asList(value.split("\r?\n", -1)));
         }
 
         @Override
@@ -246,15 +245,6 @@ public class DefaultStringPayloadGeneratorUIHandler implements
 
         @Override
         public boolean validate() {
-            if (getContentsTextArea().getText().isEmpty()) {
-                JOptionPane.showMessageDialog(
-                        null,
-                        Constant.messages.getString("fuzz.payloads.generator.strings.warnNoContent.message"),
-                        Constant.messages.getString("fuzz.payloads.generator.strings.warnNoContent.title"),
-                        JOptionPane.INFORMATION_MESSAGE);
-                getContentsTextArea().requestFocusInWindow();
-                return false;
-            }
             return true;
         }
 

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -188,8 +188,6 @@ fuzz.payloads.generator.strings.name = Strings
 fuzz.payloads.generator.strings.contents.label = Contents:
 fuzz.payloads.generator.strings.multiline.label = Multiline:
 fuzz.payloads.generator.strings.multiline.tooltip = Sets if the contents are treated as one single payload with multiple lines instead of one payload per line.
-fuzz.payloads.generator.strings.warnNoContent.message = No string added, at least one string must be added first.
-fuzz.payloads.generator.strings.warnNoContent.title = No String Added
 
 fuzz.payloads.generator.file.name = File
 fuzz.payloads.generator.file.file.label = File:


### PR DESCRIPTION
Change DefaultStringPayloadGeneratorUI to correctly call the method
String.split so that the empty strings are preserved. Also change to not
validate that the text area is non empty to allow the use of just one
empty string.
Remove info/validation strings no longer used from Messages.properties
file.
Update changes in ZapAddOn.xml.
Fix zaproxy/zaproxy#1948 - Unable to add empty string payloads for
fuzzer