### PR TITLE
Wappalyzer Titlecap Fixes

### DIFF
--- a/src/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -5,9 +5,9 @@
 wappalyzer.desc	= Technology detection using Wappalyzer - http://wappalyzer.com/
 wappalyzer.panel.mnemonic = t
 wappalyzer.panel.title = Technology
-wappalyzer.scanner = Wappalyzer scanner (tech detection)
+wappalyzer.scanner = Wappalyzer Scanner (Tech Detection)
 
-wappalyzer.search.popup		= Show evidence
+wappalyzer.search.popup		= Show Evidence
 
 wappalyzer.table.header.icon		=
 wappalyzer.table.header.name		= Technology


### PR DESCRIPTION
Minor adjustments to the addon's messages.properties file for title
caps.

See zaproxy/zaproxy#2000