### PR TITLE
ascanrulesBeta: improve error handling in scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
@@ -182,6 +182,10 @@ public class HPP extends AbstractAppPlugin {
 			if(vulnLinks.isEmpty()) {
 				log.debug("Page not vulnerable to HPP attacks");
 			}
+		} catch (URIException e) {
+			if (log.isDebugEnabled()) {
+				log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+			}
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		}


### PR DESCRIPTION
Change HPP scanner to catch URIException when sending a message as that
can be thrown if the URI is not correct (non HTTP/S scheme or invalid
encoding).

Related to zaproxy/zaproxy#2224 - HPP Scanner - Multiple Issues
 ---
From @zapbot scans.