### PR TITLE
spiderAjax: show messages with I/O errors

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
@@ -81,6 +81,7 @@ public class AjaxSpiderResultsTableModel
         addState(statesMap, ResourceState.OUT_OF_CONTEXT, "outofcontext");
         addState(statesMap, ResourceState.OUT_OF_SCOPE, "outofscope");
         addState(statesMap, ResourceState.EXCLUDED, "excluded");
+        addState(statesMap, ResourceState.IO_ERROR, "ioerror");
     }
 
     public AjaxSpiderResultsTableModel() {

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderListener.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderListener.java
@@ -28,7 +28,8 @@ interface SpiderListener {
 		PROCESSED,
 		OUT_OF_SCOPE,
 		OUT_OF_CONTEXT,
-		EXCLUDED
+		EXCLUDED,
+		IO_ERROR
 	}
 
 	void spiderStarted();

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -14,6 +14,7 @@
 	Reset URL counter on session change.<br>
 	Show excluded URLs in the AJAX Spider tab and through the ZAP API.<br>
 	Use provided browsers from Selenium add-on.<br>
+	Show messages that were not successful because of I/O errors.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
@@ -40,6 +40,7 @@ spiderajax.panel.table.cell.processed = Processed
 spiderajax.panel.table.cell.outofcontext = Out of Context
 spiderajax.panel.table.cell.outofscope = Out of Scope
 spiderajax.panel.table.cell.excluded = Excluded
+spiderajax.panel.table.cell.ioerror = I/O Error
 spiderajax.panel.table.header.processed = Processed
 spiderajax.proxy.local.label.defaultElems= Click default elements only (a, button, input)
 spiderajax.proxy.local.label.browsers= <html><body><br><p>Choose the browser that you want to use in the AJAX Spider Plugin:</p></body></html>


### PR DESCRIPTION
Change AJAX Spider to also show/provide the messages that were not sent
successfully because of I/O errors (e.g. target not reachable),
otherwise it might seem that the spider is not working and not all
information is provided.
Update changes in ZapAddOn.xml file.