### PR TITLE
Issue 2177 Adjust Logging

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
@@ -492,8 +492,17 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
 									}
 								}
 							}
+							catch (SQLException sqlEx) {
+								StringBuilder errorSb=new StringBuilder(300);
+								errorSb.append("Error executing SQL on temporary SVN SQLite database '");
+								errorSb.append(sqliteConnectionUrl);
+								errorSb.append("': ");
+								errorSb.append(sqlEx);
+								errorSb.append("\nThe saved response likely wasn't a SQLite db.");
+								log.debug(errorSb);
+							}
 							catch (Exception e) {
-								log.error ("Error executing SQL on temporary SVN SQLite database '"+ sqliteConnectionUrl + "': "+ e);
+								log.debug("An error has occurred, related to the temporary SVN SQLite DB. "+e);
 							}
 							finally {
 								//the JDBC driver in use does not play well with "try with resource" construct. I tried!

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Issue 2178: SQLInjectionMySQL - adjust logging, catch specific exceptions.<br>
 	Issue 2179: SQLInjectionPostgresql - adjust logging, catch specific exceptions.<br>
 	Issue 2272: SQLInjectionHypersonic - adjust logging, catch specific exceptions.<br>
+	Issue 2177: SourceCodeDisclosureSVN - adjust logging.<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
When the response does result in creation of a SVN wc.db temp file - log
read or query errors at debug level and only include the exception only
if debug is enabled.

Fixes zaproxy/zaproxy#2177