### PR TITLE
fuzz: show current and allow to preview payloads in processor dialogues

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -20,6 +20,8 @@
     Allow to preview payloads generated or from external sources (Issue 1896)<br>
     Fix the location where the characters are added in expand payload processor.<br>
     Allow to modify the selected Payload Processor script.<br>
+    Show current payloads when adding/modifying processors (Issue 1898).<br>
+    Allow to preview processing of payloads (Issue 1931).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/impl/AddProcessorDialog.java
+++ b/src/org/zaproxy/zap/extension/fuzz/impl/AddProcessorDialog.java
@@ -30,9 +30,11 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.fuzz.payloads.Payload;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PayloadProcessorUI;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PayloadProcessorUIPanel;
 import org.zaproxy.zap.model.MessageLocation;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
 import org.zaproxy.zap.utils.SortedComboBoxModel;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
@@ -57,10 +59,13 @@ public class AddProcessorDialog extends AbstractFormDialog {
 
     private PayloadProcessorUIPanel<?, ?, ?, ?> currentPanel;
 
-    public AddProcessorDialog(Dialog owner, PayloadProcessorsContainer processorsUIHandlers, MessageLocation messageLocation) {
+    private PayloadPreviewPanel previewPanel;
+
+    public AddProcessorDialog(Dialog owner, PayloadProcessorsContainer processorsUIHandlers, MessageLocation messageLocation, ResettableAutoCloseableIterator<Payload<?>> payloads) {
         super(owner, DIALOG_TITLE, false);
 
         this.processorsUIHandlers = processorsUIHandlers;
+        previewPanel = new PayloadPreviewPanel(payloads);
 
         getPayloadUIHandlersComboBox().setSelectedIndex(-1);
         for (PayloadProcessorUIPanel<?, ?, ?, ?> panel : processorsUIHandlers.getPanels()) {
@@ -100,14 +105,16 @@ public class AddProcessorDialog extends AbstractFormDialog {
                                 .addGroup(
                                         groupLayout.createParallelGroup(GroupLayout.Alignment.LEADING).addComponent(
                                                 getPayloadUIHandlersComboBox())))
-                .addComponent(contentsPanel));
+                .addComponent(contentsPanel)
+                .addComponent(previewPanel.getPanel()));
 
         groupLayout.setVerticalGroup(groupLayout.createSequentialGroup()
                 .addGroup(
                         groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(typeLabel)
                                 .addComponent(getPayloadUIHandlersComboBox()))
-                .addComponent(contentsPanel));
+                .addComponent(contentsPanel)
+                .addComponent(previewPanel.getPanel()));
 
         return fieldsPanel;
     }
@@ -123,6 +130,7 @@ public class AddProcessorDialog extends AbstractFormDialog {
             panel.clear();
         }
         contentsPanel.removeAll();
+        previewPanel.clear();
     }
 
     @Override
@@ -155,6 +163,9 @@ public class AddProcessorDialog extends AbstractFormDialog {
 
                         currentPanel = processorsUIHandlers.getPanel(panelName);
                         contentsPanelCardLayout.show(contentsPanel, panelName);
+
+                        previewPanel.resetPreview();
+                        previewPanel.setPayloadProcessorUIPanel(currentPanel);
 
                         setHelpTarget(currentPanel.getHelpTarget());
                     }

--- a/src/org/zaproxy/zap/extension/fuzz/impl/MessageLocationPayloadsPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/impl/MessageLocationPayloadsPanel.java
@@ -41,6 +41,7 @@ import org.zaproxy.zap.extension.fuzz.payloads.generator.PayloadGenerator;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUI;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PayloadProcessorUIHandlersRegistry;
 import org.zaproxy.zap.model.MessageLocation;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
 import org.zaproxy.zap.utils.StringUIUtils;
 import org.zaproxy.zap.view.AbstractMultipleOrderedOptionsBaseTablePanel;
 
@@ -182,6 +183,7 @@ public class MessageLocationPayloadsPanel extends JPanel {
 
                     processorsDialog.setMessageLocation(messageLocation);
                     processorsDialog.setPayloadProcessors(payloadTableEntry.getPayloadProcessors());
+                    processorsDialog.setPayloads((ResettableAutoCloseableIterator<Payload<?>>) payloadTableEntry.getPayloadGeneratorUI().getPayloadGenerator().iterator());
                     processorsDialog.setVisible(true);
 
                     payloadTableEntry.setPayloadProcessors(processorsDialog.getProcessors());

--- a/src/org/zaproxy/zap/extension/fuzz/impl/ModifyProcessorDialog.java
+++ b/src/org/zaproxy/zap/extension/fuzz/impl/ModifyProcessorDialog.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.extension.fuzz.payloads.Payload;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.PayloadProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PayloadProcessorUI;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PayloadProcessorUIPanel;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
 public class ModifyProcessorDialog<T0, T01 extends Payload<T0>, T1 extends PayloadProcessor<T0, T01>, T2 extends PayloadProcessorUI<T0, T01, T1>>
@@ -46,10 +47,15 @@ public class ModifyProcessorDialog<T0, T01 extends Payload<T0>, T1 extends Paylo
 
     private PayloadProcessorUIPanel<T0, T01, T1, T2> contentPanel;
 
-    public ModifyProcessorDialog(Dialog owner, PayloadProcessorUIPanel<T0, T01, T1, T2> panel, T2 processorUI) {
+    private PayloadPreviewPanel previewPanel;
+
+    public ModifyProcessorDialog(Dialog owner, PayloadProcessorUIPanel<T0, T01, T1, T2> panel, T2 processorUI, ResettableAutoCloseableIterator<Payload<?>> payloads) {
         super(owner, DIALOG_TITLE, false);
 
         nameType = processorUI.getName();
+
+        previewPanel = new PayloadPreviewPanel(payloads);
+        previewPanel.setPayloadProcessorUIPanel(panel);
 
         contentPanel = panel;
         contentPanel.setPayloadProcessorUI(processorUI);
@@ -82,14 +88,16 @@ public class ModifyProcessorDialog<T0, T01 extends Payload<T0>, T1 extends Paylo
                                 .addGroup(
                                         groupLayout.createParallelGroup(GroupLayout.Alignment.LEADING).addComponent(
                                                 nameTypeLabel)))
-                .addComponent(contentPanel.getComponent()));
+                .addComponent(contentPanel.getComponent())
+                .addComponent(previewPanel.getPanel()));
 
         groupLayout.setVerticalGroup(groupLayout.createSequentialGroup()
                 .addGroup(
                         groupLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(typeLabel)
                                 .addComponent(nameTypeLabel))
-                .addComponent(contentPanel.getComponent()));
+                .addComponent(contentPanel.getComponent())
+                .addComponent(previewPanel.getPanel()));
 
         return fieldsPanel;
     }
@@ -102,6 +110,7 @@ public class ModifyProcessorDialog<T0, T01 extends Payload<T0>, T1 extends Paylo
     @Override
     protected void clearFields() {
         contentPanel.clear();
+        previewPanel.clear();
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/fuzz/impl/PayloadPreviewPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/impl/PayloadPreviewPanel.java
@@ -1,0 +1,294 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2015 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.impl;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.AdjustmentEvent;
+import java.awt.event.AdjustmentListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import javax.swing.GroupLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.fuzz.payloads.Payload;
+import org.zaproxy.zap.extension.fuzz.payloads.processor.PayloadProcessingException;
+import org.zaproxy.zap.extension.fuzz.payloads.processor.PayloadProcessor;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PayloadProcessorUIPanel;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
+
+class PayloadPreviewPanel {
+
+    private static final Logger LOGGER = Logger.getLogger(PayloadPreviewPanel.class);
+
+    private static final String GENERATE_PREVIEW_BUTTON_LABEL = Constant.messages.getString("fuzz.fuzzer.processors.button.generatePreview.label");
+    private static final String LOCK_SCROLL_BARS_BUTTON_LABEL = Constant.messages.getString("fuzz.fuzzer.processors.button.lockScroll.label");
+    private static final String CURRENT_PAYLOADS_FIELD_LABEL = Constant.messages.getString("fuzz.fuzzer.processors.currentPayloads.label");
+    private static final String PROCESSED_PAYLOADS_FIELD_LABEL = Constant.messages.getString("fuzz.fuzzer.processors.processedPayloads.label");
+
+    private static final int MAX_NUMBER_PAYLOADS_PREVIEW = 50;
+
+    private final JPanel mainPanel;
+    private final ResettableAutoCloseableIterator<Payload<?>> payloads;
+
+    private JButton payloadsPreviewGenerateButton;
+
+    private JTextArea currentPayloadsTextArea;
+    private JTextArea processedPayloadsTextArea;
+
+    private PayloadProcessorUIPanel<?, ?, ?, ?> payloadProcessorUIPanel;
+
+    public PayloadPreviewPanel(ResettableAutoCloseableIterator<Payload<?>> payloads) {
+        this.payloads = payloads;
+
+        JLabel currentPayloadsLabel = new JLabel(CURRENT_PAYLOADS_FIELD_LABEL);
+        currentPayloadsLabel.setLabelFor(getCurrentPayloadsTextArea());
+
+        JLabel processedPayloadsLabel = new JLabel(PROCESSED_PAYLOADS_FIELD_LABEL);
+        processedPayloadsLabel.setLabelFor(getProcessedPayloadsTextArea());
+
+        JScrollPane currentPayloadsScrollPane = new JScrollPane(getCurrentPayloadsTextArea());
+        JScrollPane processedPayloadsScrollPane = new JScrollPane(getProcessedPayloadsTextArea());
+
+        SyncScrollBarsAdjustmentListener syncScrollPanes = new SyncScrollBarsAdjustmentListener(
+                currentPayloadsScrollPane,
+                processedPayloadsScrollPane);
+
+        JPanel panel = createSplitPanel(
+                createLabelledPanel(currentPayloadsLabel, currentPayloadsScrollPane),
+                createLabelledPanel(processedPayloadsLabel, processedPayloadsScrollPane),
+                syncScrollPanes);
+
+        mainPanel = new JPanel();
+
+        GroupLayout layout = new GroupLayout(mainPanel);
+        mainPanel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addComponent(getPayloadsPreviewGenerateButton())
+                        .addComponent(panel));
+        layout.setVerticalGroup(
+                layout.createSequentialGroup().addComponent(getPayloadsPreviewGenerateButton()).addComponent(panel));
+
+        updatePayloadsTextArea(
+                getCurrentPayloadsTextArea(),
+                (PayloadProcessor<?, Payload<?>>) NullPayloadProcessor.NULL_PAYLOAD_PROCESSOR);
+    }
+
+    public void setPayloadProcessorUIPanel(PayloadProcessorUIPanel<?, ?, ?, ?> panel) {
+        this.payloadProcessorUIPanel = panel;
+        getPayloadsPreviewGenerateButton().setEnabled(panel != null);
+    }
+
+    public void resetPreview() {
+        getProcessedPayloadsTextArea().setText("");
+    }
+
+    private JButton getPayloadsPreviewGenerateButton() {
+        if (payloadsPreviewGenerateButton == null) {
+            payloadsPreviewGenerateButton = new JButton(GENERATE_PREVIEW_BUTTON_LABEL);
+            payloadsPreviewGenerateButton.setEnabled(false);
+            payloadsPreviewGenerateButton.addActionListener(new ActionListener() {
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    updateProcessedPayloadsTextArea();
+                }
+            });
+        }
+        return payloadsPreviewGenerateButton;
+    }
+
+    private JTextArea getCurrentPayloadsTextArea() {
+        if (currentPayloadsTextArea == null) {
+            currentPayloadsTextArea = new JTextArea(20, 20);
+            currentPayloadsTextArea.setEditable(false);
+        }
+        return currentPayloadsTextArea;
+    }
+
+    private JTextArea getProcessedPayloadsTextArea() {
+        if (processedPayloadsTextArea == null) {
+            processedPayloadsTextArea = new JTextArea(20, 20);
+            processedPayloadsTextArea.setEditable(false);
+        }
+        return processedPayloadsTextArea;
+    }
+
+    private void updatePayloadsTextArea(JTextArea textArea, PayloadProcessor<?, Payload<?>> processor) {
+        if (payloads == null || processor == null) {
+            return;
+        }
+
+        StringBuilder contents = new StringBuilder();
+        try {
+            for (int i = 0; i < MAX_NUMBER_PAYLOADS_PREVIEW && payloads.hasNext(); i++) {
+                if (contents.length() > 0) {
+                    contents.append('\n');
+                }
+                contents.append(processor.process(payloads.next().copy()).getValue());
+            }
+            textArea.setEnabled(true);
+        } catch (Exception e) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Failed to iterate the payloads: " + e.getMessage());
+            }
+            contents.setLength(0);
+            contents.append(Constant.messages.getString("fuzz.fuzzer.processors.payloadsPreview.error"));
+            textArea.setEnabled(false);
+        } finally {
+            try {
+                payloads.reset();
+            } catch (Exception e) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Failed to close iterator: " + e.getMessage());
+                }
+            }
+        }
+        textArea.setText(contents.toString());
+        textArea.setCaretPosition(0);
+    }
+
+    private void updateProcessedPayloadsTextArea() {
+        updatePayloadsTextArea(
+                getProcessedPayloadsTextArea(),
+                (PayloadProcessor<?, Payload<?>>) payloadProcessorUIPanel.getPayloadProcessor());
+    }
+
+    public JPanel getPanel() {
+        return mainPanel;
+    }
+
+    public void clear() {
+        getCurrentPayloadsTextArea().setText("");
+        getProcessedPayloadsTextArea().setText("");
+    }
+
+    private static class NullPayloadProcessor<T1, T2 extends Payload<T1>> implements PayloadProcessor<T1, T2> {
+
+        @SuppressWarnings("rawtypes")
+        public static final NullPayloadProcessor NULL_PAYLOAD_PROCESSOR = new NullPayloadProcessor();
+
+        @Override
+        public T2 process(T2 payload) throws PayloadProcessingException {
+            return payload;
+        }
+
+        @Override
+        public PayloadProcessor<T1, T2> copy() {
+            return this;
+        }
+    }
+
+    private static JPanel createSplitPanel(
+            JPanel leftPanel,
+            JPanel rightPanel,
+            final SyncScrollBarsAdjustmentListener syncScrollPanes) {
+        JPanel panel = new JPanel();
+
+        GroupLayout layout = new GroupLayout(panel);
+        panel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftPanel, rightPanel);
+        splitPane.setDividerLocation(0.5D);
+        splitPane.setResizeWeight(0.5D);
+
+        JCheckBox syncScrollBarsCheckbox = new JCheckBox(LOCK_SCROLL_BARS_BUTTON_LABEL);
+        syncScrollBarsCheckbox.setSelected(true);
+        syncScrollBarsCheckbox.addItemListener(new ItemListener() {
+
+            @Override
+            public void itemStateChanged(ItemEvent e) {
+                syncScrollPanes.setSync(e.getStateChange() == ItemEvent.SELECTED);
+            }
+        });
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                        .addComponent(splitPane)
+                        .addComponent(syncScrollBarsCheckbox));
+        layout.setVerticalGroup(layout.createSequentialGroup().addComponent(splitPane).addComponent(syncScrollBarsCheckbox));
+
+        return panel;
+    }
+
+    private static JPanel createLabelledPanel(JLabel label, JComponent component) {
+        JPanel panel = new JPanel();
+
+        GroupLayout layout = new GroupLayout(panel);
+        panel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup(GroupLayout.Alignment.LEADING).addComponent(label).addComponent(component));
+        layout.setVerticalGroup(layout.createSequentialGroup().addComponent(label).addComponent(component));
+
+        return panel;
+    }
+
+    private static class SyncScrollBarsAdjustmentListener implements AdjustmentListener {
+
+        private final JScrollPane scrollPaneA;
+        private final JScrollPane scrollPaneB;
+        private boolean sync;
+
+        public SyncScrollBarsAdjustmentListener(JScrollPane scrollPaneA, JScrollPane scrollPaneB) {
+            this.scrollPaneA = scrollPaneA;
+            scrollPaneA.getHorizontalScrollBar().addAdjustmentListener(this);
+            scrollPaneA.getVerticalScrollBar().addAdjustmentListener(this);
+            this.scrollPaneB = scrollPaneB;
+            scrollPaneB.getHorizontalScrollBar().addAdjustmentListener(this);
+            scrollPaneB.getVerticalScrollBar().addAdjustmentListener(this);
+            this.sync = true;
+        }
+
+        @Override
+        public void adjustmentValueChanged(AdjustmentEvent e) {
+            if (sync) {
+                if (scrollPaneA.getVerticalScrollBar().equals(e.getSource())) {
+                    scrollPaneB.getVerticalScrollBar().setValue(scrollPaneA.getVerticalScrollBar().getValue());
+                } else if (scrollPaneB.getVerticalScrollBar().equals(e.getSource())) {
+                    scrollPaneA.getVerticalScrollBar().setValue(scrollPaneB.getVerticalScrollBar().getValue());
+                } else if (scrollPaneA.getHorizontalScrollBar().equals(e.getSource())) {
+                    scrollPaneB.getHorizontalScrollBar().setValue(scrollPaneA.getHorizontalScrollBar().getValue());
+                } else if (scrollPaneB.getHorizontalScrollBar().equals(e.getSource())) {
+                    scrollPaneA.getHorizontalScrollBar().setValue(scrollPaneB.getHorizontalScrollBar().getValue());
+                }
+            }
+        }
+
+        public void setSync(boolean sync) {
+            this.sync = sync;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/fuzz/impl/PayloadsProcessedIterator.java
+++ b/src/org/zaproxy/zap/extension/fuzz/impl/PayloadsProcessedIterator.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2015 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.zaproxy.zap.extension.fuzz.payloads.Payload;
+import org.zaproxy.zap.extension.fuzz.payloads.generator.PayloadGenerationException;
+import org.zaproxy.zap.extension.fuzz.payloads.generator.PayloadGenerator;
+import org.zaproxy.zap.extension.fuzz.payloads.processor.PayloadProcessingException;
+import org.zaproxy.zap.extension.fuzz.payloads.processor.PayloadProcessor;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
+
+class PayloadsProcessedIterator<T, E extends Payload<T>> implements ResettableAutoCloseableIterator<E>, PayloadGenerator<T, E> {
+
+    private final List<PayloadProcessor<T, E>> processors;
+    private ResettableAutoCloseableIterator<E> payloadIterator;
+
+    public PayloadsProcessedIterator(
+            ResettableAutoCloseableIterator<E> payloadIterator,
+            List<PayloadProcessor<T, E>> processors) {
+        this.payloadIterator = payloadIterator;
+        this.processors = new ArrayList<>(processors);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return payloadIterator.hasNext();
+    }
+
+    @Override
+    public E next() {
+        E value = (E) payloadIterator.next().copy();
+        for (PayloadProcessor<T, E> processor : processors) {
+            try {
+                value = processor.process(value);
+            } catch (PayloadProcessingException e) {
+                throw new PayloadGenerationException("An error occurred while processing the payload: " + e.toString(), e);
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public void remove() {
+    }
+
+    @Override
+    public void reset() {
+        payloadIterator.reset();
+        for (int i = 0; i < processors.size(); i++) {
+            processors.set(i, processors.get(i).copy());
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        payloadIterator.close();
+    }
+
+    @Override
+    public long getNumberOfPayloads() {
+        return 0;
+    }
+
+    @Override
+    public ResettableAutoCloseableIterator<E> iterator() {
+        return this;
+    }
+
+    @Override
+    public PayloadGenerator<T, E> copy() {
+        return this;
+    }
+}

--- a/src/org/zaproxy/zap/extension/fuzz/impl/ProcessorsPayloadDialog.java
+++ b/src/org/zaproxy/zap/extension/fuzz/impl/ProcessorsPayloadDialog.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.fuzz.impl;
 
 import java.awt.Window;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,6 +36,7 @@ import org.zaproxy.zap.extension.fuzz.payloads.Payload;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.PayloadProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PayloadProcessorUI;
 import org.zaproxy.zap.model.MessageLocation;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
 import org.zaproxy.zap.view.AbstractFormDialog;
 import org.zaproxy.zap.view.AbstractMultipleOrderedOptionsBaseTablePanel;
 
@@ -57,6 +59,8 @@ public class ProcessorsPayloadDialog extends AbstractFormDialog {
     private PayloadProcessorsContainer processorsUIHandlers;
 
     private List<PayloadProcessorTableEntry> processors;
+
+    private ResettableAutoCloseableIterator<Payload<?>> payloads;
 
     private MessageLocation messageLocation;
 
@@ -99,6 +103,7 @@ public class ProcessorsPayloadDialog extends AbstractFormDialog {
     @Override
     protected void clearFields() {
         messageLocation = null;
+        payloads = null;
         processorsTablePanel.setProcessors(Collections.<PayloadProcessorTableEntry> emptyList());
     }
 
@@ -157,7 +162,8 @@ public class ProcessorsPayloadDialog extends AbstractFormDialog {
             AddProcessorDialog addProcessorDialog = new AddProcessorDialog(
                     ProcessorsPayloadDialog.this,
                     processorsUIHandlers,
-                    messageLocation);
+                    messageLocation,
+                    getProcessedPayloads());
             addProcessorDialog.pack();
             addProcessorDialog.setVisible(true);
 
@@ -175,7 +181,7 @@ public class ProcessorsPayloadDialog extends AbstractFormDialog {
 
         @Override
         public PayloadProcessorTableEntry showModifyDialogue(PayloadProcessorTableEntry e) {
-            PayloadProcessorUI<?, ?, ?> processorUI = showModifyDialogueImpl((PayloadProcessorUI)e.getPayloadProcessorUI());
+            PayloadProcessorUI<?, ?, ?> processorUI = showModifyDialogueImpl(e, (PayloadProcessorUI)e.getPayloadProcessorUI());
 
             if (processorUI != null) {
                 e.setPayloadProcessorUI(processorUI);
@@ -185,11 +191,12 @@ public class ProcessorsPayloadDialog extends AbstractFormDialog {
         }
 
         private <T, T0 extends Payload<T>, T1 extends PayloadProcessor<T, T0>, T2 extends PayloadProcessorUI<T, T0, T1>> T2 showModifyDialogueImpl(
-                T2 payloadGeneratorUI) {
+                PayloadProcessorTableEntry e, T2 payloadGeneratorUI) {
             ModifyProcessorDialog<T, T0, T1, T2> modifyProcessorDialog = new ModifyProcessorDialog<>(
                     ProcessorsPayloadDialog.this,
                     processorsUIHandlers.getPanel(payloadGeneratorUI),
-                    payloadGeneratorUI);
+                    payloadGeneratorUI,
+                    getProcessedPayloads(e.getOrder() - 1));
             modifyProcessorDialog.pack();
             modifyProcessorDialog.setVisible(true);
 
@@ -226,5 +233,27 @@ public class ProcessorsPayloadDialog extends AbstractFormDialog {
     public void setPayloadProcessors(List<PayloadProcessorTableEntry> processors) {
         this.processors = processors;
         this.processorsTablePanel.setProcessors(processors);
+    }
+
+    public void setPayloads(ResettableAutoCloseableIterator<Payload<?>> payloads) {
+        this.payloads = payloads;
+    }
+
+    private ResettableAutoCloseableIterator<Payload<?>> getProcessedPayloads() {
+        return getProcessedPayloads(-1);
+    }
+
+    private ResettableAutoCloseableIterator<Payload<?>> getProcessedPayloads(int numberOfProcessors) {
+        List<PayloadProcessor<?, Payload<?>>> currentProcessors = new ArrayList<>();
+        int count = 0;
+        for (PayloadProcessorTableEntry processorEntry : processorsTablePanel.getProcessors()) {
+            if (numberOfProcessors > -1 && count >= numberOfProcessors) {
+                break;
+            }
+            currentProcessors
+                    .add((PayloadProcessor<?, Payload<?>>) processorEntry.getPayloadProcessorUI().getPayloadProcessor());
+            count++;
+        }
+        return new PayloadsProcessedIterator(payloads, currentProcessors);
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
@@ -159,7 +159,6 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
         private JButton payloadsPreviewGenerateButton;
 
         public ScriptStringPayloadGeneratorAdapterUIPanel(List<ScriptWrapper> scriptWrappers) {
-            System.out.println("ScriptStringPayloadGeneratorAdapterUIPanel.<init>");
             scriptComboBox = new JComboBox<>(new SortedComboBoxModel<ScriptUIEntry>());
             for (ScriptWrapper scriptWrapper : scriptWrappers) {
                 if (scriptWrapper.isEnabled()) {

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64DecodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64DecodeProcessorUIHandler.java
@@ -116,6 +116,11 @@ public class Base64DecodeProcessorUIHandler implements
         }
 
         @Override
+        public Base64DecodeProcessor getPayloadProcessor() {
+            return new Base64DecodeProcessor((Charset) getCharsetComboBox().getSelectedItem());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64EncodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64EncodeProcessorUIHandler.java
@@ -187,6 +187,13 @@ public class Base64EncodeProcessorUIHandler implements
         }
 
         @Override
+        public Base64EncodeProcessor getPayloadProcessor() {
+            return new Base64EncodeProcessor(
+                    (Charset) getCharsetComboBox().getSelectedItem(),
+                    getBreakLinesCheckBox().isSelected());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ExpandStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ExpandStringProcessorUIHandler.java
@@ -283,6 +283,20 @@ public class ExpandStringProcessorUIHandler implements
         }
 
         @Override
+        public ExpandStringProcessor getPayloadProcessor() {
+            if (!validate()) {
+                return null;
+            }
+            ExpandStringProcessor.Position position = (getBeginPositionRadioButton().isSelected()
+                    ? ExpandStringProcessor.Position.BEGIN
+                    : ExpandStringProcessor.Position.END);
+            return new ExpandStringProcessor(
+                    position,
+                    getValueTextField().getText(),
+                    getLengthNumberSpinner().getValue().intValue());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptEscapeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptEscapeProcessorUIHandler.java
@@ -115,6 +115,11 @@ public class JavaScriptEscapeProcessorUIHandler implements
         }
 
         @Override
+        public JavaScriptEscapeProcessor getPayloadProcessor() {
+            return JavaScriptEscapeProcessor.INSTANCE;
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptUnescapeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptUnescapeProcessorUIHandler.java
@@ -115,6 +115,11 @@ public class JavaScriptUnescapeProcessorUIHandler implements
         }
 
         @Override
+        public JavaScriptUnescapeProcessor getPayloadProcessor() {
+            return JavaScriptUnescapeProcessor.INSTANCE;
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/MD5HashProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/MD5HashProcessorUIHandler.java
@@ -115,6 +115,11 @@ public class MD5HashProcessorUIHandler implements
         }
 
         @Override
+        public MD5HashProcessor getPayloadProcessor() {
+            return new MD5HashProcessor((Charset) getCharsetComboBox().getSelectedItem(), getUpperCaseCheckBox().isSelected());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PayloadProcessorUIPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PayloadProcessorUIPanel.java
@@ -35,6 +35,8 @@ public interface PayloadProcessorUIPanel<T1, T2 extends Payload<T1>, T3 extends 
 
     T4 getPayloadProcessorUI();
 
+    T3 getPayloadProcessor();
+
     void clear();
 
     boolean validate();

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PostfixStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PostfixStringProcessorUIHandler.java
@@ -169,6 +169,14 @@ public class PostfixStringProcessorUIHandler implements
         }
 
         @Override
+        public PostfixStringProcessor getPayloadProcessor() {
+            if (!validate()) {
+                return null;
+            }
+            return new PostfixStringProcessor(getValueTextField().getText());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PrefixStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PrefixStringProcessorUIHandler.java
@@ -169,6 +169,14 @@ public class PrefixStringProcessorUIHandler implements
         }
 
         @Override
+        public PrefixStringProcessor getPayloadProcessor() {
+            if (!validate()) {
+                return null;
+            }
+            return new PrefixStringProcessor(getValueTextField().getText());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA1HashProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA1HashProcessorUIHandler.java
@@ -117,6 +117,11 @@ public class SHA1HashProcessorUIHandler implements
         }
 
         @Override
+        public SHA1HashProcessor getPayloadProcessor() {
+            return new SHA1HashProcessor((Charset) getCharsetComboBox().getSelectedItem(), getUpperCaseCheckBox().isSelected());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA256HashProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA256HashProcessorUIHandler.java
@@ -117,6 +117,13 @@ public class SHA256HashProcessorUIHandler implements
         }
 
         @Override
+        public SHA256HashProcessor getPayloadProcessor() {
+            return new SHA256HashProcessor(
+                    (Charset) getCharsetComboBox().getSelectedItem(),
+                    getUpperCaseCheckBox().isSelected());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/TrimStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/TrimStringProcessorUIHandler.java
@@ -164,6 +164,11 @@ public class TrimStringProcessorUIHandler implements
         }
 
         @Override
+        public TrimStringProcessor getPayloadProcessor() {
+            return new TrimStringProcessor(getLengthNumberSpinner().getValue().intValue());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLDecodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLDecodeProcessorUIHandler.java
@@ -115,6 +115,11 @@ public class URLDecodeProcessorUIHandler implements
         }
 
         @Override
+        public URLDecodeProcessor getPayloadProcessor() {
+            return new URLDecodeProcessor((Charset) getCharsetComboBox().getSelectedItem());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLEncodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLEncodeProcessorUIHandler.java
@@ -115,6 +115,11 @@ public class URLEncodeProcessorUIHandler implements
         }
 
         @Override
+        public URLEncodeProcessor getPayloadProcessor() {
+            return new URLEncodeProcessor((Charset) getCharsetComboBox().getSelectedItem());
+        }
+
+        @Override
         public String getHelpTarget() {
             // THC add help page...
             return null;

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -184,6 +184,11 @@ fuzz.fuzzer.processors.table.header.order = #
 fuzz.fuzzer.processors.table.header.type = Type
 fuzz.fuzzer.processors.table.header.description = Description
 
+fuzz.fuzzer.processors.button.generatePreview.label = Generate Preview
+fuzz.fuzzer.processors.button.lockScroll.label = Lock Scroll
+fuzz.fuzzer.processors.currentPayloads.label = Current Payloads:
+fuzz.fuzzer.processors.payloadsPreview.error = Failed to create preview.
+fuzz.fuzzer.processors.processedPayloads.label = Processed Payloads:
 
 fuzz.payloads.generator.strings.name = Strings
 fuzz.payloads.generator.strings.contents.label = Contents:
@@ -294,6 +299,8 @@ fuzz.payload.processor.script.name = Script
 fuzz.payload.processor.script.script.label = Script:
 fuzz.payload.processor.script.warnNoScript.message = No script selected, a script must be selected first.
 fuzz.payload.processor.script.warnNoScript.title = No Script Selected
+fuzz.payload.processor.script.warnNoInterface.message = The selected script does not implement the required interface.\nPlease take a look at the provided templates for examples.
+fuzz.payload.processor.script.warnNoInterface.title = Script Incorrect Implementation
 
 fuzz.payload.processor.sha1Hash.name = SHA-1 Hash
 fuzz.payload.processor.sha1Hash.description = Using encoding ''{0}''


### PR DESCRIPTION
Change all processor dialogues to allow to see the current payloads and
to preview the processing of the payloads with the selected options. The
payloads are shown in text areas under the processor options. The
current payloads are shown with previous processors applied (when adding
more processors per payload or adding processors per message location).
The preview does not allow to see all generated/processed payloads since
those might consume too much memory (more than what is actually
available), it is shown a fixed number of payloads which allow to have
an idea of what the processor does.
Add script validation to ScriptStringPayloadProcessorAdapterUIPanel, to
inform the user if the script does not implement the required interface
Update changes in ZapAddOn.xml.
Fix zaproxy/zaproxy#1898 - Enhancement: User Story - I can view current
list of payloads while creating processors in the Add and Modify
Processor forms
Fix zaproxy/zaproxy#1931 - Enhancement: Payload Processing Preview