### PR TITLE
jxbrowser: document the ID of the browser

### DIFF
--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>JxBrowser (core)</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>First version</changes>
+	<changes>Update help page to mention the ID of the browser.</changes>
 	<dependencies/>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jxbrowser.ExtensionJxBrowser</extension>

--- a/src/org/zaproxy/zap/extension/jxbrowser/resources/help/contents/jxbrowser.html
+++ b/src/org/zaproxy/zap/extension/jxbrowser/resources/help/contents/jxbrowser.html
@@ -16,7 +16,8 @@ You can still use any other browser to proxy via ZAP but you will need to manual
 to proxy via ZAP.
 </p>
 <h3>Using JxBrowser for Automation</h3>
-The lack of external dependencies makes JxBrowser particularly useful for automated testing.
+The lack of external dependencies makes JxBrowser particularly useful for automated testing. The JxBrowser can be selected, for
+use with other functionalities (e.g. AJAX Spider), through the command line or the ZAP API using the ID <code>jxbrowser</code>.
 <p>
 It is not a headless browser but it can be run headless using technologies such as virtual frame buffers.
 The ZAP docker images contain a script that starts ZAP with xvfb. 


### PR DESCRIPTION
Update help page to mention the ID of the browser, needed for choosing
JxBrowser through the command line or the ZAP API.
Bump version and update changes in ZapAddOn.xml file.