### PR TITLE
Generify ActiveScannerTest (beta)

### DIFF
--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
@@ -58,13 +58,13 @@ import org.zaproxy.zap.extension.ScannerTestUtils;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
 import org.zaproxy.zap.utils.ClassLoaderUtil;
 
-public abstract class ActiveScannerTest extends ScannerTestUtils {
+public abstract class ActiveScannerTest<T extends AbstractPlugin> extends ScannerTestUtils {
 
     private static final String INSTALL_PATH = "test/resources/install";
     private static final File HOME_DIR = new File("test/resources/home");
     private static final String BASE_RESOURCE_DIR = "test/resources/org/zaproxy/zap/extension/ascanrulesBeta/";
 
-    protected AbstractPlugin rule;
+    protected T rule;
     protected HostProcess parent;
 
     /**
@@ -186,7 +186,7 @@ public abstract class ActiveScannerTest extends ScannerTestUtils {
         FileUtils.deleteDirectory(dir);
     }
 
-    protected abstract AbstractPlugin createScanner();
+    protected abstract T createScanner();
 
     protected HttpMessage getHttpMessage(String url) throws HttpMalformedHeaderException {
         return this.getHttpMessage("GET", url, "<html></html>");

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
@@ -36,7 +36,7 @@ import fi.iki.elonen.NanoHTTPD.Response;
 /**
  * Unit test for {@link RemoteCodeExecutionCVE20121823}.
  */
-public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest {
+public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest<RemoteCodeExecutionCVE20121823> {
 
     @Override
     protected RemoteCodeExecutionCVE20121823 createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
@@ -37,7 +37,7 @@ import fi.iki.elonen.NanoHTTPD.Response;
 /**
  * Unit test for {@link SourceCodeDisclosureCVE20121823}.
  */
-public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest {
+public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<SourceCodeDisclosureCVE20121823> {
 
     private static final String RESPONSE_HEADER_404_NOT_FOUND = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n";
     private static final String PHP_SOURCE_TAGS = "<?php $x=0; echo '<h1>Welcome!</h1>'; ?>";

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINFUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINFUnitTest.java
@@ -39,7 +39,7 @@ import fi.iki.elonen.NanoHTTPD.Response;
 /**
  * Unit test for {@link SourceCodeDisclosureWEBINF}.
  */
-public class SourceCodeDisclosureWEBINFUnitTest extends ActiveScannerTest {
+public class SourceCodeDisclosureWEBINFUnitTest extends ActiveScannerTest<SourceCodeDisclosureWEBINF> {
 
     private static final String JAVA_LIKE_FILE_NAME_PATH = "/WEB-INF/classes/about/html.class";
 


### PR DESCRIPTION
Change class ActiveScannerTest to be generic so the instance variable
"rule" has the type of the scanner being tested, to allow the tests to
access the scanners without casts.