### PR TITLE
fuzz: add SHA-512 payload processor

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -74,6 +74,7 @@ import org.zaproxy.zap.extension.fuzz.payloads.processor.PostfixStringProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.PrefixStringProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.SHA1HashProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.SHA256HashProcessor;
+import org.zaproxy.zap.extension.fuzz.payloads.processor.SHA512HashProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.ScriptStringPayloadProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.ScriptStringPayloadProcessorAdapter;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.TrimStringProcessor;
@@ -95,6 +96,7 @@ import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PostfixStringProces
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.PrefixStringProcessorUIHandler;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.SHA1HashProcessorUIHandler;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.SHA256HashProcessorUIHandler;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.SHA512HashProcessorUIHandler;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.ScriptStringPayloadProcessorAdapterUIHandler;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.TrimStringProcessorUIHandler;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.URLDecodeProcessorUIHandler;
@@ -246,6 +248,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
                 new PrefixStringProcessorUIHandler());
         payloadProcessorsUIRegistry.registerProcessorUIHandler(SHA1HashProcessor.class, new SHA1HashProcessorUIHandler());
         payloadProcessorsUIRegistry.registerProcessorUIHandler(SHA256HashProcessor.class, new SHA256HashProcessorUIHandler());
+        payloadProcessorsUIRegistry.registerProcessorUIHandler(SHA512HashProcessor.class, new SHA512HashProcessorUIHandler());
         payloadProcessorsUIRegistry.registerProcessorUIHandler(TrimStringProcessor.class, new TrimStringProcessorUIHandler());
         payloadProcessorsUIRegistry.registerProcessorUIHandler(URLDecodeProcessor.class, new URLDecodeProcessorUIHandler());
         URLEncodeProcessorUIHandler urlEncodeProcessorUIHandler = new URLEncodeProcessorUIHandler();

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -10,6 +10,7 @@
     <![CDATA[
     Added Export button to export results as CSV file.<br>
     Enable "Limit maximum errors" by default and increase the default number.<br>
+    Add SHA-512 Hash payload processor (Issue 2643).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/processor/SHA512HashProcessor.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/processor/SHA512HashProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.payloads.processor;
+
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class SHA512HashProcessor extends AbstractStringHashProcessor {
+
+    private static final String SHA512_ALGORITHM = "SHA-512";
+
+    private final MessageDigest messageDigest;
+
+    public SHA512HashProcessor() {
+        this(false);
+    }
+
+    public SHA512HashProcessor(boolean upperCase) {
+        super(upperCase);
+        messageDigest = createSHA512MessageDigest();
+    }
+
+    public SHA512HashProcessor(String charsetName) {
+        this(charsetName, false);
+    }
+
+    public SHA512HashProcessor(String charsetName, boolean upperCase) {
+        super(charsetName, upperCase);
+        messageDigest = createSHA512MessageDigest();
+    }
+
+    public SHA512HashProcessor(Charset charset) {
+        this(charset, false);
+    }
+
+    public SHA512HashProcessor(Charset charset, boolean upperCase) {
+        super(charset, upperCase);
+        messageDigest = createSHA512MessageDigest();
+    }
+
+    private static MessageDigest createSHA512MessageDigest() {
+        try {
+            return createMessageDigest(SHA512_ALGORITHM);
+        } catch (NoSuchAlgorithmException ignore) {
+            // SHA-512 is one of the standard MessageDigest algorithms
+            // that Java implementations are required to support.
+        }
+        return null;
+    }
+
+    @Override
+    protected MessageDigest getMessageDigest() {
+        return messageDigest;
+    }
+
+    @Override
+    public SHA512HashProcessor copy() {
+        return new SHA512HashProcessor(getCharset(), isUpperCase());
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA512HashProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA512HashProcessorUIHandler.java
@@ -1,0 +1,130 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.payloads.ui.processors;
+
+import java.nio.charset.Charset;
+import java.text.MessageFormat;
+
+import javax.swing.JPanel;
+
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.fuzz.payloads.DefaultPayload;
+import org.zaproxy.zap.extension.fuzz.payloads.processor.SHA512HashProcessor;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.AbstractStringHashProcessorUIPanel.AbstractStringHashProcessorUI;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.processors.SHA512HashProcessorUIHandler.SHA512HashProcessorUI;
+
+public class SHA512HashProcessorUIHandler
+        implements PayloadProcessorUIHandler<DefaultPayload, SHA512HashProcessor, SHA512HashProcessorUI> {
+
+    private static final String PROCESSOR_NAME = Constant.messages.getString("fuzz.payload.processor.sha512Hash.name");
+
+    @Override
+    public String getName() {
+        return PROCESSOR_NAME;
+    }
+
+    @Override
+    public Class<SHA512HashProcessorUI> getPayloadProcessorUIClass() {
+        return SHA512HashProcessorUI.class;
+    }
+
+    @Override
+    public Class<SHA512HashProcessorUIPanel> getPayloadProcessorUIPanelClass() {
+        return SHA512HashProcessorUIPanel.class;
+    }
+
+    @Override
+    public SHA512HashProcessorUIPanel createPanel() {
+        return new SHA512HashProcessorUIPanel();
+    }
+
+    public static class SHA512HashProcessorUI extends AbstractStringHashProcessorUI<SHA512HashProcessor> {
+
+        public SHA512HashProcessorUI(Charset charset, boolean upperCase) {
+            super(charset, upperCase);
+        }
+
+        @Override
+        public Class<SHA512HashProcessor> getPayloadProcessorClass() {
+            return SHA512HashProcessor.class;
+        }
+
+        @Override
+        public String getName() {
+            return PROCESSOR_NAME;
+        }
+
+        @Override
+        public boolean isMutable() {
+            return true;
+        }
+
+        @Override
+        public String getDescription() {
+            return MessageFormat
+                    .format(Constant.messages.getString("fuzz.payload.processor.sha512Hash.description"), getCharset().name());
+        }
+
+        @Override
+        public SHA512HashProcessor getPayloadProcessor() {
+            return new SHA512HashProcessor(getCharset(), isUpperCase());
+        }
+
+        @Override
+        public SHA512HashProcessorUI copy() {
+            return this;
+        }
+
+    }
+
+    public static class SHA512HashProcessorUIPanel
+            extends AbstractStringHashProcessorUIPanel<SHA512HashProcessor, SHA512HashProcessorUI> {
+
+        private final JPanel fieldsPanel;
+
+        public SHA512HashProcessorUIPanel() {
+            fieldsPanel = createDefaultFieldsPanel();
+        }
+
+        @Override
+        public JPanel getComponent() {
+            return fieldsPanel;
+        }
+
+        @Override
+        public SHA512HashProcessorUI getPayloadProcessorUI() {
+            return new SHA512HashProcessorUI(
+                    (Charset) getCharsetComboBox().getSelectedItem(),
+                    getUpperCaseCheckBox().isSelected());
+        }
+
+        @Override
+        public SHA512HashProcessor getPayloadProcessor() {
+            return new SHA512HashProcessor(
+                    (Charset) getCharsetComboBox().getSelectedItem(),
+                    getUpperCaseCheckBox().isSelected());
+        }
+
+        @Override
+        public String getHelpTarget() {
+            return "addon.fuzzer.processors";
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -337,6 +337,9 @@ fuzz.payload.processor.sha1Hash.description = Using encoding ''{0}''
 fuzz.payload.processor.sha256Hash.name = SHA-256 Hash
 fuzz.payload.processor.sha256Hash.description = Using encoding ''{0}''
 
+fuzz.payload.processor.sha512Hash.name = SHA-512 Hash
+fuzz.payload.processor.sha512Hash.description = Using encoding ''{0}''
+
 fuzz.payload.processor.trim.name = Trim
 fuzz.payload.processor.trim.description = To {0} characters
 fuzz.payload.processor.expand.length.label = Length:

--- a/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/processors.html
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/processors.html
@@ -22,6 +22,7 @@ Built in payload processors include:
 <li>Prefix String</li>
 <li>SHA-1 Hash</li>
 <li>SHA-256 Hash</li>
+<li>SHA-512 Hash</li>
 <li>Trim</li>
 <li>URL Decode</li>
 <li>URL Encode</li>


### PR DESCRIPTION
Add a new payload processor to create SHA-512 hashes.
Update help processors page and changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2643 - SHA-512 Payload Processor