### PR TITLE
selenium: allow add-ons to add new browsers

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/src/org/zaproxy/zap/extension/selenium/Browser.java
@@ -90,6 +90,16 @@ public enum Browser {
     public static Browser getBrowserWithId(String id) {
         Validate.notEmpty(id, "Parameter id must not be null or empty.");
 
+        Browser browser = getBrowserWithIdNoFailSafe(id);
+        if (browser != null) {
+            return browser;
+        }
+        return getFailSafeBrowser();
+    }
+
+    public static Browser getBrowserWithIdNoFailSafe(String id) {
+        Validate.notEmpty(id, "Parameter id must not be null or empty.");
+
         if (CHROME.id.equals(id)) {
             return CHROME;
         } else if (FIREFOX.id.equals(id)) {
@@ -106,7 +116,7 @@ public enum Browser {
             return SAFARI;
         }
 
-        return getFailSafeBrowser();
+        return null;
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/selenium/ProvidedBrowser.java
+++ b/src/org/zaproxy/zap/extension/selenium/ProvidedBrowser.java
@@ -1,0 +1,51 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.selenium;
+
+/**
+ * A provided browser, either by Selenium add-on or other add-ons.
+ * 
+ * @since 1.1.0
+ */
+public interface ProvidedBrowser {
+
+    /**
+     * Gets the ID of the WebDriver provider.
+     *
+     * @return the ID of the WebDriver provider.
+     */
+    String getProviderId();
+
+    /**
+     * Gets the ID of the browser.
+     *
+     * @return the ID of the browser.
+     */
+    String getId();
+
+    /**
+     * The name of the browser.
+     * <p>
+     * The name will be shown in UI components.
+     *
+     * @return the name of the browser.
+     */
+    String getName();
+}

--- a/src/org/zaproxy/zap/extension/selenium/ProvidedBrowserUI.java
+++ b/src/org/zaproxy/zap/extension/selenium/ProvidedBrowserUI.java
@@ -1,0 +1,131 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.selenium;
+
+import java.text.Collator;
+
+import org.apache.commons.lang.Validate;
+
+/**
+ * A representation of a {@link ProvidedBrowser} for UI components.
+ * <p>
+ * The method {@code toString()} returns the name of the browser.
+ *
+ * @since 1.1.0
+ */
+public class ProvidedBrowserUI implements Comparable<ProvidedBrowserUI> {
+
+    private final ProvidedBrowser browser;
+
+    /**
+     * Constructs a {@code ProvidedBrowserUI} with the given {@code browser}.
+     *
+     * @param browser the browser.
+     * @throws IllegalArgumentException if the {@code browser} is {@code null} or its name {@code null} or empty.
+     */
+    public ProvidedBrowserUI(ProvidedBrowser browser) {
+        Validate.notNull(browser, "Parameter browser must not be null");
+        Validate.notEmpty(browser.getName(), "Parameter name must not be null");
+
+        this.browser = browser;
+    }
+
+    /**
+     * Gets the name of the browser, never {@code null}.
+     *
+     * @return the name of the browser
+     */
+    public final String getName() {
+        return browser.getName();
+    }
+
+    /**
+     * Gets the browser, never {@code null}.
+     *
+     * @return the browser
+     */
+    public final ProvidedBrowser getBrowser() {
+        return browser;
+    }
+
+    /**
+     * Returns the name for the browser.
+     * 
+     * @see #getName()
+     */
+    @Override
+    public String toString() {
+        return browser.getName();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + browser.getId().hashCode();
+        result = prime * result + browser.getProviderId().hashCode();
+        return result;
+    }
+
+    /**
+     * Two {@code ProvidedBrowserUI} are considered equal if both have the same ID and provider.
+     * 
+     * @see #getName()
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ProvidedBrowserUI other = (ProvidedBrowserUI) obj;
+        if (!browser.getId().equals(other.browser.getId())) {
+            return false;
+        }
+        if (!browser.getProviderId().equals(other.browser.getProviderId())) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Compares the names of browsers, using a {@code Collator} of the default {@code Locale}.
+     * 
+     * @see #getName()
+     * @see Collator
+     */
+    @Override
+    public int compareTo(ProvidedBrowserUI other) {
+        if (other == null) {
+            return 1;
+        }
+
+        int result = Collator.getInstance().compare(getName(), other.getName());
+        if (result != 0) {
+            return result;
+        }
+        return Collator.getInstance().compare(browser.getProviderId(), other.browser.getProviderId());
+    }
+}

--- a/src/org/zaproxy/zap/extension/selenium/ProvidedBrowsersComboBoxModel.java
+++ b/src/org/zaproxy/zap/extension/selenium/ProvidedBrowsersComboBoxModel.java
@@ -1,0 +1,151 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.selenium;
+
+import java.util.List;
+
+import javax.swing.AbstractListModel;
+import javax.swing.ComboBoxModel;
+
+import org.apache.commons.lang.Validate;
+
+/**
+ * A {@code ComboBoxModel} of {@link ProvidedBrowserUI}s.
+ *
+ * @since 1.1.0
+ */
+public class ProvidedBrowsersComboBoxModel extends AbstractListModel<ProvidedBrowserUI>
+        implements ComboBoxModel<ProvidedBrowserUI> {
+
+    private static final long serialVersionUID = -2353742370704132293L;
+
+    /**
+     * The {@code ProvidedBrowserUI}s contained in this model.
+     */
+    private final List<ProvidedBrowserUI> browsers;
+
+    /**
+     * The currently selected browser, {@code null} if no browser is selected.
+     */
+    private ProvidedBrowserUI selectedBrowser;
+
+    /**
+     * Constructs a {@code BrowsersComboBoxModel} with the given {@code browsers}.
+     * <p>
+     * The selected item will be set to the first browser of the given list of {@code browsers}.
+     * 
+     * @param browsers the browsers that will have this combo box model
+     * @throws IllegalArgumentException if the given {@code List} of {@code browsers} is {@code null} or empty.
+     */
+    public ProvidedBrowsersComboBoxModel(List<ProvidedBrowserUI> browsers) {
+        Validate.notEmpty(browsers);
+
+        this.browsers = browsers;
+        this.selectedBrowser = this.browsers.get(0);
+    }
+
+    @Override
+    public ProvidedBrowserUI getSelectedItem() {
+        return selectedBrowser;
+    }
+
+    /**
+     * Convenience method that sets the selected browser using the browser ID.
+     * <p>
+     * No changes are done to the selected item if the browser with the given ID is not contained in this model.
+     * 
+     * @param providerBrowserId the id of the browser, {@code null} to clear the selection
+     * @see #setSelectedBrowser(ProvidedBrowser)
+     */
+    public void setSelectedBrowser(String providerBrowserId) {
+        if (providerBrowserId == null) {
+            setSelectedBrowserImpl(null);
+            return;
+        }
+
+        for (ProvidedBrowserUI browserUI : browsers) {
+            if (providerBrowserId.equals(browserUI.getBrowser().getId())) {
+                setSelectedBrowserImpl(browserUI);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Convenience method that sets the selected item using the given {@code browser}.
+     * <p>
+     * No changes are done to the selected item if the given browser is not contained in this model.
+     * 
+     * @param browser the browser, {@code null} to clear the selection
+     * @see #setSelectedItem(Object)
+     */
+    public void setSelectedBrowser(ProvidedBrowser browser) {
+        if (browser == null) {
+            setSelectedBrowserImpl(null);
+            return;
+        }
+
+        for (ProvidedBrowserUI browserUI : browsers) {
+            if (browser.equals(browserUI.getBrowser())) {
+                setSelectedBrowserImpl(browserUI);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Sets the given {@code item} as the selected item. Might be {@code null} to clear the selection.
+     * <p>
+     * No changes are done to the selected item if the given {@code item} is not contained in this model.
+     * 
+     * @throws IllegalArgumentException if {@code item} is not a {@code ProvidedBrowserUI} when non-{@code null}.
+     */
+    @Override
+    public void setSelectedItem(Object item) {
+        if (item != null && !(item instanceof ProvidedBrowserUI)) {
+            throw new IllegalArgumentException("Parameter item must be of type ProvidedBrowserUI.");
+        }
+
+        ProvidedBrowserUI browser = (ProvidedBrowserUI) item;
+        if (browser != null && !browsers.contains(browser)) {
+            return;
+        }
+
+        setSelectedBrowserImpl(browser);
+    }
+
+    private void setSelectedBrowserImpl(ProvidedBrowserUI browser) {
+        if ((selectedBrowser != null && !selectedBrowser.equals(browser)) || selectedBrowser == null && browser != null) {
+            selectedBrowser = browser;
+            fireContentsChanged(this, -1, -1);
+        }
+    }
+
+    @Override
+    public int getSize() {
+        return browsers.size();
+    }
+
+    @Override
+    public ProvidedBrowserUI getElementAt(int index) {
+        return browsers.get(index);
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/selenium/SingleWebDriverProvider.java
+++ b/src/org/zaproxy/zap/extension/selenium/SingleWebDriverProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.selenium;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * A provider of a single browser (configuration).
+ *
+ * @since 1.1.0
+ */
+public interface SingleWebDriverProvider {
+
+    /**
+     * The ID of the WebDriver provider.
+     *
+     * @return the ID of the WebDriver provider.
+     */
+    String getId();
+
+    /**
+     * The browser provided by the implementation.
+     *
+     * @return the provided browser.
+     */
+    ProvidedBrowser getProvidedBrowser();
+
+    /**
+     * Gets a {@code WebDriver} to the provided browser for the given requester.
+     *
+     * @param requesterId the ID of the (ZAP) component that's requesting the {@code WebDriver}.
+     * @return the {@code WebDriver} to the provided browser.
+     */
+    WebDriver getWebDriver(int requesterId);
+
+    /**
+     * Gets a {@code WebDriver} to the provided browser for the given requester, proxying through the given address and port.
+     *
+     * @param requesterId the ID of the (ZAP) component that's requesting the {@code WebDriver}.
+     * @param proxyAddress the address of the proxy.
+     * @param proxyPort the port of the proxy.
+     * @return the {@code WebDriver} to the provided browser, proxying through the given address and port.
+     * @throws IllegalArgumentException if {@code proxyAddress} is {@code null} or empty, or if {@code proxyPort} is not a valid
+     *             port number (between 1 and 65535).
+     */
+    WebDriver getWebDriver(int requesterId, String proxyAddress, int proxyPort);
+}

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -1,16 +1,14 @@
 <zapaddon>
 	<name>Selenium</name>
-	<version>8</version>
-	<semver>1.0.0</semver><!-- This version should be kept in sync with the one of the extension. -->
+	<version>9</version>
+	<semver>1.1.0</semver><!-- This version should be kept in sync with the one of the extension. -->
 	<status>release</status>
 	<description>WebDriver provider and includes HtmlUnit browser</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Allow to use Firefox 48+ (Issue 2743).<br>
-	Allow to specify the path to geckodriver.<br>
-	Use bundled WebDrivers by default.<br>
+	Allow add-ons to add new browsers.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/internal/BuiltInSingleWebDriverProvider.java
+++ b/src/org/zaproxy/zap/extension/selenium/internal/BuiltInSingleWebDriverProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.selenium.internal;
+
+import org.openqa.selenium.WebDriver;
+import org.zaproxy.zap.extension.selenium.Browser;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowser;
+import org.zaproxy.zap.extension.selenium.SingleWebDriverProvider;
+
+/**
+ * A {@link SingleWebDriverProvider} for built-in supported browsers.
+ * <p>
+ * <strong>Note:</strong> Does not belong to the public API.
+ */
+public class BuiltInSingleWebDriverProvider implements SingleWebDriverProvider {
+
+    private final String name;
+    private final Browser browser;
+    private final ProvidedBrowser providedBrowser;
+
+    public BuiltInSingleWebDriverProvider(String name, Browser browser) {
+        this.name = name;
+        this.browser = browser;
+        this.providedBrowser = new ProvidedBrowserImpl();
+    }
+
+    @Override
+    public String getId() {
+        return browser.getId();
+    }
+
+    @Override
+    public ProvidedBrowser getProvidedBrowser() {
+        return providedBrowser;
+    }
+
+    @Override
+    public WebDriver getWebDriver(int requester) {
+        return ExtensionSelenium.getWebDriver(browser);
+    }
+
+    @Override
+    public WebDriver getWebDriver(int requester, String proxyAddress, int proxyPort) {
+        return ExtensionSelenium.getWebDriver(browser, proxyAddress, proxyPort);
+    }
+
+    private class ProvidedBrowserImpl implements ProvidedBrowser {
+
+        @Override
+        public String getProviderId() {
+            return browser.getId();
+        }
+
+        @Override
+        public String getId() {
+            return browser.getId();
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -28,6 +28,7 @@ selenium.warn.message.failed.start.browser = Failed to start ''{0}'', is the bro
 selenium.warn.message.failed.start.browser.chrome = Failed to start Chrome browser.\nMake sure that Chrome and ChromeDriver are available.\nFor more details refer to "Options Selenium screen" help page.
 selenium.warn.message.failed.start.browser.ie = Failed to start Internet Explorer.\nMake sure that both Internet Explorer and IEDriverServer are available.\nFor more details refer to "Options Selenium screen" help page.
 selenium.warn.message.failed.start.browser.phantomjs = Failed to start PhantomJS.\nMake sure that the PhantomJS binary is available.\nFor more details refer to "Options Selenium screen" help page.
+selenium.warn.message.failed.start.browser.notfound = The provided browser was not found.
 
 selenium.api.view.optionChromeDriverPath = Returns the current path to ChromeDriver
 selenium.api.view.optionFirefoxBinaryPath = Returns the current path to Firefox binary


### PR DESCRIPTION
Change Selenium add-on to allow to add new browsers (e.g. JxBrowser).
Bump versions and update changes in ZapAddOn.xml file.