### PR TITLE
zest: fix NullPointerException in OptionsZestIgnoreHeadersTableModel

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/OptionsZestIgnoreHeadersTableModel.java
+++ b/src/org/zaproxy/zap/extension/zest/OptionsZestIgnoreHeadersTableModel.java
@@ -36,8 +36,8 @@ public class OptionsZestIgnoreHeadersTableModel extends AbstractTableModel {
 				Constant.messages.getString("zest.options.label.ignore"),
 				Constant.messages.getString("zest.options.label.header")};
     
-    private List<String> allHeaders = null;
-    private List<String> ignoredHeaders = null;
+    private List<String> allHeaders = Collections.emptyList();
+    private List<String> ignoredHeaders = Collections.emptyList();
     
     /**
      * 

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Add missing field (operand B) in 'Assign variable to a calculation' dialogue.<br>
 	Send authentication requests with ZAP's configurations (Issue 2114).<br>
 	Fix "Active scan sequence" (Issue 2120).<br>
+	Fix exception while opening a dialogue.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change OptionsZestIgnoreHeadersTableModel to initialise the instance
variables "allHeaders" and "ignoredHeaders", with an empty list,
preventing, with the former, the EDT from failing to query its number of
rows (when validating the Component tree).
Update changes in ZapAddOn.xml file.

--
Issue reported in OWASP ZAP User Group: https://groups.google.com/d/msg/zaproxy-users/SMsOOxUUBGw/3m_PJz1lBAAJ