### PR TITLE
websocket: adjust log levels, from info to debug

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketProxy.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketProxy.java
@@ -763,7 +763,9 @@ public abstract class WebSocketProxy {
 	 * @throws IOException
 	 */
 	public void sendAndNotify(WebSocketMessageDTO msg) throws IOException {
-		logger.info("send custom message");
+		if (logger.isDebugEnabled()) {
+			logger.debug("sending custom message");
+		}
 		WebSocketMessage message = createWebSocketMessage(msg);
 		
 		OutputStream out;
@@ -782,7 +784,9 @@ public abstract class WebSocketProxy {
 	}
 
 	public boolean send(WebSocketMessageDTO msg) throws IOException {
-		logger.info("send custom message");
+		if (logger.isDebugEnabled()) {
+			logger.debug("sending custom message");
+		}
 		WebSocketMessage message = createWebSocketMessage(msg);
 
 		OutputStream out;

--- a/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
@@ -413,9 +413,9 @@ public class WebSocketProxyV13 extends WebSocketProxy {
 			}
 			
 			if (isText(opcode)) {
-				logger.info("got text frame payload");
+				logger.debug("got text frame payload");
 			} else if (isBinary(opcode)) {
-				logger.info("got binary frame payload");				
+				logger.debug("got binary frame payload");				
 			} else {
 				if (opcode == OPCODE_CLOSE) {
 					if (payload.length > 1) {

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Unload WebSockets components during uninstallation.<br>
 	Use hostname/port of the handshake message to build the name of the channel.<br>
+	Adjust log levels, from INFO to DEBUG.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
@@ -574,7 +574,9 @@ public class TableWebSocket extends ParosAbstractTable {
 						// proceed with insert
 						stmt = psInsertChannel;
 						addIdOnSuccess = true;
-						logger.info("insert channel: " + channel.toString());
+						if (logger.isDebugEnabled()) {
+							logger.debug("insert channel: " + channel.toString());
+						}
 					}
 
 					if(logger.isDebugEnabled()) {logger.debug("url (length " + channel.url.length() + "):" + channel.url);}
@@ -634,7 +636,9 @@ public class TableWebSocket extends ParosAbstractTable {
 						throw new SQLException("channel not inserted: " + message.channel.id);
 					}
 					
-					logger.info("insert message: " + message.toString());
+					if (logger.isDebugEnabled()) {
+						logger.debug("insert message: " + message.toString());
+					}
 
 					psInsertMessage.setInt(1, message.id);
 					psInsertMessage.setInt(2, message.channel.id);


### PR DESCRIPTION
Change to log trivial actions (like establish a WebSocket channel,
receive/insert a message or sending a custom message) as DEBUG instead
of INFO, to not flood the logs.
For example, the log file would be flooded with messages like:
  INFO TableWebSocket  - insert channel: example.com:80 (#1)
  INFO WebSocketProxyV13  - got text frame payload
  INFO TableWebSocket - insert message: #1.1
  INFO WebSocketProxyV13  - got text frame payload
  INFO TableWebSocket  - insert message: #1.2
  INFO WebSocketProxyV13  - got text frame payload
  INFO TableWebSocket  - insert message: #1.3
  INFO WebSocketProxyV13  - got text frame payload
  INFO TableWebSocket  - insert message: #1.4
  INFO WebSocketProxy  - send custom message
  INFO TableWebSocket  - insert message: #1.5

(Thread name and package were stripped from the previous excerpt for
clarity.)

Update changes in ZapAddOn.xml file.