### PR TITLE
ascanrulesbeta: fix src disclosure false positive

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINF.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINF.java
@@ -212,6 +212,13 @@ public class SourceCodeDisclosureWEBINF extends AbstractHostPlugin {
 						Decompiler.decompile (classFile.getAbsolutePath(), decompiledText, decompilerSettings);
 						String javaSourceCode = decompiledText.toString();
 						
+						if (javaSourceCode.startsWith("!!! ERROR: Failed to load class")) {
+							// Not a Java class file...
+							javaClassesFound.remove(classname);
+							javaClassesHandled.add(classname);
+							continue;
+						}
+
 						if ( log.isDebugEnabled() ) {
 							log.debug("Source Code Disclosure alert for: "+ classname);
 						}

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -1,19 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules (beta)</name>
-	<version>21</version>
+	<version>22</version>
 	<status>beta</status>
 	<description>The beta quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Support changing the length of time used in timing attacks via config options.<br>
-	Support ignoring specified forms when checking for CSRF vulnerabilities.<br>
-	Do not attempt to parse empty cross domain policy files.<br>
-	Correct creation of attack URL in Source Code Disclosure - CVE-2012-1823.<br>
-	Correct creation of attack URL in Remote Code Execution - CVE-2012-1823.<br>
-	Respect OS techs included when scanning with Remote Code Execution - CVE-2012-1823.<br>
-	Adjust log levels of some scanners, from INFO to DEBUG.<br>
+	Fix FP in "Source Code Disclosure - /WEB-INF folder" on successful responses (Issue 3048).<br>
     ]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
@@ -93,7 +93,7 @@ public abstract class ActiveScannerTest extends ScannerTestUtils {
     }
 
     /**
-     * Set ups the log to ease debugging.
+     * Sets up the log to ease debugging.
      */
     protected void setUpLog() {
         // Useful if you need to get some info when debugging

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/HTTPDTestServer.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/HTTPDTestServer.java
@@ -44,7 +44,7 @@ public class HTTPDTestServer extends NanoHTTPD {
     public Response serve(IHTTPSession session) {
         String uri = session.getUri();
         for (NanoServerHandler handler : handlers) {
-            if (uri.startsWith("/" + handler.getName() + "/")) {
+            if (uri.startsWith(handler.getName())) {
                 return handler.serve(session);
             }
         }

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
@@ -57,7 +57,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldScanUrlsWithEncodedCharsInPath() throws Exception {
         // Given
-        String test = "shouldScanUrlsWithEncodedCharsInPath";
+        String test = "/shouldScanUrlsWithEncodedCharsInPath/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -66,7 +66,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
                 return new Response("Nothing echoed...");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/%7B+%25%24");
+        HttpMessage message = getHttpMessage(test + "%7B+%25%24");
         rule.init(message, parent);
         // When
         rule.scan();
@@ -77,8 +77,8 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldNotScanUrlsIfWinAndNixTechIsNotIncluded() throws Exception {
         // Given
-        String test = "shouldNotScanUrlsIfWinAndNixTechIsNotIncluded";
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        String test = "/shouldNotScanUrlsIfWinAndNixTechIsNotIncluded/";
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         rule.setTechSet(techSetWithout(Tech.Linux, Tech.MacOS, Tech.Windows));
         // When
@@ -90,7 +90,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldNotAlertIfTheAttackIsNotEchoedInTheResponse() throws Exception {
         // Given
-        String test = "shouldNotAlertIfTheAttackIsNotEchoedInTheResponse";
+        String test = "/shouldNotAlertIfTheAttackIsNotEchoedInTheResponse/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -99,7 +99,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
                 return new Response("Nothing echoed...");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -110,7 +110,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldNotAlertEvenIfAttackResponseBodyHasBiggerSize() throws Exception {
         // Given
-        String test = "shouldNotAlertEvenIfResponseBodyHasBiggerSize";
+        String test = "/shouldNotAlertEvenIfResponseBodyHasBiggerSize/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -124,7 +124,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
                 return new Response(strBuilder.toString());
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -136,9 +136,9 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     public void shouldAlertIfWindowsAttackWasSuccessful() throws Exception {
         // Given
         final String body = RemoteCodeExecutionCVE20121823.RANDOM_STRING + "<html><body>X Y Z</body></html>";
-        String test = "shouldAlertIfWindowsAttackWasSuccessful";
+        String test = "/shouldAlertIfWindowsAttackWasSuccessful/";
         nano.addHandler(new WinResponse(test, body));
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -158,9 +158,9 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     public void shouldNotDoWinAttackIfWinTechIsNotIncluded() throws Exception {
         // Given
         final String body = RemoteCodeExecutionCVE20121823.RANDOM_STRING + "<html><body>X Y Z</body></html>";
-        String test = "shouldNotDoWinAttackIfWinTechIsNotIncluded";
+        String test = "/shouldNotDoWinAttackIfWinTechIsNotIncluded/";
         nano.addHandler(new WinResponse(test, body));
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         rule.setTechSet(techSetWithout(Tech.Windows));
         // When
@@ -174,9 +174,9 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     public void shouldAlertIfNixAttackWasSuccessful() throws Exception {
         // Given
         final String body = RemoteCodeExecutionCVE20121823.RANDOM_STRING + "<html><body>X Y Z</body></html>";
-        String test = "shouldAlertIfNixAttackWasSuccessful";
+        String test = "/shouldAlertIfNixAttackWasSuccessful/";
         nano.addHandler(new NixResponse(test, body));
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -195,10 +195,10 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldNotDoNixAttackIfNixTechsAreNotIncluded() throws Exception {
         // Given
-        String test = "shouldNotDoNixAttackIfNixTechsAreNotIncluded";
+        String test = "/shouldNotDoNixAttackIfNixTechsAreNotIncluded/";
         nano.addHandler(
                 new NixResponse(test, RemoteCodeExecutionCVE20121823.RANDOM_STRING + "<html><body>X Y Z</body></html>"));
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         rule.setTechSet(techSetWithout(Tech.Linux, Tech.MacOS));
         // When

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
@@ -119,7 +119,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldScanUrlsWithEncodedCharsInPath() throws Exception {
         // Given
-        String test = "shouldScanUrlsWithEncodedCharsInPath";
+        String test = "/shouldScanUrlsWithEncodedCharsInPath/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -127,7 +127,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
                 return new Response("No Source Code here!");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/%7B+%25%24");
+        HttpMessage message = getHttpMessage(test + "%7B+%25%24");
         rule.init(message, parent);
         // When
         rule.scan();
@@ -138,7 +138,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldNotAlertIfThereIsNoSourceCodeDisclosure() throws Exception {
         // Given
-        String test = "shouldNotAlertIfThereIsNoSourceCodeDisclosure";
+        String test = "/shouldNotAlertIfThereIsNoSourceCodeDisclosure/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -146,7 +146,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
                 return new Response("No Source Code here!");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -157,7 +157,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldAlertIfPhpSourceTagsWereDisclosedInResponseBody() throws Exception {
         // Given
-        String test = "shouldAlertIfPhpSourceTagsWereDisclosedInResponseBody";
+        String test = "/shouldAlertIfPhpSourceTagsWereDisclosedInResponseBody/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -166,7 +166,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
                 return new Response("<html><body>" + encodedPhpCode + "</body></html>");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -183,7 +183,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpSourceTagsWereDisclosedInResponseBody() throws Exception {
         // Given
-        String test = "shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpSourceTagsWereDisclosedInResponseBody";
+        String test = "/shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpSourceTagsWereDisclosedInResponseBody/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -195,7 +195,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
                         "<html><body>" + encodedPhpCode + "</body></html>");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -207,7 +207,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldAlertIfPhpEchoTagsWereDisclosedInResponseBody() throws Exception {
         // Given
-        String test = "shouldAlertIfPhpEchoTagsWereDisclosedInResponseBody";
+        String test = "/shouldAlertIfPhpEchoTagsWereDisclosedInResponseBody/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -216,7 +216,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
                 return new Response("<html><body>" + encodedPhpCode + "</body></html>");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();
@@ -233,7 +233,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
     @Test
     public void shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpEchoTagsWereDisclosedInResponseBody() throws Exception {
         // Given
-        String test = "shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpEchoTagsWereDisclosedInResponseBody";
+        String test = "/shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpEchoTagsWereDisclosedInResponseBody/";
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
@@ -245,7 +245,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
                         "<html><body>" + encodedPhpCode + "</body></html>");
             }
         });
-        HttpMessage message = getHttpMessage("/" + test + "/");
+        HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);
         // When
         rule.scan();

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINFUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINFUnitTest.java
@@ -1,0 +1,214 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesBeta;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.ByteArrayInputStream;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+
+/**
+ * Unit test for {@link SourceCodeDisclosureWEBINF}.
+ */
+public class SourceCodeDisclosureWEBINFUnitTest extends ActiveScannerTest {
+
+    private static final String JAVA_LIKE_FILE_NAME_PATH = "/WEB-INF/classes/about/html.class";
+
+    @Override
+    protected SourceCodeDisclosureWEBINF createScanner() {
+        return new SourceCodeDisclosureWEBINF();
+    }
+
+    @Test
+    public void shouldTryToObtainWebInfFiles() throws Exception {
+        // Given
+        rule.init(getHttpMessage("/some/path"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(2));
+        assertThat(requestPath(httpMessagesSent.get(0)), is(equalTo("/WEB-INF/web.xml")));
+        assertThat(requestPath(httpMessagesSent.get(1)), is(equalTo("/WEB-INF/applicationContext.xml")));
+    }
+
+    @Test
+    public void shouldNotContinueScanningIfReturnedContentHasNoJavaLikeFileNames() throws Exception {
+        // Given
+        nano.addHandler(new NotFoundResponse(""));
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(2));
+    }
+
+    @Test
+    public void shouldContinueScanningIfReturnedContentHasJavaLikeFileNamesEvenIfNotWebInfData() throws Exception {
+        // Given
+        nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(3));
+        assertThat(requestPath(httpMessagesSent.get(2)), is(equalTo(JAVA_LIKE_FILE_NAME_PATH)));
+    }
+
+    @Test
+    public void shouldNotAlertIfJavaLikeFileNameIsNot200Ok() throws Exception {
+        // Given
+        nano.addHandler(new NotFoundResponse(JAVA_LIKE_FILE_NAME_PATH));
+        nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(3));
+        assertThat(requestPath(httpMessagesSent.get(2)), is(equalTo(JAVA_LIKE_FILE_NAME_PATH)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfJavaLikeFileNameIsNotAJavaClassEvenIfIs200Ok() throws Exception {
+        // Given
+        nano.addHandler(new OkResponse(JAVA_LIKE_FILE_NAME_PATH));
+        nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(3));
+        assertThat(requestPath(httpMessagesSent.get(2)), is(equalTo(JAVA_LIKE_FILE_NAME_PATH)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertIfJavaSourceWasDisclosed() throws Exception {
+        // Given
+        nano.addHandler(new JavaClassResponse(JAVA_LIKE_FILE_NAME_PATH));
+        nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(3));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("class A\n{\n}\n")));
+    }
+
+    private static String requestPath(HttpMessage message) {
+        try {
+            return message.getRequestHeader().getURI().getPath();
+        } catch (URIException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class NonWebInfWithJavaLikeFileNameResponse extends NanoServerHandler {
+
+        public NonWebInfWithJavaLikeFileNameResponse() {
+            super("");
+        }
+
+        @Override
+        public Response serve(IHTTPSession session) {
+            return new Response(
+                    Response.Status.NOT_FOUND,
+                    "text/html",
+                    "<html><body><h1>404 Not Found</h1>\n<a href=\"/about.html\">About Page</a></body></html>");
+        }
+    }
+
+    private static class JavaClassResponse extends NanoServerHandler {
+
+        private static final byte[] JAVA_CLASS;
+
+        static {
+            try {
+                JAVA_CLASS = Hex.decodeHex(
+                        ("cafebabe00000034000d0a0003000a07000b07000c0100063c696e69743e0100"
+                                + "03282956010004436f646501000f4c696e654e756d6265725461626c6501000a"
+                                + "536f7572636546696c65010006412e6a6176610c00040005010001410100106a"
+                                + "6176612f6c616e672f4f626a6563740020000200030000000000010000000400"
+                                + "05000100060000001d00010001000000052ab70001b100000001000700000006"
+                                + "00010000000100010008000000020009").toCharArray());
+            } catch (DecoderException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public JavaClassResponse(String path) {
+            super(path);
+        }
+
+        @Override
+        public Response serve(IHTTPSession session) {
+            return new Response(Response.Status.OK, "application/class", new ByteArrayInputStream(JAVA_CLASS));
+        }
+    }
+
+    private static class NotFoundResponse extends NanoServerHandler {
+
+        public NotFoundResponse(String path) {
+            super(path);
+        }
+
+        @Override
+        public Response serve(IHTTPSession session) {
+            return new Response(
+                    Response.Status.NOT_FOUND,
+                    "text/html",
+                    "<html><body><h1>404 Not Found</h1>\nNot Found.</body></html>");
+        }
+    }
+
+    private static class OkResponse extends NanoServerHandler {
+
+        public OkResponse(String path) {
+            super(path);
+        }
+
+        @Override
+        public Response serve(IHTTPSession session) {
+            return new Response(
+                    Response.Status.OK,
+                    "text/html",
+                    "<html><body><h1>Some Title</h1>\nSome content.</body></html>");
+        }
+    }
+
+}


### PR DESCRIPTION
Change SourceCodeDisclosureWEBINF to not raise an alert if the
successful response does not decompile correctly to a Java class.
Add tests to assert (some of) the expected behaviour of the scanner.
Bump version and update changes in ZapAddOn.xml file.

Also, change how path segment is checked in test server to allow the
tests to precisely define what the path is.
Update existing unit tests to match the new behaviour of the test
server.
Fix typo in JavaDoc of helper test method.

Fix zaproxy/zaproxy#3048 - False positive on source disclosure when
target answers invalid url with 200 OK