### PR TITLE
websocket: remove use of JAX-WS API exception

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -1,15 +1,12 @@
 <zapaddon>
 	<name>WebSockets</name>
-	<version>11</version>
+	<version>12</version>
 	<status>release</status>
 	<description>Allows you to inspect WebSocket communication.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Unload WebSockets components during uninstallation.<br>
-	Use hostname/port of the handshake message to build the name of the channel.<br>
-	Adjust log levels, from INFO to DEBUG.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/manualsend/WebSocketPanelSender.java
+++ b/src/org/zaproxy/zap/extension/websocket/manualsend/WebSocketPanelSender.java
@@ -22,8 +22,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.ws.WebServiceException;
-
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.manualrequest.MessageSender;
@@ -51,33 +49,28 @@ public class WebSocketPanelSender implements MessageSender, WebSocketObserver {
     }
     
     @Override
-    public void handleSendMessage(Message aMessage) throws WebServiceException {
+    public void handleSendMessage(Message aMessage) throws IOException {
         final WebSocketMessageDTO websocketMessage = (WebSocketMessageDTO)aMessage;
     	
         if (websocketMessage.channel == null || websocketMessage.channel.id == null) {
     		logger.warn("Invalid WebSocket channel selected. Unable to send manual crafted message!");
-    		throw new WebServiceException(Constant.messages.getString("websocket.manual_send.fail.invalid_channel") 
+    		throw new IllegalArgumentException(Constant.messages.getString("websocket.manual_send.fail.invalid_channel") 
     				+ " " + Constant.messages.getString("websocket.manual_send.fail"));
     	}
         
         if (websocketMessage.opcode == null) {
     		logger.warn("Invalid WebSocket opcode selected. Unable to send manual crafted message!");
-    		throw new WebServiceException(Constant.messages.getString("websocket.manual_send.fail.invalid_opcode") 
+    		throw new IllegalArgumentException(Constant.messages.getString("websocket.manual_send.fail.invalid_opcode") 
     				+ " " + Constant.messages.getString("websocket.manual_send.fail"));
     	}
     	
-        try {
-        	WebSocketProxy wsProxy = getDelegate(websocketMessage.channel.id);
-        	if (!websocketMessage.isOutgoing && wsProxy.isClientMode()) {
-        		logger.warn("Invalid WebSocket direction 'incoming' selected for Proxy in Client Mode. Unable to send manual crafted message!");
-        		throw new WebServiceException(Constant.messages.getString("websocket.manual_send.fail.invalid_direction_client_mode") 
-        				+ " " + Constant.messages.getString("websocket.manual_send.fail"));
-        	}
-        	wsProxy.sendAndNotify(websocketMessage);
-        } catch (final IOException ioe) {
-        	logger.warn(ioe.getMessage(), ioe);
-            throw new WebServiceException("IO error in sending WebSocket message.");
-        }
+    	WebSocketProxy wsProxy = getDelegate(websocketMessage.channel.id);
+    	if (!websocketMessage.isOutgoing && wsProxy.isClientMode()) {
+    		logger.warn("Invalid WebSocket direction 'incoming' selected for Proxy in Client Mode. Unable to send manual crafted message!");
+    		throw new IllegalArgumentException(Constant.messages.getString("websocket.manual_send.fail.invalid_direction_client_mode") 
+    				+ " " + Constant.messages.getString("websocket.manual_send.fail"));
+    	}
+    	wsProxy.sendAndNotify(websocketMessage);
     }
     
     @Override
@@ -85,10 +78,10 @@ public class WebSocketPanelSender implements MessageSender, WebSocketObserver {
         
     }
     
-    private WebSocketProxy getDelegate(Integer channelId) throws WebServiceException {
+    private WebSocketProxy getDelegate(Integer channelId) {
     	if (!connectedProxies.containsKey(channelId)) {
     		logger.warn("Selected WebSocket channel is not connected. Unable to send manual crafted message!");
-    		throw new WebServiceException(Constant.messages.getString("websocket.manual_send.fail.disconnected_channel") 
+    		throw new IllegalArgumentException(Constant.messages.getString("websocket.manual_send.fail.disconnected_channel") 
     				+ " " + Constant.messages.getString("websocket.manual_send.fail"));
     	}
         return connectedProxies.get(channelId);

--- a/src/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesPopupMenuItem.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesPopupMenuItem.java
@@ -22,7 +22,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
 import javax.swing.JTable;
-import javax.xml.ws.WebServiceException;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
@@ -77,9 +76,8 @@ public abstract class WebSocketMessagesPopupMenuItem extends ExtensionPopupMenuI
 
     /**
      * What happens if choosen?
-     * @throws Exception 
      */
-	protected abstract void performAction() throws WebServiceException;
+	protected abstract void performAction();
 
 	/**
 	 * Which panel is allowed to show this popup item?


### PR DESCRIPTION
Change classes WebSocketMessagesPopupMenuItem and WebSocketPanelSender
to not use an exception from JAX-WS API (WebServiceException), for the
former class remove the declared exception (it's not needed, pop up menu
items should handle the exceptions appropriately), for the latter class
change to declare that it throws IOException and to throw
IllegalArgumentException when the WebSocket message or WebSocketProxy
are not correct (for example, if there's no connection with the given
ID).
The change allows to run the WebSockets add-on with Java 9 (EA), which
was leading to an exception:
 java.lang.NoClassDefFoundError: javax/xml/ws/WebServiceException

Bump version and remove old changes in ZapAddOn.xml file.