### PR TITLE
New script dialog default engine when only one

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Update help page to mention HTTP Sender scripts.<br>
 	Allow to save scripts through the context menu.<br>
 	Reset Console Output panel on session changes.<br>
+	If there is only one script engine available, make it the default when creating a new script.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -142,7 +142,10 @@ public class NewScriptDialog extends StandardFieldsDialog {
 	
 	private List<String> getEngines() {
 		ArrayList<String> list = new ArrayList<String>();
-		list.add("");
+		int engineCount = extension.getExtScript().getScriptingEngines().size();
+		if (engineCount > 1) {
+			list.add("");
+		}
 		list.addAll(extension.getExtScript().getScriptingEngines());
 		return list;
 	}


### PR DESCRIPTION
Modified `NewScriptDialog` to not pad the list with a blank entry if there
is only one script engine available.
Updated changes section of `ZapAddOn.xml`