### PR TITLE
TestPathTraversal Logging Tweaks

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
@@ -19,6 +19,7 @@ package org.zaproxy.zap.extension.ascanrules;
 
 import java.io.IOException;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.Tech;
@@ -433,9 +435,19 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
             // this is nice because it means we do not have to guess any file names, and would only require one
             // request to find the vulnerability 
             // but it would be foiled by simple input validation on "..", for instance.
-        } catch (IOException e) {
-            log.warn("Error scanning parameters for Path Traversal: " + e.getMessage(), e);
-        }
+		} catch (SocketTimeoutException ste) {
+			log.warn("A timeout occurred while checking [" + msg.getRequestHeader().getMethod() + "] ["
+					+ msg.getRequestHeader().getURI() + "], parameter [" + param + "] for Path Traversal. "
+					+ "The currently configured timeout is: "
+					+ Integer.toString(Model.getSingleton().getOptionsParam().getConnectionParam().getTimeoutInSecs()));
+			if (log.isDebugEnabled()) {
+				log.debug("Caught " + ste.getClass().getName() + " " + ste.getMessage());
+			}
+		} catch (IOException e) {
+			log.warn("An error occurred while checking [" + msg.getRequestHeader().getMethod() + "] ["
+					+ msg.getRequestHeader().getURI() + "], parameter [" + param + "] for Path Traversal."
+					+ "Caught " + e.getClass().getName() + " " + e.getMessage());
+		}
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	TestPathTraversal - catch InvalidRedirectLocationException and URIException.<br>
 	TestRemoteFileInclude - adjust logging (debug not error).<br>
 	Run SQL Injection if any DB tech is enabled but skip specific non-applicable error checks.<br>
+	Issue 2624: Improve Error Logging in PathTraversal Plugin.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Catch SocketTimeoutException, enhance logging by including details of
the configured timeout. Add isDebugEnabled check to also include
exceptions specifics. Also include specific method/URL/Param details if
logging IOException. Finally update ZapAddOn.xml, to reflect the change.

Fixes zaproxy/zaproxy#2624