### PR TITLE
spiderAjax: add a spider menu item to Tools menu

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -17,6 +17,9 @@
  */
 package org.zaproxy.zap.extension.spiderAjax;
 
+import java.awt.Event;
+import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -24,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.swing.ImageIcon;
+import javax.swing.KeyStroke;
 
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
@@ -44,6 +48,7 @@ import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.ZapMenuItem;
 
 /**
  * Main class of the plugin, it instantiates the rest of them.
@@ -66,6 +71,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 
 	private SpiderPanel spiderPanel = null;
 	private PopupMenuAjaxSite popupMenuSpiderSite = null;
+	private ZapMenuItem menuItemCustomScan;
 	private AjaxSpiderDialog spiderDialog = null;
 	private OptionsAjaxSpider optionsAjaxSpider = null;
 	private List<String> excludeList = null;
@@ -121,6 +127,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 			extensionHook.getHookView().addStatusPanel(getSpiderPanel());
 			extensionHook.getHookView().addOptionPanel(getOptionsSpiderPanel());
 			extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAjaxSite());
+			extensionHook.getHookMenu().addToolsMenuItem(getMenuItemCustomScan());
 			ExtensionHelp.enableHelpKey(getSpiderPanel(), "addon.spiderajax.tab");
 		}
 	}
@@ -188,6 +195,27 @@ public class ExtensionAjax extends ExtensionAdaptor {
 			popupMenuSpiderSite = new PopupMenuAjaxSite(this.getMessages().getString("spiderajax.site.popup"), this);
 		}
 		return popupMenuSpiderSite;
+	}
+
+	private ZapMenuItem getMenuItemCustomScan() {
+		if (menuItemCustomScan == null) {
+			menuItemCustomScan = new ZapMenuItem(
+					"spiderajax.menu.tools.label",
+					KeyStroke.getKeyStroke(
+							KeyEvent.VK_X,
+							Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK,
+							false));
+			menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
+
+			menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {
+
+				@Override
+				public void actionPerformed(java.awt.event.ActionEvent e) {
+					showScanDialog(null);
+				}
+			});
+		}
+		return menuItemCustomScan;
 	}
 
 	/**
@@ -333,6 +361,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 		public void sessionModeChanged(Mode mode) {
 			if (getView() != null) {
 				getSpiderPanel().sessionModeChanged(mode);
+				getMenuItemCustomScan().setEnabled(mode != Mode.safe);
 			}
 		}
 	}

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
+	Allow to show the AJAX Spider dialogue through Tools menu (and keyboard shortcut).<br>
 	Fixed the issue that prevented the ajaxSpider from resetting the crawled url count to zero while starting a new scan (Issue 2610).<br>
 	]]>
 	</changes>

--- a/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
@@ -2,6 +2,8 @@
 
 spiderajax.active.action = AJAX Spider scan
 spiderajax.desc                     = AJAX Spider, uses Crawljax
+spiderajax.menu.tools.label = AJAX Spider...
+spiderajax.menu.tools.label.mnemonic = X
 spiderajax.options.dialog.elem.add.title = Add Element
 spiderajax.options.dialog.elem.add.button.confirm = Add
 spiderajax.options.dialog.elem.field.label.name = Element


### PR DESCRIPTION
Add a menu item to Tools menu that allows to shows the AJAX Spider
dialogue (and with a keyboard shortcut).
Update changes in ZapAddOn.xml file.