### PR TITLE
Suppress "options" compile warning

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -61,6 +61,7 @@
 			excludes="org/zaproxy/zap/extension/*/files/**,org/zaproxy/zap/extension/*/resources/**">
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-path"/>
+			<compilerarg value="-Xlint:-options"/>
 			<compilerarg value="-Werror"/>
 			<classpath>
 				<fileset dir="${dist.lib.dir}">
@@ -74,6 +75,7 @@
 		<javac srcdir="${test.src}" destdir="${build}" source="${src.version}" target="${src.version}" includeantruntime="false" debug="${debug}" encoding="UTF-8">
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-path"/>
+			<compilerarg value="-Xlint:-options"/>
 			<compilerarg value="-Werror"/>
 			<classpath>
 				<fileset dir="${dist.lib.dir}">


### PR DESCRIPTION
Add the compile argument "-Xlint:-options" to javac tasks of "compile"
target to suppress the following warning:
 [javac] warning: [options] bootstrap class path not set in conjunction
 with -source 1.7

to allow to compile the add-ons with Java 8 (warnings are considered as
errors).
 ---
From OWASP ZAP Developer Group: https://groups.google.com/d/topic/zaproxy-develop/2kFdlLmXzpA/discussion