### PR TITLE
sqliplugin: internationalisation, reduce log level and add stop check

### DIFF
--- a/src/org/zaproxy/zap/extension/sqliplugin/ExtensionSQLiPlugin.java
+++ b/src/org/zaproxy/zap/extension/sqliplugin/ExtensionSQLiPlugin.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.sqliplugin;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+
+/**
+ * A helper extension to force the load, done by core, of the resource messages bundled in the add-on.
+ */
+public class ExtensionSQLiPlugin extends ExtensionAdaptor {
+
+    private static final String MESSAGE_PREFIX = "sqliplugin.ext.";
+
+    public ExtensionSQLiPlugin() {
+        super();
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public String getAuthor() {
+        return "Andrea Pompili (Yhawke)";
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/sqliplugin/SQLiUnionEngine.java
+++ b/src/org/zaproxy/zap/extension/sqliplugin/SQLiUnionEngine.java
@@ -722,11 +722,13 @@ public class SQLiUnionEngine {
         int found = -1;
         
         if (orderByTest(1) && !orderByTest(new Integer(SQLiPayloadManager.randomInt()))) {
-            log.info("ORDER BY technique seems to be usable. "
-                    + "This should reduce the time needed "
-                    + "to find the right number "
-                    + "of query columns. Automatically extending the "
-                    + "range for current UNION query injection technique test");
+            if (log.isDebugEnabled()) {
+                log.debug("ORDER BY technique seems to be usable. "
+                        + "This should reduce the time needed "
+                        + "to find the right number "
+                        + "of query columns. Automatically extending the "
+                        + "range for current UNION query injection technique test");
+            }
 
             int lowCols = 1;
             int highCols = ORDER_BY_STEP;
@@ -817,7 +819,9 @@ public class SQLiUnionEngine {
         if (lowerCount == 1) {
             int found = orderByTechnique();
             if (found >= 0) {
-                log.info("target url appears to have " + found + " column in query");
+                if (log.isDebugEnabled()) {
+                    log.debug("target url appears to have " + found + " column in query");
+                }
                 return found;
             }
         }

--- a/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
@@ -1,17 +1,18 @@
 <zapaddon>
 	<name>Advanced SQLInjection Scanner</name>
-	<version>9</version>
+	<version>10</version>
 	<status>beta</status>
 	<description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
 	<author>Andrea Pompili (Yhawke)</author>
 	<url/>
 	<changes><![CDATA[
-            Split boundary and plugin definition in two different files<br>
-            Updated all plugin and boundary files to the newest SQLMap database<br>
-            Changed to target DB tecnhonolgy (Issue 1618).
+	Log level adjustements.<br>
+	Internationalisation of scanner and alert's data.<br>
+	Check for skip/stop more often.<br>
         ]]>
         </changes>
 	<extensions>
+		<extension>org.zaproxy.zap.extension.sqliplugin.ExtensionSQLiPlugin</extension>
 	</extensions>
 	<ascanrules>
 		<ascanrule>org.zaproxy.zap.extension.sqliplugin.SQLInjectionPlugin</ascanrule>

--- a/src/org/zaproxy/zap/extension/sqliplugin/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/sqliplugin/resources/Messages.properties
@@ -1,0 +1,29 @@
+
+sqliplugin.ext.name = Advanced SQL Injection
+sqliplugin.ext.desc = Helper extension for Advanced SQL Injection scanner.
+
+sqliplugin.scanner.name = Advanced SQL Injection
+sqliplugin.scanner.alert.name = Advanced SQL Injection - {0}
+sqliplugin.scanner.alert.desc = A SQL injection may be possible using the attached payload
+sqliplugin.scanner.alert.soln = Do not trust client side input, even if there is client side validation in place.\n\
+In general, type check all data on the server side.\n\
+If the application uses JDBC, use PreparedStatement or CallableStatement, with parameters passed by '?'\n\
+If the application uses ASP, use ADO Command Objects with strong type checking and parameterized queries.\n\
+If database Stored Procedures can be used, use them.\n\
+Do *not* concatenate strings into queries in the stored procedure, or use 'exec', 'exec immediate', or equivalent functionality!\n\
+Do not create dynamic SQL queries using simple string concatenation.\n\
+Escape all data received from the client.\n\
+Apply a 'whitelist' of allowed characters, or a 'blacklist' of disallowed characters in user input.\n\
+Apply the privilege of least privilege by using the least privileged database user possible.\n\
+In particular, avoid using the 'sa' or 'db-owner' database users. This does not eliminate SQL injection, but minimizes its impact.\n\
+Grant the minimum database access that is necessary for the application.
+sqliplugin.scanner.alert.info.unionbased = RDBMS [{0}] likely, given UNION-specific error message fragment for [{1}] columns\n\
+The vulnerability was detected by manipulating the parameter with an SQL ''UNION'' clause to cause a database error message to be returned and recognised.
+sqliplugin.scanner.alert.info.booleanbased = The page results were successfully manipulated using the boolean conditions [{0}] and [{1}]\n\
+The parameter value being modified was stripped from the HTML output for the purposes of the comparison.\n\
+Data was returned for the original parameter.\n\
+The vulnerability was detected by successfully restricting the data originally returned, by manipulating the parameter.
+sqliplugin.scanner.alert.info.errorbased = RDBMS [{0}] likely, given error message fragment [{1}] in HTML results.\n\
+The vulnerability was detected by manipulating the parameter to cause a database error message to be returned and recognised.
+sqliplugin.scanner.alert.info.timebased = The query time is controllable using parameter value [{0}], which caused the request to take [{1}] milliseconds, when the original unmodified query with value [{2}] took on average [{3}] milliseconds.
+sqliplugin.scanner.alert.refs = https://www.owasp.org/index.php/Top_10_2010-A1\nhttps://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet


### PR DESCRIPTION
Change scanner SQLInjectionPlugin to:
 - Internationalise the name of the scanner and data of the alerts (add
 helper extension, ExtensionSQLiPlugin, to force the load of the
 resource messages);
 - Reduce log level of messages from INFO to DEBUG (when an alert is
 raised, a parameter is not "injectable" and info about UNION tests, in
 class SQLiUnionEngine), to reduce the number of messages logged by
 default (those messages are not really needed for everyday use, the
 absence or presence of an alert already indicates that fact, if an
 error occurred while raising the alert it would be logged by core code
 with higher level, ERROR) and change TRACE log level message to DEBUG,
 the former is not used;
 - Check for skip/stop more often (before sending a message), to improve
 the time it takes to stop (changes for zaproxy/zaproxy#1734 - Scanners
 take too much time to skip/stop).

Bump version and update changes in ZapAddOn.xml file.