### PR TITLE
tokengen: show same cookies just once

### DIFF
--- a/src/org/zaproxy/zap/extension/tokengen/GenerateTokensDialog.java
+++ b/src/org/zaproxy/zap/extension/tokengen/GenerateTokensDialog.java
@@ -203,7 +203,10 @@ public class GenerateTokensDialog extends AbstractDialog {
 		TreeSet<HtmlParameter> params = httpMessage.getCookieParams();
 		Iterator<HtmlParameter> cIter = params.iterator();
 		while (cIter.hasNext()) {
-			cookieParams.add(cIter.next().getName());
+			String cookieName = cIter.next().getName();
+			if (!cookieParams.contains(cookieName)) {
+				cookieParams.add(cookieName);
+			}
 		}
 		
 		urlParams = new Vector<>();

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Show same cookies once in Generate Tokens dialogue (Issue 2116).<br>
 	Added help file.<br>
 	]]>
 	</changes>


### PR DESCRIPTION
Change GenerateTokensDialog to show the same cookies just once (happens
when both the request and response headers have the same cookie).
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#2116 - Issue with Token generator