### PR TITLE
CacheControlScanner Accommodate Multiple Headers

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/CacheControlScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/CacheControlScanner.java
@@ -51,16 +51,15 @@ public class CacheControlScanner extends PluginPassiveScanner {
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 		if (msg.getRequestHeader().isSecure() && !msg.getRequestHeader().getURI().toString().toLowerCase().endsWith(".css") && !msg.getResponseHeader().isImage() && msg.getResponseBody().length() > 0) {
-			Vector<String> cacheControl = msg.getResponseHeader().getHeaders(HttpHeader.CACHE_CONTROL);
-			if (cacheControl != null) {
-				for (String cacheControlDirective : cacheControl) {
-					if (cacheControlDirective.toLowerCase().indexOf("no-store") < 0 || cacheControlDirective.toLowerCase().indexOf("no-cache") < 0 || cacheControlDirective.toLowerCase().indexOf("must-revalidate") < 0 || cacheControlDirective.toLowerCase().indexOf("private") < 0) {
-						this.raiseAlert(msg, id, cacheControlDirective);
-					}
-				}
-			}
-			else { // No cache control header at all
-				this.raiseAlert(msg, id, null);
+			Vector<String> cacheControlVect = msg.getResponseHeader().getHeaders(HttpHeader.CACHE_CONTROL);
+			String cacheControlHeaders = (cacheControlVect != null) ? cacheControlVect.toString().toLowerCase() : "";
+
+			if (cacheControlHeaders.isEmpty() || //No Cache-Control header at all 
+					cacheControlHeaders.indexOf("no-store") < 0 || 
+					cacheControlHeaders.indexOf("no-cache") < 0 || 
+					cacheControlHeaders.indexOf("must-revalidate") < 0 ||
+					cacheControlHeaders.indexOf("private") < 0) {
+				this.raiseAlert(msg, id, null); //Didn't find a header on the request that matched the criteria
 			}
 			
 			Vector<String> pragma = msg.getResponseHeader().getHeaders(HttpHeader.PRAGMA);

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Issue 823 - i18n (internationalise) release passive scan rules.<br>
 	Add CWE and WASC IDs to passive scanners which may have been lacking those details.<br>
+	Issue 2405 - Accommodate responses with multiple Cache-Control headers.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Per the HTTP 1.1 spec it is possible for a response to have multiple
headers of the same type (i.e.: Cache-Control) [
https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2 &
https://tools.ietf.org/html/rfc7230#section-3.2.2], an
alert is only raised if none of the headers on a response fulfill the
criteria being sought.

Fixes zaproxy/zaproxy#2405