### PR TITLE
ascanrulesBeta: skip empty cross domain files

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Support changing the length of time used in timing attacks via config options.<br>
 	Support ignoring specified forms when checking for CSRF vulnerabilities.<br>
+	Do not attempt to parse empty cross domain policy files.<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change CrossDomainScanner to skip empty cross domain policy files (that
is, responses with no content), there's no point attempting to parse and
process them, moreover it prevents outputs like:
 [Fatal Error] :1:1: Premature end of file.
caused by the empty responses.
Remove wildcard import and reorder related imports.
Update changes in ZapAddOn.xml file.
 ---
Reported in the IRC channel.