### PR TITLE
beta: remove unnecessary extensions' constructors

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -103,16 +103,16 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
     private Logger log = Logger.getLogger(this.getClass());
 
     public ExtensionAlertFilters() {
-        super();
- 		initialize();
+        super(NAME);
     }
 
-    /**
-     * @param name
-     */
-    public ExtensionAlertFilters(String name) {
-        super(name);
- 		initialize();
+    @Override
+    public void init() {
+        super.init();
+
+        ZAP.getEventBus().registerConsumer(this, 
+                AlertEventPublisher.getPublisher().getPublisherName(), 
+                new String[] {AlertEventPublisher.ALERT_ADDED_EVENT});
     }
 
 	private static ExtensionActiveScan getExtAscan() {
@@ -161,18 +161,6 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 			getAllRuleNames();
 		}
 		return idToName.get(Integer.valueOf(ruleId));
-	}
-
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
-        ZAP.getEventBus().registerConsumer(this, 
-        		AlertEventPublisher.getPublisher().getPublisherName(), 
-        		new String[] {AlertEventPublisher.ALERT_ADDED_EVENT});
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/beanshell/ExtensionBeanShell.java
+++ b/src/org/zaproxy/zap/extension/beanshell/ExtensionBeanShell.java
@@ -39,22 +39,7 @@ public class ExtensionBeanShell extends ExtensionAdaptor {
      * 
      */
     public ExtensionBeanShell() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionBeanShell(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionBeanShell");
+        super("ExtensionBeanShell");
         this.setOrder(38);
 	}
 	

--- a/src/org/zaproxy/zap/extension/beanshell/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/beanshell/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>BeanShell Console</name>
-	<version>5</version>
+	<version>6</version>
 	<status>beta</status>
 	<description>Provides a BeanShell Console</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for ZAP 2.4</changes>
+	<changes>Minor code changes.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.beanshell.ExtensionBeanShell</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
@@ -66,22 +66,7 @@ public class ExtensionBruteForce extends ExtensionAdaptor
      * 
      */
     public ExtensionBruteForce() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionBruteForce(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionBruteForce");
+        super("ExtensionBruteForce");
         this.setOrder(32);
 	}
 	

--- a/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Forced Browse</name>
-	<version>5</version>
+	<version>6</version>
 	<status>beta</status>
 	<description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Adding request count on Forced browser tab as specified on issue #1873
+	Minor code changes.
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/diff/ExtensionDiff.java
+++ b/src/org/zaproxy/zap/extension/diff/ExtensionDiff.java
@@ -40,15 +40,8 @@ public class ExtensionDiff extends ExtensionAdaptor {
      * 
      */
     public ExtensionDiff() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionDiff(String name) {
-        super(name);
+        super("ExtensionDiff");
+        this.setOrder(75);
     }
 
     @Override
@@ -66,17 +59,6 @@ public class ExtensionDiff extends ExtensionAdaptor {
         }
         super.unload();
     }
-
-	/**
-	 * This method initializes this
-	 * 
-	 * @return void
-	 */
-	private void initialize() {
-        this.setName("ExtensionDiff");
-        this.setOrder(75);
-	}
-	
 
 	public void hook(ExtensionHook extensionHook) {
 	    super.hook(extensionHook);

--- a/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Diff</name>
-	<version>6</version>
+	<version>7</version>
 	<status>beta</status>
 	<description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Do not add line break tags to resultant diff (Issue 1571)<br>
-	Automatically close the diff dialogue when uninstalling.<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
+++ b/src/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
@@ -62,22 +62,7 @@ public class ExtensionImportUrls extends ExtensionAdaptor {
 	private static Logger log = Logger.getLogger(ExtensionImportUrls.class);
 
 	public ExtensionImportUrls() {
-		super();
-		initialize();
-	}
-
-	/**
-	 * @param name
-	 */
-	public ExtensionImportUrls(String name) {
-		super(name);
-	}
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
 		this.setOrder(157);
 	}
 

--- a/src/org/zaproxy/zap/extension/invoke/ExtensionInvoke.java
+++ b/src/org/zaproxy/zap/extension/invoke/ExtensionInvoke.java
@@ -42,22 +42,7 @@ public class ExtensionInvoke extends ExtensionAdaptor {
      * 
      */
     public ExtensionInvoke() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionInvoke(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("ExtensionInvoke");
+        super("ExtensionInvoke");
         this.setOrder(46);
 	}
 	

--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Invoke Applications</name>
-	<version>4</version>
+	<version>5</version>
 	<status>beta</status>
 	<description>Invoke external applications passing context related information such as URLs and parameters</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Allow to invoke the applications in all UI components that show HTTP messages.<br>
-	Allow to manually specify the application path and working directory (Issue 2708).<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
+++ b/src/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
@@ -46,22 +46,7 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
 	private ScriptEngine rubyScriptEngine = null;
 
 	public ExtensionJruby() {
-		super();
-		initialize();
-	}
-
-	/**
-	 * @param name
-	 */
-	public ExtensionJruby(String name) {
-		super(name);
-	}
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
 		this.setOrder(76);
 	}
 

--- a/src/org/zaproxy/zap/extension/jruby/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jruby/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Ruby scripting</name>
-	<version>4</version>
+	<version>5</version>
 	<status>beta</status>
 	<description>Allows Ruby to be used for ZAP scripting - templates included</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for ZAP 2.4</changes>
+	<changes>Minor code changes.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jruby.ExtensionJruby</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/jython/ExtensionJython.java
+++ b/src/org/zaproxy/zap/extension/jython/ExtensionJython.java
@@ -42,22 +42,7 @@ public class ExtensionJython extends ExtensionAdaptor {
 	private ExtensionScript extScript = null;
 
 	public ExtensionJython() {
-		super();
-		initialize();
-	}
-
-	/**
-	 * @param name
-	 */
-	public ExtensionJython(String name) {
-		super(name);
-	}
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
 		this.setOrder(74);
 	}
 

--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Python scripting</name>
-	<version>4</version>
+	<version>5</version>
 	<status>beta</status>
 	<description>Allows Python to be used for ZAP scripting - templates included</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for ZAP 2.4</changes>
+	<changes>Minor code changes</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jython.ExtensionJython</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
@@ -158,12 +158,7 @@ public class ExtensionPlugNHack extends ExtensionAdaptor implements ProxyListene
 	 */
 	
 	public ExtensionPlugNHack() {
-		super();
-		initialize();
-	}
-
-    private void initialize() {
-        this.setName(NAME);
+		super(NAME);
         this.setOrder(101);
     }
     

--- a/src/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
+++ b/src/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
@@ -61,23 +61,8 @@ public class ExtensionPortScan extends ExtensionAdaptor
      *
      */
     public ExtensionPortScan() {
-        super();
+        super("ExtensionPortScan");
         this.setI18nPrefix("ports");
-        initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionPortScan(String name) {
-        super(name);
-    }
-
-    /**
-     * This method initializes this
-     */
-    private void initialize() {
-        this.setName("ExtensionPortScan");
         this.setOrder(34);
     }
 

--- a/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
 	<name>Port Scanner</name>
-	<version>7</version>
+	<version>8</version>
 	<status>beta</status>
 	<description>Allows to port scan a target server</description>
 	<author>ZAP Dev Team</author>
@@ -8,7 +8,6 @@
 	<changes>
 	<![CDATA[
 	Minor code changes.<br>
-	Do not access view components when view is not initialised (Issue 1617).
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -92,22 +92,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 	}
 
     public ExtensionScriptsUI() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionScriptsUI(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
 		// Make sure this extension is loaded after the ExtensionScript and after the
 		// ExtensionAuthentication, so the Popup for using the scripts as authentication is properly
 		// enabled (it needs the authentication method types to already be registered).

--- a/src/org/zaproxy/zap/extension/tips/ExtensionTipsAndTricks.java
+++ b/src/org/zaproxy/zap/extension/tips/ExtensionTipsAndTricks.java
@@ -57,23 +57,7 @@ public class ExtensionTipsAndTricks extends ExtensionAdaptor {
     private Random random = new Random();
 
     public ExtensionTipsAndTricks() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionTipsAndTricks(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/tips/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tips/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Tips and Tricks</name>
-	<version>5</version>
+	<version>6</version>
 	<status>beta</status>
 	<description>Display ZAP Tips and Tricks</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated help page to show latest tips, fix typos and use proper charset.</changes>
+	<changes>Minor code changes.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.tips.ExtensionTipsAndTricks</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
+++ b/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
@@ -65,23 +65,7 @@ public class ExtensionTokenGen extends ExtensionAdaptor {
      * 
      */
     public ExtensionTokenGen() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionTokenGen(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
         this.setI18nPrefix("tokengen");
 	}
 	

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Token generation and analysis</name>
-	<version>10</version>
+	<version>11</version>
 	<status>beta</status>
 	<description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Change active Pause Button to a Play button (Issue 1802).<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/treetools/ExtensionTreeTools.java
+++ b/src/org/zaproxy/zap/extension/treetools/ExtensionTreeTools.java
@@ -33,22 +33,7 @@ public class ExtensionTreeTools extends ExtensionAdaptor {
      * 
      */
     public ExtensionTreeTools() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionTreeTools(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-        this.setName("TreeTools");
+        super("TreeTools");
         this.setOrder(667);	// Want this to be as low as possible :)
 	}
 	

--- a/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>TreeTools</name>
-	<version>6</version>
+	<version>7</version>
 	<status>beta</status>
 	<description>Tools to add functionality to the tree view.</description>
 	<author>Carl Sampson</author>
 	<url/>
-	<changes>Safe menu items will now be enabled in protected and safe modes (Issue 1278).</changes>
+	<changes>Minor code changes.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.treetools.ExtensionTreeTools</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -157,22 +157,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 	}
 
 	public ExtensionZest() {
-		super();
-		initialize();
-	}
-
-	/**
-	 * @param name
-	 */
-	public ExtensionZest(String name) {
-		super(name);
-	}
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
 		this.setOrder(73); // Almost looks like ZE ;)
 	}
 

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Zest - Graphical Security Scripting Language</name>
-	<version>22</version>
+	<version>23</version>
 	<status>beta</status>
 	<description>A graphical security scripting language, ZAPs macro language on steroids</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
-	Change Sequence scripts to not use Sites tree nodes directly.<br>
-	Correct assertion of response body length when using charset (Issue 2669).<br>
-	Require just the parameters defined in the Authentication script (Issue 2734).<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Remove unnecessary extensions' constructors, they are not required nor
used by core code to start/load the extensions (it's enough with the
no-arg constructor moreover add-ons do not need nor should start other
extensions). Also, in the cases where an auxiliary "initialize" method
was in use it was merged into the no-arg constructor (in most of the
cases it was only being called by the no-arg constructor).
Bump version and update changes in ZapAddOn.xml files, where needed.