### PR TITLE
scripts: fix NPEs on engine added/removed

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -667,7 +667,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 		}
 
 		ScriptNode node = getSelectedNode();
-		if (node.getUserObject() != null && (node.getUserObject() instanceof ScriptWrapper)) {
+		if (node != null && node.getUserObject() instanceof ScriptWrapper) {
 			ScriptWrapper scriptWrapper = (ScriptWrapper) node.getUserObject();
 			if (ExtensionScript.hasSameScriptEngine(scriptWrapper, scriptEngineWrapper)) {
 				displayScript(scriptWrapper);
@@ -682,7 +682,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 		}
 
 		ScriptNode node = getSelectedNode();
-		if (node.getUserObject() != null && (node.getUserObject() instanceof ScriptWrapper)) {
+		if (node != null && node.getUserObject() instanceof ScriptWrapper) {
 			ScriptWrapper scriptWrapper = (ScriptWrapper) node.getUserObject();
 			if (ExtensionScript.hasSameScriptEngine(scriptWrapper, scriptEngineWrapper)) {
 				displayType(scriptWrapper.getType());

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
+	Fix exceptions when installing/uninstalling script engines, with no script selected.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change class ExtensionScriptsUI to check if there's any script selected
(that is, non-null) before checking if the script should be re-displayed
when a script engine is added, or its script type shown when an engine
is removed.
There's no script selected, for example, when the selected script is
removed, which was then causing NullPointerExceptions if an engine
script (for example, Zest add-on) was immediately added/removed after
that.

Update changes in ZapAddOn.xml file.