### PR TITLE
saverawmessage: remember last selected directory

### DIFF
--- a/src/org/zaproxy/zap/extension/saverawmessage/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saverawmessage/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Save Raw Message</name>
-	<version>2</version>
+	<version>3</version>
 	<status>release</status>
 	<description>Allows to save content of HTTP messages as binary</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Safe menu item will now be enabled in protected and safe modes (Issue 1278).</changes>
+	<changes>Remember last selected directory (Issue 2446).</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.saverawmessage.ExtensionSaveRawHttpMessage</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/saverawmessage/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/saverawmessage/resources/Messages.properties
@@ -1,5 +1,4 @@
 saveraw.file.description       = Raw
-saveraw.file.overwrite.warning = File already exists. Do you want to overwrite it?
 saveraw.file.save.error        = Error saving file to {0}.
 saveraw.popup.option = Save Raw
 saveraw.popup.option.all = All


### PR DESCRIPTION
Change class PopupMenuSaveRawMessage to use WritableFileChooser, which
already takes care to persist the last selected directory when choosing
the location to save the raw HTTP message.
Remove message no longer used for confirmation to overwrite existing
file, WritableFileChooser already does that.
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2446 - Remember current dir when using Save Raw
Results