### PR TITLE
fuzz: fix the insert location of the string in expand string processor

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -18,6 +18,7 @@
     Improve stop time.<br>
     Fix (potential) thread leak after stopping a paused fuzzer.<br>
     Allow to preview payloads generated or from external sources (Issue 1896)<br>
+    Fix the location where the characters are added in expand payload processor.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/processor/ExpandStringProcessor.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/processor/ExpandStringProcessor.java
@@ -72,11 +72,11 @@ public class ExpandStringProcessor implements StringPayloadProcessor {
 
         switch (position) {
         case END:
-            expandedValue.append(valuePayload);
+            expandedValue.insert(0, valuePayload);
             break;
         case BEGIN:
         default:
-            expandedValue.insert(0, valuePayload);
+            expandedValue.append(valuePayload);
         }
 
         payload.setValue(expandedValue.toString());


### PR DESCRIPTION
Switch the begin/end statements that add the original string to the
expanded string.
Update changes in ZapAddOn.xml.