### PR TITLE
fuzz: fix typos in the help pages

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -10,6 +10,7 @@
     <![CDATA[
     Correct method name in HTTP processor JavaScript template.<br>
     Fix exception when adding file fuzzers with selected empty "Custom Fuzzers".<br>
+    Fix typos in the help pages.<br>
     Automatically add Anti-CSRF Token Refresher, if available.<br>
     ]]>
     </changes>

--- a/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/payloads.html
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/payloads.html
@@ -17,7 +17,7 @@ The following types of generators are provided by default:
 <li>File - select any local file for one off attacks</li>
 <li>File Fuzzers - select any combination of the fuzzing files registered with ZAP, eg via add-ons like fuzzdb</li>
 <li>Regex - generate attacks based on regex patterns</li>
-<li>Strings - raw strings, which can be entered manually ir pasted in</li>
+<li>Strings - raw strings, which can be entered manually or pasted in</li>
 <li>Script - custom scripts that can generate any payloads required</li>
 </ul>
 You can write custom payload generator scripts - these can supply any payloads that you need.

--- a/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/processors.html
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/processors.html
@@ -27,7 +27,7 @@ Built in payload processors include:
 <li>URL Decode</li>
 <li>URL Encode</li>
 </ul>
-You can also custom payload processor scripts - these can perform any manipulation of the payload that you need.
+You can also write custom payload processor scripts - these can perform any manipulation of the payload that you need.
 <br><br>
 Add-ons can also define additional Payload Processors.
 


### PR DESCRIPTION
Fix typos (missing word or wrong char) in the help pages.
Update changes in ZapAddOn.xml file.