### PR TITLE
Add helper test methods for active scanners

### DIFF
--- a/test/org/zaproxy/zap/extension/ascanrules/NanoServerHandler.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/NanoServerHandler.java
@@ -19,6 +19,11 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+import org.parosproxy.paros.network.HttpHeader;
+
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 
@@ -35,4 +40,68 @@ public abstract class NanoServerHandler {
     }
     
     abstract Response serve(IHTTPSession session);
+
+    /**
+     * Consumes the request body.
+     *
+     * @param session the session that has the request
+     */
+    protected void consumeBody(IHTTPSession session) {
+        try {
+            session.getInputStream().skip(getBodySize(session));
+        } catch (IOException e) {
+            System.err.println("Failed to consume body:");
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Gets the size of the request body.
+     *
+     * @param session the session that has the request
+     * @return the size of the body
+     */
+    protected int getBodySize(IHTTPSession session) {
+        String contentLengthHeader = session.getHeaders().get(HttpHeader.CONTENT_LENGTH.toLowerCase());
+        if (contentLengthHeader == null) {
+            return 0;
+        }
+
+        int contentLength = 0;
+        try {
+            contentLength = Integer.parseInt(contentLengthHeader);
+        } catch (NumberFormatException e) {
+            System.err.println("Failed to parse " + HttpHeader.CONTENT_LENGTH + " value: " + contentLengthHeader);
+            e.printStackTrace();
+            return 0;
+        }
+
+        if (contentLength <= 0) {
+            return 0;
+        }
+        return contentLength;
+    }
+
+    /**
+     * Gets the request body.
+     *
+     * @param session the session that has the request
+     * @return the body
+     */
+    public String getBody(IHTTPSession session) {
+        int contentLength = getBodySize(session);
+        if (contentLength == 0) {
+            return "";
+        }
+
+        byte[] bytes = new byte[contentLength];
+        try {
+            IOUtils.readFully(session.getInputStream(), bytes);
+        } catch (IOException e) {
+            System.err.println("Failed to read the body:");
+            e.printStackTrace();
+            return "";
+        }
+        return new String(bytes);
+    }
 }


### PR DESCRIPTION
Add methods to consume/get the request body and obtain the number of
messages sent by the active scanners.
(Same behaviour as in beta branch.)