### PR TITLE
Update references to registry of scanners' IDs

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
@@ -55,7 +55,7 @@ public class ExampleFileActiveScanner extends AbstractAppParamPlugin {
 	public int getId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
 		 */
 		return 60101;
 	}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
@@ -49,7 +49,7 @@ public class ExampleSimpleActiveScanner extends AbstractAppParamPlugin {
 	public int getId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
 		 */
 		return 60100;
 	}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SlackerCookieDetector.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SlackerCookieDetector.java
@@ -252,11 +252,6 @@ public class SlackerCookieDetector extends AbstractAppPlugin {
 		return Constant.messages.getString("ascanalpha.cookieslack.session.warning", cookie);
 	}
 
-	/**
-	 * This should be unique across all active and passive rules. The master
-	 * list:
-	 * https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
-	 */
 	@Override
 	public int getId() {
 		return 90027;

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanner.java
@@ -160,7 +160,7 @@ public class ExampleFilePassiveScanner extends PluginPassiveScanner {
 	public int getPluginId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
 		 */
 		return 60001;
 	}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanner.java
@@ -59,7 +59,7 @@ public class ExampleSimplePassiveScanner extends PluginPassiveScanner {
 	public int getPluginId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
 		 */
 		return 60000;
 	}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
@@ -62,10 +62,6 @@ public class ImageLocationScanner extends PluginPassiveScanner {
 
 	@Override
 	public int getPluginId() {
-		/*
-		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
-		 */
 		return PLUGIN_ID;
 	}
 

--- a/src/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
@@ -57,10 +57,6 @@ public class SOAPActionSpoofingActiveScanner extends AbstractAppPlugin {
 	
 	@Override
 	public int getId() {
-		/*
-		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
-		 */
 		return 90026;
 	}
 

--- a/src/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanner.java
@@ -47,10 +47,6 @@ public class SOAPXMLInjectionActiveScanner extends AbstractAppParamPlugin {
 	
 	@Override
 	public int getId() {
-		/*
-		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
-		 */
 		return 90029;
 	}
 

--- a/src/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanner.java
@@ -93,10 +93,6 @@ public class WSDLFilePassiveScanner extends PluginPassiveScanner {
 
 	@Override
 	public int getPluginId() {
-		/*
-		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/alerts.xml
-		 */
 		return 90030;
 	}
 	


### PR DESCRIPTION
Change to reference scanners.md (instead of alerts.xml, which was
replaced by the former file).
Remove references from non-example code.

Related to zaproxy/zaproxy#3034 - Remove alerts.xml file