### PR TITLE
ajaxSpider: show alerts/tags in AJAX Spider tab

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTable.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTable.java
@@ -1,0 +1,78 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.spiderAjax;
+
+import javax.swing.SortOrder;
+import javax.swing.table.TableModel;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.zaproxy.zap.view.table.HistoryReferencesTable;
+
+public class AjaxSpiderResultsTable extends HistoryReferencesTable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String RESULTS_TABLE_NAME = "AjaxSpiderResultsTable";
+
+    private final ExtensionHistory extensionHistory;
+
+    public AjaxSpiderResultsTable(AjaxSpiderResultsTableModel resultsModel) {
+        super(resultsModel);
+
+        setName(RESULTS_TABLE_NAME);
+
+        setAutoCreateColumnsFromModel(false);
+
+        getColumnExt(Constant.messages.getString("view.href.table.header.timestamp.response")).setVisible(false);
+        getColumnExt(Constant.messages.getString("view.href.table.header.size.requestheader")).setVisible(false);
+        getColumnExt(Constant.messages.getString("view.href.table.header.size.requestbody")).setVisible(false);
+
+        extensionHistory = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+    }
+
+    @Override
+    public void setModel(TableModel dataModel) {
+        // Keep the same column sorted when model is changed
+        int sortedcolumnIndex = getSortedColumnIndex();
+        SortOrder sortOrder = getSortOrder(sortedcolumnIndex);
+        super.setModel(dataModel);
+        if (sortedcolumnIndex != -1) {
+            setSortOrder(sortedcolumnIndex, sortOrder);
+        }
+    }
+
+    @Override
+    protected HistoryReference getHistoryReferenceAtViewRow(int row) {
+        HistoryReference historyReference = super.getHistoryReferenceAtViewRow(row);
+        if (historyReference == null) {
+            return null;
+        }
+
+        if (extensionHistory == null || extensionHistory.getHistoryReference(historyReference.getHistoryId()) == null) {
+            // Associated message was deleted in the meantime.
+            return null;
+        }
+
+        return historyReference;
+    }
+}

--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
@@ -19,25 +19,132 @@
  */
 package org.zaproxy.zap.extension.spiderAjax;
 
+import java.awt.EventQueue;
+
+import javax.swing.event.TableModelEvent;
+
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.eventBus.Event;
+import org.zaproxy.zap.eventBus.EventConsumer;
+import org.zaproxy.zap.extension.alert.AlertEventPublisher;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableModel;
 
 public class AjaxSpiderResultsTableModel extends DefaultHistoryReferencesTableModel {
 
     private static final long serialVersionUID = 4949104995571034494L;
 
+    private final ExtensionHistory extensionHistory;
+    private AlertEventConsumer alertEventConsumer;
+
     public AjaxSpiderResultsTableModel() {
         super(new Column[] {
                 Column.HREF_ID,
                 Column.REQUEST_TIMESTAMP,
+                Column.RESPONSE_TIMESTAMP,
                 Column.METHOD,
                 Column.URL,
                 Column.STATUS_CODE,
                 Column.STATUS_REASON,
                 Column.RTT,
+                Column.SIZE_REQUEST_HEADER,
+                Column.SIZE_REQUEST_BODY,
                 Column.SIZE_RESPONSE_HEADER,
                 Column.SIZE_RESPONSE_BODY,
                 Column.HIGHEST_ALERT,
                 Column.NOTE,
                 Column.TAGS});
+
+        alertEventConsumer = new AlertEventConsumer();
+        extensionHistory = Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+        ZAP.getEventBus().registerConsumer(alertEventConsumer, AlertEventPublisher.getPublisher().getPublisherName());
     }
+
+    @Override
+    public void addHistoryReference(HistoryReference historyReference) {
+        HistoryReference latestHistoryReference = historyReference;
+        if (extensionHistory != null) {
+            latestHistoryReference = extensionHistory.getHistoryReference(historyReference.getHistoryId());
+        }
+        super.addHistoryReference(latestHistoryReference);
+    }
+
+    void unload() {
+        if (alertEventConsumer != null) {
+            ZAP.getEventBus().unregisterConsumer(alertEventConsumer, AlertEventPublisher.getPublisher().getPublisherName());
+            alertEventConsumer = null;
+        }
+    }
+
+    private class AlertEventConsumer implements EventConsumer {
+
+        @Override
+        public void eventReceived(Event event) {
+            switch (event.getEventType()) {
+            case AlertEventPublisher.ALERT_ADDED_EVENT:
+                // TODO Replace once available in the zap.jar AlertEventPublisher.ALERT_CHANGED_EVENT
+            case "alert.changed":
+            case AlertEventPublisher.ALERT_REMOVED_EVENT:
+                // TODO Replace once available in the zap.jar AlertEventPublisher.HISTORY_REFERENCE_ID
+                refreshEntry(Integer.valueOf(event.getParameters().get("historyId")));
+                break;
+            case AlertEventPublisher.ALL_ALERTS_REMOVED_EVENT:
+            default:
+                refreshEntries();
+                break;
+            }
+        }
+
+        private void refreshEntry(final int id) {
+            if (EventQueue.isDispatchThread()) {
+                refreshEntryRow(id);
+                return;
+            }
+
+            EventQueue.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    refreshEntry(id);
+                }
+            });
+        }
+
+        private void refreshEntries() {
+            if (EventQueue.isDispatchThread()) {
+                refreshEntryRows();
+                return;
+            }
+
+            EventQueue.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    refreshEntries();
+                }
+            });
+        }
+
+        // TODO Remove once available in the zap.jar.
+        public void refreshEntryRows() {
+            if (getRowCount() == 0) {
+                return;
+            }
+
+            for (int i = 0; i < getRowCount(); i++) {
+                getEntry(i).refreshCachedValues();
+            }
+
+            fireTableChanged(
+                    new TableModelEvent(
+                            AjaxSpiderResultsTableModel.this,
+                            0,
+                            getRowCount() - 1,
+                            getColumnIndex(Column.HIGHEST_ALERT),
+                            TableModelEvent.UPDATE));
+        }
+    }
+
 }

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -132,6 +132,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
     public void unload() {
         if (getView() != null) {
             getSpiderPanel().stopScan();
+            getSpiderPanel().unload();
             
             getView().getMainFrame().getMainFooterPanel().removeFooterToolbarRightLabel(getSpiderPanel().getScanStatus().getCountLabel());
         }

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -57,8 +57,6 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 	private static final long serialVersionUID = 1L;
 	private static final Logger logger = Logger.getLogger(SpiderPanel.class);
 	
-	private static final String RESULTS_TABLE_NAME = "AjaxSpiderResultsTable";
-
 	private javax.swing.JScrollPane scrollLog = null;
 	private javax.swing.JPanel AJAXSpiderPanel = null;
 	private javax.swing.JToolBar panelToolbar = null;
@@ -371,8 +369,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 
 	private HistoryReferencesTable getSpiderResultsTable() {
 	    if (spiderResultsTable == null) {
-	        spiderResultsTable = new HistoryReferencesTable(spiderResultsTableModel);
-	        spiderResultsTable.setName(RESULTS_TABLE_NAME);
+	        spiderResultsTable = new AjaxSpiderResultsTable(spiderResultsTableModel);
 	    }
 	    return spiderResultsTable;
 	}
@@ -470,6 +467,9 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 		visitedUrls.clear();
 	}
 	
+	void unload() {
+		spiderResultsTableModel.unload();
+	}
 	
 	public void sessionModeChanged(Mode mode) {
 		switch (mode) {

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
+	Show alerts/tags in the AJAX Spider tab.<br>
 	Use a custom initiator ID (10) for AJAX Spider requests.<br>
 	Show always the latest configured browsers in AJAX Spider dialogue (Issue 3057).<br>
 	Honour global excluded URLs (Issue 3172).<br>
@@ -27,7 +28,7 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.2</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>
 


### PR DESCRIPTION
Change AJAX Spider tab to show the alerts/tags of the messages, also,
allow to see more details of the message (size header/body and response
timestamp).
Update changes and bump minimum ZAP version (required to properly show
the alerts) in ZapAddOn.xml file.