### PR TITLE
pscanrulesAlpha: fix a NPE in UserControlledCharsetScanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCharsetScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCharsetScanner.java
@@ -111,6 +111,9 @@ public class UserControlledCharsetScanner extends PluginPassiveScanner {
 			}
 			
 			String bodyContentCharset = getBodyContentCharset(bodyContentType);
+			if (bodyContentCharset == null) {
+				continue;
+			}
 	        for (HtmlParameter param: params) {        	        	
 	            if (bodyContentCharset.equalsIgnoreCase(param.getValue())) {
 	            	raiseAlert(msg, id, "META", "Content-Type", param, bodyContentCharset);

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 		Add CWE and WASC IDs to passive scanners which may have been lacking those details.<br>
+		Fix exception when scanning with "User Controllable Charset" scanner.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change UserControlledCharsetScanner to skip meta elements that specify
the content type but not a charset (thus null), which would lead to a
NullPointerException when attempting to compare the charset with the
values of the parameters.
Update changes in ZapAddOn.xml file.