### PR TITLE
pscanrules: do not require private cache directive

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/CacheControlScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/CacheControlScanner.java
@@ -80,8 +80,7 @@ public class CacheControlScanner extends PluginPassiveScanner {
 			if (cacheControlHeaders.isEmpty() || //No Cache-Control header at all 
 					cacheControlHeaders.indexOf("no-store") < 0 || 
 					cacheControlHeaders.indexOf("no-cache") < 0 || 
-					cacheControlHeaders.indexOf("must-revalidate") < 0 ||
-					cacheControlHeaders.indexOf("private") < 0) {
+					cacheControlHeaders.indexOf("must-revalidate") < 0) {
 				this.raiseAlert(msg, id, HttpHeader.CACHE_CONTROL, cacheControlHeaders);
 			}
 			

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Only report issues on errors and redirects at LOW threshold.<br>
 	Only report X-Frame-Options issues at LOW threshold if CSP 'frame-ancestors' element present.<br> 
 	Issue 2732: False positives for security headers missing due to redirections.<br>
+	Do not require private directive in Cache-Control response header (Issue 2900).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -39,7 +39,7 @@ pscanrules.applicationerrorscanner.soln = Review the source code of this page. I
 
 pscanrules.cachecontrolscanner.name = Incomplete or No Cache-control and Pragma HTTP Header Set
 pscanrules.cachecontrolscanner.desc = The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.
-pscanrules.cachecontrolscanner.soln = Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate, private; and that the pragma HTTP header is set with no-cache.
+pscanrules.cachecontrolscanner.soln = Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.
 pscanrules.cachecontrolscanner.refs = https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching
 
 pscanrules.contenttypemissingscanner.name = Content-Type Header Missing


### PR DESCRIPTION
Change CacheConstrolScanner to not require the private directive, the
directives already required are enough.
Update tests, ZapAddOn.xml file and resource message.

Fix zaproxy/zaproxy#2900 - Remove Cache-Control: 'private' check from
the passive scanner