### PR TITLE
Add URL Import API

### DIFF
--- a/src/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
+++ b/src/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.importurls;
+
+import java.io.File;
+
+import net.sf.json.JSONObject;
+
+import org.apache.log4j.Logger;
+import org.zaproxy.zap.extension.api.ApiAction;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiException.Type;
+import org.zaproxy.zap.utils.ApiUtils;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+
+/**
+ * The API for importing URLs from a file.
+ */
+public class ImportUrlsAPI extends ApiImplementor {
+
+	private static final Logger LOG = Logger.getLogger(ImportUrlsAPI.class);
+
+	private static final String PREFIX = "importurls";
+
+	private static final String ACTION_IMPORTURLS = "importurls";
+
+	private static final String PARAM_FILE_PATH = "filePath";
+
+	private ExtensionImportUrls extension;
+
+	public ImportUrlsAPI(ExtensionImportUrls extension) {
+		super();
+		this.extension = extension;
+		this.addApiAction(new ApiAction(ACTION_IMPORTURLS, new String[] { PARAM_FILE_PATH }));
+	}
+
+	@Override
+	public String getPrefix() {
+		return PREFIX;
+	}
+
+	@Override
+	public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+		LOG.debug("handleApiAction " + name + " " + params.toString());
+
+		switch (name) {
+		case ACTION_IMPORTURLS:
+			extension.importUrlFile(new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH)));
+			return ApiResponseElement.OK;
+		default:
+			throw new ApiException(Type.BAD_ACTION);
+		}
+
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Import files containing URLs</name>
-	<version>2</version>
+	<version>3</version>
 	<status>beta</status>
 	<description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Promoted to beta, updated for ZAP 2.4</changes>
+	<changes>Issue 1643: Add an API end point for importing URLs from file.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.importurls.ExtensionImportUrls</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/importurls/resources/help/contents/importUrls.html
+++ b/src/org/zaproxy/zap/extension/importurls/resources/help/contents/importUrls.html
@@ -7,6 +7,9 @@ Import URLs
 </HEAD>
 <BODY BGCOLOR="#ffffff">
 <H1>Import URLs</H1>
-This add-on adds an option to import a file of URLs. The file must be plain text with one URL per line.<br>
+This add-on adds an option to import a file of URLs. The file must be plain text with one URL per line.
+</p>
+This add-on also exposes a ZAP API endpoint <tt>/importurls/importurls (filePath*)</tt> to facilitate programmatic 
+use of the functionality.
 </BODY>
 </HTML>


### PR DESCRIPTION
Add ImportUrlsAPI which accepts a simple parameter filePath. Expecting a
ZAP URL export or plain text file containing a single URL per line.

Adjust ExtensionImportUrls:
- hook, now includes registration of the API implementor.
- importUrlFile, modified slightly. It had been assuming that the method
on every line of ZAP URL exports was GET. Now instead of assuming ZAP
formatted exports start with GET it checks if the line starts with http.
If not it assumes everything up to the first tab is the method.

Note: The import function still assumes that all URLs are accessible via 
GET. This should largely be true, and it is doubtful that we would find
much benefit in trying the original (exported) method, because for
example on a POST we wouldn't have the necessary parameters (same for a
PUT, or some sort of webdav method).

Fixes zaproxy/zaproxy#1643