### PR TITLE
Alert Filters Minor Cleanup and Fix

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/AlertFilter.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/AlertFilter.java
@@ -130,18 +130,18 @@ public class AlertFilter extends Enableable {
 	 * @param alertFilter the AlertFilter
 	 * @return the encoded string
 	 */
-	public static String encode(AlertFilter alertFilteruser) {
+	public static String encode(AlertFilter alertFilter) {
 		StringBuilder out = new StringBuilder();
-		out.append(alertFilteruser.isEnabled()).append(FIELD_SEPARATOR);
-		out.append(alertFilteruser.getRuleId()).append(FIELD_SEPARATOR);
-		out.append(alertFilteruser.getNewRisk()).append(FIELD_SEPARATOR);
-		if (alertFilteruser.url != null) {
-			out.append(Base64.encodeBase64String(alertFilteruser.url.getBytes()));
+		out.append(alertFilter.isEnabled()).append(FIELD_SEPARATOR);
+		out.append(alertFilter.getRuleId()).append(FIELD_SEPARATOR);
+		out.append(alertFilter.getNewRisk()).append(FIELD_SEPARATOR);
+		if (alertFilter.url != null) {
+			out.append(Base64.encodeBase64String(alertFilter.url.getBytes()));
 		}
 		out.append(FIELD_SEPARATOR);
-		out.append(alertFilteruser.isRegex()).append(FIELD_SEPARATOR);
-		if (alertFilteruser.parameter != null) {
-			out.append(Base64.encodeBase64String(alertFilteruser.parameter.getBytes()));
+		out.append(alertFilter.isRegex()).append(FIELD_SEPARATOR);
+		if (alertFilter.parameter != null) {
+			out.append(Base64.encodeBase64String(alertFilter.parameter.getBytes()));
 		}
 		out.append(FIELD_SEPARATOR);
 		// log.debug("Encoded AlertFilter: " + out.toString());
@@ -149,10 +149,10 @@ public class AlertFilter extends Enableable {
 	}
 
 	/**
-	 * Decodes an User from an encoded string. The string provided as input should have been
+	 * Decodes an alert filter from an encoded string. The string provided as input should have been
 	 * obtained through calls to {@link #encode(AlertFilter)}.
 	 * @param encodedString the encoded string
-	 * @return the user
+	 * @return the decoded alert filter
 	 */
 	protected static AlertFilter decode(int contextId, String encodedString) {
 		String[] pieces = encodedString.split(FIELD_SEPARATOR, -1);

--- a/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
@@ -36,11 +36,10 @@ import org.zaproxy.zap.extension.api.ApiResponseList;
 import org.zaproxy.zap.extension.api.ApiResponseSet;
 import org.zaproxy.zap.extension.api.ApiView;
 import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.utils.ApiUtils;
 
 /**
- * The API for manipulating {@link User Users}.
+ * The API for manipulating {@link AlertFilter alert filters}.
  */
 public class AlertFilterAPI extends ApiImplementor {
 

--- a/src/org/zaproxy/zap/extension/alertFilters/AlertFilterTableModel.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/AlertFilterTableModel.java
@@ -54,7 +54,7 @@ public class AlertFilterTableModel extends AbstractMultipleOptionsTableModel<Ale
 	}
 
 	/**
-	 * Instantiates a new user table model.
+	 * Instantiates a new alert filter table model.
 	 */
 	public AlertFilterTableModel() {
 		this.alertFilters = new ArrayList<>();
@@ -129,9 +129,9 @@ public class AlertFilterTableModel extends AbstractMultipleOptionsTableModel<Ale
 	}
 	
 	/**
-	 * Adds a new user to this model
+	 * Adds a new alert filter to this model
 	 *
-	 * @param af the user
+	 * @param af the alert filter being added
 	 */
 	public void addAlertFilter(AlertFilter af){
 		this.alertFilters.add(af);

--- a/src/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterManager.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterManager.java
@@ -82,7 +82,7 @@ public class ContextAlertFilterManager {
 	/**
 	 * Adds an alertFilter.
 	 * 
-	 * @param alertFilter the alertFilter
+	 * @param alertFilter the alertFilter being added 
 	 */
 	public void addAlertFilter(AlertFilter alertFilter) {
 		alertFilters.add(alertFilter);
@@ -91,7 +91,7 @@ public class ContextAlertFilterManager {
 	/**
 	 * Removes an alertFilter.
 	 * 
-	 * @param alertFilter the alertFilter
+	 * @param alertFilter the alertFilter being removed 
 	 */
 	public boolean removeAlertFilter(AlertFilter alertFilter) {
 		return alertFilters.remove(alertFilter);

--- a/src/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
@@ -50,7 +50,6 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 	private static final String CONFIRM_BUTTON_LABEL = 
 			Constant.messages.getString("alertFilters.dialog.add.button.confirm");
 
-	//private ExtensionAlertFilters extension = null;
 	private JPanel fieldsPanel;
 	private JCheckBox enabledCheckBox;
 	private JComboBox<String> alertCombo;
@@ -70,7 +69,6 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 	 */
 	public DialogAddAlertFilter(Dialog owner, ExtensionAlertFilters extension) {
 		super(owner, DIALOG_TITLE);
-		//this.extension = extension;
 	}
 
 	/**
@@ -83,7 +81,6 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 	 */
 	public DialogAddAlertFilter(Dialog owner, ExtensionAlertFilters extension, String title) {
 		super(owner, title);
-		//this.extension = extension;
 	}
 
 	/**
@@ -131,6 +128,13 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 	@Override
 	protected void clearFields() {
 		this.enabledCheckBox.setSelected(true);
+		this.alertCombo.setSelectedIndex(0);
+		this.newLevelCombo.setSelectedIndex(0);
+		this.urlTextField.setText("");
+		this.urlTextField.discardAllEdits();
+		this.regexCheckBox.setSelected(false);
+		this.paramTextField.setText("");
+		this.paramTextField.discardAllEdits();
 		this.setConfirmButtonEnabled(true);
 	}
 

--- a/src/org/zaproxy/zap/extension/alertFilters/DialogModifyAlertFilter.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/DialogModifyAlertFilter.java
@@ -25,9 +25,6 @@ import org.parosproxy.paros.Constant;
 
 public class DialogModifyAlertFilter extends DialogAddAlertFilter {
 
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = 7828871270310672334L;
 	private static final String DIALOG_TITLE = 
 			Constant.messages.getString("alertFilters.dialog.modify.title");

--- a/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -82,7 +82,7 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 	public static final String CONTEXT_CONFIG_ALERT_FILTERS = Context.CONTEXT_CONFIG + ".alertFilters";
 	public static final String CONTEXT_CONFIG_ALERT_FILTER = CONTEXT_CONFIG_ALERT_FILTERS + ".filter";
 	
-	private static final int TYPE_ALERT_FILTER = 500; // RecordContext.TYPE_USER
+	private static final int TYPE_ALERT_FILTER = 500; // RecordContext
 
 	/** The alertFilter panels, mapped to each context. */
 	private Map<Integer, ContextAlertFilterPanel> alertFilterPanelsMap = new HashMap<>();
@@ -102,9 +102,6 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 	
     private Logger log = Logger.getLogger(this.getClass());
 
-	/**
-     * 
-     */
     public ExtensionAlertFilters() {
         super();
  		initialize();
@@ -220,8 +217,8 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 	/**
 	 * Gets the context alert filter manager for a given context.
 	 * 
-	 * @param contextId the context id
-	 * @return the context alert filter manager
+	 * @param contextId the context id the manager relates to
+	 * @return the context alert filter manager for the given context
 	 */
 	public ContextAlertFilterManager getContextAlertFilterManager(int contextId) {
 		ContextAlertFilterManager manager = contextManagers.get(contextId);
@@ -292,8 +289,8 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 	/**
 	 * Gets the context panel for a given context.
 	 * 
-	 * @param contextId the context id
-	 * @return the context panel
+	 * @param contextId the context id the panel should relate to
+	 * @return the context panel for the given context
 	 */
 	private ContextAlertFilterPanel getContextPanel(int contextId) {
 		ContextAlertFilterPanel panel = this.alertFilterPanelsMap.get(contextId);

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Context Alert Filters</name>
-	<version>3</version>
+	<version>4</version>
 	<status>beta</status>
 	<description>Allows you to automate the changing of alert risk levels.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Various minor UI improvements<br>
+	Minor functional improvement.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
- DialogAddAlertFilter - clearFields(), now resets all relevant field,
addressing an issue reported in IRC. Removed some unused commented code.
- AlertFilter - Various JavaDoc fixes (remove references to "user")
- AlertFilterAPI - Various JavaDoc fixes (remove references to "user"),
remove unused import.
- AlertFilterTableModel - Various JavaDoc fixes (remove references to
"user").
- ExtensionAlertFilters - Various JavaDoc fixes (remove references to
"user").
- ContextAlertFilterManager - Minor JavaDoc updates.
- DialogModifyAlertFilter - Remove placeholder JavaDoc constructs.

- ZapAddOn.xml - Updated to v4 and new change comment added.