### PR TITLE
websocket: use handshake message for channel name

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
@@ -59,6 +59,13 @@ public class WebSocketProxyV13 extends WebSocketProxy {
 	}
 
 	/**
+	 * @see WebSocketProxy#WebSocketProxy(Socket, Socket, String, int)
+	 */
+	public WebSocketProxyV13(Socket localSocket, Socket remoteSocket, String targetHost, int targetPort) throws WebSocketException {
+		super(localSocket, remoteSocket, targetHost, targetPort);
+	}
+
+	/**
 	 * @see WebSocketProxy#createWebSocketMessage(InputStream, byte)
 	 */
 	@Override

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Unload WebSockets components during uninstallation.<br>
+	Use hostname/port of the handshake message to build the name of the channel.<br>
 	]]>
 	</changes>
 	<classnames>


### PR DESCRIPTION
Change to use the hostname/port of the HTTP handshake message for the
name of the channel, instead of the address/port of the remote socket.
It would create the wrong name if ZAP was configured with an outgoing
proxy (that is, it would use the address/port of the proxy).
Update changes in ZapAddOn.xml file.