### PR TITLE
invoke: enable pop up menu in all HTTP components

### DIFF
--- a/src/org/zaproxy/zap/extension/invoke/PopupMenuInvokers.java
+++ b/src/org/zaproxy/zap/extension/invoke/PopupMenuInvokers.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.invoke;
 import java.util.List;
 
 import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
 
 public class PopupMenuInvokers extends PopupMenuHttpMessageContainer {
@@ -46,17 +45,6 @@ public class PopupMenuInvokers extends PopupMenuHttpMessageContainer {
     @Override
     protected boolean isButtonEnabledForNumberOfSelectedMessages(int numberOfSelectedMessages) {
         return true;
-    }
-
-    @Override
-    protected boolean isEnableForInvoker(Invoker invoker, HttpMessageContainer httpMessageContainer) {
-        switch (invoker) {
-        case SITES_PANEL:
-        case HISTORY_PANEL:
-            return true;
-        default:
-            return false;
-        }
     }
 
     public void setApps(List<InvokableApp> apps) {

--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -1,14 +1,14 @@
 <zapaddon>
 	<name>Invoke Applications</name>
-	<version>3</version>
+	<version>4</version>
 	<status>beta</status>
 	<description>Invoke external applications passing context related information such as URLs and parameters</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
-	Show applications immediately after ZAP re/start (Issue 1709).]]>
+	Allow to invoke the applications in all UI components that show HTTP messages.<br>
+	]]>
 	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.invoke.ExtensionInvoke</extension>


### PR DESCRIPTION
Change class PopupMenuInvokers to be enabled in all UI components that
show HTTP messages, not just Sites or History tabs.
Bump version and update changes in ZapAddOn.xml file.
 ---
Issue reported in the IRC channel.