### PR TITLE
saml: use toString() to obtain the response body

### DIFF
--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
     <name>SAML Extension</name>
-    <version>6</version>
+    <version>7</version>
     <status>alpha</status>
     <description>Detect, Show, Edit, Fuzz SAML requests</description>
     <author>ZAP Dev Team</author>
     <url>https://github.com/zaproxy/zaproxy</url>
 	<changes>
 	<![CDATA[
-	Use ZAP's home directory for SAML configuration file.<br>
+	Minor code change to work with ZAP 2.5.0.<br>
 	]]>
 	</changes>
     <dependson/>

--- a/src/org/zaproxy/zap/extension/saml/ui/SamlManualEditor.java
+++ b/src/org/zaproxy/zap/extension/saml/ui/SamlManualEditor.java
@@ -223,7 +223,7 @@ public class SamlManualEditor extends JFrame {
      * @param msg
      */
     private void updateResponse(HttpMessage msg) {
-        respBodyTextPane.setText(msg.getResponseBody().createCachedString("UTF-8"));
+        respBodyTextPane.setText(msg.getResponseBody().toString());
         respHeadTextPane.setText(msg.getResponseHeader().toString());
         tabbedPane.setSelectedIndex(1);
     }


### PR DESCRIPTION
Change class SamlManualEditor to use HttpResponseBody.toString() to get
the string representation of the response body instead of using the
method createCachedString(String), the latter method was removed in a
newer version of ZAP (2.5.0), as it's not intended to be called
directly.
Bump version and update changes in ZapAddOn.xml file.