### PR TITLE
pscanrules: empty attack and n/a parameter fields

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanner.java
@@ -156,7 +156,7 @@ public class ApplicationErrorScanner extends PluginPassiveScanner {
         alert.setDetail(
                 getDescription(),
                 msg.getRequestHeader().getURI().toString(),
-                "N/A",
+                "",
                 "",
                 "",
                 getSolution(),

--- a/src/org/zaproxy/zap/extension/pscanrules/MixedContentScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/MixedContentScanner.java
@@ -127,7 +127,7 @@ public class MixedContentScanner extends PluginPassiveScanner {
     	alert.setDetail(
     	    getDescription(), 
     	    msg.getRequestHeader().getURI().toString(),
-    	    "", first, all,
+    	    "", "", all,
     	    getSolution(),
             getReference(), 
             first, // evidence

--- a/src/org/zaproxy/zap/extension/pscanrules/TestInfoPrivateAddressDisclosure.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/TestInfoPrivateAddressDisclosure.java
@@ -127,7 +127,7 @@ public class TestInfoPrivateAddressDisclosure extends PluginPassiveScanner {
                     this.getDescription(),
                     msg.getRequestHeader().getURI().toString(),
                     "",
-                    firstOne,
+                    "",
                     sbTxtFound.toString(),
                     this.getSolution(),
                     this.getReference(),

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -8,6 +8,8 @@
 	<changes>
 	<![CDATA[
 	Correctly check that the cookie being set has the Secure and HttpOnly attributes.<br>
+	Do not set the attack field for Private IP Disclosure and Secure Pages Include Mixed Content.<br>
+	Remove "N/A" parameter from the alert of Application Error Disclosure.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change scanners "Private IP Disclosure" and "Secure Pages Include Mixed
Content" to not fill/set the attack field of the alert, there's no
attack being done, and remove the parameter ("N/A") from the alert
raised by the scanner "Application Error Disclosure".
Bump version and updates changes in ZapAddOn.xml file.