### PR TITLE
spiderAjax: change AjaxSpiderParam to clone its configuration

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -22,7 +22,9 @@ package org.zaproxy.zap.extension.spiderAjax;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.configuration.FileConfiguration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.log4j.Logger;
 import org.zaproxy.zap.common.VersionedAbstractParam;
@@ -278,6 +280,19 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
             // Remove old version element, from now on the version is saved as an attribute of root element
             getConfig().clearProperty(OLD_CONFIG_VERSION_KEY);
         }
+    }
+
+    // TODO remove the override once AbstractParam is released with the clone method fixed (see Issue 2151).
+    @Override
+    public AjaxSpiderParam clone() {
+        try {
+            AjaxSpiderParam clone = new AjaxSpiderParam();
+            clone.load((FileConfiguration) ConfigurationUtils.cloneConfiguration(getConfig()));
+            return clone;
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+        }
+        return null;
     }
 
     public int getNumberOfBrowsers() {

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -1,12 +1,12 @@
 <zapaddon>
 	<name>Ajax Spider</name>
-	<version>14</version>
+	<version>15</version>
 	<description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
-	Issue 2102: Allow ajax spider options to be set via the API.<br>
+	Fix issue that prevented the spider from clicking all elements set in the options (Issue 2151).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Apply the fix done to core class AbstractParam (that fixes its clone
method by cloning the configuration) so that the AJAX Spider add-on can
be fixed without waiting for a core release.
Bump version and update changes in ZapAddOn.xml file.
Related to zaproxy/zaproxy#2151 - AJAX Spider does not click all
elements set in the options