### PR TITLE
Disable Plug-n-Hack button if API turned off

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -40,14 +40,16 @@ import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.extension.report.ReportLastScan;
+import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.ext.ExtensionExtension;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 
-public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChangedListener, CommandLineListener {
+public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChangedListener, CommandLineListener, OptionsChangedListener {
 	
 	public static final String NAME = "ExtensionQuickStart";
 	protected static final String SCRIPT_CONSOLE_HOME_PAGE = Constant.ZAP_HOMEPAGE;
@@ -94,6 +96,8 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
 	        extensionHook.getHookView().addWorkPanel(getQuickStartPanel());
 	        
 	        ExtensionHelp.enableHelpKey(getQuickStartPanel(), "quickstart");
+	        
+	    	extensionHook.addOptionsChangedListener(this);
 	    }
         extensionHook.addSessionListener(this);
 
@@ -431,5 +435,11 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
 				e.printStackTrace();
 			}
 		}
+	}
+
+	@Override
+	public void optionsChanged(OptionsParam optionsParam) {
+		//PnH button has the same enable state as the API
+		getQuickStartPanel().updatePnhPanelElements(optionsParam.getApiParam().isEnabled());		
 	}
 }

--- a/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -259,10 +259,23 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 	private ZapTextField getConfField () {
 		if (confField == null) {
 			confField = new ZapTextField();
-			confField.setText(getPlugNHackUrl());
 			confField.setEditable(false);
+			updateConfField(Model.getSingleton().getOptionsParam().getApiParam().isEnabled());
 		}
 		return confField;
+	}
+	
+	private void updateConfField(boolean apiState) {
+		if (confField == null) {
+			return;
+		}
+		//PnH URL Field has the same enable state as the API
+		confField.setEnabled(apiState);
+		if (apiState) {
+			confField.setText(getPlugNHackUrl());
+		} else {
+			confField.setText(Constant.messages.getString("quickstart.mitm.api.disabled"));
+		}
 	}
 	
 	private JButton getConfButton() {
@@ -273,6 +286,8 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 			confButton.setIcon(DisplayUtils.getScaledIcon(new ImageIcon(
 					QuickStartPanel.class.getResource("/org/zaproxy/zap/extension/quickstart/resources/plug.png"))));
 
+			updateConfButton(Model.getSingleton().getOptionsParam().getApiParam().isEnabled());
+			
 			confButton.addActionListener(new java.awt.event.ActionListener() { 
 				@Override
 				public void actionPerformed(java.awt.event.ActionEvent e) {
@@ -283,6 +298,24 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 		return confButton;
 	}
 
+	private void updateConfButton(boolean apiState) {
+		if (confButton == null) {
+			return;
+		}
+		//PnH button has the same enable state as the API
+		confButton.setEnabled(apiState);
+		if (apiState) {
+			confButton.setToolTipText(Constant.messages.getString("quickstart.button.tooltip.mitm"));
+		} else {
+			confButton.setToolTipText(Constant.messages.getString("quickstart.mitm.api.disabled"));
+		}
+	}
+	
+	public void updatePnhPanelElements(boolean apiState) {
+		updateConfButton(apiState);
+		updateConfField(apiState);
+	}
+	
 	boolean attackUrl () {
 		URL url;
 		try {

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Quick Start</name>
-	<version>17</version>
+	<version>18</version>
 	<status>release</status>
 	<description>Provides a tab which allows you to quickly test a target application</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	 Add progress indications for quick scan launched from the command line (Issue 1891) <br>
-	 Improve Quick Attack error messages (Issue 2032) <br>
+	 Issue 1271: Quickstart PnH panel components should mirror the enabled state of the API (i.e.: If API disabled, disable PnH components).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
@@ -9,6 +9,7 @@ quickstart.button.label.attack			= Attack
 quickstart.button.tooltip.attack		= Perform a quick penetration test on the URL
 quickstart.button.label.mitm			= Plug-n-Hack
 quickstart.button.tooltip.mitm			= Configure your browser to proxy through ZAP using Plug-n-Hack
+quickstart.mitm.api.disabled			= Only enabled if the API is enabled in ZAP's options.
 quickstart.button.label.stop			= Stop
 quickstart.button.tooltip.stop			= Stop the attack
 quickstart.cmdline.outputto				= Writing results to {0}


### PR DESCRIPTION
QuickStartPanel: Add new private methods (updateConfButton, and
updateConfField) to update text, tooltip, and enabled state of the
relevant PnH panel elements based on the enabled state of the API. Added
new public method (updatePnhPanelElements) which wraps the two private
methods to ensure sync when used by outside callers. Modified
getConfButton and getConfField methods to trigger the update methods
when instantiating the related elements.
ExtensionQuickStart: Add OptionsChangedListener hook, overridden
optionsChanged method triggers updatePnhPanelElements in
QuickStartPanel.

Fixes zaproxy/zaproxy#1271