### PR TITLE
coreLang: fix installation issue

### DIFF
--- a/src/org/zaproxy/zap/extension/coreLang/ExtensionCoreLanguages.java
+++ b/src/org/zaproxy/zap/extension/coreLang/ExtensionCoreLanguages.java
@@ -18,6 +18,8 @@
 
 package org.zaproxy.zap.extension.coreLang;
 
+import java.nio.file.Paths;
+
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.zaproxy.zap.extension.lang.LangImporter;
@@ -52,7 +54,7 @@ public class ExtensionCoreLanguages extends ExtensionAdaptor {
     @Override
     public void postInstall() {
     	// Import the language file
-    	LangImporter.importLanguagePack(Constant.getZapHome() + "/lang/ZAP_2.4.3_language_pack.1.zaplang");
+    	LangImporter.importLanguagePack(Paths.get(Constant.getZapHome(), getAddOn().getFiles().get(0)).toString());
     }
 
 }

--- a/src/org/zaproxy/zap/extension/coreLang/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/coreLang/ZapAddOn.xml
@@ -3,10 +3,10 @@
 	<name>Core Language Files</name>
 	<description>Translations of the core language files</description>
 	<author>ZAP Dev Team</author>
-	<version>10</version>
+	<version>11</version>
 	<status>release</status>
 	<url>https://crowdin.com/project/owasp-zap</url>
-	<changes>Updated for 2.5.0</changes>
+	<changes>Fix installation issue.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.coreLang.ExtensionCoreLanguages</extension>
 	</extensions>
@@ -14,6 +14,7 @@
 	<pscanrules/>
 	<filters/>
 	<files>
+		<!-- Note: the declaration order of the file(s) is important in this add-on, see ExtensionCoreLanguages.postInstall() -->
 		<file>lang/ZAP_2.5.0_language_pack.1.zaplang</file>
 	</files>
 	<not-before-version>2.5.0</not-before-version>


### PR DESCRIPTION
Change class ExtensionCoreLanguages to use the file path defined in the
manifest (ZapAddOn.xml) instead of hard coding it, to make sure the file
path/name is always kept in sync and prevent installation issues because
of missing (non existing) file.
Bump version and update changes in ZapAddOn.xml file.