### PR TITLE
ajaxSpider: reset URL counter on session change

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -468,6 +468,11 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 		stopScan();
 		spiderResultsTableModel.clear();
 		visitedUrls.clear();
+
+		if (View.isInitialised()) {
+			this.foundCount = 0;
+			this.foundLabel.setText(Integer.toString(this.foundCount));
+		}
 	}
 	
 	

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Use a custom initiator ID (10) for AJAX Spider requests.<br>
 	Show always the latest configured browsers in AJAX Spider dialogue (Issue 3057).<br>
 	Honour global excluded URLs (Issue 3172).<br>
+	Reset URL counter on session change.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change SpiderPanel to reset the URL counter shown in the AJAX Spider tab
when the session changes.
Update changes in ZapAddOn.xml file.