### PR TITLE
sqliplugin: check all DB technologies available

### DIFF
--- a/src/org/zaproxy/zap/extension/sqliplugin/SQLInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/sqliplugin/SQLInjectionPlugin.java
@@ -190,7 +190,22 @@ public class SQLInjectionPlugin extends AbstractAppParamPlugin {
 
     @Override
     public boolean targets(TechSet technologies) {
-        return technologies.includes(Tech.Db);
+        if (technologies.includes(Tech.Db)) {
+            return true;
+        }
+
+        for (SQLiTest test : SQLiPayloadManager.getInstance().getTests()) {
+            if (test.getDetails() == null) {
+                continue;
+            }
+
+            for (DBMSHelper dbms : test.getDetails().getDbms()) {
+                if (technologies.includes(dbms.getTech())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
@@ -1,19 +1,13 @@
 <zapaddon>
 	<name>Advanced SQLInjection Scanner</name>
-	<version>10</version>
+	<version>11</version>
 	<status>beta</status>
 	<description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
 	<author>Andrea Pompili (Yhawke)</author>
 	<url/>
 	<changes><![CDATA[
-	Prevent XXE vulnerability.<br>
-	Log level adjustments.<br>
-	Internationalisation of scanner and alert's data.<br>
-	Check for skip/stop more often.<br>
-            Added EXP error based payloads<br>
-            Preserved the space in commented suffixes<br>
-        ]]>
-        </changes>
+	Check all DB techs when evaluating if the scanner should be run.<br>
+	]]></changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.sqliplugin.ExtensionSQLiPlugin</extension>
 	</extensions>


### PR DESCRIPTION
Change SQLInjectionPlugin scanner to check all DB technologies available
when evaluating if the scanner should be run or not, allowing to run it
even if it's only selected a specific DB technology (not just when it's
selected the top DB technology).
Bump version and update changes in ZapAddOn.xml file.
 ---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/5vlQfn5I26g/discussion