### PR TITLE
Resetting the crawled url counter for AjaxSpider this closes zaproxy/…

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -397,7 +397,8 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 		if (View.isInitialised()) {
 			// Show the tab in case its been closed
 			this.setTabFocus();
-			this.foundCount ++;
+			this.foundCount = 0;
+			this.foundLabel.setText(Integer.toString(this.foundCount));
 		}
 		try {
 			this.runnable = extension.createSpiderThread(site, inScope, params, this);

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Ajax Spider</name>
-	<version>15</version>
+	<version>16</version>
 	<status>release</status>
 	<description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
-	Fix issue that prevented the spider from clicking all elements set in the options (Issue 2151).<br>
-	Minor update in help pages.<br>
-	Suppress log of innocuous warning.<br>
+	Fixed the issue that prevented the ajaxSpider from resetting the crawled url count to zero while starting a new scan (Issue 2610).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
…zaproxy#2610
- Initially crawled url count has been set to zero.
- Every time a new scan starts the counter is reset to zero and then incremented accordingly.