### PR TITLE
wappalyzer: use plain passive scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -28,13 +28,14 @@ import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
-import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.extension.pscan.PassiveScanner;
 
-public class WappalyzerPassiveScanner extends PluginPassiveScanner {
+public class WappalyzerPassiveScanner implements PassiveScanner {
 
 	private ExtensionWappalyzer extension = null;
 	private List<Application> applications = null;
@@ -141,6 +142,43 @@ public class WappalyzerPassiveScanner extends PluginPassiveScanner {
 	
 	@Override
 	public void setParent(PassiveScanThread parent) {
+		// Does not apply.
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		// Does not apply.
+	}
+
+	@Override
+	public AlertThreshold getLevel() {
+		return AlertThreshold.MEDIUM;
+	}
+
+	@Override
+	public void setLevel(AlertThreshold level) {
+		// Does not apply.
+	}
+
+	// @Override
+	public boolean appliesToHistoryType(int historyType) {
+		// TODO replace with core code once available
+		// return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
+
+		switch (historyType) {
+		case HistoryReference.TYPE_PROXIED:
+		case HistoryReference.TYPE_ZAP_USER:
+		case HistoryReference.TYPE_SPIDER:
+		case HistoryReference.TYPE_SPIDER_AJAX:
+			return true;
+		default:
+			return false;
+		}
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
@@ -1,22 +1,20 @@
 <zapaddon>
 	<name>Technology detection using Wappalyzer</name>
-	<version>7</version>
+	<version>8</version>
 	<status>alpha</status>
 	<description>Technology detection using Wappalyzer: wappalyzer.com</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Allow to update/uninstall the add-on without restarting ZAP.<br>
+	Remove the use of passive scan rule.<br>
 	]]>
 	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.wappalyzer.ExtensionWappalyzer</extension>
 	</extensions>
 	<ascanrules/>
-	<pscanrules>
-		<pscanrule>org.zaproxy.zap.extension.wappalyzer.WappalyzerPassiveScanner</pscanrule>
-	</pscanrules>
+	<pscanrules/>
 	<filters/>
 	<files/>
 	<not-before-version>2.4.3</not-before-version>


### PR DESCRIPTION
Change WappalyzerPassiveScanner to implement PassiveScanner instead of
extending PluginPassiveScanner, the latter is used for passive scanners
that raise alerts (also shown and configured in Passive Scan Rules
options panel).
The passive scanner used by the wappalyzer add-on does not require/have
any configurations, it's always enabled and changes to alert threshold
have no effect.

Change ExtensionWappalyzer to depend on ExtensionPassiveScan and to add
and remove the passive scanner when initialised and unloaded,
respectively.
Bump version and update changes in ZapAddOn.xml file.