### PR TITLE
Add Missing Help Entries

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -11,24 +11,40 @@ Passive Scan Rules
 The following release quality passive scan rules are included in this add-on:
 
 <H2>Application Errors</H2>        
+ Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string.
  
 <H2>Cache Control</H2>
+Checks "Cache-Control" and "Pragma" response headers against general industry best practice settings for protection of sensitive content. 
 
 <H2>Content Type Missing</H2>
+Raises an alert if the response is lacking a Content-Type header or if the header exists but the value is empty.
 
-<H2>Cookie HTTP Only</H2>
+<H2>Cookie HttpOnly</H2>
+Ensures that as cookies are set they are flagged HttpOnly. The HttpOnly flag indicates to browsers that the cookie 
+being set should be acted upon by client side script (such as JavaScript).
 
 <H2>Cookie Secure Flag</H2>
+Looks for cookies set during HTTPS sessions, raises an alert for those that are set but do not include the secure flag.
+A cookie set with the secure flag will not be sent during a plain HTTP session.
 
 <H2>Cross Domain Script Inclusion</H2>
+Validates whether or not scripts are included from domains other than the domain hosting the content. 
+By looking at the "src" attributes of "script" tags in the response.
 
 <H2>Header XSS Protection</H2>
+Checks for the existence of and value/setting of the X-XSS-Protection header. 
+This response header can be used to configure a user-agent's built in reflective XSS protection.
 
 <H2>Mixed Content</H2>
+For content served via HTTPS analyse all the src attributes in the response looking for those sourced
+via plain HTTP.
 
 <H2>Password Autocomplete</H2>
+Looks for "password" type input fields and checks for the setting "autocomplete=off".
 
 <H2>Private Address Disclosure</H2>
+Checks response content for inclusion of RFC 1918 IPv4 addresses. A malicious user might leverage knowledge
+of internal addressing to perform social engineering attacks or other exploits.
 
 <H2>Session Id in URL Rewrite</H2>
 This scanner checks for the existence of session token type parameters being rewritten to the URL. 


### PR DESCRIPTION
Update pscanrules.html adding help content for numerous release quality
passive scanners that were missing descriptions.