### PR TITLE
ascanrules: use time defined in rule configs

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Improve error handling in some scanners.<br>
+	Support changing the length of time used in timing attacks via config options.<br>
 	]]>
     </changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/src/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -32,6 +32,8 @@ matches the payload, the scanner raises an alert and returns immediately. In the
 return output in the response, the scanner will attempt a blind injection attack by submitting sleep instructions as the payload and comparing the elapsed time between sending the request
 and receiving the response against a heuristic time-delay lower limit. If the elapsed time is greater than this limit, an alert is raised with medium confidence
 and the scanner returns immediately.
+<br>
+Post 2.5.0 you can change the length of time used for the blind injection attack by changing the <code>rules.common.sleep</code> parameter via the Options 'Rule configuration' panel.
 
 <H2>Client Browser Cache</H2>
 


### PR DESCRIPTION
Change CommandInjectionPlugin to use the time defined in rule configs.
Update help page to mention the new 2.6.0 functionality (as done for
other rules).
Update changes in ZapAddOn.xml file.

Related to:
 - zaproxy/zaproxy#2647 - Support a/pscan rule configuration
 - zaproxy/zaproxy#3037 - False positive for remote command execution