### PR TITLE
Blind Command Injection Improvement

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -120,7 +120,7 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
     public static final double WARN_TIME_STDEV = 0.5 * 1000;
     
     // *NIX Blind OS Command constants
-    private static final String  NIX_BLIND_TEST_CMD = "sleep {0}s";
+    private static final String  NIX_BLIND_TEST_CMD = "sleep {0}";
     // Windows Blind OS Command constants
     private static final String  WIN_BLIND_TEST_CMD = "timeout /T {0}";
     // PowerSHell Blind Command constants

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+	Issue 2973: Drop suffix on *Nix Blind Command Injection time based variants to maximize compatibility.
 	Improve error handling in some scanners.<br>
 	]]>
     </changes>


### PR DESCRIPTION
Drop suffix on *Nix Time Based Blind Command Injection variants, to
increase OS coverage/compatibility.

Update ZapAddOn.xml change section to reflect the modification.

Fixes zaproxy/zaproxy#2973