### PR TITLE
fuzz: create enough tasks to keep available threads busy, but no more

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -13,6 +13,7 @@
     Show the correct Payload Generator script when showing modify dialogue.<br>
     Correctly use the number of payloads from script for calculation of progress (Issue 1881).<br>
     Show the number of payloads from the script in Fuzzer dialogue (Issue 1887).<br>
+    Improve memory usage (Issue 2051).<br>
     ]]>
     </changes>
     <extensions>


### PR DESCRIPTION
Change AbstractFuzzer to just create 3 times (1/3 being consumed) the
number of tasks as available threads (so that the consumer threads do
not wait for new tasks, but also do not create all tasks at once).
Update changes in ZapAddOn.xml.
Fix zaproxy/zaproxy#2051 - Improve Fuzzer memory usage