### PR TITLE
scripts: mention HTTP Sender script in help page

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Remove unused resource messages (Issue 2386).<br>
+	Update help page to mention HTTP Sender scripts.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
@@ -27,6 +27,7 @@ Different types of scripts are supported:
 <li>Active Rules - these run as part of the Active Scanner and can be individually enabled</li>
 <li>Passive Rules - these run as part of the Passive Scanner and can be individually enabled</li> 
 <li>Proxy Rules - these run 'inline', can change every request and response and can be individually enabled. They can also trigger break points</li> 
+<li>HTTP Sender - scripts that run against every request/response sent/received by ZAP. This includes the proxied messages, messages sent during active scanner, fuzzer, ...</li>
 <li>Targeted Rules - scripts that invoked with a target URL and are only run when your start them manually</li>
 <li>Authentication - scripts that invoked when authentication is performed for a Context. To be used, they need to
 be selected when configuring the Script-Based Authentication Method for a Context. </li> 


### PR DESCRIPTION
Change scripts.html help page to also mention the HTTP Sender scripts.
Update changes in ZapAddOn.xml file.