### PR TITLE
Change license header to plain comment (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.


### PR DESCRIPTION
Change license header in scanners from JavaDoc comment to a plain
comment.