### PR TITLE
zest: add reqs to Sequence scripts when recording

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Always show the expected URL in request statements (Issue 2854).<br>
+	Add HTTP requests to Sequence scripts when recording (Issue 3044).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
+++ b/src/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
@@ -27,8 +27,6 @@ import javax.swing.JTree;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
-import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType;
-import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
@@ -88,10 +86,7 @@ public class ZestRecordOnOffPopupMenu extends ExtensionPopupMenuItem {
             		ScriptNode node = extension.getSelectedZestNode();
             		if (node != null && node.getUserObject() instanceof ZestScriptWrapper) {
             			ZestScriptWrapper script = (ZestScriptWrapper) node.getUserObject();
-	    			    if ((ExtensionScript.TYPE_STANDALONE.equals(script.getType().getName()) || 
-	    			    		ScriptBasedAuthenticationMethodType.SCRIPT_TYPE_AUTH.equals(script.getType().getName())) && 
-	    			    		record != script.isRecording()) {
-	    			    	// Only valid for Standalone and authentication Zest scripts
+	    			    if (script.getType().hasCapability("append") && record != script.isRecording()) {
 	    			    	this.setEnabled(true);
 	    			    	return true;
 	    			    } else {


### PR DESCRIPTION
Change ExtensionZest to also add the requests to Sequence scripts,
moreover add the requests to any script that has the "append"
capability, that is, the ones that can be recorded.
Change ZestRecordOnOffPopupMenu to be enabled to all the scripts that
can be recorded.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3044 - Recording of Zest Sequence scripts not
working