### PR TITLE
Cannot use auth script in daemon mode

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -1656,8 +1656,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 
 	@Override
 	public void scriptAdded(ScriptWrapper script, boolean display) {
-		if (View.isInitialised() && this.getExtScript().getScriptUI() != null
-				&& script.getEngineName().equals(ZestScriptEngineFactory.NAME)) {
+		if (script.getEngineName().equals(ZestScriptEngineFactory.NAME)) {
 
 			ScriptNode typeNode = this.getExtScript().getTreeModel()
 					.getTypeNode(script.getTypeName());
@@ -1682,7 +1681,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 
 			this.getZestTreeModel().addScript(parentNode, zsw);
 
-			if (display) {
+			if (display && View.isInitialised()) {
 				this.updated(parentNode);
 				this.display(zsw, parentNode, true);
 				this.dialogManager.showZestEditScriptDialog(parentNode, zsw, false);

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Send authentication requests with ZAP's configurations (Issue 2114).<br>
 	Fix "Active scan sequence" (Issue 2120).<br>
 	Fix exception while opening a dialogue.<br>
+	Cannot use auth script in daemon mode (Issue 2294).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Fixes zaproxy/zaproxy#2294  Zest: cannot use auth script in daemon mode