### PR TITLE
tlsdebug: add task to generate the wiki

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -643,6 +643,10 @@
 	<target name="deploy-tlsDebug" description="deploy the tlsDebug extension">
 		<build-deploy-addon name="tlsdebug" />
 	</target>
+
+	<target name="generate-wiki-tlsdebug" description="Generates the wiki of TLS Debug">
+		<generate-wiki addon="tlsdebug" />
+	</target>
 	
 	<target name="deploy-viewstate" description="deploy the viewstate extension">
 		<build-deploy-addon name="viewstate" />


### PR DESCRIPTION
Add a new Ant task to build.xml to generate the wiki of the add-on.