### PR TITLE
WavsepReport Fix Build Warnings

### DIFF
--- a/src/org/zaproxy/zap/extension/wavsepRpt/ExtensionWavsepReport.java
+++ b/src/org/zaproxy/zap/extension/wavsepRpt/ExtensionWavsepReport.java
@@ -302,14 +302,14 @@ public class ExtensionWavsepReport extends ExtensionAdaptor {
 			for (Alert alert : node.getAlerts()) {
 				String shortForm = null;
 				for (String[] sf : SHORT_FORMS) {
-					if (alert.getAlert().equalsIgnoreCase(sf[0])) {
+					if (alert.getName().equalsIgnoreCase(sf[0])) {
 						shortForm = sf[1];
 						break;
 					}
 				}
 				if (shortForm == null) {
 					// Wont be a rule for it
-					missingShortForms.add(alert.getAlert());
+					missingShortForms.add(alert.getName());
 					continue;
 				}
 				boolean foundRule = false;

--- a/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Wavsep report generator</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>Wavsep report generator.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>First version</changes>
+	<changes></changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.wavsepRpt.ExtensionWavsepReport</extension>
 	</extensions>


### PR DESCRIPTION
Building anything in the Alpha branch causes a bunch of warnings due to deprecation etc. This PR addresses the deprecated items in the wavsepRpt addon.

Updated manifest version and removed old changes entry as well.