### PR TITLE
customreport: allow to dynamically update/uninstall the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
+++ b/src/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
@@ -84,6 +84,21 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
 
         }
 
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+
+        if (optionDialog != null) {
+            optionDialog.dispose();
+            optionDialog = null;
+        }
+    }
+
         private ZapMenuItem getMenuCustomHtmlReport() {
         if (menuCustomHtmlReport == null) {
                 menuCustomHtmlReport = new ZapMenuItem( "menu.report.html.generate" );
@@ -91,6 +106,10 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
                 menuCustomHtmlReport.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
+                    if (optionDialog != null) {
+                        optionDialog.requestFocusInWindow();
+                        return;
+                    }
                 	getNewOptionFrame();
                 	optionDialog.setVisible(true);
                 	optionDialog.centerFrame();
@@ -124,7 +143,7 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
             ReportLastScan report = new ReportLastScan();
             
 		    report.generateReport(this.getView(), this.getModel(), this  );
-		    this.optionDialog.setVisible( false );
+		    this.emitFrame();
         }
 
 		private ScopePanel getScopeTab(){
@@ -218,6 +237,8 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
 
 		public void emitFrame() {
 			optionDialog.setVisible(false);
+			optionDialog.dispose();
+			optionDialog = null;
 		}
 		
 }

--- a/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
@@ -1,10 +1,14 @@
 <zapaddon>
         <name>CustomReport</name>
-        <version>1</version>
+        <version>2</version>
         <description>New HTML report module allows users to customize report content.</description>
         <author>Chienli Ma</author>
         <url></url>
-        <changes></changes>
+        <changes>
+        <![CDATA[
+        Allow to update/uninstall the add-on without restarting ZAP.<br>
+        ]]>
+        </changes>
         <dependson/>
         <extensions>
                 <extension>org.zaproxy.zap.extension.customreport.ExtensionCustomReport</extension>


### PR DESCRIPTION
Change class ExtensionCustomReport to declare that it can be dynamically
unloaded and on unloading close/dispose the "Generate report" dialogue.
Also, change to not create/show another dialogue if one is already open.
Bump version and update changes in ZapAddOn.xml file.