### PR TITLE
Address AScan Release Errors/Exceptions

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
@@ -23,6 +23,8 @@ import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -355,7 +357,7 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
             //send the modified message (with a hopefully non-existent filename), and see what we get back
 			try {
 	            sendAndReceive(msg);
-			} catch (SocketException|IllegalStateException|UnknownHostException|IllegalArgumentException ex) {
+			} catch (SocketException|IllegalStateException|UnknownHostException|IllegalArgumentException|InvalidRedirectLocationException|URIException ex) {
 				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
 						" when accessing: " + msg.getRequestHeader().getURI().toString());
 				return; //Something went wrong, no point continuing
@@ -386,7 +388,7 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
                     //send the modified message (with the url filename), and see what we get back
         			try {
         	            sendAndReceive(msg);
-        			} catch (SocketException|IllegalStateException|UnknownHostException|IllegalArgumentException ex) {
+        			} catch (SocketException|IllegalStateException|UnknownHostException|IllegalArgumentException|InvalidRedirectLocationException|URIException ex) {
         				if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
         						" when accessing: " + msg.getRequestHeader().getURI().toString());
         				continue; //Something went wrong, move to the next prefix in the loop
@@ -457,7 +459,7 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
         // send the modified request, and see what we get back
 		try {
             sendAndReceive(msg);
-		} catch (SocketException|IllegalStateException|UnknownHostException|IllegalArgumentException ex) {
+		} catch (SocketException|IllegalStateException|UnknownHostException|IllegalArgumentException|InvalidRedirectLocationException|URIException ex) {
 			if (log.isDebugEnabled()) log.debug("Caught " + ex.getClass().getName() + " " + ex.getMessage() + 
 					" when accessing: " + msg.getRequestHeader().getURI().toString());
 			return false; //Something went wrong, no point continuing

--- a/src/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
@@ -247,7 +247,10 @@ public class TestRemoteFileInclude extends AbstractAppParamPlugin {
             }
 
         } catch (Exception e) {
-            log.error("Error scanning parameters for Path Traversal: " + e.getMessage() + " Caused by: " + e.getCause());
+        	if (log.isDebugEnabled()) {
+                log.debug("Error checking [" + getBaseMsg().getRequestHeader().getMethod() + "] [" + getBaseMsg().getRequestHeader().getURI()
+                        + "], parameter [" + param + "] for Remote File Include. " + e.getMessage());
+            }
         }
     }
 

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -1,26 +1,14 @@
 <zapaddon>
 	<name>Active scanner rules</name>
-	<version>23</version>
+	<version>24</version>
 	<status>release</status>
 	<description>The release quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 823 - i18n (internationalise) release active scan rules.<br>
-	Issue 2001 - Add PowerShell variants to CommandInjection Plugin.<br>
-	Add CWE and WASC IDs to active scanners which may have been lacking those details.<br>
-	Add missing skip/stop checks to some scanners (Issue 1734).<br>
-	Remote File Include FP if original title includes 'Google' (Issue 2240).<br> 
-	Issue 2264: TestPathTraversal - adjust logging, catch specific exceptions.<br>
-	Issue 2265: TestRemoteFileInclude - adjust logging, catch specific exceptions.<br>
-	Issue 2266: TestCrossSiteScriptV2 - adjust logging, catch specific exceptions.<br>
-	Issue 2267 & 1860: TestSQLInjection - adjust logging, catch specific exceptions.<br>
-	Issue 2268: CodeInjectionPlugin - adjust logging, catch specific exceptions.<br>
-	Issue 2269: BufferOverflow - adjust logging, catch specific exceptions.<br>
-	Issue 2270: FormatString - adjust logging, catch specific exceptions.<br>
-	Issue 2271: TestParameterTamper - adjust logging, catch specific exceptions.<br>
-	Issue 1550: CommandInjectionPlugin - adjust logging, catch specific exceptions.<br>
+	TestPathTraversal - catch InvalidRedirectLocationException and URIException.<br>
+	TestRemoteFileInclude - adjust logging (debug not error).<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Per https://twitter.com/psiinon/status/741229375140581376 &
zapbot/zap-mgmt-scripts@205f4cc

TestPathTraversal - catch InvalidRedirectLocationException and
URIException.
TestRemoteFileInclude - adjust logging (debug not error).