### PR TITLE
Added unit test for CharsetMismatchScanner class

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CharsetMismatchScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CharsetMismatchScanner.java
@@ -18,12 +18,14 @@
 package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import java.util.List;
+
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTag;
 import net.htmlparser.jericho.StartTagType;
 
+import org.apache.commons.lang.StringUtils;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -113,7 +115,9 @@ public class CharsetMismatchScanner extends PluginPassiveScanner {
 					String httpEquiv = metaElement.getAttributeValue("http-equiv");
 					String bodyContentType = metaElement.getAttributeValue("content");
 					// Ref: http://www.w3.org/TR/html5/document-metadata.html#charset
-					metaCharset = metaElement.getAttributeValue("charset");				
+					if (StringUtils.isBlank(metaCharset)) {
+						metaCharset = metaElement.getAttributeValue("charset");
+					}
 						
 					// If META element defines HTTP-EQUIV and CONTENT attributes, 
 					// or META element defines charset

--- a/test/org/zaproxy/zap/extension/ScannerTestUtils.java
+++ b/test/org/zaproxy/zap/extension/ScannerTestUtils.java
@@ -166,5 +166,34 @@ public abstract class ScannerTestUtils {
             }
         };
     }
+    
+    
+    /**
+     * Creates a matcher that matches when the examined {@code Alert} has a other info that contains the string loaded with the given
+     * key.
+     *
+     * @param key the key for the name
+     * @return the name matcher
+     */
+    protected static Matcher<Alert> containsOtherInfoLoadedWithKey(final String key, final Object... params) {
+        return new BaseMatcher<Alert>() {
+
+            @Override
+            public boolean matches(Object actualValue) {
+                return ((Alert) actualValue).getOtherInfo().contains(Constant.messages.getString(key, params));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("alert other info contains ").appendValue(Constant.messages.getString(key, params));
+            }
+
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                description.appendText("was ").appendValue(((Alert) item).getOtherInfo());
+            }
+        };
+    }
+
 
 }

--- a/test/org/zaproxy/zap/extension/pscanrulesBeta/CharsetMismatchScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesBeta/CharsetMismatchScannerUnitTest.java
@@ -1,0 +1,299 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesBeta;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class CharsetMismatchScannerUnitTest extends PassiveScannerTest {
+    
+    private static final String BASE_RESOURCE_KEY = "pscanbeta.charsetmismatch.";
+    private static final String NO_MISMATCH_METACONTENTTYPE_MISSING = BASE_RESOURCE_KEY + "variant.no_mismatch_metacontenttype_missing";
+    private static final String HEADER_METACONTENTYPE_MISMATCH = BASE_RESOURCE_KEY + "variant.header_metacontentype_mismatch";
+    private static final String HEADER_METACHARSET_MISMATCH = BASE_RESOURCE_KEY + "variant.header_metacharset_mismatch";
+    private static final String METACONTENTTYPE_METACHARSET_MISMATCH = BASE_RESOURCE_KEY + "variant.metacontenttype_metacharset_mismatch";
+    private static final String XML_MISMATCH = BASE_RESOURCE_KEY + "extrainfo.xml";
+    
+    private HttpMessage msg;
+    
+    @Before
+    public void before() throws HttpMalformedHeaderException {
+        rule.setLevel(AlertThreshold.LOW);
+        
+        msg = new HttpMessage();
+        msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
+    }
+    
+    @Override
+    protected PluginPassiveScanner createScanner() {
+        return new CharsetMismatchScanner();
+    }
+
+    @Test
+    public void shouldPassWhenZeroContentLength() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;charset=UTF-8\r\n" +
+                "Content-Length: 0\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+
+    }
+
+    @Test
+    public void shouldPassWhenNoHeaderCharset() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+    
+    @Test
+    public void shouldPassWhenNoContentType() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldPassWhenTheSameMetaCharsetAndHeaderHtml() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html>"
+                + "<head>"
+                + "<meta http-equiv='Content-Type' content='charset=UTF-8' />"
+                + "<meta charset='UTF-8' />"
+                + "</head>"
+                + "</html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenDifferentMetaCharsetAndHeaderHtml() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html>"
+                + "<head>"
+                + "<meta charset='ISO-123' />"
+                + "</head>"
+                + "</html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.get(0), containsNameLoadedWithKey(HEADER_METACHARSET_MISMATCH));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
+        
+        assertThat(alertsRaised.get(1), containsNameLoadedWithKey(NO_MISMATCH_METACONTENTTYPE_MISSING));
+        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getWascId(), equalTo(15));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenNoBodyCharsetTheSameMetaAndHeaderHtml() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html>"
+                + "<head>"
+                + "<meta charset='UTF-8' />"
+                + "</head>"
+                + "</html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0), containsNameLoadedWithKey(NO_MISMATCH_METACONTENTTYPE_MISSING));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenDifferentBodyCharsetAndHeaderHtml() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html>"
+                + "<head>"
+                + "<meta http-equiv='Content-Type' content='charset=ISO-123' />"
+                + "</head>"
+                + "</html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0), containsNameLoadedWithKey(HEADER_METACONTENTYPE_MISMATCH));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenDifferentMetaAndHeaderPlusAdditionalMetaParametersHtml() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html>"
+                + "<head>"
+                + "<meta charset='ISO-123' />"
+                + "<meta name='CUSTOM_NAME' content='CUSTOM_VALUE'/>"
+                + "</head>"
+                + "</html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.get(0), containsNameLoadedWithKey(HEADER_METACHARSET_MISMATCH));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
+        
+        assertThat(alertsRaised.get(1), containsNameLoadedWithKey(NO_MISMATCH_METACONTENTTYPE_MISSING));
+        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getWascId(), equalTo(15));
+    }
+    
+    @Test
+    public void shouldRaiseAlertWhenDifferentMetaCharsetAndContentType() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<html>"
+                + "<head>"
+                + "<meta http-equiv='Content-Type' content='charset=UTF-8' />"
+                + "<meta charset='ISO-123' />"
+                + "</head>"
+                + "</html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/html;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.get(0), containsNameLoadedWithKey(METACONTENTTYPE_METACHARSET_MISMATCH));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
+        
+        assertThat(alertsRaised.get(1), containsNameLoadedWithKey(HEADER_METACHARSET_MISMATCH));
+        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getWascId(), equalTo(15));
+    }
+    
+
+    @Test
+    public void shouldPassWhenTheSameEncodingAndHeaderXml() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<?xml version='1.0' encoding='UTF-8'?>"
+                + "<zap></zap>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/xml;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+    
+    @Test
+    public void shouldRaiseAlertWhenDifferentEncodingAndHeaderXml() throws HttpMalformedHeaderException {
+        // Given
+        msg.setResponseBody("<?xml version='1.0' encoding='ISO-123'?>"
+                + "<zap></zap>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: text/xml;charset=UTF-8\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0), containsOtherInfoLoadedWithKey(XML_MISMATCH, "UTF-8", "ISO-123"));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
+    }
+}
+


### PR DESCRIPTION
Test for issue [2799](https://github.com/zaproxy/zaproxy/issues/2799)
There is probably one bug, unit test implemented for this bug in method differentMetaAndHeaderPlusAdditionalMetaParametersHtml. 
