### PR TITLE
Add some tests for CommandInjectionPlugin

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -305,6 +305,17 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
     }
 
     /**
+     * Gets the number of seconds used in time-based attacks.
+     * <p>
+     * <strong>Note:</strong> Method provided only to ease the unit tests.
+     * 
+     * @return the number of seconds used in time-based attacks.
+     */
+    int getTimeSleep() {
+        return timeSleepSeconds;
+    }
+
+    /**
      * Scan for OS Command Injection Vulnerabilites
      * 
      * @param msg a request only copy of the original message (the response isn't copied)

--- a/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
@@ -59,13 +59,13 @@ import org.zaproxy.zap.extension.ascan.ScanPolicy;
 //import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ClassLoaderUtil;
 
-public abstract class ActiveScannerTest extends ScannerTestUtils {
+public abstract class ActiveScannerTest<T extends AbstractPlugin> extends ScannerTestUtils {
 
     private static final String INSTALL_PATH = "test/resources/install";
     private static final File HOME_DIR = new File("test/resources/home");
     private static final String BASE_RESOURCE_DIR = "test/resources/org/zaproxy/zap/extension/ascanrules/";
 
-    protected AbstractPlugin rule;
+    protected T rule;
     protected HostProcess parent;
 
     /**
@@ -187,7 +187,7 @@ public abstract class ActiveScannerTest extends ScannerTestUtils {
         FileUtils.deleteDirectory(dir);
     }
 
-    protected abstract AbstractPlugin createScanner();
+    protected abstract T createScanner();
     
     protected HttpMessage getHttpMessage(String url) throws HttpMalformedHeaderException {
         return this.getHttpMessage("GET", url, "<html></html>");

--- a/test/org/zaproxy/zap/extension/ascanrules/CommandInjectionPluginUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/CommandInjectionPluginUnitTest.java
@@ -1,0 +1,96 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.configuration.Configuration;
+import org.junit.Test;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/**
+ * Unit test for {@link CommandInjectionPlugin}.
+ */
+public class CommandInjectionPluginUnitTest extends ActiveScannerTest<CommandInjectionPlugin> {
+
+    @Override
+    protected CommandInjectionPlugin createScanner() {
+        CommandInjectionPlugin scanner = new CommandInjectionPlugin();
+        scanner.setConfig(new ZapXmlConfiguration());
+        return scanner;
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void shouldFailToInitWithoutConfig() throws Exception {
+        // Given
+        CommandInjectionPlugin scanner = new CommandInjectionPlugin();
+        // When
+        scanner.init(getHttpMessage(""), parent);
+        // Then = NullPointerException
+    }
+
+    @Test
+    public void shouldInitWithConfig() throws Exception {
+        // Given
+        CommandInjectionPlugin scanner = new CommandInjectionPlugin();
+        scanner.setConfig(new ZapXmlConfiguration());
+        // When
+        scanner.init(getHttpMessage(""), parent);
+        // Then = No exception.
+    }
+
+    @Test
+    public void shouldUse5SecsByDefaultForTimeBasedAttacks() throws Exception {
+        // Given / When
+        int time = rule.getTimeSleep();
+        // Then
+        assertThat(time, is(equalTo(5)));
+    }
+
+    @Test
+    public void shouldUseTimeDefinedInConfigForTimeBasedAttacks() throws Exception {
+        // Given
+        rule.setConfig(configWithSleepRule("10"));
+        // When
+        rule.init(getHttpMessage(""), parent);
+        // Then
+        assertThat(rule.getTimeSleep(), is(equalTo(10)));
+    }
+
+    @Test
+    public void shouldDefaultTo5SecsIfConfigTimeIsMalformedValueForTimeBasedAttacks() throws Exception {
+        // Given
+        rule.setConfig(configWithSleepRule("not a valid value"));
+        // When
+        rule.init(getHttpMessage(""), parent);
+        // Then
+        assertThat(rule.getTimeSleep(), is(equalTo(5)));
+    }
+
+    private static Configuration configWithSleepRule(String value) {
+        Configuration config = new ZapXmlConfiguration();
+        // TODO Replace with RuleConfigParam.RULE_COMMON_SLEEP_TIME once available.
+        config.setProperty("rules.common.sleep", value);
+        return config;
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest.java
@@ -28,14 +28,13 @@ import java.net.URLDecoder;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 
-public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
+public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSiteScriptV2> {
 
     @Override
     protected TestCrossSiteScriptV2 createScanner() {
@@ -65,7 +64,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo("</p><script>alert(1);</script><p>"));
@@ -103,7 +102,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(0));
     }
@@ -131,7 +130,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo("--><script>alert(1);</script><!--"));
@@ -166,7 +165,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), 
@@ -205,7 +204,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(0));
     }
@@ -233,7 +232,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(),  equalTo("<script>alert(1);</script>"));
@@ -266,7 +265,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(),  equalTo("<script>alert(1);</script>"));
@@ -299,7 +298,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(),  equalTo("<script>alert(1);</script>"));
@@ -334,7 +333,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), 
@@ -373,7 +372,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(0));
     }
@@ -403,7 +402,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), 
@@ -443,7 +442,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(0));
     }
@@ -473,7 +472,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo(";alert(1)"));
@@ -508,7 +507,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo("javascript:alert(1);"));
@@ -543,7 +542,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo(" src=http://badsite.com"));
@@ -586,7 +585,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest {
         
         this.rule.init(msg, this.parent);
 
-        ((AbstractAppParamPlugin)this.rule).scan();
+        this.rule.scan();
 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), 


### PR DESCRIPTION
Add tests for CommandInjectionPlugin to check that the value used in
time-based attacks is the expected.
Change class ActiveScannerTest to be generic so the instance variable
"rule" has the type of the scanner being tested (to allow to use its
methods without casts).
Update existing unit test, TestCrossSiteScriptV2UnitTest, to set the
type argument for ActiveScannerTest (and remove unnecessary casts).