### PR TITLE
ascanrules: improve error handling in scanners

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
@@ -32,6 +32,7 @@ package org.zaproxy.zap.extension.ascanrules;
 import java.io.IOException;
 import java.net.UnknownHostException;
 
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -155,8 +156,10 @@ public class BufferOverflow extends AbstractAppParamPlugin  {
     		}
     			
 				return;	
-
-			
+		} catch (URIException e) {
+			if (log.isDebugEnabled()) {
+				log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+			}
 		} catch (IOException e) {
 			log.error(e.getMessage(), e);
 		}	

--- a/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 
 import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -281,9 +282,10 @@ public class FormatString extends AbstractAppParamPlugin  {
 			}
 			return;	
 
-
-
-			
+		} catch (URIException e) {
+			if (log.isDebugEnabled()) {
+				log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+			}
 		} catch (IOException e) {
 			log.error(e.getMessage(), e);
 		}	

--- a/src/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.net.UnknownHostException;
 
 import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -108,8 +109,14 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
 		setParameter(msg2, param, attack);
         try {
 			sendAndReceive(msg2);
+        } catch (URIException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+            }
+            return null;
     	} catch (InvalidRedirectLocationException|UnknownHostException e) {
     		// Not an error, just means we probably attacked the redirect location
+    	    return null;
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		}
@@ -136,6 +143,11 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
 			setParameter(msg2, param, Constant.getEyeCatcher());
             try {
     			sendAndReceive(msg2);
+            } catch (URIException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+                }
+                return;
         	} catch (InvalidRedirectLocationException|UnknownHostException e) {
         		// Not an error, just means we probably attacked the redirect location
         		// Try the second eye catcher
@@ -161,6 +173,11 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
     			setParameter(msg2, param, value + Constant.getEyeCatcher());
                 try {
         			sendAndReceive(msg2);
+                } catch (URIException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+                    }
+                    return;
             	} catch (InvalidRedirectLocationException|UnknownHostException e) {
             		//Second eyecatcher failed for some reason, no need to continue
             		return;

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -1,16 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules</name>
-	<version>25</version>
+	<version>26</version>
 	<status>release</status>
 	<description>The release quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 1211 - SQLi Scanner may raise seemingly duplicate alerts (fixed).<br>
-	Use correct HTTP message and attack for alerts of "Format String Error".<br>
-	Fixed test for wrong tag in Reflected XSS rule.<br>
-	Issue 1632 - False Negative XSS on injection outside of HTML tags.<br>
+	Improve error handling in some scanners.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Change scanners BufferOverflow, FormatString and TestCrossSiteScriptV2
to catch URIException when sending a message as that can be thrown if
the URI is not correct (non HTTP/S scheme or invalid encoding).
Also, change TestCrossSiteScriptV2 to not attempt to use the message if
it was not successfully sent (e.g. because of the above exception).
Bump version and update changes in ZapAddOn.xml file.
 ---
From @zapbot scans.