### PR TITLE
spiderAjax: honour global excluded URLs

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -100,7 +100,9 @@ public class SpiderThread implements Runnable {
 		spiderListeners = new ArrayList<>(2);
 		spiderListeners.add(spiderListener);
 		this.session = extension.getModel().getSession();
-		this.exclusionList = session.getExcludeFromSpiderRegexs();
+		this.exclusionList = new ArrayList<>();
+		exclusionList.addAll(session.getExcludeFromSpiderRegexs());
+		exclusionList.addAll(session.getGlobalExcludeURLRegexs());
 		this.targetHost = target.getStartUri().getHost();
 
 		createOutOfScopeResponse(extension.getMessages().getString("spiderajax.outofscope.response"));

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Use a custom initiator ID (10) for AJAX Spider requests.<br>
 	Show always the latest configured browsers in AJAX Spider dialogue (Issue 3057).<br>
+	Honour global excluded URLs (Issue 3172).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change SpiderThread to also use the list of global excluded URLs when
checking if the requested URL should be excluded.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3172 - AJAX Spider should honour global excluded
URLs