### PR TITLE
wappalyzer: remove unused pop up menu constructors

### DIFF
--- a/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -299,8 +299,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor implements SessionChan
 
 	private PopupMenuEvidence getPopupMenuEvidence () {
 		if (popupMenuEvidence == null) {
-			popupMenuEvidence = new PopupMenuEvidence();
-			popupMenuEvidence.setExtension(this);
+			popupMenuEvidence = new PopupMenuEvidence(this);
 		}
 		return popupMenuEvidence;
 	}

--- a/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
@@ -40,15 +40,7 @@ public class PopupMenuEvidence extends ExtensionPopupMenuItem {
     
     private List<PopupMenuEvidenceSearch> subMenus = new ArrayList<PopupMenuEvidenceSearch>();
 
-    public PopupMenuEvidence() {
-        super();
-    }
-
-    public PopupMenuEvidence(String label) {
-        super(label);
-    }
-
-	public void setExtension(ExtensionWappalyzer extension) {
+    public PopupMenuEvidence(ExtensionWappalyzer extension) {
 		this.extension = extension;
 	}
 
@@ -95,9 +87,8 @@ public class PopupMenuEvidence extends ExtensionPopupMenuItem {
     }
     
     private void addSubMenu(String label, Pattern p, ExtensionSearch.Type type) {
-    	// TODO add prefix for pattern types?
-		PopupMenuEvidenceSearch menu = new PopupMenuEvidenceSearch(label, p, type);
-		menu.setExtension(extension);
+    	// TODO add label as prefix for pattern types?
+		PopupMenuEvidenceSearch menu = new PopupMenuEvidenceSearch(p.pattern(), extension, p, type);
 		menu.setMenuIndex(this.getMenuIndex());
 		View.getSingleton().getPopupList().add(menu);
 		this.subMenus.add(menu);

--- a/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidenceSearch.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidenceSearch.java
@@ -30,24 +30,8 @@ public class PopupMenuEvidenceSearch extends ExtensionPopupMenuItem {
 
 	private static final long serialVersionUID = 1L;
 
-    private ExtensionWappalyzer extension;
-    private Pattern pattern = null;
-    private ExtensionSearch.Type type = null;
-
-    public PopupMenuEvidenceSearch(String label, Pattern pattern, ExtensionSearch.Type type) {
+    public PopupMenuEvidenceSearch(String label, final ExtensionWappalyzer extension, final Pattern pattern, final ExtensionSearch.Type type) {
         super(label);
-        this.pattern = pattern;
-        this.type = type;
- 		initialize();
-    }
-
-	public void setExtension(ExtensionWappalyzer extension) {
-		this.extension = extension;
-	}
-
-	private void initialize() {
-		// TODO add prefix for pattern type?
-        this.setText(pattern.pattern());
         this.addActionListener(new java.awt.event.ActionListener() { 
 
         	@Override


### PR DESCRIPTION
Remove unused pop up menu constructors and change existing ones to
require the expected dependencies, also, merge "initialize" method into
the constructor.