### PR TITLE
ascanrules: fix tech related NPE in SQLi scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -1459,4 +1459,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 	public int getWascId() {
 		return 19;
 	}
+
+	@Override
+	public TechSet getTechSet() {
+		TechSet techSet = super.getTechSet();
+		if (techSet != null) {
+			return techSet;
+		}
+		return TechSet.AllTech;
+	}
 }


### PR DESCRIPTION
Change TestSQLInjection scanner to use all technologies if none was
previously set (i.e. null), fixing NullPointerException when evaluating
if the DB technologies are or not included.

Issue introduced in #439 - ascanrules: run SQLi scanner for any DB tech
 ---
From @zapbot weekly scans.