### PR TITLE
zest: allow to properly remove the scripts

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Allow to loop files even if fuzzers.jbrf does not exist (Issue 3400).<br>
+	Properly remove Zest scripts (Issue 3401).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -173,6 +173,10 @@ public class ZestScriptWrapper extends ScriptWrapper {
 		// Do nothing - its all handled elsewhere
 	}
 
+	@Override
+	public int hashCode() {
+		return original.hashCode();
+	}
 
 	@Override
 	public boolean equals (Object script) {


### PR DESCRIPTION
Change ZestScriptWrapper to use the hashCode of ScriptWrapper, to remove
the corresponding ScriptWrapper from core extension.
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3401 - Unable to remove Zest scripts