### PR TITLE
CookieLooselyScopedScanner remove attack field and update description

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScanner.java
@@ -136,7 +136,7 @@ public class CookieLooselyScopedScanner extends PluginPassiveScanner {
 		}		
 		
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), null, getExploitMessage(), 
+				.getURI().toString(), null, "", 
 				Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", host, sbCookies),
 				getSolutionMessage(), getReferenceMessage(), 
 				"",	// No Evidence
@@ -171,9 +171,5 @@ public class CookieLooselyScopedScanner extends PluginPassiveScanner {
 
 	private String getReferenceMessage() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-	}
-
-	private String getExploitMessage() {
-		return Constant.messages.getString(MESSAGE_PREFIX + "exploit");
 	}
 }

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Issue 2576: CSRFCountermeasures, remove unneeded Attack and Evidence messages.<br>
+	Issue 2574: CookieLooselyScopedScanner, remove attack field and update description.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -26,9 +26,8 @@ pscanbeta.charsetmismatch.extrainfo.html.metacontenttype_metacharset_mismatch=Th
 pscanbeta.charsetmismatch.extrainfo.xml=There was a charset mismatch between the HTTP Header and the XML encoding declaration: [{0}] and [{1}] do not match.
 
 pscanbeta.cookielooselyscoped.name=Loosely Scoped Cookie
-pscanbeta.cookielooselyscoped.desc=Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com.
+pscanbeta.cookielooselyscoped.desc=Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com. Cookies set from a subdomain like app.foo.bar are transmitted only to that domain by the browser. However, cookies scoped to a parent-level domain may be transmitted to the parent, or any subdomain of the parent.
 pscanbeta.cookielooselyscoped.soln=Always scope cookies to a FQDN (Fully Qualified Domain Name).
-pscanbeta.cookielooselyscoped.exploit=Cookies set from a subdomain like app.foo.bar are transmitted only to that domain by the browser. However, cookies scoped to a parent-level domain may be transmitted to the parent, or any subdomain of the parent.
 pscanbeta.cookielooselyscoped.refs=http://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies
 pscanbeta.cookielooselyscoped.extrainfo=The origin domain used for comparison was: \r\n{0}\r\n{1}
 pscanbeta.cookielooselyscoped.extrainfo.cookie={0}\r\n


### PR DESCRIPTION
CookieLooselyScopedScanner contains a text in attack field which should be in description field instead. This commit updates the text.