### PR TITLE
spiderAjax: show, always, the PhantomJS warning

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
@@ -19,13 +19,10 @@ package org.zaproxy.zap.extension.spiderAjax;
 
 import javax.swing.ImageIcon;
 
-import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.SiteNode;
-import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
@@ -92,19 +89,6 @@ public class PopupMenuAjaxSite extends PopupMenuItemSiteNodeContainer {
 	@Override
 	public void performAction(SiteNode node) {
 	    if (node != null) {
-            if (Browser.PHANTOM_JS.getId() == extension.getAjaxSpiderParam().getBrowserId()) {
-                try {
-                    String host = node.getHistoryReference().getURI().getHost();
-                    if ("localhost".equalsIgnoreCase(host) || "127.0.0.1".equals(host) || "[::1]".equals(host)) {
-                        View.getSingleton().showWarningDialog(
-                                extension.getMessages().getString("spiderajax.warn.message.phantomjs.bug.invalid.target"));
-                        return;
-                    }
-                } catch (URIException e) {
-                    logger.warn("Failed to get host:", e);
-                }
-            }
-	        
 	    	extension.showScanDialog(node);
 	    }
 	}

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fixed the issue that prevented the ajaxSpider from resetting the crawled url count to zero while starting a new scan (Issue 2610).<br>
+	Warn always if attempting to AJAX spider "localhost" with PhantomJS.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Move the warning about the PhantomJS issue (that prevents localhost
traffic from being proxied through ZAP) to AJAX Spider dialogue to show
it, always. Previously, it would not be shown if the browser selected in
the options were not PhantomJS.
Update changes in ZapAddOn.xml file.