### PR TITLE
ajaxSpider: show excluded requests

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTable.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTable.java
@@ -19,14 +19,22 @@
  */
 package org.zaproxy.zap.extension.spiderAjax;
 
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
 import javax.swing.SortOrder;
 import javax.swing.table.TableModel;
 
+import org.jdesktop.swingx.renderer.DefaultTableRenderer;
+import org.jdesktop.swingx.renderer.IconValues;
+import org.jdesktop.swingx.renderer.MappedValue;
+import org.jdesktop.swingx.renderer.StringValues;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
+import org.zaproxy.zap.view.table.decorator.AbstractTableCellItemIconHighlighter;
 
 public class AjaxSpiderResultsTable extends HistoryReferencesTable {
 
@@ -42,6 +50,10 @@ public class AjaxSpiderResultsTable extends HistoryReferencesTable {
         setName(RESULTS_TABLE_NAME);
 
         setAutoCreateColumnsFromModel(false);
+
+        getColumnExt(0)
+                .setCellRenderer(new DefaultTableRenderer(new MappedValue(StringValues.EMPTY, IconValues.NONE), JLabel.CENTER));
+        getColumnExt(0).setHighlighters(new ProcessedCellItemIconHighlighter(0));
 
         getColumnExt(Constant.messages.getString("view.href.table.header.timestamp.response")).setVisible(false);
         getColumnExt(Constant.messages.getString("view.href.table.header.size.requestheader")).setVisible(false);
@@ -74,5 +86,40 @@ public class AjaxSpiderResultsTable extends HistoryReferencesTable {
         }
 
         return historyReference;
+    }
+
+    /**
+     * A {@link org.jdesktop.swingx.decorator.Highlighter Highlighter} for a column that indicates, using icons, whether or not
+     * an entry was processed, that is, is or not in scope.
+     * <p>
+     * The expected type/class of the cell values is {@code Boolean}.
+     */
+    private static class ProcessedCellItemIconHighlighter extends AbstractTableCellItemIconHighlighter {
+
+        /** The icon that indicates the entry was processed. */
+        private static final ImageIcon PROCESSED_ICON = new ImageIcon(
+                AjaxSpiderResultsTable.class.getResource("/resource/icon/16/152.png"));
+
+        /** The icon that indicates the entry was not processed. */
+        private static final ImageIcon NOT_PROCESSED_ICON = new ImageIcon(
+                AjaxSpiderResultsTable.class.getResource("/resource/icon/16/149.png"));
+
+        public ProcessedCellItemIconHighlighter(final int columnIndex) {
+            super(columnIndex);
+        }
+
+        @Override
+        protected Icon getIcon(final Object cellItem) {
+            return getProcessedIcon(((Boolean) cellItem).booleanValue());
+        }
+
+        private static Icon getProcessedIcon(final boolean processed) {
+            return processed ? PROCESSED_ICON : NOT_PROCESSED_ICON;
+        }
+
+        @Override
+        protected boolean isHighlighted(final Object cellItem) {
+            return true;
+        }
     }
 }

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -450,7 +450,8 @@ public class ExtensionAjax extends ExtensionAdaptor {
 		}
 
 		@Override
-		public void foundMessage(HistoryReference historyReference, HttpMessage httpMessage) {
+		public void foundMessage(HistoryReference historyReference, HttpMessage httpMessage, boolean inScope) {
+			// Nothing to do.
 		}
 
 		@Override

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderListener.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderListener.java
@@ -26,7 +26,7 @@ interface SpiderListener {
 
 	void spiderStarted();
 
-	void foundMessage(HistoryReference historyReference, HttpMessage httpMessage);
+	void foundMessage(HistoryReference historyReference, HttpMessage httpMessage, boolean inScope);
 
 	void spiderStopped();
 }

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -251,9 +251,9 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 	 * @param msg the http message
 	 * @param url the targeted url
 	 */
-	private boolean addHistoryUrl(HistoryReference r, HttpMessage msg, String url){
+	private boolean addHistoryUrl(HistoryReference r, HttpMessage msg, String url, boolean inScope){
 			if(isNewUrl(r, msg)){
-				this.spiderResultsTableModel.addHistoryReference(r);
+				this.spiderResultsTableModel.addHistoryReference(r, inScope);
 				return true;
 			}
 			return false;
@@ -492,8 +492,8 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 	}
 
 	@Override
-	public void foundMessage(HistoryReference historyReference, HttpMessage httpMessage) {
-		boolean added = addHistoryUrl(historyReference, httpMessage, targetSite);
+	public void foundMessage(HistoryReference historyReference, HttpMessage httpMessage, boolean inScope) {
+		boolean added = addHistoryUrl(historyReference, httpMessage, targetSite, inScope);
 		if (View.isInitialised() && added) {
 			foundCount++;
 			this.foundLabel.setText(Integer.toString(this.foundCount));

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Show always the latest configured browsers in AJAX Spider dialogue (Issue 3057).<br>
 	Honour global excluded URLs (Issue 3172).<br>
 	Reset URL counter on session change.<br>
+	Show excluded URLs in the AJAX Spider tab and through the ZAP API.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
@@ -36,6 +36,7 @@ spiderajax.panel.subtitle           = Crawled URLs:
 spiderajax.panel.title              = AJAX Spider
 spiderajax.panel.mnemonic			= j
 spiderajax.panel.toolbar.currentscans.label = Current Scans:
+spiderajax.panel.table.header.processed = Processed
 spiderajax.proxy.local.label.defaultElems= Click default elements only (a, button, input)
 spiderajax.proxy.local.label.browsers= <html><body><br><p>Choose the browser that you want to use in the AJAX Spider Plugin:</p></body></html>
 spiderajax.scandialog.title			= AJAX Spider


### PR DESCRIPTION
Change AJAX Spider tab to show the requests that were excluded (i.e. out
of spider scope).
Change the API to allow to obtain the resources in and out of scope,
through a new endpoing "fullResults".
Update changes in ZapAddOn.xml file.