### PR TITLE
invoke: consume std/err output at the same time

### DIFF
--- a/src/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
+++ b/src/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
@@ -111,11 +111,11 @@ public class InvokeAppWorker extends SwingWorker<Void, Void> {
 		if (workingDir != null) {
 			pb.directory(workingDir);
 		}
+		pb.redirectErrorStream(true);
 		Process proc = pb.start();
 
 		if (captureOutput) {
-			try (BufferedReader brErr = new BufferedReader(new InputStreamReader(proc.getErrorStream()));
-				BufferedReader brOut = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
+			try (BufferedReader brOut = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {
 				String line;
 				boolean isOutput = false;
 				StringBuilder sb = new StringBuilder();
@@ -124,14 +124,7 @@ public class InvokeAppWorker extends SwingWorker<Void, Void> {
 					sb.append('\n');	
 				}
 	
-				// Show any error messages
-				while ((line = brErr.readLine()) != null) {
-					View.getSingleton().getOutputPanel().append(line + "\n");
-					sb.append(line);	
-					sb.append('\n');	
-					isOutput = true;
-				}
-				// Show any stdout messages
+				// Show any stdout/error messages
 				while ((line = brOut.readLine()) != null) {
 					View.getSingleton().getOutputPanel().append(line + "\n");
 					sb.append(line);	

--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -7,7 +7,8 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Consume all output of the applications in all cases (Issue 3074).<br>
+	Show error/std output in the order it is received (Issue 3078).<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change InvokeAppWorker to consume std/err output using only one input
stream, preventing the output buffers of the application from becoming
full (and leading to hangs), and from showing, in ZAP, first the error
output and then the standard output.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3074 - external program hang
Fix zaproxy/zaproxy#3078 - external program: async STDERR and STDOUT