### PR TITLE
ascanrulesAlpha: add missing override annotations

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
@@ -65,12 +65,14 @@ public class ExampleFileActiveScanner extends AbstractAppParamPlugin {
 		return Constant.messages.getString(MESSAGE_PREFIX + "name");
 	}
 	
+	@Override
 	public boolean targets(TechSet technologies) { // This method allows the programmer or user to restrict when a 
 		//scanner is run based on the technologies selected.  For example, to restrict the scanner to run just when 
 		//C language is selected 
 		return technologies.includes(Tech.C); 
 	}
 		
+	@Override
 	public String getDescription() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
 	}
@@ -79,10 +81,12 @@ public class ExampleFileActiveScanner extends AbstractAppParamPlugin {
 		return Constant.messages.getString(MESSAGE_PREFIX + "other");
 	}
 
+	@Override
 	public String getSolution() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
 	}
 
+	@Override
 	public String getReference() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
 	}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
@@ -179,6 +179,7 @@ public class LDAPInjection extends AbstractAppParamPlugin {
 	        }
     }
 
+    @Override
     public void scan(HttpMessage msg, NameValuePair originalParam) {
     	/*
     	 * Scan everything _except_ URL path parameters.
@@ -194,6 +195,7 @@ public class LDAPInjection extends AbstractAppParamPlugin {
      * scans the user specified parameter for LDAP injection
      * vulnerabilities. Requires one extra request for each parameter checked
      */
+	@Override
 	public void scan(HttpMessage originalmsg, String paramname, String paramvalue) {
 		
 		//for the purposes of our logic, we can handle a NULL parameter as an empty string. Saves on NPEs.

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
@@ -191,6 +191,7 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
 	 * scans for Proxy Disclosure issues, using the TRACE and OPTIONS method with 'Max-Forwards', and the TRACK method.
 	 * The code attempts to enumerate and identify all proxies identified between the Zap instance and the origin web server.
 	 */
+	@Override
 	public void scan() {
 		try {
 			//where's what we're going to do (roughly):

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
@@ -190,6 +190,7 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 	/**
 	 * scan everything except URL path parameters, if these were enabled
 	 */
+	@Override
 	public void scan(HttpMessage msg, NameValuePair originalParam) {
 		/*
 		 * Scan everything _except_ URL path parameters, if these were enabled.


### PR DESCRIPTION
Add missing override annotations in some scanners.