### PR TITLE
A new Active Scan rule HttpOnlySite.

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/HttpOnlySite.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/HttpOnlySite.java
@@ -1,0 +1,220 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.URI;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.Constant;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import javax.net.ssl.SSLException;
+
+/**
+ * Active scan rule which raises an alert if a site accessed via HTTP is not served under HTTPS 
+ * https://github.com/zaproxy/zaproxy/issues/2207
+ * @author sanchitlucknow@gmail.com
+ */
+public class HttpOnlySite extends AbstractHostPlugin {
+
+	/**
+	 * Prefix for internationalised messages used by this rule
+	 */
+	private static final String MESSAGE_PREFIX = "ascanalpha.httponlysite.";
+	private static final int PLUGIN_ID = 10106;
+	private static final int REDIR_LIMIT = 10;
+
+	private static final Logger log = Logger.getLogger(HttpOnlySite.class);
+	
+	@Override
+	public int getId() {
+		return PLUGIN_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "name");
+	}
+	
+	@Override
+	public String getDescription() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+	}
+
+	@Override
+	public String getSolution() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+	}
+
+	@Override
+	public String getReference() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+	}
+
+	@Override
+	public String[] getDependency() {
+		return null;
+	}
+
+	@Override
+	public int getCategory() {
+		return Category.MISC;
+	}
+	
+	@Override
+	public int getRisk() {
+		return Alert.RISK_MEDIUM;
+	}
+
+	@Override
+	public int getCweId() {
+		return 311; // CWE-311: Missing Encryption of Sensitive Data
+	}
+
+	@Override
+	public int getWascId() {
+		return 4; // WASC-04: Insufficient Transport Layer Protection
+	}
+
+	@Override
+	public void init() {
+
+	}
+
+	public void raiseAlert(HttpMessage newRequest, String message) {
+		String newUri = newRequest.getRequestHeader().getURI().toString();
+		String otherInfoDetail = Constant.messages.getString(MESSAGE_PREFIX+"otherinfo." + message);
+		bingo(getRisk(), //Risk
+				Alert.CONFIDENCE_MEDIUM, //Confidence/Reliability
+				getName(), //Name
+				getDescription(), //Description
+				getBaseMsg().getRequestHeader().getURI().toString(), //Original URI
+				null, //Param
+				"", //Attack
+				Constant.messages.getString(MESSAGE_PREFIX+"otherinfo", otherInfoDetail, newUri), //OtherInfo 
+				getSolution(), //Solution
+				"", //Evidence
+				getCweId(), //CWE ID
+				getWascId(), //WASC ID
+				newRequest); //HTTPMessage
+	}
+
+	public URI constructURI(String redirect, URI oldURI) {
+		try {
+			return new URI(oldURI, redirect, true);
+		} catch (URIException err) {
+			try {
+				return new URI(oldURI, redirect, true);
+			} catch (URIException ex) {
+				return null;
+			}
+		}
+	}
+
+	@Override
+	public void scan() {
+		
+		if (getBaseMsg().getRequestHeader().isSecure()) { //Base request is HTTPS
+			if (log.isDebugEnabled()){
+				log.debug ("The original request was HTTPS, so there is not much point in looking further.");
+			}
+			return;
+		}
+
+		HttpMessage newRequest = getNewMsg();
+		try{
+			String host = newRequest.getRequestHeader().getURI().getHost();
+			String path = newRequest.getRequestHeader().getURI().getPath();
+			newRequest.getRequestHeader().setURI(new URI("https",null, host, 443, path));
+		} catch (URIException e) {
+			log.error("Error creating HTTPS URL from HTTP URL:", e);
+			return;
+		}
+
+		if (isStop()) {
+			if (log.isDebugEnabled()) {
+				log.debug("Scanner "+getName()+" Stopping.");
+			}
+			return;
+		}
+
+		try {
+			int count = 0;
+			while(count < REDIR_LIMIT) {
+				if (isStop()) {
+					if (log.isDebugEnabled()) {
+						log.debug("Scanner "+getName()+" Stopping.");
+					}
+					return;
+				}
+				sendAndReceive(newRequest, false);
+				int status = newRequest.getResponseHeader().getStatusCode();
+				if(!HttpStatusCode.isRedirection(status)) {
+					break;
+				}
+				String redirect = newRequest.getResponseHeader().getHeader(HttpResponseHeader.LOCATION);
+				if(redirect == null || redirect.isEmpty()) {
+					raiseAlert(newRequest, "noredirection");
+					return;
+				}
+				URI oldURI = newRequest.getRequestHeader().getURI();
+				URI newURI = constructURI(redirect, oldURI);
+				if(newURI == null) {
+					raiseAlert(newRequest, "urinotencoded");
+					return;
+				}
+				newRequest.getRequestHeader().setURI(newURI);
+				if(!oldURI.getHost().equals(newURI.getHost())) {
+					raiseAlert(newRequest, "differenthosts");
+					return;
+				}
+				if(newRequest.getRequestHeader().isSecure()) {
+				    count++;
+				} else {
+					raiseAlert(newRequest, "redirecttohttp");
+					return;
+				}
+			}
+			if(count == REDIR_LIMIT) { //When redirection limit is exceeded
+				raiseAlert(newRequest, "redirectionlimit");
+				return;
+			}
+		} catch (SocketException | SocketTimeoutException e) {
+			raiseAlert(newRequest, "connectionfail");
+			return; 
+		} catch (SSLException e) {
+			if(e.getMessage().contains("plaintext")) {
+				raiseAlert(newRequest, "nossl");
+			}
+			return; 
+		} catch (IOException e) {
+			log.error("Request couldn't go through:", e);
+			return; 
+		}
+	}
+}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Deleted Integer Overflow scanner.<br>
 	Issue 823: i18n (internationalise) alpha rules.<br>
 	Add CWE and WASC IDs to active scanners which may have been lacking those details.<br>
+	Issue 2207: Added Http Only Site Active scan rule.<br>
   	]]>
 	</changes>
 	<extensions>
@@ -18,6 +19,7 @@
 	<ascanrules>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleSimpleActiveScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleFileActiveScanner</ascanrule>
+		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.HttpOnlySite</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.HttpsAsHttpScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.LDAPInjection</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ProxyDisclosureScanner</ascanrule>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -25,6 +25,19 @@ ascanalpha.examplefile.other=This is for information that doesnt fit in any of t
 ascanalpha.examplefile.soln=A general description of how to solve the problem
 ascanalpha.examplefile.refs=http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html
 
+ascanalpha.httponlysite.name = HTTP Only Site
+ascanalpha.httponlysite.desc = The site is only served under HTTP and not HTTPS.
+ascanalpha.httponlysite.soln = Configure your web or application server to use SSL (https).
+ascanalpha.httponlysite.refs = https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet\nhttps://www.owasp.org/index.php/SSL_Best_Practices\nhttps://letsencrypt.org/
+ascanalpha.httponlysite.otherinfo = {0}\nZAP attempted to connect via: {1}
+ascanalpha.httponlysite.otherinfo.connectionfail = Failed to connect.
+ascanalpha.httponlysite.otherinfo.differenthosts = Different Hosts.
+ascanalpha.httponlysite.otherinfo.redirectionlimit = Redirection limit reached.
+ascanalpha.httponlysite.otherinfo.noredirection = There was no automatic redirection.
+ascanalpha.httponlysite.otherinfo.nossl = Site has no SSL/TLS support.
+ascanalpha.httponlysite.otherinfo.redirecttohttp = Redirected to HTTP.
+ascanalpha.httponlysite.otherinfo.urinotencoded = Redirection URI couldn't be encoded.
+
 ascanalpha.httpsashttpscanner.name = HTTPS Content Available via HTTP
 ascanalpha.httpsashttpscanner.desc = Content which was initially accessed via HTTPS (i.e.: using SSL/TLS encryption) is also accessible via HTTP (without encryption). 
 ascanalpha.httpsashttpscanner.soln = Ensure that your web server, application server, load balancer, etc. is configured to only serve such content via HTTPS. Consider implementing HTTP Strict Transport Security.

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -32,6 +32,9 @@ Uses local file inclusion techniques to scan for files containing source code on
 <H2>Source Code Disclosure - Git</H2>
 Uses Git source code repository metadata to scan for files containing source code on the web server.
 
+<H2>HTTP Only Site</H2>
+This active scanner checks whether an HTTP site is served under HTTPS.
+
 <H2>HTTPS As HTTP Scanner</H2>
 This active scanner attempts to access content that was originally accessed via HTTPS (SSL/TLS) via HTTP.
 


### PR DESCRIPTION
Hello,

According to the issue zaproxy/zaproxy#2207 the original idea of this issue was to raise alerts on all http sites whether or not https was available
But the other rule already raises alerts if http versions of https sites are available
So we thought that it might make sense to just raise alerts if https is _not_ available.
I have implemented this Active Scan rule which raises an alert if a site is only served under HTTP and not HTTPS. The work is still under progress so I would like to hear your feedback @thc202 , @kingthorin , @psiinon . Here is the TODO:

- ~~PLUGIN_ID~~ 
- ~~CATEGORY~~
- ~~RISK~~
- ~~CONFIDENCE~~
- ~~CWE~~ 
- ~~WASC~~ 
- ~~Attack Parameter in the Alert~~
- ~~Description~~ 
- ~~References~~ 
- ~~Solution~~ 
- ~~Testing any other case if needed.~~ 
- ~~Custom Redirection (in cases like 3xx status codes)~~

Everything is done. Commits squashed :)

Thanks :smile: 