### PR TITLE
zest: fix NullPointerException when active scanning a sequence script

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	Add missing error messages for 'Assign variable via string delimiters'.<br>
 	Add missing field (operand B) in 'Assign variable to a calculation' dialogue.<br>
 	Send authentication requests with ZAP's configurations (Issue 2114).<br>
+	Fix "Active scan sequence" (Issue 2120).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
@@ -486,6 +486,8 @@ zest.script.remove.confirm				= Are you sure you want to delete this script?
 zest.script.remove.popup				= Delete Script
 zest.scripts.panel.title				= Zest Scripts
 
+zest.script.sequence.scanname = {0} (Script)
+
 zest.surround.with.popup				= Surround with...
 
 zest.targeted.script.default			= Default


### PR DESCRIPTION
Change class ZestSequenceRunner to use a custom StructuralSiteNode (not
backed by a HistoryReference) for the nodes to be scanned, to return a
custom name and a URI, preventing the NullPointerException(s) from
happening.
The issue was caused by a change in Target's implementation which
started to use a StructuralSiteNode instead of a plain SiteNode.
As part of the changes the nodes to be scanned and the Target were
changed to use a custom name. The custom name (name of the script plus
" (script)") is used, in the active scan tab and progress dialogue, to
properly indicate what is being scanned, otherwise it would not show
anything (that is, an empty string). The custom URI is not actually
scanned it's just used for comparisons with sibling nodes (which never
happen since there are just one "host" node).
Update changes in ZapAddOn.xml file.
Fix zaproxy/zaproxy#2120 - Zest "Active scan sequence" not working