### PR TITLE
exportreport: remove version number from the help

### DIFF
--- a/src/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
+++ b/src/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
@@ -9,7 +9,7 @@
 
     <BODY BGCOLOR="#ffffff">
 
-        <H1><U>Export Report Version 2</U></H1>
+        <H1><U>Export Report</U></H1>
         Report Export module that allows users to customize content and export in a desired format.
         <UL>
             <LI>Created by <A href="https://github.com/JordanGS">JordanGS</A>.</LI>
@@ -41,7 +41,7 @@
             <LI>Scan Version - Placeholder for future</LI>
             <LI>Report Version - Defaults to current version of ZAP tool</LI>
         </UL>
-        <H4>Version 2 UI</H4>
+        <H4>UI</H4>
         <UL style="list-style-type:none">
             <LI>
                 <img src="images/SourceInfo.png" alt="Source Info">
@@ -58,7 +58,7 @@
             <LI>Low</LI>
             <LI>Informational</LI>
         </UL>
-        <H4>Version 2 UI</H4>
+        <H4>UI</H4>
         <UL style="list-style-type:none">
             <LI>
                 <img src="images/AlertSeverity.png" alt="Source Info">
@@ -86,7 +86,7 @@
             <LI>Response Body</LI>
         </UL>
 
-        <H4>Version 2 UI</H4>
+        <H4>UI</H4>
 
         <UL style="list-style-type:none">
             <LI>
@@ -113,7 +113,7 @@
             <LI>Google Documents (.doc <img src="../../images/doc.png" alt="DOC Icon">)</LI>
         </UL>            
 
-        <H4>Version 2 UI</H4>
+        <H4>UI</H4>
         <UL style="list-style-type:none">
             <LI>
                 Show all accepted files


### PR DESCRIPTION
Remove mentions to the (current) version of the add-on from the help
page, to avoid the need to update the help page each time the version is
changed.