### PR TITLE
Support security annotations for forms that dont need anti CSRF tokens.

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Fix FP in "Source Code Disclosure - /WEB-INF folder" on successful responses (Issue 3048).<br>
 	Fix FP in "Integer Overflow Error" on 500 error responses (Issue 3064).<br>
+	Support security annotations for forms that dont need anti-CSRF tokens.<br>
     ]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -23,6 +23,7 @@ ascanbeta.crossdomain.silverlight.soln = Configure the clientaccesspolicy.xml fi
 ascanbeta.crossdomain.silverlight.extrainfo = The web server permits malicious cross-domain requests originating from Silverlight components served from any third party domain, to this domain. If the victim user is logged into this service, the malicious requests are processed using the privileges of the victim, and can result in data from this service being compromised by an unauthorised third party web site, via the victim's web browsers. It can also result in Cross Site Request Forgery (CSRF) type attacks. This is particularly likely to be an issue if a Cookie based session implementation is in use.
 
 ascanbeta.csrftokenscan.name=Anti CSRF Tokens Scanner
+ascanbeta.csrftokenscan.extrainfo.annotation = This is an informational alert as the form has a security annotation indicating that it does not need an anti-CSRF Token. This should be tested manually to ensure the annotation is correct.
 
 ascanbeta.heartbleed.name=Heartbleed OpenSSL Vulnerability
 ascanbeta.heartbleed.desc=The TLS implementation in OpenSSL 1.0.1 before 1.0.1g does not properly handle Heartbeat Extension packets, which allows remote attackers to obtain sensitive information from process memory via crafted packets that trigger a buffer over-read, potentially disclosing sensitive information.

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -1,17 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (beta)</name>
-	<version>14</version>
+	<version>15</version>
 	<status>beta</status>
 	<description>The beta quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 2576: CSRFCountermeasures, remove unneeded Attack and Evidence messages.<br>
-	Issue 2574: CookieLooselyScopedScanner, remove attack field and update description.<br>
-	Support ignoring specified forms when checking for CSRF vulnerabilities.<br>
-	Correct the plugin ID of Absence of Anti-CSRF Tokens from 40014 to 10202.<br>
-	Issue 2860: Add further reference links.
+	Support security annotations for forms that dont need anti-CSRF tokens.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -70,6 +70,7 @@ pscanbeta.insecurejsfviewstate.extrainfo=JSF ViewState [{0}] is insecure
 pscanbeta.noanticsrftokens.name=Absence of Anti-CSRF Tokens
 pscanbeta.noanticsrftokens.desc=No Anti-CSRF tokens were found in a HTML submission form.
 pscanbeta.noanticsrftokens.alert.extrainfo=No known Anti-CSRF tokens {0} were found in the following HTML forms: {1}.
+pscanbeta.noanticsrftokens.extrainfo.annotation=This is an informational alert as the form has a security annotation indicating that it does not need an anti-CSRF Token. This should be tested manually to ensure the annotation is correct.
 
 pscanbeta.servletparameterpollutionscanner.name=HTTP Parameter Override
 pscanbeta.servletparameterpollutionscanner.desc=Unspecified form action: HTTP parameter override attack potentially possible. This is a known problem with Java Servlets but other platforms may also be vulnerable.


### PR DESCRIPTION
Note that this includes a couple of changes that were implemented in #570 - I have updated my local copy of the CSRFCountermeasures tests but want to see it the original submitter was going to update them before adding my changes.