### PR TITLE
ascanrulesAlpha: improve error handling

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
@@ -17,12 +17,15 @@
  */
 package org.zaproxy.zap.extension.ascanrulesAlpha;
 
+import java.net.UnknownHostException;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -421,6 +424,10 @@ public class LDAPInjection extends AbstractAppParamPlugin {
                 //by using the "*" LDAP expression, to eek out more data from the LDAP directory into the response.
                 //but that's a task for another day.
 
+        } catch (InvalidRedirectLocationException | UnknownHostException | URIException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+            }
         } catch (Exception e) {
             //Do not try to internationalise this.. we need an error message in any event.. 
             //if it's in English, it's still better than not having it at all. 

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
@@ -17,9 +17,12 @@
  */
 package org.zaproxy.zap.extension.ascanrulesAlpha;
 
+import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -585,6 +588,10 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
 			}	//end of doUnionBased
 			
 
+		} catch (InvalidRedirectLocationException | UnknownHostException | URIException e) {
+			if (log.isDebugEnabled()) {
+				log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+			}
 		} catch (Exception e) {
 			//Do not try to internationalise this.. we need an error message in any event.. 
 			//if it's in English, it's still better than not having it at all. 

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
@@ -17,6 +17,7 @@
  */
 package org.zaproxy.zap.extension.ascanrulesAlpha;
 
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
@@ -27,6 +28,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 
 /**
  *  @author kniepdennis@gmail.com
@@ -155,6 +157,10 @@ public class TestUserAgent extends AbstractAppPlugin {
             header.setHeader(HttpHeader.USER_AGENT, userAgent);
             sendAndReceive(newMsg);
             return newMsg;
+        } catch (UnknownHostException | URIException e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to send HTTP message, cause: " + e.getMessage());
+            }
         } catch (IOException e) {
             log.warn(e.getMessage(), e);
         }

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules (alpha)</name>
-	<version>18</version>
+	<version>19</version>
 	<status>alpha</status>
 	<description>The alpha quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>
 	<changes>
 	<![CDATA[
-	Added Apache Range Header DoS (CVE-2011-3192) scanner.<br>
-	Fix exception when raising a "Source Code Disclosure - File Inclusion" alert.<br>
-	Adjust log levels of some scanners, from INFO to DEBUG.<br>
+	Improve error handling in some scanners.<br>
   	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change scanners LDAPInjection, SQLInjectionSQLite and TestUserAgent
to catch URIException (URI is not correct, non HTTP/S scheme or invalid
encoding), UnknownHostException (if the target host is not known) and
InvalidRedirectLocationException (if redirection is not valid) when
sending messages.
Bump version and update changes in ZapAddOn.xml file.

---
From @zapbot scans.