### PR TITLE
Override HttpsInfo add-on ID in build-all target

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -369,7 +369,7 @@
 		<build-addon name="help_fr_FR" />
 		<build-addon name="help_ja_JP" />
 		<build-addon name="highlighter" />
-		<build-addon name="httpsinfo" />
+		<build-addon name="httpsinfo" addonid="httpsInfo" />
 		<build-addon name="importLogFiles" />
 		<build-addon name="pscanrulesAlpha" >
 				<!-- Add the extra classes required -->


### PR DESCRIPTION
Change the target build-all in build.xml file to override the ID of the
HttpsInfo add-on, to also keep the same ID as the old versions when all
add-ons are built.