### PR TITLE
sse: keep database up-to-date in EventStreamPanel

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -549,7 +549,7 @@
 	</target>
 	
 	<target name="deploy-serverSentEvents" description="deploy the Server-Sent Events extension">
-		<build-deploy-addon name="serverSentEvents" />
+		<build-deploy-addon name="sse" />
 	</target>
 
     <target name="generate-wiki-serverSentEvents" description="Generates the wiki of Server-Sent Events">

--- a/src/org/zaproxy/zap/extension/sse/ExtensionServerSentEvents.java
+++ b/src/org/zaproxy/zap/extension/sse/ExtensionServerSentEvents.java
@@ -174,6 +174,10 @@ public class ExtensionServerSentEvents extends ExtensionAdaptor implements Persi
 		try {
 			table.databaseOpen(db.getDatabaseServer());
 			
+			if (panel != null) {
+				panel.setTable(table);
+			}
+
 			if (storage == null) {
 				storage = new EventStreamStorage(table);
 				addObserver(storage);

--- a/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Server-Sent Events</name>
-	<version>8</version>
+	<version>9</version>
 	<status>alpha</status>
 	<description>Allows you to view Server-Sent Events (SSE) communication.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for ZAP 2.4</changes>
+	<changes></changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.sse.ExtensionServerSentEvents</extension>
 	</extensions>


### PR DESCRIPTION
With the changes done to core, zaproxy/zaproxy#2428, the database table
that was kept in the class EventStreamPanel is no longer up-to-date with
the latest opened database (since old listeners are removed when the
database is closed) leading to exceptions (like,
SQLNonTransientConnectionException: connection exception: closed).

Change class ExtensionServerSentEvents to update the database in
EventStreamPanel when the database is open, to always have the latest
database table (the one with active connection).

Fix add-on name in build.xml for its deploying target.

Bump version and remove old changes in ZapAddOn.xml file.