### PR TITLE
fuzz: fix issues related to stopping the fuzzer

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -15,6 +15,8 @@
     Show the number of payloads from the script in Fuzzer dialogue (Issue 1887).<br>
     Improve memory usage (Issue 2051).<br>
     Correct the delay used when sending messages.<br>
+    Improve stop time.<br>
+    Fix (potential) thread leak after stopping a paused fuzzer.<br>
     ]]>
     </changes>
     <extensions>


### PR DESCRIPTION
Fix (potential) task submitter thread leak after stopping a paused
fuzzer, it was caused by not unpausing the thread when stopping (the
state was already set to stop so the pause comparison failed, always).
Improve stop time by letting the task threads to query the state of
the fuzzer, allowing to stop sooner (done by releasing the state lock,
which was no longer required as the stop state was already set, so the
"main" thread no longer has to wait 2 seconds for the task threads to
stop (which wouldn't, as the state lock was being held)).
Update changes in ZapAddOn.xml.