### PR TITLE
tokengen: fix division by zero

### DIFF
--- a/src/org/zaproxy/zap/extension/tokengen/CharacterFrequencyMap.java
+++ b/src/org/zaproxy/zap/extension/tokengen/CharacterFrequencyMap.java
@@ -128,10 +128,9 @@ public class CharacterFrequencyMap {
 	
 	public TokenAnalysisTestResult checkCharacterUniformity() {
 		TokenAnalysisTestResult result = new TokenAnalysisTestResult(TokenAnalysisTestResult.Type.CHR_UNIFORMITY);
-		Result res = Result.PASS;
 		List<String> details = new ArrayList<>();
 		List<String> issues = new ArrayList<>();
-		int mid = (size() / numberOfChars());
+		int mid = numberOfChars() != 0 ? (size() / numberOfChars()) : 0;
 		int mdev = mdev(numberOfChars());
 		int min = mid - mdev;
 		int max = mid + mdev;
@@ -155,15 +154,18 @@ public class CharacterFrequencyMap {
 				sb.append(instantsOfChr);
 				if (instantsOfChr > max) {
 					issues.add("Column " + i + " Character " + c + " appears " + instantsOfChr + " times: more than expected (" + max + ")");
-					res = Result.FAIL;
 				} else if (instantsOfChr < min) {
 					issues.add("Column " + i + " Character " + c + " appears " + instantsOfChr + " times: less than expected (" + min + ")");
-					res = Result.FAIL;
 				}
 			}
 			details.add(sb.toString());
 		}
-		result.setResult(res);
+
+		if (maxLength == 0) {
+			issues.add("Tokens have zero characters.");
+		}
+
+		result.setResult(issues.isEmpty() ? Result.PASS : Result.FAIL);
 		result.setFailures(issues);
 		result.setDetails(details);
 		return result;

--- a/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
+++ b/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
@@ -68,6 +68,13 @@ public class ExtensionTokenGen extends ExtensionAdaptor {
         super(NAME);
         this.setI18nPrefix("tokengen");
 	}
+
+    @Override
+    public void init() {
+        super.init();
+
+        TokenAnalysisTestResult.setResourceBundle(getMessages());
+    }
 	
 	@Override
 	public void hook(ExtensionHook extensionHook) {

--- a/src/org/zaproxy/zap/extension/tokengen/TokenAnalysisTestResult.java
+++ b/src/org/zaproxy/zap/extension/tokengen/TokenAnalysisTestResult.java
@@ -18,13 +18,17 @@
 package org.zaproxy.zap.extension.tokengen;
 
 import java.util.List;
-
-import org.parosproxy.paros.Constant;
+import java.util.ResourceBundle;
 
 public class TokenAnalysisTestResult {
 	
 	public enum Type {MAX_ENTROPY, CHR_UNIFORMITY, CHR_TRANSITIONS, COUNT_1_BIT, COUNT_2_BITS, COUNT_3_BITS, COUNT_4_BITS, COUNT_8_BITS, COUNT_16_BITS};
 	public enum Result {FAIL, LOW, MEDIUM, HIGH, PASS};
+
+	private static ResourceBundle resourceBundle;
+
+	private static final String BASE_RSRC_KEY = "tokengen.analyse.test.";
+
 	private Type type;
 	private String name;
 	private String summary;
@@ -34,7 +38,7 @@ public class TokenAnalysisTestResult {
 	
 	public TokenAnalysisTestResult (Type type) {
 		this.type = type;
-		this.name = Constant.messages.getString("tokengen.analyse.test." + type.name().toLowerCase());
+		this.name = resourceBundle != null ? resourceBundle.getString(BASE_RSRC_KEY + type.name().toLowerCase()) : type.name();
 	}
 	
 	public Type getType() {
@@ -68,5 +72,17 @@ public class TokenAnalysisTestResult {
 	}
 	public void setFailures(List<String> failures) {
 		this.failures = failures;
+	}
+
+	/**
+	 * Sets the {@code ResourceBundle} used to obtain the internationalised name of the result.
+	 * <p>
+	 * It's used the {@link TokenAnalysisTestResult.Type Type}'s name if no {@code ResourceBundle} is set.
+	 *
+	 * @param resourceBundle the {@code ResourceBundle} to obtain the name of the result
+	 * @see #getName()
+	 */
+	static void setResourceBundle(ResourceBundle resourceBundle) {
+		TokenAnalysisTestResult.resourceBundle = resourceBundle;
 	}
 }

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Show same cookies once in Generate Tokens dialogue (Issue 2116).<br>
+	Fix exception when no tokens are found (Issue 2116).<br>
 	Added help file.<br>
 	Issue 2338: Allow dynamic timeout adjustment to combat read timeout issues.<br>
 	Ensure initial dialog is properly sized.<br>

--- a/test/org/zaproxy/zap/extension/tokengen/CharacterFrequencyMapUnitTest.java
+++ b/test/org/zaproxy/zap/extension/tokengen/CharacterFrequencyMapUnitTest.java
@@ -1,0 +1,91 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.tokengen;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link CharacterFrequencyMap}.
+ */
+public class CharacterFrequencyMapUnitTest {
+
+    @Test
+    public void shouldFailCharacterUniformityWithoutTokens() throws Exception {
+        // Given
+        CharacterFrequencyMap cfm = new CharacterFrequencyMap();
+        // When
+        TokenAnalysisTestResult result = cfm.checkCharacterUniformity();
+        // Then
+        assertThat(result.getType(), is(equalTo(TokenAnalysisTestResult.Type.CHR_UNIFORMITY)));
+        assertThat(result.getName(), is(equalTo(TokenAnalysisTestResult.Type.CHR_UNIFORMITY.name())));
+        assertThat(result.getResult(), is(equalTo(TokenAnalysisTestResult.Result.FAIL)));
+        assertThat(result.getFailures(), is(contains("Tokens have zero characters.")));
+        assertThat(result.getDetails(), is(empty()));
+        assertThat(result.getSummary(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldFailCharacterUniformityIfTokenCharsAreNotUniform() throws Exception {
+        // Given
+        CharacterFrequencyMap cfm = new CharacterFrequencyMap();
+        for (int i = 0; i < 1000; i++) {
+            cfm.addToken("ABC");
+        }
+        // When
+        TokenAnalysisTestResult result = cfm.checkCharacterUniformity();
+        // Then
+        assertThat(result.getType(), is(equalTo(TokenAnalysisTestResult.Type.CHR_UNIFORMITY)));
+        assertThat(result.getName(), is(equalTo(TokenAnalysisTestResult.Type.CHR_UNIFORMITY.name())));
+        assertThat(result.getResult(), is(equalTo(TokenAnalysisTestResult.Result.FAIL)));
+        assertThat(
+                result.getFailures(),
+                contains(
+                        "Column 0 Character A appears 1000 times: more than expected (669)",
+                        "Column 1 Character B appears 1000 times: more than expected (669)",
+                        "Column 2 Character C appears 1000 times: more than expected (669)"));
+        assertThat(result.getDetails(), is(contains("Col 0 A:1000 B:0 C:0", "Col 1 A:0 B:1000 C:0", "Col 2 A:0 B:0 C:1000")));
+        assertThat(result.getSummary(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldPassCharacterUniformityIfTokensCharsAreUniform() throws Exception {
+        // Given
+        CharacterFrequencyMap cfm = new CharacterFrequencyMap();
+        cfm.addToken("ABC");
+        cfm.addToken("BCA");
+        cfm.addToken("CAB");
+        // When
+        TokenAnalysisTestResult result = cfm.checkCharacterUniformity();
+        // Then
+        assertThat(result.getType(), is(equalTo(TokenAnalysisTestResult.Type.CHR_UNIFORMITY)));
+        assertThat(result.getName(), is(equalTo(TokenAnalysisTestResult.Type.CHR_UNIFORMITY.name())));
+        assertThat(result.getResult(), is(equalTo(TokenAnalysisTestResult.Result.PASS)));
+        assertThat(result.getFailures(), is(empty()));
+        assertThat(result.getDetails(), contains("Col 0 A:1 B:1 C:1", "Col 1 A:1 B:1 C:1", "Col 2 A:1 B:1 C:1"));
+        assertThat(result.getSummary(), is(nullValue()));
+    }
+}


### PR DESCRIPTION
Change CharacterFrequencyMap to prevent a division by zero when there
are no tokens (also, fail the character uniformity test in that case).
Change TokenAnalysisTestResult to remove dependency on Constant class,
to make tests easier.
Add tests to assert (some of) the expected behaviour of
CharacterFrequencyMap.
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#2116 - Issue with Token generator