### PR TITLE
pscanrules: correctly check cookie attributes

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanner.java
@@ -21,6 +21,7 @@ import java.util.Vector;
 
 import net.htmlparser.jericho.Source;
 
+import org.apache.commons.collections.iterators.IteratorChain;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
@@ -36,6 +37,8 @@ public class CookieHttpOnlyScanner extends PluginPassiveScanner {
 	 */
 	private static final String MESSAGE_PREFIX = "pscanrules.cookiehttponlyscanner.";
 	private static final int PLUGIN_ID = 10010;
+
+	private static final String HTTP_ONLY_COOKIE_ATTRIBUTE = "HttpOnly";
 	
 	private PassiveScanThread parent = null;
 
@@ -51,23 +54,23 @@ public class CookieHttpOnlyScanner extends PluginPassiveScanner {
 
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+		IteratorChain iterator = new IteratorChain();
 		Vector<String> cookies1 = msg.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE);
 
 		if (cookies1 != null) {
-			for (String cookie : cookies1) {
-				if (cookie.toLowerCase().indexOf("httponly") < 0) {
-					this.raiseAlert(msg, id, cookie);
-				}
-			}
+			iterator.addIterator(cookies1.iterator());
 		}
 
 		Vector<String> cookies2 = msg.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE2);
 		
 		if (cookies2 != null) {
-			for (String cookie : cookies2) {
-				if (cookie.toLowerCase().indexOf("httponly") < 0) {
-					this.raiseAlert(msg, id, cookie);
-				}
+			iterator.addIterator(cookies2.iterator());
+		}
+
+		while (iterator.hasNext()) {
+			String headerValue = (String) iterator.next();
+			if (!SetCookieUtils.hasAttribute(headerValue, HTTP_ONLY_COOKIE_ATTRIBUTE)) {
+				this.raiseAlert(msg, id, headerValue);
 			}
 		}
 	}

--- a/src/org/zaproxy/zap/extension/pscanrules/SetCookieUtils.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/SetCookieUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+/**
+ * Utility class to extract/parse/check Set-Cookie header values.
+ */
+class SetCookieUtils {
+
+    private static final int NOT_FOUND = -1;
+
+    private SetCookieUtils() {
+        // Utility class.
+    }
+
+    /**
+     * Tells whether or not the given Set-Cookie header value has an attribute with the given name.
+     * <p>
+     * If the pair cookie name/value is not conformant (e.g. empty name, missing name/value separator) it returns {@code false}.
+     *
+     * @param headerValue the value of the header
+     * @param attributeName the name of the attribute to check
+     * @return {@code true} if the the header has the attribute, {@code false} otherwise
+     * @see <a href="https://tools.ietf.org/html/rfc6265#section-5.2">RFC 6265 - Section 5.2</a>
+     */
+    public static boolean hasAttribute(String headerValue, String attributeName) {
+        validateParameterNotNull(headerValue, "headerValue");
+        validateParameterNotNull(attributeName, "attributeName");
+
+        if (headerValue.isEmpty() || attributeName.isEmpty()) {
+            return false;
+        }
+
+        String[] cookieElements = headerValue.split(";");
+        if (cookieElements.length == 1 || !isCookieNameValuePairValid(cookieElements[0])) {
+            return false;
+        }
+
+        for (int i = 1; i < cookieElements.length; i++) {
+            String[] attribute = cookieElements[i].split("=", 2);
+            if (attributeName.equalsIgnoreCase(attribute[0].trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isCookieNameValuePairValid(String nameValuePair) {
+        int nameValuePairIdx = nameValuePair.indexOf('=');
+        if (nameValuePairIdx == NOT_FOUND) {
+            return false;
+        }
+
+        String cookieName = nameValuePair.substring(0, nameValuePairIdx).trim();
+        if (cookieName.isEmpty()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void validateParameterNotNull(Object parameter, String name) {
+        if (parameter == null) {
+            throw new IllegalArgumentException("The parameter " + name + " must not be null.");
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -1,16 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules</name>
-	<version>16</version>
+	<version>17</version>
 	<status>release</status>
 	<description>The release quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 823 - i18n (internationalise) release passive scan rules.<br>
-	Add CWE and WASC IDs to passive scanners which may have been lacking those details.<br>
-	Issue 2405 - Accommodate responses with multiple Cache-Control headers.<br>
-	Issue 395 - Add handling for allowed cross domain hosts (via context definition at HIGH threshold).<br>
+	Correctly check that the cookie being set has the Secure and HttpOnly attributes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrules/SetCookieUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/SetCookieUtilsUnitTest.java
@@ -1,0 +1,194 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link SetCookieUtils}.
+ */
+public class SetCookieUtilsUnitTest {
+
+    private static final String EMPTY_HEADER_VALUE = "";
+    private static final String EMPTY_ATTRIBUTE_NAME = "";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCheckNullHeaderValue() {
+        // Given
+        String headerValue = null;
+        // When
+        SetCookieUtils.hasAttribute(headerValue, EMPTY_ATTRIBUTE_NAME);
+        // Then = IllegalArgumentException
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailToCheckNullAttributeName() {
+        // Given
+        String attributeName = null;
+        // When
+        SetCookieUtils.hasAttribute(EMPTY_HEADER_VALUE, attributeName);
+        // Then = IllegalArgumentException
+    }
+
+    @Test
+    public void shouldNotFindEmptyAttribute() {
+        // Given
+        String headerValue = "Name=Value; Attribute1; Attribute2=AV2; ;;";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, EMPTY_ATTRIBUTE_NAME);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindAttributeInEmptyHeader() {
+        // Given
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(EMPTY_HEADER_VALUE, attribute);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindAttributeIfHeaderHasNoAttributes() {
+        // Given
+        String headerValue = "Name=Value";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindAttributeInNamelessCookie() {
+        // Given
+        String headerValue = "=Value; Attribute1; Attribute2=AV2; ;;";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindAttributeIfCookieHasNoNameValueSepartor() {
+        // Given
+        String headerValue = "Name; Attribute1; Attribute2=AV2; ;;";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindAttributeEvenIfCookieNameIsEqual() {
+        // Given
+        String headerValue = "Attribute1=Value; Attribute2=AV2";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindAttributeEvenIfCookieValueIsEqual() {
+        // Given
+        String headerValue = "Name=Attribute1; Attribute2=AV2";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldNotFindAttributeEvenIfAnAttributeValueIsEqual() {
+        // Given
+        String headerValue = "Name=Value; Attribute2=Attribute1";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldFindAttributeInValidCookieHeader() {
+        // Given
+        String headerValue = "Cookie=Value; Attribute1; Attribute2=AV2";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldFindAttributeEvenIfCookieHasNoValue() {
+        // Given
+        String headerValue = "Cookie=; Attribute1; Attribute2=AV2";
+        String attribute = "Attribute1";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldFindAttributeEvenIfItHasValue() {
+        // Given
+        String headerValue = "Cookie=Value; Attribute1; Attribute2=AV2";
+        String attribute = "Attribute2";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldFindAttributeEvenIfItHasSpacesInName() {
+        // Given
+        String headerValue = "Cookie=Value; Attribute1;  Attribute2  =AV2";
+        String attribute = "Attribute2";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldFindAttributeEvenIfItHasDifferentCase() {
+        // Given
+        String headerValue = "Cookie=Value; Attribute1; Attribute2=AV2";
+        String attribute = "aTtRiBuTe2";
+        // When
+        boolean found = SetCookieUtils.hasAttribute(headerValue, attribute);
+        // Then
+        assertThat(found, is(equalTo(true)));
+    }
+}


### PR DESCRIPTION
Change scanners CookieSecureFlagScanner and CookieHttpOnlyScanner to
correctly check the attributes of the cookies being set. The previous
behaviour just checked that the name of the attribute existed in the
whole header value, not if it existed an attribute with the expected
name leading to false negatives if the attribute names were contained
in other attribute values or cookie name/value. 
Add helper class, SetCookieUtils, to check if an attribute is present in
the value of a Set-Cookie header.
Change the previously mentioned scanners to use that class.
Add tests to assert the expected behaviour of class SetCookieUtils.
Bump version and update changes in ZapAddOn.xml file.