### PR TITLE
selenium: add support for Firefox 48+

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -539,7 +539,7 @@
 				<!-- Add the extra classes required -->
 				<jar jarfile="${dist}/${file}" update="true" compress="true">
 					<zipfileset dir="${build}" prefix="">
-						<include name="org/openqa/selenium/phantomjs/**"/>
+						<include name="org/openqa/selenium/**"/>
 					</zipfileset>
 				</jar>
 			</build-addon>

--- a/src/org/openqa/selenium/firefox/GeckoDriverService.java
+++ b/src/org/openqa/selenium/firefox/GeckoDriverService.java
@@ -1,0 +1,133 @@
+// Licensed to the Software Freedom Conservancy (SFC) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The SFC licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.openqa.selenium.firefox;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.firefox.internal.Executable;
+import org.openqa.selenium.remote.service.DriverService;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages the life and death of an GeckoDriver aka 'wires'.
+ */
+public class GeckoDriverService extends DriverService {
+
+  /**
+   * System property that defines the location of the GeckoDriver executable
+   * that will be used by the {@link #createDefaultService() default service}.
+   */
+  public static final String GECKO_DRIVER_EXE_PROPERTY = "webdriver.gecko.driver";
+
+  /**
+   *
+   * @param executable The GeckoDriver executable.
+   * @param port Which port to start the GeckoDriver on.
+   * @param args The arguments to the launched server.
+   * @param environment The environment for the launched server.
+   * @throws IOException If an I/O error occurs.
+   */
+  public GeckoDriverService(File executable, int port, ImmutableList<String> args,
+                            ImmutableMap<String, String> environment) throws IOException {
+    super(executable, port, args, environment);
+  }
+
+  /**
+   * Configures and returns a new {@link GeckoDriverService} using the default configuration. In
+   * this configuration, the service will use the GeckoDriver executable identified by the
+   * {@link #GECKO_DRIVER_EXE_PROPERTY} system property. Each service created by this method will
+   * be configured to use a free port on the current system.
+   *
+   * @return A new GeckoDriverService using the default configuration.
+   */
+  public static GeckoDriverService createDefaultService() {
+    return new Builder().usingAnyFreePort().build();
+  }
+
+  @Override
+  protected void waitUntilAvailable() throws MalformedURLException {
+    waitForPortUp(getUrl().getPort(), 20, SECONDS);
+  }
+
+  private static void waitForPortUp(int port, int timeout, TimeUnit unit) {
+    long end = System.currentTimeMillis() + unit.toMillis(timeout);
+    while (System.currentTimeMillis() < end) {
+      try {
+        Socket socket = new Socket();
+        socket.connect(new InetSocketAddress("localhost", port), 1000);
+        socket.close();
+        return;
+      } catch (ConnectException e) {
+        // Ignore this
+      } catch (SocketTimeoutException e) {
+        // Ignore this
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  /**
+   * Builder used to configure new {@link GeckoDriverService} instances.
+   */
+  public static class Builder extends DriverService.Builder<
+    GeckoDriverService, GeckoDriverService.Builder> {
+
+    @Override
+    protected File findDefaultExecutable() {
+      return findExecutable("wires", GECKO_DRIVER_EXE_PROPERTY,
+          "https://github.com/jgraham/wires",
+          "https://github.com/jgraham/wires");
+    }
+
+    @Override
+    protected ImmutableList<String> createArgs() {
+      ImmutableList.Builder<String> argsBuilder = ImmutableList.builder();
+      argsBuilder.add(String.format("--webdriver-port=%d", getPort()));
+      if (getLogFile() != null) {
+        argsBuilder.add(String.format("--log-file=\"%s\"", getLogFile().getAbsolutePath()));
+      }
+      argsBuilder.add("-b");
+      argsBuilder.add(new Executable(null).getPath());
+      return argsBuilder.build();
+    }
+
+    @Override
+    protected GeckoDriverService createDriverService(File exe, int port,
+                                                                ImmutableList<String> args,
+                                                                ImmutableMap<String, String> environment) {
+      try {
+        return new GeckoDriverService(exe, port, args, environment);
+      } catch (IOException e) {
+        throw new WebDriverException(e);
+      }
+    }
+  }
+}

--- a/src/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
+++ b/src/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
@@ -34,7 +34,8 @@ import org.zaproxy.zap.extension.api.ZapApiIgnore;
  * It allows to change, programmatically, the following options:
  * <ul>
  * <li>The path to ChromeDriver;</li>
- * <li>The path to Firefox binary.</li>
+ * <li>The path to Firefox binary;</li>
+ * <li>The path to Firefox driver (geckodriver);</li>
  * <li>The path to IEDriverServer;</li>
  * <li>The path to PhantomJS binary.</li>
  * </ul>
@@ -46,6 +47,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
 
     public static final String CHROME_DRIVER_SYSTEM_PROPERTY = ChromeDriverService.CHROME_DRIVER_EXE_PROPERTY;
     public static final String FIREFOX_BINARY_SYSTEM_PROPERTY = "zap.selenium.webdriver.firefox.bin";
+    public static final String FIREFOX_DRIVER_SYSTEM_PROPERTY = "webdriver.gecko.driver";
     public static final String IE_DRIVER_SYSTEM_PROPERTY = InternetExplorerDriverService.IE_DRIVER_EXE_PROPERTY;
     public static final String PHANTOM_JS_BINARY_SYSTEM_PROPERTY = PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY;
 
@@ -83,6 +85,11 @@ public class SeleniumOptions extends VersionedAbstractParam {
     private static final String FIREFOX_BINARY_KEY = SELENIUM_BASE_KEY + ".firefoxBinary";
 
     /**
+     * The configuration key to read/write the path Firefox driver (geckodriver).
+     */
+    private static final String FIREFOX_DRIVER_KEY = SELENIUM_BASE_KEY + ".firefoxDriver";
+
+    /**
      * The configuration key to read/write the path to IEDriverServer.
      */
     private static final String IE_DRIVER_KEY = SELENIUM_BASE_KEY + ".ieDriver";
@@ -101,6 +108,11 @@ public class SeleniumOptions extends VersionedAbstractParam {
      * The path to Firefox binary.
      */
     private String firefoxBinaryPath = "";
+
+    /**
+     * The path to Firefox driver (geckodriver).
+     */
+    private String firefoxDriverPath = "";
 
     /**
      * The path to IEDriverServer.
@@ -128,6 +140,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
     protected void parseImpl() {
         chromeDriverPath = readSystemPropertyWithOptionFallback(CHROME_DRIVER_SYSTEM_PROPERTY, CHROME_DRIVER_KEY);
         firefoxBinaryPath = readSystemPropertyWithOptionFallback(FIREFOX_BINARY_SYSTEM_PROPERTY, FIREFOX_BINARY_KEY);
+        firefoxDriverPath = readSystemPropertyWithOptionFallback(FIREFOX_DRIVER_SYSTEM_PROPERTY, FIREFOX_DRIVER_KEY);
         ieDriverPath = readSystemPropertyWithOptionFallback(IE_DRIVER_SYSTEM_PROPERTY, IE_DRIVER_KEY);
         phantomJsBinaryPath = readSystemPropertyWithOptionFallback(PHANTOM_JS_BINARY_SYSTEM_PROPERTY, PHANTOM_JS_BINARY_KEY);
     }
@@ -226,6 +239,31 @@ public class SeleniumOptions extends VersionedAbstractParam {
             this.firefoxBinaryPath = firefoxBinaryPath;
 
             saveAndSetSystemProperty(FIREFOX_BINARY_KEY, FIREFOX_BINARY_SYSTEM_PROPERTY, firefoxBinaryPath);
+        }
+    }
+
+    /**
+     * Gets the path to Firefox driver (geckodriver).
+     *
+     * @return the path to Firefox driver, or empty if not set.
+     */
+    public String getFirefoxDriverPath() {
+        return firefoxDriverPath;
+    }
+
+    /**
+     * Sets the path to Firefox driver (geckodriver).
+     *
+     * @param firefoxDriverPath the path to Firefox driver, or empty if not known.
+     * @throws IllegalArgumentException if {@code firefoxDriverPath} is {@code null}.
+     */
+    public void setFirefoxDriverPath(String firefoxDriverPath) {
+        Validate.notNull(firefoxDriverPath, "Parameter firefoxDriverPath must not be null.");
+
+        if (!this.firefoxDriverPath.equals(firefoxDriverPath)) {
+            this.firefoxDriverPath = firefoxDriverPath;
+
+            saveAndSetSystemProperty(FIREFOX_DRIVER_KEY, FIREFOX_DRIVER_SYSTEM_PROPERTY, firefoxDriverPath);
         }
     }
 

--- a/src/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
@@ -40,6 +40,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
  * <ul>
  * <li>The path to ChromeDriver;</li>
  * <li>The path to Firefox binary.</li>
+ * <li>The path to Firefox driver (geckodriver).</li>
  * <li>The path to IEDriverServer;</li>
  * <li>The path to PhantomJS binary.</li>
  * </ul>
@@ -52,6 +53,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
 
     private final JTextField chromeDriverTextField;
     private final JTextField firefoxBinaryTextField;
+    private final JTextField firefoxDriverTextField;
     private final JTextField ieDriverTextField;
     private final JTextField phantomJsBinaryTextField;
 
@@ -76,6 +78,11 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         JLabel firefoxBinaryLabel = new JLabel(resourceBundle.getString("selenium.options.label.firefox.binary"));
         firefoxBinaryLabel.setLabelFor(firefoxBinaryTextField);
 
+        firefoxDriverTextField = createTextField();
+        JButton firefoxDriverButton = createButtonFileChooser(selectFileButtonLabel, firefoxDriverTextField);
+        JLabel firefoxDriverLabel = new JLabel(resourceBundle.getString("selenium.options.label.firefox.driver"));
+        firefoxDriverLabel.setLabelFor(firefoxDriverTextField);
+
         ieDriverTextField = createTextField();
         JButton ieDriverButton = createButtonFileChooser(selectFileButtonLabel, ieDriverTextField);
         JLabel ieDriverLabel = new JLabel(resourceBundle.getString("selenium.options.label.driver.ie"));
@@ -91,6 +98,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                         layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
                                 .addComponent(chromeDriverLabel)
                                 .addComponent(firefoxBinaryLabel)
+                                .addComponent(firefoxDriverLabel)
                                 .addComponent(ieDriverLabel)
                                 .addComponent(phantomJsBinaryLabel))
                 .addGroup(
@@ -103,6 +111,10 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                                         layout.createSequentialGroup()
                                                 .addComponent(firefoxBinaryTextField)
                                                 .addComponent(firefoxBinaryButton))
+                                .addGroup(
+                                        layout.createSequentialGroup()
+                                                .addComponent(firefoxDriverTextField)
+                                                .addComponent(firefoxDriverButton))
                                 .addGroup(
                                         layout.createSequentialGroup()
                                                 .addComponent(ieDriverTextField)
@@ -123,6 +135,11 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                                 .addComponent(firefoxBinaryLabel)
                                 .addComponent(firefoxBinaryTextField)
                                 .addComponent(firefoxBinaryButton))
+                .addGroup(
+                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                .addComponent(firefoxDriverLabel)
+                                .addComponent(firefoxDriverTextField)
+                                .addComponent(firefoxDriverButton))
                 .addGroup(
                         layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                 .addComponent(ieDriverLabel)
@@ -153,6 +170,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
 
         chromeDriverTextField.setText(seleniumOptions.getChromeDriverPath());
         firefoxBinaryTextField.setText(seleniumOptions.getFirefoxBinaryPath());
+        firefoxDriverTextField.setText(seleniumOptions.getFirefoxDriverPath());
         ieDriverTextField.setText(seleniumOptions.getIeDriverPath());
         phantomJsBinaryTextField.setText(seleniumOptions.getPhantomJsBinaryPath());
     }
@@ -168,6 +186,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
 
         seleniumOptions.setChromeDriverPath(chromeDriverTextField.getText());
         seleniumOptions.setFirefoxBinaryPath(firefoxBinaryTextField.getText());
+        seleniumOptions.setFirefoxDriverPath(firefoxDriverTextField.getText());
         seleniumOptions.setIeDriverPath(ieDriverTextField.getText());
         seleniumOptions.setPhantomJsBinaryPath(phantomJsBinaryTextField.getText());
     }

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
 	<name>Selenium</name>
-	<version>7</version>
+	<version>8</version>
 	<semver>1.0.0</semver><!-- This version should be kept in sync with the one of the extension. -->
 	<status>release</status>
 	<description>WebDriver provider and includes HtmlUnit browser</description>
@@ -8,9 +8,8 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Allow to use Firefox 47.0.1 (Issue 2739).<br>
-	Allow to manually specify the paths to binaries and WebDrivers in the options.<br>
-	Allow to choose which Firefox binary is used.<br>
+	Allow to use Firefox 48+ (Issue 2743).<br>
+	Allow to specify the path to geckodriver.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -14,6 +14,7 @@ selenium.options.title = Selenium
 selenium.options.label.button.select.file = Select...
 selenium.options.label.driver.chrome = ChromeDriver:
 selenium.options.label.firefox.binary = Firefox binary:
+selenium.options.label.firefox.driver = Firefox driver (geckodriver):
 selenium.options.label.driver.ie = IEDriverServer:
 selenium.options.label.phantomjs.binary = PhantomJS binary:
 
@@ -24,9 +25,11 @@ selenium.warn.message.failed.start.browser.phantomjs = Failed to start PhantomJS
 
 selenium.api.view.optionChromeDriverPath = Returns the current path to ChromeDriver
 selenium.api.view.optionFirefoxBinaryPath = Returns the current path to Firefox binary
+selenium.api.view.optionFirefoxDriverPath = Returns the current path to Firefox driver (geckodriver)
 selenium.api.view.optionIeDriverPath = Returns the current path to IEDriverServer
 selenium.api.view.optionPhantomJsBinaryPath = Returns the current path to PhantomJS binary
 selenium.api.action.setOptionChromeDriverPath = Sets the current path to ChromeDriver
 selenium.api.action.setOptionFirefoxBinaryPath = Sets the current path to Firefox binary
+selenium.api.action.setOptionFirefoxDriverPath = Sets the current path to Firefox driver (geckodriver)
 selenium.api.action.setOptionIeDriverPath = Sets the current path to IEDriverServer
 selenium.api.action.setOptionPhantomJsBinaryPath = Sets the current path to PhantomJS binary

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/api.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/api.html
@@ -31,6 +31,12 @@
 			<td>Returns the current path to Firefox binary</td>
 		</tr>
 		<tr>
+			<td>optionFirefoxDriverPath</td>
+			<td>view</td>
+			<td></td>
+			<td>Returns the current path to Firefox driver (geckodriver)</td>
+		</tr>
+		<tr>
 			<td>optionIeDriverPath</td>
 			<td>view</td>
 			<td></td>
@@ -53,6 +59,12 @@
 			<td>action</td>
 			<td>String*</td>
 			<td>Sets the current path to Firefox binary</td>
+		</tr>
+		<tr>
+			<td>setOptionFirefoxDriverPath</td>
+			<td>action</td>
+			<td>String*</td>
+			<td>Sets the current path to Firefox driver (geckodriver)</td>
 		</tr>
 		<tr>
 			<td>setOptionIeDriverPath</td>

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
@@ -14,7 +14,8 @@
 	<ul>
 		<li>Chrome</li>
 		<li>Firefox - the following versions are known to work: 45 (ESR), 46 and 47.0.1
-			(older version might work too). Some versions do not work correctly: 47.0 and 48+.</li>
+			(older version might work too). Some versions are known to not work, for example, 47.0.
+			Newer versions (&ge; 48) require geckodriver.</li>
 		<li>HtmlUnit</li>
 		<li>Internet Explorer</li>
 		<li>Opera</li>
@@ -28,30 +29,40 @@
 			Selenium screen</a>, to access and control them:
 	<ul>
 		<li>Chrome - requires ChromeDriver, if not on the system's PATH, it can be set in
-			the options. For more information on ChromeDriver and how to obtain it refer to <a
+			the options. For more information on ChromeDriver and how to obtain it refer to the <a
 			href="https://sites.google.com/a/chromium.org/chromedriver/">ChromeDriver website</a>.
 		</li>
+		<li>Firefox - requires geckodriver for versions &ge; 48, it can be set in the
+			options. For more information on geckodriver and how to obtain it refer to the <a
+			href="https://github.com/mozilla/geckodriver">geckodriver website</a> (see footer note
+			for caveat when using geckodriver).
+		</li>
 		<li>PhantomJS - requires PhantomJS binary, if not on the system's PATH, it can be
-			set in the options. For more information on PhantomJS and how to obtain it refer to <a
-			href="http://phantomjs.org/">PhantomJS website</a> (see footer note for caveat when
+			set in the options. For more information on PhantomJS and how to obtain it refer to the
+			<a href="http://phantomjs.org/">PhantomJS website</a> (see footer note for caveat when
 			using PhantomJS).
 		</li>
 		<li>Internet Explorer - requires IEDriverServer, if not on the system's PATH, it
-			can be set in the options. For more information on IEDriverServer refer to <a
+			can be set in the options. For more information on IEDriverServer refer to the <a
 			href="https://code.google.com/p/selenium/wiki/InternetExplorerDriver">IEDriverServer
 				website</a> (see footer note for caveat when using Internet Explorer).
 		</li>
 	</ul>
 
 	<p>
+		<strong>Firefox/geckodriver Note:</strong> There's an issue (<a
+			href="https://bugzilla.mozilla.org/show_bug.cgi?id=1103196">Bug 1103196</a>) that
+		prevents HTTPS sites from being used in versions &ge; 48 and &lt; 52.
+	<p>
 		<strong>PhantomJS Note:</strong> There's an issue (<a
 			href="https://github.com/ariya/phantomjs/issues/11342">Issue #11342</a>) that prevents
 		sites at localhost, 127.0.0.1 and ::1 from being proxied through ZAP. Until a fix is
 		available is advised to not use it in those cases. Some add-ons might choose to show
-		warning message when that happens.
+		warning message when that happens. As workaround one could define, in the <code>hosts</code>
+		file, a domain name mapping to the local address and use that domain name instead.
 	<p>
 		<strong>Internet Explorer Note:</strong> Not all versions of Internet Explorer work out
-		of the box, refer to <a
+		of the box, refer to the <a
 			href="https://code.google.com/p/selenium/wiki/InternetExplorerDriver#Required_Configuration">IEDriverServer
 			website</a> for more details on how to configure them.
 	<H2>See also</H2>

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
@@ -31,6 +31,11 @@
 			<td align="center">(None)</td>
 		</tr>
 		<tr>
+			<td>Firefox driver (geckodriver)</td>
+			<td>This allows you to select the location of Firefox driver (geckodriver).</td>
+			<td align="center">(None)</td>
+		</tr>
+		<tr>
 			<td>IEDriverServer</td>
 			<td>This allows you to select the location of IEDriverServer.</td>
 			<td align="center">(None)</td>


### PR DESCRIPTION
Change ExtensionSelenium to use geckodriver/marionette, allowing to use
newer versions of Firefox (>= 48).
Change options to allow to specify the path to geckodriver.
Backport GeckoDriverService to not require updating Selenium (which
needs Java 8).
Update help pages to mention the supported versions of Firefox.
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2743 - Unable to use Firefox 48+ with AJAX Spider