### PR TITLE
fuzz: issues with payload generator scripts

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -11,6 +11,7 @@
     Fix an error that prevented the use of empty strings as payloads (Issue 1948).<br>
     Fix exception while closing ZAP with running fuzz processes.<br>
     Show the correct Payload Generator script when showing modify dialogue.<br>
+    Correctly use the number of payloads from script for calculation of progress (Issue 1881).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -10,6 +10,7 @@
     Add HTTP processor for tagging fuzz results.<br>
     Fix an error that prevented the use of empty strings as payloads (Issue 1948).<br>
     Fix exception while closing ZAP with running fuzz processes.<br>
+    Show the correct Payload Generator script when showing modify dialogue.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -12,6 +12,7 @@
     Fix exception while closing ZAP with running fuzz processes.<br>
     Show the correct Payload Generator script when showing modify dialogue.<br>
     Correctly use the number of payloads from script for calculation of progress (Issue 1881).<br>
+    Show the number of payloads from the script in Fuzzer dialogue (Issue 1887).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/generator/ScriptStringPayloadGeneratorAdapter.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/generator/ScriptStringPayloadGeneratorAdapter.java
@@ -50,6 +50,22 @@ public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerat
         this.scriptWrapper = scriptWrapper;
     }
 
+    public ScriptStringPayloadGeneratorAdapter(ScriptWrapper scriptWrapper, ScriptStringPayloadGenerator script) {
+        if (scriptWrapper == null) {
+            throw new IllegalArgumentException("Parameter scriptWrapper must not be null.");
+        }
+        if (!ScriptStringPayloadGenerator.TYPE_NAME.equals(scriptWrapper.getTypeName())) {
+            throw new IllegalArgumentException("Parameter scriptWrapper must wrap a script of type \""
+                    + ScriptStringPayloadGenerator.TYPE_NAME + "\".");
+        }
+        if (script == null) {
+            throw new IllegalArgumentException("Parameter script must not be null.");
+        }
+        this.scriptWrapper = scriptWrapper;
+        this.scriptPayloadGenerator = script;
+        this.initialised = true;
+    }
+
     @Override
     public long getNumberOfPayloads() {
         if (!initialised) {

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/generator/ScriptStringPayloadGeneratorAdapter.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/generator/ScriptStringPayloadGeneratorAdapter.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.fuzz.payloads.generator;
 
+import org.apache.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.zaproxy.zap.extension.fuzz.payloads.DefaultStringPayload;
 import org.zaproxy.zap.extension.fuzz.payloads.StringPayload;
@@ -32,7 +33,11 @@ import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
  */
 public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerator {
 
+    private static final Logger LOGGER = Logger.getLogger(ScriptStringPayloadGeneratorAdapter.class);
+
     private final ScriptWrapper scriptWrapper;
+    private boolean initialised;
+    private ScriptStringPayloadGenerator scriptPayloadGenerator;
 
     public ScriptStringPayloadGeneratorAdapter(ScriptWrapper scriptWrapper) {
         if (scriptWrapper == null) {
@@ -47,11 +52,30 @@ public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerat
 
     @Override
     public long getNumberOfPayloads() {
+        if (!initialised) {
+            try {
+                scriptPayloadGenerator = initialiseImpl(scriptWrapper);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to initialise '" + scriptWrapper.getName() + "':", e);
+            }
+            initialised = true;
+        }
+
+        if (scriptPayloadGenerator != null) {
+            try {
+                return scriptPayloadGenerator.getNumberOfPayloads();
+            } catch (Exception e) {
+                LOGGER.warn("Failed to obtain number of payloads from script '" + scriptWrapper.getName() + "':", e);
+            }
+        }
         return UNKNOWN_NUMBER_OF_PAYLOADS;
     }
 
     @Override
     public ResettableAutoCloseableIterator<StringPayload> iterator() {
+        if (scriptPayloadGenerator != null) {
+            return new ScriptPayloadGeneratorIterator(scriptWrapper, scriptPayloadGenerator);
+        }
         return new ScriptPayloadGeneratorIterator(scriptWrapper);
     }
 
@@ -70,10 +94,18 @@ public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerat
             this.scriptWrapper = scriptWrapper;
         }
 
+        public ScriptPayloadGeneratorIterator(
+                ScriptWrapper scriptWrapper,
+                ScriptStringPayloadGenerator scriptPayloadGenerator) {
+            this.scriptWrapper = scriptWrapper;
+            this.scriptPayloadGenerator = scriptPayloadGenerator;
+            this.initialised = true;
+        }
+
         @Override
         public boolean hasNext() {
             if (!initialised) {
-                initialise();
+                scriptPayloadGenerator = initialise(scriptWrapper);
                 initialised = true;
             }
 
@@ -88,7 +120,7 @@ public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerat
                 // The same applies to all other script try-catch blocks.
                 // For example, when a variable or function is not defined it throws:
                 // jdk.nashorn.internal.runtime.ECMAException
-                handleScriptException(e);
+                handleScriptException(scriptWrapper, e);
             }
 
             // Unreachable code, handleScriptException(Exception) throws PayloadGenerationException.
@@ -100,7 +132,7 @@ public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerat
             try {
                 return new DefaultStringPayload(scriptPayloadGenerator.next());
             } catch (Exception e) {
-                handleScriptException(e);
+                handleScriptException(scriptWrapper, e);
             }
 
             // Unreachable code, handleScriptException(Exception) throws PayloadGenerationException.
@@ -116,7 +148,7 @@ public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerat
             try {
                 scriptPayloadGenerator.reset();
             } catch (Exception e) {
-                handleScriptException(e);
+                handleScriptException(scriptWrapper, e);
             }
         }
 
@@ -125,30 +157,38 @@ public class ScriptStringPayloadGeneratorAdapter implements StringPayloadGenerat
             try {
                 scriptPayloadGenerator.close();
             } catch (Exception e) {
-                handleScriptException(e);
+                handleScriptException(scriptWrapper, e);
             }
         }
 
-        private void initialise() throws PayloadGenerationException {
-            ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
-            if (extensionScript != null) {
-                try {
-                    scriptPayloadGenerator = extensionScript.getInterface(scriptWrapper, ScriptStringPayloadGenerator.class);
-                } catch (Exception e) {
-                    handleScriptException(e);
-                }
+        private static ScriptStringPayloadGenerator initialise(ScriptWrapper scriptWrapper) throws PayloadGenerationException {
+            try {
+                return initialiseImpl(scriptWrapper);
+            } catch (Exception e) {
+                handleScriptException(scriptWrapper, e);
             }
+            return null;
         }
 
-        private void handleScriptException(Exception cause) throws PayloadGenerationException {
-            ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
-            if (extensionScript != null) {
-                extensionScript.setError(scriptWrapper, cause);
-                extensionScript.setEnabled(scriptWrapper, false);
-            }
-
+        private static void handleScriptException(ScriptWrapper scriptWrapper, Exception cause) throws PayloadGenerationException {
+            handleScriptExceptionImpl(scriptWrapper, cause);
             throw new PayloadGenerationException("Failed to generate the payload:", cause);
         }
+    }
 
+    private static ScriptStringPayloadGenerator initialiseImpl(ScriptWrapper scriptWrapper) throws Exception {
+        ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        if (extensionScript != null) {
+            return extensionScript.getInterface(scriptWrapper, ScriptStringPayloadGenerator.class);
+        }
+        return null;
+    }
+
+    private static void handleScriptExceptionImpl(ScriptWrapper scriptWrapper, Exception cause) {
+        ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        if (extensionScript != null) {
+            extensionScript.setError(scriptWrapper, cause);
+            extensionScript.setEnabled(scriptWrapper, false);
+        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
@@ -162,7 +162,7 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
 
         @Override
         public void setPayloadGeneratorUI(ScriptStringPayloadGeneratorAdapterUI payloadGeneratorUI) {
-            scriptComboBox.setSelectedItem(payloadGeneratorUI.getScriptWrapper());
+            scriptComboBox.setSelectedItem(new ScriptUIEntry(payloadGeneratorUI.getScriptWrapper()));
         }
 
         @Override

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
@@ -27,8 +27,11 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
 import org.zaproxy.zap.extension.fuzz.payloads.StringPayload;
+import org.zaproxy.zap.extension.fuzz.payloads.generator.PayloadGenerator;
 import org.zaproxy.zap.extension.fuzz.payloads.generator.ScriptStringPayloadGenerator;
 import org.zaproxy.zap.extension.fuzz.payloads.generator.ScriptStringPayloadGeneratorAdapter;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUI;
@@ -43,6 +46,8 @@ import org.zaproxy.zap.utils.SortedComboBoxModel;
 public class ScriptStringPayloadGeneratorAdapterUIHandler
         implements
         PayloadGeneratorUIHandler<String, StringPayload, ScriptStringPayloadGeneratorAdapter, ScriptStringPayloadGeneratorAdapterUI> {
+
+    private static final Logger LOGGER = Logger.getLogger(ScriptStringPayloadGeneratorAdapterUIHandler.class);
 
     private static final String PAYLOAD_GENERATOR_NAME = Constant.messages.getString("fuzz.payloads.generator.script.name");
 
@@ -77,13 +82,19 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
             PayloadGeneratorUI<String, StringPayload, ScriptStringPayloadGeneratorAdapter> {
 
         private final ScriptWrapper scriptWrapper;
+        private ScriptStringPayloadGenerator scriptPayloadGenerator;
 
-        public ScriptStringPayloadGeneratorAdapterUI(ScriptWrapper scriptWrapper) {
+        public ScriptStringPayloadGeneratorAdapterUI(ScriptWrapper scriptWrapper, ScriptStringPayloadGenerator scriptPayloadGenerator) {
             this.scriptWrapper = scriptWrapper;
+            this.scriptPayloadGenerator = scriptPayloadGenerator;
         }
 
         public ScriptWrapper getScriptWrapper() {
             return scriptWrapper;
+        }
+
+        public ScriptStringPayloadGenerator getScriptStringPayloadGenerator() {
+            return scriptPayloadGenerator;
         }
 
         @Override
@@ -103,12 +114,17 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
 
         @Override
         public long getNumberOfPayloads() {
-            return 0;
+            try {
+                return scriptPayloadGenerator.getNumberOfPayloads();
+            } catch (Exception e) {
+                LOGGER.warn("Failed to obtain number of payloads from script '" + scriptWrapper.getName() + "':", e);
+            }
+            return PayloadGenerator.UNKNOWN_NUMBER_OF_PAYLOADS;
         }
 
         @Override
         public ScriptStringPayloadGeneratorAdapter getPayloadGenerator() {
-            return new ScriptStringPayloadGeneratorAdapter(scriptWrapper);
+            return new ScriptStringPayloadGeneratorAdapter(scriptWrapper, scriptPayloadGenerator);
         }
 
         @Override
@@ -163,17 +179,25 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
         @Override
         public void setPayloadGeneratorUI(ScriptStringPayloadGeneratorAdapterUI payloadGeneratorUI) {
             scriptComboBox.setSelectedItem(new ScriptUIEntry(payloadGeneratorUI.getScriptWrapper()));
+            ScriptUIEntry scriptUIEntry = (ScriptUIEntry) scriptComboBox.getSelectedItem();
+            if (scriptUIEntry != null) {
+                scriptUIEntry.setScriptPayloadGenerator(payloadGeneratorUI.getScriptStringPayloadGenerator());
+            }
         }
 
         @Override
         public ScriptStringPayloadGeneratorAdapterUI getPayloadGeneratorUI() {
-            return new ScriptStringPayloadGeneratorAdapterUI(
-                    ((ScriptUIEntry) scriptComboBox.getSelectedItem()).getScriptWrapper());
+            ScriptUIEntry scriptUIEntry = ((ScriptUIEntry) scriptComboBox.getSelectedItem());
+            ScriptWrapper scriptWrapper =  scriptUIEntry.getScriptWrapper();
+            return new ScriptStringPayloadGeneratorAdapterUI(scriptWrapper, scriptUIEntry.getScriptPayloadGenerator());
         }
 
         @Override
         public void clear() {
             scriptComboBox.setSelectedIndex(-1);
+            for (int i = 0; i < scriptComboBox.getItemCount(); i++) {
+                scriptComboBox.getItemAt(i).setScriptPayloadGenerator(null);
+            }
         }
 
         @Override
@@ -187,6 +211,46 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
                 scriptComboBox.requestFocusInWindow();
                 return false;
             }
+
+            ScriptUIEntry scriptUIEntry = ((ScriptUIEntry) scriptComboBox.getSelectedItem());
+            ScriptWrapper scriptWrapper =  scriptUIEntry.getScriptWrapper();
+            ScriptStringPayloadGenerator scriptPayloadGenerator = scriptUIEntry.getScriptPayloadGenerator();
+            if (scriptPayloadGenerator == null) {
+                try {
+                    scriptPayloadGenerator = initialiseImpl(scriptWrapper);
+                    if (scriptPayloadGenerator == null) {
+                        JOptionPane.showMessageDialog(
+                                null,
+                                Constant.messages.getString("fuzz.payloads.generator.script.warnNoInterface.message"),
+                                Constant.messages.getString("fuzz.payloads.generator.script.warnNoInterface.title"),
+                                JOptionPane.INFORMATION_MESSAGE);
+                        return false;
+                    }
+                } catch (Exception e) {
+                    handleScriptExceptionImpl(scriptWrapper, e);
+                    JOptionPane.showMessageDialog(
+                            null,
+                            Constant.messages.getString("fuzz.payloads.generator.script.warnNoInterface.message"),
+                            Constant.messages.getString("fuzz.payloads.generator.script.warnNoInterface.title"),
+                            JOptionPane.INFORMATION_MESSAGE);
+                    LOGGER.warn("Failed to initialise '" + scriptWrapper.getName() + "': " + e.getMessage());
+                    return false;
+                }
+                scriptUIEntry.setScriptPayloadGenerator(scriptPayloadGenerator);
+            }
+
+            try {
+                scriptPayloadGenerator.getNumberOfPayloads();
+            } catch (Exception e) {
+                handleScriptExceptionImpl(scriptWrapper, e);
+                LOGGER.warn("Failed to obtain number of payloads from script '" + scriptWrapper.getName() + "': " + e.getMessage());
+                JOptionPane.showMessageDialog(
+                        null,
+                        Constant.messages.getString("fuzz.payloads.generator.script.warnNoNumberOfpayloads.message"),
+                        Constant.messages.getString("fuzz.payloads.generator.script.warnNoNumberOfpayloads.title"),
+                        JOptionPane.INFORMATION_MESSAGE);
+            }
+
             return true;
         }
 
@@ -200,6 +264,7 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
 
             private final ScriptWrapper scriptWrapper;
             private final String scriptName;
+            private ScriptStringPayloadGenerator scriptPayloadGenerator;
 
             public ScriptUIEntry(ScriptWrapper scriptWrapper) {
                 this.scriptWrapper = scriptWrapper;
@@ -207,6 +272,14 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
                 if (scriptName == null) {
                     throw new IllegalArgumentException("Script must have a name.");
                 }
+            }
+
+            public ScriptStringPayloadGenerator getScriptPayloadGenerator() {
+                return scriptPayloadGenerator;
+            }
+
+            public void setScriptPayloadGenerator(ScriptStringPayloadGenerator scriptPayloadGenerator) {
+                this.scriptPayloadGenerator = scriptPayloadGenerator;
             }
 
             public ScriptWrapper getScriptWrapper() {
@@ -256,6 +329,22 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
                 return scriptName.compareTo(other.scriptName);
             }
 
+        }
+    }
+
+    private static ScriptStringPayloadGenerator initialiseImpl(ScriptWrapper scriptWrapper) throws Exception {
+        ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        if (extensionScript != null) {
+            return extensionScript.getInterface(scriptWrapper, ScriptStringPayloadGenerator.class);
+        }
+        return null;
+    }
+
+    private static void handleScriptExceptionImpl(ScriptWrapper scriptWrapper, Exception cause) {
+        ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        if (extensionScript != null) {
+            extensionScript.setError(scriptWrapper, cause);
+            extensionScript.setEnabled(scriptWrapper, false);
         }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -212,6 +212,10 @@ fuzz.payloads.generator.script.name = Script
 fuzz.payloads.generator.script.script.label = Script:
 fuzz.payloads.generator.script.warnNoScript.message = No script selected, a script must be selected first.
 fuzz.payloads.generator.script.warnNoScript.title = No Script Selected
+fuzz.payloads.generator.script.warnNoInterface.message = The selected script does not implement the required interface.\nPlease take a look at the provided templates for examples.
+fuzz.payloads.generator.script.warnNoInterface.title = Script Incorrect Implementation
+fuzz.payloads.generator.script.warnNoNumberOfpayloads.message = Failed to obtain the number of payloads of the selected script.\nThe script might contain errors.
+fuzz.payloads.generator.script.warnNoNumberOfpayloads.title = Unknown Number Of Payloads
 
 fuzz.payloads.generator.regex.name = Regex (*Experimental*)
 fuzz.payloads.generator.regex.regex.label = Regex:


### PR DESCRIPTION
Fixes, touching the same classes, related to payload generator scripts:
 - Fix selection of the script in modify dialogue;
 - zaproxy/zaproxy#1881 - Fuzzer Add-on Progress Bar stuck at 100%
 - zaproxy/zaproxy#1887 - Number of payloads not shown for script
 payload generator