### PR TITLE
spiderAjax: suppress innocuous log warning

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -51,6 +51,7 @@ import com.crawljax.core.configuration.BrowserConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration;
 import com.crawljax.core.configuration.CrawljaxConfiguration.CrawljaxConfigurationBuilder;
 import com.crawljax.core.configuration.ProxyConfiguration;
+import com.crawljax.core.plugin.OnBrowserCreatedPlugin;
 import com.crawljax.core.plugin.Plugins;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.inject.ProvisionException;
@@ -173,6 +174,8 @@ public class SpiderThread implements Runnable {
 		configurationBuilder.setMaximumDepth(params.getMaxCrawlDepth());
 		configurationBuilder.setMaximumRunTime(params.getMaxDuration(),TimeUnit.MINUTES);
 		configurationBuilder.crawlRules().clickOnce(params.isClickElemsOnce());
+		
+		configurationBuilder.addPlugin(DummyPlugin.DUMMY_PLUGIN);
 				
 		return configurationBuilder.build();
 	}
@@ -358,6 +361,23 @@ public class SpiderThread implements Runnable {
 					configuration.getProxyConfiguration().getPort()), filterAttributes, crawlWaitEvent, crawlWaitReload);
 			plugins.runOnBrowserCreatedPlugins(embeddedBrowser);
 			return embeddedBrowser;
+		}
+	}
+
+	/**
+	 * A {@link com.crawljax.core.plugin.Plugin} that does nothing, used only to suppress log warning when the
+	 * {@link CrawljaxRunner} is started.
+	 * 
+	 * @see SpiderThread#createCrawljaxConfiguration()
+	 * @see SpiderThread#run()
+	 */
+	private static class DummyPlugin implements OnBrowserCreatedPlugin {
+
+		public static final DummyPlugin DUMMY_PLUGIN = new DummyPlugin();
+
+		@Override
+		public void onBrowserCreated(EmbeddedBrowser arg0) {
+			// Nothing to do.
 		}
 	}
 }

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Fix issue that prevented the spider from clicking all elements set in the options (Issue 2151).<br>
 	Minor update in help pages.<br>
+	Suppress log of innocuous warning.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change class SpiderThread to add a dummy Crawljax Plugin to suppress the
log warn that indicates that no plugins were loaded ("No plugins loaded.
There will be no output").
Update changes in ZapAddOn.xml file.
 ---
From https://github.com/jenkinsci/zaproxy-plugin/issues/19#issuecomment-211820358.