### PR TITLE
spiderAjax: use provided browsers from Selenium

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
@@ -38,8 +38,8 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.extension.selenium.Browser;
-import org.zaproxy.zap.extension.selenium.BrowserUI;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowserUI;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.Target;
@@ -130,13 +130,13 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
         });
         
         if (getExtSelenium() != null) {
-        	List<Browser> browserList = getExtSelenium().getConfiguredBrowsers();
+        	List<ProvidedBrowserUI> browserList = getExtSelenium().getProvidedBrowserUIList();
         	List <String> browserNames = new ArrayList<String>(); 
         	String defaultBrowser = null;
-        	for (Browser browser : browserList) {
-        		browserNames.add(extSel.getName(browser));
-        		if (browser.getId().equals(params.getBrowserId())) {
-        			defaultBrowser = extSel.getName(browser);
+        	for (ProvidedBrowserUI browser : browserList) {
+        		browserNames.add(browser.getName());
+        		if (browser.getBrowser().getId().equals(params.getBrowserId())) {
+        			defaultBrowser = browser.getName();
         		}
         	}
         	
@@ -200,20 +200,21 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
     }
 
     /**
-     * Updates the choices available in "Browser" combo box, based on the currently configured browsers.
+     * Updates the choices available in "Browser" combo box, based on the currently available browsers.
      *
      * @see ExtensionSelenium#getConfiguredBrowsers()
      */
     public void updateBrowsers() {
-        List<Browser> browserList = getExtSelenium().getConfiguredBrowsers();
+        List<ProvidedBrowserUI> browserList = getExtSelenium().getProvidedBrowserUIList();
         List<String> browserNames = new ArrayList<>();
         String defaultBrowser = null;
-        for (Browser browser : browserList) {
-            browserNames.add(extSel.getName(browser));
-            if (browser.getId().equals(params.getBrowserId())) {
-                defaultBrowser = extSel.getName(browser);
+        for (ProvidedBrowserUI browser : browserList) {
+            browserNames.add(browser.getName());
+            if (browser.getBrowser().getId().equals(params.getBrowserId())) {
+                defaultBrowser = browser.getName();
             }
         }
+        
         setComboFields(FIELD_BROWSER, browserNames, defaultBrowser);
     }
 
@@ -345,9 +346,9 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
     public void save() {
     	AjaxSpiderParam params = this.extension.getAjaxSpiderParam().clone();
     	
-        Browser selectedBrowser = getSelectedBrowser();
+        String selectedBrowser = getSelectedBrowser();
         if (selectedBrowser != null) {
-            params.setBrowserId(selectedBrowser.getId());
+            params.setBrowserId(selectedBrowser);
         }
 
         if (this.getBoolValue(FIELD_ADVANCED)) {
@@ -405,16 +406,16 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
      *
      * @return the selected browser, {@code null} if none selected
      */
-    private Browser getSelectedBrowser() {
+    private String getSelectedBrowser() {
         if (isEmptyField(FIELD_BROWSER)) {
             return null;
         }
 
         String browserName = this.getStringValue(FIELD_BROWSER);
-        List<BrowserUI> browserList = getExtSelenium().getBrowserUIList();
-        for (BrowserUI bui : browserList) {
+        List<ProvidedBrowserUI> browserList = getExtSelenium().getProvidedBrowserUIList();
+        for (ProvidedBrowserUI bui : browserList) {
             if (browserName.equals(bui.getName())) {
-                return bui.getBrowser();
+                return bui.getBrowser().getId();
             }
         }
         return null;
@@ -483,12 +484,12 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
             }
         }
 
-        Browser selectedBrowser = getSelectedBrowser();
+        String selectedBrowser = getSelectedBrowser();
         if (selectedBrowser == null) {
             return Constant.messages.getString("spiderajax.scandialog.nobrowser.error");
         }
 
-        if (Browser.PHANTOM_JS.getId() == selectedBrowser.getId()) {
+        if (Browser.PHANTOM_JS.getId() == selectedBrowser) {
             String host = startUri.getHost();
             if ("localhost".equalsIgnoreCase(host) || "127.0.0.1".equals(host) || "[::1]".equals(host)) {
                 return Constant.messages.getString("spiderajax.warn.message.phantomjs.bug.invalid.target");

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -219,7 +219,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 			ExtensionSelenium extSelenium = Control.getSingleton()
 					.getExtensionLoader()
 					.getExtension(ExtensionSelenium.class);
-			optionsAjaxSpider = new OptionsAjaxSpider(this.getMessages(), extSelenium.createBrowsersComboBoxModel());
+			optionsAjaxSpider = new OptionsAjaxSpider(this.getMessages(), extSelenium.createProvidedBrowsersComboBoxModel());
 		}
 		return optionsAjaxSpider;
 	}

--- a/src/org/zaproxy/zap/extension/spiderAjax/OptionsAjaxSpider.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/OptionsAjaxSpider.java
@@ -34,7 +34,7 @@ import javax.swing.JScrollPane;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
-import org.zaproxy.zap.extension.selenium.BrowsersComboBoxModel;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowsersComboBoxModel;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
 
 public class OptionsAjaxSpider extends AbstractParamPanel {
@@ -46,7 +46,7 @@ public class OptionsAjaxSpider extends AbstractParamPanel {
 	private OptionsAjaxSpiderTableModel ajaxSpiderClickModel = null;
 
 	private JPanel panelCrawljax = null;
-	private final BrowsersComboBoxModel browsersComboBoxModel;
+	private final ProvidedBrowsersComboBoxModel browsersComboBoxModel;
 	private ZapNumberSpinner txtNumBro = null;
 	private ZapNumberSpinner maximumDepthNumberSpinner = null;
 	private ZapNumberSpinner maximumStatesNumberSpinner = null;
@@ -67,7 +67,7 @@ public class OptionsAjaxSpider extends AbstractParamPanel {
 
 	private ResourceBundle resourceBundle;
 
-    public OptionsAjaxSpider(ResourceBundle resourceBundle, BrowsersComboBoxModel browsersComboBoxModel) {
+    public OptionsAjaxSpider(ResourceBundle resourceBundle, ProvidedBrowsersComboBoxModel browsersComboBoxModel) {
         super();
         this.resourceBundle = resourceBundle;
         this.browsersComboBoxModel = browsersComboBoxModel;

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -38,8 +38,8 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.extension.spiderAjax.SpiderListener.ResourceState;
 import org.zaproxy.zap.extension.spiderAjax.internal.ProxyServer;
@@ -211,8 +211,8 @@ public class SpiderThread implements Runnable {
                 ExtensionSelenium extSelenium = Control.getSingleton()
                         .getExtensionLoader()
                         .getExtension(ExtensionSelenium.class);
-                Browser browser = Browser.getBrowserWithId(target.getOptions().getBrowserId());
-                View.getSingleton().showWarningDialog(extSelenium.getWarnMessageFailedToStart(browser));
+                String providedBrowserId = target.getOptions().getBrowserId();
+                View.getSingleton().showWarningDialog(extSelenium.getWarnMessageFailedToStart(providedBrowserId));
             }
 		} catch (Exception e) {
 			logger.error(e, e);
@@ -369,11 +369,11 @@ public class SpiderThread implements Runnable {
 		@Inject
 		private Plugins plugins;
 
-		private final String browserId;
+		private final String providedBrowserId;
 
-		public AjaxSpiderBrowserBuilder(String browserId) {
+		public AjaxSpiderBrowserBuilder(String providedBrowserId) {
 			super();
-			this.browserId = browserId;
+			this.providedBrowserId = providedBrowserId;
 		}
 
 		/**
@@ -391,8 +391,10 @@ public class SpiderThread implements Runnable {
 			long crawlWaitReload = configuration.getCrawlRules().getWaitAfterReloadUrl();
 			long crawlWaitEvent = configuration.getCrawlRules().getWaitAfterEvent();
 
-			EmbeddedBrowser embeddedBrowser = WebDriverBackedEmbeddedBrowser.withDriver(ExtensionSelenium.getWebDriver(
-					Browser.getBrowserWithId(browserId),
+			ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+			EmbeddedBrowser embeddedBrowser = WebDriverBackedEmbeddedBrowser.withDriver(extSelenium.getWebDriver(
+					HttpSender.SPIDER_INITIATOR,
+					providedBrowserId,
 					configuration.getProxyConfiguration().getHostname(),
 					configuration.getProxyConfiguration().getPort()), filterAttributes, crawlWaitEvent, crawlWaitReload);
 			plugins.runOnBrowserCreatedPlugins(embeddedBrowser);

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -13,13 +13,14 @@
 	Honour global excluded URLs (Issue 3172).<br>
 	Reset URL counter on session change.<br>
 	Show excluded URLs in the AJAX Spider tab and through the ZAP API.<br>
+	Use provided browsers from Selenium add-on.<br>
 	]]>
 	</changes>
 	<dependencies>
 		<addons>
 			<addon>
 				<id>selenium</id>
-				<semver>1.*</semver>
+				<semver><![CDATA[ >=1.1.0 & <2.0.0 ]]></semver>
 			</addon>
 		</addons>
 	</dependencies>


### PR DESCRIPTION
Change AJAX Spider to allow to use the provided browsers from Selenium.
Update changes and bump (minimum) Selenium version in ZapAddOn.xml file.