### PR TITLE
Issue 3148 HTTP HSTS Threshold Check

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/StrictTransportSecurityScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/StrictTransportSecurityScanner.java
@@ -32,6 +32,7 @@ import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -126,7 +127,8 @@ public class StrictTransportSecurityScanner extends PluginPassiveScanner{
 					raiseAlert(VulnType.HSTS_MALFORMED_MAX_AGE, stsOption.get(0), msg, id);
 				}
 			}
-		} else if (stsOption != null && !stsOption.isEmpty()) { //isSecure is false at this point
+		} else if (this.getLevel().equals(AlertThreshold.LOW) && stsOption != null && !stsOption.isEmpty()) { 
+			//isSecure is false at this point
 			//HSTS Header found on non-HTTPS response (technically there could be more than one 
 			//but we only care that there is one or more)
 			raiseAlert(VulnType.HSTS_ON_PLAIN_RESP, stsOption.get(0), msg, id);

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>12</version>
+	<version>13</version>
 	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-		Refactoring the x-powered-by scanner to raise one alert if it finds repetitive headers.<br>
-		Update the CSP scanner to handle the Content-Security-Policy-Report-Only header.<br>
+		Issue 3148: Only report HSTS on plain HTTP issue at Low threshold.
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Only report HSTS on plain HTTP if threshold is Low.

Fixes zaproxy/zaproxy#3148