### PR TITLE
exportreport: correct link to Jenkins plugin

### DIFF
--- a/src/org/zaproxy/zap/extension/exportreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/exportreport/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Export Report</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>Report Export module that allows users to customize content and export in a desired format.</description>
 	<author>Goran Sarenkapa - JordanGS</author>
 	<url></url>
-	<changes>Added API call support and minor enhancements and bug fixes.</changes>
+	<changes>Correct link to official ZAP Jenkins plugin in help page.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.exportreport.ExtensionExportReport</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
+++ b/src/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
@@ -15,7 +15,7 @@
             <LI>Created by <A href="https://github.com/JordanGS">JordanGS</A>.</LI>
             <LI>Minimum Supported Version: Weekly Release ZAP_D-2016-09-05</LI>
             <LI>Project on  <A href="https://github.com/JordanGS/workspace">GitHub</A>. You can also find a .zip of the minimum supported release in the zap-download folder.</LI>
-            <LI>Supported and incorporated in the <A href="https://wiki.jenkins-ci.org/display/JENKINS/ZAProxy+Plugin">Official OWASP Zed Attack Proxy Jenkins Plugin</A>.</LI>
+            <LI>Supported and incorporated in the <A href="https://wiki.jenkins-ci.org/display/JENKINS/zap+plugin">Official OWASP Zed Attack Proxy Jenkins Plugin</A>.</LI>
         </UL>
 
         <H2><U>Table of Contents</U></H2>
@@ -148,7 +148,7 @@
             <LI><B>-session</B>: Opens the given session after starting ZAP</LI>
             <LI><B>-cmd</B>: Runs ZAP 'inline', ie without starting the UI or a daemon</LI>
         </UL>
-        See the <A href=" https://github.com/zaproxy/zap-core-help/wiki/HelpCmdline">Wiki</A> for more details on the natively supported command line options.
+        See the <A href="https://github.com/zaproxy/zap-core-help/wiki/HelpCmdline">Wiki</A> for more details on the natively supported command line options.
 
         <H4>Export Report Extension Command Line Options</H4>
         <UL style="list-style: none;">


### PR DESCRIPTION
Correct the link to official Jenkins plugin in the help page, also
remove an unnecessary space from a URL.
Bump version and update changes in ZapAddOn.xml file.