### PR TITLE
fuzz: use JSDoc in JavaScript templates

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/httpfuzzerprocessor/Fuzzer HTTP Processor default template.js
+++ b/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/httpfuzzerprocessor/Fuzzer HTTP Processor default template.js
@@ -1,7 +1,14 @@
 // Auxiliary variables/constants needed for processing.
 var count = 1;
 
-// Called after injecting the payloads and before forward the message to the server.
+/**
+ * Processes the fuzzed message (payloads already injected).
+ * 
+ * Called before forwarding the message to the server.
+ * 
+ * @param {HttpFuzzerTaskProcessorUtils} utils - A utility object that contains functions that ease common tasks.
+ * @param {HttpMessage} message - The fuzzed message, that will be forward to the server.
+ */
 function processMessage(utils, message) {
 	// To obtain the list of payloads:
 	//    utils.getPayloads()
@@ -26,7 +33,15 @@ function processMessage(utils, message) {
 	count++;
 }
 
-// Called after receiving the fuzzed message from the server
+/**
+ * Processes the fuzz result.
+ * 
+ * Called after receiving the fuzzed message from the server.
+ * 
+ * @param {HttpFuzzerTaskProcessorUtils} utils - A utility object that contains functions that ease common tasks.
+ * @param {HttpFuzzResult} fuzzResult - The result of sending the fuzzed message.
+ * @return {boolean} Whether the result should be accepted, or discarded and not shown.
+ */
 function processResult(utils, fuzzResult){
 	// All the above 'utils' functions are available plus:
 	// To raise an alert:
@@ -38,6 +53,5 @@ function processResult(utils, fuzzResult){
 	if (condition)
 		fuzzResult.addCustomState("Key Custom State", "Message Contains X")
 	
-	// Returns true to accept the result, false to discard and not show it
 	return true;
 }

--- a/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/payloadgenerator/Payload Generator default template.js
+++ b/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/payloadgenerator/Payload Generator default template.js
@@ -3,35 +3,55 @@ var NUMBER_OF_PAYLOADS = 10;
 var INITIAL_VALUE = 1;
 var count = INITIAL_VALUE;
 
-// The number of generated payloads, zero to indicate unknown number.
-// The number is used as a hint for progress calculations.
+/**
+ * Returns the number of generated payloads, zero to indicate unknown number.
+ * The number is used as a hint for progress calculations.
+ * 
+ * @return {number} The number of generated payloads.
+ */
 function getNumberOfPayloads() {
 	return NUMBER_OF_PAYLOADS;
 }
 
-// Returns true if there are still payloads to generate, false otherwise.
-// Called before each call to next().
+/**
+ * Returns true if there are still payloads to generate, false otherwise.
+ * 
+ * Called before each call to next().
+ * 
+ * @return {boolean} If there are still payloads to generate.
+ */
 function hasNext() {
 	return (count <= NUMBER_OF_PAYLOADS);
 }
 
-// Returns the next generated payload.
-// This method is called while hasNext() returns true.
+/**
+ * Returns the next generated payload.
+ * 
+ * This method is called while hasNext() returns true.
+ * 
+ * @return {string} The next generated payload.
+ */
 function next() {
 	payload = count;
 	count++;
 	return payload;
 }
 
-// Resets the internal state of the payload generator, as if no calls to
-// hasNext() or next() have been previously made.
-// Normally called once the method hasNext() returns false and while payloads
-// are still needed.
+/**
+ * Resets the internal state of the payload generator, as if no calls to
+ * hasNext() or next() have been previously made.
+ * 
+ * Normally called once the method hasNext() returns false and while payloads
+ * are still needed.
+ */
 function reset() {
 	count = INITIAL_VALUE;
 }
 
-// Releases any resources used for generation of payloads (for example, a file).
-// Called once the payload generator is no longer needed.
+/**
+ * Releases any resources used for generation of payloads (for example, a file).
+ * 
+ * Called once the payload generator is no longer needed.
+ */
 function close() {
 }

--- a/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/payloadprocessor/Payload Processor default template.js
+++ b/src/org/zaproxy/zap/extension/fuzz/files/scripts/templates/payloadprocessor/Payload Processor default template.js
@@ -1,8 +1,14 @@
 // Auxiliary variables/constants for processing.
 var id = 0;
 
-// Called for each payload that needs to be processed.
-// The type of variable 'payload' is string.
+/**
+ * Processes the payload.
+ * 
+ * Called for each payload that needs to be processed.
+ * 
+ * @param {string} payload - The payload before being injected into the message.
+ * @return {string} The payload processed.
+ */
 function process(payload) {
 	// Do some processing to payload
 	payload = payload + '-' + id;


### PR DESCRIPTION
Convert the plain comments into JSDoc comments in the script templates.