### PR TITLE
websocket: unload components from core

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -136,6 +136,11 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 	private Map<Integer, WebSocketProxy> wsProxies;
 
 	/**
+	 * Database table.
+	 */
+	private TableWebSocket table;
+
+	/**
 	 * Interface to database.
 	 */
 	private WebSocketStorage storage;
@@ -195,7 +200,7 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 	
     @Override
     public void databaseOpen(Database db) throws DatabaseException, DatabaseUnsupportedException {
-		TableWebSocket table = new TableWebSocket();
+		table = new TableWebSocket();
 		db.addDatabaseListener(table);
 		try {
 			table.databaseOpen(db.getDatabaseServer());
@@ -318,8 +323,10 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 				extManReqEdit.addManualSendEditor(sendDialog);
 				hookMenu.addToolsMenuItem(sendDialog.getMenuItem());
 				
+				resenderDialog = createReSendDialog(sender);
+
 				// add 'Resend Message' menu item to WebSocket tab context menu
-				hookMenu.addPopupMenuItem(new ResendWebSocketMessageMenuItem(createReSendDialog(sender)));
+				hookMenu.addPopupMenuItem(new ResendWebSocketMessageMenuItem(resenderDialog));
 				
 				
 				// setup persistent connection listener for http manual send editor
@@ -350,9 +357,6 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 		Control control = Control.getSingleton();
 		ExtensionLoader extLoader = control.getExtensionLoader();
 		
-		// clear up Session Properties
-		getView().getSessionDialog().removeParamPanel(sessionExcludePanel);
-		
 		// clear up Breakpoints
 		ExtensionBreak extBreak = (ExtensionBreak) extLoader.getExtension(ExtensionBreak.NAME);
 		if (extBreak != null) {
@@ -375,8 +379,24 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 			}
 		}
 		
+		if (table != null) {
+			getModel().getDb().removeDatabaseListener(table);
+		}
+
 		if (getView() != null) {
+			getWebSocketPanel().unload();
+
+			getView().getSessionDialog().removeParamPanel(sessionExcludePanel);
+
 			clearupWebSocketsForWorkPanel();
+
+			if (sendDialog != null) {
+				sendDialog.unload();
+			}
+
+			if (resenderDialog != null) {
+				resenderDialog.unload();
+			}
 		}
 	}
 
@@ -397,6 +417,19 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 	 */
 	public void addAllChannelObserver(WebSocketObserver observer) {
 		allChannelObservers.add(observer);
+	}
+
+	/**
+	 * Removes the given {@code observer}, that was attached to every channel connected.
+	 * 
+	 * @param observer the observer to be removed
+	 * @throws IllegalArgumentException if the given {@code observer} is {@code null}.
+	 */
+	public void removeAllChannelObserver(WebSocketObserver observer) {
+		if (observer == null) {
+			throw new IllegalArgumentException("The parameter observer must not be null.");
+		}
+		allChannelObservers.remove(observer);
 	}
 
 	/**
@@ -909,6 +942,11 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 	 * Send custom WebSocket messages.
 	 */
 	private ManualWebSocketSendEditorDialog sendDialog;
+
+	/**
+	 * Resends custom WebSocket messages.
+	 */
+	private ManualWebSocketSendEditorDialog resenderDialog;
 
 	private WebSocketPanel getWebSocketPanel() {
 		if (panel == null) {

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>WebSockets</name>
-	<version>10</version>
+	<version>11</version>
 	<status>release</status>
 	<description>Allows you to inspect WebSocket communication.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Fix issue with length of handshake's url (Issue 2097).<br>
-	Restore fuzzing capabilities (Issue 1905).<br>
+	Unload WebSockets components during uninstallation.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
+++ b/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
@@ -139,10 +139,13 @@ public class ExtensionWebSocketFuzzer extends ExtensionAdaptor {
     public void unload() {
         super.unload();
 
+        ExtensionFuzz extensionFuzz = Control.getSingleton().getExtensionLoader().getExtension(ExtensionFuzz.class);
+        extensionFuzz.removeFuzzerHandler(websocketFuzzerHandler);
+
         ExtensionWebSocket extensionWebSocket = Control.getSingleton()
                 .getExtensionLoader()
                 .getExtension(ExtensionWebSocket.class);
-        extensionWebSocket.addAllChannelObserver(getAllChannelObserver());
+        extensionWebSocket.removeAllChannelObserver(getAllChannelObserver());
 
         ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
         if (extensionScript != null) {

--- a/src/org/zaproxy/zap/extension/websocket/manualsend/ManualWebSocketSendEditorDialog.java
+++ b/src/org/zaproxy/zap/extension/websocket/manualsend/ManualWebSocketSendEditorDialog.java
@@ -34,7 +34,6 @@ import org.parosproxy.paros.extension.manualrequest.ManualRequestEditorDialog;
 import org.parosproxy.paros.extension.manualrequest.MessageSender;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
-import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
 import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.extension.websocket.WebSocketMessage;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
@@ -54,7 +53,7 @@ public class ManualWebSocketSendEditorDialog extends ManualRequestEditorDialog {
 	
 	private WebSocketPanelSender sender;
 
-	private HttpPanelRequest requestPanel;
+	private WebSocketSendPanel requestPanel;
 	private WebSocketMessagePanel wsMessagePanel;
 	private ChannelSortedListModel channelsModel;
 
@@ -120,7 +119,7 @@ public class ManualWebSocketSendEditorDialog extends ManualRequestEditorDialog {
 	}
 
 	@Override
-	protected HttpPanelRequest getRequestPanel() {
+	protected WebSocketSendPanel getRequestPanel() {
 		if (requestPanel == null) {
 			requestPanel = new WebSocketSendPanel(true, configurationKey);
 			requestPanel.setEnableViewSelect(true);
@@ -182,6 +181,10 @@ public class ManualWebSocketSendEditorDialog extends ManualRequestEditorDialog {
 		msg.readableOpcode = WebSocketMessage.opcode2string(msg.opcode);
 		
 		setMessage(msg);
+	}
+
+	public void unload() {
+		getRequestPanel().unload();
 	}
 	
 	private static final class WebSocketMessagePanel extends JPanel {

--- a/src/org/zaproxy/zap/extension/websocket/manualsend/WebSocketSendPanel.java
+++ b/src/org/zaproxy/zap/extension/websocket/manualsend/WebSocketSendPanel.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.websocket.manualsend;
 import javax.swing.JComboBox;
 
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
+import org.zaproxy.zap.view.HttpPanelManager;
 
 /**
  * Craft custom WebSocket message and send them. Avoid HTTP method panel to
@@ -39,5 +40,9 @@ public class WebSocketSendPanel extends HttpPanelRequest {
 		if (comboChangeMethod == null) {
 			comboChangeMethod = new JComboBox<>();
 		}
+	}
+
+	public void unload() {
+		HttpPanelManager.getInstance().removeRequestPanel(this);
 	}
 }

--- a/src/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
@@ -796,4 +796,11 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
 		this.table = table;
 		this.messagesModel.setTable(table);
 	}
+
+	public void unload() {
+		if (filterDialog != null) {
+			filterDialog.dispose();
+			filterDialog = null;
+		}
+	}
 }


### PR DESCRIPTION
Change ExtensionWebSocket class to unload/remove database listener
(TableWebSocket), send/resend dialogues (WebSocketSendPanel) and filter
dialogue (through WebSocketPanel) and change to allow to remove
WebSocketObserver.
Change ExtensionWebSocketFuzzer to remove the fuzzer handler from the
ExtensionFuzz and to remove the added WebSocketObserver from
ExtensionWebSocket.
Bump version and update changes in ZapAddOn.xml file.