### PR TITLE
saml: show (and internationalise) 'SAML Actions' main menu

### DIFF
--- a/src/org/zaproxy/zap/extension/saml/SAMLExtension.java
+++ b/src/org/zaproxy/zap/extension/saml/SAMLExtension.java
@@ -7,6 +7,7 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.ExtensionPopupMenu;
 import org.zaproxy.zap.extension.saml.ui.SamlExtentionSettingsUI;
+import org.zaproxy.zap.view.popup.ExtensionPopupMenuMessageContainer;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
@@ -48,7 +49,7 @@ public class SAMLExtension extends ExtensionAdaptor {
                 final SAMLProxyListener proxyListener = new SAMLProxyListener();
                 extensionHook.addProxyListener(proxyListener);
 
-                ExtensionPopupMenu samlMenu = new ExtensionPopupMenu("SAML Actions");
+                ExtensionPopupMenu samlMenu = new ExtensionPopupMenuMessageContainer(SamlI18n.getMessage("saml.popup.mainmenu"));
                 ExtensionPopupMenuItem samlResendMenuItem = new SAMLResendMenuItem(SamlI18n.getMessage("saml.popup.view_resend"));
 
                 samlMenu.add(samlResendMenuItem);

--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
     <name>SAML Extension</name>
-    <version>4</version>
+    <version>5</version>
     <status>alpha</status>
     <description>Detect, Show, Edit, Fuzz SAML requests</description>
     <author>ZAP Dev Team</author>
     <url>https://github.com/zaproxy/zaproxy</url>
-	<changes>Updated add-on's info URL.</changes>
+	<changes>
+	<![CDATA[
+	Internationalise and show 'SAML Actions' menu.<br>
+	]]>
+	</changes>
     <dependson/>
     <extensions>
         <extension>org.zaproxy.zap.extension.saml.SAMLExtension</extension>

--- a/src/org/zaproxy/zap/extension/saml/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/saml/resources/Messages.properties
@@ -1,3 +1,4 @@
+saml.popup.mainmenu=SAML Actions
 saml.popup.view_resend=View/Resend...
 saml.toolmenu.settings=SAML Settings
 


### PR DESCRIPTION
Change class SAMLExtension to use ExtensionPopupMenuMessageContainer
instead of ExtensionPopupMenu to show the main pop up menu, the former
is enabled by default for components with HTTP messages (which contain
the SAML messages). Also, internationalise the label of the menu.
Bump version and update changes in ZapAddOn.xml file.