### PR TITLE
spiderAjax: show latest configured browsers always

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
@@ -199,6 +199,24 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
     	return extSel;
     }
 
+    /**
+     * Updates the choices available in "Browser" combo box, based on the currently configured browsers.
+     *
+     * @see ExtensionSelenium#getConfiguredBrowsers()
+     */
+    public void updateBrowsers() {
+        List<Browser> browserList = getExtSelenium().getConfiguredBrowsers();
+        List<String> browserNames = new ArrayList<>();
+        String defaultBrowser = null;
+        for (Browser browser : browserList) {
+            browserNames.add(extSel.getName(browser));
+            if (browser.getId().equals(params.getBrowserId())) {
+                defaultBrowser = extSel.getName(browser);
+            }
+        }
+        setComboFields(FIELD_BROWSER, browserNames, defaultBrowser);
+    }
+
     /*
 	private OptionsAjaxSpiderTableModel getAjaxSpiderClickModel() {
 		if (ajaxSpiderClickModel == null) {

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -230,6 +230,8 @@ public class ExtensionAjax extends ExtensionAdaptor {
 			spiderDialog.init(new Target(node));
 		} else if (node != null) {
 			spiderDialog.init(new Target(node));
+		} else {
+			spiderDialog.updateBrowsers();
 		}
 		
 		spiderDialog.setVisible(true);

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Use a custom initiator ID (10) for AJAX Spider requests.<br>
+	Show always the latest configured browsers in AJAX Spider dialogue (Issue 3057).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change AjaxSpiderDialog to allow to update the browsers shown and change
ExtensionAjax to call that method when showing the dialogue.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3057 - AJAX Spider dialogue might not show all
configured browsers