### PR TITLE
bruteforce: do not use singleton pattern

### DIFF
--- a/src/com/sittinglittleduck/DirBuster/GenBaseCase.java
+++ b/src/com/sittinglittleduck/DirBuster/GenBaseCase.java
@@ -40,18 +40,19 @@ public class GenBaseCase
 {
 
     /** Creates a new instance of GenBaseCase */
-    public GenBaseCase()
+    private GenBaseCase()
     {
     }
 
     /**
      * Generates the base case
+     * @param manager the manager class
      * @param url The directy or file we need a base case for
      * @param isDir true if it's dir, else false if it's a file
      * @param fileExtention File extention to be scanned, set to null if it's a dir that is to be tested
      * @return A BaseCase Object
      */
-    public static BaseCase genBaseCase(String url, boolean isDir, String fileExtention) throws MalformedURLException, IOException
+    public static BaseCase genBaseCase(Manager manager, String url, boolean isDir, String fileExtention) throws MalformedURLException, IOException
     {
         String type;
         if(isDir)
@@ -68,9 +69,6 @@ public class GenBaseCase
          */
         boolean useRegexInstead = false;
         String regex = null;
-
-        //get the manager instance
-        Manager manager = Manager.getInstance();
 
         BaseCase tempBaseCase = manager.getBaseCase(url, isDir, fileExtention);
 
@@ -178,8 +176,8 @@ public class GenBaseCase
              * get the base case twice more, for consisitency checking
              */
             String baseResponce1 = baseResponce;
-            String baseResponce2 = getBaseCaseAgain(failurl, failString);
-            String baseResponce3 = getBaseCaseAgain(failurl, failString);
+            String baseResponce2 = getBaseCaseAgain(manager, failurl, failString);
+            String baseResponce3 = getBaseCaseAgain(manager, failurl, failString);
 
 
             if(baseResponce1 != null && baseResponce2 != null && baseResponce3 != null)
@@ -252,9 +250,8 @@ public class GenBaseCase
     /*
      * Used to generate a basecase when we are URL fuzzing
      */
-    public static BaseCase genURLFuzzBaseCase(String fuzzStart, String FuzzEnd) throws MalformedURLException, IOException
+    public static BaseCase genURLFuzzBaseCase(Manager manager, String fuzzStart, String FuzzEnd) throws MalformedURLException, IOException
     {
-        Manager manager = Manager.getInstance();
         BaseCase baseCase = null;
         int failcode = 0;
         String failString = Config.failCaseString;
@@ -333,10 +330,9 @@ public class GenBaseCase
     /*
      * this function is used to get base case again, so we can check that the base case is consitent.
      */
-    private static String getBaseCaseAgain(URL failurl, String failString) throws IOException
+    private static String getBaseCaseAgain(Manager manager, URL failurl, String failString) throws IOException
     {
         int failcode;
-        Manager manager = Manager.getInstance();
         String baseResponce = "";
 
         GetMethod httpget = new GetMethod(failurl.toString());

--- a/src/com/sittinglittleduck/DirBuster/HTMLparse.java
+++ b/src/com/sittinglittleduck/DirBuster/HTMLparse.java
@@ -39,15 +39,15 @@ public class HTMLparse extends Thread
 
     private String sourceAsString = null;
     private WorkUnit work = null;
-    private Manager manager;
+    private final Manager manager;
     boolean working;
     private boolean continueWorking = true;
 
     /** Creates a new instance of HTMLparse */
-    public HTMLparse()
+    public HTMLparse(Manager manager)
     {
         super("DirBuster-HTMLparse");
-        manager = Manager.getInstance();
+        this.manager = manager;
     }
 
     public void stopWorking()
@@ -98,8 +98,6 @@ public class HTMLparse extends Thread
                     Vector links = new Vector(50, 10);
                     Vector imageLinks = new Vector(50, 10);
                     Vector foundItems = new Vector(20, 10);
-
-                    manager = Manager.getInstance();
 
                     //create the source
                     Source source = new Source(sourceAsString);
@@ -297,7 +295,7 @@ public class HTMLparse extends Thread
             if(item.length() == 1)
             {
                 //System.out.println("found a / in findBaseCasePoint");
-                return GenBaseCase.genBaseCase(manager.getFirstPartOfURL() + "/", true, null);
+                return GenBaseCase.genBaseCase(manager, manager.getFirstPartOfURL() + "/", true, null);
             }
             String[] array = item.split("/");
 
@@ -331,7 +329,7 @@ public class HTMLparse extends Thread
 
             Thread.sleep(100);
 
-            return GenBaseCase.genBaseCase(manager.getFirstPartOfURL() + baseItem, isDir, fileExtention);
+            return GenBaseCase.genBaseCase(manager, manager.getFirstPartOfURL() + baseItem, isDir, fileExtention);
         }
         catch(MalformedURLException ex)
         {

--- a/src/com/sittinglittleduck/DirBuster/Manager.java
+++ b/src/com/sittinglittleduck/DirBuster/Manager.java
@@ -99,8 +99,6 @@ public class Manager implements ProcessChecker.ProcessUpdate
     //variable for httpclient
     private HttpClient httpclient;
     private HttpState initialState;
-    //singleton instance of the object
-    private static Manager manager = null;
     private Vector producedBasesCases = new Vector(10, 10);
     //used to store all the links that have parsed, will not contain a list a all items, processed
     //as this will consume to much memory.  There for there is a chance of some duplication.
@@ -215,19 +213,6 @@ public class Manager implements ProcessChecker.ProcessUpdate
          * create the httpclient
          */
         createHttpClient();
-
-        // ZAP: Set up manager
-        manager = this;
-    }
-
-    public static Manager getInstance()
-    {
-        if(manager == null)
-        {
-            manager = new Manager();
-        }
-
-        return manager;
     }
 
     //set up dictionay based attack with normal start
@@ -277,7 +262,7 @@ public class Manager implements ProcessChecker.ProcessUpdate
 
         setpUpHttpClient();
         createTheThreads();
-        workGen = new WorkerGenerator();
+        workGen = new WorkerGenerator(this);
 
 
     }
@@ -340,7 +325,7 @@ public class Manager implements ProcessChecker.ProcessUpdate
 
         setpUpHttpClient();
         createTheThreads();
-        workGenBrute = new BruteForceWorkGenerator();
+        workGenBrute = new BruteForceWorkGenerator(this);
 
     }
 
@@ -371,7 +356,7 @@ public class Manager implements ProcessChecker.ProcessUpdate
 
         setpUpHttpClient();
         createTheThreads();
-        workGenFuzz = new WorkerGeneratorURLFuzz();
+        workGenFuzz = new WorkerGeneratorURLFuzz(this);
     }
 
     /*
@@ -417,7 +402,7 @@ public class Manager implements ProcessChecker.ProcessUpdate
 
         setpUpHttpClient();
         createTheThreads();
-        workGenBruteFuzz = new BruteForceURLFuzz();
+        workGenBruteFuzz = new BruteForceURLFuzz(this);
     }
 
     private void createHttpClient()
@@ -498,7 +483,7 @@ public class Manager implements ProcessChecker.ProcessUpdate
 
         for(int i = 0; i < workerCount; i++)
         {
-            workers.addElement(new Worker(i));
+            workers.addElement(new Worker(i, this));
         //workers[i] = new Worker(this, i);
         //tpes.execute(workers[i]);
         }
@@ -506,7 +491,7 @@ public class Manager implements ProcessChecker.ProcessUpdate
         //create the htmlparse threads
         for(int i = 0; i < workerCount; i++)
         {
-            parseWorkers.addElement(new HTMLparse());
+            parseWorkers.addElement(new HTMLparse(this));
         }
         //work queue
         workQueue = new ArrayBlockingQueue<WorkUnit>(workerCount * 3);
@@ -545,10 +530,10 @@ public class Manager implements ProcessChecker.ProcessUpdate
             processedLinks.clear();
 
 
-            task = new ProcessChecker();
+            task = new ProcessChecker(this);
             timer.scheduleAtFixedRate(task, 1000L, 1000L);
 
-            task2 = new ProcessEnd();
+            task2 = new ProcessEnd(this);
             timer.scheduleAtFixedRate(task2, 30000L, 30000L);
 
             //start the pure brute force thread
@@ -968,7 +953,7 @@ public class Manager implements ProcessChecker.ProcessUpdate
         for(int i = 0; i < number; i++)
         {
             int threadid = currentNumber + i;
-            workers.addElement(new Worker(threadid));
+            workers.addElement(new Worker(threadid, this));
 
             new Thread((Worker) workers.elementAt(threadid)).start();
         }

--- a/src/com/sittinglittleduck/DirBuster/ProcessChecker.java
+++ b/src/com/sittinglittleduck/DirBuster/ProcessChecker.java
@@ -25,7 +25,7 @@ import java.util.Vector;
 public class ProcessChecker extends TimerTask
 {
 
-    Manager manager;
+    private final Manager manager;
     private long timeStarted;
     private long lastTotal = 0L;
     private Vector lastTen = new Vector(10, 1);
@@ -39,9 +39,9 @@ public class ProcessChecker extends TimerTask
         void isAlive();
     }
 
-    public ProcessChecker()
+    public ProcessChecker(Manager manager)
     {
-        this.manager = Manager.getInstance();
+        this.manager = manager;
         timeStarted = System.currentTimeMillis();
 
     }

--- a/src/com/sittinglittleduck/DirBuster/ProcessEnd.java
+++ b/src/com/sittinglittleduck/DirBuster/ProcessEnd.java
@@ -25,7 +25,7 @@ import java.util.Vector;
 public class ProcessEnd extends TimerTask
 {
 
-    Manager manager;
+    private final Manager manager;
 
     /** Creates a new instance of ProcessChecker */
     public interface ProcessUpdate
@@ -34,9 +34,9 @@ public class ProcessEnd extends TimerTask
         void isAlive();
     }
 
-    public ProcessEnd()
+    public ProcessEnd(Manager manager)
     {
-        this.manager = Manager.getInstance();
+        this.manager = manager;
 
     }
 

--- a/src/com/sittinglittleduck/DirBuster/ReportWriter.java
+++ b/src/com/sittinglittleduck/DirBuster/ReportWriter.java
@@ -30,13 +30,13 @@ import java.util.logging.Logger;
 public class ReportWriter
 {
 
-    private String fileToWriteTo;
-    private Manager manager;
+    private final String fileToWriteTo;
+    private final Manager manager;
 
-    public ReportWriter(String fileToWriteTo)
+    public ReportWriter(Manager manager, String fileToWriteTo)
     {
         this.fileToWriteTo = fileToWriteTo;
-        manager = Manager.getInstance();
+        this.manager = manager;
     }
 
     /*

--- a/src/com/sittinglittleduck/DirBuster/Worker.java
+++ b/src/com/sittinglittleduck/DirBuster/Worker.java
@@ -49,7 +49,7 @@ public class Worker implements Runnable
     private BlockingQueue<WorkUnit> queue;
     private URL url;
     private WorkUnit work;
-    private Manager manager;
+    private final Manager manager;
     private HttpClient httpclient;
     private boolean pleaseWait = false;
     private int threadId;
@@ -61,10 +61,9 @@ public class Worker implements Runnable
      * @param threadId Unique thread id for the worker
      * @param manager The manager class the worker thread reports to
      */
-    public Worker(int threadId)
+    public Worker(int threadId, Manager manager)
     {
-        //get the manager instance
-        manager = Manager.getInstance();
+        this.manager = manager;
 
         //get the work queue from, the manager
         queue = manager.workQueue;

--- a/src/com/sittinglittleduck/DirBuster/headless/CatchExit.java
+++ b/src/com/sittinglittleduck/DirBuster/headless/CatchExit.java
@@ -29,13 +29,17 @@ import com.sittinglittleduck.DirBuster.ReportWriter;
  */
 public class CatchExit implements Runnable
 {
+    private final Manager manager;
+    
+    public CatchExit(Manager manager) {
+        this.manager = manager;
+    }
 
     public void run()
     {
-        Manager manager = Manager.getInstance();
         //String reportLocation = System.getProperty("user.dir") + File.separatorChar + "DirBuster-Report-" + manager.getHost() + "-" + manager.getPort() +".txt";
         String reportLocation = manager.getReportLocation();
-        ReportWriter report = new ReportWriter(reportLocation);
+        ReportWriter report = new ReportWriter(manager, reportLocation);
         System.out.println("");
         System.out.println("Caught exit of DirBuster");
         System.out.println("Writing report");

--- a/src/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/src/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -49,7 +49,7 @@ public class BruteForceURLFuzz implements Runnable
     private int[] listindex;
     private int minLen;
     private int maxLen;
-    private Manager manager;
+    private final Manager manager;
     private BlockingQueue<WorkUnit> workQueue;
     private BlockingQueue<DirToCheck> dirQueue;
     private String firstPart;
@@ -64,9 +64,9 @@ public class BruteForceURLFuzz implements Runnable
     private String urlFuzzEnd;
 
     /** Creates a new instance of BruteForceWorkGenerator */
-    public BruteForceURLFuzz()
+    public BruteForceURLFuzz(Manager manager)
     {
-        manager = Manager.getInstance();
+        this.manager = manager;
 
         this.maxLen = manager.getMaxLen();
         this.minLen = manager.getMinLen();
@@ -155,7 +155,7 @@ public class BruteForceURLFuzz implements Runnable
         {
             //get fail responce code for a dir test
 
-            baseCaseObj = GenBaseCase.genURLFuzzBaseCase(firstPart + urlFuzzStart, urlFuzzEnd);
+            baseCaseObj = GenBaseCase.genURLFuzzBaseCase(manager, firstPart + urlFuzzStart, urlFuzzEnd);
 
         }
         catch (MalformedURLException e)

--- a/src/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/src/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -49,7 +49,7 @@ public class BruteForceWorkGenerator implements Runnable
     private int maxLen;
     
     
-    private Manager manager;
+    private final Manager manager;
     private BlockingQueue<WorkUnit> workQueue;
     private BlockingQueue<DirToCheck> dirQueue;
     
@@ -72,9 +72,9 @@ public class BruteForceWorkGenerator implements Runnable
     HttpClient httpclient;
     
     /** Creates a new instance of BruteForceWorkGenerator */
-    public BruteForceWorkGenerator()
+    public BruteForceWorkGenerator(Manager manager)
     {
-        manager = Manager.getInstance();
+        this.manager = manager;
         
         this.maxLen = manager.getMaxLen();
         this.minLen = manager.getMinLen();
@@ -164,7 +164,7 @@ public class BruteForceWorkGenerator implements Runnable
                 {
                     //get fail responce code for a dir test
                     
-                    baseCaseObj = GenBaseCase.genBaseCase(firstPart + currentDir, true, null);
+                    baseCaseObj = GenBaseCase.genBaseCase(manager, firstPart + currentDir, true, null);
                     
                 }
                 catch(MalformedURLException e)
@@ -217,7 +217,7 @@ public class BruteForceWorkGenerator implements Runnable
                         {
                             //deal with the files
                             
-                            baseCaseObj = GenBaseCase.genBaseCase(firstPart + currentDir, false, fileExtention);
+                            baseCaseObj = GenBaseCase.genBaseCase(manager, firstPart + currentDir, false, fileExtention);
                             
                         }
                         catch(MalformedURLException e)

--- a/src/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
+++ b/src/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
@@ -49,7 +49,7 @@ import com.sittinglittleduck.DirBuster.WorkUnit;
 public class WorkerGenerator implements Runnable
 {
 
-    private Manager manager;
+    private final Manager manager;
     private BlockingQueue<WorkUnit> workQueue;
     private BlockingQueue<DirToCheck> dirQueue;
     private String inputFile;
@@ -65,9 +65,9 @@ public class WorkerGenerator implements Runnable
      * Creates a new instance of WorkerGenerator
      * @param manager Manager object
      */
-    public WorkerGenerator()
+    public WorkerGenerator(Manager manager)
     {
-        manager = Manager.getInstance();
+        this.manager = manager;
         workQueue = manager.workQueue;
         dirQueue = manager.dirQueue;
         if(manager.isBlankExt())
@@ -227,7 +227,7 @@ public class WorkerGenerator implements Runnable
                 {
                     baseResponce = null;
 
-                    baseCaseObj = GenBaseCase.genBaseCase(firstPart + currentDir, true, null);
+                    baseCaseObj = GenBaseCase.genBaseCase(manager, firstPart + currentDir, true, null);
                 }
                 catch(MalformedURLException e)
                 {
@@ -391,7 +391,7 @@ public class WorkerGenerator implements Runnable
                         try
                         {
                             //get the base for this extention
-                            baseCaseObj = GenBaseCase.genBaseCase(firstPart + currentDir, false, fileExtention);
+                            baseCaseObj = GenBaseCase.genBaseCase(manager, firstPart + currentDir, false, fileExtention);
                         }
                         catch(MalformedURLException e)
                         {

--- a/src/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/src/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -52,7 +52,7 @@ import com.sittinglittleduck.DirBuster.WorkUnit;
 public class WorkerGeneratorURLFuzz implements Runnable
 {
 
-    private Manager manager;
+    private final Manager manager;
     private BlockingQueue<WorkUnit> workQueue;
     private BlockingQueue<DirToCheck> dirQueue;
     private String inputFile;
@@ -76,9 +76,9 @@ public class WorkerGeneratorURLFuzz implements Runnable
      * Creates a new instance of WorkerGenerator
      * @param manager Manager object
      */
-    public WorkerGeneratorURLFuzz()
+    public WorkerGeneratorURLFuzz(Manager manager)
     {
-        manager = Manager.getInstance();
+        this.manager = manager;
         workQueue = manager.workQueue;
         dirQueue = manager.dirQueue;
         if (manager.isBlankExt())
@@ -185,7 +185,7 @@ public class WorkerGeneratorURLFuzz implements Runnable
             System.out.println("Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
             int filesProcessed = 0;
 
-            BaseCase baseCaseObj = GenBaseCase.genURLFuzzBaseCase(firstPart + urlFuzzStart, urlFuzzEnd);
+            BaseCase baseCaseObj = GenBaseCase.genURLFuzzBaseCase(manager, firstPart + urlFuzzStart, urlFuzzEnd);
 
             
             while ((line = d.readLine()) != null)

--- a/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Allow to set higher number of threads (Issue 2912).<br>
+	Fix issue with multiple concurrent scans.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change DirBuster code to not use the singleton pattern for the Manager
class as ZAP allows to run multiple scans at the same time, which would
lead to inconsistent results (e.g. results of one scan being used/shown
in another).
Update changes in ZapAddOn.xml file.