### PR TITLE
fuzz: fix NPE during unload in daemon mode

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -316,11 +316,13 @@ public class ExtensionFuzz extends ExtensionAdaptor {
             fuzzScansPanel.unload();
         }
 
-        ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+        if (getView() != null) {
+            ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
 
-        if (extensionScript != null) {
-            extensionScript.removeScripType(scriptTypeGenerator);
-            extensionScript.removeScripType(scriptTypeProcessor);
+            if (extensionScript != null) {
+                extensionScript.removeScripType(scriptTypeGenerator);
+                extensionScript.removeScripType(scriptTypeProcessor);
+            }
         }
     }
 

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
     <name>AdvFuzzer</name>
-    <version>6</version>
+    <version>7</version>
     <semver>2.0.1</semver>
     <status>beta</status>
     <description>Advanced fuzzer for manual testing</description>
@@ -8,11 +8,7 @@
     <url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</url>
     <changes>
     <![CDATA[
-    Added Export button to export results as CSV file.<br>
-    Enable "Limit maximum errors" by default and increase the default number.<br>
-    Improve error handling when reading/writing files from/to fuzzers directory.<br>
-    Add SHA-512 Hash payload processor (Issue 2643).<br>
-    Allow to search the fuzzer file names when selecting them.<br>
+    Fix exception during the unload of the add-on, when in daemon mode.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -169,9 +169,11 @@ public class ExtensionHttpFuzzer extends ExtensionAdaptor {
             extensionSearch.removeCustomHttpSearcher(httpFuzzerSearcher);
         }
 
-        ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
-        if (extensionScript != null) {
-            extensionScript.removeScripType(scriptType);
+        if (getView() != null) {
+            ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+            if (extensionScript != null) {
+                extensionScript.removeScripType(scriptType);
+            }
         }
     }
 


### PR DESCRIPTION
Change classes ExtensionFuzz and ExtensionHttpFuzzer to check that the
view is initialised before removing the script types from the
ExtensionScript preventing the NullPointerException (the script types
are only created if there's a view/GUI).
Bump version and update changes in ZapAddOn.xml file.
 ---
From @zapbot "release" scans.