### PR TITLE
XPoweredByHeaderInfoLeakScanner modify evidence

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/XPoweredByHeaderInfoLeakScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/XPoweredByHeaderInfoLeakScanner.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 public class XPoweredByHeaderInfoLeakScanner extends PluginPassiveScanner{
 
 	private static final String MESSAGE_PREFIX = "pscanalpha.xpoweredbyheaderinfoleak.";
+	private static final String HEADER_NAME = "X-Powered-By";
 	private static final int PLUGIN_ID = 10037;
 	
 	private PassiveScanThread parent = null;
@@ -58,7 +59,7 @@ public class XPoweredByHeaderInfoLeakScanner extends PluginPassiveScanner{
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 		long start = System.currentTimeMillis();
 	
-		Vector<String> xpbOptions = msg.getResponseHeader().getHeaders("X-Powered-By");
+		Vector<String> xpbOptions = msg.getResponseHeader().getHeaders(HEADER_NAME);
 		if (xpbOptions != null) { //Header Found
 			for (String xpbDirective : xpbOptions) {
 				Alert alert = new Alert(getPluginId(), Alert.RISK_LOW, Alert.CONFIDENCE_MEDIUM, //PluginID, Risk, Reliability
@@ -71,7 +72,7 @@ public class XPoweredByHeaderInfoLeakScanner extends PluginPassiveScanner{
 		    				"", // Other info
 		    				getSolution(), //Solution
 		    				getReference(), //References
-		    				xpbDirective,	// Evidence - Return the X-Powered-By Header info
+		    				HEADER_NAME, // Evidence - Return the header name
 		    				200, // CWE Id
 		    				13,	// WASC Id
 		    				msg); //HttpMessage

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,16 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>9</version>
+	<version>10</version>
 	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-		Add CWE and WASC IDs to passive scanners which may have been lacking those details.<br>
-		Fix exception when scanning with "User Controllable Charset" scanner.<br>
-		Fix exception when scanning with "Image Location Scanner" scanner.<br>
-		Strict-Transport-Security Header Scanner added support for max-age=0 per rfc6797.<br>
+		XPoweredByHeaderInfoLeakScanner modify evidence (Issue 2575)<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
The highlight of X-Powered-By header alert in the response tab is incorrectly chosen because of the evidence text. Hence I've modified the evidence text so that correct header is highlighted. Though subjective, but I believe it is better to display both the header name and header value in evidence text.

### Before fix
<img width="1427" alt="2016-06-15_2340" src="https://cloud.githubusercontent.com/assets/3061095/16092639/52901dac-3356-11e6-9cfd-7a285c48c0cc.png">

### After fix
<img width="1434" alt="2016-06-15_2351" src="https://cloud.githubusercontent.com/assets/3061095/16092650/5ad32734-3356-11e6-98b6-e0bdbacd3636.png">




