### PR TITLE
Wappalyzer Minor Code Cleanup

### DIFF
--- a/src/org/zaproxy/zap/extension/wappalyzer/Application.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/Application.java
@@ -116,10 +116,4 @@ public class Application {
 		this.icon = icon;
 	}
 
-	// TODO global js variables - cant use?
-	//private Pattern env;
-	
-	
-	
-
 }

--- a/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -118,13 +118,8 @@ public class ExtensionWappalyzer extends ExtensionAdaptor implements SessionChan
 		super(name);
 	}
 
-	/**
-	 * This method initializes this
-	 */
-	@SuppressWarnings("unchecked")
 	private void initialize() {
 		this.setName(NAME);
-		// TODO - something sensible
 		this.setOrder(201);
 		
 		try {
@@ -510,19 +505,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor implements SessionChan
 			}
 			this.getTechPanel().addSite(site);
 		}
-		/*
-		try {
-			List<RecordParam> params = Model.getSingleton().getDb().getTableParam().getAll();
-			
-			for (RecordParam param : params) {
-				SiteParameters sps = this.getSiteParameters(param.getSite());
-				sps.addParam(param.getSite(), param);
-				
-			}
-		} catch (SQLException e) {
-            logger.error(e.getMessage(), e);
-		}
-		*/
+
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
@@ -32,7 +32,6 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 
-
 public class PopupMenuEvidence extends ExtensionPopupMenuItem {
 
 	private static final long serialVersionUID = 1L;
@@ -41,16 +40,10 @@ public class PopupMenuEvidence extends ExtensionPopupMenuItem {
     
     private List<PopupMenuEvidenceSearch> subMenus = new ArrayList<PopupMenuEvidenceSearch>();
 
-	/**
-     * 
-     */
     public PopupMenuEvidence() {
         super();
     }
 
-    /**
-     * @param label
-     */
     public PopupMenuEvidence(String label) {
         super(label);
     }

--- a/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidenceSearch.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidenceSearch.java
@@ -26,7 +26,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
 
-
 public class PopupMenuEvidenceSearch extends ExtensionPopupMenuItem {
 
 	private static final long serialVersionUID = 1L;
@@ -35,9 +34,6 @@ public class PopupMenuEvidenceSearch extends ExtensionPopupMenuItem {
     private Pattern pattern = null;
     private ExtensionSearch.Type type = null;
 
-    /**
-     * @param label
-     */
     public PopupMenuEvidenceSearch(String label, Pattern pattern, ExtensionSearch.Type type) {
         super(label);
         this.pattern = pattern;
@@ -49,9 +45,6 @@ public class PopupMenuEvidenceSearch extends ExtensionPopupMenuItem {
 		this.extension = extension;
 	}
 
-    /**
-	 * This method initialises this
-	 */
 	private void initialize() {
 		// TODO add prefix for pattern type?
         this.setText(pattern.pattern());
@@ -83,7 +76,6 @@ public class PopupMenuEvidenceSearch extends ExtensionPopupMenuItem {
         return false;
     }
     
-
     @Override
     public boolean isSafe() {
     	return true;

--- a/src/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -55,25 +55,16 @@ public class TechPanel extends AbstractPanel {
 	private String currentSite = null;
 	private JComboBox<String> siteSelect = null;
 	private SortedComboBoxModel<String> siteModel = new SortedComboBoxModel<>();
-	//private JButton optionsButton = null;
 
 	private JXTable techTable = null;
 	private TechTableModel techModel = new TechTableModel();
-	
-    //private static Log log = LogFactory.getLog(ParamsPanel.class);
-    
-    /**
-     * 
-     */
+   
     public TechPanel(ExtensionWappalyzer extension) {
         super();
         this.extension = extension;
  		initialize();
     }
 
-	/**
-	 * This method initializes this
-	 */
 	private  void initialize() {
         this.setLayout(new CardLayout());
         this.setSize(474, 251);
@@ -84,12 +75,12 @@ public class TechPanel extends AbstractPanel {
 		this.setMnemonic(Constant.messages.getChar("wappalyzer.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
 	}
+	
 	/**
 	 * This method initializes panelCommand	
 	 * 	
 	 * @return javax.swing.JPanel	
-	 */    
-	/**/
+	 */
 	private javax.swing.JPanel getPanelCommand() {
 		if (panelCommand == null) {
 
@@ -120,7 +111,6 @@ public class TechPanel extends AbstractPanel {
 		}
 		return panelCommand;
 	}
-	/**/
 
 	private javax.swing.JToolBar getPanelToolbar() {
 		if (panelToolbar == null) {
@@ -163,8 +153,6 @@ public class TechPanel extends AbstractPanel {
 			gridBagConstraintsx.fill = java.awt.GridBagConstraints.HORIZONTAL;
 
 			JLabel t1 = new JLabel();
-
-			//panelToolbar.add(getOptionsButton(), gridBagConstraints0);
 
 			panelToolbar.add(new JLabel(Constant.messages.getString("wappalyzer.toolbar.site.label")), gridBagConstraints1);
 			panelToolbar.add(getSiteSelect(), gridBagConstraints2);

--- a/src/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 public class WappalyzerPassiveScanner implements PassiveScanner {
 
@@ -42,9 +43,6 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
 
 	private static final Logger logger = Logger.getLogger(WappalyzerPassiveScanner.class);
 
-	/**
-	 * Prefix for internationalized messages used by this rule
-	 */
 	public WappalyzerPassiveScanner() {
 		super();
 	}
@@ -165,20 +163,9 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
 		// Does not apply.
 	}
 
-	// @Override
+	@Override
 	public boolean appliesToHistoryType(int historyType) {
-		// TODO replace with core code once available
-		// return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
-
-		switch (historyType) {
-		case HistoryReference.TYPE_PROXIED:
-		case HistoryReference.TYPE_ZAP_USER:
-		case HistoryReference.TYPE_SPIDER:
-		case HistoryReference.TYPE_SPIDER_AJAX:
-			return true;
-		default:
-			return false;
-		}
+		return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Remove the use of passive scan rule.<br>
+	Minor code cleanup.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -17,6 +18,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.3</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
- Remove unnecessary code comments.
- Remove some extra lines.
- Remove some default/boilerplate JavaDoc content.
- Remove one un-necessary Warning Suppression.

- WappalyzerPassiveScanner address TODO in overridden method
appliesToHistoryType accept core handling for getDefautlHistoryTypes.
- ZapAddOn.xml update changes section.
