### PR TITLE
CSRFCountermeasures Remove Attack & Evidence Msg

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
@@ -180,7 +180,6 @@ public class CSRFCountermeasures extends PluginPassiveScanner {
 				String tokenNamesFlattened = tokenNames.toString();
 				
 				String desc = Constant.messages.getString("pscanbeta.noanticsrftokens.desc");
-				String attack = Constant.messages.getString("pscanbeta.noanticsrftokens.alert.attack");
 				String extraInfo = Constant.messages.getString("pscanbeta.noanticsrftokens.alert.extrainfo", tokenNamesFlattened, formDetails);
 				
 			    Alert alert = new Alert(getPluginId(), Alert.RISK_LOW, Alert.CONFIDENCE_MEDIUM,  getName());
@@ -188,11 +187,11 @@ public class CSRFCountermeasures extends PluginPassiveScanner {
 			    			desc + "\n"+getDescription(), 
 				    		msg.getRequestHeader().getURI().toString(),
 				    		"",  //parameter: none.
-				    		attack, 
+				    		"", 
 				    		extraInfo,
 				    		getSolution(), 
 				            getReference(), 
-							attack,	// Evidence
+							"",	// Evidence
 							352, // CWE-352: Cross-Site Request Forgery (CSRF)
 							9,	// WASC Id
 				            msg);

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -1,18 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (beta)</name>
-	<version>13</version>
+	<version>14</version>
 	<status>beta</status>
 	<description>The beta quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 1966: Charset Mismatch passive scanner now handles HTML5 meta charset, and multiple conditions.<br>
-	Issue 316: 'Information Disclosure - Debug Error' added mysql and ASP.Net messages.<br>
-	Issue 823: i18n (internationalise) beta passive scan rules.<br>
-	Issue 2230: Weak Auth Passive Scanner - Evidence vs Attack.<br>
-	Add CWE and WASC IDs to passive scanners which may have been lacking those details.<br>
-	Create help for scanners which were missing entries.<br>
+	Issue 2576: CSRFCountermeasures, remove unneeded Attack and Evidence messages.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -70,7 +70,6 @@ pscanbeta.insecurejsfviewstate.extrainfo=JSF ViewState [{0}] is insecure
 
 pscanbeta.noanticsrftokens.name=Absence of Anti-CSRF Tokens
 pscanbeta.noanticsrftokens.desc=No Anti-CSRF tokens were found in a HTML submission form.
-pscanbeta.noanticsrftokens.alert.attack=None. Warning only.
 pscanbeta.noanticsrftokens.alert.extrainfo=No known Anti-CSRF tokens {0} were found in the following HTML forms: {1}.
 
 pscanbeta.servletparameterpollutionscanner.name=HTTP Parameter Override


### PR DESCRIPTION
Attack and Evidence fields in alerts generated by CSRFCountermeasures
were unnecessary, and didn't add any value. 

Fixes zaproxy/zaproxy#2576