### PR TITLE
zest: execute mouse click action just once

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Always show the expected URL in request statements (Issue 2854).<br>
 	Add HTTP requests to Sequence scripts when recording (Issue 3044).<br>
+	Execute nodes' mouse click action just once (Issue 3099).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
@@ -121,14 +121,6 @@ public class ZestDialogManager extends AbstractPanel {
 		this.setIcon(ExtensionZest.ZEST_ICON);
 
 		mouseListener = new java.awt.event.MouseAdapter() {
-			@Override
-			public void mousePressed(java.awt.event.MouseEvent e) {
-			}
-
-			@Override
-			public void mouseReleased(java.awt.event.MouseEvent e) {
-				mouseClicked(e);
-			}
 
 			@Override
 			public void mouseClicked(java.awt.event.MouseEvent e) {


### PR DESCRIPTION
Change ZestDialogManager to execute the mouse click action just once
(i.e. with just the clicked event, release event is included in the
former event).

Fix zaproxy/zaproxy#3099 - Zest nodes' mouse click action done twice