### PR TITLE
fuzz: allow to search fuzzer file names

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -11,6 +11,7 @@
     Added Export button to export results as CSV file.<br>
     Enable "Limit maximum errors" by default and increase the default number.<br>
     Add SHA-512 Hash payload processor (Issue 2643).<br>
+    Allow to search the fuzzer file names when selecting them.<br>
     ]]>
     </changes>
     <extensions>


### PR DESCRIPTION
Change class FuzzerPayloadGeneratorUIPanel to allow to search the names
of the fuzzer files when selecting them, the change adds a find bar to
the top of the tree that shows the available files. The find bar/panel
contains a text field, for the search term, and two buttons, to navigate
the matching tree nodes (next/previous).

Fix zaproxy/zaproxy#2227 - Fuzzer: option to search for payload names