### PR TITLE
invoke: fix typos in help pages

### DIFF
--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Consume all output of the applications in all cases (Issue 3074).<br>
 	Show error/std output in the order it is received (Issue 3078).<br>
+	Fix typos in the help pages.
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/invoke/resources/help/contents/concepts.html
+++ b/src/org/zaproxy/zap/extension/invoke/resources/help/contents/concepts.html
@@ -8,7 +8,7 @@
 	<H1>Invoke Applications</H1>
 	<p>
 		Other applications can be invoked passing in context information, such as the URL of the
-		message selected.<br> So, for example, Nmap could be invoked passing the the site
+		message selected.<br> So, for example, Nmap could be invoked passing the site
 		which you want it to scan.
 	</p>
 	<p>

--- a/src/org/zaproxy/zap/extension/invoke/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/invoke/resources/help/contents/options.html
@@ -60,9 +60,9 @@
 	<H3>Capture Output</H3>
 	If checked then the command run and any output it generates will be displayed on the
 	<i>Output tab</i>.
-	<br> You should always use this options when running scripts or commands that do not
+	<br> You should always use this option when running scripts or commands that do not
 	have a UI.
-	<br> You can also use this options for troubleshooting - if an application does not
+	<br> You can also use this option for troubleshooting - if an application does not
 	run as expected then copy the command run and try it from a command line prompt.
 
 	<H3>Output to Note</H3>


### PR DESCRIPTION
Change pages "Options Applications screen" and "Invoke Applications" to
fix some typos.
Update changes in ZapAddOn.xml file.