### PR TITLE
fuzz: skip fuzzers dir enumeration if not present

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -388,9 +388,15 @@ public class ExtensionFuzz extends ExtensionAdaptor {
     }
 
     private void readFuzzersDir() {
+        Path fuzzerDirectory = Paths.get(Constant.getInstance().FUZZER_DIR);
+        if (!Files.isDirectory(fuzzerDirectory)) {
+            fuzzersDir = new FuzzersDir(Collections.<FuzzerPayloadCategory>emptyList());
+            return;
+        }
+
         try {
             Files.walkFileTree(
-                    Paths.get(Constant.getInstance().FUZZER_DIR),
+                    fuzzerDirectory,
                     Collections.<FileVisitOption> emptySet(),
                     Integer.MAX_VALUE,
                     new SimpleFileVisitor<Path>() {

--- a/src/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.MessageFormat;
 import java.util.ResourceBundle;
 
 import javax.swing.BorderFactory;
@@ -326,6 +327,16 @@ public class FuzzOptionsPanel extends AbstractParamPanel {
                     boolean copyFile = false;
                     if (Files.exists(newFile)) {
                         copyFile = confirmOverwrite();
+                    } else if (!Files.exists(newFile.getParent())) {
+                        try {
+                            Files.createDirectories(newFile.getParent());
+                            copyFile = true;
+                        } catch (IOException ex) {
+                            View.getSingleton().showWarningDialog(
+                                    MessageFormat.format(
+                                            resourceBundle.getString("fuzz.options.add.file.fail.error.create.dirs"),
+                                            newFile.getParent()));
+                        }
                     } else if (!Files.isWritable(newFile.getParent())) {
                         View.getSingleton().showWarningDialog(
                                 resourceBundle.getString("fuzz.options.add.file.dirperms.error")

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -10,6 +10,7 @@
     <![CDATA[
     Added Export button to export results as CSV file.<br>
     Enable "Limit maximum errors" by default and increase the default number.<br>
+    Improve error handling when reading/writing files from/to fuzzers directory.<br>
     Add SHA-512 Hash payload processor (Issue 2643).<br>
     ]]>
     </changes>

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -55,6 +55,7 @@ fuzz.options.add.file.duplicate.error    = A custom file of the same name alread
 fuzz.options.add.file.duplicate.error.title = File Already Exists
 fuzz.options.add.file.duplicate.error.button.confirm = Overwrite
 fuzz.options.add.file.fail.error         = Failed to add the file:
+fuzz.options.add.file.fail.error.create.dirs = Failed to create target directory:\n{0}\nIs it writable?
 fuzz.options.add.file.ok                 = Custom file installed
 fuzz.options.button.addfile = Select File...
 fuzz.options.label.addfile  = Add custom Fuzz file:


### PR DESCRIPTION
Change ExtensionFuzz to not attempt to enumerate the fuzzers directory
if the directory does not exist. Also, change FuzzOptionsPanel to create
the directory if it does not exist when importing/adding a fuzzer file.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2387 - Fuzzer Extension exception when removing PnH
Extension