### PR TITLE
fuzz: allow to modify the selected payload processor script

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -19,6 +19,7 @@
     Fix (potential) thread leak after stopping a paused fuzzer.<br>
     Allow to preview payloads generated or from external sources (Issue 1896)<br>
     Fix the location where the characters are added in expand payload processor.<br>
+    Allow to modify the selected Payload Processor script.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ScriptStringPayloadProcessorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ScriptStringPayloadProcessorAdapterUIHandler.java
@@ -94,7 +94,7 @@ public class ScriptStringPayloadProcessorAdapterUIHandler
 
         @Override
         public boolean isMutable() {
-            return false;
+            return true;
         }
 
         @Override
@@ -154,18 +154,13 @@ public class ScriptStringPayloadProcessorAdapterUIHandler
 
         @Override
         public void setPayloadProcessorUI(ScriptStringPayloadProcessorAdapterUI payloadProcessorUI) {
-            scriptComboBox.setSelectedItem(payloadProcessorUI.getScriptWrapper());
+            scriptComboBox.setSelectedItem(new ScriptUIEntry(payloadProcessorUI.getScriptWrapper()));
         }
 
         @Override
         public ScriptStringPayloadProcessorAdapterUI getPayloadProcessorUI() {
             return new ScriptStringPayloadProcessorAdapterUI(
                     ((ScriptUIEntry) scriptComboBox.getSelectedItem()).getScriptWrapper());
-        }
-
-        @Override
-        public void clear() {
-            scriptComboBox.setSelectedIndex(-1);
         }
 
         @Override


### PR DESCRIPTION
Change ScriptStringPayloadProcessorAdapterUI to allow to modify the
selected payload processor script otherwise it requires to remove and
add the payload processor script (and move it to correct position).
Change ScriptStringPayloadProcessorAdapterUIPanel to correctly select
the payload processor script when showing the modify dialogue (by
selecting using a ScriptUIEntry instead of ScriptWrapper) and to not
deselect the scripts when clearing (so that there's always a script
selected when adding).
Update changes in ZapAddOn.xml.