### PR TITLE
websocket: change break dialogues to be modal

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Make breakpoint dialogues modal.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/brk/PopupMenuAddBreakWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/brk/PopupMenuAddBreakWebSocket.java
@@ -76,7 +76,7 @@ public class PopupMenuAddBreakWebSocket extends ExtensionPopupMenuItem {
             try {
                 tableWebSocket = (JTable) invoker;
                 int[] rows = tableWebSocket.getSelectedRows();
-                if (rows.length == 1 && extension.canAddBreakpoint()) {
+                if (rows.length == 1) {
                     this.setEnabled(true);
                 } else {
                     this.setEnabled(false);

--- a/src/org/zaproxy/zap/extension/websocket/brk/PopupMenuEditBreak.java
+++ b/src/org/zaproxy/zap/extension/websocket/brk/PopupMenuEditBreak.java
@@ -52,11 +52,6 @@ public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(BreakpointsPanel.PANEL_NAME)) {
-            if (extension.canEditBreakpoint()) {
-                this.setEnabled(true);
-            } else {
-                this.setEnabled(false);
-            }
             return true;
         }
         return false;

--- a/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialog.java
+++ b/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialog.java
@@ -51,9 +51,10 @@ public abstract class WebSocketBreakDialog extends AbstractDialog {
 	private JScrollPane jScrollPane = null;
 
     public WebSocketBreakDialog(WebSocketBreakpointsUiManagerInterface breakPointsManager, ChannelSortedListModel channelsModel) throws HeadlessException {
-        super(View.getSingleton().getMainFrame(), false);
+        super(View.getSingleton().getMainFrame(), true);
         
         this.breakPointsManager = breakPointsManager;
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         
         wsUiHelper = new WebSocketUiHelper();
         wsUiHelper.setChannelsModel(channelsModel);

--- a/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogAdd.java
+++ b/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogAdd.java
@@ -54,7 +54,7 @@ public class WebSocketBreakDialogAdd extends WebSocketBreakDialog {
 	
 				@Override
 				public void actionPerformed(ActionEvent e) {
-				    breakPointsManager.hideAddDialog();
+				    dispose();
 				}
 			};
 		}
@@ -70,7 +70,7 @@ public class WebSocketBreakDialogAdd extends WebSocketBreakDialog {
 				public void actionPerformed(ActionEvent evt) {
 					try {
 						breakPointsManager.addBreakpoint(getWebSocketBreakpointMessage());
-					    breakPointsManager.hideAddDialog();
+						dispose();
 					} catch (PatternSyntaxException e) {
 						// show popup
 						View.getSingleton().showWarningDialog(Constant.messages.getString("filter.replacedialog.invalidpattern"));

--- a/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogEdit.java
+++ b/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogEdit.java
@@ -57,7 +57,7 @@ public class WebSocketBreakDialogEdit extends WebSocketBreakDialog {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     breakpoint = null;
-                    breakPointsManager.hideEditDialog();
+                    dispose();
                 }
 			};
 		}
@@ -74,7 +74,7 @@ public class WebSocketBreakDialogEdit extends WebSocketBreakDialog {
 					try {
 						breakPointsManager.editBreakpoint(breakpoint, getWebSocketBreakpointMessage());
 	                    breakpoint = null;
-	                    breakPointsManager.hideEditDialog();
+	                    dispose();
 					} catch (PatternSyntaxException e) {
 						// show popup
 						View.getSingleton().showWarningDialog(Constant.messages.getString("filter.replacedialog.invalidpattern"));

--- a/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakpointsUiManagerInterface.java
+++ b/src/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakpointsUiManagerInterface.java
@@ -57,7 +57,6 @@ public class WebSocketBreakpointsUiManagerInterface implements BreakpointsUiMana
 
     @Override
     public void handleAddBreakpoint(Message aMessage) {
-        extensionBreak.dialogShown(ExtensionBreak.DialogType.ADD);
         showAddDialog(aMessage);
     }
 
@@ -67,7 +66,6 @@ public class WebSocketBreakpointsUiManagerInterface implements BreakpointsUiMana
 
     @Override
     public void handleEditBreakpoint(BreakpointMessageInterface breakpoint) {
-        extensionBreak.dialogShown(ExtensionBreak.DialogType.EDIT);
         showEditDialog((WebSocketBreakpointMessage)breakpoint);
     }
 
@@ -98,11 +96,6 @@ public class WebSocketBreakpointsUiManagerInterface implements BreakpointsUiMana
         }
     }
 
-    void hideAddDialog() {
-        addDialog.dispose();
-        extensionBreak.dialogClosed();
-    }
-    
     private void populateEditDialogAndSetVisible(WebSocketBreakpointMessage breakpoint) {
         editDialog.setBreakpoint(breakpoint);
         editDialog.setVisible(true);
@@ -115,10 +108,5 @@ public class WebSocketBreakpointsUiManagerInterface implements BreakpointsUiMana
         } else if (!editDialog.isVisible()) {
             populateEditDialogAndSetVisible(breakpoint);
         }
-    }
-
-    void hideEditDialog() {
-        editDialog.dispose();
-        extensionBreak.dialogClosed();
     }
 }


### PR DESCRIPTION
Change the breakpoint dialogues to be modal, to prevent interactions
with other UI components (and core code) while the dialogues are shown.
Reduces code complexity in core and add-ons, it's also less error prone,
since it no longer requires the break implementations and core code to
track/tell which type of dialogues (add/edit/remove) are currently
shown.
Bump version and update changes in ZapAddOn.xml file.