### PR TITLE
AlertFilters Minor UI Improvements2

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterPanel.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterPanel.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.alertFilters;
 
 import java.awt.CardLayout;
+import java.awt.Component;
 import java.awt.GridBagLayout;
 
 import javax.swing.JCheckBox;
@@ -103,7 +104,14 @@ public class ContextAlertFilterPanel extends AbstractContextPropertiesPanel {
 			super(model);
 			this.extension = extension;
 
-			getTable().getColumnExt(0).setMaxWidth(70);
+			Component rendererComponent;
+			if (getTable().getColumnExt(0).getHeaderRenderer()==null) {// If there isn't a header renderer then get the default renderer
+				rendererComponent = getTable().getTableHeader().getDefaultRenderer().getTableCellRendererComponent(null, getTable().getColumnExt(0).getHeaderValue(), false, false, 0, 0);
+			} else {// If there is a custom renderer then get it
+				rendererComponent = getTable().getColumnExt(0).getHeaderRenderer().getTableCellRendererComponent(null, getTable().getColumnExt(0).getHeaderValue(), false, false, 0, 0);
+			}
+			
+			getTable().getColumnExt(0).setMaxWidth(rendererComponent.getMaximumSize().width);
 			getTable().setSortOrder(1, SortOrder.ASCENDING);
 			getTable().packAll();
 		}

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -1,16 +1,12 @@
 <zapaddon>
 	<name>Context Alert Filters</name>
-	<version>2</version>
+	<version>3</version>
 	<status>beta</status>
 	<description>Allows you to automate the changing of alert risk levels.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Updated to use alertIds from 2.4.3+<br>
-	Misc minor bug fixes<br>
-	HTML report reports the filtered false positives as true results (Issue 2311)<br>
-	Promoted to beta and added icon<br>
 	Various minor UI improvements<br>
 	]]>
     </changes>


### PR DESCRIPTION
Builds on Pull Request 286.

In ContextAlertFilterPanel:
The Enabled column has a max width based on the optimal width 
for the header content, (can be made smaller, but not bigger).
This means that the dialog can be resized, and the main
content columns will resize, while Enabled stays static based
on the optimal length for the i18n heading being displayed.