### PR TITLE
fuzz: fix exception when adding file fuzzers

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
@@ -526,7 +526,7 @@ public class FuzzerPayloadGeneratorUIHandler implements
             List<FuzzerPayloadSource> selectedFuzzers = new ArrayList<>(paths.length);
             for (TreePath selection : paths) {
                 DefaultMutableTreeNode node = ((DefaultMutableTreeNode) selection.getLastPathComponent());
-                if (node.isLeaf()) {
+                if (node.isLeaf() && (node.getUserObject() instanceof FuzzerPayloadSource)) {
                     selectedFuzzers.add((FuzzerPayloadSource) node.getUserObject());
                 }
             }

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -9,6 +9,7 @@
     <changes>
     <![CDATA[
     Correct method name in HTTP processor JavaScript template.<br>
+    Fix exception when adding file fuzzers with selected empty "Custom Fuzzers".<br>
     ]]>
     </changes>
     <extensions>


### PR DESCRIPTION
Change FuzzerPayloadGeneratorUIHandler to check that the tree leaf nodes
being added are of the expected type (the top level nodes might be empty
thus being a leaf and treated as source of file fuzzers, which aren't).
The exception would happen, for example, when adding file fuzzers with
empty "Custom Fuzzers" node selected.
Update changes in ZapAddOn.xml file.