### PR TITLE
selenium: use bundled WebDrivers by default

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/src/org/zaproxy/zap/extension/selenium/Browser.java
@@ -19,7 +19,19 @@
  */
 package org.zaproxy.zap.extension.selenium;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
 import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
 
 /**
  * Defines the browsers supported by the add-on.
@@ -38,6 +50,12 @@ public enum Browser {
     OPERA("opera"),
     PHANTOM_JS("phantomjs"),
     SAFARI("safari");
+
+    private static final String WEB_DRIVERS_DIR_NAME = "webdriver";
+
+    private static final Logger logger = Logger.getLogger(Browser.class);
+
+    private static Path zapHomeDir;
 
     private final String id;
 
@@ -101,4 +119,155 @@ public enum Browser {
         return HTML_UNIT;
     }
 
+    /**
+     * Tells whether or not the given path is a bundled WebDriver.
+     * <p>
+     * No actual check is done to test whether or not the WebDriver really exists, just that it's under the directory of the
+     * bundled WebDrivers.
+     *
+     * @param path the path to check
+     * @return {@code true} if the path is a bundled WebDriver, {@code false} otherwise.
+     */
+    public static boolean isBundledWebDriverPath(String path) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+
+        try {
+            return Paths.get(path).startsWith(getWebDriversDir());
+        } catch (InvalidPathException e) {
+            logger.warn("Failed to create path for " + path, e);
+            return false;
+        }
+    }
+
+    private static Path getWebDriversDir() {
+        return getZapHomeDir().resolve(WEB_DRIVERS_DIR_NAME);
+    }
+
+    /**
+     * Tells whether or not a bundled WebDriver exists for the given browser.
+     *
+     * @param browser the browser that will be checked
+     * @return {@code true} if the bundled WebDriver exists, {@code false} otherwise.
+     * @see #getBundledWebDriverPath(Browser)
+     */
+    public static boolean hasBundledWebDriver(Browser browser) {
+        return getBundledWebDriverPath(browser) != null;
+    }
+
+    /**
+     * Gets the path to the bundled WebDriver of the given browser.
+     *
+     * @param browser the target browser
+     * @return the path to the bundled WebDriver, or {@code null} if none available.
+     * @see #hasBundledWebDriver(Browser)
+     */
+    public static String getBundledWebDriverPath(Browser browser) {
+        String osDirName = getOsDirName();
+        if (osDirName == null) {
+            return null;
+        }
+
+        String driverName = getWebDriverName(browser);
+        if (driverName == null) {
+            return null;
+        }
+
+        if ("windows".equals(osDirName)) {
+            driverName += ".exe";
+        }
+
+        Path basePath = getWebDriversDir().resolve(osDirName);
+        Path driver;
+        if (isOs64Bits()) {
+            driver = basePath.resolve("64").resolve(driverName);
+            if (Files.exists(driver)) {
+                try {
+                    setExecutable(driver);
+                    return driver.toAbsolutePath().toString();
+                } catch (IOException e) {
+                    logger.warn("Failed to set the bundled WebDriver executable:", e);
+                }
+            }
+        }
+
+        driver = basePath.resolve("32").resolve(driverName);
+        if (Files.exists(driver)) {
+            try {
+                setExecutable(driver);
+                return driver.toAbsolutePath().toString();
+            } catch (IOException e) {
+                logger.warn("Failed to set the bundled WebDriver executable:", e);
+            }
+        }
+
+        return null;
+    }
+
+    private static String getWebDriverName(Browser browser) {
+        switch (browser) {
+        case CHROME:
+            return "chromedriver";
+        case INTERNET_EXPLORER:
+            return "IEDriverServer";
+        case FIREFOX:
+            return "geckodriver";
+        default:
+            return null;
+        }
+    }
+
+    private static String getOsDirName() {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return "windows";
+        }
+        if (SystemUtils.IS_OS_MAC) {
+            return "macos";
+        }
+        if (SystemUtils.IS_OS_UNIX) {
+            return "linux";
+        }
+        return null;
+    }
+
+    private static boolean isOs64Bits() {
+        String arch = System.getProperty("os.arch");
+        return arch.contains("amd64") || arch.contains("x86_64");
+    }
+
+    private static void setExecutable(Path file) throws IOException {
+        if (!SystemUtils.IS_OS_MAC && !SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+
+        Set<PosixFilePermission> perms = Files.readAttributes(file, PosixFileAttributes.class).permissions();
+        if (perms.contains(PosixFilePermission.OWNER_EXECUTE)) {
+            return;
+        }
+
+        perms.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(file, perms);
+    }
+
+    static boolean ensureExecutable(Path driver) {
+        try {
+            setExecutable(driver);
+            return true;
+        } catch (IOException e) {
+            logger.warn("Failed to set the bundled WebDriver executable:", e);
+        }
+        return false;
+    }
+
+    static void setZapHomeDir(Path path) {
+        zapHomeDir = path;
+    }
+
+    private static Path getZapHomeDir() {
+        if (zapHomeDir == null) {
+            zapHomeDir = Paths.get(Constant.getZapHome());
+        }
+        return zapHomeDir;
+    }
 }

--- a/src/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
+++ b/src/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
@@ -19,6 +19,10 @@
  */
 package org.zaproxy.zap.extension.selenium;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.lang.Validate;
 import org.apache.log4j.Logger;
@@ -138,11 +142,42 @@ public class SeleniumOptions extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
-        chromeDriverPath = readSystemPropertyWithOptionFallback(CHROME_DRIVER_SYSTEM_PROPERTY, CHROME_DRIVER_KEY);
+        chromeDriverPath = getWebDriverPath(Browser.CHROME, CHROME_DRIVER_SYSTEM_PROPERTY, CHROME_DRIVER_KEY);
         firefoxBinaryPath = readSystemPropertyWithOptionFallback(FIREFOX_BINARY_SYSTEM_PROPERTY, FIREFOX_BINARY_KEY);
-        firefoxDriverPath = readSystemPropertyWithOptionFallback(FIREFOX_DRIVER_SYSTEM_PROPERTY, FIREFOX_DRIVER_KEY);
-        ieDriverPath = readSystemPropertyWithOptionFallback(IE_DRIVER_SYSTEM_PROPERTY, IE_DRIVER_KEY);
+        firefoxDriverPath = getWebDriverPath(Browser.FIREFOX, FIREFOX_DRIVER_SYSTEM_PROPERTY, FIREFOX_DRIVER_KEY);
+        ieDriverPath = getWebDriverPath(Browser.INTERNET_EXPLORER, IE_DRIVER_SYSTEM_PROPERTY, IE_DRIVER_KEY);
+
         phantomJsBinaryPath = readSystemPropertyWithOptionFallback(PHANTOM_JS_BINARY_SYSTEM_PROPERTY, PHANTOM_JS_BINARY_KEY);
+    }
+
+    /**
+     * Gets the path to the WebDriver of the given browser.
+     * <p>
+     * Reads the given {@code systemProperty}, falling back to the option with the given {@code optionKey} if not set. If both
+     * properties are empty it returns the path to the bundled WebDriver, if available.
+     *
+     * @param browser the target browser
+     * @param systemProperty the name of the system property
+     * @param optionKey the key of the option used as fallback
+     * @return the path to the WebDriver, or empty if none set or available.
+     * @see #readSystemPropertyWithOptionFallback(String, String)
+     */
+    private String getWebDriverPath(Browser browser, String systemProperty, String optionKey) {
+        String path = readSystemPropertyWithOptionFallback(systemProperty, optionKey);
+        if (path.isEmpty()) {
+            String bundledPath = Browser.getBundledWebDriverPath(browser);
+            if (bundledPath != null) {
+                saveAndSetSystemProperty(optionKey, systemProperty, bundledPath);
+                return bundledPath;
+            }
+        } else if (Browser.isBundledWebDriverPath(path)) {
+            Path driver = Paths.get(path);
+            if (!Files.exists(driver) || !Browser.ensureExecutable(driver)) {
+                saveAndSetSystemProperty(optionKey, systemProperty, "");
+                return "";
+            }
+        }
+        return path;
     }
 
     /**
@@ -153,8 +188,8 @@ public class SeleniumOptions extends VersionedAbstractParam {
      * 
      * @param systemProperty the name of the system property
      * @param optionKey the key of the option used as fallback
-     * @return the value of the system property, or if not set, the option read from the configuration file, might be
-     *         {@code null} if neither the system property nor the option are set.
+     * @return the value of the system property, or if not set, the option read from the configuration file. If neither the
+     *         system property nor the option are set it returns an empty {@code String}.
      */
     private String readSystemPropertyWithOptionFallback(String systemProperty, String optionKey) {
         String value = System.getProperty(systemProperty);

--- a/src/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
@@ -19,19 +19,28 @@
  */
 package org.zaproxy.zap.extension.selenium;
 
+import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ResourceBundle;
 
+import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JTextField;
+import javax.swing.border.TitledBorder;
 
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.zap.utils.FontUtils;
 
 /**
  * The GUI Selenium options panel.
@@ -52,26 +61,45 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
     private static final long serialVersionUID = -4918932139321106800L;
 
     private final JTextField chromeDriverTextField;
-    private final JTextField firefoxBinaryTextField;
+    private final JLabel infoBundledChromeDriverLabel;
+    private final JButton useBundledChromeDriverButton;
     private final JTextField firefoxDriverTextField;
+    private final JLabel infoBundledFirefoxDriverLabel;
+    private final JButton useBundledFirefoxDriverButton;
     private final JTextField ieDriverTextField;
+    private final JLabel infoBundledIeDriverLabel;
+    private final JButton useBundledIeDriverButton;
+
+    private final JTextField firefoxBinaryTextField;
     private final JTextField phantomJsBinaryTextField;
 
     public SeleniumOptionsPanel(ResourceBundle resourceBundle) {
         setName(resourceBundle.getString("selenium.options.title"));
 
-        GroupLayout layout = new GroupLayout(this);
-        setLayout(layout);
-
-        layout.setAutoCreateGaps(true);
-        layout.setAutoCreateContainerGaps(true);
-
         String selectFileButtonLabel = resourceBundle.getString("selenium.options.label.button.select.file");
+        String bundledWebDriverButtonLabel = resourceBundle.getString("selenium.options.label.button.bundleddriver");
+        String bundledWebDriverButtonToolTip = resourceBundle.getString("selenium.options.tooltip.button.bundleddriver");
+
+        String infoBundledWebDriverlabel = resourceBundle.getString("selenium.options.label.nobundleddriver");
+        String infoBundledWebDriverToolTip = resourceBundle.getString("selenium.options.tooltip.nobundleddriver");
+        ImageIcon infoIcon = new ImageIcon(
+                SeleniumOptionsPanel.class.getResource("/resource/icon/fugue/information-white.png"));
 
         chromeDriverTextField = createTextField();
         JButton chromeDriverButton = createButtonFileChooser(selectFileButtonLabel, chromeDriverTextField);
         JLabel chromeDriverLabel = new JLabel(resourceBundle.getString("selenium.options.label.driver.chrome"));
         chromeDriverLabel.setLabelFor(chromeDriverButton);
+
+        infoBundledChromeDriverLabel = createBundledWebDriverLabel(
+                infoBundledWebDriverlabel,
+                infoBundledWebDriverToolTip,
+                infoIcon);
+        useBundledChromeDriverButton = createBundledWebDriverButton(
+                bundledWebDriverButtonLabel,
+                bundledWebDriverButtonToolTip,
+                infoBundledWebDriverToolTip,
+                chromeDriverTextField,
+                Browser.CHROME);
 
         firefoxBinaryTextField = createTextField();
         JButton firefoxBinaryButton = createButtonFileChooser(selectFileButtonLabel, firefoxBinaryTextField);
@@ -83,73 +111,198 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         JLabel firefoxDriverLabel = new JLabel(resourceBundle.getString("selenium.options.label.firefox.driver"));
         firefoxDriverLabel.setLabelFor(firefoxDriverTextField);
 
+        infoBundledFirefoxDriverLabel = createBundledWebDriverLabel(
+                infoBundledWebDriverlabel,
+                infoBundledWebDriverToolTip,
+                infoIcon);
+        useBundledFirefoxDriverButton = createBundledWebDriverButton(
+                bundledWebDriverButtonLabel,
+                bundledWebDriverButtonToolTip,
+                infoBundledWebDriverToolTip,
+                firefoxDriverTextField,
+                Browser.FIREFOX);
+
         ieDriverTextField = createTextField();
         JButton ieDriverButton = createButtonFileChooser(selectFileButtonLabel, ieDriverTextField);
         JLabel ieDriverLabel = new JLabel(resourceBundle.getString("selenium.options.label.driver.ie"));
         ieDriverLabel.setLabelFor(ieDriverButton);
+
+        infoBundledIeDriverLabel = createBundledWebDriverLabel(
+                infoBundledWebDriverlabel,
+                infoBundledWebDriverToolTip,
+                infoIcon);
+        useBundledIeDriverButton = createBundledWebDriverButton(
+                bundledWebDriverButtonLabel,
+                bundledWebDriverButtonToolTip,
+                infoBundledWebDriverToolTip,
+                ieDriverTextField,
+                Browser.INTERNET_EXPLORER);
 
         phantomJsBinaryTextField = createTextField();
         JButton phantomJsBinaryButton = createButtonFileChooser(selectFileButtonLabel, phantomJsBinaryTextField);
         JLabel phantomJsBinaryLabel = new JLabel(resourceBundle.getString("selenium.options.label.phantomjs.binary"));
         phantomJsBinaryLabel.setLabelFor(phantomJsBinaryButton);
 
-        layout.setHorizontalGroup(layout.createSequentialGroup()
-                .addGroup(
-                        layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
-                                .addComponent(chromeDriverLabel)
-                                .addComponent(firefoxBinaryLabel)
-                                .addComponent(firefoxDriverLabel)
-                                .addComponent(ieDriverLabel)
-                                .addComponent(phantomJsBinaryLabel))
-                .addGroup(
-                        layout.createParallelGroup(GroupLayout.Alignment.LEADING)
-                                .addGroup(
-                                        layout.createSequentialGroup()
-                                                .addComponent(chromeDriverTextField)
-                                                .addComponent(chromeDriverButton))
-                                .addGroup(
-                                        layout.createSequentialGroup()
-                                                .addComponent(firefoxBinaryTextField)
-                                                .addComponent(firefoxBinaryButton))
-                                .addGroup(
-                                        layout.createSequentialGroup()
-                                                .addComponent(firefoxDriverTextField)
-                                                .addComponent(firefoxDriverButton))
-                                .addGroup(
-                                        layout.createSequentialGroup()
-                                                .addComponent(ieDriverTextField)
-                                                .addComponent(ieDriverButton))
-                                .addGroup(
-                                        layout.createSequentialGroup()
-                                                .addComponent(phantomJsBinaryTextField)
-                                                .addComponent(phantomJsBinaryButton))));
+        JPanel driversPanel = new JPanel();
+        driversPanel.setBorder(
+                BorderFactory.createTitledBorder(
+                        null,
+                        resourceBundle.getString("selenium.options.webdrivers.title"),
+                        TitledBorder.DEFAULT_JUSTIFICATION,
+                        TitledBorder.DEFAULT_POSITION,
+                        FontUtils.getFont(FontUtils.Size.standard),
+                        Color.black));
 
-        layout.setVerticalGroup(layout.createSequentialGroup()
-                .addGroup(
-                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                .addComponent(chromeDriverLabel)
-                                .addComponent(chromeDriverTextField)
-                                .addComponent(chromeDriverButton))
-                .addGroup(
-                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                .addComponent(firefoxBinaryLabel)
-                                .addComponent(firefoxBinaryTextField)
-                                .addComponent(firefoxBinaryButton))
-                .addGroup(
-                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                .addComponent(firefoxDriverLabel)
-                                .addComponent(firefoxDriverTextField)
-                                .addComponent(firefoxDriverButton))
-                .addGroup(
-                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                .addComponent(ieDriverLabel)
-                                .addComponent(ieDriverTextField)
-                                .addComponent(ieDriverButton))
-                .addGroup(
-                        layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                .addComponent(phantomJsBinaryLabel)
-                                .addComponent(phantomJsBinaryTextField)
-                                .addComponent(phantomJsBinaryButton)));
+        GroupLayout driversLayout = new GroupLayout(driversPanel);
+        driversPanel.setLayout(driversLayout);
+
+        driversLayout.setAutoCreateGaps(true);
+        driversLayout.setAutoCreateContainerGaps(true);
+
+        driversLayout.setHorizontalGroup(
+                driversLayout.createSequentialGroup()
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+                                        .addComponent(chromeDriverLabel)
+                                        .addComponent(firefoxDriverLabel)
+                                        .addComponent(ieDriverLabel))
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                        .addGroup(
+                                                driversLayout.createSequentialGroup()
+                                                        .addGroup(
+                                                                driversLayout.createParallelGroup()
+                                                                        .addComponent(chromeDriverTextField)
+                                                                        .addComponent(infoBundledChromeDriverLabel))
+                                                        .addGroup(
+                                                                driversLayout.createParallelGroup()
+                                                                        .addComponent(chromeDriverButton)
+                                                                        .addComponent(useBundledChromeDriverButton)))
+                                        .addGroup(
+                                                driversLayout.createSequentialGroup()
+                                                        .addGroup(
+                                                                driversLayout.createParallelGroup()
+                                                                        .addComponent(firefoxDriverTextField)
+                                                                        .addComponent(infoBundledFirefoxDriverLabel))
+                                                        .addGroup(
+                                                                driversLayout.createParallelGroup()
+                                                                        .addComponent(firefoxDriverButton)
+                                                                        .addComponent(useBundledFirefoxDriverButton)))
+                                        .addGroup(
+                                                driversLayout.createSequentialGroup()
+                                                        .addGroup(
+                                                                driversLayout.createParallelGroup()
+                                                                        .addComponent(ieDriverTextField)
+                                                                        .addComponent(infoBundledIeDriverLabel))
+                                                        .addGroup(
+                                                                driversLayout.createParallelGroup()
+                                                                        .addComponent(ieDriverButton)
+                                                                        .addComponent(useBundledIeDriverButton)))));
+
+        driversLayout.setVerticalGroup(
+                driversLayout.createSequentialGroup()
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(chromeDriverLabel)
+                                        .addComponent(chromeDriverTextField)
+                                        .addComponent(chromeDriverButton))
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(infoBundledChromeDriverLabel)
+                                        .addComponent(useBundledChromeDriverButton))
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(firefoxDriverLabel)
+                                        .addComponent(firefoxDriverTextField)
+                                        .addComponent(firefoxDriverButton))
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(infoBundledFirefoxDriverLabel)
+                                        .addComponent(useBundledFirefoxDriverButton))
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(ieDriverLabel)
+                                        .addComponent(ieDriverTextField)
+                                        .addComponent(ieDriverButton))
+                        .addGroup(
+                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(infoBundledIeDriverLabel)
+                                        .addComponent(useBundledIeDriverButton)));
+
+        JPanel binariesPanel = new JPanel();
+        binariesPanel.setBorder(
+                BorderFactory.createTitledBorder(
+                        null,
+                        resourceBundle.getString("selenium.options.binaries.title"),
+                        TitledBorder.DEFAULT_JUSTIFICATION,
+                        TitledBorder.DEFAULT_POSITION,
+                        FontUtils.getFont(FontUtils.Size.standard),
+                        Color.black));
+
+        GroupLayout binariesLayout = new GroupLayout(binariesPanel);
+        binariesPanel.setLayout(binariesLayout);
+
+        binariesLayout.setAutoCreateGaps(true);
+        binariesLayout.setAutoCreateContainerGaps(true);
+
+        binariesLayout.setHorizontalGroup(
+                binariesLayout.createSequentialGroup()
+                        .addGroup(
+                                binariesLayout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+                                        .addComponent(firefoxBinaryLabel)
+                                        .addComponent(phantomJsBinaryLabel))
+                        .addGroup(
+                                binariesLayout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                        .addGroup(
+                                                binariesLayout.createSequentialGroup()
+                                                        .addComponent(firefoxBinaryTextField)
+                                                        .addComponent(firefoxBinaryButton))
+                                        .addGroup(
+                                                binariesLayout.createSequentialGroup()
+                                                        .addComponent(phantomJsBinaryTextField)
+                                                        .addComponent(phantomJsBinaryButton))));
+
+        binariesLayout.setVerticalGroup(
+                binariesLayout.createSequentialGroup()
+                        .addGroup(
+                                binariesLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(firefoxBinaryLabel)
+                                        .addComponent(firefoxBinaryTextField)
+                                        .addComponent(firefoxBinaryButton))
+                        .addGroup(
+                                binariesLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(phantomJsBinaryLabel)
+                                        .addComponent(phantomJsBinaryTextField)
+                                        .addComponent(phantomJsBinaryButton)));
+
+        GroupLayout layout = new GroupLayout(this);
+        setLayout(layout);
+
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setHorizontalGroup(layout.createParallelGroup().addComponent(driversPanel).addComponent(binariesPanel));
+        layout.setVerticalGroup(layout.createSequentialGroup().addComponent(driversPanel).addComponent(binariesPanel));
+    }
+
+    private JButton createBundledWebDriverButton(
+            String label,
+            String toolTip,
+            String disabledToolTip,
+            JTextField bindTextField,
+            Browser browser) {
+        ZapButton button = new ZapButton(label);
+        button.setToolTipText(toolTip);
+        button.setDisabledToolTipText(disabledToolTip);
+        button.addActionListener(new BundledWebDriverAction(bindTextField, browser));
+        return button;
+    }
+
+    private JLabel createBundledWebDriverLabel(String text, String toolTip, Icon icon) {
+        JLabel label = new JLabel(text);
+        label.setIcon(icon);
+        label.setToolTipText(toolTip);
+        return label;
     }
 
     private static JTextField createTextField() {
@@ -168,11 +321,52 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         OptionsParam optionsParam = (OptionsParam) obj;
         SeleniumOptions seleniumOptions = optionsParam.getParamSet(SeleniumOptions.class);
 
-        chromeDriverTextField.setText(seleniumOptions.getChromeDriverPath());
+        boolean driverAvailable = Browser.hasBundledWebDriver(Browser.CHROME);
+        infoBundledChromeDriverLabel.setVisible(!driverAvailable);
+        useBundledChromeDriverButton.setEnabled(driverAvailable);
+
+        chromeDriverTextField
+                .setText(getEffectiveDriverPath(Browser.CHROME, seleniumOptions.getChromeDriverPath(), driverAvailable));
+
+        driverAvailable = Browser.hasBundledWebDriver(Browser.FIREFOX);
+        infoBundledFirefoxDriverLabel.setVisible(!driverAvailable);
+        useBundledFirefoxDriverButton.setEnabled(driverAvailable);
+
+        firefoxDriverTextField
+                .setText(getEffectiveDriverPath(Browser.FIREFOX, seleniumOptions.getFirefoxDriverPath(), driverAvailable));
+
+        driverAvailable = Browser.hasBundledWebDriver(Browser.INTERNET_EXPLORER);
+        infoBundledIeDriverLabel.setVisible(!driverAvailable);
+        useBundledIeDriverButton.setEnabled(driverAvailable);
+
+        ieDriverTextField
+                .setText(getEffectiveDriverPath(Browser.INTERNET_EXPLORER, seleniumOptions.getIeDriverPath(), driverAvailable));
+
         firefoxBinaryTextField.setText(seleniumOptions.getFirefoxBinaryPath());
-        firefoxDriverTextField.setText(seleniumOptions.getFirefoxDriverPath());
-        ieDriverTextField.setText(seleniumOptions.getIeDriverPath());
         phantomJsBinaryTextField.setText(seleniumOptions.getPhantomJsBinaryPath());
+    }
+
+    private static String getEffectiveDriverPath(Browser browser, String driverPath, boolean bundledDriverAvailable) {
+        if (driverPath.isEmpty()) {
+            if (bundledDriverAvailable) {
+                return Browser.getBundledWebDriverPath(browser);
+            }
+            return "";
+        }
+
+        if (!Browser.isBundledWebDriverPath(driverPath)) {
+            return driverPath;
+        }
+
+        if (!bundledDriverAvailable) {
+            return "";
+        }
+
+        if (Files.exists(Paths.get(driverPath))) {
+            return driverPath;
+        }
+
+        return Browser.getBundledWebDriverPath(browser);
     }
 
     @Override
@@ -219,6 +413,55 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
 
                 textField.setText(selectedFile.getAbsolutePath());
             }
+        }
+    }
+
+    private static class BundledWebDriverAction implements ActionListener {
+
+        private final JTextField textField;
+        private final Browser browser;
+
+        public BundledWebDriverAction(JTextField bindTextField, Browser browser) {
+            this.textField = bindTextField;
+            this.browser = browser;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            textField.setText(Browser.getBundledWebDriverPath(browser));
+        }
+    }
+
+    private static class ZapButton extends JButton {
+
+        private static final long serialVersionUID = 1L;
+
+        private String defaultToolTipText;
+        private String disabledToolTipText;
+
+        public ZapButton(String label) {
+            super(label);
+        }
+
+        @Override
+        public void setEnabled(boolean b) {
+            super.setEnabled(b);
+            updateCurrentToolTipText();
+        }
+
+        private void updateCurrentToolTipText() {
+            super.setToolTipText((!isEnabled() && disabledToolTipText != null) ? disabledToolTipText : defaultToolTipText);
+        }
+
+        @Override
+        public void setToolTipText(String text) {
+            defaultToolTipText = text;
+            updateCurrentToolTipText();
+        }
+
+        public void setDisabledToolTipText(String text) {
+            disabledToolTipText = text;
+            updateCurrentToolTipText();
         }
     }
 }

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	<![CDATA[
 	Allow to use Firefox 48+ (Issue 2743).<br>
 	Allow to specify the path to geckodriver.<br>
+	Use bundled WebDrivers by default.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -11,12 +11,18 @@ selenium.browser.name.phantomjs = PhantomJS
 selenium.browser.name.safari = Safari
 
 selenium.options.title = Selenium
+selenium.options.label.nobundleddriver = No bundled WebDriver available.
+selenium.options.tooltip.nobundleddriver = <html>No bundled WebDriver available.<br />Refer to the help page for more details.</html>
+selenium.options.label.button.bundleddriver = Bundled
+selenium.options.tooltip.button.bundleddriver = <html>Sets the path to the bundled WebDriver.<br />Refer to the help page for more details.</html>
+selenium.options.webdrivers.title = WebDrivers
+selenium.options.binaries.title = Binaries
 selenium.options.label.button.select.file = Select...
 selenium.options.label.driver.chrome = ChromeDriver:
-selenium.options.label.firefox.binary = Firefox binary:
-selenium.options.label.firefox.driver = Firefox driver (geckodriver):
+selenium.options.label.firefox.binary = Firefox:
+selenium.options.label.firefox.driver = geckodriver:
 selenium.options.label.driver.ie = IEDriverServer:
-selenium.options.label.phantomjs.binary = PhantomJS binary:
+selenium.options.label.phantomjs.binary = PhantomJS:
 
 selenium.warn.message.failed.start.browser = Failed to start ''{0}'', is the browser installed/available?
 selenium.warn.message.failed.start.browser.chrome = Failed to start Chrome browser.\nMake sure that Chrome and ChromeDriver are available.\nFor more details refer to "Options Selenium screen" help page.

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
@@ -20,34 +20,48 @@
 			<th>Default</th>
 		</tr>
 		<tr>
+			<th colspan="3">WebDrivers</th>
+		</tr>
+		<tr>
 			<td>ChromeDriver</td>
 			<td>This allows you to select the location of ChromeDriver.</td>
-			<td align="center">(None)</td>
+			<td align="center">The path to the bundled WebDriver, if available.</td>
 		</tr>
 		<tr>
-			<td>Firefox binary</td>
-			<td>This allows you to select the location of Firefox binary (for example, to use
-				other version than the system default).</td>
-			<td align="center">(None)</td>
-		</tr>
-		<tr>
-			<td>Firefox driver (geckodriver)</td>
-			<td>This allows you to select the location of Firefox driver (geckodriver).</td>
-			<td align="center">(None)</td>
+			<td>geckodriver</td>
+			<td>This allows you to select the location of geckodriver (Firefox driver).</td>
+			<td align="center">The path to the bundled WebDriver, if available.</td>
 		</tr>
 		<tr>
 			<td>IEDriverServer</td>
 			<td>This allows you to select the location of IEDriverServer.</td>
+			<td align="center">The path to the bundled WebDriver, if available.</td>
+		</tr>
+		<tr>
+			<th colspan="3">Binaries</th>
+		</tr>
+		<tr>
+			<td>Firefox</td>
+			<td>This allows you to select the location of Firefox binary (for example, to use
+				a version other than the system default).</td>
 			<td align="center">(None)</td>
 		</tr>
 		<tr>
-			<td>PhantomJS binary</td>
+			<td>PhantomJS</td>
 			<td>This allows you to select the location of PhantomJS binary.</td>
 			<td align="center">(None)</td>
 		</tr>
 	</table>
-	<p>It's also possible to set the above locations using Java system properties, in
-		which case the above options will be overridden and shown those values instead.
+	<strong>Note:</strong> It's also possible to set the above locations (binaries and
+	WebDrivers) using Java system properties, in which case the above options will be
+	overridden and those values shown instead.
+
+	<h2>Bundled WebDrivers</h2>
+	ZAP provides add-ons with the WebDrivers, when those add-ons are installed ZAP will
+	attempt to use the bundled WebDrivers by default. Some OSs might not have a WebDriver for
+	some of the browsers, in those cases ZAP will inform there's no WebDriver available. The
+	bundled WebDrivers can also be (re)set with the 'Bundled' button (for example, if another
+	WebDriver was manually set).
 	<h2>See also</h2>
 	<table>
 		<tr>


### PR DESCRIPTION
Change Selenium add-on to use the bundled WebDrivers by default (when
available and no WebDriver was previously set).
Update help to mention the new behaviour.
Update changes in ZapAddOn.xml file.