### PR TITLE
scripts: discard undoable edits no longer needed

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -117,6 +117,7 @@ public class CommandPanel extends AbstractPanel {
 
 	public void clear() {
 	    getTxtOutput().setText("");
+	    getTxtOutput().discardAllEdits();
 	}
 
 	public String getCommandScript() {
@@ -125,6 +126,7 @@ public class CommandPanel extends AbstractPanel {
 	
 	protected void appendToCommandScript (String str) {
 		getTxtOutput().append(str);
+		getTxtOutput().discardAllEdits();
 		getTxtOutput().requestFocus();
 	}
 	

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Script Console</name>
-	<version>16</version>
+	<version>17</version>
 	<status>beta</status>
 	<description>Supports all JSR 223 scripting languages</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
-	Fix exceptions when installing/uninstalling script engines, with no script selected.<br>
+	Discard undoable edits after setting a script (Isssue 2675).<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change class CommandPanel to discard the undoable edits of the text area
when no longer needed, that is, when the text area is cleared and when a
new script is set, preventing the edits from accumulating and exhausting
the whole memory (it also prevents undoing the changes to previous
scripts or templates).
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2675 - Memory exhaustion with Script Console and big
scripts