### PR TITLE
ascanrules: tweak PowerShell control pattern to reduce false positives

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -64,7 +64,7 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
     
     // PowerShell Command constants
     private static final String PS_TEST_CMD = "get-help";
-    private static final Pattern PS_CTRL_PATTERN = Pattern.compile("get-help|cmdlets|get-alias", Pattern.CASE_INSENSITIVE);
+    private static final Pattern PS_CTRL_PATTERN = Pattern.compile("(?:\\sget-help)|cmdlet|get-alias", Pattern.CASE_INSENSITIVE);
     
     // Useful if space char isn't allowed by filters
     // http://www.blackhatlibrary.net/Command_Injection


### PR DESCRIPTION
Change PowerShell pattern in CommandInjectionPlugin to require the
presence, in the response, of not only "get-help" but one of its
following tokens ("cmdlets" or "get-alias") with at least one character
in between, to reduce false positives when the attack/input ("get-help")
is simply reflected in the response.