### PR TITLE
jxbrowser: show custom message if failed to start

### DIFF
--- a/src/org/zaproxy/zap/extension/jxbrowser/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/jxbrowser/resources/Messages.properties
@@ -16,3 +16,4 @@ jxbrowser.browser.popupmenu.opennewtab	= Open link in new tab
 jxbrowser.browser.popupmenu.reload		= Reload
 jxbrowser.button.launch			= Launch the ZAP JxBrowser proxying through ZAP
 jxbrowser.menu.launch			= Launch the ZAP JxBrowser
+jxbrowser.warn.message.failed.start.browser = Failed to start JxBrowser.\nMake sure that ChromeDriver is available.\nFor more details refer to "Options Selenium screen" help page.

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux32/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux32/selenium/JxBrowserProvider.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
 import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
@@ -72,8 +73,7 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
 
     @Override
     public String getWarnMessageFailedToStart(Throwable arg0) {
-        // Do not return a custom message, for now.
-        return null;
+        return Constant.messages.getString("jxbrowser.warn.message.failed.start.browser");
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/JxBrowserProvider.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
 import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
@@ -72,8 +73,7 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
 
     @Override
     public String getWarnMessageFailedToStart(Throwable arg0) {
-        // Do not return a custom message, for now.
-        return null;
+        return Constant.messages.getString("jxbrowser.warn.message.failed.start.browser");
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/JxBrowserProvider.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
 import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
@@ -72,8 +73,7 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
 
     @Override
     public String getWarnMessageFailedToStart(Throwable arg0) {
-        // Do not return a custom message, for now.
-        return null;
+        return Constant.messages.getString("jxbrowser.warn.message.failed.start.browser");
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/JxBrowserProvider.java
@@ -32,6 +32,7 @@ import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.jxbrowser.BrowserFrame;
 import org.zaproxy.zap.extension.jxbrowser.BrowserPanel;
@@ -72,8 +73,7 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
 
     @Override
     public String getWarnMessageFailedToStart(Throwable arg0) {
-        // Do not return a custom message, for now.
-        return null;
+        return Constant.messages.getString("jxbrowser.warn.message.failed.start.browser");
     }
 
     @Override


### PR DESCRIPTION
Change JxBrowserProvider(s) to return a custom error message, with the
more likely cause of why the JxBrowser failed to start when using the
WebDriver.