### PR TITLE
 Allow ajax spider options to be set via the API

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -110,7 +110,6 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
     private static final boolean DEFAULT_RANDOM_INPUTS = true;
 
     private int numberOfBrowsers;
-    private int numberOfThreads;
     private int maxCrawlDepth;
     private int maxCrawlStates;
     private int maxDuration;
@@ -290,10 +289,6 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
         getConfig().setProperty(NUMBER_OF_BROWSERS_KEY, Integer.valueOf(numberOfBrowsers));
     }
     
-    public int getNumberOfThreads() {
-        return numberOfThreads;
-    }
-        
     public int getMaxCrawlDepth() {
     	return maxCrawlDepth; 
     }

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -99,6 +99,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 		super.init();
 		
 		ajaxSpiderApi = new AjaxSpiderAPI(this);
+        this.ajaxSpiderApi.addApiOptions(getAjaxSpiderParam());
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -1,13 +1,12 @@
 <zapaddon>
 	<name>Ajax Spider</name>
-	<version>13</version>
+	<version>14</version>
 	<description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
-	Updated add-on's info URL.<br>
-	Changed to use the (full) URI of selected node (to be used as spider's seed).
+	Issue 2102: Allow ajax spider options to be set via the API.<br>
 	]]>
 	</changes>
 	<dependencies>
@@ -25,7 +24,7 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.4.2</not-before-version>
 	<not-from-version/>
 </zapaddon>
 


### PR DESCRIPTION
Fixes zaproxy/zaproxy#2102 Allow ajax spider options to be set via the API 