### PR TITLE
websocket: correct name of error resource message

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
@@ -328,7 +328,7 @@ public class FuzzOptionsPanel extends AbstractParamPanel {
                         copyFile = confirmOverwrite();
                     } else if (!Files.isWritable(newFile.getParent())) {
                         View.getSingleton().showWarningDialog(
-                                resourceBundle.getString("fuzz.options.add.dirperms.error")
+                                resourceBundle.getString("fuzz.options.add.file.dirperms.error")
                                         + newFile.getParent().toAbsolutePath());
                     } else {
                         copyFile = true;

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -9,6 +9,7 @@
     <changes>
     <![CDATA[
     Fix modification of file and file fuzzers in Windows.<br>
+    Correctly inform when the fuzzers directory is not writable.<br>
     ]]>
     </changes>
     <extensions>


### PR DESCRIPTION
Fix the name of the resource message used to indicate that the "fuzzers"
directory is not writable, which was leading to an exception:
ERROR org.zaproxy.zap.ZAP$UncaughtExceptionLogger  - Exception in thread
 "AWT-EventQueue-0"
java.util.MissingResourceException: Can't find resource for bundle
 java.util.PropertyResourceBundle, key fuzz.options.add.dirperms.error
 at java.util.ResourceBundle.getObject(ResourceBundle.java:450)
 at java.util.ResourceBundle.getString(ResourceBundle.java:407)
 at org.zaproxy.zap.extension.fuzz.FuzzOptionsPanel$3.actionPerformed
 (FuzzOptionsPanel.java:330)

The name is "fuzz.options.add.file.dirperms.error" not the above.

Add change to ZapAddOn.xml file.