### PR TITLE
spiderAjax: ensure New Scan button is enabled

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -231,7 +231,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 			startScanButton = new JButton();
 			startScanButton.setText(this.extension.getMessages().getString("spiderajax.toolbar.button.start"));
 			startScanButton.setIcon(new ImageIcon(SpiderPanel.class.getResource("/resource/icon/16/spiderAjax.png")));
-			startScanButton.setEnabled(false);
+			startScanButton.setEnabled(!Mode.safe.equals(Control.getSingleton().getMode()));
 			startScanButton.addActionListener(new ActionListener () {
 
 				@Override
@@ -481,6 +481,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 		case standard:
 		case protect:
 		case attack:
+			this.getStartScanButton().setEnabled(!extension.isSpiderRunning());
 			break;
 		case safe:
 			stopScan();

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -15,6 +15,7 @@
 	Show excluded URLs in the AJAX Spider tab and through the ZAP API.<br>
 	Use provided browsers from Selenium add-on.<br>
 	Show messages that were not successful because of I/O errors.<br>
+	Ensure New Scan button is enabled, when the mode allows it.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change SpiderPanel to ensure that the New Scan button is enabled, when
the current mode allows it.
Update changes in ZapAddOn.xml file.