### PR TITLE
ascanrules: add isStop() checks (to scanners without any check)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
@@ -25,6 +25,7 @@
 // ZAP: 2012/12/28 Issue 447: Include the evidence in the attack field
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
+// ZAP: 2016/02/02 Add isStop() checks
 package org.zaproxy.zap.extension.ascanrules;
 
 import java.util.regex.Pattern;
@@ -122,7 +123,7 @@ public class TestParameterTamper extends AbstractAppParamPlugin {
             return;
         }
 
-        for (int i = 0; i < PARAM_LIST.length; i++) {
+        for (int i = 0; i < PARAM_LIST.length && !isStop(); i++) {
             msg = getNewMsg();
             if (i == 0) {
                 // remove entire parameter when i=0;

--- a/src/org/zaproxy/zap/extension/ascanrules/TestServerSideInclude.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestServerSideInclude.java
@@ -23,11 +23,14 @@
 // ZAP: 2012/08/01 Removed the "(non-Javadoc)" comments.
 // ZAP: 2012/12/28 Issue 447: Include the evidence in the attack field
 // ZAP: 2015/07/27 Issue 1618: Target Technology Not Honored
+// ZAP: 2016/02/02 Add isStop() checks and refactor the code to reduce code duplication
 
 package org.zaproxy.zap.extension.ascanrules;
 
+import java.io.IOException;
 import java.util.regex.Pattern;
 
+import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -38,6 +41,8 @@ import org.zaproxy.zap.model.TechSet;
 
 
 public class TestServerSideInclude extends AbstractAppParamPlugin {
+
+    private static final Logger LOGGER = Logger.getLogger(TestServerSideInclude.class);
 
 	/**
 	 * Prefix for internationalised messages used by this rule
@@ -108,64 +113,60 @@ public class TestServerSideInclude extends AbstractAppParamPlugin {
     @Override
     public void scan(HttpMessage msg, String param, String value) {
         
-		StringBuilder evidence = new StringBuilder();
-
 		if (this.inScope(Tech.Linux) || this.inScope(Tech.MacOS)) {
-			try {
-				setParameter(msg, param, SSI_UNIX);
-	            sendAndReceive(msg);
-	    		//result = msg.getResponseBody().toString();
-	    		if (matchBodyPattern(msg, patternSSIUnix, evidence)) {
-	    			bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM, null, param, evidence.toString(), SSI_UNIX, msg);
-	    			return;
-	    		}
-	
-	        } catch (Exception e) {
-	        }
+			if (testServerSideInclude(param, SSI_UNIX, patternSSIUnix)) {
+				return;
+			}
 
-			try {
-			    msg = getNewMsg();
-				setParameter(msg, param, SSI_UNIX2);
-	            sendAndReceive(msg);
-	    		//result = msg.getResponseBody().toString();
-	    		if (matchBodyPattern(msg, patternSSIUnix, evidence)) {    		    
-	    			bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM, null, param, evidence.toString(), SSI_UNIX2, msg);
-	    			return;
-	    		}
-	
-	        } catch (Exception e) {
-	        }	
+			if (testServerSideInclude(param, SSI_UNIX2, patternSSIUnix)) {
+				return;
+			}
 		}
 
 		if (this.inScope(Tech.Windows)) {
-			try {
-			    msg = getNewMsg();
-				setParameter(msg, param, SSI_WIN);
-	            sendAndReceive(msg);
-	    		//result = msg.getResponseBody().toString();
-	    		if (matchBodyPattern(msg, patternSSIWin, evidence)) {    		    
-	    			bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM, null, param, evidence.toString(), SSI_WIN, msg);
-	    			return;
-	    		}
-	
-	        } catch (Exception e) {
-	        }	
-	
-			try {
-			    msg = getNewMsg();
-				setParameter(msg, param, SSI_WIN2);
-	            sendAndReceive(msg);
-	    		//result = msg.getResponseBody().toString();
-	    		if (matchBodyPattern(msg, patternSSIWin, evidence)) {    		    
-	    			bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM, null, param, evidence.toString(), SSI_WIN2, msg);
-	    			return;
-	    		}
-	
-	        } catch (Exception e) {
-	        }	
+			if (testServerSideInclude(param, SSI_WIN, patternSSIWin)) {
+				return;
+			}
+
+			if (testServerSideInclude(param, SSI_WIN2, patternSSIWin)) {
+				return;
+			}
 		}
 
 	}
+
+    /**
+     * Tests for SSI vulnerability in the give {@code parameter} with the given {@code value}.
+     *
+     * @param parameter the name of the parameter that will be used for testing SSI
+     * @param value the value of the parameter that will be used for testing SSI
+     * @param testEvidence the pattern used to assert that the test worked
+     * @return {@code true} if the test should stop, either because a vulnerability was found or the scanner was stopped,
+     *         {@code false} otherwise.
+     */
+    private boolean testServerSideInclude(String parameter, String value, Pattern testEvidence) {
+        if (isStop()) {
+            return true;
+        }
+
+        HttpMessage message = getNewMsg();
+        try {
+            setParameter(message, parameter, value);
+            sendAndReceive(message);
+
+            StringBuilder evidence = new StringBuilder();
+            if (matchBodyPattern(message, testEvidence, evidence)) {
+                bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM, null, parameter, evidence.toString(), value, message);
+                return true;
+            }
+        } catch (IOException e) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("IO exception while sending a message [URI=" + getBaseMsg().getRequestHeader().getURI()
+                              + ", parameter=" + parameter + ", value=" + value + "]:", e);
+            }
+        }
+        return false;
+    }
 
 	@Override
 	public int getRisk() {

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Issue 823 - i18n (internationalise) release active scan rules.<br>
 	Issue 2001 - Add PowerShell variants to CommandInjection Plugin.<br>
 	Add CWE and WASC IDs to active scanners which may have been lacking those details.<br>
+	Add missing skip/stop checks to some scanners (Issue 1734).<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Change classes TestCrossSiteScriptV2, TestParameterTamper,
TestPersistentXSSAttack and TestServerSideInclude to check if the
scanner was stopped/skipped, by calling isStop() method.
For class TestServerSideInclude also extracted a method to reduce code
duplication.
Update changes in ZapAddOn.xml file.
Changes for zaproxy/zaproxy#1734 - Scanners take too much time to
skip/stop