### PR TITLE
Support to add the python module path interface to jython extension

### DIFF
--- a/src/org/zaproxy/zap/extension/jython/JythonOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/jython/JythonOptionsPanel.java
@@ -1,0 +1,115 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jython;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
+
+import javax.swing.GroupLayout;
+import javax.swing.JButton;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+
+import org.python.google.common.base.Strings;
+
+public class JythonOptionsPanel extends AbstractParamPanel {
+
+	private static final long serialVersionUID = -2690686914494943483L;
+
+	private JTextField modulesPathTextField;
+	private JButton pathChooseButton;
+
+	public JythonOptionsPanel() {
+		super();
+		this.initComponents();
+	}
+	
+	private void initComponents() {
+		super.setName(Constant.messages.getString("jython.options.title"));
+
+		JLabel modulesPathLabel = new JLabel(Constant.messages.getString("jython.options.label.modulepath"));
+		this.modulesPathTextField = new JTextField();
+		this.pathChooseButton = new JButton(Constant.messages.getString("jython.options.label.choose"));
+
+		GroupLayout layout = new GroupLayout(this);
+		super.setLayout(layout);
+		layout.setAutoCreateGaps(true);
+		layout.setAutoCreateContainerGaps(true);
+		layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+				.addGroup(layout.createSequentialGroup().addComponent(modulesPathLabel)
+						.addComponent(this.modulesPathTextField).addComponent(this.pathChooseButton)));
+		layout.setVerticalGroup(layout.createSequentialGroup()
+				.addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE).addComponent(modulesPathLabel)
+						.addComponent(this.modulesPathTextField).addComponent(this.pathChooseButton)));
+		
+		this.pathChooseButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				JFileChooser chooser = new JFileChooser( JythonOptionsPanel.this.modulesPathTextField.getText() );
+				chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+				chooser.setAcceptAllFileFilterUsed(false);
+				if (JFileChooser.APPROVE_OPTION == chooser.showOpenDialog(JythonOptionsPanel.this)) {
+					JythonOptionsPanel.this.modulesPathTextField.setText(chooser.getSelectedFile().getPath());
+				}
+			}
+		});
+	}
+
+	@Override
+	public String getHelpIndex() {
+		return null;
+	}
+
+	@Override
+	public void initParam(Object object) {
+		JythonOptionsParam jythonOptionsParam = ((OptionsParam) object).getParamSet(JythonOptionsParam.class);
+		this.modulesPathTextField.setText(Strings.nullToEmpty(jythonOptionsParam.getModulePath()));
+	}
+
+	@Override
+	public void saveParam(Object object) throws Exception {
+		JythonOptionsParam jythonOptionsParam = ((OptionsParam) object).getParamSet(JythonOptionsParam.class);
+		jythonOptionsParam.setModulePath(Strings.nullToEmpty(this.modulesPathTextField.getText()));
+	}
+
+	@Override
+	public void validateParam(Object object) throws Exception {
+		String modulesPathString = this.modulesPathTextField.getText();
+		if (!Strings.isNullOrEmpty(modulesPathString)) {
+			File modulesPath = new File(modulesPathString);
+			if (!modulesPath.exists()) {
+				throw new NoSuchFileException(
+						Constant.messages.getString("jython.options.error.modulepath.notexist", modulesPath));
+			}
+			if (!modulesPath.isDirectory()) {
+				throw new NotDirectoryException(
+						Constant.messages.getString("jython.options.error.modulepath.notdirectory", modulesPath));
+			}
+		}
+	}
+}

--- a/src/org/zaproxy/zap/extension/jython/JythonOptionsParam.java
+++ b/src/org/zaproxy/zap/extension/jython/JythonOptionsParam.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jython;
+
+import org.apache.commons.configuration.ConversionException;
+import org.apache.log4j.Logger;
+import org.zaproxy.zap.common.VersionedAbstractParam;
+
+public class JythonOptionsParam extends VersionedAbstractParam {
+
+	private static final Logger logger = Logger.getLogger(JythonOptionsParam.class);
+	
+	/**
+	 * The version of the configurations. Used to keep track of configurations changes between releases, if updates are needed.
+	 * <p>
+	 * It only needs to be updated for configurations changes (not releases of the add-on).
+	 * </p>
+	 */
+	private static final int CURRENT_VERSION = 1;
+	
+	/**
+	 * The base configuration key for all "jython" configurations.
+	 */
+	private static final String BASE_KEY = "jython";
+	
+	public static final String MODULE_PATH_PROPERTY = BASE_KEY + ".modulepath";
+	
+	/**
+	 * The path to python modules
+	 */
+	private String modulePath;
+
+	public String getModulePath() {
+		return this.modulePath;
+	}
+
+	public void setModulePath(String modulePath) {
+		this.modulePath = modulePath;
+		super.getConfig().setProperty(MODULE_PATH_PROPERTY, modulePath);
+	}
+
+	@Override
+	protected void parseImpl() {
+		try {
+			this.modulePath = super.getConfig().getString(MODULE_PATH_PROPERTY, "");
+		} catch (ConversionException e) {
+			logger.error("Error while loading '" + MODULE_PATH_PROPERTY + "':", e);
+		}
+	}
+
+	@Override
+	protected String getConfigVersionKey() {
+		return BASE_KEY + VERSION_ATTRIBUTE;
+	}
+
+	@Override
+	protected int getCurrentVersion() {
+		return CURRENT_VERSION;
+	}
+
+	@Override
+	protected void updateConfigsImpl(int fileVersion) {
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/jython/Messages.properties
+++ b/src/org/zaproxy/zap/extension/jython/Messages.properties
@@ -3,3 +3,8 @@
 # This file defines the default (English) variants of all of the internationalised messages
 
 jython.desc	= Allows Python to be used for ZAP scripting
+jython.options.title = Jython
+jython.options.label.modulepath = Additional Python modules path:
+jython.options.label.choose = Select...
+jython.options.error.modulepath.notexist = {0} does not exist
+jython.options.error.modulepath.notdirectory = {0} is not a directory

--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -5,7 +5,7 @@
 	<description>Allows Python to be used for ZAP scripting - templates included</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Add HTTP Sender template script.</changes>
+	<changes>add the python module path interface</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jython.ExtensionJython</extension>
 	</extensions>


### PR DESCRIPTION
Support the interface to add the python module path.
The "python.path" system property is treated as a module search path inside Jython.
This implementation adds the "zap.jython.modulepath" ZAP option, and set its value to "python.path" system property.