### PR TITLE
ascanrules: reduce log level from INFO to DEBUG (and TRACE to DEBUG)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
@@ -229,8 +229,8 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
             HttpMessage msg = getNewMsg();
             setParameter(msg, paramName, phpPayload);
 
-            if (log.isTraceEnabled()) {
-                log.trace("Testing [" + paramName + "] = [" + phpPayload + "]");
+            if (log.isDebugEnabled()) {
+                log.debug("Testing [" + paramName + "] = [" + phpPayload + "]");
             }
             
             try {
@@ -241,8 +241,10 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
                 if (msg.getResponseBody().toString().contains(PHP_CONTROL_TOKEN)) {
                     // We Found IT!                     
                     // First do logging
-                    log.info("[PHP Code Injection Found] on parameter [" + paramName 
-                            + "] with payload [" + phpPayload + "]");
+                    if (log.isDebugEnabled()) {
+                        log.debug("[PHP Code Injection Found] on parameter [" + paramName 
+                                + "] with payload [" + phpPayload + "]");
+                    }
                     
                     // Now create the alert message
                     this.bingo(
@@ -297,8 +299,8 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
             HttpMessage msg = getNewMsg();
             setParameter(msg, paramName, MessageFormat.format(aspPayload, bignum1, bignum2));
             
-            if (log.isTraceEnabled()) {
-                log.trace("Testing [" + paramName + "] = [" + aspPayload + "]");
+            if (log.isDebugEnabled()) {
+                log.debug("Testing [" + paramName + "] = [" + aspPayload + "]");
             }
 
             try {
@@ -309,8 +311,10 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
                 if (msg.getResponseBody().toString().contains(Integer.toString(bignum1*bignum2))) {
                     // We Found IT!
                     // First do logging
-                    log.info("[ASP Code Injection Found] on parameter [" + paramName 
-                            + "]  with payload [" + aspPayload + "]");
+                    if (log.isDebugEnabled()) {
+                        log.debug("[ASP Code Injection Found] on parameter [" + paramName 
+                                + "]  with payload [" + aspPayload + "]");
+                    }
                     
                     // Now create the alert message
                     this.bingo(

--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -411,7 +411,9 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
                 if (matcher.find()) {
                     // We Found IT!                    
                     // First do logging
-                    log.info("[OS Command Injection Found] on parameter [" + paramName + "] with value [" + paramValue + "]");
+                    if (log.isDebugEnabled()) {
+                        log.debug("[OS Command Injection Found] on parameter [" + paramName + "] with value [" + paramValue + "]");
+                    }
                     
                     // Now create the alert message
                     this.bingo(
@@ -484,7 +486,9 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
                     
                     // We Found IT!                    
                     // First do logging
-                    log.info("[Blind OS Command Injection Found] on parameter [" + paramName + "] with value [" + paramValue + "]");
+                    if (log.isDebugEnabled()) {
+                        log.debug("[Blind OS Command Injection Found] on parameter [" + paramName + "] with value [" + paramValue + "]");
+                    }
                     
                     // Now create the alert message
                     this.bingo(

--- a/src/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
@@ -288,9 +288,11 @@ public class TestExternalRedirect extends AbstractAppParamPlugin {
                 if (redirectType != NO_REDIRECT) {
                     // We Found IT!                    
                     // First do logging
-                    logger.info("[External Redirection Found] on parameter [" + param 
-                            + "] with payload [" + payload 
-                            + "]");
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("[External Redirection Found] on parameter [" + param 
+                                + "] with payload [" + payload 
+                                + "]");
+                    }
                     
                     // Now create the alert message
                     this.bingo(


### PR DESCRIPTION
Change scanners CodeInjectionPlugin, CommandInjectionPlugin and
TestExternalRedirect to log the messages when an alert is found with
DEBUG level instead of INFO, to reduce the number of messages logged by
default (those messages are not really needed for everyday use, the
absence or presence of an alert already indicates that fact, if an error
occurred while raising the alert it would be logged by core code with
higher level, ERROR). For CodeInjectionPlugin also change TRACE log
level messages to DEBUG, the former is not used.