### PR TITLE
Added UnitTest & fix for TestInfoPrivateAddressDisclosure

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/TestInfoPrivateAddressDisclosure.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/TestInfoPrivateAddressDisclosure.java
@@ -23,6 +23,7 @@
 // instead of String.
 // ZAP: 2012/04/25 Added @Override annotation to all appropriate methods.
 // ZAP: 2012/12/28 Issue 447: Include the evidence in the attack field, and made into a passive scan rule
+// ZAP: 2016/10/26 Issue 2834: Fixed the regex
 package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.regex.Matcher;
@@ -36,47 +37,36 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
+/**
+ * Plugin that scans the content for private IP V4 addresses as well as 
+ * Amazon EC2 private hostnames (for example, ip-10-34-56-78).
+ */
 public class TestInfoPrivateAddressDisclosure extends PluginPassiveScanner {
 
-	/**
-	 * Prefix for internationalised messages used by this rule
-	 */
-	private static final String MESSAGE_PREFIX = "pscanrules.testinfoprivateaddressdisclosure.";
-	
-    private static final String REGULAR_IP_OCTET = "\\b(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})";
-    private static final String REGULAR_PORTS = "\\b(6553[0-5]|65[0-5][0-2][0-9]|6[0-4][0-9]{4}|[0-5]?[0-9]{0,4})";
-    
-    // Private IP's including localhost
+    /**
+     * Prefix for internationalised messages used by this rule
+     */
+    private static final String MESSAGE_PREFIX = "pscanrules.testinfoprivateaddressdisclosure.";
+
+    private static final String REGULAR_IP_OCTET = "(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})";
+
+    /**
+     * Pattern for private IP V4 addresses as well as Amazon EC2 private hostnames
+     */
     public static final Pattern patternPrivateIP = Pattern.compile(
             "("
-            + "10\\.(" + REGULAR_IP_OCTET + "\\.){2}" + REGULAR_IP_OCTET + "|"
-            + "172\\." + "\\b(3[01]|2[0-9]|1[6-9])\\." + REGULAR_IP_OCTET + "\\." + REGULAR_IP_OCTET + "|"
-            + "192\\.168\\." + REGULAR_IP_OCTET + "\\." + REGULAR_IP_OCTET + "|"
+            + "\\b10\\.(" + REGULAR_IP_OCTET + "\\.){2}" + REGULAR_IP_OCTET + "\\b|"
+            + "\\b172\\." + "(3[01]|2[0-9]|1[6-9])\\." + REGULAR_IP_OCTET + "\\." + REGULAR_IP_OCTET + "\\b|"
+            + "\\b192\\.168\\." + REGULAR_IP_OCTET + "\\." + REGULAR_IP_OCTET + "\\b|"
             //find IPs from AWS hostnames such as "ip-10-2-3-200"
-            + "10\\-(" + REGULAR_IP_OCTET + "\\-){2}" + REGULAR_IP_OCTET + "|"
-            + "172\\-" + "\\b(3[01]|2[0-9]|1[6-9])\\-" + REGULAR_IP_OCTET + "\\-" + REGULAR_IP_OCTET + "|"
-            + "192\\-168\\-" + REGULAR_IP_OCTET + "\\-" + REGULAR_IP_OCTET             
+            + "\\bip-10-(" + REGULAR_IP_OCTET + "-){2}" + REGULAR_IP_OCTET + "\\b|"
+            + "\\bip-172-" + "(3[01]|2[0-9]|1[6-9])-" + REGULAR_IP_OCTET + "-" + REGULAR_IP_OCTET + "\\b|"
+            + "\\bip-192-168-" + REGULAR_IP_OCTET + "-" + REGULAR_IP_OCTET + "\\b"
             + ")"
-            + "(\\:" + REGULAR_PORTS + ")?",
-            Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-    
-    /*"(10\\." +
-     "\\b((([0-1]?[0-9]?|2[0-4])[0-9])|25[0-5])\\." +
-     "\\b((([0-1]?[0-9]?|2[0-4])[0-9])|25[0-5])\\." +
-     "\\b((([0-1]?[0-9]?|2[0-4])[0-9])|25[0-5])" +
-     "|" +
-     "172\\." +
-     "\\b(1[6-9]|2[0-9]|3[01])\\." +
-     "\\b((([0-1]?[0-9]?|2[0-4])[0-9])|25[0-5])\\." +
-     "\\b((([0-1]?[0-9]?|2[0-4])[0-9])|25[0-5])" +
-     "|" +
-     "192\\.168\\." +
-     "\\b((([0-1]?[0-9]?|2[0-4])[0-9])|25[0-5])\\." +
-     "\\b((([0-1]?[0-9]?|2[0-4])[0-9])|25[0-5]))"
-     , PATTERN_PARAM);
-     */
-    //"(10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.\\d{2,2}\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3})", PATTERN_PARAM);
-    
+            // find regular ports (0-65535)
+            + "(:(0|[1-9]\\d{0,3}|[1-5]\\d{4}|6[0-4]\\d{3}|65([0-4]\\d{2}|5[0-2]\\d|53[0-5]))\\b)?",
+            Pattern.MULTILINE);
+
     private PassiveScanThread parent = null;
 
     @Override

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Correct evidence of alerts raised by scanner "Application Error Disclosure".<br>
+	Fixed some false positives caused by scanner "Private Address Disclosure".<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -74,8 +74,8 @@ pscanrules.passwordautocompletescanner.soln=Turn off the AUTOCOMPLETE attribute 
 pscanrules.passwordautocompletescanner.refs=http://www.w3schools.com/tags/att_input_autocomplete.asp\nhttps://msdn.microsoft.com/en-us/library/ms533486%28v=vs.85%29.aspx
 
 pscanrules.testinfoprivateaddressdisclosure.name = Private IP Disclosure
-pscanrules.testinfoprivateaddressdisclosure.desc = A private IP such as 10.x.x.x, 172.x.x.x, 192.168.x.x has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.
-pscanrules.testinfoprivateaddressdisclosure.soln = Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP comment instead of HTML/JavaScript comment which can be seen by client browsers.
+pscanrules.testinfoprivateaddressdisclosure.desc = A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x) or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the HTTP response body. This information might be helpful for further attacks targeting internal systems.
+pscanrules.testinfoprivateaddressdisclosure.soln = Remove the private IP address from the HTTP response body.  For comments, use JSP/ASP/PHP comment instead of HTML/JavaScript comment which can be seen by client browsers.
 pscanrules.testinfoprivateaddressdisclosure.refs = https://tools.ietf.org/html/rfc1918
 
 pscanrules.testinfosessionidurl.name = Session ID in URL Rewrite

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -52,8 +52,10 @@ via plain HTTP.
 Looks for "password" type input fields and checks for the setting "autocomplete=off".
 
 <H2>Private Address Disclosure</H2>
-Checks response content for inclusion of RFC 1918 IPv4 addresses. A malicious user might leverage knowledge
-of internal addressing to perform social engineering attacks or other exploits.
+Checks the response content for inclusion of RFC 1918 IPv4 addresses as well as 
+Amazon EC2 private hostnames (for example, ip-10-0-56-78). This information can give an attacker 
+useful information about the IP address scheme of the internal network, and might be helpful for 
+further attacks targeting internal systems.
 
 <H2>Session Id in URL Rewrite</H2>
 This scanner checks for the existence of session token type parameters being rewritten to the URL. 

--- a/test/org/zaproxy/zap/extension/pscanrules/TestInfoPrivateAddressDisclosureUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/TestInfoPrivateAddressDisclosureUnitTest.java
@@ -1,0 +1,338 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class TestInfoPrivateAddressDisclosureUnitTest extends PassiveScannerTest {
+	private static final String URI = "https://www.example.com/";
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new TestInfoPrivateAddressDisclosure();
+	}
+
+	@Test
+	public void alertsIfPrivateIp() throws HttpMalformedHeaderException {
+		// ip as candidate / evidence
+		String[][] data = new String[][] {
+				// IPs defined in RFC 1918
+				{ "10.0.0.0",           "10.0.0.0" },
+				{ "10.10.10.10",        "10.10.10.10" },
+				{ "10.255.255.255",     "10.255.255.255" },
+
+				{ "172.16.0.0",         "172.16.0.0" },
+				{ "172.25.16.32",       "172.25.16.32" },
+				{ "172.31.255.255",     "172.31.255.255" },
+
+				{ "192.168.0.0",        "192.168.0.0" },
+				{ "192.168.36.127",     "192.168.36.127" },
+				{ "192.168.255.255",    "192.168.255.255" },
+
+				// some other stuff
+				{ "10.0.0.0:",          "10.0.0.0" },
+				{ "10.0.0.0:6553",      "10.0.0.0:6553" },
+				{ " 10.0.0.0 ",         "10.0.0.0" },
+				{ "/10.0.0.0.",         "10.0.0.0" },
+				{ ";10.0.0.0,",         "10.0.0.0" },
+				{ "\n10.0.0.0\t",       "10.0.0.0" },
+				{ "\n10.0.0.0\t",       "10.0.0.0" },
+
+				{ "10.0.0.0:bla",       "10.0.0.0" },
+				{ "15.10.0.0.0.12.27",  "10.0.0.0" },
+				{ "100.10.0.0.0.10.12", "10.0.0.0" }, 
+				{ "255.10.0.0.0:6555",  "10.0.0.0:6555" },
+
+				{ "10.0.0.0:128",       "10.0.0.0:128" },
+				{ "ip-10.0.0.0",        "10.0.0.0" },
+				{ "IP-10.0.0.0",        "10.0.0.0" },
+				
+				{ "172.30.10.10.10.0.0.0",      "172.30.10.10" },
+				{ "172.30.10.10.10.0.0.0:6555", "172.30.10.10" }
+		};
+		for (int i = 0; i < data.length; i++) {
+			String candidate = data[i][0];
+			String evidence = data[i][1];
+			HttpMessage msg = createHttpMessage(candidate);
+			rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+			assertThat(candidate, alertsRaised.size(), equalTo(i + 1));
+			assertThat(alertsRaised.get(i).getEvidence(), equalTo(evidence));
+			validateAlert(alertsRaised.get(i));
+		}
+	}
+
+	@Test
+	public void passesIfNonPrivateOrInvalidIp() throws HttpMalformedHeaderException {
+		String[] candidates = new String[] {
+				// the "borders" of private IP ranges
+				"9.255.255.255",
+				"11.0.0.0",
+				"172.15.255.255",
+				"172.32.0.0",
+				"192.167.255.255",
+				"192.169.0.0",
+				// outside & between the private ranges
+				"8.8.8.8",
+				"26.10.3.11",
+				"84.168.27.12",
+				"127.0.0.1",
+				"186.27.16.2",
+				"255.255.255.255",
+				// some invalid ones
+				"10",
+				"10.0.0",
+				"10.0.0:0",
+				"10/0.0.0",
+				"10.0\n0.0",
+				"10.0.0 0",
+				"10.0.0.a",
+				"999.0.0.0", 
+				"10.999.0.0",
+				"10.0.756.0",
+				"ip-10-0-0-256",
+				// no word boundaries
+				"2050:10.0.0.0bla",
+				"205010.0.0.0:bla",
+				"abcd10.0.0.0bla",
+				"abcd10.0.0.999",
+				"ip-10.0.0.9999",
+		};
+		for (String candidate : candidates) {
+			HttpMessage msg = createHttpMessage(candidate);
+			rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		}
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void alertsIfPrivIpAndAddsPortToEvidence() throws HttpMalformedHeaderException {
+		// ip and aws-hostname which get concatenated with the ports as candidates
+		String[] ipHost = new String[] {"10.0.0.0", "ip-10-0-0-0"};
+		// several ports in the range 0-65535
+		String[] ports = new String[] {
+				":0",
+				":1",     ":6",     ":9",
+				":10",    ":25",    ":99",
+				":100",   ":443",   ":999",
+				":1000",  ":8080",  ":9999",
+				":10000", ":16443", ":19999",
+				":20000", ":24128", ":29999",
+				":30000", ":35097", ":39999",
+				":40000", ":41962", ":49999",
+				":50000", ":56481", ":59999",
+				":61000", ":61443", ":61999",
+				":62000", ":62128", ":62999",
+				":63000", ":63097", ":63999",
+				":64000", ":64962", ":64999",
+				":65000", ":65010", ":65029",
+				":65100", ":65210", ":65329",
+				":65400", ":65410", ":65499",
+				":65500", ":65510", ":65518",
+				":65520", ":65529", ":65535"
+		};
+		for (int pi = 0; pi < ports.length; pi++) {
+			for (int ii = 0; ii < ipHost.length; ii++) {
+				alertsRaised.clear();
+				String candidate = ipHost[ii] + ports[pi];
+				HttpMessage msg = createHttpMessage(candidate);
+				rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+				
+				assertThat(candidate, alertsRaised.size(), equalTo(1));
+				assertThat(alertsRaised.get(0).getEvidence(), equalTo(candidate));
+				validateAlert(alertsRaised.get(0));
+			}
+		}
+	}
+
+	@Test
+	public void alertsIfPrivIpAndDropsPortNoInEvidence() throws HttpMalformedHeaderException {
+		// ip and aws-hostname which get concatenated with the ports as candidates
+		String[] ipHost = new String[] {"10.0.0.0", "ip-10-0-0-0"};
+		// several ports to be ignored
+		String[] ports = new String[] {
+				":65536",
+				":78736",
+				":99999",
+				":4A3",
+//				// no word boundaries
+				":600000",
+				":649999",
+				":64999A"
+		};
+		for (int pi = 0; pi < ports.length; pi++) {
+			for (int ii = 0; ii < ipHost.length; ii++) {
+				alertsRaised.clear();
+				String candidate = ipHost[ii] + ports[pi];
+				HttpMessage msg = createHttpMessage(candidate);
+				rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+				
+				assertThat(candidate, alertsRaised.size(), equalTo(1));
+				assertThat(alertsRaised.get(0).getEvidence(), equalTo(ipHost[ii]));
+				validateAlert(alertsRaised.get(0));
+			}
+		}
+	}
+
+	@Test
+	public void alertsIfPrivateAwsHostname() throws HttpMalformedHeaderException {
+		// ip as candidate / evidence
+		String[][] data = new String[][] {
+			// body text               evidence
+			// Pattern of IPs defined in RFC 1918
+			{ "ip-10-0-0-0",          "ip-10-0-0-0" },
+			{ "ip-10-10-10-10",       "ip-10-10-10-10" },
+			{ "ip-10-255-255-255",    "ip-10-255-255-255" },
+			{ "ip-172-16-0-0",        "ip-172-16-0-0" },
+			{ "ip-172-25-16-32",      "ip-172-25-16-32" },
+			{ "ip-172-31-255-255",    "ip-172-31-255-255" },
+			{ "ip-192-168-0-0",       "ip-192-168-0-0" },
+			{ "ip-192-168-36-127",    "ip-192-168-36-127" },
+			{ "ip-192-168-255-255",   "ip-192-168-255-255" },
+			// other stuff
+			{ "ip-10-0-0-0:",         "ip-10-0-0-0" },
+			{ "ip-10-0-0-0:6553",     "ip-10-0-0-0:6553" },
+			{ " ip-10-0-0-0 ",        "ip-10-0-0-0" },
+			{ "/ip-10-0-0-0-",        "ip-10-0-0-0" },
+			{ ";ip-10-0-0-0,",        "ip-10-0-0-0" },
+			{ "\nip-10-0-0-0\t",      "ip-10-0-0-0" },
+
+			{ "ip-10-0-0-0:bla",      "ip-10-0-0-0" },
+			{ "15-ip-10-0-0-0-12-27", "ip-10-0-0-0" },
+			{ "255:ip-10-0-0-0:6555", "ip-10-0-0-0:6555" },
+			{ "/ip-10-01-07-17.jpg",  "ip-10-01-07-17" },
+		};
+		for (int i = 0; i < data.length; i++) {
+			String candidate = data[i][0];
+			String evidence = data[i][1];
+			HttpMessage msg = createHttpMessage(candidate);
+			rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+	
+			assertThat(candidate, alertsRaised.size(), equalTo(i + 1));
+			assertThat(alertsRaised.get(i).getEvidence(), equalTo(evidence));
+			validateAlert(alertsRaised.get(i));
+		}
+	}
+
+	@Test
+	public void passesIfInvalidAwsHostname() throws HttpMalformedHeaderException {
+		String[] candidates = new String[] {
+				// "outside borders" of private-IP-range-patterns
+				"ip-9-255-255-255",
+				"ip-11-0-0-0",
+				"ip-172-15-255-255",
+				"ip-172-32-0-0",
+				"ip-192-167-255-255",
+				"ip-192-169-0-0",
+				// outside & betw. private-IP-range-patterns
+				"ip-8-8-8-8",
+				"ip-26-10-3-11",
+				"ip-84-168-27-12",
+				"ip-127-0-0-1",
+				"ip-186-27-16-2",
+				"ip-255-255-255-255",
+				// some invalid IP ones
+				"ip-10",
+				"ip-10-0-0",
+				"ip-10-0-0:0",
+				"ip-10/0-0-0",
+				"ip-10-0\n0-0",
+				"ip-10-0-0 0",
+				"ip-10-0-0-a",
+				"ip-999-0-0-0",
+				"ip-10-999-0-0",
+				"ip-10-0-756-0",
+				// others
+				"ip- 10-0-0-0 ",
+				"ip-\n10-0-0-0\t",
+				"10-0-0-0",
+				"2050ip-10-0-0-0bla",
+				"gossip-10-0-0-0bla",
+				"ip-10-0-0-999",
+				"ip-10-0-0-9999999", 
+				"IP-10-0-0-0:",
+				"/IP-10-01-07-17.jpg",
+		};
+		for (String candidate : candidates) {
+			HttpMessage msg = createHttpMessage(candidate);
+			rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+			assertThat(candidate, alertsRaised.size(), equalTo(0));
+		}
+	}
+
+	@Test
+	public void alertsWithJustTheFirstEvidenceIfPrivIpAndPrivHostname() throws HttpMalformedHeaderException {
+		// candidate, evidence, otherInfo
+		String[][] data = new String[][] {
+				{ "10.0.0.0:128 ip-192-168-0-0",
+						"10.0.0.0:128",
+						"10.0.0.0:128ip-192-168-0-0" },
+				{ "ip-10-0-0-0:128:192.168.0.0", 
+						"ip-10-0-0-0:128", 
+						"ip-10-0-0-0:128192.168.0.0" },
+				{ "172.16.0.0/ip-10-0-0-0:128:192.168.0.0", 
+						"172.16.0.0", 
+						"172.16.0.0ip-10-0-0-0:128192.168.0.0" }
+		};
+		for (int i = 0; i < data.length; i++) {
+			String candidate = data[i][0];
+			HttpMessage msg = createHttpMessage(candidate);
+			rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+			assertThat(candidate, alertsRaised.size(), equalTo(i + 1));
+			assertThat(alertsRaised.get(i).getEvidence(), equalTo(data[i][1]));
+			validateAlert(alertsRaised.get(i));
+			
+			String otherInfo = alertsRaised.get(i).getOtherInfo().replaceAll("\\n", "");
+			assertThat(otherInfo, equalTo(data[i][2]));
+		}
+	}
+
+	@Test
+	public void testOfScanHttpRequestSend() throws HttpMalformedHeaderException {
+		// the method should do nothing (test just for code coverage)
+		rule.scanHttpRequestSend(null, -1);
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+
+	private static void validateAlert(Alert alert) {
+		assertThat(alert.getPluginId(), equalTo(00002));
+		assertThat(alert.getRisk(), equalTo(Alert.RISK_LOW));
+		assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+		assertThat(alert.getUri(), equalTo(URI));
+	}	
+
+	private HttpMessage createHttpMessage(String body) throws HttpMalformedHeaderException {
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader("GET " + URI + " HTTP/1.1");
+		msg.setResponseHeader("HTTP/1.1 200 OK\r\n");
+		msg.setResponseBody(body);
+		return msg;
+	}
+
+}


### PR DESCRIPTION
Changes, as mentioned in #2834:
- prefix AWS-hostnames (ip-)
- Fixed a typo in a regex
- updated the alert-description and help page
  Added a UnitTest acc. to #2790

This closes zaproxy/zaproxy#2834 and zaproxy/zaproxy#2790
