### PR TITLE
Remove unnecessary extensions' constructors

### DIFF
--- a/src/org/zaproxy/zap/extension/gettingStarted/ExtensionGettingStarted.java
+++ b/src/org/zaproxy/zap/extension/gettingStarted/ExtensionGettingStarted.java
@@ -40,15 +40,7 @@ public class ExtensionGettingStarted extends ExtensionAdaptor {
     private ZapMenuItem menuGettingStarted = null;
 
     public ExtensionGettingStarted() {
-        this("ExtensionGettingStarted");
-    }
-
-    public ExtensionGettingStarted(String name) {
-        super(name);
-        initialize();
-    }
-
-    private void initialize() {
+        super("ExtensionGettingStarted");
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/gettingStarted/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/gettingStarted/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Getting Started with ZAP Guide</name>
-	<version>5</version>
+	<version>6</version>
 	<status>release</status>
 	<description>A short Getting Started with ZAP Guide</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for the new 2.5 guide</changes>
+	<changes>Minor code changes.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.gettingStarted.ExtensionGettingStarted</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/onlineMenu/ExtensionOnlineMenu.java
+++ b/src/org/zaproxy/zap/extension/onlineMenu/ExtensionOnlineMenu.java
@@ -53,23 +53,7 @@ public class ExtensionOnlineMenu extends ExtensionAdaptor {
 	private static final String PREFIX = "onlineMenu";
 
     public ExtensionOnlineMenu() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionOnlineMenu(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Online menus</name>
-	<version>4</version>
+	<version>5</version>
 	<status>release</status>
 	<description>ZAP Online menu items</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsOnlineMenuOnlineMenu</url>
 	<changes>
 	<![CDATA[
-	   Issue 1999 - Fix Title Caps<br>
-       Issue 2009 - Add Online links to the FAQ and Newsletter pages<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -69,23 +69,7 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
     private int spinner = 0;
 
     public ExtensionQuickStart() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionQuickStart(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName(NAME);
-        //this.setOrder(0);
+        super(NAME);
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Quick Start</name>
-	<version>18</version>
+	<version>19</version>
 	<status>release</status>
 	<description>Provides a tab which allows you to quickly test a target application</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	 Issue 1271: Quickstart PnH panel components should mirror the enabled state of the API (i.e.: If API disabled, disable PnH components).<br>
-	 PnH message shown even if add-on not installed.<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -89,16 +89,6 @@ public class ExtensionAjax extends ExtensionAdaptor {
 	 */
 	public ExtensionAjax() throws ClassNotFoundException {
 		super(NAME);
-		initialize();
-	}
-
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-		this.setName(NAME);
 		this.setI18nPrefix("spiderajax");
 		this.setOrder(234);
 	}

--- a/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
+++ b/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
@@ -71,8 +71,7 @@ public class ExtensionWebSocketFuzzer extends ExtensionAdaptor {
     private AllChannelObserver allChannelObserver;
 
     public ExtensionWebSocketFuzzer() {
-        super();
-        setName("ExtensionWebSocketFuzzer");
+        super("ExtensionWebSocketFuzzer");
     }
 
     @Override


### PR DESCRIPTION
Remove unnecessary extensions' constructors, they are not required nor
used by core code to start/load the extensions (it's enough with the
no-arg constructor moreover add-ons do not need nor should start other
extensions). Also, in the cases where an auxiliary "initialize" method
was in use it was merged into the no-arg constructor (in most of the
cases it was only being called by the no-arg constructor).
Bump version and update changes in ZapAddOn.xml files, where needed.