### PR TITLE
zest: show always the expected request URL

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Always show the expected URL in request statements (Issue 2854).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -479,4 +479,12 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 			super.setVariable(name, value);
 		}
 	}
+
+	@Override
+	public ZestResponse send(ZestRequest request) throws IOException {
+		if (request.getUrl() == null) {
+			throw new IOException("Request does not contain a request-uri.");
+		}
+		return super.send(request);
+	}
 }


### PR DESCRIPTION
Change ZestRequestDialog to show the URL with tokens if defined, if not,
show "plain" URL (if defined, otherwise fallback to empty URL). Also,
reset the "plain" URL when setting the URL with tokens and reset the URL
with tokens when setting the "plain" URL, which ensures that it's shown
and used the correct URL.
Change ZestZapRunner to throw an exception if the request-uri is not set
(e.g. the URL is not well-formed).
Update changes in ZapAddOn.xml file (remove existing code change
mention, it's no longer needed or of interest).
Fix zaproxy/zaproxy#2854 - Cannot use variable in Zest Script as part of
POST URL