### PR TITLE
Issue 2174 - Handle Previously Uncaught Exceptions

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionPlugin.java
@@ -18,7 +18,11 @@
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.Random;
+
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -171,8 +175,16 @@ public class ExpressionLanguageInjectionPlugin extends AbstractAppParamPlugin {
         try {
             // Set the expression value
             setParameter(msg, paramName, payload);
+            try {
             // Send the request and retrieve the response
             sendAndReceive(msg);
+            } catch (InvalidRedirectLocationException|URIException|
+            		UnknownHostException|IllegalArgumentException ex) {
+            	log.info("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+						"\n The target may have replied with a poorly formed redirect due to our input.");
+            	return;
+            }
             // Check if the resulting content contains the executed addition
             if (msg.getResponseBody().toString().contains(addedString)) {
                 // We Found IT!

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Add CWE and WASC IDs to active scanners which may have been lacking those details.<br>
 	Create help for scanners which were missing entries.<br>
 	Issue 2180: Adjust logging, and implement plugin skip if runtime requirements not met.</br>
+	Issue 2174: Adjust logging, catch specific exceptions.
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Added try/catch block around sendAndReceive for exceptions identified
via zapbot automated wavsep testing.

Fixes zaproxy/zaproxy#2174