### PR TITLE
fuzz: correct the delay used when sending messages

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/AbstractFuzzer.java
+++ b/src/org/zaproxy/zap/extension/fuzz/AbstractFuzzer.java
@@ -186,6 +186,7 @@ public abstract class AbstractFuzzer<M extends Message> implements Fuzzer<M> {
         if (fuzzerOptions.getSendMessageDelay() > 0) {
             PausableScheduledThreadPoolExecutor executor = new PausableScheduledThreadPoolExecutor(poolSize, threadFactory);
             executor.setDefaultDelay(fuzzerOptions.getSendMessageDelay(), fuzzerOptions.getSendMessageDelayTimeUnit());
+            executor.setIncrementalDefaultDelay(true);
             return executor;
         }
 

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -14,6 +14,7 @@
     Correctly use the number of payloads from script for calculation of progress (Issue 1881).<br>
     Show the number of payloads from the script in Fuzzer dialogue (Issue 1887).<br>
     Improve memory usage (Issue 2051).<br>
+    Correct the delay used when sending messages.<br>
     ]]>
     </changes>
     <extensions>


### PR DESCRIPTION
Change AbstractFuzzer class to create the tasks with incremental delay
so that all tasks wait the same time before sending the messages.
Otherwise the messages would be sent sooner than the delay specified.
Update changes in ZapAddOn.xml.