### PR TITLE
selenium: allow providers to show custom warn msg

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -525,12 +525,19 @@ public class ExtensionSelenium extends ExtensionAdaptor {
      * remaining cases there's a generic error message.
      *
      * @param providedBrowserId the ID of provided browser that failed to start
+     * @param e the error/exception that was thrown while obtaining/starting the WebDriver/browser.
      * @return a {@code String} with the error message
+     * @since 1.1.0
      */
-    public String getWarnMessageFailedToStart(String providedBrowserId) {
+    public String getWarnMessageFailedToStart(String providedBrowserId, Throwable e) {
         ProvidedBrowser providedBrowser = getProvidedBrowser(providedBrowserId);
         if (providedBrowser == null) {
             return getMessages().getString("selenium.warn.message.failed.start.browser.notfound");
+        }
+
+        String msg = getProviderWarnMessage(providedBrowser, e);
+        if (msg != null) {
+            return msg;
         }
 
         Browser browser = Browser.getBrowserWithIdNoFailSafe(providedBrowser.getProviderId());
@@ -539,6 +546,14 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         }
         return MessageFormat
                 .format(getMessages().getString("selenium.warn.message.failed.start.browser"), providedBrowser.getName());
+    }
+
+    private String getProviderWarnMessage(ProvidedBrowser providedBrowser, Throwable e) {
+        SingleWebDriverProvider provider = webDriverProviders.get(providedBrowser.getProviderId());
+        if (provider == null) {
+            return null;
+        }
+        return provider.getWarnMessageFailedToStart(e);
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/selenium/SingleWebDriverProvider.java
+++ b/src/org/zaproxy/zap/extension/selenium/SingleWebDriverProvider.java
@@ -61,4 +61,16 @@ public interface SingleWebDriverProvider {
      *             port number (between 1 and 65535).
      */
     WebDriver getWebDriver(int requesterId, String proxyAddress, int proxyPort);
+
+    /**
+     * Gets a warning message that indicates the possible cause of the failure that prevented the WebDriver/browser from
+     * starting.
+     * <p>
+     * The message will be shown in UI components.
+     *
+     * @param e the error/exception that was thrown while obtaining/starting the WebDriver/browser.
+     * @return the warning message that indicates the possible cause of the failure, might be {@code null} if there's no custom
+     *         warning message (Selenium extension will provide a generic warning message in those cases).
+     */
+    String getWarnMessageFailedToStart(Throwable e);
 }

--- a/src/org/zaproxy/zap/extension/selenium/internal/BuiltInSingleWebDriverProvider.java
+++ b/src/org/zaproxy/zap/extension/selenium/internal/BuiltInSingleWebDriverProvider.java
@@ -62,6 +62,12 @@ public class BuiltInSingleWebDriverProvider implements SingleWebDriverProvider {
         return ExtensionSelenium.getWebDriver(browser, proxyAddress, proxyPort);
     }
 
+    @Override
+    public String getWarnMessageFailedToStart(Throwable e) {
+        // No custom warning message, use the ones provided by Selenium extension.
+        return null;
+    }
+
     private class ProvidedBrowserImpl implements ProvidedBrowser {
 
         @Override

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -212,7 +212,7 @@ public class SpiderThread implements Runnable {
                         .getExtensionLoader()
                         .getExtension(ExtensionSelenium.class);
                 String providedBrowserId = target.getOptions().getBrowserId();
-                View.getSingleton().showWarningDialog(extSelenium.getWarnMessageFailedToStart(providedBrowserId));
+                View.getSingleton().showWarningDialog(extSelenium.getWarnMessageFailedToStart(providedBrowserId, e));
             }
 		} catch (Exception e) {
 			logger.error(e, e);


### PR DESCRIPTION
Change Selenium add-on to allow WebDriver providers to show a custom
warning message, when the WebDriver/browser failed to start.
Update AJAX Spider add-on to pass the exception that occurred while
starting the WebDriver/browser (useful for the providers to return a
more accurate warning message).