### PR TITLE
jxbrowser: provide WebDrivers

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -39,7 +39,7 @@
 	<classpathentry kind="lib" path="testlib/objenesis-1.2.jar"/>
 	<classpathentry kind="lib" path="testlib/powermock-mockito-1.4.12-full.jar"/>
 	<classpathentry kind="lib" path="testlib/simple-5.0.2.jar"/>
-	<classpathentry kind="lib" path="lib/selenium-release-3.zap"/>
+	<classpathentry kind="lib" path="lib/selenium-release-9.zap"/>
 	<classpathentry kind="lib" path="lib/zap-2.5.0.jar"/>
 	<classpathentry kind="lib" path="lib/json-20160212.jar"/>
 	<classpathentry kind="lib" path="lib/commons-compress-1.13.jar"/>

--- a/src/org/zaproxy/zap/extension/jxbrowser/BrowserPanel.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/BrowserPanel.java
@@ -64,9 +64,18 @@ public class BrowserPanel extends JPanel {
     }
 
     public BrowserPanel(BrowserFrame frame, boolean incToolbar) {
+        this(frame, incToolbar, null);
+    }
+
+    public BrowserPanel(BrowserFrame frame, boolean incToolbar, Browser browser) {
         this.frame = frame;
-        // Set up the browser
-        getBrowser();
+        
+        if (browser == null) {
+            // Set up the browser
+            getBrowser();
+        } else {
+            this.browser = browser;
+        }
         JToolBar toolbar = null;
 
         if (incToolbar) {
@@ -79,15 +88,15 @@ public class BrowserPanel extends JPanel {
             getBackButton().addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    browser.goBack();
-                    url.setText(browser.getURL());
+                    BrowserPanel.this.browser.goBack();
+                    url.setText(BrowserPanel.this.browser.getURL());
                 }
             });
             getForwardButton().addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    browser.goForward();
-                    url.setText(browser.getURL());
+                    BrowserPanel.this.browser.goForward();
+                    url.setText(BrowserPanel.this.browser.getURL());
                 }
             });
 
@@ -101,11 +110,11 @@ public class BrowserPanel extends JPanel {
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    browser.loadURL(url.getText());
+                    BrowserPanel.this.browser.loadURL(url.getText());
                 }
             });
 
-            browser.addLoadListener(new LoadListener() {
+            this.browser.addLoadListener(new LoadListener() {
 
                 @Override
                 public void onDocumentLoadedInFrame(FrameLoadEvent arg0) {
@@ -113,7 +122,7 @@ public class BrowserPanel extends JPanel {
 
                 @Override
                 public void onDocumentLoadedInMainFrame(LoadEvent arg0) {
-                    url.setText(browser.getURL());
+                    url.setText(BrowserPanel.this.browser.getURL());
                 }
 
                 @Override
@@ -139,7 +148,7 @@ public class BrowserPanel extends JPanel {
         if (incToolbar) {
             this.add(toolbar, BorderLayout.NORTH);
         }
-        BrowserView browserView = new BrowserView(browser);
+        BrowserView browserView = new BrowserView(this.browser);
         // Disabled for now - too many issues with it
         //getBrowser().setContextMenuHandler(getContextMenuHandler(browserView));
         this.add(browserView, BorderLayout.CENTER);

--- a/src/org/zaproxy/zap/extension/jxbrowser/Utils.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/Utils.java
@@ -1,0 +1,39 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowser;
+
+/**
+ * Utility methods used/for JxBrowser classes/extensions.
+ */
+public final class Utils {
+
+    private Utils() {
+    }
+
+    /**
+     * Tells whether or not the current OS/JVM is 64bits arch.
+     *
+     * @return {@code true} if the OS/JVM is 64bits arch, {@code false} otherwise.
+     */
+    public static boolean isOs64Bits() {
+        String arch = System.getProperty("os.arch");
+        return arch.contains("amd64") || arch.contains("x86_64");
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapBrowserFrame.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapBrowserFrame.java
@@ -29,6 +29,8 @@ import javax.swing.JTabbedPane;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.TabbedPanel2;
 
+import com.teamdev.jxbrowser.chromium.Browser;
+
 public class ZapBrowserFrame extends BrowserFrame {
 
     private static final long serialVersionUID = 1L;
@@ -43,8 +45,22 @@ public class ZapBrowserFrame extends BrowserFrame {
         super(incToolbar, supportTabs);
     }
 
+    public ZapBrowserFrame(final boolean incToolbar, final boolean supportTabs, boolean createBrowser) {
+        super(incToolbar, supportTabs, createBrowser);
+    }
+
+    public ZapBrowserFrame(final boolean incToolbar, final boolean supportTabs, boolean createBrowser, boolean showNewTab) {
+        super(incToolbar, supportTabs, createBrowser, showNewTab);
+    }
+
+    @Override
     protected BrowserPanel getNewBrowserPanel(boolean incToolbar) {
         return new ZapBrowserPanel(this, incToolbar);
+    }
+
+    @Override
+    protected BrowserPanel getNewBrowserPanel(boolean incToolbar, Browser browser) {
+        return new ZapBrowserPanel(this, incToolbar, browser);
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapBrowserPanel.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapBrowserPanel.java
@@ -54,6 +54,10 @@ public class ZapBrowserPanel extends BrowserPanel {
         super(frame, incToolbar);
     }
 
+    public ZapBrowserPanel(BrowserFrame frame, boolean incToolbar, Browser browser) {
+        super(frame, incToolbar, browser);
+    }
+
     @Override
     public Browser getBrowser() {
         if (browser == null) {

--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapTabbedPanel.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapTabbedPanel.java
@@ -69,6 +69,10 @@ public class ZapTabbedPanel extends JTabbedPane {
     @Override
     public void remove(Component component) {
         int pos = this.indexOfComponent(component);
+        if (pos == -1) {
+            return;
+        }
+
         if (pos == getTabCount() - 2) {
             setSelectedIndex(getTabCount() - 3);
         }
@@ -77,6 +81,10 @@ public class ZapTabbedPanel extends JTabbedPane {
     }
 
     private void setCloseButtonStates() {
+        if (this.getTabCount() == 0) {
+            return;
+        }
+
         // Hide all 'close' buttons except for the selected tab
         if (this.getTabCount() <= 2) {
             // just one tab and maybe the Plus one, so dont allow the first one to be closed

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux32/ExtensionJxBrowserLinux32.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux32/ExtensionJxBrowserLinux32.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.jxbrowser.ExtensionJxBrowser;
+import org.zaproxy.zap.extension.jxbrowser.Utils;
 import org.zaproxy.zap.extension.jxbrowser.ZapBrowserFrame;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -62,7 +63,7 @@ public class ExtensionJxBrowserLinux32 extends ExtensionAdaptor {
 
         if (getView() != null) {
 
-            if (Constant.isLinux() && !isOs64Bits()) {
+            if (Constant.isLinux() && !Utils.isOs64Bits()) {
                 // Only show if we're running on the right platform
                 View.getSingleton().addMainToolbarButton(this.getLaunchBrowserButton());
 
@@ -78,11 +79,6 @@ public class ExtensionJxBrowserLinux32 extends ExtensionAdaptor {
                 extensionHook.getHookMenu().addToolsMenuItem(menulaunch);
             }
         }
-    }
-
-    private static boolean isOs64Bits() {
-        String arch = System.getProperty("os.arch");
-        return arch.contains("amd64") || arch.contains("x86_64");
     }
 
     private JButton getLaunchBrowserButton() {

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux32/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux32/ZapAddOn.xml
@@ -18,6 +18,17 @@
 	</dependencies>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jxbrowserlinux32.ExtensionJxBrowserLinux32</extension>
+		<extension v="1">
+			<classname>org.zaproxy.zap.extension.jxbrowserlinux32.selenium.ExtSelJxBrowserLinux32</classname>
+			<dependencies>
+				<addons>
+					<addon>
+						<id>selenium</id>
+						<semver><![CDATA[ >=1.1.0 & <2.0.0 ]]></semver>
+					</addon>
+				</addons>
+			</dependencies>
+		</extension>
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux32/selenium/ExtSelJxBrowserLinux32.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux32/selenium/ExtSelJxBrowserLinux32.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowserlinux32.selenium;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.jxbrowser.Utils;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+
+/**
+ * An {@link org.parosproxy.paros.extension.Extension Extension} that installs a {@link JxBrowserProvider}, if in Linux 32bits.
+ */
+public class ExtSelJxBrowserLinux32 extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtSelJxBrowserLinux32";
+
+    private JxBrowserProvider webDriverProvider;
+
+    public ExtSelJxBrowserLinux32() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        if (Constant.isLinux() && !Utils.isOs64Bits()) {
+            webDriverProvider = new JxBrowserProvider();
+
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.addWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+
+        if (webDriverProvider != null) {
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.removeWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux32/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux32/selenium/JxBrowserProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowserlinux32.selenium;
+
+import java.awt.EventQueue;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
+import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
+import org.zaproxy.zap.extension.jxbrowser.ZapBrowserFrame;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowser;
+import org.zaproxy.zap.extension.selenium.SingleWebDriverProvider;
+
+import com.teamdev.jxbrowser.chromium.Browser;
+import com.teamdev.jxbrowser.chromium.BrowserContext;
+import com.teamdev.jxbrowser.chromium.BrowserContextParams;
+import com.teamdev.jxbrowser.chromium.BrowserPreferences;
+import com.teamdev.jxbrowser.chromium.CustomProxyConfig;
+
+/**
+ * A {@link SingleWebDriverProvider} for JxBrowser.
+ */
+public class JxBrowserProvider implements SingleWebDriverProvider {
+
+    private static final String PROVIDER_ID = "jxbrowser";
+
+    private final ProvidedBrowser providedBrowser;
+    private BrowserFrame zbf;
+    private int chromePort;
+
+    public JxBrowserProvider() {
+        this.providedBrowser = new ProvidedBrowserImpl();
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public ProvidedBrowser getProvidedBrowser() {
+        return providedBrowser;
+    }
+
+    @Override
+    public String getWarnMessageFailedToStart(Throwable arg0) {
+        // Do not return a custom message, for now.
+        return null;
+    }
+
+    @Override
+    public WebDriver getWebDriver(int requesterId) {
+        return getRemoteWebDriver(null, 0);
+    }
+
+    private RemoteWebDriver getRemoteWebDriver(final String proxyAddress, final int proxyPort) {
+        if (View.isInitialised()) {
+            try {
+                GetWebDriverRunnable wb = new GetWebDriverRunnable(proxyAddress, proxyPort);
+                EventQueue.invokeAndWait(wb);
+                return wb.getWebDriver();
+            } catch (InvocationTargetException | InterruptedException e) {
+                throw new WebDriverException(e);
+            }
+        }
+
+        synchronized (this) {
+            return getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+    }
+
+    private RemoteWebDriver getRemoteWebDriverImpl(String proxyAddress, int proxyPort) {
+        try {
+            if (zbf == null) {
+                zbf = new ZapBrowserFrame(false, true, false, false);
+                chromePort = getFreePort();
+            } else if (!zbf.isVisible()) {
+                zbf.setVisible(true);
+            }
+
+            File dataDir = Files.createTempDirectory("zap-jxbrowser").toFile();
+            dataDir.deleteOnExit();
+            BrowserContextParams contextParams = new BrowserContextParams(dataDir.getAbsolutePath());
+
+            if (proxyAddress != null && !proxyAddress.isEmpty()) {
+                String hostPort = proxyAddress + ":" + proxyPort;
+                String proxyRules = "http=" + hostPort + ";https=" + hostPort;
+                contextParams.setProxyConfig(new CustomProxyConfig(proxyRules));
+            }
+
+            BrowserPreferences.setChromiumSwitches("--remote-debugging-port=" + chromePort);
+            Browser browser = new Browser(new BrowserContext(contextParams));
+            final BrowserPanel browserPanel = zbf.addNewBrowserPanel(false, browser);
+
+            final ChromeDriverService service = new ChromeDriverService.Builder().usingAnyFreePort().build();
+            service.start();
+
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            ChromeOptions options = new ChromeOptions();
+
+            options.setExperimentalOption("debuggerAddress", "localhost:" + chromePort);
+            capabilities.setCapability(ChromeOptions.CAPABILITY, options);
+
+            return new RemoteWebDriver(service.getUrl(), capabilities) {
+
+                @Override
+                public void close() {
+                    super.close();
+
+                    cleanUpBrowser(browserPanel);
+                    // XXX should stop here too?
+                    // service.stop();
+                }
+
+                @Override
+                public void quit() {
+                    super.quit();
+
+                    cleanUpBrowser(browserPanel);
+
+                    boolean interrupted = Thread.interrupted();
+                    service.stop();
+                    if (interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            };
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private void cleanUpBrowser(final BrowserPanel browserPanel) {
+        if (View.isInitialised()) {
+            EventQueue.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    if (zbf == null) {
+                        return;
+                    }
+
+                    cleanUpBrowserImpl(browserPanel);
+                }
+            });
+        } else {
+            synchronized (this) {
+                if (zbf == null) {
+                    return;
+                }
+                cleanUpBrowserImpl(browserPanel);
+            }
+        }
+    }
+
+    private void cleanUpBrowserImpl(BrowserPanel browserPanel) {
+        browserPanel.getBrowser().dispose();
+        zbf.removeTab(browserPanel);
+
+        if (!zbf.hasPanels()) {
+            zbf.dispose();
+            zbf = null;
+        }
+    }
+
+    @Override
+    public synchronized WebDriver getWebDriver(int requesterId, String proxyAddress, int proxyPort) {
+        return getRemoteWebDriver(proxyAddress, proxyPort);
+    }
+
+    private int getFreePort() {
+        try (ServerSocket socket = new ServerSocket(0, 400, InetAddress.getByName("localhost"))) {
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private class ProvidedBrowserImpl implements ProvidedBrowser {
+
+        @Override
+        public String getProviderId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getName() {
+            return "JxBrowser";
+        }
+    }
+
+    private class GetWebDriverRunnable implements Runnable {
+
+        private final String proxyAddress;
+        private final int proxyPort;
+
+        private RemoteWebDriver webDriver;
+
+        public GetWebDriverRunnable(String proxyAddress, int proxyPort) {
+            this.proxyAddress = proxyAddress;
+            this.proxyPort = proxyPort;
+        }
+
+        @Override
+        public void run() {
+            webDriver = getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+
+        public RemoteWebDriver getWebDriver() {
+            return webDriver;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/ExtensionJxBrowserLinux64.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/ExtensionJxBrowserLinux64.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.jxbrowser.ExtensionJxBrowser;
+import org.zaproxy.zap.extension.jxbrowser.Utils;
 import org.zaproxy.zap.extension.jxbrowser.ZapBrowserFrame;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -62,7 +63,7 @@ public class ExtensionJxBrowserLinux64 extends ExtensionAdaptor {
 
         if (getView() != null) {
 
-            if (Constant.isLinux() && isOs64Bits()) {
+            if (Constant.isLinux() && Utils.isOs64Bits()) {
                 // Only show if we're running on the right platform
                 View.getSingleton().addMainToolbarButton(this.getLaunchBrowserButton());
     
@@ -78,11 +79,6 @@ public class ExtensionJxBrowserLinux64 extends ExtensionAdaptor {
                 extensionHook.getHookMenu().addToolsMenuItem(menulaunch);
             }
         }
-    }
-    
-    private static boolean isOs64Bits() {
-        String arch = System.getProperty("os.arch");
-        return arch.contains("amd64") || arch.contains("x86_64");
     }
     
     private JButton getLaunchBrowserButton() {

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/ZapAddOn.xml
@@ -18,6 +18,17 @@
 	</dependencies>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jxbrowserlinux64.ExtensionJxBrowserLinux64</extension>
+		<extension v="1">
+			<classname>org.zaproxy.zap.extension.jxbrowserlinux64.selenium.ExtSelJxBrowserLinux64</classname>
+			<dependencies>
+				<addons>
+					<addon>
+						<id>selenium</id>
+						<semver><![CDATA[ >=1.1.0 & <2.0.0 ]]></semver>
+					</addon>
+				</addons>
+			</dependencies>
+		</extension>
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/ExtSelJxBrowserLinux64.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/ExtSelJxBrowserLinux64.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowserlinux64.selenium;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.jxbrowser.Utils;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+
+/**
+ * An {@link org.parosproxy.paros.extension.Extension Extension} that installs a {@link JxBrowserProvider}, if in Linux 64bits.
+ */
+public class ExtSelJxBrowserLinux64 extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtSelJxBrowserLinux64";
+
+    private JxBrowserProvider webDriverProvider;
+
+    public ExtSelJxBrowserLinux64() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        if (Constant.isLinux() && Utils.isOs64Bits()) {
+            webDriverProvider = new JxBrowserProvider();
+
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.addWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+
+        if (webDriverProvider != null) {
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.removeWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/JxBrowserProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowserlinux64.selenium;
+
+import java.awt.EventQueue;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
+import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
+import org.zaproxy.zap.extension.jxbrowser.ZapBrowserFrame;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowser;
+import org.zaproxy.zap.extension.selenium.SingleWebDriverProvider;
+
+import com.teamdev.jxbrowser.chromium.Browser;
+import com.teamdev.jxbrowser.chromium.BrowserContext;
+import com.teamdev.jxbrowser.chromium.BrowserContextParams;
+import com.teamdev.jxbrowser.chromium.BrowserPreferences;
+import com.teamdev.jxbrowser.chromium.CustomProxyConfig;
+
+/**
+ * A {@link SingleWebDriverProvider} for JxBrowser.
+ */
+public class JxBrowserProvider implements SingleWebDriverProvider {
+
+    private static final String PROVIDER_ID = "jxbrowser";
+
+    private final ProvidedBrowser providedBrowser;
+    private BrowserFrame zbf;
+    private int chromePort;
+
+    public JxBrowserProvider() {
+        this.providedBrowser = new ProvidedBrowserImpl();
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public ProvidedBrowser getProvidedBrowser() {
+        return providedBrowser;
+    }
+
+    @Override
+    public String getWarnMessageFailedToStart(Throwable arg0) {
+        // Do not return a custom message, for now.
+        return null;
+    }
+
+    @Override
+    public WebDriver getWebDriver(int requesterId) {
+        return getRemoteWebDriver(null, 0);
+    }
+
+    private RemoteWebDriver getRemoteWebDriver(final String proxyAddress, final int proxyPort) {
+        if (View.isInitialised()) {
+            try {
+                GetWebDriverRunnable wb = new GetWebDriverRunnable(proxyAddress, proxyPort);
+                EventQueue.invokeAndWait(wb);
+                return wb.getWebDriver();
+            } catch (InvocationTargetException | InterruptedException e) {
+                throw new WebDriverException(e);
+            }
+        }
+
+        synchronized (this) {
+            return getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+    }
+
+    private RemoteWebDriver getRemoteWebDriverImpl(String proxyAddress, int proxyPort) {
+        try {
+            if (zbf == null) {
+                zbf = new ZapBrowserFrame(false, true, false, false);
+                chromePort = getFreePort();
+            } else if (!zbf.isVisible()) {
+                zbf.setVisible(true);
+            }
+
+            File dataDir = Files.createTempDirectory("zap-jxbrowser").toFile();
+            dataDir.deleteOnExit();
+            BrowserContextParams contextParams = new BrowserContextParams(dataDir.getAbsolutePath());
+
+            if (proxyAddress != null && !proxyAddress.isEmpty()) {
+                String hostPort = proxyAddress + ":" + proxyPort;
+                String proxyRules = "http=" + hostPort + ";https=" + hostPort;
+                contextParams.setProxyConfig(new CustomProxyConfig(proxyRules));
+            }
+
+            BrowserPreferences.setChromiumSwitches("--remote-debugging-port=" + chromePort);
+            Browser browser = new Browser(new BrowserContext(contextParams));
+            final BrowserPanel browserPanel = zbf.addNewBrowserPanel(false, browser);
+
+            final ChromeDriverService service = new ChromeDriverService.Builder().usingAnyFreePort().build();
+            service.start();
+
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            ChromeOptions options = new ChromeOptions();
+
+            options.setExperimentalOption("debuggerAddress", "localhost:" + chromePort);
+            capabilities.setCapability(ChromeOptions.CAPABILITY, options);
+
+            return new RemoteWebDriver(service.getUrl(), capabilities) {
+
+                @Override
+                public void close() {
+                    super.close();
+
+                    cleanUpBrowser(browserPanel);
+                    // XXX should stop here too?
+                    // service.stop();
+                }
+
+                @Override
+                public void quit() {
+                    super.quit();
+
+                    cleanUpBrowser(browserPanel);
+
+                    boolean interrupted = Thread.interrupted();
+                    service.stop();
+                    if (interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            };
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private void cleanUpBrowser(final BrowserPanel browserPanel) {
+        if (View.isInitialised()) {
+            EventQueue.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    if (zbf == null) {
+                        return;
+                    }
+
+                    cleanUpBrowserImpl(browserPanel);
+                }
+            });
+        } else {
+            synchronized (this) {
+                if (zbf == null) {
+                    return;
+                }
+                cleanUpBrowserImpl(browserPanel);
+            }
+        }
+    }
+
+    private void cleanUpBrowserImpl(BrowserPanel browserPanel) {
+        browserPanel.getBrowser().dispose();
+        zbf.removeTab(browserPanel);
+
+        if (!zbf.hasPanels()) {
+            zbf.dispose();
+            zbf = null;
+        }
+    }
+
+    @Override
+    public synchronized WebDriver getWebDriver(int requesterId, String proxyAddress, int proxyPort) {
+        return getRemoteWebDriver(proxyAddress, proxyPort);
+    }
+
+    private int getFreePort() {
+        try (ServerSocket socket = new ServerSocket(0, 400, InetAddress.getByName("localhost"))) {
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private class ProvidedBrowserImpl implements ProvidedBrowser {
+
+        @Override
+        public String getProviderId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getName() {
+            return "JxBrowser";
+        }
+    }
+
+    private class GetWebDriverRunnable implements Runnable {
+
+        private final String proxyAddress;
+        private final int proxyPort;
+
+        private RemoteWebDriver webDriver;
+
+        public GetWebDriverRunnable(String proxyAddress, int proxyPort) {
+            this.proxyAddress = proxyAddress;
+            this.proxyPort = proxyPort;
+        }
+
+        @Override
+        public void run() {
+            webDriver = getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+
+        public RemoteWebDriver getWebDriver() {
+            return webDriver;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowsermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowsermacos/ZapAddOn.xml
@@ -18,6 +18,17 @@
 	</dependencies>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jxbrowsermacos.ExtensionJxBrowserMacOS</extension>
+		<extension v="1">
+			<classname>org.zaproxy.zap.extension.jxbrowsermacos.selenium.ExtSelJxBrowserMacOs</classname>
+			<dependencies>
+				<addons>
+					<addon>
+						<id>selenium</id>
+						<semver><![CDATA[ >=1.1.0 & <2.0.0 ]]></semver>
+					</addon>
+				</addons>
+			</dependencies>
+		</extension>
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>

--- a/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/ExtSelJxBrowserMacOs.java
+++ b/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/ExtSelJxBrowserMacOs.java
@@ -1,0 +1,72 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowsermacos.selenium;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+
+/**
+ * An {@link org.parosproxy.paros.extension.Extension Extension} that installs a {@link JxBrowserProvider}, if in macOS.
+ */
+public class ExtSelJxBrowserMacOs extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtSelJxBrowserMacOs";
+
+    private JxBrowserProvider webDriverProvider;
+
+    public ExtSelJxBrowserMacOs() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        if (Constant.isMacOsX()) {
+            webDriverProvider = new JxBrowserProvider();
+
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.addWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+
+        if (webDriverProvider != null) {
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.removeWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/JxBrowserProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowsermacos.selenium;
+
+import java.awt.EventQueue;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
+import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
+import org.zaproxy.zap.extension.jxbrowser.ZapBrowserFrame;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowser;
+import org.zaproxy.zap.extension.selenium.SingleWebDriverProvider;
+
+import com.teamdev.jxbrowser.chromium.Browser;
+import com.teamdev.jxbrowser.chromium.BrowserContext;
+import com.teamdev.jxbrowser.chromium.BrowserContextParams;
+import com.teamdev.jxbrowser.chromium.BrowserPreferences;
+import com.teamdev.jxbrowser.chromium.CustomProxyConfig;
+
+/**
+ * A {@link SingleWebDriverProvider} for JxBrowser.
+ */
+public class JxBrowserProvider implements SingleWebDriverProvider {
+
+    private static final String PROVIDER_ID = "jxbrowser";
+
+    private final ProvidedBrowser providedBrowser;
+    private BrowserFrame zbf;
+    private int chromePort;
+
+    public JxBrowserProvider() {
+        this.providedBrowser = new ProvidedBrowserImpl();
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public ProvidedBrowser getProvidedBrowser() {
+        return providedBrowser;
+    }
+
+    @Override
+    public String getWarnMessageFailedToStart(Throwable arg0) {
+        // Do not return a custom message, for now.
+        return null;
+    }
+
+    @Override
+    public WebDriver getWebDriver(int requesterId) {
+        return getRemoteWebDriver(null, 0);
+    }
+
+    private RemoteWebDriver getRemoteWebDriver(final String proxyAddress, final int proxyPort) {
+        if (View.isInitialised()) {
+            try {
+                GetWebDriverRunnable wb = new GetWebDriverRunnable(proxyAddress, proxyPort);
+                EventQueue.invokeAndWait(wb);
+                return wb.getWebDriver();
+            } catch (InvocationTargetException | InterruptedException e) {
+                throw new WebDriverException(e);
+            }
+        }
+
+        synchronized (this) {
+            return getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+    }
+
+    private RemoteWebDriver getRemoteWebDriverImpl(String proxyAddress, int proxyPort) {
+        try {
+            if (zbf == null) {
+                zbf = new ZapBrowserFrame(false, true, false, false);
+                chromePort = getFreePort();
+            } else if (!zbf.isVisible()) {
+                zbf.setVisible(true);
+            }
+
+            File dataDir = Files.createTempDirectory("zap-jxbrowser").toFile();
+            dataDir.deleteOnExit();
+            BrowserContextParams contextParams = new BrowserContextParams(dataDir.getAbsolutePath());
+
+            if (proxyAddress != null && !proxyAddress.isEmpty()) {
+                String hostPort = proxyAddress + ":" + proxyPort;
+                String proxyRules = "http=" + hostPort + ";https=" + hostPort;
+                contextParams.setProxyConfig(new CustomProxyConfig(proxyRules));
+            }
+
+            BrowserPreferences.setChromiumSwitches("--remote-debugging-port=" + chromePort);
+            Browser browser = new Browser(new BrowserContext(contextParams));
+            final BrowserPanel browserPanel = zbf.addNewBrowserPanel(false, browser);
+
+            final ChromeDriverService service = new ChromeDriverService.Builder().usingAnyFreePort().build();
+            service.start();
+
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            ChromeOptions options = new ChromeOptions();
+
+            options.setExperimentalOption("debuggerAddress", "localhost:" + chromePort);
+            capabilities.setCapability(ChromeOptions.CAPABILITY, options);
+
+            return new RemoteWebDriver(service.getUrl(), capabilities) {
+
+                @Override
+                public void close() {
+                    super.close();
+
+                    cleanUpBrowser(browserPanel);
+                    // XXX should stop here too?
+                    // service.stop();
+                }
+
+                @Override
+                public void quit() {
+                    super.quit();
+
+                    cleanUpBrowser(browserPanel);
+
+                    boolean interrupted = Thread.interrupted();
+                    service.stop();
+                    if (interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            };
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private void cleanUpBrowser(final BrowserPanel browserPanel) {
+        if (View.isInitialised()) {
+            EventQueue.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    if (zbf == null) {
+                        return;
+                    }
+
+                    cleanUpBrowserImpl(browserPanel);
+                }
+            });
+        } else {
+            synchronized (this) {
+                if (zbf == null) {
+                    return;
+                }
+                cleanUpBrowserImpl(browserPanel);
+            }
+        }
+    }
+
+    private void cleanUpBrowserImpl(BrowserPanel browserPanel) {
+        browserPanel.getBrowser().dispose();
+        zbf.removeTab(browserPanel);
+
+        if (!zbf.hasPanels()) {
+            zbf.dispose();
+            zbf = null;
+        }
+    }
+
+    @Override
+    public synchronized WebDriver getWebDriver(int requesterId, String proxyAddress, int proxyPort) {
+        return getRemoteWebDriver(proxyAddress, proxyPort);
+    }
+
+    private int getFreePort() {
+        try (ServerSocket socket = new ServerSocket(0, 400, InetAddress.getByName("localhost"))) {
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private class ProvidedBrowserImpl implements ProvidedBrowser {
+
+        @Override
+        public String getProviderId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getName() {
+            return "JxBrowser";
+        }
+    }
+
+    private class GetWebDriverRunnable implements Runnable {
+
+        private final String proxyAddress;
+        private final int proxyPort;
+
+        private RemoteWebDriver webDriver;
+
+        public GetWebDriverRunnable(String proxyAddress, int proxyPort) {
+            this.proxyAddress = proxyAddress;
+            this.proxyPort = proxyPort;
+        }
+
+        @Override
+        public void run() {
+            webDriver = getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+
+        public RemoteWebDriver getWebDriver() {
+            return webDriver;
+        }
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/ZapAddOn.xml
@@ -18,6 +18,17 @@
 	</dependencies>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jxbrowserwindows.ExtensionJxBrowserWindows</extension>
+		<extension v="1">
+			<classname>org.zaproxy.zap.extension.jxbrowserwindows.selenium.ExtSelJxBrowserWindows</classname>
+			<dependencies>
+				<addons>
+					<addon>
+						<id>selenium</id>
+						<semver><![CDATA[ >=1.1.0 & <2.0.0 ]]></semver>
+					</addon>
+				</addons>
+			</dependencies>
+		</extension>
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/ExtSelJxBrowserWindows.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/ExtSelJxBrowserWindows.java
@@ -1,0 +1,72 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowserwindows.selenium;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+
+/**
+ * An {@link org.parosproxy.paros.extension.Extension Extension} that installs a {@link JxBrowserProvider}, if in Windows.
+ */
+public class ExtSelJxBrowserWindows extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtSelJxBrowserWindows";
+
+    private JxBrowserProvider webDriverProvider;
+
+    public ExtSelJxBrowserWindows() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        if (Constant.isWindows()) {
+            webDriverProvider = new JxBrowserProvider();
+
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.addWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+
+        if (webDriverProvider != null) {
+            ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
+            extSelenium.removeWebDriverProvider(webDriverProvider);
+        }
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+}

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/JxBrowserProvider.java
@@ -1,0 +1,246 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.jxbrowserwindows.selenium;
+
+import java.awt.EventQueue;
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
+import org.openqa.selenium.chrome.ChromeDriverService;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
+import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
+import org.zaproxy.zap.extension.jxbrowser.ZapBrowserFrame;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowser;
+import org.zaproxy.zap.extension.selenium.SingleWebDriverProvider;
+
+import com.teamdev.jxbrowser.chromium.Browser;
+import com.teamdev.jxbrowser.chromium.BrowserContext;
+import com.teamdev.jxbrowser.chromium.BrowserContextParams;
+import com.teamdev.jxbrowser.chromium.BrowserPreferences;
+import com.teamdev.jxbrowser.chromium.CustomProxyConfig;
+
+/**
+ * A {@link SingleWebDriverProvider} for JxBrowser.
+ */
+public class JxBrowserProvider implements SingleWebDriverProvider {
+
+    private static final String PROVIDER_ID = "jxbrowser";
+
+    private final ProvidedBrowser providedBrowser;
+    private BrowserFrame zbf;
+    private int chromePort;
+
+    public JxBrowserProvider() {
+        this.providedBrowser = new ProvidedBrowserImpl();
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public ProvidedBrowser getProvidedBrowser() {
+        return providedBrowser;
+    }
+
+    @Override
+    public String getWarnMessageFailedToStart(Throwable arg0) {
+        // Do not return a custom message, for now.
+        return null;
+    }
+
+    @Override
+    public WebDriver getWebDriver(int requesterId) {
+        return getRemoteWebDriver(null, 0);
+    }
+
+    private RemoteWebDriver getRemoteWebDriver(final String proxyAddress, final int proxyPort) {
+        if (View.isInitialised()) {
+            try {
+                GetWebDriverRunnable wb = new GetWebDriverRunnable(proxyAddress, proxyPort);
+                EventQueue.invokeAndWait(wb);
+                return wb.getWebDriver();
+            } catch (InvocationTargetException | InterruptedException e) {
+                throw new WebDriverException(e);
+            }
+        }
+
+        synchronized (this) {
+            return getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+    }
+
+    private RemoteWebDriver getRemoteWebDriverImpl(String proxyAddress, int proxyPort) {
+        try {
+            if (zbf == null) {
+                zbf = new ZapBrowserFrame(false, true, false, false);
+                chromePort = getFreePort();
+            } else if (!zbf.isVisible()) {
+                zbf.setVisible(true);
+            }
+
+            File dataDir = Files.createTempDirectory("zap-jxbrowser").toFile();
+            dataDir.deleteOnExit();
+            BrowserContextParams contextParams = new BrowserContextParams(dataDir.getAbsolutePath());
+
+            if (proxyAddress != null && !proxyAddress.isEmpty()) {
+                String hostPort = proxyAddress + ":" + proxyPort;
+                String proxyRules = "http=" + hostPort + ";https=" + hostPort;
+                contextParams.setProxyConfig(new CustomProxyConfig(proxyRules));
+            }
+
+            BrowserPreferences.setChromiumSwitches("--remote-debugging-port=" + chromePort);
+            Browser browser = new Browser(new BrowserContext(contextParams));
+            final BrowserPanel browserPanel = zbf.addNewBrowserPanel(false, browser);
+
+            final ChromeDriverService service = new ChromeDriverService.Builder().usingAnyFreePort().build();
+            service.start();
+
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            ChromeOptions options = new ChromeOptions();
+
+            options.setExperimentalOption("debuggerAddress", "localhost:" + chromePort);
+            capabilities.setCapability(ChromeOptions.CAPABILITY, options);
+
+            return new RemoteWebDriver(service.getUrl(), capabilities) {
+
+                @Override
+                public void close() {
+                    super.close();
+
+                    cleanUpBrowser(browserPanel);
+                    // XXX should stop here too?
+                    // service.stop();
+                }
+
+                @Override
+                public void quit() {
+                    super.quit();
+
+                    cleanUpBrowser(browserPanel);
+
+                    boolean interrupted = Thread.interrupted();
+                    service.stop();
+                    if (interrupted) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            };
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private void cleanUpBrowser(final BrowserPanel browserPanel) {
+        if (View.isInitialised()) {
+            EventQueue.invokeLater(new Runnable() {
+
+                @Override
+                public void run() {
+                    if (zbf == null) {
+                        return;
+                    }
+
+                    cleanUpBrowserImpl(browserPanel);
+                }
+            });
+        } else {
+            synchronized (this) {
+                if (zbf == null) {
+                    return;
+                }
+                cleanUpBrowserImpl(browserPanel);
+            }
+        }
+    }
+
+    private void cleanUpBrowserImpl(BrowserPanel browserPanel) {
+        browserPanel.getBrowser().dispose();
+        zbf.removeTab(browserPanel);
+
+        if (!zbf.hasPanels()) {
+            zbf.dispose();
+            zbf = null;
+        }
+    }
+
+    @Override
+    public synchronized WebDriver getWebDriver(int requesterId, String proxyAddress, int proxyPort) {
+        return getRemoteWebDriver(proxyAddress, proxyPort);
+    }
+
+    private int getFreePort() {
+        try (ServerSocket socket = new ServerSocket(0, 400, InetAddress.getByName("localhost"))) {
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new WebDriverException(e);
+        }
+    }
+
+    private class ProvidedBrowserImpl implements ProvidedBrowser {
+
+        @Override
+        public String getProviderId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getId() {
+            return PROVIDER_ID;
+        }
+
+        @Override
+        public String getName() {
+            return "JxBrowser";
+        }
+    }
+
+    private class GetWebDriverRunnable implements Runnable {
+
+        private final String proxyAddress;
+        private final int proxyPort;
+
+        private RemoteWebDriver webDriver;
+
+        public GetWebDriverRunnable(String proxyAddress, int proxyPort) {
+            this.proxyAddress = proxyAddress;
+            this.proxyPort = proxyPort;
+        }
+
+        @Override
+        public void run() {
+            webDriver = getRemoteWebDriverImpl(proxyAddress, proxyPort);
+        }
+
+        public RemoteWebDriver getWebDriver() {
+            return webDriver;
+        }
+    }
+}


### PR DESCRIPTION
Change JxBrowser add-ons to provide WebDrivers, so that it can be used
by other add-ons (e.g. AJAX Spider).
Change some classes to allow to create tabs with Browsers, to have just
one window/dialogue for all browsers required by automated tools.

The JxBrowserProvider implementation is duplicated as core does not
support the sharing of the class in other non-dependent add-ons. The
duplication will be removed once core supports that.
The JxBrowser add-ons do not depend (directly) on the Selenium add-on,
allowing the JxBrowser to be used without Selenium add-on.