### PR TITLE
fuzz: correct info message shown

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzer.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzer.java
@@ -166,7 +166,7 @@ public class HttpFuzzer extends AbstractFuzzer<HttpMessage> {
             errorsModel.addFuzzerError(
                     taskId,
                     Constant.messages.getString("fuzz.httpfuzzer.results.error.source.httpfuzzer"),
-                    Constant.messages.getString("fuzz.httpfuzzer.results.error.message.failedSendOriginalMessage"));
+                    Constant.messages.getString("fuzz.httpfuzzer.results.error.message.maxErrorsReached"));
         }
     }
 


### PR DESCRIPTION
Change HttpFuzzer class to use the correct resource message key to show
the information message that indicates the fuzzer process stopped
because the maximum number of errors has been reached.