### PR TITLE
fuzz: allow to modify the payloads of file and file fuzzers generators

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -25,6 +25,7 @@
     Allow to save (to file) String, Regex, File and Script payloads (Issue 1932).<br>
     Fix issues in generation of payloads from regular expressions (Issue 1884).<br>
     Add support for regex repetitions (Issue 1885).<br>
+    Allow to modify the payloads of File and File Fuzzers (Issue 1897).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/AbstractPersistentPayloadGeneratorUIPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/AbstractPersistentPayloadGeneratorUIPanel.java
@@ -50,7 +50,7 @@ import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUIPanel;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
 
-abstract class AbstractPersistentPayloadGeneratorUIPanel<T1, T2 extends Payload<T1>, T3 extends PayloadGenerator<T1, T2>, T4 extends PayloadGeneratorUI<T1, T2, T3>>
+public abstract class AbstractPersistentPayloadGeneratorUIPanel<T1, T2 extends Payload<T1>, T3 extends PayloadGenerator<T1, T2>, T4 extends PayloadGeneratorUI<T1, T2, T3>>
         implements PayloadGeneratorUIPanel<T1, T2, T3, T4> {
 
     private static final Logger LOGGER = Logger.getLogger(AbstractPersistentPayloadGeneratorUIPanel.class);
@@ -62,27 +62,32 @@ abstract class AbstractPersistentPayloadGeneratorUIPanel<T1, T2 extends Payload<
 
     protected JButton getSaveButton() {
         if (saveButton == null) {
-            saveButton = new JButton(SAVE_BUTTON_LABEL);
-            saveButton.setToolTipText(SAVE_BUTTON_TOOL_TIP);
-            saveButton.setEnabled(false);
-            saveButton.setIcon(
-                    DisplayUtils.getScaledIcon(
-                            new ImageIcon(
-                                    AbstractPersistentPayloadGeneratorUIPanel.class.getResource("/resource/icon/16/096.png"))));
-            saveButton.addActionListener(new ActionListener() {
+            saveButton = createSaveButton();
+        }
+        return saveButton;
+    }
 
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    T3 payloadGenerator = getPayloadGenerator();
-                    if (payloadGenerator != null) {
-                        Path file = getFile();
-                        if (file != null) {
-                            saveToFile(payloadGenerator, file);
-                        }
+    protected JButton createSaveButton() {
+        JButton saveButton = new JButton(SAVE_BUTTON_LABEL);
+        saveButton.setToolTipText(SAVE_BUTTON_TOOL_TIP);
+        saveButton.setEnabled(false);
+        saveButton.setIcon(
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(
+                                AbstractPersistentPayloadGeneratorUIPanel.class.getResource("/resource/icon/16/096.png"))));
+        saveButton.addActionListener(new ActionListener() {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                T3 payloadGenerator = getPayloadGenerator();
+                if (payloadGenerator != null) {
+                    Path file = getFile();
+                    if (file != null) {
+                        saveToFile(payloadGenerator, file);
                     }
                 }
-            });
-        }
+            }
+        });
         return saveButton;
     }
 

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ModifyPayloadsPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ModifyPayloadsPanel.java
@@ -1,0 +1,364 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2015 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.payloads.ui.impl;
+
+import java.awt.Desktop;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import javax.swing.GroupLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.text.BadLocationException;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.fuzz.payloads.DefaultStringPayload;
+import org.zaproxy.zap.extension.fuzz.payloads.Payload;
+import org.zaproxy.zap.extension.fuzz.payloads.StringPayload;
+import org.zaproxy.zap.extension.fuzz.payloads.generator.FileStringPayloadGenerator;
+import org.zaproxy.zap.extension.fuzz.payloads.generator.PayloadGenerator;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUI;
+import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
+import org.zaproxy.zap.utils.ZapTextArea;
+
+public abstract class ModifyPayloadsPanel<T1, T2 extends Payload<T1>, T3 extends PayloadGenerator<T1, T2>, T4 extends PayloadGeneratorUI<T1, T2, T3>> {
+
+    private final Logger logger = Logger.getLogger(getClass());
+
+    private static final String PAYLOADS_FIELD_LABEL = Constant.messages
+            .getString("fuzz.payloads.generator.generic.edit.payloads.label");
+
+    private static final int MAX_NUMBER_PAYLOADS_FOR_EDITION = 250000;
+    private static final int MAX_FILE_SIZE_FOR_EDITION = 5 * 1024 * 1024;
+
+    private final JPanel fieldsPanel;
+
+    private ZapTextArea payloadsTextArea;
+    private JButton saveButton;
+
+    private Path file;
+    private boolean createTempFile;
+    private boolean externalEditor;
+
+    private T4 payloadGeneratorUI;
+
+    public ModifyPayloadsPanel(JButton saveButton) {
+        this.fieldsPanel = new JPanel();
+        this.saveButton = saveButton;
+        this.saveButton.setEnabled(false);
+
+        GroupLayout layoutModifyPanel = new GroupLayout(fieldsPanel);
+        fieldsPanel.setLayout(layoutModifyPanel);
+        layoutModifyPanel.setAutoCreateGaps(true);
+
+        JLabel valueLabel = new JLabel(PAYLOADS_FIELD_LABEL);
+        valueLabel.setLabelFor(getPayloadsTextArea());
+
+        JScrollPane payloadsTextAreaScrollPane = new JScrollPane(getPayloadsTextArea());
+
+        layoutModifyPanel.setHorizontalGroup(layoutModifyPanel.createSequentialGroup()
+                .addGroup(layoutModifyPanel.createParallelGroup(GroupLayout.Alignment.TRAILING).addComponent(valueLabel))
+                .addGroup(
+                        layoutModifyPanel.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                .addComponent(payloadsTextAreaScrollPane)
+                                .addComponent(saveButton)));
+
+        layoutModifyPanel.setVerticalGroup(
+                layoutModifyPanel.createSequentialGroup()
+                        .addGroup(
+                                layoutModifyPanel.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(valueLabel)
+                                        .addComponent(payloadsTextAreaScrollPane))
+                        .addComponent(saveButton));
+    }
+
+    public abstract T3 getPayloadGenerator();
+
+    public T4 getFileStringPayloadGeneratorUI() {
+        int numberOfPayloads = 0;
+        if (externalEditor) {
+            if (createTempFile) {
+                return payloadGeneratorUI;
+            }
+
+            try {
+                numberOfPayloads = FileStringPayloadGenerator
+                        .calculateNumberOfPayloads(file, StandardCharsets.UTF_8, -1, "", false, false);
+            } catch (IOException e) {
+                logger.warn("Failed to calculate number of payloads: " + e.getMessage());
+            }
+        } else {
+            numberOfPayloads = getPayloadsTextArea().getLineCount();
+        }
+        return createPayloadGeneratorUI(numberOfPayloads);
+    }
+
+    protected abstract T4 createPayloadGeneratorUI(int numberOfPayloads);
+
+    public boolean isValidForPersistence() {
+        return saveButton.isEnabled();
+    }
+
+    public boolean validate() {
+        if (!getPayloadsTextArea().isEnabled()) {
+            return true;
+        }
+        if (createTempFile) {
+            if (!createTempFile()) {
+                return false;
+            }
+        }
+        persistPayloads();
+        return true;
+    }
+
+    private void persistPayloads() {
+        int numberOfPayloads = getPayloadsTextArea().getLineCount();
+        try (BufferedWriter bw = Files.newBufferedWriter(
+                file,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING)) {
+            for (int i = 0; i < numberOfPayloads; i++) {
+                int offset = getPayloadsTextArea().getLineStartOffset(i);
+                int length = getPayloadsTextArea().getLineEndOffset(i) - offset;
+                bw.write(getPayloadsTextArea().getText(offset, length));
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to write the payloads to the file: " + e.getMessage());
+            View.getSingleton()
+                    .showWarningDialog(Constant.messages.getString("fuzz.payloads.generator.generic.edit.errorWrite"));
+        }
+    }
+
+    private boolean createTempFile() {
+        try {
+            file = Files.createTempFile(
+                    null,
+                    ".tmp.txt",
+                    PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r-----")));
+            createTempFile = false;
+            return true;
+        } catch (IOException e) {
+            logger.warn("Failed to create temporary file to write the payloads: " + e.getMessage());
+            View.getSingleton()
+                    .showWarningDialog(Constant.messages.getString("fuzz.payloads.generator.generic.edit.errorCreate"));
+        }
+        return false;
+    }
+
+    private boolean writeToFile(T3 payloadGenerator, Path file) {
+        try (BufferedWriter bw = Files.newBufferedWriter(
+                file,
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING);
+             ResettableAutoCloseableIterator<T2> it = payloadGenerator.iterator()) {
+            while (it.hasNext()) {
+                bw.write(it.next().getValue().toString());
+                if (it.hasNext()) {
+                    bw.write('\n');
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to write the payloads to the file: " + e.getMessage());
+            View.getSingleton()
+                    .showWarningDialog(Constant.messages.getString("fuzz.payloads.generator.generic.edit.errorWrite"));
+            return false;
+        }
+        return true;
+    }
+
+    public JPanel getPanel() {
+        return fieldsPanel;
+    }
+
+    protected Path getFile() {
+        return file;
+    }
+
+    protected T4 getPayloadGeneratorUI() {
+        return payloadGeneratorUI;
+    }
+
+    protected ZapTextArea getPayloadsTextArea() {
+        if (payloadsTextArea == null) {
+            payloadsTextArea = new ZapTextArea(25, 25);
+            payloadsTextArea.setEnabled(false);
+        }
+        return payloadsTextArea;
+    }
+
+    public void setPayloadGeneratorUI(T4 payloadGeneratorUI, boolean temporary, Path file) {
+        this.payloadGeneratorUI = payloadGeneratorUI;
+        createTempFile = temporary;
+        this.file = file;
+
+        externalEditor = false;
+        if (!canEdit(file)) {
+            externalEditor = true;
+            openExternalEditor();
+            return;
+        }
+
+        updatePayloadsTextArea(payloadGeneratorUI.getPayloadGenerator());
+    }
+
+    private boolean canEdit(Path file) {
+        if (payloadGeneratorUI.getNumberOfPayloads() >= MAX_NUMBER_PAYLOADS_FOR_EDITION) {
+            return false;
+        }
+
+        if (file == null) {
+            return true;
+        }
+
+        try {
+            return !(Files.size(file) >= MAX_FILE_SIZE_FOR_EDITION);
+        } catch (IOException e) {
+            logger.warn("Failed to query the size of the file [" + file + "]: " + e.getMessage());
+            getPayloadsTextArea().setText(Constant.messages.getString("fuzz.payloads.generator.generic.edit.errorSize"));
+        }
+        return false;
+    }
+
+    private void openExternalEditor() {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
+            if (JOptionPane.showConfirmDialog(
+                    null,
+                    Constant.messages.getString("fuzz.payloads.generator.generic.edit.external.message"),
+                    Constant.messages.getString("fuzz.payloads.generator.generic.edit.external.title"),
+                    JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
+                boolean openFile = false;
+                if (!createTempFile) {
+                    openFile = true;
+                } else {
+                    if (createTempFile()) {
+                        writeToFile(payloadGeneratorUI.getPayloadGenerator(), file);
+                        openFile = true;
+                    }
+                }
+
+                if (openFile) {
+                    try {
+                        getPayloadsTextArea()
+                                .setText(Constant.messages.getString("fuzz.payloads.generator.generic.edit.external.opening"));
+                        Desktop.getDesktop().open(file.toFile());
+                        getPayloadsTextArea().setText(
+                                Constant.messages.getString("fuzz.payloads.generator.generic.edit.external.closeDialog"));
+                        return;
+                    } catch (IOException e) {
+                        View.getSingleton().showWarningDialog(
+                                Constant.messages.getString("fuzz.payloads.generator.generic.edit.external.errorFailedOpen"));
+                    }
+                }
+            }
+        }
+        getPayloadsTextArea().setText(Constant.messages.getString("fuzz.payloads.generator.generic.edit.warnTooBig"));
+    }
+
+    private void updatePayloadsTextArea(T3 fileStringPayloadGenerator) {
+        StringBuilder contents = new StringBuilder(2500);
+        try {
+            try (ResettableAutoCloseableIterator<T2> payloads = fileStringPayloadGenerator.iterator()) {
+                while (payloads.hasNext()) {
+                    if (contents.length() > 0) {
+                        contents.append('\n');
+                    }
+                    contents.append(payloads.next().getValue());
+                }
+            }
+            getPayloadsTextArea().setEnabled(true);
+            saveButton.setEnabled(true);
+        } catch (Exception e) {
+            logger.warn("Failed to read the payloads from the file: " + e.getMessage(), e);
+            contents.setLength(0);
+            contents.append(Constant.messages.getString("fuzz.payloads.generator.generic.edit.errorRead"));
+        }
+        getPayloadsTextArea().setText(contents.toString());
+        getPayloadsTextArea().setCaretPosition(0);
+        getPayloadsTextArea().discardAllEdits();
+    }
+
+    public void clear() {
+        getPayloadsTextArea().setText("");
+        getPayloadsTextArea().discardAllEdits();
+        getPayloadsTextArea().setEnabled(false);
+        saveButton.setEnabled(false);
+        file = null;
+        createTempFile = false;
+        externalEditor = false;
+        payloadGeneratorUI = null;
+    }
+
+    protected static class TextAreaPayloadIterator implements ResettableAutoCloseableIterator<StringPayload> {
+
+        private final JTextArea payloadsTextArea;
+        private final int numberOfPayloads;
+        private int line;
+
+        public TextAreaPayloadIterator(JTextArea payloadsTextArea) {
+            this.payloadsTextArea = payloadsTextArea;
+            this.numberOfPayloads = payloadsTextArea.getLineCount();
+        }
+
+        @Override
+        public void close() throws Exception {
+        }
+
+        @Override
+        public void remove() {
+        }
+
+        @Override
+        public StringPayload next() {
+            try {
+                int offset = payloadsTextArea.getLineStartOffset(line);
+                int length = payloadsTextArea.getLineEndOffset(line) - offset;
+
+                line++;
+                return new DefaultStringPayload(payloadsTextArea.getText(offset, length - 1));
+            } catch (BadLocationException ignore) {
+            }
+            return null;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return line < numberOfPayloads;
+        }
+
+        @Override
+        public void reset() {
+            line = 0;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -190,6 +190,18 @@ fuzz.fuzzer.processors.currentPayloads.label = Current Payloads:
 fuzz.fuzzer.processors.payloadsPreview.error = Failed to create preview.
 fuzz.fuzzer.processors.processedPayloads.label = Processed Payloads:
 
+fuzz.payloads.generator.generic.edit.errorCreate = Failed to create copy of file for edition.
+fuzz.payloads.generator.generic.edit.errorRead = Failed to read the payloads from the file.
+fuzz.payloads.generator.generic.edit.errorSize = Failed to query the size of the file.
+fuzz.payloads.generator.generic.edit.errorWrite = Failed to write the payloads to the file.
+fuzz.payloads.generator.generic.edit.external.opening = Opening external program...
+fuzz.payloads.generator.generic.edit.external.closeDialog = Close this dialogue once finished the editions.
+fuzz.payloads.generator.generic.edit.external.errorFailedOpen = Failed to open the file for edition.
+fuzz.payloads.generator.generic.edit.external.message = The file is too big to be edited in ZAP.\nDo you want to edit the file with external program?
+fuzz.payloads.generator.generic.edit.external.title = File Too Big
+fuzz.payloads.generator.generic.edit.payloads.label = Payloads:
+fuzz.payloads.generator.generic.edit.warnTooBig = The file is to big to be edited from within ZAP.
+
 fuzz.payloads.generators.save.button = Save...
 fuzz.payloads.generators.save.tooltip = Allows to save the (generated) payloads, to be available in custom 'File Fuzzers'.
 fuzz.payloads.generators.save.dialog.title = Save Payloads


### PR DESCRIPTION
Change File and File Fuzzers payload generators to allow to modify the
payloads read/generated from the file(s). The payloads can be changed
in the modify dialogue of the corresponding generator, through a text
area. To not change the original file(s) nor keep the payloads in memory
longer than needed it's created a temporary file, used to save and load
the payloads as needed. The edition from within ZAP is limited to a
maximum number of payloads and size of the file that contains them (thus
limiting the size of the payloads). If the file is outside the limits
it's edited with an external text editor, if available.
Update changes in ZapAddOn.xml.
Fix zaproxy/zaproxy#1897 - Enhancement: User Story - I can view and
modify the contents of the payloads I selected