### PR TITLE
exportreport: use correct desc in report (UI)

### DIFF
--- a/src/org/zaproxy/zap/extension/exportreport/export/ExportReport.java
+++ b/src/org/zaproxy/zap/extension/exportreport/export/ExportReport.java
@@ -76,7 +76,7 @@ public class ExportReport {
 
             String xmlPath = "";
             try {
-                xmlPath = ReportExport.generateDUMP(path, fileName, extension.extensionGetTitle(), extension.extensionGetBy(), extension.extensionGetFor(), extension.extensionGetScanDate(), extension.extensionGetScanVer(), extension.extensionGetReportDate(), extension.extensionGetReportVer(), extension.getDescription(), extension.getIncludedAlertSeverity(), extension.getIncludedAlertDetails());
+                xmlPath = ReportExport.generateDUMP(path, fileName, extension.extensionGetTitle(), extension.extensionGetBy(), extension.extensionGetFor(), extension.extensionGetScanDate(), extension.extensionGetScanVer(), extension.extensionGetReportDate(), extension.extensionGetReportVer(), extension.extensionGetDescription(), extension.getIncludedAlertSeverity(), extension.getIncludedAlertDetails());
             } catch (UnsupportedEncodingException e) {
                 logger.error(e.getMessage(), e);
                 view.showWarningDialog(Constant.messages.getString("exportreport.message.error.dump"));


### PR DESCRIPTION
Change ExportReport to call the correct method to obtain the description
set in the dialogue, for the report.