### PR TITLE
scripts: force compatibility with older ZAP versions (>= 2.4.0)

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.scripts;
 
 import java.awt.CardLayout;
+import java.awt.Component;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyListener;
 
@@ -64,7 +65,7 @@ public class CommandPanel extends AbstractPanel {
 	 */    
 	private JScrollPane getJScrollPane() {
 		if (jScrollPane == null) {
-			jScrollPane = new RTextScrollPane(getTxtOutput(), false);
+			jScrollPane = new RTextScrollPane((Component) getTxtOutput(), false);
 			
 			((RTextScrollPane)jScrollPane).setLineNumbersEnabled(true);
 

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -1,13 +1,11 @@
 <zapaddon>
 	<name>Script Console</name>
-	<version>15</version> <!-- SNAPSHOT - not released! -->
+	<version>16</version>
 	<description>Supports all JSR 223 scripting languages</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
-	Issue 1653: Support context menu key for trees.<br>
-	Updated add-on's info URL.
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change class CommandPanel to force the use of an older constructor of
RTextScrollPane so that the add-on can still be built for older ZAP
versions (>= 2.4.0). The change is required because the new version of
RSyntaxTextArea library introduced a new constructor which would be used
instead of the old constructor (leading to NoSuchMethodError).
Update version (and remove old changes) in ZapAddOn.xml file.