### PR TITLE
quickstart: validate "Attack URL" as a request-uri

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/src/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -26,6 +26,7 @@ import java.text.MessageFormat;
 import javax.swing.SwingUtilities;
 
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -217,6 +218,10 @@ public class AttackThread extends Thread {
 		} catch (UnknownHostException e1) {
 			extension.notifyProgress(Progress.failed,
 					Constant.messages.getString("quickstart.progress.failed.badhost"));
+		} catch (URIException e) {
+			extension.notifyProgress(Progress.failed,
+					MessageFormat.format(
+							Constant.messages.getString("quickstart.progress.failed.reason"), e.getMessage()));
 		} catch (Exception e1) {
         	logger.error(e1.getMessage(), e1);
 			extension.notifyProgress(Progress.failed,

--- a/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -32,6 +32,8 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Vector;
 
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -378,7 +380,9 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
 			URL targetURL;
 			try {
 				targetURL = new URL(url);
-			} catch (MalformedURLException e) {
+				// Validate the actual request-uri of the HTTP message accessed.
+				new URI(url, true);
+			} catch (MalformedURLException | URIException e) {
 				reportError(Constant.messages.getString("quickstart.cmdline.quickurl.error.invalidUrl"));
 				e.printStackTrace();
 				return false;

--- a/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -324,6 +324,8 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 		URL url;
 		try {
 			url = new URL(this.getUrlField().getText());
+			// Validate the actual request-uri of the HTTP message accessed.
+			new URI(this.getUrlField().getText(), true);
 		} catch (Exception e) {
 			extension.getView().showWarningDialog(Constant.messages.getString("quickstart.url.warning.invalid"));
 			this.getUrlField().requestFocusInWindow();

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Validate the provided URL as a request-uri.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change the "Attack URL" validations, in GUI and command line, to also
check that the provided URL is a valid request-uri. Also, do not
consider incorrect URIs as ZAP errors (i.e. do not log an error if the
URI is not valid).
Update changes in ZapAddOn.xml file.