### PR TITLE
scripts: fix typo in ZapAddOn.xml file

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
-	Discard undoable edits after setting a script (Isssue 2675).<br>
+	Discard undoable edits after setting a script (Issue 2675).<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Fix a typo in the changes of ZapAddOn.xml file ("Issue" not "Isssue").