### PR TITLE
zest: change external URLs to links in help page

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/resources/help/contents/zest.html
+++ b/src/org/zaproxy/zap/extension/zest/resources/help/contents/zest.html
@@ -87,11 +87,11 @@ A right click menu is provided (where relevant) in the edit dialogs to allow you
 <table>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-	<td>https://developer.mozilla.org/en-US/docs/zest</td>
+	<td><a href="https://developer.mozilla.org/en-US/docs/zest">https://developer.mozilla.org/en-US/docs/zest</a></td>
 	<td>Zest overview</td></tr>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-	<td>https://github.com/mozilla/zest</td>
+	<td><a href="https://github.com/mozilla/zest">https://github.com/mozilla/zest</a></td>
 	<td>The Zest github repository, including details of the language</td>
 </tr>
 </table>


### PR DESCRIPTION
Change Zest help page to have external URLs as links, so they can be
accessed without having to manually copy them to a browser.