### PR TITLE
websocket: fix NPE during unload in daemon mode

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Make breakpoint dialogues modal.<br>
+	Fix exception during the unload of the add-on, when in daemon mode.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
+++ b/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
@@ -147,9 +147,11 @@ public class ExtensionWebSocketFuzzer extends ExtensionAdaptor {
                 .getExtension(ExtensionWebSocket.class);
         extensionWebSocket.removeAllChannelObserver(getAllChannelObserver());
 
-        ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
-        if (extensionScript != null) {
-            extensionScript.removeScripType(scriptType);
+        if (getView() != null) {
+            ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+            if (extensionScript != null) {
+                extensionScript.removeScripType(scriptType);
+            }
         }
         MessageLocationReplacers.getInstance().removeReplacer(WebSocketMessageDTO.class, replacer);
     }


### PR DESCRIPTION
Change class ExtensionWebSocketFuzzer to check that the view is
initialised before removing the script type from the ExtensionScript
preventing the NullPointerException (the script type is only created if
there's a view/GUI).
Update changes in ZapAddOn.xml file.
 ---
From @zapbot "release" scans.