### PR TITLE
fix zaproxy/zaproxy#2097 long URL in WebSocket

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
@@ -88,7 +88,7 @@ public class TableWebSocket extends ParosAbstractTable {
 								+ "channel_id BIGINT PRIMARY KEY,"
 								+ "host VARCHAR(255) NOT NULL,"
 								+ "port INTEGER NOT NULL,"
-								+ "url VARCHAR(255) NOT NULL,"
+								+ "url VARCHAR(1048576) NOT NULL,"
 								+ "start_timestamp TIMESTAMP NOT NULL,"
 								+ "end_timestamp TIMESTAMP NULL,"
 								+ "history_id INTEGER NULL,"
@@ -580,7 +580,9 @@ public class TableWebSocket extends ParosAbstractTable {
 						addIdOnSuccess = true;
 						logger.info("insert channel: " + channel.toString());
 					}
-			
+
+					if(logger.isDebugEnabled()) {logger.debug("url (length " + channel.url.length() + "):" + channel.url);}
+
 					stmt.setString(1, channel.host);
 					stmt.setInt(2, channel.port);
 					stmt.setString(3, channel.url);


### PR DESCRIPTION
URLs longer then 255 (actually 288) were truncated (1st Exception)
and could not be found later (2nd kind)
add debug log option
was discussed: github.com/zaproxy/zap-extensions/pull/131