### PR TITLE
scripts: allow to save a script with context menu

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -75,6 +75,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 	private PopupDuplicateScript popupDuplicateScript = null;
 	private PopupNewScriptFromType popupNewScriptFromType = null;
 	private PopupContextMenuItemFactory popupFactoryUseScriptForAuthentication = null;
+	private PopupMenuItemSaveScript popupMenuItemSaveScript;
 	
 	private ExtensionScript extScript = null;
 	private ScriptsTreeCellRenderer renderer = null;
@@ -120,6 +121,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
             if(PopupUseScriptAsAuthenticationScript.arePrerequisitesSatisfied())
             	extensionHook.getHookMenu().addPopupMenuItem(getPopupFactoryUseScriptForAuthentication());
             
+            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuItemSaveScript());
             ExtensionHelp.enableHelpKey(getConsolePanel(), "addon.scripts.console");
             ExtensionHelp.enableHelpKey(getScriptsPanel(), "addon.scripts.tree");
 
@@ -266,6 +268,13 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 		}
 
 		return popupFactoryUseScriptForAuthentication;
+	}
+
+	private PopupMenuItemSaveScript getPopupMenuItemSaveScript() {
+		if (popupMenuItemSaveScript == null) {
+			popupMenuItemSaveScript = new PopupMenuItemSaveScript(getScriptsPanel());
+		}
+		return popupMenuItemSaveScript;
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/scripts/PopupMenuItemSaveScript.java
+++ b/src/org/zaproxy/zap/extension/scripts/PopupMenuItemSaveScript.java
@@ -1,0 +1,112 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts;
+
+import java.awt.Component;
+
+import javax.swing.ImageIcon;
+import javax.swing.JTree;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.zaproxy.zap.extension.script.ScriptNode;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
+
+/**
+ * An {@link ExtensionPopupMenuItem} that allows to save the script selected in the Scripts tree.
+ */
+public class PopupMenuItemSaveScript extends ExtensionPopupMenuItem {
+
+    private static final long serialVersionUID = 1L;
+
+    private ScriptsListPanel scriptsPanel;
+    private ScriptWrapper selectedScript;
+
+    /**
+     * Constructs a {@code PopupMenuItemSaveScript} with the given scripts panel.
+     *
+     * @param scriptsPanel the scripts panel.
+     * @throws IllegalArgumentException if scripts panel is {@code null}.
+     */
+    public PopupMenuItemSaveScript(ScriptsListPanel scriptsPanel) {
+        super(Constant.messages.getString("scripts.list.toolbar.button.save"));
+
+        if (scriptsPanel == null) {
+            throw new IllegalArgumentException("The parameter scriptsPanel must not be null.");
+        }
+
+        setIcon(DisplayUtils.getScaledIcon(new ImageIcon(PopupMenuItemSaveScript.class.getResource("/resource/icon/16/096.png"))));
+
+        this.scriptsPanel = scriptsPanel;
+
+        this.addActionListener(new java.awt.event.ActionListener() {
+
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                PopupMenuItemSaveScript.this.scriptsPanel.saveScript(selectedScript);
+                selectedScript = null;
+            }
+        });
+    }
+
+    @Override
+    public boolean isEnableForComponent(Component invoker) {
+        if (!ScriptsListPanel.TREE.equals(invoker.getName())) {
+            return false;
+        }
+
+        JTree scriptsTree = (JTree) invoker;
+        ScriptNode node = (ScriptNode) scriptsTree.getLastSelectedPathComponent();
+        if (node == null || node.isTemplate() || !(node.getUserObject() instanceof ScriptWrapper)) {
+            return false;
+        }
+
+        if (scriptsTree.getSelectionCount() != 1) {
+            setEnabled(false);
+            return true;
+        }
+
+        ScriptWrapper selectedScript = (ScriptWrapper) node.getUserObject();
+        if (selectedScript.isChanged()) {
+            setEnabled(true);
+            this.selectedScript = selectedScript;
+        } else {
+            setEnabled(false);
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+
+    @Override
+    public void dismissed(ExtensionPopupMenuComponent selectedMenuComponent) {
+        super.dismissed(selectedMenuComponent);
+
+        if (selectedMenuComponent != this) {
+            selectedScript = null;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -294,7 +294,7 @@ public class ScriptsListPanel extends AbstractPanel {
 		return dir;
 	}
 
-	private void saveScript (ScriptWrapper script) {
+	protected void saveScript (ScriptWrapper script) {
 		if (script.getFile() != null) {
 			try {
 				extension.getExtScript().saveScript(script);

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Remove unused resource messages (Issue 2386).<br>
 	Update help page to mention HTTP Sender scripts.<br>
+	Allow to save scripts through the context menu.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Add a context menu item to Scripts tree that allows to save the selected
script.
Update changes in ZapAddOn.xml file.