### PR TITLE
ascanruleAlpha: adjust log levels

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/RelativePathConfusionScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/RelativePathConfusionScanner.java
@@ -477,8 +477,9 @@ public class RelativePathConfusionScanner extends AbstractAppPlugin {
 						hackedMessage
 						);
                 
-                //log it and GTFO
-                log.info("A Relative Path Confusion issue exists on "+ getBaseMsg().getRequestHeader().getURI().getURI());
+                if (log.isDebugEnabled()) {
+                    log.debug("A Relative Path Confusion issue exists on "+ getBaseMsg().getRequestHeader().getURI().getURI());
+                }
             	return;
             	
 			} else {

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
@@ -283,7 +283,9 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 					} else {
 						//if we verified the response
 						if (dataMatchesExtension (sourceattackmsg.getResponseBody().getBytes(), fileExtension)) {
-							log.info("Source code disclosure!  The output for the source code filename ["+ prefixedUrlfilename + "] differs sufficiently from that of the random parameter, at "+ randomversussourcefilenamematchpercentage  + "%, compared to a threshold of "+ this.thresholdPercentage + "%");
+							if (log.isDebugEnabled()) {
+								log.debug("Source code disclosure!  The output for the source code filename ["+ prefixedUrlfilename + "] differs sufficiently from that of the random parameter, at "+ randomversussourcefilenamematchpercentage  + "%, compared to a threshold of "+ this.thresholdPercentage + "%");
+							}
 
 							//if we get to here, is is very likely that we have source file inclusion attack. alert it.
 							bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM,
@@ -354,7 +356,9 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 						//compared to the original
 						int randomversussourcefilenamematchpercentage = calcLengthMatchPercentage(sourceattackmsg.getResponseBody().length(), randomfileattackmsg.getResponseBody().length());
 						if ( randomversussourcefilenamematchpercentage < this.thresholdPercentage ) {
-							log.info("Source code disclosure!  The output for the WAR/EAR filename ["+ prefixedUrlfilename + "] differs sufficiently (in length) from that of the random parameter, at "+ randomversussourcefilenamematchpercentage  + "%, compared to a threshold of "+ this.thresholdPercentage + "%");
+							if (log.isDebugEnabled()) {
+								log.debug("Source code disclosure!  The output for the WAR/EAR filename ["+ prefixedUrlfilename + "] differs sufficiently (in length) from that of the random parameter, at "+ randomversussourcefilenamematchpercentage  + "%, compared to a threshold of "+ this.thresholdPercentage + "%");
+							}
 
 							//Note: no verification of the file contents in this case.
 

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureGit.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureGit.java
@@ -332,7 +332,9 @@ public class SourceCodeDisclosureGit extends AbstractAppPlugin {
 				//check the contents of the output to some degree, if we have a file extension.
 				//if not, just try it (could be a false positive, but hey)    			
 				if (dataMatchesExtension (disclosedData, fileExtension)) {
-					log.info("Source code disclosure, using Git metadata leakage!");
+					if (log.isDebugEnabled()) {
+						log.debug("Source code disclosure, using Git metadata leakage!");
+					}
 
 					//source file inclusion attack. alert it.
 					//Note that, unlike with SVN, the Git data is extracted not from one file, but by parsing a series of files.

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Added Apache Range Header DoS (CVE-2011-3192) scanner.<br>
 	Fix exception when raising a "Source Code Disclosure - File Inclusion" alert.<br>
+	Adjust log levels of some scanners, from INFO to DEBUG.<br>
   	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -71,9 +71,6 @@ ascanalpha.ldapinjection.booleanbased.alert.extrainfo=parameter [{0}] on [{1}] [
 #ascanalpha.ldapinjection.alert.attack=[{0}] field [{1}] set to [{2}]
 ascanalpha.ldapinjection.alert.attack=parameter [{0}] set to [{1}]
 ascanalpha.ldapinjection.booleanbased.alert.attack=Equivalent LDAP expression: [{0}]. Random parameter: [{1}].
-#ascanalpha.ldapinjection.alert.logmessage=A likely LDAP injection vulnerability has been found with [{0}] URL [{1}] on [{2}] field [{3}], using an attack with LDAP meta-characters [{4}], yielding known [{5}] error message [{6}], which was not present in the original response.
-ascanalpha.ldapinjection.alert.logmessage=A likely LDAP injection vulnerability has been found with [{0}] URL [{1}] on parameter [{2}], using an attack with LDAP meta-characters [{3}], yielding known [{4}] error message [{5}], which was not present in the original response.
-ascanalpha.ldapinjection.booleanbased.alert.logmessage=A likely LDAP injection vulnerability has been found with [{0}] URL [{1}] on parameter [{2}], using [{3}] to simulate a logically equivalent condition, and using [{4}] to simulate a FALSE condition. 
 # a colon delimited list of the known LDAP implementations (used to reference "ldapinjection.<implementation>.errormessages" here)  
 ascanalpha.ldapinjection.knownimplementations=activedirectory:openldap:389directoryserver:apachedirectoryservices
 # OpenLDAP Error messages


### PR DESCRIPTION
Change classes SourceCodeDisclosureFileInclusion, LDAPInjection,
SourceCodeDisclosureGit and RelativePathConfusionScanner to reduce the
log levels, from INFO to DEBUG, of messages logged when an alert is
raised to reduce the number of messages logged by default (those
messages are not really needed, the absence or presence of an alert
already indicates that fact).
For LDAPInjection remove its log messages from Messages.properties file
as they do not need to be internationalised.
Update changes in ZapAddOn.xml file.
 ---
From @zapbot scans.