### PR TITLE
fuzz: show help button in dialogues

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
@@ -573,12 +573,6 @@ public class FuzzerPayloadGeneratorUIHandler implements
             return false;
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
-
         private static class ModifyFileFuzzersPayloadsPanel
                 extends ModifyPayloadsPanel<DefaultPayload, FuzzerPayloadGenerator, FuzzerPayloadGeneratorUI> {
 

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -8,6 +8,7 @@
     <url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</url>
     <changes>
     <![CDATA[
+    Show help button in fuzzer dialogues.<br>
     Correct method name in HTTP processor JavaScript template.<br>
     Fix exception when adding file fuzzers with selected empty "Custom Fuzzers".<br>
     Automatically add Anti-CSRF Token Refresher, if available.<br>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/AbstractHttpFuzzerMessageProcessorUIPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/AbstractHttpFuzzerMessageProcessorUIPanel.java
@@ -39,7 +39,7 @@ public abstract class AbstractHttpFuzzerMessageProcessorUIPanel<T extends HttpFu
 
     @Override
     public String getHelpTarget() {
-        return null;
+        return "addon.fuzzer.httpmessageprocessors";
     }
 
 }

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/AntiCsrfHttpFuzzerMessageProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/AntiCsrfHttpFuzzerMessageProcessorUIHandler.java
@@ -286,11 +286,5 @@ public class AntiCsrfHttpFuzzerMessageProcessorUIHandler implements
         public AntiCsrfHttpFuzzerMessageProcessorUI getFuzzerMessageProcessorUI() {
             return new AntiCsrfHttpFuzzerMessageProcessorUI(extensionAntiCSRF, antiCsrfToken, showTokensCheckBox.isSelected());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/FuzzerHttpMessageScriptProcessorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/FuzzerHttpMessageScriptProcessorAdapterUIHandler.java
@@ -196,12 +196,6 @@ public class FuzzerHttpMessageScriptProcessorAdapterUIHandler implements
             return true;
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help target...
-            return null;
-        }
-
         private static class ScriptUIEntry implements Comparable<ScriptUIEntry> {
 
             private final ScriptWrapper scriptWrapper;

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/HttpFuzzerReflectionDetectorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/HttpFuzzerReflectionDetectorUIHandler.java
@@ -128,11 +128,5 @@ public class HttpFuzzerReflectionDetectorUIHandler implements
             return HttpFuzzerReflectionDetectorUI.INSTANCE;
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
-
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/RequestContentLengthUpdaterProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/RequestContentLengthUpdaterProcessorUIHandler.java
@@ -130,11 +130,5 @@ public class RequestContentLengthUpdaterProcessorUIHandler implements
             return RequestContentLengthUpdatedProcessorUI.INSTANCE;
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
-
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/UserHttpFuzzerMessageProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/UserHttpFuzzerMessageProcessorUIHandler.java
@@ -282,12 +282,6 @@ public class UserHttpFuzzerMessageProcessorUIHandler implements
                 }
             }
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 
     private static class ContextUI extends AbstractListModel<UserUI> implements ComboBoxModel<UserUI> {

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpFuzzerMessageProcessorTagUIPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpFuzzerMessageProcessorTagUIPanel.java
@@ -204,10 +204,4 @@ public class HttpFuzzerMessageProcessorTagUIPanel
         }
         return VALID;
     }
-
-    @Override
-    public String getHelpTarget() {
-        // THC add help target...
-        return null;
-    }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/AbstractPersistentPayloadGeneratorUIPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/AbstractPersistentPayloadGeneratorUIPanel.java
@@ -126,6 +126,11 @@ public abstract class AbstractPersistentPayloadGeneratorUIPanel<T extends Payloa
             extensionFuzz.addCustomFileFuzzer(file);
         }
     }
+    
+    @Override
+    public String getHelpTarget() {
+        return "addon.fuzzer.payloads";
+    }
 
     protected abstract T2 getPayloadGenerator();
 

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultStringPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultStringPayloadGeneratorUIHandler.java
@@ -264,11 +264,5 @@ public class DefaultStringPayloadGeneratorUIHandler implements
         public boolean validate() {
             return true;
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/FileStringPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/FileStringPayloadGeneratorUIHandler.java
@@ -657,12 +657,6 @@ public class FileStringPayloadGeneratorUIHandler implements
             return true;
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
-
         private static class ModifyFileStringPayloadsPanel
                 extends ModifyPayloadsPanel<DefaultPayload, FileStringPayloadGenerator, FileStringPayloadGeneratorUI> {
 

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/RegexPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/RegexPayloadGeneratorUIHandler.java
@@ -415,12 +415,6 @@ public class RegexPayloadGeneratorUIHandler implements
                     getMaximumForPayloadCalculation(getMaxPayloadsNumberSpinner().getValue().intValue()));
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
-
         private static int getMaximumForPayloadPersistence(int limit) {
             if (limit == 0) {
                 return MAX_NUMBER_PAYLOADS_PERSISTENCE;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/ScriptStringPayloadGeneratorAdapterUIHandler.java
@@ -397,12 +397,6 @@ public class ScriptStringPayloadGeneratorAdapterUIHandler
             return true;
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
-
         private static class ScriptUIEntry implements Comparable<ScriptUIEntry> {
 
             private final ScriptWrapper scriptWrapper;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/AbstractProcessorUIPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/AbstractProcessorUIPanel.java
@@ -41,7 +41,7 @@ public abstract class AbstractProcessorUIPanel<T extends Payload, T2 extends Pay
 
     @Override
     public String getHelpTarget() {
-        return null;
+        return "addon.fuzzer.processors";
     }
 
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64DecodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64DecodeProcessorUIHandler.java
@@ -119,11 +119,5 @@ public class Base64DecodeProcessorUIHandler implements
         public Base64DecodeProcessor getPayloadProcessor() {
             return new Base64DecodeProcessor((Charset) getCharsetComboBox().getSelectedItem());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64EncodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/Base64EncodeProcessorUIHandler.java
@@ -192,11 +192,5 @@ public class Base64EncodeProcessorUIHandler implements
                     (Charset) getCharsetComboBox().getSelectedItem(),
                     getBreakLinesCheckBox().isSelected());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ExpandStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ExpandStringProcessorUIHandler.java
@@ -298,8 +298,7 @@ public class ExpandStringProcessorUIHandler implements
 
         @Override
         public String getHelpTarget() {
-            // THC add help page...
-            return null;
+            return "addon.fuzzer.processors";
         }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptEscapeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptEscapeProcessorUIHandler.java
@@ -118,12 +118,6 @@ public class JavaScriptEscapeProcessorUIHandler implements
         public JavaScriptEscapeProcessor getPayloadProcessor() {
             return JavaScriptEscapeProcessor.INSTANCE;
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptUnescapeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/JavaScriptUnescapeProcessorUIHandler.java
@@ -118,12 +118,6 @@ public class JavaScriptUnescapeProcessorUIHandler implements
         public JavaScriptUnescapeProcessor getPayloadProcessor() {
             return JavaScriptUnescapeProcessor.INSTANCE;
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/MD5HashProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/MD5HashProcessorUIHandler.java
@@ -118,11 +118,5 @@ public class MD5HashProcessorUIHandler implements
         public MD5HashProcessor getPayloadProcessor() {
             return new MD5HashProcessor((Charset) getCharsetComboBox().getSelectedItem(), getUpperCaseCheckBox().isSelected());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PostfixStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PostfixStringProcessorUIHandler.java
@@ -175,12 +175,6 @@ public class PostfixStringProcessorUIHandler implements
             }
             return new PostfixStringProcessor(getValueTextField().getText());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PrefixStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/PrefixStringProcessorUIHandler.java
@@ -175,12 +175,6 @@ public class PrefixStringProcessorUIHandler implements
             }
             return new PrefixStringProcessor(getValueTextField().getText());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA1HashProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA1HashProcessorUIHandler.java
@@ -120,11 +120,5 @@ public class SHA1HashProcessorUIHandler implements
         public SHA1HashProcessor getPayloadProcessor() {
             return new SHA1HashProcessor((Charset) getCharsetComboBox().getSelectedItem(), getUpperCaseCheckBox().isSelected());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA256HashProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/SHA256HashProcessorUIHandler.java
@@ -122,11 +122,5 @@ public class SHA256HashProcessorUIHandler implements
                     (Charset) getCharsetComboBox().getSelectedItem(),
                     getUpperCaseCheckBox().isSelected());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ScriptStringPayloadProcessorAdapterUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/ScriptStringPayloadProcessorAdapterUIHandler.java
@@ -216,12 +216,6 @@ public class ScriptStringPayloadProcessorAdapterUIHandler
                     ((ScriptUIEntry) scriptComboBox.getSelectedItem()).getScriptWrapper());
         }
 
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
-
         private static class ScriptUIEntry implements Comparable<ScriptUIEntry> {
 
             private final ScriptWrapper scriptWrapper;

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/TrimStringProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/TrimStringProcessorUIHandler.java
@@ -167,12 +167,6 @@ public class TrimStringProcessorUIHandler implements
         public TrimStringProcessor getPayloadProcessor() {
             return new TrimStringProcessor(getLengthNumberSpinner().getValue().intValue());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLDecodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLDecodeProcessorUIHandler.java
@@ -118,11 +118,5 @@ public class URLDecodeProcessorUIHandler implements
         public URLDecodeProcessor getPayloadProcessor() {
             return new URLDecodeProcessor((Charset) getCharsetComboBox().getSelectedItem());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLEncodeProcessorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/processors/URLEncodeProcessorUIHandler.java
@@ -118,11 +118,5 @@ public class URLEncodeProcessorUIHandler implements
         public URLEncodeProcessor getPayloadProcessor() {
             return new URLEncodeProcessor((Charset) getCharsetComboBox().getSelectedItem());
         }
-
-        @Override
-        public String getHelpTarget() {
-            // THC add help page...
-            return null;
-        }
     }
 }


### PR DESCRIPTION
Add help target/index to the fuzzer dialogues (mainly base classes), to
allow to access the help pages directly with a help button.
Update changes in ZapAddOn.xml file.