### PR TITLE
openapi: fallback to scheme of request URI

### DIFF
--- a/src/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
+++ b/src/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
@@ -30,6 +30,8 @@ import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerConverter;
 import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 
+import io.swagger.models.Scheme;
+
 public class OpenApiSpider extends SpiderParser {
 
     private static final Logger log = Logger.getLogger(OpenApiSpider.class);
@@ -46,7 +48,8 @@ public class OpenApiSpider extends SpiderParser {
         if (!isEnabled) return false;
 
         try {
-            Converter converter = new SwaggerConverter(message.getResponseBody().toString());
+            Scheme defaultScheme = Scheme.forValue(message.getRequestHeader().getURI().getScheme().toLowerCase());
+            Converter converter = new SwaggerConverter(defaultScheme, message.getResponseBody().toString());
             requestor.run(converter.getRequestModels());
         } catch (Exception e) {
             log.debug(e.getMessage(), e);

--- a/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>OpenAPI Support</name>
-	<version>3</version>
+	<version>4</version>
 	<status>alpha</status>
 	<description>Imports and spiders Open API definitions.</description>
 	<author>ZAP Core Team plus Joanna Bona, Artur Grzesica, Michal Materniak and Marcin Spiewak</author>
 	<url></url>
-	<changes>Added cmdline support.</changes>
+	<changes>Fallback to scheme of request URI (Issue 3433).</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.openapi.ExtensionOpenApi</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/src/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -41,9 +41,15 @@ public class SwaggerConverter implements Converter {
     private OperationHelper operationHelper;
     private RequestModelConverter requestConverter;
     private Generators generators;
+    private final Scheme defaultScheme;
 
     public SwaggerConverter(String defn) {
+        this(null, defn);
+    }
+
+    public SwaggerConverter(Scheme defaultScheme, String defn) {
         LOG.debug("Examining defn ");
+        this.defaultScheme = defaultScheme;
         generators = new Generators();
         operationHelper = new OperationHelper();
         requestConverter = new RequestModelConverter();
@@ -68,20 +74,15 @@ public class SwaggerConverter implements Converter {
         Swagger swagger = new SwaggerParser().parse(this.defn);
         if (swagger != null) {
             generators.getModelGenerator().setDefinitions(swagger.getDefinitions());
-            for (Scheme scheme : swagger.getSchemes()) {
-                switch (scheme) {
-                case HTTP:
-                case HTTPS:
-                    for (Map.Entry<String, Path> entry : swagger.getPaths().entrySet()) {
-                        String url = generators.getPathGenerator().getBasicURL(swagger, scheme, entry.getKey());
-                        Path path = entry.getValue();
-                        operations.addAll(operationHelper.getAllOperations(path, url));
-                    }
-                    break;
-                case WS:
-                case WSS:
-                    // Dont currently support these
-                    break;
+            List<Scheme> schemes = swagger.getSchemes();
+            if (schemes == null || schemes.isEmpty()) {
+                if (defaultScheme == null) {
+                    throw new SwaggerException("Default scheme required but not provided.");
+                }
+                addOperations(swagger, defaultScheme, operations);
+            } else {
+                for (Scheme scheme : swagger.getSchemes()) {
+                    addOperations(swagger, scheme, operations);
                 }
             }
         } else {
@@ -96,6 +97,23 @@ public class SwaggerConverter implements Converter {
             return res.getMessages();
         }
         return null;
+    }
+
+    private void addOperations(Swagger swagger, Scheme scheme, List<OperationModel> operations) {
+        switch (scheme) {
+        case HTTP:
+        case HTTPS:
+            for (Map.Entry<String, Path> entry : swagger.getPaths().entrySet()) {
+                String url = generators.getPathGenerator().getBasicURL(swagger, scheme, entry.getKey());
+                Path path = entry.getValue();
+                operations.addAll(operationHelper.getAllOperations(path, url));
+            }
+            break;
+        case WS:
+        case WSS:
+            // Dont currently support these
+            break;
+        }
     }
 
 }


### PR DESCRIPTION
Change OpenApiSpider and ExtensionOpenApi to use the scheme of the
request URI, used to obtain the spec, when the scheme is not specified
in the spec.
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3433 - OpenAPI: Parsing of JSON downloaded from a
URL fails if no schemes element is present