### PR TITLE
spiderAjax: remove old options from help page

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix issue that prevented the spider from clicking all elements set in the options (Issue 2151).<br>
+	Minor update in help pages.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/options.html
@@ -33,23 +33,6 @@
 				"Selenium" add-on help pages.</td>
 			<td align="center">Firefox</td>
 		</tr>
-		<tr><td>Select ChromeDriver</td>
-			<td>This allows you to select the location of ChromeDriver. For more information
-				refer to the above Chrome Browser entry.</td>
-		<td align = "center">(None)</td>
-		</tr>
-		<tr>
-			<td>Select PhantomJS binary</td>
-			<td>This allows you to select the location of PhantomJS binary. For more
-				information refer to the above PhantomJS Browser entry.</td>
-			<td align="center">(None)</td>
-		</tr>
-		<tr>
-			<td>Select IEDriverServer</td>
-			<td>This allows you to select the location of IEDriverServer. For more information
-				refer to the above Internet Explorer Browser entry.</td>
-			<td align="center">(None)</td>
-		</tr>
 		<tr>
 			<td>Number of browser windows to open</td>
 			<td>You can configure the number of windows to be used by AJAX Spider.


### PR DESCRIPTION
Remove old options from AJAX Spider's "options.html" help page, the
options no longer exist, browsers' configurations are now done through
the "Selenium" options panel.
Update changes in ZapAddOn.xml file.