### PR TITLE
spiderAjax: allow to spider just a site's subtree

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -69,6 +69,7 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 	private static final String PARAM_IN_SCOPE = "inScope";
 	private static final String PARAM_START = "start";
 	private static final String PARAM_COUNT = "count";
+	private static final String PARAM_SUBTREE_ONLY = "subtreeOnly";
 
 	private enum SpiderStatus {
 		STOPPED,
@@ -89,14 +90,14 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 		this.extension = extension;
 		this.historyReferences = Collections.emptyList();
 
-		ApiAction scan = new ApiAction(ACTION_START_SCAN, null, new String[] { PARAM_URL, PARAM_IN_SCOPE, PARAM_CONTEXT_NAME });
+		ApiAction scan = new ApiAction(ACTION_START_SCAN, null, new String[] { PARAM_URL, PARAM_IN_SCOPE, PARAM_CONTEXT_NAME, PARAM_SUBTREE_ONLY });
 		scan.setDescriptionTag("spiderajax.api.action.scan");
 		this.addApiAction(scan);
 
 		ApiAction scanAsUser = new ApiAction(
 				ACTION_START_SCAN_AS_USER,
 				new String[] { PARAM_CONTEXT_NAME, PARAM_USER_NAME },
-				new String[] { PARAM_URL });
+				new String[] { PARAM_URL, PARAM_SUBTREE_ONLY });
 		scanAsUser.setDescriptionTag("spiderajax.api.action.scanAsUser");
 		this.addApiAction(scanAsUser);
 		this.addApiAction(new ApiAction(ACTION_STOP_SCAN));
@@ -129,7 +130,7 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 					context = ApiUtils.getContextByName(contextName);
 				}
 			}
-			startScan(url, null, context, getParam(params, PARAM_IN_SCOPE, false));
+			startScan(url, null, context, getParam(params, PARAM_IN_SCOPE, false), getParam(params, PARAM_SUBTREE_ONLY, false));
 			break;
 
 		case ACTION_START_SCAN_AS_USER:
@@ -145,7 +146,7 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 				throw new ApiException(Type.USER_NOT_FOUND, PARAM_USER_NAME);
 			}
 
-			startScan(urlUserScan, user, context, getParam(params, PARAM_IN_SCOPE, false));
+			startScan(urlUserScan, user, context, getParam(params, PARAM_IN_SCOPE, false), getParam(params, PARAM_SUBTREE_ONLY, false));
 			break;
 
 		case ACTION_STOP_SCAN:
@@ -188,9 +189,10 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 	 * @param user the user, might be {@code null} if spidering a context with URLs already accessed.
 	 * @param context the context to spider, might be {@code null}.
 	 * @param inScopeOnly if should just spider in scope. Spider of context takes precedence.
+	 * @param subtreeOnly if the scan should be done only under a site's subtree
 	 * @throws ApiException if there's an error with the data provided, for example, no starting URL when one is required.
 	 */
-	private void startScan(String url, User user, Context context, boolean inScopeOnly) throws ApiException {
+	private void startScan(String url, User user, Context context, boolean inScopeOnly, boolean subtreeOnly) throws ApiException {
 		URI startURI = null;
 		boolean validateUrl = true;
 		if (url == null || url.isEmpty()) {
@@ -241,7 +243,8 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 		AjaxSpiderTarget.Builder targetBuilder = AjaxSpiderTarget.newBuilder(extension.getModel().getSession())
 				.setInScopeOnly(inScopeOnly)
 				.setOptions(extension.getAjaxSpiderParam())
-				.setStartUri(startURI);
+				.setStartUri(startURI)
+				.setSubtreeOnly(subtreeOnly);
 
 		if (user != null) {
 			targetBuilder.setUser(user);

--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
@@ -57,6 +57,7 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
     private static final String FIELD_CONTEXT = "spiderajax.scandialog.label.context";
     private static final String FIELD_USER = "spiderajax.scandialog.label.user";
     private static final String FIELD_IN_SCOPE = "spiderajax.scandialog.label.inscope";
+    private static final String FIELD_SUBTREE_ONLY = "spiderajax.scandialog.label.spiderSubtreeOnly"; 
     private static final String FIELD_BROWSER = "spiderajax.scandialog.label.browser";
     private static final String FIELD_ADVANCED = "spiderajax.scandialog.label.adv";
     
@@ -80,6 +81,15 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
     private Target target;
 	private AjaxSpiderParam params = null;
 	//private OptionsAjaxSpiderTableModel ajaxSpiderClickModel = null;
+
+    /**
+     * Flag that holds the previous checked state of the "Subtree Only" checkbox.
+     * <p>
+     * Used to restore the previous checked state between dialogue invocations.
+     * 
+     * @see #FIELD_SUBTREE_ONLY
+     */
+    private boolean subtreeOnlyPreviousCheckedState;
 
     private final ExtensionUserManagement extUserMgmt;
 
@@ -107,6 +117,7 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
         this.addComboField(0, FIELD_CONTEXT, new String[] {}, "");
         this.addComboField(0, FIELD_USER, new String[] {}, "");
         this.addCheckBoxField(0, FIELD_IN_SCOPE, false);
+        this.addCheckBoxField(0, FIELD_SUBTREE_ONLY, subtreeOnlyPreviousCheckedState);
         this.addFieldListener(FIELD_IN_SCOPE, new ActionListener() {
 
             @Override
@@ -352,7 +363,8 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
         AjaxSpiderTarget.Builder targetBuilder = AjaxSpiderTarget.newBuilder(extension.getModel().getSession())
                 .setInScopeOnly(getBoolValue(FIELD_IN_SCOPE))
                 .setOptions(params)
-                .setStartUri(startUri);
+                .setStartUri(startUri)
+                .setSubtreeOnly(getBoolValue(FIELD_SUBTREE_ONLY));
 
         User user = getSelectedUser();
         if (user != null) {
@@ -364,6 +376,8 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
             }
             targetBuilder.setContext(context);
         }
+
+        subtreeOnlyPreviousCheckedState = getBoolValue(FIELD_SUBTREE_ONLY);
 
         this.extension.startScan(targetBuilder.build());
     }
@@ -423,6 +437,9 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
             if (startNode != null) {
                 startUri = URI.create(startNode.getHistoryReference().getURI().toString());
             } else if (context != null) {
+                if (getBoolValue(FIELD_SUBTREE_ONLY)) {
+                    return Constant.messages.getString("spiderajax.scandialog.nostart.subtreeOnly.error");
+                }
                 startUri = extension.getFirstUriInContext(context);
             }
         }

--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderTarget.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderTarget.java
@@ -35,13 +35,21 @@ public final class AjaxSpiderTarget {
     private final Context context;
     private final User user;
     private final AjaxSpiderParam options;
+    private final boolean subtreeOnly;
 
-    private AjaxSpiderTarget(URI startUri, boolean inScopeOnly, Context context, User user, AjaxSpiderParam options) {
+    private AjaxSpiderTarget(
+            URI startUri,
+            boolean inScopeOnly,
+            Context context,
+            User user,
+            AjaxSpiderParam options,
+            boolean subtreeOnly) {
         this.startUri = startUri;
         this.inScopeOnly = inScopeOnly;
         this.context = context;
         this.user = user;
         this.options = options;
+        this.subtreeOnly = subtreeOnly;
     }
 
     /**
@@ -83,6 +91,15 @@ public final class AjaxSpiderTarget {
     }
 
     /**
+     * Tells whether or not the spider should spider only a subtree.
+     *
+     * @return {@code true} to spider only a subtree, {@code false} otherwise.
+     */
+    public boolean isSubtreeOnly() {
+        return subtreeOnly;
+    }
+
+    /**
      * Gets the options for spidering.
      *
      * @return the options, never {@code null}.
@@ -112,6 +129,7 @@ public final class AjaxSpiderTarget {
         private Context context;
         private User user;
         private AjaxSpiderParam options;
+        private boolean subtreeOnly;
 
         /**
          * Constructs a {@code Builder} with the given session
@@ -195,6 +213,18 @@ public final class AjaxSpiderTarget {
         }
 
         /**
+         * Sets whether or not the spider should spider only a subtree.
+         *
+         * @param subtreeOnly {@code true} to spider only a subtree, {@code false} otherwise.
+         * @return this builder
+         */
+        public Builder setSubtreeOnly(boolean subtreeOnly) {
+            this.subtreeOnly = subtreeOnly;
+
+            return this;
+        }
+
+        /**
          * Builds a new target using the configurations previously set.
          *
          * @return a new {@code AjaxSpiderTarget} with configurations previously set.
@@ -222,7 +252,7 @@ public final class AjaxSpiderTarget {
                 throw new IllegalStateException("The starting URI is not in scope.");
             }
 
-            return new AjaxSpiderTarget(startUri, inScopeOnly, context, user, options);
+            return new AjaxSpiderTarget(startUri, inScopeOnly, context, user, options, subtreeOnly);
         }
     }
 }

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -266,7 +266,9 @@ public class ExtensionAjax extends ExtensionAdaptor {
 	 * @return a {@code String} containing the display name, never {@code null}
 	 */
 	String createDisplayName(AjaxSpiderTarget target) {
-		if (target.getContext() != null) {
+		if (target.isSubtreeOnly()) {
+			return abbreviateDisplayName(HttpPrefixUriValidator.getNormalisedPrefix(target.getStartUri().toString()));
+		} else if (target.getContext() != null) {
 			return Constant.messages.getString("context.prefixName", target.getContext().getName());
 		} else if (target.isInScopeOnly()) {
 			return Constant.messages.getString("target.allInScope");

--- a/src/org/zaproxy/zap/extension/spiderAjax/HttpPrefixUriValidator.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/HttpPrefixUriValidator.java
@@ -1,0 +1,331 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2016 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.spiderAjax;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.log4j.Logger;
+
+/**
+ * A {@code URI} validator based on a HTTP or HTTPS {@code URI}.
+ * <p>
+ * The {@code URI}s are required to start with the {@code URI} (the prefix) to be considered valid.
+ * 
+ * @see #isValid(URI)
+ */
+class HttpPrefixUriValidator {
+
+    private static final Logger LOGGER = Logger.getLogger(HttpPrefixUriValidator.class);
+
+    /** The normalised form of HTTP scheme, that is, all letters lowercase. */
+    private static final String HTTP_SCHEME = "http";
+    /** The normalised form of HTTPS scheme, that is, all letters lowercase. */
+    private static final String HTTPS_SCHEME = "https";
+
+    /** The port number that indicates that a port is the default of a scheme. */
+    private static final int DEFAULT_PORT = -1;
+    /** The port number that indicates that a port is of an unknown scheme (that is, non HTTP and HTTPS). */
+    private static final int UNKNOWN_PORT = -2;
+    /** The default port number of HTTP scheme. */
+    private static final int DEFAULT_HTTP_PORT = 80;
+    /** The default port number of HTTPS scheme. */
+    private static final int DEFAULT_HTTPS_PORT = 443;
+
+    /** The scheme used for filtering. Never {@code null}. */
+    private final String scheme;
+
+    /** The host used for filtering. Never {@code null}. */
+    private final String host;
+
+    /** The port used for filtering. */
+    private final int port;
+
+    /** The path used for filtering. Might be {@code null}. */
+    private final char[] path;
+
+    /**
+     * Constructs a {@code HttpPrefixFetchFilter} using the given {@code URI} as prefix.
+     * <p>
+     * The user info, query component and fragment of the given {@code URI} are discarded. The scheme and domain comparisons are
+     * done in a case insensitive way while the path component comparison is case sensitive.
+     *
+     * @param prefix the {@code URI} that will be used as prefix
+     * @throws IllegalArgumentException if any of the following conditions is {@code true}:
+     *             <ul>
+     *             <li>The given {@code prefix} is {@code null};</li>
+     *             <li>The given {@code prefix} has {@code null} scheme;</li>
+     *             <li>The scheme of the given {@code prefix} is not HTTP or HTTPS;</li>
+     *             <li>The given {@code prefix} has {@code null} host;</li>
+     *             <li>The given {@code prefix} has malformed host.</li>
+     *             </ul>
+     */
+    public HttpPrefixUriValidator(URI prefix) {
+        if (prefix == null) {
+            throw new IllegalArgumentException("Parameter prefix must not be null.");
+        }
+
+        char[] rawScheme = prefix.getRawScheme();
+        if (rawScheme == null) {
+            throw new IllegalArgumentException("Parameter prefix must have a scheme.");
+        }
+        String normalisedScheme = normalisedScheme(rawScheme);
+        if (!isHttpOrHttps(normalisedScheme)) {
+            throw new IllegalArgumentException("The prefix's scheme must be HTTP or HTTPS.");
+        }
+        scheme = normalisedScheme;
+
+        if (prefix.getRawHost() == null) {
+            throw new IllegalArgumentException("Parameter prefix must have a host.");
+        }
+        try {
+            host = normalisedHost(prefix);
+        } catch (URIException e) {
+            throw new IllegalArgumentException("Failed to obtain the host from the prefix:", e);
+        }
+
+        port = normalisedPort(scheme, prefix.getPort());
+        path = prefix.getRawPath();
+    }
+
+    /**
+     * Returns the normalised form of the given {@code scheme}.
+     * <p>
+     * The normalisation process consists in converting the scheme to lowercase, if {@code null} it is returned an empty
+     * {@code String}.
+     *
+     * @param scheme the scheme that will be normalised
+     * @return a {@code String} with the host scheme, never {@code null}
+     * @see URI#getRawScheme()
+     */
+    private static String normalisedScheme(char[] scheme) {
+        if (scheme == null) {
+            return "";
+        }
+        return new String(scheme).toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTP or HTTPS.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTP or HTTPS, {@code false} otherwise
+     */
+    private static boolean isHttpOrHttps(String scheme) {
+        return isHttp(scheme) || isHttps(scheme);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTP.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTP, {@code false} otherwise
+     */
+    private static boolean isHttp(String scheme) {
+        return HTTP_SCHEME.equals(scheme);
+    }
+
+    /**
+     * Tells whether or not the given {@code scheme} is HTTPS.
+     *
+     * @param scheme the normalised scheme, might be {@code null}
+     * @return {@code true} if the {@code scheme} is HTTPS, {@code false} otherwise
+     */
+    private static boolean isHttps(String scheme) {
+        return HTTPS_SCHEME.equals(scheme);
+    }
+
+    /**
+     * Returns the normalised form of the host of the given {@code uri}.
+     * <p>
+     * The normalisation process consists in converting the host to lowercase, if {@code null} it is returned an empty
+     * {@code String}.
+     *
+     * @param uri the URI whose host will be extracted and normalised
+     * @return a {@code String} with the host normalised, never {@code null}
+     * @throws URIException if the host of the given {@code uri} is malformed
+     */
+    private static String normalisedHost(URI uri) throws URIException {
+        if (uri.getRawHost() == null) {
+            return "";
+        }
+        return uri.getHost().toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Returns the normalised form of the given {@code port}, based on the given {@code scheme}.
+     * <p>
+     * If the port is non-default (as given by {@link #DEFAULT_PORT}), it's immediately returned. Otherwise, for schemes HTTP
+     * and HTTPS it's returned 80 and 443, respectively, for any other scheme it's returned {@link #UNKNOWN_PORT}.
+     *
+     * @param scheme the (normalised) scheme of the URI where the port was defined
+     * @param port the port to normalise
+     * @return the normalised port
+     * @see #normalisedScheme(char[])
+     * @see URI#getPort()
+     */
+    private static int normalisedPort(String scheme, int port) {
+        if (port != DEFAULT_PORT) {
+            return port;
+        }
+
+        if (isHttp(scheme)) {
+            return DEFAULT_HTTP_PORT;
+        }
+
+        if (isHttps(scheme)) {
+            return DEFAULT_HTTPS_PORT;
+        }
+
+        return UNKNOWN_PORT;
+    }
+
+    /**
+     * Gets the prefix normalised, as it is used to filter the {@code URI}s.
+     *
+     * @return a {@code String} with the prefix normalised
+     * @see #isValid(URI)
+     */
+    public String getNormalisedPrefix() {
+        StringBuilder strBuilder = new StringBuilder();
+        strBuilder.append(scheme).append("://").append(host);
+        if (!isDefaultHttpOrHttpsPort(scheme, port)) {
+            strBuilder.append(':').append(port);
+        }
+        if (path != null) {
+            strBuilder.append(path);
+        }
+        return strBuilder.toString();
+    }
+
+    public static String getNormalisedPrefix(String uri) {
+        if (uri == null) {
+            throw new IllegalArgumentException("Parameter uri must not be null.");
+        }
+
+        try {
+            return new HttpPrefixUriValidator(new URI(uri, true)).getNormalisedPrefix();
+        } catch (URIException e) {
+            LOGGER.warn("Failed to normalise prefix:", e);
+        }
+        return uri;
+    }
+
+    /**
+     * Tells whether or not the given {@code port} is the default for the given {@code scheme}.
+     * <p>
+     * The method returns always {@code false} for non HTTP or HTTPS schemes.
+     *
+     * @param scheme the scheme of a URI, might be {@code null}
+     * @param port the port of a URI
+     * @return {@code true} if the {@code port} is the default for the given {@code scheme}, {@code false} otherwise
+     */
+    private static boolean isDefaultHttpOrHttpsPort(String scheme, int port) {
+        if (port == DEFAULT_HTTP_PORT && isHttp(scheme)) {
+            return true;
+        }
+        if (port == DEFAULT_HTTPS_PORT && isHttps(scheme)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given URI is valid, by starting or not with the defined prefix.
+     * 
+     * @param uri the uri to be validated
+     * @return {@code true} if valid, that is, the {@code uri} starts with the {@code prefix}, {@code false} otherwise
+     */
+    public boolean isValid(URI uri) {
+        if (uri == null) {
+            return false;
+        }
+
+        String otherScheme = normalisedScheme(uri.getRawScheme());
+        if (port != normalisedPort(otherScheme, uri.getPort())) {
+            return false;
+        }
+
+        if (!scheme.equals(otherScheme)) {
+            return false;
+        }
+
+        if (!hasSameHost(uri)) {
+            return false;
+        }
+
+        if (!startsWith(uri.getRawPath(), path)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Tells whether or not the given {@code uri} has the same host as required by this prefix.
+     * <p>
+     * For malformed hosts it returns always {@code false}.
+     *
+     * @param uri the {@code URI} whose host will be checked
+     * @return {@code true} if the host is same, {@code false} otherwise
+     */
+    private boolean hasSameHost(URI uri) {
+        try {
+            return host.equals(normalisedHost(uri));
+        } catch (URIException e) {
+            LOGGER.warn("Failed to normalise host: " + Arrays.toString(uri.getRawHost()), e);
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given {@code array} starts with the given {@code prefix}.
+     * <p>
+     * The {@code prefix} might be {@code null} in which case it's considered that the {@code array} starts with the prefix.
+     *
+     * @param array the array that will be tested if starts with the prefix, might be {@code null}
+     * @param prefix the array used as prefix, might be {@code null}
+     * @return {@code true} if the {@code array} starts with the {@code prefix}, {@code false} otherwise
+     */
+    private static boolean startsWith(char[] array, char[] prefix) {
+        if (prefix == null) {
+            return true;
+        }
+
+        if (array == null) {
+            return false;
+        }
+
+        int length = prefix.length;
+        if (array.length < length) {
+            return false;
+        }
+
+        for (int i = 0; i < length; i++) {
+            if (prefix[i] != array[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Allow to spider a context (Issue 1955).<br>
 	Allow to spider as a user (Issue 1956).<br>
 	Allow to manually specify the start URL in AJAX Spider dialogue (Issue 1957).<br>
+	Allow to spider just a site's subtree (Issue 2847).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
@@ -1,7 +1,7 @@
 # This file defines the default (English) variants of all of the internationalised messages of the plugin
 
-spiderajax.api.action.scan = Runs the spider against the given URL and/or context, optionally, spidering everything in scope. The parameter 'contextName' can be used to constrain the scan to a Context, the option 'in scope' is ignored if a context was also specified.
-spiderajax.api.action.scanAsUser = Runs the spider from the perspective of a User, obtained using the given context name and user name. The parameter 'url' allows to specify the starting point for the spider, otherwise it's used an existing URL from the context (if any).
+spiderajax.api.action.scan = Runs the spider against the given URL and/or context, optionally, spidering everything in scope. The parameter 'contextName' can be used to constrain the scan to a Context, the option 'in scope' is ignored if a context was also specified. The parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
+spiderajax.api.action.scanAsUser = Runs the spider from the perspective of a User, obtained using the given context name and user name. The parameter 'url' allows to specify the starting point for the spider, otherwise it's used an existing URL from the context (if any). The parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
 
 spiderajax.active.action = AJAX Spider scan
 spiderajax.desc                     = AJAX Spider, uses Crawljax
@@ -46,6 +46,7 @@ spiderajax.scandialog.label.browser	= Browser:
 spiderajax.scandialog.label.context = Context:
 spiderajax.scandialog.label.inscope	= Just In Scope:
 spiderajax.scandialog.label.start	= Starting point:
+spiderajax.scandialog.label.spiderSubtreeOnly = Spider Subtree Only
 spiderajax.scandialog.label.adv		= Show advanced options
 spiderajax.scandialog.label.user = User:
 spiderajax.scandialog.button.scan	= Start Scan
@@ -54,6 +55,7 @@ spiderajax.scandialog.alreadyrunning.error = A spider scan is already running.
 spiderajax.scandialog.nobrowser.error = No browser was selected.
 spiderajax.scandialog.nostart.error = You must select a valid starting point\nincluding the protocol e.g. https://www.example.com
 spiderajax.scandialog.nostart.context.error = The selected context does not have a starting point.
+spiderajax.scandialog.nostart.subtreeOnly.error = A site node must be selected or a URL manually introduced, to spider a site's subtree.
 spiderajax.scandialog.notSafe.error = AJAX Spider scans are not allowed in 'Safe' mode.
 spiderajax.scandialog.startNotInScope.error = The starting point is not in scope.
 spiderajax.scandialog.startNotInContext.error = The starting point does not belong to selected context.

--- a/src/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/scandialog.html
+++ b/src/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/scandialog.html
@@ -29,6 +29,10 @@ If set then any URLs which are out of scope will be ignored.
 <p>
 <strong>Note:</strong> The option <code>Just in scope</code> is mutually exclusive with <code>Context</code> option, if one is used the other is ignored.
 
+<h3>Spider Subtree Only</h3>
+If set then the spider will only access resources that are under the starting point (URI).
+When evaluating if a resource is found within the specified subtree, the spider considers only the scheme, host, port, and path components of the URI.
+
 <h3>Browser</h3>
 
 The type of browser to use.<br>


### PR DESCRIPTION
Change the AJAX Spider to allow to spider just a site's subtree, through
the API and GUI.
Update help page of spider dialogue and API endpoints' descriptions.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2847 - AJAX Spider Configuration should be more
similar to standard Spider