### PR TITLE
Updated Loosely Scoped Cookie References

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Issue 2574: CookieLooselyScopedScanner, remove attack field and update description.<br>
 	Support ignoring specified forms when checking for CSRF vulnerabilities.<br>
 	Correct the plugin ID of Absence of Anti-CSRF Tokens from 40014 to 10202.<br>
+	Issue 2860: Add further reference links.
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -28,7 +28,7 @@ pscanbeta.charsetmismatch.extrainfo.xml=There was a charset mismatch between the
 pscanbeta.cookielooselyscoped.name=Loosely Scoped Cookie
 pscanbeta.cookielooselyscoped.desc=Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com. Cookies set from a subdomain like app.foo.bar are transmitted only to that domain by the browser. However, cookies scoped to a parent-level domain may be transmitted to the parent, or any subdomain of the parent.
 pscanbeta.cookielooselyscoped.soln=Always scope cookies to a FQDN (Fully Qualified Domain Name).
-pscanbeta.cookielooselyscoped.refs=http://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies
+pscanbeta.cookielooselyscoped.refs=https://tools.ietf.org/html/rfc6265#section-4.1\nhttps://www.owasp.org/index.php/Testing_for_cookies_attributes_(OTG-SESS-002)\nhttp://code.google.com/p/browsersec/wiki/Part2#Same-origin_policy_for_cookies
 pscanbeta.cookielooselyscoped.extrainfo=The origin domain used for comparison was: \r\n{0}\r\n{1}
 pscanbeta.cookielooselyscoped.extrainfo.cookie={0}\r\n
 


### PR DESCRIPTION
Fixes zaproxy/zaproxy#2860 by adding the suggested relevant links.
Update ZapAddOn.xml with changes entry.