### PR TITLE
scripts: remove unused resource messages

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Script Console</name>
-	<version>17</version>
+	<version>18</version>
 	<status>beta</status>
 	<description>Supports all JSR 223 scripting languages</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
-	Discard undoable edits after setting a script (Issue 2675).<br>
+	Remove unused resource messages (Issue 2386).<br>
 	]]>
 	</changes>
 	<extensions>
@@ -17,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -42,10 +42,6 @@ scripts.disable.popup					= Disable Script(s)
 scripts.duplicate.popup					= Duplicate Script ...
 scripts.instantiate.popup				= New Script ...
 
-scripts.interface.active.error			= The script does not correctly implement the required interface. 
-scripts.interface.passive.error			= The script does not correctly implement the required interface. 
-scripts.interface.targeted.error		= The script does not correctly implement the required interface. 
-
 scripts.list.panel.title				= Scripts
 scripts.list.panel.mnemonic				= s
 scripts.list.toolbar.button.load		= Load Script ...


### PR DESCRIPTION
Remove resource messages that were being used by (just) core code (in
versions prior release of ZAP 2.5.0).
Bump version, updated changes and change minimum ZAP version (to 2.5.0)
in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2386 - Remove unused "Script Console" resource
messages