### PR TITLE
zest: add missing field in dialogue 'Assign variable to a calculation'

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<changes>
 	<![CDATA[
 	Add missing error messages for 'Assign variable via string delimiters'.<br>
+	Add missing field (operand B) in 'Assign variable to a calculation' dialogue.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
@@ -162,6 +162,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
 			ZestAssignCalc za = (ZestAssignCalc) assign;
 			this.addTextField(FIELD_VARIABLE, assign.getVariableName());
 			this.addTextField(FIELD_OPERAND_A, za.getOperandA());
+			this.addTextField(FIELD_OPERAND_B, za.getOperandB());
 			this.addComboField(FIELD_OPERATION, 
 					new String[] {
 					Constant.messages.getString("zest.dialog.assign.oper.add"),


### PR DESCRIPTION
Add the missing field, operand B, to 'Assign variable to a calculation'
dialogue.
Update changes in ZapAddOn.xml file.