### PR TITLE
accessControl: fix NullPointerException in AccessControlStatusPanel

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>Access Control Testing</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>Adds a set of tools for testing access control in web applications.</description>
 	<author>ZAP Dev Team</author>
 	<url />
-	<changes>Initial version</changes>
+	<changes>
+	<![CDATA[
+	Fix an exception when cancelling the "Save" access control report dialogue.<br>
+	]]> 
+	</changes>
 	<dependson />
 	<extensions>
 		<extension>org.zaproxy.zap.extension.accessControl.ExtensionAccessControl</extension>

--- a/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
+++ b/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
@@ -230,14 +230,16 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel imp
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					File targetFile = selectReportLocation();
+					if (targetFile == null) {
+						return;
+					}
+
 					File generatedFile = null;
-					if (targetFile != null) {
-						try {
-							generatedFile = extension.generateAccessControlReport(getSelectedContext()
-									.getIndex(), targetFile);
-						} catch (ParserConfigurationException e1) {
-							e1.printStackTrace();
-						}
+					try {
+						generatedFile = extension.generateAccessControlReport(getSelectedContext()
+								.getIndex(), targetFile);
+					} catch (ParserConfigurationException e1) {
+						log.error("Failed to generate access control report:", e1);
 					}
 					// Check if the generation was OK
 					if (generatedFile == null) {


### PR DESCRIPTION
Change AccessControlStatusPanel to return immediately when the user
cancels the "Save" dialogue (for the access control report), otherwise
the not selected (null) file would be used in an error message (which
assumed that the report was generated but failed) leading to the
exception. Also, log the exception if it's not possible to create the
XML document during generation of the report (instead of print it to
standard output).
Bump version and update changes in ZapAddOn.xml file.