### PR TITLE
websocket: remove menu's use of database table

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.Socket;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -278,7 +279,7 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 			hookView.addOptionPanel(getOptionsPanel());
 			
 			// add 'Exclude from WebSockets' menu item to WebSocket tab context menu
-			hookMenu.addPopupMenuItem(new ExcludeFromWebSocketsMenuItem(this, storage.getTable()));
+			hookMenu.addPopupMenuItem(new ExcludeFromWebSocketsMenuItem(this));
 
 			// setup Session Properties
 			sessionExcludePanel =  new SessionExcludeFromWebSocket(this);
@@ -790,6 +791,20 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 				}
 			}
 		}
+	}
+
+	/**
+	 * Gets the channels that match the given {@code criteria}.
+	 *
+	 * @param criteria the criteria
+	 * @return a {@code List} containing the channels that match the given {@code criteria}.
+	 * @throws DatabaseException if an error occurred while obtain the channel.
+	 */
+	public List<WebSocketChannelDTO> getChannels(WebSocketChannelDTO criteria) throws DatabaseException {
+		if (storage != null) {
+			return storage.getTable().getChannels(criteria);
+		}
+		return Collections.emptyList();
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/websocket/ui/ExcludeFromWebSocketsMenuItem.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/ExcludeFromWebSocketsMenuItem.java
@@ -28,7 +28,6 @@ import org.zaproxy.zap.extension.websocket.ExtensionWebSocket;
 import org.zaproxy.zap.extension.websocket.WebSocketChannelDTO;
 import org.zaproxy.zap.extension.websocket.WebSocketException;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
-import org.zaproxy.zap.extension.websocket.db.TableWebSocket;
 
 /**
  * Menu Item for Popup. Used in WebSockets tab, when you click on some message
@@ -39,15 +38,12 @@ public class ExcludeFromWebSocketsMenuItem extends WebSocketMessagesPopupMenuIte
 
 	private static final Logger logger = Logger.getLogger(ExcludeFromWebSocketsMenuItem.class);
     
-    private final TableWebSocket table;
-
 	private ExtensionWebSocket extWs;
     
-    public ExcludeFromWebSocketsMenuItem(ExtensionWebSocket extWs, TableWebSocket table) {
+    public ExcludeFromWebSocketsMenuItem(ExtensionWebSocket extWs) {
         super();
 
         this.extWs = extWs;
-        this.table = table;
     }
 
 	@Override
@@ -106,7 +102,7 @@ public class ExcludeFromWebSocketsMenuItem extends WebSocketMessagesPopupMenuIte
 		channel.id = message.channel.id;
 		
 		try {
-			List<WebSocketChannelDTO> channels = table.getChannels(channel);
+			List<WebSocketChannelDTO> channels = extWs.getChannels(channel);
 			if (channels.size() == 1) {
 				return channels.get(0);
 			}


### PR DESCRIPTION
With the changes done to core, zaproxy/zaproxy#2428, the database table
that was kept in the menu item is no longer up-to-date with the latest
opened database (since old listeners are removed when the database is
closed) leading to exceptions (like, SQLNonTransientConnectionException:
connection exception: closed).

Change class ExcludeFromWebSocketsMenuItem to not use the database table
(directly) to obtain the channels, instead use ExtensionWebSocket which
keeps track of the (latest) usable table.
Change class ExtensionWebSocket to allow to obtain the channels.

~~Bump version in ZapAddOn.xml file.~~