### PR TITLE
Report missing CSP header as LOW even if CSP Report header present.

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScanner.java
@@ -113,7 +113,7 @@ public class ContentSecurityPolicyMissingScanner extends PluginPassiveScanner{
 			// Always report if the latest header isnt found,
 			// but only report if the older ones arent present at Low threshold 
 			Alert alert = new Alert(getPluginId(), // PluginID
-					cspROHeaderFound ? Alert.RISK_INFO : Alert.RISK_LOW, // Risk
+					Alert.RISK_LOW, // Risk
 					Alert.CONFIDENCE_MEDIUM, // Reliability
 					getName());
 			alert.setDetail(getAlertAtrribute("desc"), // Description

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>13</version>
+	<version>14</version>
 	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-		Issue 3148: Only report HSTS on plain HTTP issue at Low threshold.
+		Report missing CSP header as LOW even if CSP Report header present.
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Justification - CSP only helps if its turned on. Having the Report-Only header is good for testing CSP but doesnt improve the security of the site. So we should report a missing (non report) header in the same way regardless of whether the Report-Only header is present. Thats what we'd like at Mozilla anyway, but happy to discuss other options :)