### PR TITLE
New Apache Range Header DoS Scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ApacheRangeHeaderDos.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ApacheRangeHeaderDos.java
@@ -1,0 +1,180 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+import org.parosproxy.paros.Constant;
+
+import java.io.IOException;
+
+/**
+ * Active scan rule which checks whether or not the server is subject to the
+ * Apache Range Header Denial of Service vulnerability: CVE-2011-3192. Based
+ * loosely on:
+ * https://github.com/alienwithin/php-utilities/blob/master/apache-byte-range-
+ * server-dos/apache_byte_range_server_dos.php
+ * 
+ * @author kingthorin+owaspzap@gmail.com
+ */
+public class ApacheRangeHeaderDos extends AbstractAppPlugin {
+
+	/**
+	 * Prefix for internationalised messages used by this rule
+	 */
+	private static final String MESSAGE_PREFIX = "ascanalpha.apacherangeheaderdosscanner.";
+	private static final int PLUGIN_ID = 10053;
+
+	private static final Logger LOG = Logger.getLogger(ApacheRangeHeaderDos.class);
+
+	@Override
+	public int getId() {
+		return PLUGIN_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "name");
+	}
+
+	@Override
+	public String getDescription() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+	}
+
+	@Override
+	public String getSolution() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+	}
+
+	@Override
+	public String getReference() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+	}
+
+	@Override
+	public String[] getDependency() {
+		return null;
+	}
+
+	@Override
+	public boolean targets(TechSet technologies) {
+		return technologies.includes(Tech.Apache);
+	}
+
+	@Override
+	public int getCategory() {
+		return Category.SERVER;
+	}
+
+	@Override
+	public int getRisk() {
+		return Alert.RISK_MEDIUM;
+	}
+
+	@Override
+	public int getCweId() {
+		return 400; // CWE-400: Uncontrolled Resource Consumption
+	}
+
+	@Override
+	public int getWascId() {
+		return 10; // WASC-10: Denial of Service
+	}
+
+	@Override
+	public void init() {
+
+	}
+
+	@Override
+	public void scan() {
+
+		// Check if the user stopped things. One request per URL so check before
+		// sending the request
+		if (isStop()) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Scanner " + getName() + " Stopping.");
+			}
+			return;
+		}
+
+		if (acceptsRangeRequests()) {// Server handles ranges
+			HttpMessage newRequest = getNewMsg();
+			setRequestHeaders(newRequest, "3-0,1-1,2-2,3-3,4-4,5-5,6-6,7-7,8-8,9-9,10-10,11-11");
+			// Send a request for 11 ranges, 1 more than permitted
+			try {
+				sendAndReceive(newRequest, false);
+			} catch (IOException e) {
+				LOG.warn("An error occurred while checking [" + newRequest.getRequestHeader().getMethod() + "] ["
+						+ newRequest.getRequestHeader().getURI() + "] for Apache Range Header DoS (CVE-2011-3192)."
+						+ "Caught " + e.getClass().getName() + " " + e.getMessage());
+				return;
+			}
+
+			if (newRequest.getResponseHeader().getStatusCode() == HttpStatusCode.PARTIAL_CONTENT) {
+				bingo(getRisk(), // Risk
+						Alert.CONFIDENCE_MEDIUM, // Confidence/Reliability
+						getName(), // Name
+						getDescription(), // Description
+						newRequest.getRequestHeader().getURI().toString(), // URI
+						null, // Param
+						"", // Attack
+						"", // OtherInfo
+						getSolution(), // Solution
+						newRequest.getResponseHeader().getPrimeHeader(), // Evidence
+						getCweId(), // CWE ID
+						getWascId(), // WASC ID
+						newRequest); // HTTPMessage
+			}
+		}
+	}
+
+	private boolean acceptsRangeRequests() {
+		HttpMessage chkRequest = getNewMsg();
+		setRequestHeaders(chkRequest, "0-6");
+
+		try {
+			sendAndReceive(chkRequest, false);
+		} catch (IOException e) {
+			LOG.warn("An error occurred while validating [" + chkRequest.getRequestHeader().getMethod() + "] ["
+					+ chkRequest.getRequestHeader().getURI()
+					+ "] for Apache Range Header DoS (CVE-2011-3192) applicability." + "Caught "
+					+ e.getClass().getName() + " " + e.getMessage());
+			return false;
+		}
+
+		return chkRequest.getResponseHeader().getStatusCode() == HttpStatusCode.PARTIAL_CONTENT;
+	}
+
+	private void setRequestHeaders(HttpMessage aMessage, String rangeValue) {
+		rangeValue = "bytes=" + rangeValue;
+		aMessage.getRequestHeader().setHeader("Range", rangeValue);
+		aMessage.getRequestHeader().setHeader("Range-Request", rangeValue);
+		aMessage.getRequestHeader().setHeader("Connection", "close");
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -1,19 +1,20 @@
 <zapaddon>
 	<name>Active scanner rules (alpha)</name>
-	<version>17</version>
+	<version>18</version>
 	<status>alpha</status>
 	<description>The alpha quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>
 	<changes>
 	<![CDATA[
-	Added Httpoxy scanner.<br>
+	Added Apache Range Header DoS (CVE-2011-3192) scanner.<br>
   	]]>
 	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.ascanrulesAlpha.ExtensionAscanRulesAlpha</extension>
 	</extensions>
 	<ascanrules>
+		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ApacheRangeHeaderDos</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleSimpleActiveScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleFileActiveScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.HttpOnlySite</ascanrule>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -3,6 +3,11 @@
 # This file defines the default (English) variants of all of the internationalised messages
 ascanalpha.desc = Active Scan Rules - alpha
 
+ascanalpha.apacherangeheaderdosscanner.name = Apache Range Header DoS (CVE-2011-3192)
+ascanalpha.apacherangeheaderdosscanner.desc = The byterange filter in earlier versions of the Apache HTTP Server allows remote attackers to cause a denial of service (memory and CPU exhaustion) via a Range request header that identifies multiple overlapping ranges. This issue was exploited in the wild in August 2011.
+ascanalpha.apacherangeheaderdosscanner.soln = Upgrade your Apache server to a currently stable version. Alternative solutions or workarounds are outlined in the references. 
+ascanalpha.apacherangeheaderdosscanner.refs = https://httpd.apache.org/security/CVE-2011-3192.txt\nhttp://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2011-3192
+
 ascanalpha.cookieslack.name = Cookie Slack Detector
 ascanalpha.cookieslack.desc = Repeated GET requests: drop a different cookie each time, followed by normal request with all cookies to stabilize session, compare responses against original baseline GET. This can reveal areas where cookie based authentication/attributes are not actually enforced.
 ascanalpha.cookieslack.solution = N.a.

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -9,6 +9,10 @@ Active Scan Rules - alpha
 <H1>Active Scan Rules - alpha</H1>
 The following alpha quality active scan rules are included in this add-on:
 
+<H2>Apache Range Header DoS (CVE-2011-3192)</H2>
+Tests to see if the server is vulnerable to the Apache Range Header Denial of Service issue, by requesting eleven (11) 
+different byte ranges. Eleven ranges is one more than is accepted by patched/fixed servers.
+
 <H2>Cookie Slack Detector</H2>
 Tests cookies to detect if some have no effect on response size when omitted, especially cookies containing the name "session" or "userid"
 


### PR DESCRIPTION
Add scanner for Apache Range Header DoS (CVE-2011-3192). Includes help
updates, and ZapAddOn.xml updates.