### PR TITLE
selenium: move webdrivers section to main page

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
 	<name>Selenium</name>
-	<version>10</version>
+	<version>11</version>
 	<semver>1.1.0</semver><!-- This version should be kept in sync with the one of the extension. -->
 	<status>release</status>
 	<description>WebDriver provider and includes HtmlUnit browser</description>
@@ -8,7 +8,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Update help page to mention the IDs of the browsers.<br>
+	Move Bundled WebDrivers section to main help page and recommend using newer browser versions.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
@@ -78,6 +78,16 @@
 	<p>
 		Some of the requirements (e.g. WebDrivers) of the browsers can be configured in the <a
 			href="options.html">Options Selenium screen</a>.
+
+	<h2>Bundled WebDrivers</h2>
+	ZAP provides add-ons with the WebDrivers, when those add-ons are installed ZAP will
+	attempt to use those bundled WebDrivers by default. Some OSs might not have a WebDriver
+	for some of the browsers, in those cases ZAP will inform, in the options panel, that
+	there's no bundled WebDriver available. The bundled WebDrivers can also be (re)set with
+	the 'Bundled' button (for example, if another WebDriver was manually set). Not all
+	browser versions are supported with the bundled WebDrivers, it's recommended that
+	newer/latest versions of the browsers be used whenever possible.
+
 	<p>
 		<strong>Note:</strong> ZAP add-ons can add additional browsers.
 

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
@@ -56,12 +56,9 @@
 	WebDrivers) using Java system properties, in which case the above options will be
 	overridden and those values shown instead.
 
-	<h2>Bundled WebDrivers</h2>
-	ZAP provides add-ons with the WebDrivers, when those add-ons are installed ZAP will
-	attempt to use the bundled WebDrivers by default. Some OSs might not have a WebDriver for
-	some of the browsers, in those cases ZAP will inform there's no WebDriver available. The
-	bundled WebDrivers can also be (re)set with the 'Bundled' button (for example, if another
-	WebDriver was manually set).
+	<p>
+	More details about the bundled WebDrivers can be found on the overview page.
+
 	<h2>See also</h2>
 	<table>
 		<tr>


### PR DESCRIPTION
Move the bundled WebDrivers section to the main help page, to be more
visible, also, recommend using newer versions of the browsers with the
bundled WebDrivers.

For zaproxy/zaproxy#3369 - AJAX Spider via Firefox closes immediately
after upgrade to ZAP 2.6.0