### PR TITLE
spiderAjax: log browser and name the threads used

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -266,7 +266,7 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 		spiderThread = extension.createSpiderThread(displayName, target, this);
 
 		try {
-			new Thread(spiderThread).start();
+			new Thread(spiderThread, "ZAP-AjaxSpiderApi").start();
 		} catch (Exception e) {
 			logger.error(e);
 		}

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -405,7 +405,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 		visitedUrls.clear();
 		this.targetSite = displayName;
 		try {
-			new Thread(runnable).start();
+			new Thread(runnable, "ZAP-AjaxSpider").start();
 		} catch (Exception e) {
 			logger.error(e);
 		}

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -195,7 +195,7 @@ public class SpiderThread implements Runnable {
 	 */
 	@Override
 	public void run() {
-		logger.info("Running Crawljax: " + displayName);
+		logger.info("Running Crawljax (with " + target.getOptions().getBrowserId()  + "): " + displayName);
 		this.running = true;
 		notifyListenersSpiderStarted();
 		logger.info("Starting proxy...");


### PR DESCRIPTION
Log the ID of the browser used with Crawljax, when starting.
Set a name to the threads started by the AJAX spider.