### PR TITLE
ascanrulesbeta: fix FP in Integer Overflow scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflow.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflow.java
@@ -108,7 +108,7 @@ public class IntegerOverflow extends AbstractAppParamPlugin  {
 		if (checkStop() == true) {
 			return;
 		}
-		if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
+		if (getBaseMsg().getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
 		{
 			return;//Stop
 		}

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix FP in "Source Code Disclosure - /WEB-INF folder" on successful responses (Issue 3048).<br>
+	Fix FP in "Integer Overflow Error" on 500 error responses (Issue 3064).<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change IntegerOverflow to use the base message to check the status code
of the response instead of using the message being scanned, which does
not have a response (always passing the 500 status code check).
Add tests to assert (some of) the expected behaviour.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3064 - False positives with Integer Overflow scanner
and 500 error responses