### PR TITLE
alpha: remove unnecessary extensions' constructors

### DIFF
--- a/src/org/zaproxy/zap/extension/birtreports/BirtScriptMenu.java
+++ b/src/org/zaproxy/zap/extension/birtreports/BirtScriptMenu.java
@@ -43,23 +43,7 @@ public class BirtScriptMenu extends ExtensionAdaptor {
      *
      */
     public BirtScriptMenu() {
-        super();
-                initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public BirtScriptMenu(String name) {
-        super(name);
-    }
-
-        /**
-         * This method initializes this
-         *
-         */
-        private void initialize() {
-        this.setName("BirtScriptMenu");
+        super("BirtScriptMenu");
         // Load extension specific language files - these are held in the extension jar
         messages = ResourceBundle.getBundle(
                         this.getClass().getPackage().getName() + ".resources.Messages", Constant.getLocale());

--- a/src/org/zaproxy/zap/extension/birtreports/BirtTopMenu.java
+++ b/src/org/zaproxy/zap/extension/birtreports/BirtTopMenu.java
@@ -45,23 +45,7 @@ public class BirtTopMenu extends ExtensionAdaptor {
      *
      */
     public BirtTopMenu() {
-        super();
-        initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public BirtTopMenu(String name) {
-        super(name);
-    }
-
-        /**
-         * This method initializes this
-         *
-         */
-        private void initialize() {
-        this.setName("BirtTopMenu");
+        super("BirtTopMenu");
         // Load extension specific language files - these are held in the extension jar
         messages = ResourceBundle.getBundle(
                         this.getClass().getPackage().getName() + ".resources.Messages", Constant.getLocale());

--- a/src/org/zaproxy/zap/extension/birtreports/logoTopMenu.java
+++ b/src/org/zaproxy/zap/extension/birtreports/logoTopMenu.java
@@ -43,23 +43,7 @@ public class logoTopMenu extends ExtensionAdaptor {
      *
      */
     public logoTopMenu() {
-        super();
-                initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public logoTopMenu(String name) {
-        super(name);
-    }
-
-        /**
-         * This method initializes this
-         *
-         */
-        private void initialize() {
-        this.setName("logoTopMenu");
+        super("logoTopMenu");
         // Load extension specific language files - these are held in the extension jar
         messages = ResourceBundle.getBundle(
                         this.getClass().getPackage().getName() + ".resources.Messages", Constant.getLocale());

--- a/src/org/zaproxy/zap/extension/cmss/CMSSTopMenu.java
+++ b/src/org/zaproxy/zap/extension/cmss/CMSSTopMenu.java
@@ -42,23 +42,7 @@ public class CMSSTopMenu extends ExtensionAdaptor {
      * 
      */
     public CMSSTopMenu() {
-        super();
-                initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public CMSSTopMenu(String name) {
-        super(name);
-    }
-
-        /**
-         * This method initializes this
-         * 
-         */
-        private void initialize() {
-        this.setName("ExtensionTopMenu");
+        super("ExtensionTopMenu");
         // Load extension specific language files - these are held in the extension jar
         messages = ResourceBundle.getBundle(
                         this.getClass().getPackage().getName() + ".resources.Messages", Constant.getLocale());

--- a/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
@@ -1,10 +1,11 @@
 <zapaddon>
 	<name>WAFP Extension</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>Fingerprint web applications</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy</url>
+	<changes>Minor code changes.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.cmss.CMSSTopMenu</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/codedx/CodeDxExtension.java
+++ b/src/org/zaproxy/zap/extension/codedx/CodeDxExtension.java
@@ -41,12 +41,7 @@ public class CodeDxExtension extends ExtensionAdaptor {
     public List<Alert> alerts;
 
     public CodeDxExtension() {
-        super();
-        initialize();
-    }
-
-    private void initialize() {
-        this.setName(NAME);
+        super(NAME);
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Code Dx Extension</name>
-	<version>3</version>
+	<version>4</version>
 	<status>alpha</status>
 	<description>includes request and response data in xml reports</description>
 	<author>Code Dx, Inc.</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Allow to update/uninstall the add-on without restarting ZAP.<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
+++ b/src/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
@@ -54,23 +54,7 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
      * 
      */
     public ExtensionCustomReport() {
-        super();
-        initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionCustomReport(String name) {
-        super(name);
-    }
-
-        /**
-         * This method initializes this
-         * 
-         */
-        private void initialize() {
-        this.setName("ExtensionCustomReport");
+        super("ExtensionCustomReport");
         }
         
 		@Override

--- a/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
         <name>CustomReport</name>
-        <version>2</version>
+        <version>3</version>
         <status>alpha</status>
         <description>New HTML report module allows users to customize report content.</description>
         <author>Chienli Ma</author>
         <url></url>
         <changes>
         <![CDATA[
-        Allow to update/uninstall the add-on without restarting ZAP.<br>
+        Minor code changes.<br>
         ]]>
         </changes>
         <dependson/>

--- a/src/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
@@ -51,16 +51,7 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
     private ImportLogAPI importLogAPI;
     
     public ExtensionImportLogFiles() {
-        super();
-        initialize();
-    }
-
-    public ExtensionImportLogFiles(String name) {
-        super(name);
-    }
-
-    private void initialize() {
-        this.setName("ExtensionImportLogFiles");
+        super("ExtensionImportLogFiles");
     }
 
     @SuppressWarnings("deprecation")

--- a/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
@@ -1,12 +1,12 @@
 <zapaddon>
 	<name>Log File Importer</name>
-	<version>3</version>
+	<version>4</version>
 	<status>alpha</status>
 	<description>Allows you to import log files from ModSecurity and files previously exported from ZAP</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs
 	</url>
-	<changes>Updated add-on's info URL.</changes>
+	<changes>Minor code changes.</changes>
 	<dependson></dependson>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.importLogFiles.ExtensionImportLogFiles</extension>

--- a/src/org/zaproxy/zap/extension/requester/ExtensionRequester.java
+++ b/src/org/zaproxy/zap/extension/requester/ExtensionRequester.java
@@ -51,16 +51,7 @@ public class ExtensionRequester extends ExtensionAdaptor {
 	private RequesterOptionsPanel requesterOptionsPanel;
 	
 	public ExtensionRequester() {
-		super();		
-		initialize();
-	}
-
-	public ExtensionRequester(String name) {
-		super(name);
-	}	
-
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
 		this.setOrder(211);		
 	}	
 	

--- a/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
@@ -1,10 +1,10 @@
 <zapaddon>
 	<name>Requester</name>
-	<version>1</version>
+	<version>2</version>
 	<description>Request numbered panel.</description>
 	<author>Surikato</author>
 	<url></url>
-	<changes/>
+	<changes>Minor code changes.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.requester.ExtensionRequester</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/src/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -104,23 +104,7 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
      * 
      */
     public ExtensionRevisit() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionRevisit(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Revisit</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>Revisit a site at any time in the past using the session history</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Allow to update/uninstall the add-on without restarting ZAP.<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/sniTerminator/ExtensionSniTerminator.java
+++ b/src/org/zaproxy/zap/extension/sniTerminator/ExtensionSniTerminator.java
@@ -54,23 +54,7 @@ public class ExtensionSniTerminator extends ExtensionAdaptor {
      * 
      */
     public ExtensionSniTerminator() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionSniTerminator(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/sniTerminator/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sniTerminator/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
 	<name>SNI Terminator</name>
-	<version>4</version>
+	<version>5</version>
 	<status>alpha</status>
 	<description>Transparent HTTP proxying</description>
 	<author>ZAP Dev Team</author>
@@ -8,7 +8,7 @@
 		<javaversion>1.8</javaversion>
 	</dependencies>
 	<url>http://www.computerist.org/blog/2014/07/23/Transparent-HTTPS-proxying-with-ZAP/</url>
-	<changes>Update library to work with newer versions of ZAP.</changes>
+	<changes>Minor code changes.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.sniTerminator.ExtensionSniTerminator</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -55,23 +55,7 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
 	private WSDLCustomParser parser = new WSDLCustomParser();
 	
 	public ExtensionImportWSDL() {
-		super();
-		initialize();
-	}
-
-	/**
-	 * @param name
-	 */
-	public ExtensionImportWSDL(String name) {
-		super(name);
-		initialize();
-	}
-
-	/**
-	 * This method initializes this
-	 */
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
 		this.setOrder(158);
 	}
 

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>SOAP Scanner</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>Imports and scans WSDL files containing SOAP endpoints.</description>
 	<author>Alberto (albertov91)</author>
 	<url></url>
-	<changes> Fixes a problem where operations under the same location were overwritten. Other minor fixes.</changes>
+	<changes>Minor code changes.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.soap.ExtensionImportWSDL</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/vulncheck/VulnCheckTopMenu.java
+++ b/src/org/zaproxy/zap/extension/vulncheck/VulnCheckTopMenu.java
@@ -20,11 +20,7 @@ public class VulnCheckTopMenu extends ExtensionAdaptor {
 	}
 	
 	public VulnCheckTopMenu() {
-        super();
-                initialize();
-    }
-	private void initialize() {
-        this.setName("VulnCheckTopMenu");
+        super("VulnCheckTopMenu");
         // Load extension specific language files - these are held in the extension jar
         messages = ResourceBundle.getBundle(
                         this.getClass().getPackage().getName() + ".resources.Messages", Constant.getLocale());

--- a/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -107,19 +107,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor implements SessionChan
 	 */
 	
 	public ExtensionWappalyzer() {
-		super();
-		initialize();
-	}
-
-	/**
-	 * @param name
-	 */
-	public ExtensionWappalyzer(String name) {
-		super(name);
-	}
-
-	private void initialize() {
-		this.setName(NAME);
+		super(NAME);
 		this.setOrder(201);
 		
 		try {

--- a/src/org/zaproxy/zap/extension/wavsepRpt/ExtensionWavsepReport.java
+++ b/src/org/zaproxy/zap/extension/wavsepRpt/ExtensionWavsepReport.java
@@ -181,23 +181,7 @@ public class ExtensionWavsepReport extends ExtensionAdaptor {
      * 
      */
     public ExtensionWavsepReport() {
-        super();
- 		initialize();
-    }
-
-    /**
-     * @param name
-     */
-    public ExtensionWavsepReport(String name) {
-        super(name);
-    }
-
-	/**
-	 * This method initializes this
-	 * 
-	 */
-	private void initialize() {
-        this.setName(NAME);
+        super(NAME);
 	}
 	
 	@Override


### PR DESCRIPTION
Remove unnecessary extensions' constructors, they are not required nor
used by core code to start/load the extensions (it's enough with the
no-arg constructor moreover add-ons do not need nor should start other
extensions). Also, in the cases where an auxiliary "initialize" method
was in use it was merged into the no-arg constructor (in most of the
cases it was only being called by the no-arg constructor).
Bump version and update changes in ZapAddOn.xml files, where needed.