### PR TITLE
fuzz: fix typo in method name of HttpFuzzerTaskProcessorUtils

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerTaskProcessorUtils.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerTaskProcessorUtils.java
@@ -139,6 +139,15 @@ public class HttpFuzzerTaskProcessorUtils {
         httpFuzzer.stopScan();
     }
 
+    public List<Object> getPayloads() {
+        return payloads;
+    }
+
+    /**
+     * @deprecated (2.0.0) Use {@link #getPayloads()} instead.
+     */
+    @Deprecated
+    @SuppressWarnings("javadoc")
     public List<Object> getPaylaods() {
         return payloads;
     }


### PR DESCRIPTION
Deprecate the old method (it might be used by scripts).