### PR TITLE
httpsInfo: allow to dynamically update/uninstall the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsInfo/MenuEntry.java
+++ b/src/org/zaproxy/zap/extension/httpsInfo/MenuEntry.java
@@ -34,11 +34,12 @@ import org.parosproxy.paros.model.SiteNode;
 public class MenuEntry extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
-    private RightClickMenu extension = null;
+    private final RightClickMenu extension;
     private SiteNode node = null;
 
-    public MenuEntry(String label) {
+    public MenuEntry(String label, RightClickMenu extension) {
 	super(label);
+	this.extension = extension;
 	init();
     }
     public void init(){
@@ -46,8 +47,7 @@ public class MenuEntry extends ExtensionPopupMenuItem {
 
 	    @Override
 	    public void actionPerformed(java.awt.event.ActionEvent e) {
-		Thread bt = new Thread(new BackgroundThread(getHostName(node.getNodeName())));
-		bt.start();
+	        extension.showSslTlsInfo(getHostName(node.getNodeName()));
 	    }
 	});
     }
@@ -73,21 +73,4 @@ public class MenuEntry extends ExtensionPopupMenuItem {
 	}
 	return host;
     }
-    public void setExtension(RightClickMenu extension) {
-	this.extension = extension;
-    }
-
-class BackgroundThread implements Runnable{
-	 private String servername;
-	 public BackgroundThread(String servername){
-	  this.servername = servername;
-	 }
-	 
-	 @Override
-	 public void run() {
-		SSLServer mServer = new SSLServer(servername);
-		MDialog d = new MDialog(mServer);
-	 }
-
-	}
 }

--- a/src/org/zaproxy/zap/extension/httpsInfo/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/httpsInfo/ZapAddOn.xml
@@ -1,10 +1,14 @@
 <zapaddon>
 	<name>HttpsInfo</name>
-	<version>6</version>
+	<version>7</version>
 	<description>Adds Https status information</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Issue 1978 Uncaught NPE - Fixed.</changes>
+	<changes>
+	<![CDATA[
+	Allow to update/uninstall the add-on without restarting ZAP.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.httpsInfo.RightClickMenu</extension>
 	</extensions>


### PR DESCRIPTION
Change class (extension) RightClickMenu to declare that it can be
dynamically unloaded and move the management of the SSL/TLS dialogues to
itself to keep track of dialogues open (to be closed when the add-on is
unloaded).
Change class MenuEntry to use the extension to show the dialogues.
Bump version and update changes in ZapAddOn.xml file.