### PR TITLE
websocket: fix overlapping of text location

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Make breakpoint dialogues modal.<br>
 	Fix exception during the unload of the add-on, when in daemon mode.<br>
+	Correct fuzz location overlap detection with same start index.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/messagelocations/TextWebSocketMessageLocation.java
+++ b/src/org/zaproxy/zap/extension/websocket/messagelocations/TextWebSocketMessageLocation.java
@@ -99,7 +99,10 @@ public class TextWebSocketMessageLocation implements WebSocketMessageLocation {
 
         TextWebSocketMessageLocation otherTextLocation = (TextWebSocketMessageLocation) otherLocation;
         if (start == otherTextLocation.getStart()) {
-            return (start == end) ? end == otherTextLocation.getEnd() : false;
+            if (start == end) {
+                return end == otherTextLocation.getEnd();
+            }
+            return otherTextLocation.getStart() != otherTextLocation.getEnd();
         }
         if (start < otherTextLocation.getStart()) {
             return end > otherTextLocation.getStart();


### PR DESCRIPTION
Change TextWebSocketMessageLocation to check if the new text location
is (or not) an insertion point, when the existing text location has the
same start and different end. If it's not an insertion point it's
overlapping the existing location.

Related to zaproxy/zaproxy#2792 - Able to overlap fuzz (HTTP) locations