### PR TITLE
revisit: unload extension and reset revisit state on session changes

### DIFF
--- a/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
@@ -1,10 +1,14 @@
 <zapaddon>
 	<name>Revisit</name>
-	<version>1</version>
+	<version>2</version>
 	<description>Revisit a site at any time in the past using the session history</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>First version</changes>
+	<changes>
+	<![CDATA[
+	Allow to update/uninstall the add-on without restarting ZAP.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.revisit.ExtensionRevisit</extension>
 	</extensions>


### PR DESCRIPTION
Change class ExtensionRevisit to declare that it can be dynamically
unloaded, allowing to dynamically update/uninstall the add-on, and on
unloading remove the RevisitAPI, close/dispose the "revisit setup"
dialogue and remove icons added to Sites tree. Also, change to reset
the revisit state when creating/loading the session and to declare its
dependencies.
Bump version and update changes in ZapAddOn.xml file.