### PR TITLE
fuzz: correct method name in HTTP template

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
     <name>AdvFuzzer</name>
-    <version>7</version>
+    <version>8</version>
     <semver>2.0.1</semver>
     <status>beta</status>
     <description>Advanced fuzzer for manual testing</description>
@@ -8,8 +8,7 @@
     <url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</url>
     <changes>
     <![CDATA[
-    Fix exception during the unload of the add-on, when in daemon mode.<br>
-    Update Content-Length for all request methods, not just POST (Issue 2766).<br>
+    Correct method name in HTTP processor JavaScript template.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/httpfuzzerprocessor/Fuzzer HTTP Processor default template.js
+++ b/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/httpfuzzerprocessor/Fuzzer HTTP Processor default template.js
@@ -32,7 +32,7 @@ function processResult(utils, fuzzResult){
 	// To raise an alert:
 	//    utils.raiseAlert(risk, confidence, name, description)
 	// To obtain the fuzzed message, received from the server:
-	//    fuzzResult.getMessage()
+	//    fuzzResult.getHttpMessage()
 
 	var condition = true;
 	if (condition)


### PR DESCRIPTION
Correct a method name in "Fuzzer HTTP Processor default template.js",
which should be getHttpMessage() not getMessage().
Bump version and update changes in ZapAddOn.xml file.