### PR TITLE
ascanrules: run SQLi scanner for any DB tech

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	TestPathTraversal - catch InvalidRedirectLocationException and URIException.<br>
 	TestRemoteFileInclude - adjust logging (debug not error).<br>
+	Run SQL Injection if any DB tech is enabled but skip specific non-applicable error checks.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Change TestSQLInjection scanner to run if any DB technology is enabled
but skip specific non-applicable error checks (that is, do not check for
errors messages of non selected DBs).

More detailed changes:
 - Convert the maps that hold the error messages of the DBs to an Enum
 as it allows to include more information, the name of the database, the
 Tech it is/has and the types of error messages (specific and union);
 - Method targets(TechSet), change to check if any of the selected techs
 belongs to DB hierarchy to run or not the scanner;
 - In the scan method:
  - Change to only check generic error messages if the selected techs
  include (the top level tech) DB;
  - Change to use the defined Enum when checking for errors (specific,
  generic and union);
  - Extract methods to check the specific and union error messages to
  simplify the logic/code in the main method.

Update changes in ZapAddOn.xml file.
 ---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/5vlQfn5I26g/discussion