### PR TITLE
ascanruleBeta: adjust log levels

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOraclePlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOraclePlugin.java
@@ -210,7 +210,9 @@ public class PaddingOraclePlugin extends AbstractAppParamPlugin {
                     if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR) {
                             // We Found IT!                    
                             // First do logging
-                            log.info("[Padding Oracle Found] on parameter [" + paramName + "] with payload [" + encodedValue + "]");
+                            if (log.isDebugEnabled()) {
+                                log.debug("[Padding Oracle Found] on parameter [" + paramName + "] with payload [" + encodedValue + "]");
+                            }
 
                             // Now create the alert message
                             this.bingo(
@@ -237,7 +239,9 @@ public class PaddingOraclePlugin extends AbstractAppParamPlugin {
 
                             // We Found IT!                    
                             // First do logging
-                            log.info("[Padding Oracle Found] on parameter [" + paramName + "] with payload [" + encodedValue + "]");
+                            if (log.isDebugEnabled()) {
+                                log.debug("[Padding Oracle Found] on parameter [" + paramName + "] with payload [" + encodedValue + "]");
+                            }
 
                             // Now create the alert message
                             this.bingo(

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
@@ -304,7 +304,9 @@ public class SQLInjectionHypersonic extends AbstractAppParamPlugin {
 							paramName,  attack, 
 							extraInfo, getSolution(), msgAttack);
 
-					log.info("A likely Time Based SQL Injection Vulnerability has been found with ["+msgAttack.getRequestHeader().getMethod()+"] URL ["+msgAttack.getRequestHeader().getURI().getURI()+"] on field: ["+paramName+"]");
+					if (log.isDebugEnabled()) {
+						log.debug("A likely Time Based SQL Injection Vulnerability has been found with ["+msgAttack.getRequestHeader().getMethod()+"] URL ["+msgAttack.getRequestHeader().getURI().getURI()+"] on field: ["+paramName+"]");
+					}
 					return;
 				} //query took longer than the amount of time we attempted to retard it by						
 			}  //for each time based SQL index

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
@@ -261,7 +261,9 @@ public class SQLInjectionOracle extends AbstractAppParamPlugin {
 							paramName,  attack, 
 							extraInfo, getSolution(), msgAttack);
 
-					log.info("A likely Time Based SQL Injection Vulnerability has been found with ["+msgAttack.getRequestHeader().getMethod()+"] URL ["+msgAttack.getRequestHeader().getURI().getURI()+"] on field: ["+paramName+"]");					 
+					if (log.isDebugEnabled()) {
+						log.debug("A likely Time Based SQL Injection Vulnerability has been found with ["+msgAttack.getRequestHeader().getMethod()+"] URL ["+msgAttack.getRequestHeader().getURI().getURI()+"] on field: ["+paramName+"]");
+					}
 					return;
 				} //query took longer than the amount of time we attempted to retard it by						
 			}  //for each time based SQL index

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
@@ -289,7 +289,9 @@ public class SQLInjectionPostgresql extends AbstractAppParamPlugin {
 							paramName,  attack, 
 							extraInfo, getSolution(), msgAttack);
 
-					log.info("A likely Time Based SQL Injection Vulnerability has been found with ["+msgAttack.getRequestHeader().getMethod()+"] URL ["+msgAttack.getRequestHeader().getURI().getURI()+"] on field: ["+paramName+"]");
+					if (log.isDebugEnabled()) {
+						log.debug("A likely Time Based SQL Injection Vulnerability has been found with ["+msgAttack.getRequestHeader().getMethod()+"] URL ["+msgAttack.getRequestHeader().getURI().getURI()+"] on field: ["+paramName+"]");
+					}
 					return;
 
 				} //query took longer than the amount of time we attempted to retard it by						

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
@@ -18,6 +18,7 @@
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import java.net.URL;
+import java.text.MessageFormat;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -366,14 +367,15 @@ public class SessionFixation extends AbstractAppPlugin {
 	        					currentHtmlParameter.getName(),  attack, 
 	        					extraInfo, vulnsoln, getBaseMsg());
 	        					
-	        			//if ( log.isInfoEnabled())  {
-	        				String logMessage = Constant.messages.getString("ascanbeta.sessionidsentinsecurely.alert.logmessage", 
+	        			if ( log.isDebugEnabled())  {
+	        				String logMessage = MessageFormat.format("A session identifier in {2} field: [{3}] may be sent " +
+	        							"via an insecure mechanism at [{0}] URL [{1}]", 
 	        							getBaseMsg().getRequestHeader().getMethod(),  
 	        							getBaseMsg().getRequestHeader().getURI().getURI(), 
 	        							currentHtmlParameter.getType(), 
 	        							currentHtmlParameter.getName());
-	        				log.info(logMessage);
-	        			//}
+	        				log.debug(logMessage);
+	        			}
 	        			//Note: do NOT continue to the next field at this point.. 
 	        			//since we still need to check for Session Fixation.
 	        		}
@@ -408,14 +410,15 @@ public class SessionFixation extends AbstractAppPlugin {
 	        					currentHtmlParameter.getName(),  attack, 
 	        					extraInfo, vulnsoln, getBaseMsg());
 	        					
-	        			//if ( log.isInfoEnabled())  {
-	        				String logMessage = Constant.messages.getString("ascanbeta.sessionidaccessiblebyjavascript.alert.logmessage", 
+	        			if ( log.isDebugEnabled())  {
+	        				String logMessage = MessageFormat.format("A session identifier in [{0}] URL [{1}] {2} field: " +
+	        							"[{3}] may be accessible to JavaScript", 
 	        							getBaseMsg().getRequestHeader().getMethod(),  
 	        							getBaseMsg().getRequestHeader().getURI().getURI(), 
 	        							currentHtmlParameter.getType(), 
 	        							currentHtmlParameter.getName());
-	        				log.info(logMessage);
-	        			//}
+	        				log.debug(logMessage);
+	        			}
 	        			//Note: do NOT continue to the next field at this point.. 
 	        			//since we still need to check for Session Fixation.
 	        		}
@@ -535,15 +538,16 @@ public class SessionFixation extends AbstractAppPlugin {
 	        					currentHtmlParameter.getName(),  attack, 
 	        					extraInfo, vulnsoln, getBaseMsg());
 	        					
-	        			//if ( log.isInfoEnabled())  {
-	        				String logMessage = Constant.messages.getString("ascanbeta.sessionidexpiry.alert.logmessage", 
+	        			if ( log.isDebugEnabled())  {
+	        				String logMessage = MessageFormat.format("A session identifier in [{0}] URL [{1}] {2} field: " +
+	        							"[{3}] may be accessed until [{4}], unless the session is destroyed.", 
 	        							getBaseMsg().getRequestHeader().getMethod(),  
 	        							getBaseMsg().getRequestHeader().getURI().getURI(), 
 	        							currentHtmlParameter.getType(), 
 	        							currentHtmlParameter.getName(),
 	        							sessionExpiryDescription);
-	        				log.info(logMessage);
-	        			//}
+	        				log.debug(logMessage);
+	        			}
 	        			//Note: do NOT continue to the next field at this point.. 
 	        			//since we still need to check for Session Fixation.
 	        		}
@@ -670,10 +674,7 @@ public class SessionFixation extends AbstractAppPlugin {
 	        			}
 	        			
 	        			bingo(risk, Alert.CONFIDENCE_MEDIUM, msg2Initial.getRequestHeader().getURI().getURI(), currentHtmlParameter.getName(), attack, extraInfo, msg2Initial);
-	        			//if ( log.isInfoEnabled())  {
-	        				String logMessage = Constant.messages.getString("ascanbeta.sessionfixation.alert.logmessage", msg2Initial.getRequestHeader().getMethod(),  msg2Initial.getRequestHeader().getURI().getURI(), currentHtmlParameter.getType(), currentHtmlParameter.getName());
-	        				log.info(logMessage);
-	        			//}	        			
+	        			logSessionFixation(msg2Initial, currentHtmlParameter.getType().toString(), currentHtmlParameter.getName());
 	        		}
 
         			continue;  //jump to the next iteration of the loop (ie, the next parameter)
@@ -775,14 +776,15 @@ public class SessionFixation extends AbstractAppPlugin {
 		        					currentHtmlParameter.getName(),  attack, 
 		        					extraInfo, vulnsoln, getBaseMsg());
 		        					
-		        			//if ( log.isInfoEnabled())  {
-		        				String logMessage = Constant.messages.getString("ascanbeta.sessionidexposedinurl.alert.logmessage", 
+		        			if ( log.isDebugEnabled())  {
+		        				String logMessage = MessageFormat.format("An exposed session identifier has been found at " +
+		        							"[{0}] URL [{1}] on {2} field: [{3}]",
 		        							getBaseMsg().getRequestHeader().getMethod(),  
 		        							getBaseMsg().getRequestHeader().getURI().getURI(), 
 		        							(isPseudoUrlParameter?"pseudo ":"") +currentHtmlParameter.getType(), 
 		        							currentHtmlParameter.getName());
-		        				log.info(logMessage);
-		        			//}
+		        				log.debug(logMessage);
+		        			}
 		        			//Note: do NOT continue to the next field at this point.. 
 		        			//since we still need to check for Session Fixation.
         					}
@@ -874,10 +876,7 @@ public class SessionFixation extends AbstractAppPlugin {
 	        			}
 	        			
 	        			bingo(risk, Alert.CONFIDENCE_MEDIUM, getBaseMsg().getRequestHeader().getURI().getURI(), currentHtmlParameter.getName(), attack, extraInfo, getBaseMsg());
-	        			//if ( log.isInfoEnabled())  {
-	        				String logMessage = Constant.messages.getString("ascanbeta.sessionfixation.alert.logmessage", getBaseMsg().getRequestHeader().getMethod(),  getBaseMsg().getRequestHeader().getURI().getURI(), (isPseudoUrlParameter?"pseudo ":"") +currentHtmlParameter.getType(), currentHtmlParameter.getName());
-	        				log.info(logMessage);
-	        			//}
+	        			logSessionFixation( getBaseMsg(), (isPseudoUrlParameter?"pseudo ":"") +currentHtmlParameter.getType(), currentHtmlParameter.getName());
 	        			
 	        			continue;  //jump to the next iteration of the loop (ie, the next parameter)
 	        			
@@ -900,6 +899,20 @@ public class SessionFixation extends AbstractAppPlugin {
             log.error("An error occurred checking a url for Session Fixation issues", e);
         }
 	}	
+
+	private static void logSessionFixation(HttpMessage msg, String parameterType, String parameterName) {
+		if (!log.isDebugEnabled()) {
+			return;
+		}
+
+		String logMessage = MessageFormat.format(
+				"A likely Session Fixation Vulnerability has been found with [{0}] URL [{1}] on {2} field: [{3}]",
+				msg.getRequestHeader().getMethod(),
+				msg.getRequestHeader().getURI(),
+				parameterType,
+				parameterName);
+		log.debug(logMessage);
+	}
 	
 	/**
 	 * finds and returns the cookie matching the specified cookie name from the message response.

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
@@ -523,7 +523,6 @@ public class UsernameEnumeration extends AbstractAppPlugin {
 								currentHtmlParameter.getName(),  attack, 
 								extraInfo, vulnsoln, getBaseMsg());
 
-						log.info(extraInfo);
 					} else {
 						if ( this.debugEnabled ) log.debug("["+currentHtmlParameter.getType()+ "] parameter ["+currentHtmlParameter.getName()+"] looks ok (Invalid Usernames cannot be distinguished from Valid usernames)");
 					}

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionPlugin.java
@@ -273,8 +273,10 @@ public class XpathInjectionPlugin extends AbstractAppParamPlugin {
 
                         // We Found IT!                     
                         // First do logging
-                        log.info("[XPath Injection Found] on parameter [" + paramName
-                                + "] with payload [" + evilPayload + "]");
+                        if (log.isDebugEnabled()) {
+                            log.debug("[XPath Injection Found] on parameter [" + paramName
+                                    + "] with payload [" + evilPayload + "]");
+                        }
 
                         // Now create the alert message
                         this.bingo(

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Correct creation of attack URL in Source Code Disclosure - CVE-2012-1823.<br>
 	Correct creation of attack URL in Remote Code Execution - CVE-2012-1823.<br>
 	Respect OS techs included when scanning with Remote Code Execution - CVE-2012-1823.<br>
+	Adjust log levels of some scanners, from INFO to DEBUG.<br>
     ]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -72,7 +72,6 @@ ascanbeta.sessionfixation.alert.cookie.extrainfo.loginpage=The url on which the 
 ascanbeta.sessionfixation.alert.url.extrainfo=A likely session value has appeared in URLs in the HTML output when URL parameter/pseudo URL parameter [{0}] is set to NULL: [{1}]\nWhen this 'borrowed' session [{1}] is used in a subsequent request for this URL, a new session is not created.
 ascanbeta.sessionfixation.alert.url.extrainfo.loginpage=The url on which the issue was discovered was flagged as a logon page.
 ascanbeta.sessionfixation.alert.attack={0} field: [{1}]
-ascanbeta.sessionfixation.alert.logmessage=A likely Session Fixation Vulnerability has been found with [{0}] URL [{1}] on {2} field: [{3}]
 #Exposed Session Id messages
 ascanbeta.sessionidexposedinurl.name=Exposed Session ID
 ascanbeta.sessionidexposedinurl.desc=A session id is exposed in the URL. By sharing such a website URL (containing the session id), a naiive user may be inadvertently granting access to their data, compromising its confidentiality, integrity, and availability.  URLs containing the session identifier also appear in web browser bookmarks, web server log files, and proxy server log files. 
@@ -82,7 +81,6 @@ ascanbeta.sessionidexposedinurl.refs=https://www.owasp.org/index.php/Top_10_2010
 ascanbeta.sessionidexposedinurl.alert.extrainfo={0} field [{1}] contains an exposed session identifier [{2}]
 ascanbeta.sessionidexposedinurl.alert.extrainfo.loginpage=The url on which the issue was discovered was flagged as a logon page.
 ascanbeta.sessionidexposedinurl.alert.attack={0} field: [{1}]
-ascanbeta.sessionidexposedinurl.alert.logmessage=An exposed session identifier has been found at [{0}] URL [{1}] on {2} field: [{3}]
 #Session Id Cookie not sent securely
 ascanbeta.sessionidsentinsecurely.name=Session ID Transmitted Insecurely
 ascanbeta.sessionidsentinsecurely.desc=A session id may be sent via an insecure mechanism. In the case of a cookie sent in the request, this occurs when HTTP, rather than HTTPS, is used.  In the case of a cookie sent by the server in response (when the URL is modified by setting the named parameter field to NULL), the 'secure' flag is not set, allowing the cookie to be sent later via HTTP rather than via HTTPS. This may allow a passive eavesdropper on the network path to gain full access to the victim's session.  
@@ -93,7 +91,6 @@ ascanbeta.sessionidsentinsecurely.alert.extrainfo=session identifier {0} field [
 ascanbeta.sessionidsentinsecurely.alert.extrainfo.secureflagnotset=The 'secure' flag was not set on the session cookie supplied by the server.
 ascanbeta.sessionidsentinsecurely.alert.extrainfo.loginpage=The url on which the issue was discovered was flagged as a logon page.
 ascanbeta.sessionidsentinsecurely.alert.attack={0} field: [{1}]
-ascanbeta.sessionidsentinsecurely.alert.logmessage=A session identifier in {2} field: [{3}] may be sent via an insecure mechanism at [{0}] URL [{1}]
 #Session Id Cookie accessible by JavaScript
 ascanbeta.sessionidaccessiblebyjavascript.name=Session ID Cookie Accessible to JavaScript
 ascanbeta.sessionidaccessiblebyjavascript.desc=A Session Id cookie sent by the server (when the URL is modified by setting the named parameter field to NULL) may be accessed by JavaScript on the client. In conjunction with another vulnerability, this may allow the session to be hijacked.  
@@ -103,7 +100,6 @@ ascanbeta.sessionidaccessiblebyjavascript.refs=
 ascanbeta.sessionidaccessiblebyjavascript.alert.extrainfo=session identifier {0} field [{1}], value [{2}] may be accessed using JavaScript in the web browser
 ascanbeta.sessionidaccessiblebyjavascript.alert.extrainfo.loginpage=The url on which the issue was discovered was flagged as a logon page.
 ascanbeta.sessionidaccessiblebyjavascript.alert.attack={0} field: [{1}]
-ascanbeta.sessionidaccessiblebyjavascript.alert.logmessage=A session identifier in [{0}] URL [{1}] {2} field: [{3}] may be accessible to JavaScript  
 #Session Id Cookie Expiry
 ascanbeta.sessionidexpiry.name=Session ID Expiry Time/Max-Age is Excessive
 ascanbeta.sessionidexpiry.desc=A Session Id cookie sent by the server (when the URL is modified by setting the named parameter field to NULL) is set to be valid for an excessive period of time. This may be exploitable by an attacker if the user forgets to log out, if the logout functionality does not correctly destroy the session, or if the session id is compromised by some other means.     
@@ -113,7 +109,6 @@ ascanbeta.sessionidexpiry.refs=
 ascanbeta.sessionidexpiry.alert.extrainfo=session identifier {0} field [{1}], value [{2}] may be accessed until [{3}] (since cookie was received at {4}), unless the session is destroyed.
 ascanbeta.sessionidexpiry.alert.extrainfo.loginpage=The url on which the issue was discovered was flagged as a logon page.
 ascanbeta.sessionidexpiry.alert.attack={0} field: [{1}]
-ascanbeta.sessionidexpiry.alert.logmessage=A session identifier in [{0}] URL [{1}] {2} field: [{3}] may be accessed until [{4}], unless the session is destroyed.
 ascanbeta.sessionidexpiry.browserclose=browser close
 ascanbeta.sessionidexpiry.timemorethanoneweek=More than one week
 ascanbeta.sessionidexpiry.timemorethanoneday=More than one day


### PR DESCRIPTION
Change classes SessionFixation, PaddingOraclePlugin, SQLInjectionOracle,
SQLInjectionHypersonic, SQLInjectionPostgresql, UsernameEnumeration and
XpathInjectionPlugin to reduce the log levels, from INFO to DEBUG, of
messages logged when an alert is raised to reduce the number of messages
logged by default (those messages are not really needed, the absence or
presence of an alert already indicates that fact).
For SessionFixation remove its log messages from Messages.properties
file as they do not need to be internationalised.
Update changes in ZapAddOn.xml file.
 ---
From @zapbot scans.