### PR TITLE
domxss: skip the scanner if fails to get a browser

### DIFF
--- a/src/org/zaproxy/zap/extension/domxss/TestDomXSS.java
+++ b/src/org/zaproxy/zap/extension/domxss/TestDomXSS.java
@@ -508,7 +508,16 @@ public class TestDomXSS extends AbstractAppPlugin {
 		
 		ArrayList<WebDriverWrapper> drivers = new ArrayList<WebDriverWrapper>();
 		
-		WebDriverWrapper fxDriver = this.getFirefoxDriver();
+		WebDriverWrapper fxDriver;
+		try {
+			fxDriver = this.getFirefoxDriver();
+		} catch (WebDriverException e) {
+			getLog().warn("Skipping scanner, failed to start Firefox: " + e.getMessage());
+			// TODO add the reason why the scanner was skipped when targeting ZAP 2.6.0
+			getParent().pluginSkipped(this);
+			return;
+		}
+
 		drivers.add(fxDriver);
 
 		try	{

--- a/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>DOM XSS Active scanner rule</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>DOM XSS Active scanner rule</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Change (duplicated) scanner ID, now it's 40026.<br>
+	Skip the scanner if not able to start Firefox.<br>
 	]]>
     </changes>
 	<dependencies>


### PR DESCRIPTION
Change TestDomXSS to skip the scanner if fails to get a browser (e.g.
because of unsupported versions between Selenium and Firefox), otherwise
it would keep trying to scan other pages (and continue failing).
Bump version and update changes in the ZapAddOn.xml file.
 ---
From @zapbot scans.