### PR TITLE
Add add-on status to ZapAddOn.xml (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Access Control Testing</name>
 	<version>1</version>
+	<status>alpha</status>
 	<description>Adds a set of tools for testing access control in web applications.</description>
 	<author>ZAP Dev Team</author>
 	<url />

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>context Alert Filters</name>
 	<version>1</version>
+	<status>alpha</status>
 	<description>Allows you to automate the changing of alert risk levels</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/amf/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/amf/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
     <name>AMF</name>
     <version>1</version>
+    <status>alpha</status>
     <description>Adds support for AMF messages</description>
     <author>ZAP Dev Team</author>
     <url/>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Active scanner rules (alpha)</name>
 	<version>16</version>
+	<status>alpha</status>
 	<description>The alpha quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>

--- a/src/org/zaproxy/zap/extension/birtreports/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/birtreports/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
         <name>birtreports</name>
         <version>2</version>
+        <status>alpha</status>
         <description>Alert reports using BIRT report API</description>
         <author>Johanna Curiel And Rauf Butt</author>
         <url/>

--- a/src/org/zaproxy/zap/extension/browserView/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/browserView/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Browser View</name>
 	<version>4</version>
+	<status>alpha</status>
 	<description>Adds an option to render HTML responses like a browser</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/callgraph/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/callgraph/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Call Graph</name>
 	<version>3</version>
+	<status>alpha</status>
 	<description>Allows the user to view a call graph of the selected resources</description>
 	<author>Colm O'Flaherty</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>WAFP Extension</name>
 	<version>1</version>
+	<status>alpha</status>
 	<description>Fingerprint web applications</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy</url>

--- a/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Code Dx Extension</name>
 	<version>3</version>
+	<status>alpha</status>
 	<description>includes request and response data in xml reports</description>
 	<author>Code Dx, Inc.</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
         <name>CustomReport</name>
         <version>2</version>
+        <status>alpha</status>
         <description>New HTML report module allows users to customize report content.</description>
         <author>Chienli Ma</author>
         <url></url>

--- a/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>DOM XSS Active scanner rule</name>
 	<version>2</version>
+	<status>alpha</status>
 	<description>DOM XSS Active scanner rule</description>
 	<author>ZAP Dev Team</author>
 	<url/>

--- a/src/org/zaproxy/zap/extension/help_bs_BA/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_bs_BA/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Help - Bosnian</name>
 	<version>4</version>
+	<status>alpha</status>
 	<description>Bosnian version of the ZAP help file.</description>
 	<author>ZAP Crowdin Team</author>
 	<url>https://crowdin.com/project/owasp-zap-help</url>

--- a/src/org/zaproxy/zap/extension/help_es_ES/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_es_ES/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Help - Spanish</name>
 	<version>4</version>
+	<status>alpha</status>
 	<description>Spanish version of the ZAP help file.</description>
 	<author>ZAP Crowdin Team</author>
 	<url>https://crowdin.com/project/owasp-zap-help</url>

--- a/src/org/zaproxy/zap/extension/help_fr_FR/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_fr_FR/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Help - French</name>
 	<version>4</version>
+	<status>alpha</status>
 	<description>French version of the ZAP help file.</description>
 	<author>ZAP Crowdin Team</author>
 	<url>https://crowdin.com/project/owasp-zap-help</url>

--- a/src/org/zaproxy/zap/extension/help_ja_JP/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_ja_JP/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Help - Japanese</name>
 	<version>4</version>
+	<status>alpha</status>
 	<description>Japanese version of the ZAP help file.</description>
 	<author>ZAP Crowdin Team</author>
 	<url>https://crowdin.com/project/owasp-zap-help</url>

--- a/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Highlighter</name>
 	<version>6</version>
+	<status>alpha</status>
 	<description>Allows you to highlight strings in the request and response tabs.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/httpsInfo/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/httpsInfo/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>HttpsInfo</name>
 	<version>7</version>
+	<status>alpha</status>
 	<description>Adds Https status information</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Log File Importer</name>
 	<version>3</version>
+	<status>alpha</status>
 	<description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
 	<version>8</version>
+	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>

--- a/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Revisit</name>
 	<version>2</version>
+	<status>alpha</status>
 	<description>Revisit a site at any time in the past using the session history</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
     <name>SAML Extension</name>
     <version>4</version>
+    <status>alpha</status>
     <description>Detect, Show, Edit, Fuzz SAML requests</description>
     <author>ZAP Dev Team</author>
     <url>https://github.com/zaproxy/zaproxy</url>

--- a/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Sequence</name>
 	<version>2</version>
+	<status>alpha</status>
 	<description>Gives the possibility of defining a sequence of requests to be scanned.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Simple Example</name>
 	<version>1</version>
+	<status>alpha</status>
 	<description>A simple extension example.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/sniTerminator/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sniTerminator/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>SNI Terminator</name>
 	<version>3</version>
+	<status>alpha</status>
 	<description>Transparent HTTP proxying</description>
 	<author>ZAP Dev Team</author>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>SOAP Scanner</name>
 	<version>2</version>
+	<status>alpha</status>
 	<description>Imports and scans WSDL files containing SOAP endpoints.</description>
 	<author>Alberto (albertov91)</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Server-Sent Events</name>
 	<version>8</version>
+	<status>alpha</status>
 	<description>Allows you to view Server-Sent Events (SSE) communication.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>VulnCheck Extension</name>
 	<version>1</version>
+	<status>alpha</status>
 	<description>list vulnerabilities from known databases </description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy</url>

--- a/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Technology detection using Wappalyzer</name>
 	<version>5</version>
+	<status>alpha</status>
 	<description>Technology detection using Wappalyzer: wappalyzer.com</description>
 	<author>ZAP Dev Team</author>
 	<url></url>

--- a/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
@@ -1,6 +1,7 @@
 <zapaddon>
 	<name>Wavsep report generator</name>
 	<version>1</version>
+	<status>alpha</status>
 	<description>Wavsep report generator.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>


### PR DESCRIPTION
The change allows to have all add-ons (alpha, beta and release) in a
single branch.
Note: the build system does not yet use that information.