### PR TITLE
fuzz: make sure that the http processor script is shown as selected

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -26,6 +26,7 @@
     Fix issues in generation of payloads from regular expressions (Issue 1884).<br>
     Add support for regex repetitions (Issue 1885).<br>
     Allow to modify the payloads of File and File Fuzzers (Issue 1897).<br>
+    Show the correct Fuzzer HTTP Processor script when showing modify dialogue.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/FuzzerHttpMessageScriptProcessorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/FuzzerHttpMessageScriptProcessorAdapterUIHandler.java
@@ -168,7 +168,7 @@ public class FuzzerHttpMessageScriptProcessorAdapterUIHandler implements
 
         @Override
         public void setFuzzerMessageProcessorUI(FuzzerHttpMessageScriptProcessorAdapterUI payloadProcessorUI) {
-            scriptComboBox.setSelectedItem(payloadProcessorUI.getScriptWrapper());
+            scriptComboBox.setSelectedItem(new ScriptUIEntry(payloadProcessorUI.getScriptWrapper()));
         }
 
         @Override


### PR DESCRIPTION
Change FuzzerHttpMessageScriptProcessorAdapterUIHandler to correctly
select the HTTP processor script when showing the modify dialogue, by
selecting using a ScriptUIEntry (instead of ScriptWrapper).
Update changes in ZapAddOn.xml.