### PR TITLE
Promote webdriver add-ons to beta

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -42,6 +42,13 @@
 		<delete dir="${test.results.dir}" includeEmptyDirs="true" />
 	</target>
 
+	<target name="clean-webdrivers">
+		<!-- Not included in 'clean' as thats called when each add-on is built -->
+		<delete dir="../src/org/zaproxy/zap/extension/webdriverlinux/files"  includeEmptyDirs="true" />
+		<delete dir="../src/org/zaproxy/zap/extension/webdrivermacos/files"  includeEmptyDirs="true" />
+		<delete dir="../src/org/zaproxy/zap/extension/webdriverwindows/files"  includeEmptyDirs="true" />
+	</target>
+
 	<target name="init">
 		<!-- Create the build directory structure used by compile -->
 		<mkdir dir="${dist}" />
@@ -394,7 +401,7 @@
 		</sequential>
 	</macrodef>
 
-	<target name="build-all" depends="clean,compile" description="build all of the extensions">
+	<target name="build-all" depends="clean,compile,download-webdrivers" description="build all of the extensions">
 		<delete file="${versions.file}"/>
 		
 		<!-- Keep in alphabetical order ;) -->
@@ -418,6 +425,9 @@
 		<build-addon name="tips" />
 		<build-tokengen-addon />
 		<build-addon name="treetools" />
+		<build-addon name="webdriverlinux" />
+		<build-addon name="webdrivermacos" />
+		<build-addon name="webdriverwindows" />
 		<build-addon name="zest" />
 
 	</target>
@@ -623,6 +633,53 @@
 		</copy>
 	</target>
 
+	<target name="download-webdrivers" depends="compile" description="download the webdriver files">
+		<!-- This must be called before the WebDriver add-ons are built -->
+		<!-- It is not included by default in the build as it always downloads the file -->
+		<java classname="org.zaproxy.zap.extension.webdriverlinux.WebdriverDownload">
+			<classpath>
+				<fileset dir="${dist.lib.dir}">
+					<include name="**/*.jar" />
+					<include name="**/*.zap" />
+				</fileset>
+				<path location="${build}" />
+			</classpath>
+		</java>
+		<java classname="org.zaproxy.zap.extension.webdrivermacos.WebdriverDownload">
+			<classpath>
+				<fileset dir="${dist.lib.dir}">
+					<include name="**/*.jar" />
+					<include name="**/*.zap" />
+				</fileset>
+				<path location="${build}" />
+			</classpath>
+		</java>
+		<java classname="org.zaproxy.zap.extension.webdriverwindows.WebdriverDownload">
+			<classpath>
+				<fileset dir="${dist.lib.dir}">
+					<include name="**/*.jar" />
+					<include name="**/*.zap" />
+				</fileset>
+				<path location="${build}" />
+			</classpath>
+		</java>
+	</target>
+
+	<target name="deploy-webdriverlinux" description="deploy the webdriverlinux extension">
+		<antcall target="download-webdrivers"/>
+		<build-deploy-addon name="webdriverlinux" />
+	</target>
+
+	<target name="deploy-webdrivermacos" description="deploy the webdrivermacos extension">
+		<antcall target="download-webdrivers"/>
+		<build-deploy-addon name="webdrivermacos" />
+	</target>
+
+	<target name="deploy-webdriverwindows" description="deploy the webdriverwindows extension">
+		<antcall target="download-webdrivers"/>
+		<build-deploy-addon name="webdriverwindows" />
+	</target>
+
 	<target name="deploy-weekly" description="deploy extensions to be included in weekly releases">
 		<!-- Set to compile with debug information -->
 		<property name="javac.debug" value="true" />
@@ -640,6 +697,7 @@
 				<include name="pscanrulesBeta-${status}-*.zap"/>
 				<include name="scripts-${status}-*.zap"/>
 				<include name="tips-${status}-*.zap"/>
+				<include name="webdriver*-${status}-*.zap"/>
 				<include name="zest-${status}-*.zap"/>
 			</fileset>
 		</copy>

--- a/src/org/zaproxy/zap/extension/webdriverlinux/WebdriverDownload.java
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/WebdriverDownload.java
@@ -1,0 +1,83 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.webdriverlinux;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Paths;
+
+public class WebdriverDownload {
+
+	/**
+	 * The webdriver files are help in the zap-libs repo to prevent space problems in this one.
+	 * The zap-libs repo contains tasks for downloading the files from their orriginal locations.
+	 * The code will need to be changed and rerun whenever new versions of the webdrivers become available.
+	 * 
+	 * @param args
+	 */
+	public static void main(String[] args) {
+
+		downloadDriver(
+				"https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/linux/32/geckodriver",
+				"files/webdriver/linux/32/geckodriver");
+		downloadDriver(
+				"https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/linux/64/geckodriver",
+				"files/webdriver/linux/64/geckodriver");
+
+		downloadDriver(
+		        "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/linux/32/chromedriver",
+				"files/webdriver/linux/32/chromedriver");
+
+		downloadDriver(
+		        "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/linux/64/chromedriver",
+				"files/webdriver/linux/64/chromedriver");
+	}
+	
+	private static void downloadDriver(String urlStr, String destFile) {
+	    String baseDir = "src/";
+	    if (Paths.get("").toAbsolutePath().toString().endsWith("build")) {
+	        // Likely to be being invoked from the build script
+	        baseDir = "../src/";
+	    }
+		File dest = new File(
+				baseDir + WebdriverDownload.class.getPackage().getName().replace(".", "/") + "/" + destFile);
+		if (dest.exists()) {
+            System.out.println("Already exists: " + dest.getAbsolutePath());
+		    return;
+		}
+		File parent = dest.getParentFile();
+		if (!parent.exists() && !parent.mkdirs()) {
+			System.out.println("Failed to create directory : " + dest.getParentFile().getAbsolutePath());
+		}
+		
+        try (FileOutputStream fos = new FileOutputStream(dest)) {
+            URL website = new URL(urlStr);
+            ReadableByteChannel rbc = Channels.newChannel(website.openStream());
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            System.out.println("Updated: " + dest.getAbsolutePath());
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+	}
+}

--- a/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
@@ -1,0 +1,27 @@
+<zapaddon>
+	<name>Linux WebDrivers</name>
+	<version>2</version>
+	<status>beta</status>
+	<description>Linux WebDrivers for Firefox and Chrome.</description>
+	<author>ZAP Dev Team</author>
+	<url></url>
+	<changes>
+	<![CDATA[
+	Update geckodriver to v0.14.0<br>
+	Download files from zap-libs repo<br>
+	Promote to beta<br>
+	]]>
+	</changes>
+	<extensions/>
+	<ascanrules/>
+	<pscanrules/>
+	<filters/>
+	<files>
+		<file>webdriver/linux/32/chromedriver</file>
+		<file>webdriver/linux/32/geckodriver</file>
+		<file>webdriver/linux/64/chromedriver</file>
+		<file>webdriver/linux/64/geckodriver</file>
+	</files>
+	<not-before-version>2.4.0</not-before-version>
+	<not-from-version/>
+</zapaddon>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/WebdriverDownload.java
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/WebdriverDownload.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.webdrivermacos;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Paths;
+
+public class WebdriverDownload {
+
+    /**
+     * The webdriver files are help in the zap-libs repo to prevent space problems in this one.
+     * The zap-libs repo contains tasks for downloading the files from their orriginal locations.
+     * The code will need to be changed and rerun whenever new versions of the webdrivers become available.
+     * 
+     * @param args
+     */
+	public static void main(String[] args) {
+        downloadDriver(
+                "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/macos/64/geckodriver",
+                "files/webdriver/macos/64/geckodriver");
+        downloadDriver(
+                "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/macos/64/chromedriver",
+                "files/webdriver/macos/64/chromedriver");
+    }
+    
+    private static void downloadDriver(String urlStr, String destFile) {
+        String baseDir = "src/";
+        if (Paths.get("").toAbsolutePath().toString().endsWith("build")) {
+            // Likely to be being invoked from the build script
+            baseDir = "../src/";
+        }
+        File dest = new File(
+                baseDir + WebdriverDownload.class.getPackage().getName().replace(".", "/") + "/" + destFile);
+        if (dest.exists()) {
+            System.out.println("Already exists: " + dest.getAbsolutePath());
+            return;
+        }
+        File parent = dest.getParentFile();
+        if (!parent.exists() && !parent.mkdirs()) {
+            System.out.println("Failed to create directory : " + dest.getParentFile().getAbsolutePath());
+        }
+        
+        try (FileOutputStream fos = new FileOutputStream(dest)) {
+            URL website = new URL(urlStr);
+            ReadableByteChannel rbc = Channels.newChannel(website.openStream());
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            System.out.println("Updated: " + dest.getAbsolutePath());
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
@@ -1,0 +1,25 @@
+<zapaddon>
+	<name>MacOS WebDrivers</name>
+	<version>2</version>
+	<status>beta</status>
+	<description>MacOS WebDrivers for Firefox and Chrome.</description>
+	<author>ZAP Dev Team</author>
+	<url></url>
+	<changes>
+	<![CDATA[
+	Update geckodriver to v0.14.0<br>
+	Download files from zap-libs repo<br>
+	Promote to beta<br>
+	]]>
+	</changes>
+	<extensions/>
+	<ascanrules/>
+	<pscanrules/>
+	<filters/>
+	<files>
+		<file>webdriver/macos/64/chromedriver</file>
+		<file>webdriver/macos/64/geckodriver</file>
+	</files>
+	<not-before-version>2.4.0</not-before-version>
+	<not-from-version/>
+</zapaddon>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/WebdriverDownload.java
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/WebdriverDownload.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.webdriverwindows;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Paths;
+
+public class WebdriverDownload {
+
+    /**
+     * The webdriver files are help in the zap-libs repo to prevent space problems in this one.
+     * The zap-libs repo contains tasks for downloading the files from their orriginal locations.
+     * The code will need to be changed and rerun whenever new versions of the webdrivers become available.
+     * 
+     * @param args
+     */
+	public static void main(String[] args) {
+		
+        downloadDriver(
+                "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/windows/32/geckodriver.exe",
+                "files/webdriver/windows/32/geckodriver.exe");
+        downloadDriver(
+                "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/windows/64/geckodriver.exe",
+                "files/webdriver/windows/64/geckodriver.exe");
+
+        downloadDriver(
+                "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/windows/32/chromedriver.exe",
+                "files/webdriver/windows/32/chromedriver.exe");
+
+        downloadDriver(
+                "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/windows/32/IEDriverServer.exe",
+                "files/webdriver/windows/32/IEDriverServer.exe");
+        downloadDriver(
+                "https://github.com/zaproxy/zap-libs/raw/master/files/webdriver/windows/64/IEDriverServer.exe",
+                "files/webdriver/windows/64/IEDriverServer.exe");
+    }
+    
+    private static void downloadDriver(String urlStr, String destFile) {
+        String baseDir = "src/";
+        if (Paths.get("").toAbsolutePath().toString().endsWith("build")) {
+            // Likely to be being invoked from the build script
+            baseDir = "../src/";
+        }
+        File dest = new File(
+                baseDir + WebdriverDownload.class.getPackage().getName().replace(".", "/") + "/" + destFile);
+        if (dest.exists()) {
+            System.out.println("Already exists: " + dest.getAbsolutePath());
+            return;
+        }
+        File parent = dest.getParentFile();
+        if (!parent.exists() && !parent.mkdirs()) {
+            System.out.println("Failed to create directory : " + dest.getParentFile().getAbsolutePath());
+        }
+        
+        try (FileOutputStream fos = new FileOutputStream(dest)) {
+            URL website = new URL(urlStr);
+            ReadableByteChannel rbc = Channels.newChannel(website.openStream());
+            fos.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
+            System.out.println("Updated: " + dest.getAbsolutePath());
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
@@ -1,0 +1,28 @@
+<zapaddon>
+	<name>Windows WebDrivers</name>
+	<version>2</version>
+	<status>beta</status>
+	<description>Windows WebDrivers for Firefox, Chrome and IE.</description>
+	<author>ZAP Dev Team</author>
+	<url></url>
+	<changes>
+	<![CDATA[
+	Update geckodriver to v0.14.0<br>
+	Download files from zap-libs repo<br>
+	Promote to beta<br>
+	]]>
+	</changes>
+	<extensions/>
+	<ascanrules/>
+	<pscanrules/>
+	<filters/>
+	<files>
+		<file>webdriver/windows/32/chromedriver.exe</file>
+		<file>webdriver/windows/32/geckodriver.exe</file>
+		<file>webdriver/windows/32/IEDriverServer.exe</file>
+		<file>webdriver/windows/64/geckodriver.exe</file>
+		<file>webdriver/windows/64/IEDriverServer.exe</file>
+	</files>
+	<not-before-version>2.4.0</not-before-version>
+	<not-from-version/>
+</zapaddon>


### PR DESCRIPTION
This depends on zaproxy/zap-libs#2
I'll raise another PR to remove them from alpha when this one is merged