### PR TITLE
Issue 3065 ensure status check against base message (Release)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
@@ -116,7 +116,7 @@ public class BufferOverflow extends AbstractAppParamPlugin  {
 			}
 			return; // Stop!
 		}
-		if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
+		if (getBaseMsg().getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
 		{
 			return;//Stop
 		}

--- a/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
@@ -132,7 +132,7 @@ public class FormatString extends AbstractAppParamPlugin  {
 			return; // Stop!
 		}
 		
-		if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
+		if (getBaseMsg().getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR)// Check to see if the page closed initially
 		{
 			return;//Stop
 		}

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -7,9 +7,10 @@
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 2973: Drop suffix on *Nix Blind Command Injection time based variants to maximize compatibility.
+	Issue 2973: Drop suffix on *Nix Blind Command Injection time based variants to maximize compatibility.<br>
 	Improve error handling in some scanners.<br>
 	Support changing the length of time used in timing attacks via config options.<br>
+	Issue 3065: Ensure active scanners perform initial status checks against the proper original message(s) to prevent False Negative and False Positive conditions.
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Modify BufferOverflow, FormatString, TestDirectoryBrowsing to ensure
base message is checked for initial scanning logic.
Update ZapAddOn.xml to include the new changes, and fix a missing br on
a previous change element entry.

Fixes zaproxy/zaproxy#3065