### PR TITLE
fuzz: add Anti-CSRF Token Refresher by default

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -10,6 +10,7 @@
     <![CDATA[
     Correct method name in HTTP processor JavaScript template.<br>
     Fix exception when adding file fuzzers with selected empty "Custom Fuzzers".<br>
+    Automatically add Anti-CSRF Token Refresher, if available.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/AntiCsrfHttpFuzzerMessageProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/AntiCsrfHttpFuzzerMessageProcessorUIHandler.java
@@ -43,6 +43,7 @@ public class AntiCsrfHttpFuzzerMessageProcessorUIHandler implements
     private static final String PROCESSOR_NAME = Constant.messages.getString("fuzz.httpfuzzer.processor.acsrffuzz.name");
 
     private final ExtensionAntiCSRF extensionAntiCSRF;
+    private HttpMessage message;
 
     public AntiCsrfHttpFuzzerMessageProcessorUIHandler(ExtensionAntiCSRF extensionAntiCSRF) {
         this.extensionAntiCSRF = extensionAntiCSRF;
@@ -51,17 +52,30 @@ public class AntiCsrfHttpFuzzerMessageProcessorUIHandler implements
     @Override
     public boolean isEnabled(HttpMessage message) {
         List<AntiCsrfToken> tokens = extensionAntiCSRF.getTokens(message);
-        return (tokens != null && !tokens.isEmpty());
-    }
-
-    @Override
-    public boolean isDefault() {
+        if (tokens != null && !tokens.isEmpty()) {
+            this.message = message;
+            return true;
+        }
         return false;
     }
 
     @Override
+    public boolean isDefault() {
+        return true;
+    }
+
+    @Override
     public HttpFuzzerMessageProcessorUI<AntiCsrfHttpFuzzerMessageProcessor> createDefault() {
-        return null;
+        if (message == null) {
+            return null;
+        }
+
+        AntiCsrfHttpFuzzerMessageProcessorUI processor = new AntiCsrfHttpFuzzerMessageProcessorUI(
+                extensionAntiCSRF,
+                extensionAntiCSRF.getTokens(message).get(0),
+                false);
+        message = null;
+        return processor;
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/httpmessageprocessors.html
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/httpmessageprocessors.html
@@ -14,8 +14,9 @@ Built-in HTTP Message Processors include:
 
 <h3>Anti-CSRF Token Refresher</h3>
 Allows to refresh anti-CSRF tokens contained in the request. The anti-CSRF tokens must be properly detected by ZAP to be able to
-select and add this processor.<br>
-For more information consult the help page "Getting Started" > "Features" > "Anti CSRF Tokens".
+use this processor.<br>
+For more information consult the help page "Getting Started" > "Features" > "Anti CSRF Tokens".<br>
+<strong>Note:</strong> This processor is automatically added to the list of processors, if anti-CSRF tokens were detected.
 
 <h3>Fuzzer HTTP Processor (Script)</h3>
 Allows to select the enabled Fuzzer HTTP Processor scripts. The scripts allow you to:
@@ -30,11 +31,13 @@ Allows to select the enabled Fuzzer HTTP Processor scripts. The scripts allow yo
 </ul>
 
 <h3>Payload Reflection Detector</h3>
-Indicates in the State column of results table if one of the injected payloads were found in the response, using "<img src="images/reflected_icon.png"> Reflected".
+Indicates in the State column of results table if one of the injected payloads were found in the response, using "<img src="images/reflected_icon.png"> Reflected".<br>
+<strong>Note:</strong> This processor is automatically added to the list of processors.
 
 <h3>Request Content-Length Updater</h3>
 Updates (or adds, if not already present) the <code>Content-Length</code> request header with the length of the request body,
-for all request methods. No change is done if the size of the request body is zero and the header is not already present.
+for all request methods. No change is done if the size of the request body is zero and the header is not already present.<br>
+<strong>Note:</strong> This processor is automatically added to the list of processors.
 
 <h3>Tag Creator</h3>
 Allows to add custom ‘tags’, based on contents of the response, to the State column of the results table


### PR DESCRIPTION
Add the HTTP message processor Anti-CSRF Token Refresher by default (if
anti-CSRF tokens were detected).
Update help page to mention which processors are added by default.
Update changes in ZapAddOn.xml file.