### PR TITLE
zest: use core constant of script type capability

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -1221,7 +1221,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 				}
 			}
 		}
-		for (final ScriptNode node : getZestScriptNodesWithCapability("append")) {
+		for (final ScriptNode node : getZestScriptNodesWithCapability(ScriptType.CAPABILITY_APPEND)) {
 			ZestScriptWrapper zsw = (ZestScriptWrapper) node.getUserObject();
 			if (zsw.isRecording()) {
 				if (msg.getRequestHeader().getURI().toString().startsWith(zsw.getZestScript().getPrefix())) {

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -130,7 +130,7 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
         List<String> list = new ArrayList<String>();
         
         for (ScriptType st : extension.getExtScript().getScriptTypes()) {
-        	if (st.hasCapability("append")) {
+        	if (st.hasCapability(ScriptType.CAPABILITY_APPEND)) {
                 list.add(Constant.messages.getString(st.getI18nKey()));
         	}
         }

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
@@ -143,7 +143,7 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
         if (this.chooseType) {
         	List<String> types = new ArrayList<String>();
     		for (ScriptType st : extension.getExtScript().getScriptTypes()) {
-    			if (st.hasCapability("append")) {
+    			if (st.hasCapability(ScriptType.CAPABILITY_APPEND)) {
     				types.add(Constant.messages.getString(st.getI18nKey()));
     			}
     		}

--- a/src/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptPopupMenu.java
+++ b/src/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptPopupMenu.java
@@ -90,7 +90,7 @@ public class ZestAddToScriptPopupMenu extends PopupMenuItemHistoryReferenceConta
 		}
 		
 		for (ScriptType st : extension.getExtScript().getScriptTypes()) {
-			if (st.hasCapability("append")) {
+			if (st.hasCapability(ScriptType.CAPABILITY_APPEND)) {
 				for (ScriptNode node : extension.getZestScriptNodes(st.getName())) {
 		        	ExtensionPopupMenuItem piicm = createPopupAddToScriptMenu(node);
 		        	piicm.setMenuIndex(this.getMenuIndex());

--- a/src/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
+++ b/src/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
+import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 
@@ -86,7 +87,7 @@ public class ZestRecordOnOffPopupMenu extends ExtensionPopupMenuItem {
             		ScriptNode node = extension.getSelectedZestNode();
             		if (node != null && node.getUserObject() instanceof ZestScriptWrapper) {
             			ZestScriptWrapper script = (ZestScriptWrapper) node.getUserObject();
-	    			    if (script.getType().hasCapability("append") && record != script.isRecording()) {
+	    			    if (script.getType().hasCapability(ScriptType.CAPABILITY_APPEND) && record != script.isRecording()) {
 	    			    	this.setEnabled(true);
 	    			    	return true;
 	    			    } else {


### PR DESCRIPTION
Replace the hardcoded capability "append" with the core constant,
ScriptType.CAPABILITY_APPEND, which is available in the ZAP version(s)
targeted by the add-on.