### PR TITLE
Do not allow to dynamically unload Access Control

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
+++ b/src/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
@@ -131,7 +131,7 @@ public class ExtensionAccessControl extends ExtensionAdaptor implements SessionC
 
 	@Override
 	public boolean canUnload() {
-		return true;
+		return false;
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix an exception when cancelling the "Save" access control report dialogue.<br>
+	Do not allow to dynamically uninstall, not yet supported.<br>
 	]]> 
 	</changes>
 	<dependson />


### PR DESCRIPTION
Change the method ExtensionAcessControl.canUnload() to return false,
the extension is not completely unloaded by default (Context factories
are not unloaded, requires core changes), which might lead to issues,
for example, after uninstallation it would no longer be possible to
create new contexts as it leads to a MissingResourceException.
Update changes in ZapAddOn.xml file.