### PR TITLE
build: do not include tests in add-ons (alpha)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 bin/
 build/build/
+build/buildtest/
+build/results/
+build/temp/
 build/zap-exts/
 .idea/
 *.iml

--- a/build/build.xml
+++ b/build/build.xml
@@ -5,6 +5,7 @@
 	<property name="src.version" value="1.7" />
 	<property name="test.src" location="../test" />
 	<property name="test.lib" location="../testlib" />
+	<property name="test.build" location="buildtest" />
 	<property name="test.results.dir" value="results" />
 	<property name="build" location="build" />
 	<property name="build.lib.dir" location="lib" />
@@ -35,6 +36,7 @@
 		<delete dir="${dist}" includeEmptyDirs="true" />
 		<delete dir="${build}" includeEmptyDirs="true" />
 		<delete dir="${temp}" includeEmptyDirs="true" />
+		<delete dir="${test.build}" includeEmptyDirs="true" />
 		<delete dir="${test.results.dir}" includeEmptyDirs="true" />
 	</target>
 
@@ -43,6 +45,7 @@
 		<mkdir dir="${dist}" />
 		<mkdir dir="${build}" />
 		<mkdir dir="${temp}" />
+		<mkdir dir="${test.build}" />
 		<mkdir dir="${test.results.dir}"/>
 	</target>
 
@@ -75,16 +78,16 @@
 		</javac>
 
 		<echo message="Compiling tests..." />
-		<javac srcdir="${test.src}" destdir="${build}" source="${src.version}" target="${src.version}" includeantruntime="false" debug="${debug}" encoding="UTF-8">
+		<javac srcdir="${test.src}" destdir="${test.build}" source="${src.version}" target="${src.version}" includeantruntime="false" debug="${debug}" encoding="UTF-8">
 			<compilerarg value="-Xlint:all"/>
 			<compilerarg value="-Xlint:-path"/>
 			<compilerarg value="-Xlint:-options"/> <!-- Otherwise fails with Java 8 -->
 			<compilerarg value="-Werror"/>
 			<classpath>
+				<pathelement location="${build}" />
 				<fileset dir="${dist.lib.dir}">
 					<include name="**/*.jar" />
 				</fileset>
-				<pathelement location="${build}" />
 				<fileset dir="${test.lib}">
 					<include name="**/*.jar" />
 				</fileset>
@@ -93,8 +96,20 @@
 	</target>
 
 	<target name="test" depends="clean, compile">
+		<echo message="Copying add-on resources..." />
+		<copy todir="${test.build}">
+			<fileset dir="${src}">
+				<include name="org/zaproxy/zap/extension/*/resources/**" />
+				<!-- Probably not needed but include (just) the main help files and Messages.properties -->
+				<exclude name="org/zaproxy/zap/extension/*/resources/help_*/**" />
+				<exclude name="org/zaproxy/zap/extension/*/resources/Messages_*.properties" />
+			</fileset>
+		</copy>
+		<echo message="Running tests..." />
 		<junit printsummary="yes" haltonerror="true" failureproperty="TestsFailed">
 			<classpath>
+				<pathelement location="${test.build}"/>
+				<pathelement location="${build}"/>
 				<fileset dir="${dist.lib.dir}">
 					<include name="*.jar" />
 					<include name="*.zap" />
@@ -102,12 +117,11 @@
 				<fileset dir="${test.lib}">
 					<include name="*.jar" />
 				</fileset>
-				<pathelement location="${build}" />
 			</classpath>
 			<formatter type="plain" />
 			<formatter type="xml" />
 			<batchtest fork="yes" todir="${test.results.dir}">
-				<fileset dir="${build}">
+				<fileset dir="${test.build}">
 					<include name="**/*UnitTest.class" />
 					<exclude name="**/Abstract*Test.class" />
 				</fileset>


### PR DESCRIPTION
Compile test code to other directory ("buildtest") than the one used for
add-ons' classes ("build").
Delete the "buildtest" directory when running "clean" target.
Ignore the "build" directories, not intended to be versioned.
Include add-ons' resource files when running tests (in case tests need
them to run).