### PR TITLE
ascanrulesBeta: fix attack URL in PHP RCE scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Support ignoring specified forms when checking for CSRF vulnerabilities.<br>
 	Do not attempt to parse empty cross domain policy files.<br>
 	Correct creation of attack URL in Source Code Disclosure - CVE-2012-1823.<br>
+	Correct creation of attack URL in Remote Code Execution - CVE-2012-1823.<br>
     ]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/NanoServerHandler.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/NanoServerHandler.java
@@ -19,6 +19,11 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+import org.parosproxy.paros.network.HttpHeader;
+
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 
@@ -35,4 +40,68 @@ public abstract class NanoServerHandler {
     }
     
     abstract Response serve(IHTTPSession session);
+
+    /**
+     * Consumes the request body.
+     *
+     * @param session the session that has the request
+     */
+    protected void consumeBody(IHTTPSession session) {
+        try {
+            session.getInputStream().skip(getBodySize(session));
+        } catch (IOException e) {
+            System.err.println("Failed to consume body:");
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Gets the size of the request body.
+     *
+     * @param session the session that has the request
+     * @return the size of the body
+     */
+    protected int getBodySize(IHTTPSession session) {
+        String contentLengthHeader = session.getHeaders().get(HttpHeader.CONTENT_LENGTH.toLowerCase());
+        if (contentLengthHeader == null) {
+            return 0;
+        }
+
+        int contentLength = 0;
+        try {
+            contentLength = Integer.parseInt(contentLengthHeader);
+        } catch (NumberFormatException e) {
+            System.err.println("Failed to parse " + HttpHeader.CONTENT_LENGTH + " value: " + contentLengthHeader);
+            e.printStackTrace();
+            return 0;
+        }
+
+        if (contentLength <= 0) {
+            return 0;
+        }
+        return contentLength;
+    }
+
+    /**
+     * Gets the request body.
+     *
+     * @param session the session that has the request
+     * @return the body
+     */
+    public String getBody(IHTTPSession session) {
+        int contentLength = getBodySize(session);
+        if (contentLength == 0) {
+            return "";
+        }
+
+        byte[] bytes = new byte[contentLength];
+        try {
+            IOUtils.readFully(session.getInputStream(), bytes);
+        } catch (IOException e) {
+            System.err.println("Failed to read the body:");
+            e.printStackTrace();
+            return "";
+        }
+        return new String(bytes);
+    }
 }

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
@@ -1,0 +1,182 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesBeta;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+
+/**
+ * Unit test for {@link RemoteCodeExecutionCVE20121823}.
+ */
+public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
+
+    @Override
+    protected RemoteCodeExecutionCVE20121823 createScanner() {
+        return new RemoteCodeExecutionCVE20121823();
+    }
+
+    @Test
+    public void shouldScanUrlsWithoutPath() throws Exception {
+        // Given
+        HttpMessage message = getHttpMessage("");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(2));
+    }
+
+    @Test
+    public void shouldScanUrlsWithEncodedCharsInPath() throws Exception {
+        // Given
+        String test = "shouldScanUrlsWithEncodedCharsInPath";
+        nano.addHandler(new NanoServerHandler(test) {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                consumeBody(session);
+                return new Response("Nothing echoed...");
+            }
+        });
+        HttpMessage message = getHttpMessage("/" + test + "/%7B+%25%24");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(2));
+    }
+
+    @Test
+    public void shouldNotAlertIfTheAttackIsNotEchoedInTheResponse() throws Exception {
+        // Given
+        String test = "shouldNotAlertIfTheAttackIsNotEchoedInTheResponse";
+        nano.addHandler(new NanoServerHandler(test) {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                consumeBody(session);
+                return new Response("Nothing echoed...");
+            }
+        });
+        HttpMessage message = getHttpMessage("/" + test + "/");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertEvenIfAttackResponseBodyHasBiggerSize() throws Exception {
+        // Given
+        String test = "shouldNotAlertEvenIfResponseBodyHasBiggerSize";
+        nano.addHandler(new NanoServerHandler(test) {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                consumeBody(session);
+
+                StringBuilder strBuilder = new StringBuilder("Nothing echoed...\n");
+                for (int i = 0; i < 50; i++) {
+                    strBuilder.append(" response content...\n");
+                }
+                return new Response(strBuilder.toString());
+            }
+        });
+        HttpMessage message = getHttpMessage("/" + test + "/");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertIfWindowsAttackWasSuccessful() throws Exception {
+        // Given
+        final String body = RemoteCodeExecutionCVE20121823.randomString + "<html><body>X Y Z</body></html>";
+        String test = "shouldAlertIfWindowsAttackWasSuccessful";
+        nano.addHandler(new NanoServerHandler(test) {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                if (getBody(session).contains("cmd.exe")) {
+                    return new Response(body);
+                }
+                return new Response("Nothing echoed...");
+            }
+        });
+        HttpMessage message = getHttpMessage("/" + test + "/");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo(body)));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getAttack(), is(
+                equalTo("<?php exec('cmd.exe /C echo " + RemoteCodeExecutionCVE20121823.randomString
+                        + "',$colm);echo join(\"\n\",$colm);die();?>")));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo(body)));
+    }
+
+    @Test
+    public void shouldAlertIfNixAttackWasSuccessful() throws Exception {
+        // Given
+        final String body = RemoteCodeExecutionCVE20121823.randomString + "<html><body>X Y Z</body></html>";
+        String test = "shouldAlertIfNixAttackWasSuccessful";
+        nano.addHandler(new NanoServerHandler(test) {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                if (!getBody(session).contains("cmd.exe")) {
+                    return new Response(body);
+                }
+                return new Response("Nothing echoed...");
+            }
+        });
+        HttpMessage message = getHttpMessage("/" + test + "/");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo(body)));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getAttack(), is(
+                equalTo("<?php exec('echo " + RemoteCodeExecutionCVE20121823.randomString
+                        + "',$colm);echo join(\"\n\",$colm);die();?>")));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo(body)));
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
@@ -34,6 +34,9 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 
+/**
+ * Unit test for {@link SourceCodeDisclosureCVE20121823}.
+ */
 public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
 
     private static final String RESPONSE_HEADER_404_NOT_FOUND = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n";


### PR DESCRIPTION
Change scanner RemoteCodeExecutionCVE20121823 to create the attack URL
using the original URL components (authority and path) escaped, as
that's the expected form, otherwise it would lead to an exception:
 "escaped absolute path not valid"
if there were characters that required escaping.
Change the scanner to not attempt the second attack if the first was
successful and to update the Content-Length of the request body so the
request body can be properly consumed.

Add tests to assert the expected behaviour of the scanner.
Update changes in ZapAddOn.xml file.