### PR TITLE
zest: check the auth script for parameters

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Change Sequence scripts to not use Sites tree nodes directly.<br>
 	Correct assertion of response body length when using charset (Issue 2669).<br>
+	Require just the parameters defined in the Authentication script (Issue 2734).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change class ZestAuthenticationRunner to return as mandatory parameters
the script parameters that are not credentials parameters (that is, not
username or password) and do not have a value instead of returning
always the same parameters. Also, return as optional parameters the ones
that already have a value.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2734 - Zest authentication script requires fields
even if not needed/used