### PR TITLE
wappalyzer: allow to dynamically update/uninstall the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -299,7 +299,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor implements SessionChan
 	
 	@Override
 	public boolean canUnload() {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
@@ -30,6 +30,7 @@ import javax.swing.JMenuItem;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
+import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 
 
 public class PopupMenuEvidence extends ExtensionPopupMenuItem {
@@ -60,12 +61,7 @@ public class PopupMenuEvidence extends ExtensionPopupMenuItem {
 
     @Override
     public boolean isEnableForComponent(Component invoker) {
-    	final List<JMenuItem> mainPopupMenuItems = View.getSingleton().getPopupList();
-    	// Remove any old submenus
-    	for (PopupMenuEvidenceSearch menu : this.subMenus) {
-			mainPopupMenuItems.remove(menu);
-    	}
-    	this.subMenus.clear();
+        clearSubMenus();
     	
         if (invoker.getName() != null && invoker.getName().equals(TechPanel.PANEL_NAME)) {
             Application app = extension.getSelectedApp();
@@ -89,6 +85,15 @@ public class PopupMenuEvidence extends ExtensionPopupMenuItem {
         }
         return false;
     }
+
+    private void clearSubMenus() {
+        final List<JMenuItem> mainPopupMenuItems = View.getSingleton().getPopupList();
+        // Remove any old submenus
+        for (PopupMenuEvidenceSearch menu : this.subMenus) {
+            mainPopupMenuItems.remove(menu);
+        }
+        this.subMenus.clear();
+    }
     
     private void addSubMenu(String label, Pattern p, ExtensionSearch.Type type) {
     	// TODO add prefix for pattern types?
@@ -97,6 +102,11 @@ public class PopupMenuEvidence extends ExtensionPopupMenuItem {
 		menu.setMenuIndex(this.getMenuIndex());
 		View.getSingleton().getPopupList().add(menu);
 		this.subMenus.add(menu);
+    }
+
+    @Override
+    public void dismissed(ExtensionPopupMenuComponent selectedMenuComponent) {
+        clearSubMenus();
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>Technology detection using Wappalyzer</name>
-	<version>6</version>
+	<version>7</version>
 	<status>alpha</status>
 	<description>Technology detection using Wappalyzer: wappalyzer.com</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for latest wappalyzer data.</changes>
+	<changes>
+	<![CDATA[
+	Allow to update/uninstall the add-on without restarting ZAP.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.wappalyzer.ExtensionWappalyzer</extension>
 	</extensions>


### PR DESCRIPTION
Change class ExtensionWappalyzer to declare that it can be dynamically
unloaded and change class PopupMenuEvidence to remove its sub menus from
the list of the main pop up menu once the menu is dismissed (otherwise
it would prevent the objects of the add-on from being GC'ed after it has
been unloaded).
Bump version and update changes in ZapAddOn.xml file.