### PR TITLE
invoke: allow to manually set app and dir paths

### DIFF
--- a/src/org/zaproxy/zap/extension/invoke/DialogAddApp.java
+++ b/src/org/zaproxy/zap/extension/invoke/DialogAddApp.java
@@ -239,7 +239,6 @@ class DialogAddApp extends AbstractFormDialog {
     protected ZapTextField getFullCommandTextField() {
         if (fullCommandTextField == null) {
             fullCommandTextField = new ZapTextField(20);
-            fullCommandTextField.setEditable(false);
             fullCommandTextField.getDocument().addDocumentListener(getConfirmButtonValidatorDocListener());
         }
 
@@ -290,7 +289,6 @@ class DialogAddApp extends AbstractFormDialog {
     protected ZapTextField getWorkingDirTextField() {
         if (workingDirTextField == null) {
             workingDirTextField = new ZapTextField(20);
-            workingDirTextField.setEditable(false);
         }
 
         return workingDirTextField;

--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Allow to invoke the applications in all UI components that show HTTP messages.<br>
+	Allow to manually specify the application path and working directory (Issue 2708).<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change class DialogAddApp to have the text boxes for the application
path and working directory editable, so the user can manually specify
its values.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2708 - Allow to manually specify application path
and working directory