### PR TITLE
Handle Previously Uncaught Exceptions

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
@@ -30,6 +30,7 @@ package org.zaproxy.zap.extension.ascanrules;
 
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -127,7 +128,15 @@ public class BufferOverflow extends AbstractAppParamPlugin  {
 			msg = getNewMsg();
 			String returnAttack = randomCharacterString(2100);
 			setParameter(msg, param, returnAttack);
-			sendAndReceive(msg);
+			try {
+				sendAndReceive(msg);
+			} catch (UnknownHostException ex) {
+				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+						"\n The target may have replied with a poorly formed redirect due to our input.");
+				return; //Something went wrong no point continuing
+			}
+			
 			HttpResponseHeader requestReturn = msg.getResponseHeader();			
 			// This is where BASE baseResponseBody was you detect potential vulnerabilities in the response
     		String chkerrorheader = requestReturn.getHeadersAsString();

--- a/src/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
@@ -18,6 +18,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.text.MessageFormat;
 import java.util.Random;
 
@@ -235,7 +236,13 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
             
             try {
                 // Send the request and retrieve the response
-                sendAndReceive(msg, false);
+            	try {
+            		sendAndReceive(msg, false);
+            	} catch (SocketException ex) {
+					if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+							" when accessing: " + msg.getRequestHeader().getURI().toString());
+					continue; //Advance in the PHP payload loop, no point continuing on this payload
+				} 
                 
                 // Check if the injected content has been evaluated and printed
                 if (msg.getResponseBody().toString().contains(PHP_CONTROL_TOKEN)) {
@@ -305,8 +312,14 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
 
             try {
                 // Send the request and retrieve the response
-                sendAndReceive(msg, false);
-                
+            	try {
+            		sendAndReceive(msg, false);
+            	} catch (SocketException ex) {
+					if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+							" when accessing: " + msg.getRequestHeader().getURI().toString());
+					continue; //Advance in the ASP payload loop, no point continuing on this payload
+				}
+            	
                 // Check if the injected content has been evaluated and printed
                 if (msg.getResponseBody().toString().contains(Integer.toString(bignum1*bignum2))) {
                     // We Found IT!

--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -18,6 +18,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 import java.io.IOException;
+import java.net.SocketException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -401,7 +402,14 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
             
             try {                
                 // Send the request and retrieve the response
-                sendAndReceive(msg, false);
+                try {
+                    sendAndReceive(msg, false);
+                } catch (SocketException ex) {
+        			if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+        					" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+        					"\n The target may have replied with a poorly formed redirect due to our input.");
+        			continue; //Something went wrong, move to next payload iteration
+                }
                 elapsedTime = msg.getTimeElapsedMillis();
                 responseTimes.add(elapsedTime);
                                 
@@ -475,7 +483,14 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
             
             try {                
                 // Send the request and retrieve the response
-                sendAndReceive(msg, false);
+                try {
+                    sendAndReceive(msg, false);
+                } catch (SocketException ex) {
+        			if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+        					" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+        					"\n The target may have replied with a poorly formed redirect due to our input.");
+        			continue; //Something went wrong, move to next blind iteration
+                }
                 elapsedTime = msg.getTimeElapsedMillis();
 
                 // Check if enough time has passed                            

--- a/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
@@ -42,7 +42,9 @@
 
 package org.zaproxy.zap.extension.ascanrules;
 import java.io.IOException;
+import java.net.UnknownHostException;
 
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -152,7 +154,14 @@ public class FormatString extends AbstractAppParamPlugin  {
 			msg = getNewMsg();
 			String initialMessage = "ZAP";
 			setParameter(msg, param, initialMessage);
-			sendAndReceive(msg);
+			try {
+				sendAndReceive(msg);
+			} catch (InvalidRedirectLocationException|UnknownHostException ex) {
+				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+						"\n The target may have replied with a poorly formed redirect due to our input.");
+				return; //Something went wrong, no point continuing
+			}
 			HttpResponseBody initialResponseBody= msg.getResponseBody();
 			int initialResponseLength = initialResponseBody.length();
 		//  The following section of the code attacks GNU and generic C compiler format 
@@ -176,7 +185,14 @@ public class FormatString extends AbstractAppParamPlugin  {
 
 			msg = getNewMsg();
 			setParameter(msg, param, initialAttackMessage);
-			sendAndReceive(msg);
+			try {
+				sendAndReceive(msg);
+			} catch (InvalidRedirectLocationException|UnknownHostException ex) {
+				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+						"\n The target may have replied with a poorly formed redirect due to our input.");
+				return; //Something went wrong, no point continuing
+			}
      		if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)
     		{
     			String secondAttackMessage ;	
@@ -191,8 +207,15 @@ public class FormatString extends AbstractAppParamPlugin  {
 
     			msg = getNewMsg();
     			setParameter(msg, param, secondAttackMessage);
-    			sendAndReceive(msg);
-         		HttpResponseBody secondAttackResponseBody= msg.getResponseBody();
+    			try {
+    				sendAndReceive(msg);
+    			} catch (InvalidRedirectLocationException|UnknownHostException ex) {
+    				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+    						" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+    						"\n The target may have replied with a poorly formed redirect due to our input.");
+    				return; //Something went wrong, no point continuing
+    			}         		
+    			HttpResponseBody secondAttackResponseBody= msg.getResponseBody();
     			if (secondAttackResponseBody.length() > initialResponseLength + 20 && msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK){
     				bingo(getRisk(), 
     						Alert.CONFIDENCE_MEDIUM, 
@@ -242,7 +265,14 @@ public class FormatString extends AbstractAppParamPlugin  {
 			String microsoftAttackMessage = sb2.toString();
 			msg = getNewMsg();
 			setParameter(msg, param, microsoftAttackMessage);
-			sendAndReceive(msg);
+			try {
+				sendAndReceive(msg);
+			} catch (InvalidRedirectLocationException|UnknownHostException ex) {
+				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+						"\n The target may have replied with a poorly formed redirect due to our input.");
+				return; //Something went wrong, no point continuing
+			}			
 			if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)
 			{
 				bingo(getRisk(), 

--- a/src/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
@@ -28,8 +28,12 @@
 // ZAP: 2016/02/02 Add isStop() checks
 package org.zaproxy.zap.extension.ascanrules;
 
+import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.regex.Pattern;
 
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -113,7 +117,12 @@ public class TestParameterTamper extends AbstractAppParamPlugin {
 
         try {
             sendAndReceive(normalMsg);
-        } catch (Exception e) {
+        } catch (InvalidRedirectLocationException|SocketException|IllegalStateException|IllegalArgumentException|URIException|UnknownHostException ex) {
+			if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+					" when accessing: " + normalMsg.getRequestHeader().getURI().toString() + 
+					"\n The target may have replied with a poorly formed redirect due to our input.");
+			return; //Something went wrong, no point continuing
+		} catch (Exception e) {
             // ZAP: Log exceptions
             log.warn(e.getMessage(), e);
             return;
@@ -135,11 +144,17 @@ public class TestParameterTamper extends AbstractAppParamPlugin {
 
             }
             try {
-                sendAndReceive(msg);
+            	try {
+            		sendAndReceive(msg);
+            	} catch (InvalidRedirectLocationException|SocketException|IllegalStateException|IllegalArgumentException|URIException|UnknownHostException ex) {
+        			if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+        					" when accessing: " + msg.getRequestHeader().getURI().toString() + 
+        					"\n The target may have replied with a poorly formed redirect due to our input.");
+        			continue; //Something went wrong, move on to the next item in the PARAM_LIST
+        		}
                 if (checkResult(msg, param, attack, normalMsg.getResponseBody().toString())) {
                     return;
                 }
-
             } catch (Exception e) {
                 // ZAP: Log exceptions
                 log.warn(e.getMessage(), e);

--- a/src/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
@@ -17,6 +17,7 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
+import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -208,8 +209,15 @@ public class TestRemoteFileInclude extends AbstractAppParamPlugin {
                     msg = getNewMsg();
                     setParameter(msg, param, prefix + target);
 
-                    //send the modified request, and see what we get back
-                    sendAndReceive(msg);
+                  //send the modified request, and see what we get back
+                    try {
+                    	sendAndReceive(msg);
+                    } catch (IllegalStateException|UnknownHostException ex) {
+            			if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+            					" when accessing: " + msg.getRequestHeader().getURI().toString());
+            			continue; //Something went wrong, continue to the next target in the loop
+            		} 
+                    
                     //does it match the pattern specified for that file name?
                     String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
                     matcher = REMOTE_FILE_PATTERNS[i].matcher(response);
@@ -239,7 +247,7 @@ public class TestRemoteFileInclude extends AbstractAppParamPlugin {
             }
 
         } catch (Exception e) {
-            log.error("Error scanning parameters for Path Traversal: " + e.getMessage());
+            log.error("Error scanning parameters for Path Traversal: " + e.getMessage() + " Caused by: " + e.getCause());
         }
     }
 

--- a/src/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -17,6 +17,7 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
+import java.net.SocketException;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -498,7 +499,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 					//System.out.println("Attacking [" + msg + "], parameter [" + param + "] with value ["+ sqlErrValue + "]");
 
 					//send the message with the modified parameters
-					sendAndReceive(msg1, false); //do not follow redirects
+					try {
+						sendAndReceive(msg1, false); //do not follow redirects
+					} catch (SocketException ex) {
+						if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+								" when accessing: " + msg1.getRequestHeader().getURI().toString());
+						continue; //Something went wrong, continue to the next prefixString in the loop
+					}
 					countErrorBasedRequests++;
 
 					//now check the results against each pattern in turn, to try to identify a database, or even better: a specific database.
@@ -586,7 +593,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 			//so to work around this, simply re-run the query again now at this point.
 			//Note that we are not counting this request in our max number of requests to be issued
 			refreshedmessage = getNewMsg();
-			sendAndReceive(refreshedmessage, false); //do not follow redirects
+			try {
+				sendAndReceive(refreshedmessage, false); //do not follow redirects
+			} catch (SocketException ex) {
+				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + refreshedmessage.getRequestHeader().getURI().toString());
+				return; //Something went wrong, no point continuing
+			}
 
 			//String mResBodyNormal = getBaseMsg().getResponseBody().toString();
 			mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
@@ -614,7 +627,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 					HttpMessage msg4 = getNewMsg();
 					setParameter(msg4, param, modifiedParamValue);
 
-					sendAndReceive(msg4, false); //do not follow redirects
+					try {
+						sendAndReceive(msg4, false); //do not follow redirects
+					} catch (SocketException ex) {
+						if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+								" when accessing: " + msg4.getRequestHeader().getURI().toString());
+						return; //Something went wrong, no point continuing
+					}
 					countExpressionBasedRequests++;
 
 					String modifiedExpressionOutputUnstripped = msg4.getResponseBody().toString();
@@ -642,7 +661,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 							HttpMessage msg4Confirm = getNewMsg();
 							setParameter(msg4Confirm, param, modifiedParamValueConfirm);
 
-							sendAndReceive(msg4Confirm, false); //do not follow redirects
+							try {
+								sendAndReceive(msg4Confirm, false); //do not follow redirects
+							} catch (SocketException ex) {
+								if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+										" when accessing: " + msg4Confirm.getRequestHeader().getURI().toString());
+								continue; //Something went wrong, continue to the next item in the loop
+							}
 							countExpressionBasedRequests++;
 
 							String confirmExpressionOutputUnstripped = msg4Confirm.getResponseBody().toString();
@@ -725,7 +750,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 			//so to work around this, simply re-run the query again now at this point.
 			//Note that we are not counting this request in our max number of requests to be issued
 			refreshedmessage = getNewMsg();
-			sendAndReceive(refreshedmessage, false); //do not follow redirects
+			try {
+				sendAndReceive(refreshedmessage, false); //do not follow redirects
+			} catch (SocketException ex) {
+				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + refreshedmessage.getRequestHeader().getURI().toString());
+				return; //Something went wrong, no point continuing
+			}
 
 			//String mResBodyNormal = getBaseMsg().getResponseBody().toString();
 			mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
@@ -748,7 +779,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 				setParameter(msg2, param, sqlBooleanAndTrueValue);
 
 				//send the AND with an additional TRUE statement tacked onto the end. Hopefully it will return the same results as the original (to find a vulnerability)
-				sendAndReceive(msg2, false); //do not follow redirects
+				try {
+					sendAndReceive(msg2, false); //do not follow redirects
+				} catch (SocketException ex) {
+					if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+							" when accessing: " + msg2.getRequestHeader().getURI().toString());
+					continue; //Something went wrong, continue to the next item in the loop
+				}
 				countBooleanBasedRequests++;
 
 				//String resBodyAND = msg2.getResponseBody().toString();
@@ -771,7 +808,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 
 						setParameter(msg2_and_false, param, sqlBooleanAndFalseValue);
 
-						sendAndReceive(msg2_and_false, false); //do not follow redirects
+						try {
+							sendAndReceive(msg2_and_false, false); //do not follow redirects
+						} catch (SocketException ex) {
+							if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+									" when accessing: " + msg2_and_false.getRequestHeader().getURI().toString());
+							continue; //Something went wrong, continue on to the next item in the loop
+						}
 						countBooleanBasedRequests++;
 
 						//String resBodyANDFalse = stripOff(msg2_and_false.getResponseBody().toString(), SQL_LOGIC_AND_FALSE[i]);
@@ -826,7 +869,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 							}
 							HttpMessage msg2_or_true = getNewMsg();
 							setParameter(msg2_or_true, param, orValue);
-							sendAndReceive(msg2_or_true, false); //do not follow redirects
+							try {
+								sendAndReceive(msg2_or_true, false); //do not follow redirects
+							} catch (SocketException ex) {
+								if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+										" when accessing: " + msg2_or_true.getRequestHeader().getURI().toString());
+								continue; //Something went wrong, continue on to the next item in the loop
+							}
 							countBooleanBasedRequests++;
 
 							//String resBodyORTrue = stripOff(msg2_or_true.getResponseBody().toString(), orValue);
@@ -922,7 +971,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 				String sqlBooleanAndFalseValue = origParamValue + SQL_LOGIC_AND_FALSE[i];
 
 				setParameter(msg2, param, sqlBooleanOrTrueValue);				
-				sendAndReceive(msg2, false); //do not follow redirects
+				try {
+					sendAndReceive(msg2, false); //do not follow redirects
+				} catch (SocketException ex) {
+					if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+							" when accessing: " + msg2.getRequestHeader().getURI().toString());
+					continue; //Something went wrong, continue on to the next item in the loop
+				}
 				countBooleanBasedRequests++;
 
 				String resBodyORTrueUnstripped = msg2.getResponseBody().toString();
@@ -936,7 +991,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 					//if we can also restrict it back to the original results by appending a " and 1=2", then "Winner Winner, Chicken Dinner". 
 					HttpMessage msg2_and_false = getNewMsg();
 					setParameter(msg2_and_false, param, sqlBooleanAndFalseValue);
-					sendAndReceive(msg2_and_false, false); //do not follow redirects
+					try {
+						sendAndReceive(msg2_and_false, false); //do not follow redirects
+					} catch (SocketException ex) {
+						if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+								" when accessing: " + msg2_and_false.getRequestHeader().getURI().toString());
+						continue; //Something went wrong, continue on to the next item in the loop
+					}
 					countBooleanBasedRequests++;
 
 					String resBodyANDFalseUnstripped = msg2_and_false.getResponseBody().toString();
@@ -985,7 +1046,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 				String sqlUnionValue = origParamValue + SQL_UNION_APPENDAGES[sqlUnionStringIndex];
 				setParameter(msg3, param, sqlUnionValue);
 				//send the message with the modified parameters
-				sendAndReceive(msg3, false); //do not follow redirects
+				try {
+					sendAndReceive(msg3, false); //do not follow redirects
+				} catch (SocketException ex) {
+					if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+							" when accessing: " + msg3.getRequestHeader().getURI().toString());
+					continue; //Something went wrong, continue on to the next item in the loop
+				}
 				countUnionBasedRequests++;
 
 				//now check the results.. look first for UNION specific error messages in the output that were not there in the original output
@@ -1054,7 +1121,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 			//so to work around this, simply re-run the query again now at this point.
 			//Note that we are not counting this request in our max number of requests to be issued
 			refreshedmessage = getNewMsg();
-			sendAndReceive(refreshedmessage, false); //do not follow redirects
+			try {
+				sendAndReceive(refreshedmessage, false); //do not follow redirects
+			} catch (SocketException ex) {
+				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+						" when accessing: " + refreshedmessage.getRequestHeader().getURI().toString());
+				return; //Something went wrong, no point continuing
+			}
 
 			//String mResBodyNormal = getBaseMsg().getResponseBody().toString();
 			mResBodyNormalUnstripped = refreshedmessage.getResponseBody().toString();
@@ -1068,7 +1141,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 				HttpMessage msg5 = getNewMsg();
 				setParameter(msg5, param, modifiedParamValue);
 
-				sendAndReceive(msg5, false); //do not follow redirects
+				try {
+					sendAndReceive(msg5, false); //do not follow redirects
+				} catch (SocketException ex) {
+					if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+							" when accessing: " + msg5.getRequestHeader().getURI().toString());
+					return; //Something went wrong, no point continuing
+				}
 				countOrderByBasedRequests++;
 
 				String modifiedAscendingOutputUnstripped = msg5.getResponseBody().toString();
@@ -1094,7 +1173,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 						HttpMessage msg5Confirm = getNewMsg();
 						setParameter(msg5Confirm, param, modifiedParamValueConfirm);
 
-						sendAndReceive(msg5Confirm, false); //do not follow redirects
+						try {
+							sendAndReceive(msg5Confirm, false); //do not follow redirects
+						} catch (SocketException ex) {
+							if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
+									" when accessing: " + msg5Confirm.getRequestHeader().getURI().toString());
+							continue; //Something went wrong, continue on to the next item in the loop
+						}
 						countOrderByBasedRequests++;
 
 						String confirmOrderByOutputUnstripped = msg5Confirm.getResponseBody().toString();

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -12,6 +12,15 @@
 	Add CWE and WASC IDs to active scanners which may have been lacking those details.<br>
 	Add missing skip/stop checks to some scanners (Issue 1734).<br>
 	Remote File Include FP if original title includes 'Google' (Issue 2240).<br> 
+	Issue 2264: TestPathTraversal - adjust logging, catch specific exceptions.<br>
+	Issue 2265: TestRemoteFileInclude - adjust logging, catch specific exceptions.<br>
+	Issue 2266: TestCrossSiteScriptV2 - adjust logging, catch specific exceptions.<br>
+	Issue 2267 & 1860: TestSQLInjection - adjust logging, catch specific exceptions.<br>
+	Issue 2268: CodeInjectionPlugin - adjust logging, catch specific exceptions.<br>
+	Issue 2269: BufferOverflow - adjust logging, catch specific exceptions.<br>
+	Issue 2270: FormatString - adjust logging, catch specific exceptions.<br>
+	Issue 2271: TestParameterTamper - adjust logging, catch specific exceptions.<br>
+	Issue 1550: CommandInjectionPlugin - adjust logging, catch specific exceptions.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Release scanners.

Added try/catch block around sendAndReceive for exceptions identified
via zapbot automated wavsep testing.

Fixes zaproxy/zaproxy#2264
Fixes zaproxy/zaproxy#2265
Fixes zaproxy/zaproxy#2266
Fixes zaproxy/zaproxy#2267
Fixes zaproxy/zaproxy#2268
Fixes zaproxy/zaproxy#2269
Fixes zaproxy/zaproxy#2270
Fixes zaproxy/zaproxy#2271
Fixes zaproxy/zaproxy#1860
Fixes zaproxy/zaproxy#1550