### PR TITLE
fuzz: allow to save (to file) String, Regex, File and Script payloads

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -22,6 +22,7 @@
     Allow to modify the selected Payload Processor script.<br>
     Show current payloads when adding/modifying processors (Issue 1898).<br>
     Allow to preview processing of payloads (Issue 1931).<br>
+    Allow to save (to file) String, Regex, File and Script payloads (Issue 1932).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/AbstractPersistentPayloadGeneratorUIPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/AbstractPersistentPayloadGeneratorUIPanel.java
@@ -1,0 +1,215 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2015 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.payloads.ui.impl;
+
+import java.awt.Component;
+import java.awt.HeadlessException;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.text.MessageFormat;
+
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.fuzz.ExtensionFuzz;
+import org.zaproxy.zap.extension.fuzz.payloads.Payload;
+import org.zaproxy.zap.extension.fuzz.payloads.generator.PayloadGenerator;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUI;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUIPanel;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
+
+abstract class AbstractPersistentPayloadGeneratorUIPanel<T1, T2 extends Payload<T1>, T3 extends PayloadGenerator<T1, T2>, T4 extends PayloadGeneratorUI<T1, T2, T3>>
+        implements PayloadGeneratorUIPanel<T1, T2, T3, T4> {
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractPersistentPayloadGeneratorUIPanel.class);
+
+    private static final String SAVE_BUTTON_LABEL = Constant.messages.getString("fuzz.payloads.generators.save.button");
+    private static final String SAVE_BUTTON_TOOL_TIP = Constant.messages.getString("fuzz.payloads.generators.save.tooltip");
+
+    private JButton saveButton;
+
+    protected JButton getSaveButton() {
+        if (saveButton == null) {
+            saveButton = new JButton(SAVE_BUTTON_LABEL);
+            saveButton.setToolTipText(SAVE_BUTTON_TOOL_TIP);
+            saveButton.setEnabled(false);
+            saveButton.setIcon(
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    AbstractPersistentPayloadGeneratorUIPanel.class.getResource("/resource/icon/16/096.png"))));
+            saveButton.addActionListener(new ActionListener() {
+
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    T3 payloadGenerator = getPayloadGenerator();
+                    if (payloadGenerator != null) {
+                        Path file = getFile();
+                        if (file != null) {
+                            saveToFile(payloadGenerator, file);
+                        }
+                    }
+                }
+            });
+        }
+        return saveButton;
+    }
+
+    private Path getFile() {
+        FileChooser fileNameDialogue = new FileChooser();
+        if (fileNameDialogue.showSaveDialog(null) != FileChooser.APPROVE_OPTION) {
+            return null;
+        }
+        return fileNameDialogue.getSelectedFile().toPath();
+    }
+
+    private void saveToFile(T3 payloadGenerator, Path file) {
+        try (BufferedWriter bw = Files.newBufferedWriter(
+                file,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING);
+             ResettableAutoCloseableIterator<T2> it = payloadGenerator.iterator()) {
+            while (it.hasNext()) {
+                bw.write(it.next().getValue().toString());
+                if (it.hasNext()) {
+                    bw.write('\n');
+                }
+            }
+            addCustomFileFuzzer(file);
+        } catch (Exception e) {
+            LOGGER.warn(e.getMessage(), e);
+            View.getSingleton()
+                    .showWarningDialog(Constant.messages.getString("fuzz.payloads.generators.save.dialog.warnErrorSaving"));
+        }
+    }
+
+    private static void addCustomFileFuzzer(Path file) {
+        ExtensionFuzz extensionFuzz = Control.getSingleton().getExtensionLoader().getExtension(ExtensionFuzz.class);
+        if (extensionFuzz != null) {
+            extensionFuzz.addCustomFileFuzzer(file);
+        }
+    }
+
+    protected abstract T3 getPayloadGenerator();
+
+    private static class FileChooser extends JFileChooser {
+
+        private static final Path BASE_DIR = Paths.get(Constant.getInstance().FUZZER_DIR);
+
+        private static final long serialVersionUID = 7013510209807472291L;
+
+        public FileChooser() {
+            super(BASE_DIR.toString());
+        }
+
+        @Override
+        protected JDialog createDialog(Component parent) throws HeadlessException {
+            JDialog dialog = super.createDialog(parent);
+            dialog.setIconImages(DisplayUtils.getZapIconImages());
+            dialog.setTitle(Constant.messages.getString("fuzz.payloads.generators.save.dialog.title"));
+            return dialog;
+        }
+
+        @Override
+        public void setCurrentDirectory(File dir) {
+            if (BASE_DIR.equals(dir.toPath())) {
+                super.setCurrentDirectory(dir);
+            }
+        }
+
+        @Override
+        public void changeToParentDirectory() {
+        }
+
+        @Override
+        public boolean accept(File file) {
+            if (file.isDirectory()) {
+                return false;
+            }
+            return super.accept(file);
+        }
+
+        @Override
+        public void approveSelection() {
+            File selectedFile = getSelectedFile();
+
+            if (!selectedFile.toPath().startsWith(BASE_DIR) || Files.isDirectory(selectedFile.toPath())) {
+                JOptionPane.showMessageDialog(
+                        null,
+                        Constant.messages.getString("fuzz.payloads.generators.save.dialog.warnInvalidName.message"),
+                        Constant.messages.getString("fuzz.payloads.generators.save.dialog.warnInvalidName.title"),
+                        JOptionPane.INFORMATION_MESSAGE);
+                return;
+            }
+
+            if (Files.exists(selectedFile.toPath())) {
+                if (!Files.isWritable(selectedFile.toPath())) {
+                    JOptionPane.showMessageDialog(
+                            this,
+                            MessageFormat.format(
+                                    Constant.messages
+                                            .getString("fuzz.payloads.generators.save.dialog.warnFileNoWritePermisson.message"),
+                                    selectedFile.getAbsolutePath()),
+                            Constant.messages.getString("fuzz.payloads.generators.save.dialog.warnFileNoWritePermisson.title"),
+                            JOptionPane.WARNING_MESSAGE);
+                    return;
+                }
+
+                int result = JOptionPane.showConfirmDialog(
+                        this,
+                        Constant.messages.getString("fuzz.payloads.generators.save.dialog.overwrite.message"),
+                        Constant.messages.getString("fuzz.payloads.generators.save.dialog.overwrite.title"),
+                        JOptionPane.YES_NO_OPTION);
+                switch (result) {
+                case JOptionPane.NO_OPTION:
+                case JOptionPane.CLOSED_OPTION:
+                    return;
+                case JOptionPane.YES_OPTION:
+                }
+            } else if (!Files.isWritable(selectedFile.getParentFile().toPath())) {
+                JOptionPane.showMessageDialog(
+                        this,
+                        MessageFormat.format(
+                                Constant.messages
+                                        .getString("fuzz.payloads.generators.save.dialog.warnDirNoWritePermisson.message"),
+                                selectedFile.getParentFile().getAbsolutePath()),
+                        Constant.messages.getString("fuzz.payloads.generators.save.dialog.warnDirNoWritePermisson.title"),
+                        JOptionPane.WARNING_MESSAGE);
+                return;
+            }
+            super.approveSelection();
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultStringPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultStringPayloadGeneratorUIHandler.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.zap.extension.fuzz.payloads.ui.impl;
 
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,7 +36,6 @@ import org.zaproxy.zap.extension.fuzz.payloads.StringPayload;
 import org.zaproxy.zap.extension.fuzz.payloads.generator.DefaultStringPayloadGenerator;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUI;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUIHandler;
-import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUIPanel;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.DefaultStringPayloadGeneratorUIHandler.DefaultStringPayloadGeneratorUI;
 import org.zaproxy.zap.model.MessageLocation;
 import org.zaproxy.zap.utils.StringUIUtils;
@@ -151,8 +152,8 @@ public class DefaultStringPayloadGeneratorUIHandler implements
 
     }
 
-    public static class DefaultStringPayloadGeneratorUIPanel implements
-            PayloadGeneratorUIPanel<String, StringPayload, DefaultStringPayloadGenerator, DefaultStringPayloadGeneratorUI> {
+    public static class DefaultStringPayloadGeneratorUIPanel extends
+            AbstractPersistentPayloadGeneratorUIPanel<String, StringPayload, DefaultStringPayloadGenerator, DefaultStringPayloadGeneratorUI> {
 
         private static final String CONTENTS_FIELD_LABEL = Constant.messages.getString("fuzz.payloads.generator.strings.contents.label");
         private static final String MULTILINE_FIELD_LABEL = Constant.messages.getString("fuzz.payloads.generator.strings.multiline.label");
@@ -186,7 +187,8 @@ public class DefaultStringPayloadGeneratorUIHandler implements
                     .addGroup(
                             layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                                     .addComponent(contentsScrollPane)
-                                    .addComponent(getMultilineCheckBox())));
+                                    .addComponent(getMultilineCheckBox())
+                                    .addComponent(getSaveButton())));
 
             layout.setVerticalGroup(layout.createSequentialGroup()
                     .addGroup(
@@ -196,7 +198,10 @@ public class DefaultStringPayloadGeneratorUIHandler implements
                     .addGroup(
                             layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                     .addComponent(multilineLabel)
-                                    .addComponent(getMultilineCheckBox())));
+                                    .addComponent(getMultilineCheckBox()))
+                    .addComponent(getSaveButton()));
+
+            getSaveButton().setEnabled(true);
         }
 
         private ZapTextArea getContentsTextArea() {
@@ -212,6 +217,13 @@ public class DefaultStringPayloadGeneratorUIHandler implements
             if (multilineCheckBox == null) {
                 multilineCheckBox = new JCheckBox();
                 multilineCheckBox.setToolTipText(MULTILINE_FIELD_TOOLTIP);
+                multilineCheckBox.addItemListener(new ItemListener() {
+
+                    @Override
+                    public void itemStateChanged(ItemEvent e) {
+                        getSaveButton().setEnabled(e.getStateChange() != ItemEvent.SELECTED);
+                    }
+                });
             }
             return multilineCheckBox;
         }
@@ -234,6 +246,11 @@ public class DefaultStringPayloadGeneratorUIHandler implements
         @Override
         public DefaultStringPayloadGeneratorUI getPayloadGeneratorUI() {
             return new DefaultStringPayloadGeneratorUI(getContentsTextArea().getText(), getMultilineCheckBox().isSelected());
+        }
+
+        @Override
+        protected DefaultStringPayloadGenerator getPayloadGenerator() {
+            return new DefaultStringPayloadGenerator(Arrays.asList(getContentsTextArea().getText().split("\r?\n", -1)));
         }
 
         @Override

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -190,6 +190,19 @@ fuzz.fuzzer.processors.currentPayloads.label = Current Payloads:
 fuzz.fuzzer.processors.payloadsPreview.error = Failed to create preview.
 fuzz.fuzzer.processors.processedPayloads.label = Processed Payloads:
 
+fuzz.payloads.generators.save.button = Save...
+fuzz.payloads.generators.save.tooltip = Allows to save the (generated) payloads, to be available in custom 'File Fuzzers'.
+fuzz.payloads.generators.save.dialog.title = Save Payloads
+fuzz.payloads.generators.save.dialog.warnInvalidName.message = The specified file name is not valid.
+fuzz.payloads.generators.save.dialog.warnInvalidName.title = Invalid File Name
+fuzz.payloads.generators.save.dialog.warnDirNoWritePermisson.message = The directory is not writable:\n{0}\nPlease change the write permission to allow to write the file.
+fuzz.payloads.generators.save.dialog.warnDirNoWritePermisson.title = Directory Without Write Permission
+fuzz.payloads.generators.save.dialog.warnFileNoWritePermisson.message = The file is not writable:\n{0}\nPlease change the write permission to allow to write to the file.
+fuzz.payloads.generators.save.dialog.warnFileNoWritePermisson.title = File Without Write Permission
+fuzz.payloads.generators.save.dialog.overwrite.message = A file with the specified name already exists. Do you want to replace it?
+fuzz.payloads.generators.save.dialog.overwrite.title = Existing File
+fuzz.payloads.generators.save.dialog.warnErrorSaving = An error occurred while saving the payloads to the file.
+
 fuzz.payloads.generator.strings.name = Strings
 fuzz.payloads.generator.strings.contents.label = Contents:
 fuzz.payloads.generator.strings.multiline.label = Multiline:


### PR DESCRIPTION
Change String, Regex, File and Script payload generators to allow to
save the generated payloads to a file, that's available for selection in
the custom files of File Fuzzers. The generated payloads can be saved
using a button shown in the panel of the generators, which allows to
choose the name of the file (the location is always the same, the one
used to save the custom file fuzzers).
Update changes in ZapAddOn.xml.
Fix zaproxy/zaproxy#1932 - Enhancement: Save user-created payloads for
reuse