### PR TITLE
sequence: tidy up, dynamic unload, finish internationalisation

### DIFF
--- a/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
@@ -1,11 +1,16 @@
 <zapaddon>
 	<name>Sequence</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>Gives the possibility of defining a sequence of requests to be scanned.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated to latest core changes.</changes>
+	<changes>
+	<![CDATA[
+	Allow to dynamically unload the add-on.<br>
+	Other code changes.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.sequence.ExtensionSequence</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/sequence/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/sequence/resources/Messages.properties
@@ -2,9 +2,11 @@
 #
 # This file defines the default (English) variants of all of the internationalised messages
 
+sequence.custom.tab.description = Sequences are defined as scripts.
 sequence.custom.tab.deselectall.label	= Deselect all Sequence Scripts
 sequence.custom.tab.selectall.label		= Select all Sequence Scripts
 sequence.custom.tab.title				= Sequence
 sequence.custom.tab.name.header			= Script name
 sequence.custom.tab.inc.header			= Include in scan
-sequence.custom.tab.script.header		= Script
+sequence.popupmenuitem.activeScanSequence = Active scan sequence
+sequence.popupmenuitem.script.error.interface = The selected Sequence script ({0}) does not implement the required interface.\nPlease take a look at the provided templates for examples.


### PR DESCRIPTION
Allow to dynamically update/uninstall the add-on (just missing the
declaration that it can be unloaded and the removal of the script type).
Declare its (hard) dependencies (ExtensionScript).
Finish internationalisation (some strings that were not yet
internationalised and remove one that was but was not being shown in the
GUI).
Remove hidden column by implementing a custom TableModel, to show the
scripts available in the "Sequence" panel.
Verify and warn if the scripts do not implement SequenceScript
interface.
Initialise view components only when ZAP has a view.
Remove unnecessary type arguments, casts and null checks.
Bump version and update changes in ZapAddOn.xml file.