### PR TITLE
zest: fix UI threading issues

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -1,25 +1,13 @@
 <zapaddon>
 	<name>Zest - Graphical Security Scripting Language</name>
-	<version>20</version>
+	<version>21</version>
 	<status>beta</status>
 	<description>A graphical security scripting language, ZAPs macro language on steroids</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
-	Add missing error messages for 'Assign variable via string delimiters'.<br>
-	Add missing field (operand B) in 'Assign variable to a calculation' dialogue.<br>
-	Send authentication requests with ZAP's configurations (Issue 2114).<br>
-	Fix "Active scan sequence" (Issue 2120).<br>
-	Fix exception while opening a dialogue.<br>
-	Cannot use auth script in daemon mode (Issue 2294).<br>
-	Support httpsender scripts (Issue 2293).<br>
-	Cant paste variable into new request dialog (Issue 2007).<br>
-	Script context menu has duplicated items (Issue 2106).<br>
-	Exception while adding Zest Condition (Issue 2296).<br>
-	Should not be able to delete THEN statement (Issue 2295).<br>
-	Statement lost after drag and drop (Issue 2299).<br>
-	It's possible to drag the script node (Issue 2302).<br>
+	Fix (UI) exceptions related to Zest Results tab.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestResultsTableModel.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestResultsTableModel.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.zest;
 
+import java.awt.EventQueue;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -32,6 +33,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.view.table.AbstractCustomColumnHistoryReferencesTableModel;
 import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
@@ -65,6 +67,17 @@ public class ZestResultsTableModel extends
 
     @Override
     public void clear() {
+        if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+            EventQueue.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    clear();
+                }
+            });
+            return;
+        }
+
         results = new ArrayList<>();
         historyIdToRow = new TreeMap<>();
 
@@ -132,7 +145,18 @@ public class ZestResultsTableModel extends
     }
 
     @Override
-    public void addEntry(ZestResultsTableEntry entry) {
+    public void addEntry(final ZestResultsTableEntry entry) {
+        if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+            EventQueue.invokeLater(new Runnable() {
+                
+                @Override
+                public void run() {
+                    addEntry(entry);
+                }
+            });
+            return;
+        }
+
         int index = results.size();
         results.add(entry);
         historyIdToRow.put(entry.getHistoryId(), Integer.valueOf(index));


### PR DESCRIPTION
Change ZestResultsTableModel to add the Zest results and clear the model
in the EDT to prevent UI related threading issues. Otherwise it could
lead to exceptions like:
   java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
when the EDT attempts to obtain the results.

Bump version and update changes in ZapAddOn.xml file.