### PR TITLE
pscanrulesBeta: correct ID of anti-CSRF scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
@@ -90,7 +90,7 @@ public class CSRFCountermeasures extends PluginPassiveScanner {
 	 */
 	@Override
 	public int getPluginId() {
-		return 40014;
+		return 10202;
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Issue 2576: CSRFCountermeasures, remove unneeded Attack and Evidence messages.<br>
 	Issue 2574: CookieLooselyScopedScanner, remove attack field and update description.<br>
 	Support ignoring specified forms when checking for CSRF vulnerabilities.<br>
+	Correct the plugin ID of Absence of Anti-CSRF Tokens from 40014 to 10202.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change the plugin ID of passive scanner Absence of Anti-CSRF Tokens from
40014 to 10202, as the former ID was already in use by other scanner.
Update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#2823.