### PR TITLE
Unit tests for the CookieLooselyScopedScannerUnitTest class (issue #2800)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/temp/
 build/zap-exts/
 bin/*
 /bin/
+.idea/
+*.iml

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScanner.java
@@ -88,7 +88,7 @@ public class CookieLooselyScopedScanner extends PluginPassiveScanner {
 		
 		// if Domain attribute hasn't been specified, the cookie
 		// is scoped with the response host
-		if (cookieDomain == null) {
+		if (cookieDomain == null || cookieDomain.isEmpty()) {
 			return false;
 		}
 		
@@ -96,12 +96,16 @@ public class CookieLooselyScopedScanner extends PluginPassiveScanner {
 		String[] cookieDomains = cookie.getDomain().split("\\.");
 		// Split host FQDN into sub-domains
 		String[] hostDomains = host.split("\\.");		
-		
+
+		boolean isFromTheSameDomain = isCookieAndHostHaveTheSameDomain(cookieDomains, hostDomains);
+		if (!isFromTheSameDomain) {
+			return true;
+		}
 		// if cookie domain doesn't start with '.', and the domain is
 		// not a second-level domain (example.com), the cookie Domain and 
 		// host values should match exactly
-		if (!cookieDomain.startsWith(".") && cookieDomains.length > 2) {
-			return cookieDomain.equals(host);
+		if (!cookieDomain.startsWith(".") && cookieDomains.length >= 2 && !isFromTheSameDomain) {
+			return !cookieDomain.equals(host);
 		}
 		
 		// otherwise, remove the '.' and compare the result with the host
@@ -124,6 +128,20 @@ public class CookieLooselyScopedScanner extends PluginPassiveScanner {
 		}
 		
 		// so, the right-most domains matched, the cookie is loosely scoped		
+		return true;
+	}
+
+	private boolean isCookieAndHostHaveTheSameDomain(String[] cookieDomains, String[] hostDomains) {
+		if (cookieDomains == null || hostDomains == null || cookieDomains[0].equalsIgnoreCase("null")
+				|| hostDomains[0].equalsIgnoreCase("null")) { // this happens  when we don't have any host domain
+			return true;
+		}
+		if (!cookieDomains[cookieDomains.length - 1].equalsIgnoreCase(hostDomains[hostDomains.length - 1])) {
+			return false;
+		}
+		if (!cookieDomains[cookieDomains.length - 2].equalsIgnoreCase(hostDomains[hostDomains.length - 2])) {
+			return false;
+		}
 		return true;
 	}
 

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (beta)</name>
-	<version>16</version>
+	<version>17</version>
 	<status>beta</status>
 	<description>The beta quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Added some keywords to the list of suspicious comments. <br/>
+	Improve the domain matching in CookieLooselyScopedScanner.<br/>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScannerUnitTest.java
@@ -1,0 +1,172 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesBeta;
+
+import org.junit.Test;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+/**
+ * @author Vahid Rafiei (@vahid_r)
+ */
+public class CookieLooselyScopedScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new CookieLooselyScopedScanner();
+	}
+
+	private HttpMessage createBasicMessage() throws HttpMalformedHeaderException {
+		HttpMessage msg = new HttpMessage();
+		msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n");
+
+		return msg;
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfThereIsNoCookieInResponseHeader() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET /admin/roles/ HTTP/1.1");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfCookieDomainIsNotSet() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET /admin/roles/ HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfHostDomainStartsWithDotAndCookieDomainIsNotSet() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET .local.test.com HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfHostDomainIsDifferentFromCookieDomain() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://dev.test.org HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=local.yahoo.com;");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+	}
+
+	@Test
+	public void shouldDomainComparisonBeCaseInsensitive() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://TesT.org HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=tEst.org;");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfHostDomainAndCookieDomainAreTheSameAndDomainsAreNotSecondLevel() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://test.example.com HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=test.example.com;");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfHostDomainHasMoreSubDomainsThanCookieDomain() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://test.example.com HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=example.com;");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfHostDomainHasLessSubDomainsThanCookieDomain() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://example.com HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=stage.example.com;");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRightMostDomainsMatch() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://test.example.com/admin/roles HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=.example.com");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+	}
+}


### PR DESCRIPTION
The commit includes the following:
1. Unit tests for the CookieLooselyScopedScannerUnitTest class
2. Two necessary refactorings to make the filtering of cookie domains more robust
3. Adding IntelliJ IDEA specific files to gitignore

Fixes zaproxy/zaproxy#2800