### PR TITLE
plugnhack: change break dialogues to be modal

### DIFF
--- a/src/org/zaproxy/zap/extension/plugnhack/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/plugnhack/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Plug-n-Hack Configuration</name>
-	<version>9</version>
+	<version>10</version>
 	<status>beta</status>
 	<description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</url>
 	<changes>
 	<![CDATA[
-	Require API key before returning it (Issue 1714)<br>
-	Restrict use of CORS header in pnh (Issue 1716)<br>
-	Auto-scroll when new client events are available (Issue 1664)
+	Make breakpoint dialogues modal.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialog.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialog.java
@@ -57,7 +57,8 @@ public abstract class ClientBreakDialog extends AbstractDialog {
 
     public ClientBreakDialog(ExtensionPlugNHack extension, 
     		ClientBreakpointsUiManagerInterface breakPointsManager) throws HeadlessException {
-        super(View.getSingleton().getMainFrame(), false);
+        super(View.getSingleton().getMainFrame(), true);
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         this.extension = extension;
         this.breakPointsManager = breakPointsManager;
 

--- a/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogAdd.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogAdd.java
@@ -55,7 +55,7 @@ public class ClientBreakDialogAdd extends ClientBreakDialog {
 	
 				@Override
 				public void actionPerformed(ActionEvent e) {
-				    breakPointsManager.hideAddDialog();
+				    dispose();
 				}
 			};
 		}
@@ -71,7 +71,7 @@ public class ClientBreakDialogAdd extends ClientBreakDialog {
 				public void actionPerformed(ActionEvent evt) {
 					try {
 						breakPointsManager.addBreakpoint(getClientBreakpointMessage());
-					    breakPointsManager.hideAddDialog();
+						dispose();
 					} catch (PatternSyntaxException e) {
 						// show popup
 						View.getSingleton().showWarningDialog(Constant.messages.getString("filter.replacedialog.invalidpattern"));

--- a/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogEdit.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogEdit.java
@@ -57,7 +57,7 @@ public class ClientBreakDialogEdit extends ClientBreakDialog {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     breakpoint = null;
-                    breakPointsManager.hideEditDialog();
+                    dispose();
                 }
 			};
 		}
@@ -74,7 +74,7 @@ public class ClientBreakDialogEdit extends ClientBreakDialog {
 					try {
 						breakPointsManager.editBreakpoint(breakpoint, getClientBreakpointMessage());
 	                    breakpoint = null;
-	                    breakPointsManager.hideEditDialog();
+	                    dispose();
 					} catch (PatternSyntaxException e) {
 						// show popup
 						View.getSingleton().showWarningDialog(Constant.messages.getString("filter.replacedialog.invalidpattern"));

--- a/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakpointsUiManagerInterface.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakpointsUiManagerInterface.java
@@ -54,7 +54,6 @@ public class ClientBreakpointsUiManagerInterface implements BreakpointsUiManager
 
     @Override
     public void handleAddBreakpoint(Message aMessage) {
-        extensionBreak.dialogShown(ExtensionBreak.DialogType.ADD);
         showAddDialog(aMessage);
     }
 
@@ -64,7 +63,6 @@ public class ClientBreakpointsUiManagerInterface implements BreakpointsUiManager
 
     @Override
     public void handleEditBreakpoint(BreakpointMessageInterface breakpoint) {
-        extensionBreak.dialogShown(ExtensionBreak.DialogType.EDIT);
         showEditDialog((ClientBreakpointMessage)breakpoint);
     }
 
@@ -94,11 +92,6 @@ public class ClientBreakpointsUiManagerInterface implements BreakpointsUiManager
             populateAddDialogAndSetVisible(aMessage);
         }
     }
-
-    void hideAddDialog() {
-        addDialog.dispose();
-        extensionBreak.dialogClosed();
-    }
     
     private void populateEditDialogAndSetVisible(ClientBreakpointMessage breakpoint) {
         editDialog.setBreakpoint(breakpoint);
@@ -112,11 +105,6 @@ public class ClientBreakpointsUiManagerInterface implements BreakpointsUiManager
         } else if (!editDialog.isVisible()) {
             populateEditDialogAndSetVisible(breakpoint);
         }
-    }
-
-    void hideEditDialog() {
-        editDialog.dispose();
-        extensionBreak.dialogClosed();
     }
 
 }

--- a/src/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuAddBreakClient.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuAddBreakClient.java
@@ -75,7 +75,7 @@ public class PopupMenuAddBreakClient extends ExtensionPopupMenuItem {
             try {
                 messageTable = (JTable) invoker;
                 int[] rows = messageTable.getSelectedRows();
-                if (rows.length == 1 && extension.canAddBreakpoint()) {
+                if (rows.length == 1) {
                     this.setEnabled(true);
                 } else {
                     this.setEnabled(false);

--- a/src/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuEditBreak.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuEditBreak.java
@@ -52,11 +52,6 @@ public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
     @Override
     public boolean isEnableForComponent(Component invoker) {
         if (invoker.getName() != null && invoker.getName().equals(BreakpointsPanel.PANEL_NAME)) {
-            if (extension.canEditBreakpoint()) {
-                this.setEnabled(true);
-            } else {
-                this.setEnabled(false);
-            }
             return true;
         }
         return false;


### PR DESCRIPTION
Change the (Client) breakpoint dialogues to be modal, to prevent
interactions with other UI components (and core code) while the
dialogues are shown.
Reduces code complexity in core and add-ons, it's also less error prone,
since it no longer requires the break implementations and core code to
track/tell which type of dialogues (add/edit/remove) are currently
shown.
Bump version and update changes in ZapAddOn.xml file.