### PR TITLE
BugTracker Fix Build Warnings

### DIFF
--- a/src/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzilla.java
+++ b/src/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzilla.java
@@ -149,10 +149,10 @@ public class BugTrackerBugzilla extends BugTracker {
                 description.append(Constant.messages.getString("bugtracker.msg.evidence") + alert.getEvidence().toString() + "\n\n\n\n");
             }
             if(alert.getRisk() >= 0 ) {
-                description.append(Constant.messages.getString("bugtracker.msg.risk") + alert.MSG_RISK[alert.getRisk()] + ", ");
+                description.append(Constant.messages.getString("bugtracker.msg.risk") + Alert.MSG_RISK[alert.getRisk()] + ", ");
             }
             if(alert.getConfidence() >= 0 ) {
-                description.append(Constant.messages.getString("bugtracker.msg.conf") + alert.MSG_CONFIDENCE[alert.getConfidence()] + ", ");
+                description.append(Constant.messages.getString("bugtracker.msg.conf") + Alert.MSG_CONFIDENCE[alert.getConfidence()] + ", ");
             }
             if(alert.getCweId() >= 0 ) {
                 description.append(Constant.messages.getString("bugtracker.msg.cwe") + alert.getCweId() + ", ");

--- a/src/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
+++ b/src/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
@@ -199,10 +199,10 @@ public class BugTrackerGithub extends BugTracker {
         for(Alert alert: alerts) {
 
             if(alert.getRisk() >= 0 ) {
-                labels.append(Constant.messages.getString("bugtracker.msg.risk") + alert.MSG_RISK[alert.getRisk()] + ", ");
+                labels.append(Constant.messages.getString("bugtracker.msg.risk") + Alert.MSG_RISK[alert.getRisk()] + ", ");
             }
             if(alert.getConfidence() >= 0 ) {
-                labels.append(Constant.messages.getString("bugtracker.msg.conf") + alert.MSG_CONFIDENCE[alert.getConfidence()] + ", ");
+                labels.append(Constant.messages.getString("bugtracker.msg.conf") + Alert.MSG_CONFIDENCE[alert.getConfidence()] + ", ");
             }
             if(alert.getCweId() >= 0 ) {
                 labels.append(Constant.messages.getString("bugtracker.msg.cwe") + alert.getCweId() + ", ");

--- a/src/org/zaproxy/zap/extension/bugtracker/DialogAddBugzillaConfig.java
+++ b/src/org/zaproxy/zap/extension/bugtracker/DialogAddBugzillaConfig.java
@@ -134,7 +134,7 @@ class DialogAddBugzillaConfig extends AbstractFormDialog {
     
     @Override
     protected void performAction() {
-        config = new BugTrackerBugzillaConfigParams(getNameTextField().getText(), getPasswordTextField().getText(), getBugzillaUrlTextField().getText());
+        config = new BugTrackerBugzillaConfigParams(getNameTextField().getText(), new String(getPasswordTextField().getPassword()), getBugzillaUrlTextField().getText());
     }
     
     @Override

--- a/src/org/zaproxy/zap/extension/bugtracker/DialogAddGithubConfig.java
+++ b/src/org/zaproxy/zap/extension/bugtracker/DialogAddGithubConfig.java
@@ -134,7 +134,7 @@ class DialogAddGithubConfig extends AbstractFormDialog {
     
     @Override
     protected void performAction() {
-        config = new BugTrackerGithubConfigParams(getNameTextField().getText(), getPasswordTextField().getText(), getRepoUrlTextField().getText());
+        config = new BugTrackerGithubConfigParams(getNameTextField().getText(), new String(getPasswordTextField().getPassword()), getRepoUrlTextField().getText());
     }
     
     @Override


### PR DESCRIPTION
Building anything in the Alpha branch causes a bunch of warnings due to
deprecation etc. This PR addresses the deprecated items in the
bugtracker addon.