### PR TITLE
fuzz: limit the number of payloads used for preview of file fuzzers

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadFileSource.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadFileSource.java
@@ -42,4 +42,9 @@ public class FuzzerPayloadFileSource extends FuzzerPayloadSource {
         return new FileStringPayloadGenerator(file);
     }
 
+    @Override
+    public StringPayloadGenerator getPayloadGenerator(int limit) {
+        return new FileStringPayloadGenerator(file, limit);
+    }
+
 }

--- a/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
@@ -305,8 +305,8 @@ public class FuzzerPayloadGeneratorUIHandler implements
                     count++;
 
                     contents.append(payloadsSource.getName()).append('\n');
-                    try (ResettableAutoCloseableIterator<StringPayload> payloads = payloadsSource.getPayloadGenerator()
-                            .iterator()) {
+                    try (ResettableAutoCloseableIterator<StringPayload> payloads = payloadsSource
+                            .getPayloadGenerator(MAX_NUMBER_PAYLOADS_PREVIEW + 1).iterator()) {
                         for (int i = 0; i < MAX_NUMBER_PAYLOADS_PREVIEW && payloads.hasNext(); i++) {
                             contents.append("  ").append(i + 1).append(": ").append(payloads.next().getValue()).append('\n');
                         }

--- a/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadSource.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadSource.java
@@ -35,6 +35,8 @@ public abstract class FuzzerPayloadSource implements Comparable<FuzzerPayloadSou
 
     public abstract StringPayloadGenerator getPayloadGenerator();
 
+    public abstract StringPayloadGenerator getPayloadGenerator(int limit);
+
     @Override
     public int compareTo(FuzzerPayloadSource other) {
         if (other == null) {


### PR DESCRIPTION
Limit the actual number of payloads that are used for the preview of
file fuzzers, otherwise it would be read all the file (during the
calculation of the number of payloads) instead of just enough for the
preview.