### PR TITLE
importLogFiles: use actions when importing files

### DIFF
--- a/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
@@ -6,7 +6,7 @@
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs
 	</url>
-	<changes>Minor code changes.</changes>
+	<changes>Use API actions when importing files.</changes>
 	<dependson></dependson>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.importLogFiles.ExtensionImportLogFiles</extension>


### PR DESCRIPTION
Change ImportLogAPI to use actions (instead of views) to import the
files. Also, move the logic of one action to the method that handles the
actions (instead of the options).
Update changes in ZapAddOn.xml file.