### PR TITLE
Add add-on status to ZapAddOn.xml

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Active scanner rules</name>
 	<version>23</version>
+	<status>release</status>
 	<description>The release quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>

--- a/src/org/zaproxy/zap/extension/coreLang/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/coreLang/ZapAddOn.xml
@@ -4,6 +4,7 @@
 	<description>Translations of the core language files</description>
 	<author>ZAP Dev Team</author>
 	<version>9</version>
+	<status>release</status>
 	<url>https://crowdin.com/project/owasp-zap</url>
 	<changes>Updated for 2.4.3</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/directorylistv1/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv1/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Directory List v1.0</name>
 	<version>3</version>
+	<status>release</status>
 	<description>List of directory names to be used with "Forced Browse" add-on.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://owasp.org/index.php/DirBuster</url>

--- a/src/org/zaproxy/zap/extension/directorylistv2_3/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv2_3/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Directory List v2.3</name>
 	<version>3</version>
+	<status>release</status>
 	<description>Lists of directory names to be used with "Forced Browse" add-on.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://owasp.org/index.php/DirBuster</url>

--- a/src/org/zaproxy/zap/extension/directorylistv2_3_lc/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv2_3_lc/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Directory List v2.3 LC</name>
 	<version>3</version>
+	<status>release</status>
 	<description>Lists of lower case directory names to be used with "Forced Browse" add-on.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://owasp.org/index.php/DirBuster</url>

--- a/src/org/zaproxy/zap/extension/fuzzdb/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzzdb/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Fuzzdb files</name>
 	<version>3</version>
+	<status>release</status>
 	<description>Fuzzdb v1.09 files which can be used with the ZAP fuzzer</description>
 	<author>ZAP Dev Team</author>
 	<url>http://code.google.com/p/fuzzdb/</url>

--- a/src/org/zaproxy/zap/extension/gettingStarted/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/gettingStarted/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Getting Started with ZAP Guide</name>
 	<version>4</version>
+	<status>release</status>
 	<description>A short Getting Started with ZAP Guide</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/help/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Help - English</name>
 	<version>5</version>
+	<status>release</status>
 	<description>English (master) version of the ZAP help file.</description>
 	<author>ZAP Crowdin Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpIntro</url>

--- a/src/org/zaproxy/zap/extension/help_pt_BR/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_pt_BR/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Help - Portuguese, Brazilian</name>
 	<version>5</version>
+	<status>release</status>
 	<description>Portuguese, Brazilian version of the ZAP help file.</description>
 	<author>ZAP Crowdin Team</author>
 	<url>https://crowdin.com/project/owasp-zap-help</url>

--- a/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Online menus</name>
 	<version>4</version>
+	<status>release</status>
 	<description>ZAP Online menu items</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsOnlineMenuOnlineMenu</url>

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Passive scanner rules</name>
 	<version>16</version>
+	<status>release</status>
 	<description>The release quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Quick Start</name>
 	<version>17</version>
+	<status>release</status>
 	<description>Provides a tab which allows you to quickly test a target application</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Reveal</name>
 	<version>2</version>
+	<status>release</status>
 	<description>Show hidden fields and enable disabled fields</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/saverawmessage/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saverawmessage/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Save Raw Message</name>
 	<version>2</version>
+	<status>release</status>
 	<description>Allows to save content of HTTP messages as binary</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -2,6 +2,7 @@
 	<name>Selenium</name>
 	<version>4</version>
 	<semver>1.0.0</semver><!-- This version should be kept in sync with the one of the extension. -->
+	<status>release</status>
 	<description>WebDriver provider and includes HtmlUnit browser</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Ajax Spider</name>
 	<version>15</version>
+	<status>release</status>
 	<description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>WebSockets</name>
 	<version>10</version>
+	<status>release</status>
 	<description>Allows you to inspect WebSocket communication.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>


### PR DESCRIPTION
The change allows to have all add-ons (alpha, beta and release) in a
single branch.
Note: the build system does not yet use that information.