### PR TITLE
zest: do not reuse Sites' nodes in sequence script

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Zest - Graphical Security Scripting Language</name>
-	<version>21</version>
+	<version>22</version>
 	<status>beta</status>
 	<description>A graphical security scripting language, ZAPs macro language on steroids</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
-	Fix (UI) exceptions related to Zest Results tab.<br>
+	Change Sequence scripts to not use Sites tree nodes directly.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
@@ -352,10 +352,7 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
 				if(stmt instanceof ZestRequest) {
 					ZestRequest req = (ZestRequest)stmt;
 					HttpMessage msg = ZestZapUtils.toHttpMessage(req, req.getResponse());
-					SiteNode node = Model.getSingleton().getSession().getSiteTree().findNode(msg);
-					if (node == null) {
-						node = messageToSiteNode(msg);
-					}
+					SiteNode node = messageToSiteNode(msg);
 					if (node != null) {
 						fakeDirectory.add(node);
 					}


### PR DESCRIPTION
Change class ZestSequenceRunner to not reuse existing Sites tree nodes
when creating the sites structure to be active scanned, reusing the tree
nodes changes the internal structure of the Sites tree (when adding to
the custom sites tree the nodes are removed from the original tree).
Bump version and update changes in ZapAddOn.xml file.