### PR TITLE
Change license header to plain comment (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Zed Attack Proxy (ZAP) and its related class files.
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.


### PR DESCRIPTION
Change license header in scanners from JavaDoc comment to a plain
comment.