### PR TITLE
TestSQLInjection Modifications

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Correct alert's evidence/attack of Parameter Tampering (Issue 3524).<br>
 	Fix Path Traversal false positives when etc is a substring (Issue 3735).<br>
 	Code changes for Java 9 (Issue 2602).<br>
+	TestSQLInjection Modifications to improve handling of injected math expressions and reflected params (Issue 3139).</br>
 	]]>
     </changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
@@ -20,12 +20,19 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
 
 /**
  * Unit test for {@link TestSQLInjection}.
@@ -68,4 +75,167 @@ public class TestSQLInjectionUnitTest extends ActiveScannerTest<TestSQLInjection
         assertThat(targets, is(equalTo(false)));
     }
 
+    @Test
+    public void shouldAlertIfSumExpressionsAreSuccessful() throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(new ExpressionBasedHandler("/", param, ExpressionBasedHandler.Expression.SUM));
+        rule.init(getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.SUM.value), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo(param)));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo(ExpressionBasedHandler.Expression.SUM.baseExpression)));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+    }
+
+    @Test
+    public void shouldAlertIfSumExpressionsAreSuccessfulAndReflectedInResponse() throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(new ExpressionBasedHandler("/", param, ExpressionBasedHandler.Expression.SUM) {
+
+            @Override
+            protected String getContent(String value) {
+                return super.getContent(value) + ": " + value;
+            }
+        });
+        rule.init(getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.SUM.value), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo(param)));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo(ExpressionBasedHandler.Expression.SUM.baseExpression)));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+    }
+
+    @Test
+    public void shouldNotAlertIfSumConfirmationExpressionIsNotSuccessful() throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(new ExpressionBasedHandler("/", param, ExpressionBasedHandler.Expression.SUM, true));
+        rule.init(getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.SUM.value), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertIfMultExpressionsAreSuccessful() throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(new ExpressionBasedHandler("/", param, ExpressionBasedHandler.Expression.MULT));
+        rule.init(getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.MULT.value), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo(param)));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo(ExpressionBasedHandler.Expression.MULT.baseExpression)));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+    }
+
+    @Test
+    public void shouldAlertIfMultExpressionsAreSuccessfulAndReflectedInResponse() throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(new ExpressionBasedHandler("/", param, ExpressionBasedHandler.Expression.MULT) {
+
+            @Override
+            protected String getContent(String value) {
+                return super.getContent(value) + ": " + value;
+            }
+        });
+        rule.init(getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.MULT.value), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo(param)));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo(ExpressionBasedHandler.Expression.MULT.baseExpression)));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+    }
+
+    @Test
+    public void shouldNotAlertIfMultConfirmationExpressionIsNotSuccessful() throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(new ExpressionBasedHandler("/", param, ExpressionBasedHandler.Expression.SUM, true));
+        rule.init(getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.SUM.value), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    private static class ExpressionBasedHandler extends NanoServerHandler {
+
+        public enum Expression {
+            SUM("1", "3-2", "4-2"),
+            MULT("1", "2/2", "4/2");
+
+            private final String value;
+            private final String baseExpression;
+            private final String confirmationExpression;
+
+            Expression(String value, String expression, String confirmationExpression) {
+                this.value = value;
+                this.baseExpression = expression;
+                this.confirmationExpression = confirmationExpression;
+            }
+        }
+
+        private final String param;
+        private final Expression expression;
+        private final boolean confirmationFails;
+
+        public ExpressionBasedHandler(String path, String param, Expression expression) {
+            this(path, param, expression, false);
+        }
+
+        public ExpressionBasedHandler(String path, String param, Expression expression, boolean confirmationFails) {
+            super(path);
+
+            this.param = param;
+            this.expression = expression;
+            this.confirmationFails = confirmationFails;
+        }
+
+        @Override
+        Response serve(IHTTPSession session) {
+            String value = session.getParms().get(param);
+            if (isValidValue(value)) {
+                return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, getContent(value));
+            }
+            return new Response(Response.Status.NOT_FOUND, NanoHTTPD.MIME_HTML, "404 Not Found");
+        }
+
+        private boolean isValidValue(String value) {
+            if (confirmationFails && expression.confirmationExpression.equals(value)) {
+                return true;
+            }
+            return expression.value.equals(value) || expression.baseExpression.equals(value);
+        }
+
+        protected String getContent(String value) {
+            return "Some Content";
+        }
+    }
 }


### PR DESCRIPTION
### **I have implemented the FIX in first two commits.**

__The third commit involves some additional changes that might be implemented.
This is what I'm talking about. I've implemented it for Check4 ONLY this time to show you the idea.__
Previously `unstripped` comparison is needed for the following case: 
```
$query=" SELECT * FROM users WHERE id = " . $_GET['id']; 
$result=mysqli_query($connection, $query); 
while($row= mysqli_fetch_assoc($result)){
	echo "ID        : ".$row['id']."<br/>";
	echo "User_name : ".$row['name']."<br/>";
}
```
where parameter gets reflected back after evaluation from database.
Unstripped output:
**HTML normal parmeter=2 output**
```
ID : 2 
User_name : richguy
```
**HTML modified parmeter=4-2 output**
```
ID : 2
User_name : richguy
```
Hence they are equal
But previous stripping concept:
On stripping Off 
**HTML normal parmeter=2 output**
```
ID : 
User_name : richguy
```
**HTML modified parmeter=4-2 output**
```
ID : 2
User_name : richguy
```
They are NOT equal

But this covers both as both original as well as modified param are stripped off, so ONLY stripped comparison is required.
I have implemented the FIX in first two commits.
The third commit involves some additional changes that might be implemented.
**The purpose of the third commit is representation of idea, I'll implement it for other checks if it sounds good.**