### PR TITLE
fuzz: render custom states always

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -11,6 +11,7 @@
     Correct method name in HTTP processor JavaScript template.<br>
     Fix exception when adding file fuzzers with selected empty "Custom Fuzzers".<br>
     Automatically add Anti-CSRF Token Refresher, if available.<br>
+    Render custom states, always (Issue 3166).<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/HttpFuzzerReflectionDetectorStateHighlighter.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/HttpFuzzerReflectionDetectorStateHighlighter.java
@@ -56,4 +56,8 @@ public class HttpFuzzerReflectionDetectorStateHighlighter implements HttpFuzzerR
         return REFLECTED_CUSTOM_STATE_NAME;
     }
 
+    @Override
+    public void removeState(Map<String, Object> data) {
+        data.remove(REFLECTED_CUSTOM_STATE_KEY);
+    }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpFuzzerMessageProcessorTagCreator.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpFuzzerMessageProcessorTagCreator.java
@@ -33,9 +33,9 @@ public class HttpFuzzerMessageProcessorTagCreator implements HttpFuzzerMessagePr
 
     public static final String NAME = Constant.messages.getString("fuzz.httpfuzzer.processor.tagcreator.name");
     public static final String DESCRIPTION = Constant.messages.getString("fuzz.httpfuzzer.processor.tagcreator.desc");
-    private static final String TAG_CREATOR_LIST_STATE_KEY = "fuzz.httpfuzzer.messageprocessor.tagcreator.tags.list";
+    static final String TAG_CREATOR_LIST_STATE_KEY = "fuzz.httpfuzzer.messageprocessor.tagcreator.tags.list";
     public static final String TAG_CREATOR_TEXT_STATE_KEY = "fuzz.httpfuzzer.messageprocessor.tagcreator.tags.text";
-    private static final String TAG_SEPARATOR = ";";
+    private static final String TAG_SEPARATOR = "; ";
 
     private TagRule tagRule;
 
@@ -99,8 +99,10 @@ public class HttpFuzzerMessageProcessorTagCreator implements HttpFuzzerMessagePr
     private String joinTagsWithSeparator(List<String> tags){
         StringBuilder stringBuilder = new StringBuilder();
         for (String tag : tags) {
+            if (stringBuilder.length() > 0) {
+                stringBuilder.append(TAG_SEPARATOR);
+            }
             stringBuilder.append(tag);
-            stringBuilder.append(TAG_SEPARATOR);
         }
         return stringBuilder.toString();
     }

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpFuzzerMessageProcessorTagStateHighlighter.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpFuzzerMessageProcessorTagStateHighlighter.java
@@ -55,4 +55,10 @@ public class HttpFuzzerMessageProcessorTagStateHighlighter implements HttpFuzzer
     public String getLabel() {
         return tagsAsText;
     }
+
+    @Override
+    public void removeState(Map<String, Object> data) {
+        data.remove(TAG_CREATOR_TEXT_STATE_KEY);
+        data.remove(HttpFuzzerMessageProcessorTagCreator.TAG_CREATOR_LIST_STATE_KEY);
+    }
 }

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzerResultStateHighlighter.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzerResultStateHighlighter.java
@@ -30,4 +30,6 @@ public interface HttpFuzzerResultStateHighlighter {
     Icon getIcon();
 
     String getLabel();
+
+    void removeState(Map<String, Object> data);
 }


### PR DESCRIPTION
Change FuzzResultStateHighlighter to render the custom states always
(that is, render the value if the state does not have any renderer
associated).
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3166 - Fuzzer: Not Rendering Custom States