### PR TITLE
fuzz: enable Limit maximum errors by default

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/FuzzOptions.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzOptions.java
@@ -41,7 +41,7 @@ public class FuzzOptions extends VersionedAbstractParam {
 
     public static final int DEFAULT_RETRIES_ON_IO_ERROR = 3;
 
-    public static final int DEFAULT_MAX_ERRORS_ALLOWED = 25;
+    public static final int DEFAULT_MAX_ERRORS_ALLOWED = 1000;
 
     public static final int DEFAULT_MAX_FUZZERS_IN_UI = 5;
 

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -9,6 +9,7 @@
     <changes>
     <![CDATA[
     Added Export button to export results as CSV file.<br>
+    Enable "Limit maximum errors" by default and increase the default number.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/impl/FuzzerOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/impl/FuzzerOptionsPanel.java
@@ -75,6 +75,7 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
         retriesOnIOErrorLabel.setLabelFor(retriesOnIOErrorNumberSpinner);
 
         maxErrorsAllowedEnabledCheckBox = new JCheckBox();
+        maxErrorsAllowedEnabledCheckBox.setSelected(true);
         JLabel maxErrorsAllowedEnabledLabel = new JLabel(
                 resourceBundle.getString("fuzz.fuzzer.dialog.tab.options.label.maxErrorsAllowedEnabled"));
         maxErrorsAllowedEnabledLabel.setLabelFor(maxErrorsAllowedEnabledCheckBox);
@@ -88,7 +89,6 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
         });
 
         maxErrorsAllowedNumberSpinner = new ZapNumberSpinner(0, defaultOptions.getMaxErrorsAllowed(), Integer.MAX_VALUE);
-        maxErrorsAllowedNumberSpinner.setEnabled(false);
         JLabel maxErrorsAllowedLabel = new JLabel(resourceBundle.getString("fuzz.options.label.maxErrorsAllowed"));
         maxErrorsAllowedLabel.setLabelFor(maxErrorsAllowedNumberSpinner);
 
@@ -316,7 +316,7 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
     public void reset() {
         defaultThreadsPerFuzzerSlider.setValue(defaultOptions.getThreadCount());
         retriesOnIOErrorNumberSpinner.setValue(defaultOptions.getRetriesOnIOError());
-        maxErrorsAllowedEnabledCheckBox.setSelected(false);
+        maxErrorsAllowedEnabledCheckBox.setSelected(true);
         maxErrorsAllowedNumberSpinner.setValue(defaultOptions.getMaxErrorsAllowed());
         defaultFuzzDelayInMsSlider.setValue((int) defaultOptions.getSendMessageDelay());
         depthFirstPayloadReplacementStrategyRadioButton.setSelected(MessageLocationsReplacementStrategy.DEPTH_FIRST == defaultOptions.getPayloadsReplacementStrategy());


### PR DESCRIPTION
Enable the option Limit maximum errors by default and increase the
default number of errors allowed before stopping the scan.
Update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#2568 - Fuzzer consuming all memory on error