### PR TITLE
saml: use (ZAP) home dir for configuration file

### DIFF
--- a/src/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
+++ b/src/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
@@ -1,7 +1,7 @@
 package org.zaproxy.zap.extension.saml;
 
 import org.apache.log4j.Logger;
-import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.Constant;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -9,11 +9,13 @@ import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 import java.io.*;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Set;
 
 public class SAMLConfiguration implements AttributeListener {
 
     private static final String SAML_CONF_FILE = "zap_saml_conf.xml";
+    private static final String SAML_CONF_FILE_PATH = Paths.get(Constant.getZapHome(), SAML_CONF_FILE).toString();
     private static SAMLConfiguration configuration = new SAMLConfiguration();
 
     private SAMLConfigData configData;
@@ -34,9 +36,7 @@ public class SAMLConfiguration implements AttributeListener {
      * @throws SAMLException
      */
     public void initialize() throws SAMLException {
-        String confPath = Model.getSingleton().getOptionsParam().getUserDirectory().getAbsolutePath() + "/" +
-                SAML_CONF_FILE;
-        initialize(confPath);
+        initialize(SAML_CONF_FILE_PATH);
     }
 
     /**
@@ -167,9 +167,7 @@ public class SAMLConfiguration implements AttributeListener {
             JAXBContext context = JAXBContext.newInstance(SAMLConfigData.class);
             Marshaller marshaller = context.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
-            String confPath = Model.getSingleton().getOptionsParam().getUserDirectory().getAbsolutePath() + "/" +
-                    SAML_CONF_FILE;
-            marshaller.marshal(configData, new File(confPath));
+            marshaller.marshal(configData, new File(SAML_CONF_FILE_PATH));
             return true;
         } catch (JAXBException e) {
             log.error("Saving configuration failed");

--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
     <name>SAML Extension</name>
-    <version>5</version>
+    <version>6</version>
     <status>alpha</status>
     <description>Detect, Show, Edit, Fuzz SAML requests</description>
     <author>ZAP Dev Team</author>
     <url>https://github.com/zaproxy/zaproxy</url>
 	<changes>
 	<![CDATA[
-	Internationalise and show 'SAML Actions' menu.<br>
-	Prevent XXE vulnerability.<br>
+	Use ZAP's home directory for SAML configuration file.<br>
 	]]>
 	</changes>
     <dependson/>


### PR DESCRIPTION
Change class SAMLConfiguration to use home directory for configuration
file, instead of using the "last selected directory" which might no
longer exist (nor be the same), leading to failure to restore the
configurations and an exception during initialisation:
 ERROR org.zaproxy.zap.extension.saml.SAMLExtension  - SAML Extension
 can't be loaded. Configuration not found or invalid
 org.zaproxy.zap.extension.saml.SAMLException: SAML Configuration file
 /tmp/zap_saml_conf.xml can't be modified

Bump version and update changes in ZapAddOn.xml file.