### PR TITLE
pscanrulesAlpha: fix NullPointerException in ImageLocationScanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
@@ -89,6 +89,9 @@ public class ImageLocationScanner extends PluginPassiveScanner {
         String fileName;
 		try {
 			fileName = uri.getName();
+			if (fileName == null) {
+				fileName = "";
+			}
 		} catch (URIException e) {
 			// e.printStackTrace();
 			// If we cannot decode the URL, then just set filename to empty.

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 		Add CWE and WASC IDs to passive scanners which may have been lacking those details.<br>
 		Fix exception when scanning with "User Controllable Charset" scanner.<br>
+		Fix exception when scanning with "Image Location Scanner" scanner.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ImageLocationScanner to initialise the "fileName" with an empty
string if it does not exist (that is, when URI path component does not
exist), which would lead to a NullPointerException when attempting to
extract the extension.
Bump version and update changes in ZapAddOn.xml file.