### PR TITLE
invoke: properly split application arguments

### DIFF
--- a/src/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
+++ b/src/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
@@ -93,15 +93,15 @@ public class InvokeAppWorker extends SwingWorker<Void, Void> {
 		List<String> cmd = new ArrayList<>();
 		cmd.add(command);
 		if (parameters != null) {
-			// Replace all of the tags 
-			String params = parameters.replace("%url%", url)
-									.replace("%host%", host)
-									.replace("%port%", port)
-									.replace("%site%", site)
-									.replace("%cookie%", cookie)
-									.replace("%postdata%", postdata);
-			for (String p : params.split(" ")) {
-				cmd.add(p);
+			for (String parameter : parameters.split(" ")) {
+				// Replace all of the tags
+				String finalParameter = parameter.replace("%url%", url)
+						.replace("%host%", host)
+						.replace("%port%", port)
+						.replace("%site%", site)
+						.replace("%cookie%", cookie)
+						.replace("%postdata%", postdata);
+				cmd.add(finalParameter);
 			}
 		}
 

--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Invoke Applications</name>
-	<version>5</version>
+	<version>6</version>
 	<status>beta</status>
 	<description>Invoke external applications passing context related information such as URLs and parameters</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Consume all output of the applications in all cases (Issue 3074).<br>
-	Show error/std output in the order it is received (Issue 3078).<br>
-	Fix typos in the help pages.
+	Properly split application arguments.
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change InvokeAppWorker to properly split the application arguments to
correctly pass them to the application being launched.
Bump version and update changes in ZapAddOn.xml file.