### PR TITLE
New XFO Variants

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Correctly check that the cookie being set has the Secure and HttpOnly attributes.<br>
 	Do not set the attack field for Private IP Disclosure and Secure Pages Include Mixed Content.<br>
 	Remove "N/A" parameter from the alert of Application Error Disclosure.<br>
+	Issue 2539 - X-Frame-Options passive scanner, add compliance variants.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -8,12 +8,23 @@ pscanrules.headerxssprotectionscanner.refs = https://www.owasp.org/index.php/XSS
 pscanrules.headerxssprotectionscanner.extrainfo = The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it: \nX-XSS-Protection: 1; mode=block\nX-XSS-Protection: 1; report=http://www.example.com/xss\nThe following values would disable it:\nX-XSS-Protection: 0\nThe X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).\nNote that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
 pscanrules.headerxssprotectionscanner.soln = Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
 
-pscanrules.xframeoptionsscanner.name = X-Frame-Options Header Not Set
-pscanrules.xframeoptionsscanner.desc = X-Frame-Options header was not set for defense against 'ClickJacking' attacks.
+pscanrules.xframeoptionsscanner.name = X-Frame-Options Header Scanner
+pscanrules.xframeoptionsscanner.missing.name = X-Frame-Options Header Not Set
 pscanrules.xframeoptionsscanner.missing.desc = X-Frame-Options header is not included in the HTTP response to protect against 'ClickJacking' attacks.
-pscanrules.xframeoptionsscanner.otherinfo = At "High" threshold this scanner will not alert on client or server error responses.
-pscanrules.xframeoptionsscanner.refs = http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
-pscanrules.xframeoptionsscanner.soln = Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY.  ALLOW-FROM allows specific websites to frame the web page in supported web browsers).
+pscanrules.xframeoptionsscanner.missing.refs = http://blogs.msdn.com/b/ieinternals/archive/2010/03/30/combating-clickjacking-with-x-frame-options.aspx
+pscanrules.xframeoptionsscanner.missing.soln = Most modern Web browsers support the X-Frame-Options HTTP header. Ensure it's set on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).
+pscanrules.xframeoptionsscanner.multiple.header.name = Multiple X-Frame-Options Header Entries
+pscanrules.xframeoptionsscanner.multiple.header.desc = X-Frame-Options (XFO) headers were found, a response with multiple XFO header entries may not be predictably treated by all user-agents.
+pscanrules.xframeoptionsscanner.multiple.header.refs = https://tools.ietf.org/html/rfc7034
+pscanrules.xframeoptionsscanner.multiple.header.soln = Ensure only a single X-Frame-Options header is present in the response.
+pscanrules.xframeoptionsscanner.compliance.meta.name = X-Frame-Options Defined via META (Non-compliant with Spec)
+pscanrules.xframeoptionsscanner.compliance.meta.desc = An X-Frame-Options (XFO) META tag was found, defining XFO via a META tag is explicitly not supported by the spec (RFC 7034).
+pscanrules.xframeoptionsscanner.compliance.meta.refs = https://tools.ietf.org/html/rfc7034#section-4
+pscanrules.xframeoptionsscanner.compliance.meta.soln = Ensure X-Frame-Options is set via a response header field.
+pscanrules.xframeoptionsscanner.compliance.malformed.setting.name = X-Frame-Options Setting Malformed
+pscanrules.xframeoptionsscanner.compliance.malformed.setting.desc = An X-Frame-Options header was present in the response but the value was not correctly set.
+pscanrules.xframeoptionsscanner.compliance.malformed.setting.refs = https://tools.ietf.org/html/rfc7034#section-2.1
+pscanrules.xframeoptionsscanner.compliance.malformed.setting.soln = Ensure a valid setting is used on all web pages returned by your site (if you expect the page to be framed only by pages on your server (e.g. it's part of a FRAMESET) then you'll want to use SAMEORIGIN, otherwise if you never expect the page to be framed, you should use DENY. ALLOW-FROM allows specific websites to frame the web page in supported web browsers).
 
 pscanrules.xcontenttypeoptionsscanner.name = X-Content-Type-Options Header Missing
 pscanrules.xcontenttypeoptionsscanner.desc = The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -59,11 +59,16 @@ This scanner check for the Anti-MIME-Sniffing header X-Content-Type-Options and 
 At HIGH threshold this scanner does not alert on client or server error responses, for all other enabled 
 thresholds it alerts on all response types if the header is missing or set to something other than 'nosniff'.
  
-<H2>X-Frame-Option</H2>
-This scanner checks for the existence and validity of the X-FRAME-OPTIONS header. At HIGH threshold this scanner
+<H2>X-Frame-Options Header Scanner</H2>
+This scanner checks for the existence and validity of the X-Frame-Options header. At HIGH threshold this scanner
 does not alert on client or server error responses, for all other enabled thresholds it alerts on all response 
-types if the header is missing or invalid. Invalid meaning that the header is present with no value, or that 
-the value is not as expected (i.e.: other than "DENY", "SAMEORIGIN", or "ALLOW-FROM"). 
+types. The following conditions may result in an alert:
+<ul> 
+ <li><b>X-Frame-Options Header Not Set: </b> If the X-Frame-Options header is missing from the response completely.</li>
+ <li><b>Multiple X-Frame-Options Header Entries: </b> When more than one X-Frame-Options header is detected on the response.</li>
+ <li><b>X-Frame-Options Defined via META (Non-compliant with Spec): </b> A "http-equiv" entry was found in the response that attempts to define X-Frame-Options, which is not supported by the specification.</li>
+ <li><b>X-Frame-Options Setting Malformed: </b> The header is present with no value, or the value is not as expected (i.e.: other than "DENY", "SAMEORIGIN", or "ALLOW-FROM").</li>
+</ul>
 
 </BODY>
 </HTML>


### PR DESCRIPTION
The XFO passive scanner now checks for: multiple headers, and attempts
to define XFO via META tag. Help was also updated, as were alert text
for consistency and accuracy.

Fixes zaproxy/zaproxy#2539