### PR TITLE
fuzz: fix MissingResourceException when closing ZAP while fuzzing

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -9,6 +9,7 @@
     <![CDATA[
     Add HTTP processor for tagging fuzz results.<br>
     Fix an error that prevented the use of empty strings as payloads (Issue 1948).<br>
+    Fix exception while closing ZAP with running fuzz processes.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -9,6 +9,7 @@ fuzz.results.error.unknown.source = Unknown
 fuzz.results.error.unknown.message = Unknown error while executing fuzzer task. Log file contains details of the error.
 fuzz.results.error.messageFuzzer.source = Message Fuzzer
 
+fuzz.activeActionPrefix = Fuzzing: {0}
 
 fuzz.payloads.script.type.payloadgenerator = Payload Generator
 fuzz.payloads.script.type.payloadprocessor = Payload Processor


### PR DESCRIPTION
Add the missing resource string "fuzz.activeActionPrefix", used to
inform of the fuzz processes still running when closing ZAP.
Update changes in ZapAddOn.xml.