### PR TITLE
Refactoring/unit testing for x-powered-by scanner, cookie-same-site scanner, and gitignore in alpha branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 build/build/
 build/zap-exts/
+.idea/
+*.iml

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/XPoweredByHeaderInfoLeakScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/XPoweredByHeaderInfoLeakScanner.java
@@ -20,7 +20,10 @@
 
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
-import java.util.Vector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import net.htmlparser.jericho.Source;
 
@@ -58,30 +61,78 @@ public class XPoweredByHeaderInfoLeakScanner extends PluginPassiveScanner{
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 		long start = System.currentTimeMillis();
-	
-		Vector<String> xpbOptions = msg.getResponseHeader().getHeaders(HEADER_NAME);
-		if (xpbOptions != null) { //Header Found
-			for (String xpbDirective : xpbOptions) {
-				Alert alert = new Alert(getPluginId(), Alert.RISK_LOW, Alert.CONFIDENCE_MEDIUM, //PluginID, Risk, Reliability
-					getName()); 
-		    		alert.setDetail(
-		    				getDescription(), //Description
-		    				msg.getRequestHeader().getURI().toString(), //URI
-		    				"",	// Param
-		    				"", // Attack
-		    				"", // Other info
-		    				getSolution(), //Solution
-		    				getReference(), //References
-		    				HEADER_NAME, // Evidence - Return the header name
-		    				200, // CWE Id
-		    				13,	// WASC Id
-		    				msg); //HttpMessage
-		    	parent.raiseAlert(id, alert);
-				}
+
+		if (isXPoweredByHeaderExist(msg)) {
+			List<String> xpbHeaders = getXPoweredByHeaders(msg);
+			raiseAlert(msg, id, xpbHeaders);
+			if (logger.isDebugEnabled()) {
+				logger.debug("\tScan of record " + id + " took " + (System.currentTimeMillis() - start) + " ms");
 			}
-		    if (logger.isDebugEnabled()) {
-		    	logger.debug("\tScan of record " + id + " took " + (System.currentTimeMillis() - start) + " ms");
-	    }
+		}
+	}
+
+	/**
+	 * Checks if there is any X-Powered-By header
+	 * @param msg Response Http message
+	 * @return boolean status of existence
+	 */
+	private boolean isXPoweredByHeaderExist(HttpMessage msg) {
+		return null != msg.getResponseHeader().getHeaders(HEADER_NAME);
+	}
+
+	/**
+	 * Extracts the list of "X-Powered-By" headers, and returns them without changing
+	 * their cases.
+	 * @param msg Response Http message
+	 * @return list of the matched headers
+	 */
+	private List<String> getXPoweredByHeaders(HttpMessage msg) {
+		List<String> matchedHeaders = new ArrayList<>();
+		String headers = msg.getResponseHeader().toString();
+		String[] headerElements = headers.split("\\r\\n");
+		Pattern pattern = Pattern.compile("^X-Powered-By.*", Pattern.CASE_INSENSITIVE);
+		for (String header : headerElements) {
+			Matcher matcher = pattern.matcher(header);
+			if (matcher.find()) {
+				String match = matcher.group();
+				matchedHeaders.add(match);
+			}
+		}
+		return matchedHeaders;
+	}
+
+	/**
+	 * Raises an alert with the "Evidence" or "Other" field filled-in depending on the header repetition.
+	 * @param msg The Http message containing the response headers
+	 * @param id The ID of the message being scanned.
+	 */
+	private void raiseAlert(HttpMessage msg, int id, List<String> xpbHeaders) {
+		String alertEvidence = xpbHeaders.get(0);
+		String alertOtherInfo = "";
+		if (xpbHeaders.size() > 1) { // we have multiple X-Powered-By headers
+			StringBuilder sb = new StringBuilder();
+			sb.append(Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.msg"));
+			for (int i = 1; i < xpbHeaders.size(); i++) {
+				sb.append(xpbHeaders.get(i));
+				sb.append("\r\n");
+			}
+			alertOtherInfo = sb.toString();
+		}
+		Alert alert = new Alert(getPluginId(), Alert.RISK_LOW, Alert.CONFIDENCE_MEDIUM, //PluginID, Risk, Reliability
+				getName());
+			alert.setDetail(
+					getDescription(), //Description
+					msg.getRequestHeader().getURI().toString(), //URI
+					"",	// Param
+					"", // Attack
+					alertOtherInfo, // Other info
+					getSolution(), //Solution
+					getReference(), //References
+					alertEvidence, // Evidence
+					200, // CWE Id
+					13,	// WASC Id
+					msg); //HttpMessage
+		parent.raiseAlert(id, alert);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>11</version>
+	<version>12</version>
 	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-		Issue 2538: Strict-Transport-Security Header Scanner additional variants.<br>
-		Issue 2716: Implement a passive check for cookies without SameSite set.<br>
+		Refactoring the x-powered-by scanner to raise one alert if it finds repetitive headers.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -175,6 +175,7 @@ pscanalpha.xpoweredbyheaderinfoleak.refs=http://blogs.msdn.com/b/varunm/archive/
 pscanalpha.xpoweredbyheaderinfoleak.soln=Ensure that your web server, application server, load balancer, etc. is configured to suppress "X-Powered-By" headers.
 pscanalpha.xpoweredbyheaderinfoleak.exploit=
 pscanalpha.xpoweredbyheaderinfoleak.extrainfo=
+pscanalpha.xpoweredbyheaderinfoleak.otherinfo.msg=The following X-Powered-By headers were also found:\r\n
 
 pscanalpha.contentsecuritypolicymissing.name=Content Security Policy (CSP) Header Not Set
 pscanalpha.contentsecuritypolicymissing.desc=Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page \u2014 covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/CookieSameSiteScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/CookieSameSiteScannerUnitTest.java
@@ -21,49 +21,17 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import net.htmlparser.jericho.Source;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.core.scanner.Alert;
+
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
-import org.zaproxy.zap.utils.I18N;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-@RunWith(MockitoJUnitRunner.class)
-public class CookieSameSiteScannerUnitTest {
+public class CookieSameSiteScannerUnitTest extends PassiveScannerTest {
 
-	private CookieSameSiteScanner rule;
-	private PassiveScanThread parent;
-	private List<Alert> alertsRaised;
-
-    @BeforeClass
-    public static void beforeClass() {
-        Constant.messages = Mockito.mock(I18N.class);
-    }
-
-	@Before
-	public void setUp() throws Exception {
-		alertsRaised = new ArrayList<>();
-		parent = new PassiveScanThread(null, null, new ExtensionAlert()) {
-			@Override
-			public void raiseAlert(int arg0, Alert arg1) {
-				alertsRaised.add(arg1);
-			}
-		};
-		rule = new CookieSameSiteScanner();
-		rule.setParent(parent );
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new CookieSameSiteScanner();
 	}
 
     @Test
@@ -71,7 +39,7 @@ public class CookieSameSiteScannerUnitTest {
 		
 		HttpMessage msg = new HttpMessage();
 		msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
-		
+
 		msg.setResponseBody("<html></html>");
 		msg.setResponseHeader(
 				"HTTP/1.1 200 OK\r\n" +
@@ -79,9 +47,7 @@ public class CookieSameSiteScannerUnitTest {
 				"Set-Cookie: test=123; Path=/; HttpOnly\r\n" +
 				"Content-Type: text/html;charset=ISO-8859-1\r\n" +
 				"Content-Length: " + msg.getResponseBody().length() + "\r\n");
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-		Source source = new Source(response);
-		rule.scanHttpResponseReceive(msg, rule.getPluginId(), source);
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
 		assertThat(alertsRaised.size(), equalTo(1));
 		assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
@@ -100,9 +66,7 @@ public class CookieSameSiteScannerUnitTest {
 				"Server: Apache-Coyote/1.1\r\n" +
 				"Content-Type: text/html;charset=ISO-8859-1\r\n" +
 				"Content-Length: " + msg.getResponseBody().length() + "\r\n");
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-		Source source = new Source(response);
-		rule.scanHttpResponseReceive(msg, rule.getPluginId(), source);
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
 		assertThat(alertsRaised.size(), equalTo(0));
     }
@@ -120,9 +84,7 @@ public class CookieSameSiteScannerUnitTest {
 				"Set-Cookie: test=123; Path=/; SameSite=Lax; HttpOnly\r\n" +
 				"Content-Type: text/html;charset=ISO-8859-1\r\n" +
 				"Content-Length: " + msg.getResponseBody().length() + "\r\n");
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-		Source source = new Source(response);
-		rule.scanHttpResponseReceive(msg, rule.getPluginId(), source);
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
 		assertThat(alertsRaised.size(), equalTo(0));
 	}
@@ -140,9 +102,7 @@ public class CookieSameSiteScannerUnitTest {
 				"Set-Cookie: test=123; Path=/; SameSite=strICt; HttpOnly\r\n" +
 				"Content-Type: text/html;charset=ISO-8859-1\r\n" +
 				"Content-Length: " + msg.getResponseBody().length() + "\r\n");
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-		Source source = new Source(response);
-		rule.scanHttpResponseReceive(msg, rule.getPluginId(), source);
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
 		assertThat(alertsRaised.size(), equalTo(0));
 	}
@@ -161,9 +121,7 @@ public class CookieSameSiteScannerUnitTest {
 				"Set-Cookie: test=123; Path=/; HttpOnly\r\n" +
 				"Content-Type: text/html;charset=ISO-8859-1\r\n" +
 				"Content-Length: " + msg.getResponseBody().length() + "\r\n");
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-		Source source = new Source(response);
-		rule.scanHttpResponseReceive(msg, rule.getPluginId(), source);
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
 		assertThat(alertsRaised.size(), equalTo(1));
 		assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
@@ -183,9 +141,7 @@ public class CookieSameSiteScannerUnitTest {
 				"Set-Cookie: test=123; Path=/; SameSite=badVal; HttpOnly\r\n" +
 				"Content-Type: text/html;charset=ISO-8859-1\r\n" +
 				"Content-Length: " + msg.getResponseBody().length() + "\r\n");
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-		Source source = new Source(response);
-		rule.scanHttpResponseReceive(msg, rule.getPluginId(), source);
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
 		assertThat(alertsRaised.size(), equalTo(1));
 		assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
@@ -205,9 +161,7 @@ public class CookieSameSiteScannerUnitTest {
 				"Set-Cookie: test=123; Path=/; SameSite; HttpOnly\r\n" +
 				"Content-Type: text/html;charset=ISO-8859-1\r\n" +
 				"Content-Length: " + msg.getResponseBody().length() + "\r\n");
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
-		Source source = new Source(response);
-		rule.scanHttpResponseReceive(msg, rule.getPluginId(), source);
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
 		assertThat(alertsRaised.size(), equalTo(1));
 		assertThat(alertsRaised.get(0).getParam(), equalTo("test"));

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.htmlparser.jericho.Source;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.alert.ExtensionAlert;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.utils.I18N;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class PassiveScannerTest {
+
+	protected PluginPassiveScanner rule;
+	protected PassiveScanThread parent;
+	protected List<Alert> alertsRaised;
+
+	@BeforeClass
+	public static void beforeClass() {
+		Constant.messages = Mockito.mock(I18N.class);
+	}
+
+	public PassiveScannerTest() {
+		super();
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		alertsRaised = new ArrayList<>();
+		parent = new PassiveScanThread(null, null, new ExtensionAlert()) {
+			@Override
+			public void raiseAlert(int arg0, Alert arg1) {
+				alertsRaised.add(arg1);
+			}
+		};
+		rule = createScanner();
+		rule.setParent(parent);
+	}
+
+	protected abstract PluginPassiveScanner createScanner();
+
+	protected Source createSource(HttpMessage msg) {
+		return new Source(msg.getResponseHeader().toString() + msg.getResponseBody().toString());
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/XPoweredByHeaderInfoLeakScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/XPoweredByHeaderInfoLeakScannerUnitTest.java
@@ -1,0 +1,115 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import org.junit.Test;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+/**
+ * @author Vahid Rafiei (@vahid_r)
+ */
+public class XPoweredByHeaderInfoLeakScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new XPoweredByHeaderInfoLeakScanner();
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfThereIsNoXPoweredBy() throws Exception {
+		// Given
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+		msg.setResponseHeader(
+				"HTTP/1.1 200 OK\r\n" +
+						"Server: Apache-Coyote/1.1\r\n");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldRaiseAnAlertIfFindsXPoweredBy() throws Exception {
+		// Given
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+		msg.setResponseHeader(
+				"HTTP/1.1 200 OK\r\n" +
+						"Server: Apache-Coyote/1.1\r\n" +
+						"X-Powered-By: Servlet/3.0\r\n");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+		assertThat(alertsRaised.get(0).getEvidence(), is("X-Powered-By: Servlet/3.0"));
+	}
+
+	@Test
+	public void shouldRaiseOnlyOneAlertWithOneEvidenceAndOtherInfoIfFindsMultipleXPoweredBy() throws Exception {
+		// Given
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+		msg.setResponseHeader(
+				"HTTP/1.1 200 OK\r\n" +
+						"Server: Apache-Coyote/1.1\r\n" +
+						"X-Powered-By: PHP/5.4\r\n" +
+						"X-Powered-By: Servlet/3.0\r\n" +
+						"X-Powered-By: ASP.NET\r\n");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+		assertThat(alertsRaised.get(0).getEvidence(), is("X-Powered-By: PHP/5.4"));
+		assertThat(alertsRaised.get(0).getOtherInfo(), containsString("X-Powered-By: Servlet/3.0"));
+		assertThat(alertsRaised.get(0).getOtherInfo(), containsString("X-Powered-By: ASP.NET"));
+	}
+
+	@Test
+	public void shouldBeCaseSensitiveWhenShowingHeadersInEvidenceAndOtherInfo() throws Exception {
+		// Given
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+		msg.setResponseHeader(
+				"HTTP/1.1 200 OK\r\n" +
+						"Server: Apache-Coyote/1.1\r\n" +
+						"X-Powered-By: PHP/5.4\r\n" +
+						"x-pOwEReD-bY: Servlet/3.0\r\n");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+		assertThat(alertsRaised.get(0).getEvidence(), is("X-Powered-By: PHP/5.4"));
+		assertThat(alertsRaised.get(0).getOtherInfo(), containsString("x-pOwEReD-bY: Servlet/3.0"));
+	}
+}


### PR DESCRIPTION

The refactoring consists of
1. extending the PassiveScannerTest class to avoid the duplications
2. Raising only one alert if XPoweredByHeaderInfoLeakScanner finds
multiple x-powered-by headers
3. In case of 2, it populates the <Evidence field> with the first header
found and the <Other field> with the rest of found values; It worthwhile
to mention that
4. Updating gitignore on alpha branch, to ignore IntelliJ specific files