### PR TITLE
zest: send authentication requests with ZAP's configurations

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<![CDATA[
 	Add missing error messages for 'Assign variable via string delimiters'.<br>
 	Add missing field (operand B) in 'Assign variable to a calculation' dialogue.<br>
+	Send authentication requests with ZAP's configurations (Issue 2114).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change class ZestAuthenticationRunner to send the requests using the
class AuthenticationHelper (instead of a custom HttpClient), which
respects ZAP's configurations (connection timeout, outgoing proxy...).
Update changes in ZapAddOn.xml file.
Fix zaproxy/zaproxy#2114 - Zest authentication requests not sent with
ZAP's configurations