### PR TITLE
zest: correct assertion of response body length

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Change Sequence scripts to not use Sites tree nodes directly.<br>
+	Correct assertion of response body length when using charset (Issue 2669).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change class ExtensionZest to assert the response body length using as
initial value the length of the body after converting it to a string
(instead of the using the number of bytes), ensuring that both values
(the initial value and the one used to verify the assertion) are in the
same format.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2669 - Zest does not calculate page length correctly
in assertion