### PR TITLE
zest: clear zest results on session changes

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -74,11 +74,14 @@ import org.mozilla.zest.core.v1.ZestVariables;
 import org.mozilla.zest.impl.ZestScriptEngineFactory;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.SessionChangedListener;
+import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
@@ -168,6 +171,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 
 		if (getView() != null) {
 			extensionHook.addProxyListener(this);
+			extensionHook.addSessionListener(new ViewSessionChangedListener());
 
 			extensionHook.getHookView().addStatusPanel(
 					this.getZestResultsPanel());
@@ -1805,5 +1809,29 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 		return requests;
 	}
 
+	/**
+	 * A {@code SessionChangedListener} for view/UI related functionalities.
+	*/
+	private class ViewSessionChangedListener implements SessionChangedListener {
 
+		@Override
+		public void sessionAboutToChange(Session session) {
+			clearResults();
+		}
+
+		@Override
+		public void sessionChanged(Session session) {
+			// Nothing to do.
+		}
+
+		@Override
+		public void sessionModeChanged(Mode mode) {
+			// Nothing to do.
+		}
+
+		@Override
+		public void sessionScopeChanged(Session session) {
+			// Nothing to do.
+		}
+	}
 }

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Always show the expected URL in request statements (Issue 2854).<br>
 	Add HTTP requests to Sequence scripts when recording (Issue 3044).<br>
 	Execute nodes' mouse click action just once (Issue 3099).<br>
+	Clear Zest Results panel on session changes.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change ExtensionZest to clear the results shown in Zest Results panel
when the session changes.
Update changes in ZapAddOn.xml file.