### PR TITLE
New Passive Scanner for X-ChromeLogger-Data

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/XChromeLoggerDataInfoLeakScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/XChromeLoggerDataInfoLeakScanner.java
@@ -1,0 +1,132 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2015 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+import net.htmlparser.jericho.Source;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.parosproxy.paros.extension.encoder.Base64;
+
+/**
+ * X-ChromeLogger-Data header information leak passive scan rule 
+ * @author kingthorin+owaspzap@gmail.com
+ */
+public class XChromeLoggerDataInfoLeakScanner extends PluginPassiveScanner{
+
+	private static final String MESSAGE_PREFIX = "pscanalpha.xchromeloggerdata.";
+	private static final int PLUGIN_ID = 10052;
+	
+	private PassiveScanThread parent = null;
+	private static final Logger logger = Logger.getLogger(XChromeLoggerDataInfoLeakScanner.class);
+	
+	@Override
+	public void setParent(PassiveScanThread parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public void scanHttpRequestSend(HttpMessage msg, int id) {
+		// Only checking the response for this plugin
+	}
+	
+	@Override
+	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+		long start = System.currentTimeMillis();
+
+		Vector<String> xcldHeader = msg.getResponseHeader().getHeaders("X-ChromeLogger-Data"); //Get the header(s)
+		Vector<String> xcpdHeader = msg.getResponseHeader().getHeaders("X-ChromePhp-Data"); //Add any header(s) using the alternate name
+		
+		List<String> loggerHeaders = new ArrayList<String>(2);
+		
+		if(xcldHeader != null && !xcldHeader.isEmpty()) {
+			loggerHeaders.addAll(xcldHeader);
+		}
+		if(xcpdHeader !=null && !xcpdHeader.isEmpty()) {
+			loggerHeaders.addAll(xcpdHeader);
+		}
+
+		if (!loggerHeaders.isEmpty()) { //Header(s) Found
+			for (String xcldField : loggerHeaders) {
+					Alert alert = new Alert(getPluginId(), Alert.RISK_MEDIUM, Alert.CONFIDENCE_HIGH, //PluginID, Risk, Reliability
+						getName()); 
+		    			alert.setDetail(
+		    					getDescription(), //Description
+		    					msg.getRequestHeader().getURI().toString(), //URI
+		    					"",	// Param
+		    					"", // Attack
+		    					getOtherInfo(xcldField), // Other info
+		    					getSolution(), //Solution
+		    					getReference(), //References
+		    					xcldField,	// Evidence 
+		    					200, // CWE Id 
+		    					13,	// WASC Id 
+		    					msg); //HttpMessage
+		    		parent.raiseAlert(id, alert);
+				}
+			}
+	    	if (logger.isDebugEnabled()) {
+	    		logger.debug("\tScan of record " + id + " took " + (System.currentTimeMillis() - start) + " ms");
+	    	}
+	}
+
+	@Override
+	public int getPluginId() {
+		return PLUGIN_ID;
+	}
+	
+	@Override
+	public String getName() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "name");
+	}
+	
+	private String getDescription() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+	}
+
+	private String getSolution() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+	}
+
+	private String getReference() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+	}
+	
+	private String getOtherInfo(String headerValue) {
+		try {
+    		byte[] decodedByteArray = Base64.decode(headerValue);
+            return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.msg") + "\n" + new String(decodedByteArray, StandardCharsets.UTF_8);
+		} catch (IOException e) {
+            return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.error") + " " + headerValue;
+		}
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,13 +1,12 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>7</version>
+	<version>8</version>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-		ImageLocationScanner detects more GPS tag varieties, scans png & tiff files, adds i18n.<br>
-		Fix exception when scanning with "Base64 Disclosure" (Issue 2037).
+		Add passive scanner to identify info leaks via X-ChromeLogger-Data or X-ChromePhp-Data.
 	]]>
 	</changes>
 	<extensions>
@@ -40,6 +39,7 @@
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.UserControlledJavascriptEventScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.UserControlledOpenRedirectScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XBackendServerInformationLeak</pscanrule>
+		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XChromeLoggerDataInfoLeakScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XPoweredByHeaderInfoLeakScanner</pscanrule>
 	</pscanrules>
 	<filters/>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -202,3 +202,10 @@ pscanalpha.imagelocationscanner.alertDetailPrefix = This image contains the foll
 pscanalpha.imagelocationscanner.desc = The image was found to contain embedded location information, such as GPS coordinates.  Depending on the context of the image in the website, this information may expose private details of the users of a site.  For example, a site that allows users to upload profile pictures taken in the home may expose the home's address.  
 pscanalpha.imagelocationscanner.refs = http://www.veggiespam.com/ils/
 pscanalpha.imagelecationscanner.soln = Before allowing images to be stored on the server and/or transmitted to the browser, strip out the embedded location information from image.  This could mean removing all Exif data or just the GPS component.
+
+pscanalpha.xchromeloggerdata.name=X-ChromeLogger-Data Header Information Leak
+pscanalpha.xchromeloggerdata.desc=The server is leaking information through the X-ChromeLogger-Data (or X-ChromePhp-Date) response header. The content of such headers can be customized by the developer, however it is not uncommon to find: server file system locations, vhost declarations, etc.
+pscanalpha.xchromeloggerdata.refs=https://craig.is/writing/chrome-logger
+pscanalpha.xchromeloggerdata.soln=Disable this functionality in Production when it might leak information that could be leveraged by an attacker. Alternatively ensure that use of the functionality is tied to a strong authorization check and only available to administrators or support personnel for troubleshooting purposes not general users.
+pscanalpha.xchromeloggerdata.otherinfo.msg=The following represents an attempt to base64 decode the value:
+pscanalpha.xchromeloggerdata.otherinfo.error=Header value could not be base64 decoded:

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -138,5 +138,8 @@ This checks response headers for the presence of X-Backend-Server details.
 This check predicts the size of various redirect type responses and generates an alert if the response is greater than the predicted size. 
 A large redirect response may indicate that although a redirect has taken place the page actually contained content (which may reveal sensitive information, PII, etc).
 
+<H2>X-ChromeLogger-Data Header Information Leak</H2>
+This checks response headers for the presence of X-ChromeLogger-Data or X-ChromePhp-Data details.
+
 </BODY>
 </HTML>


### PR DESCRIPTION
Add new passive scanner to detect the presence of the response headers
X-ChromeLogger-Data or X-ChromePhp-Data which may leak server,
infrastructure, or code details which an attacker may leverage to
further abuse the system.