### PR TITLE
DOM XSS Scanner Fix Build Warnings

### DIFF
--- a/src/org/zaproxy/zap/extension/domxss/TestDomXSS.java
+++ b/src/org/zaproxy/zap/extension/domxss/TestDomXSS.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.ElementNotVisibleException;
+import org.openqa.selenium.NoSuchSessionException;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UnhandledAlertException;
@@ -37,7 +38,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
-import org.openqa.selenium.remote.SessionNotFoundException;
 import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.proxy.OverrideMessageProxyListener;
@@ -307,7 +307,7 @@ public class TestDomXSS extends AbstractAppPlugin {
 			
 		} catch(UnhandledAlertException uae) {
 			throw uae;
-		} catch(SessionNotFoundException enve) {
+		} catch(NoSuchSessionException enve) {
 			// Pause, retry
 			try {
 				Thread.sleep(1000);
@@ -347,7 +347,7 @@ public class TestDomXSS extends AbstractAppPlugin {
 
 		} catch(UnhandledAlertException uae) {
 			throw uae;
-		} catch(SessionNotFoundException enve) {
+		} catch(NoSuchSessionException enve) {
 			// Pause, retry
 			try {
 				Thread.sleep(1000);
@@ -467,7 +467,7 @@ public class TestDomXSS extends AbstractAppPlugin {
     			Stats.incCounter("domxss.vulns.div2");
 				throw new DomAlertException(url, attackVector, 
 						tagName, attributeId, attributeName);
-			} catch(SessionNotFoundException enve) {
+			} catch(NoSuchSessionException enve) {
 				log.debug(enve);
 				// replaceDriver(driver);
 			} catch(ElementNotVisibleException enve) {

--- a/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
@@ -1,20 +1,20 @@
 <zapaddon>
 	<name>DOM XSS Active scanner rule</name>
-	<version>3</version>
+	<version>4</version>
 	<status>alpha</status>
 	<description>DOM XSS Active scanner rule</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Skip the scanner if not able to start Firefox.<br>
+	 <br>
 	]]>
     </changes>
 	<dependencies>
 		<addons>
 			<addon>
 				<id>selenium</id>
-				<semver>1.*</semver>
+				<not-before-version>7</not-before-version>
 			</addon>
 		</addons>
 	</dependencies>


### PR DESCRIPTION
Building anything in the Alpha branch causes a bunch of warnings due to deprecation etc. This PR addresses the deprecated items in the domxss addon.

Also updated manifest version, removed old changes block, and appropriately set dependency info.

http://atetric.com/atetric/javadoc/org.seleniumhq.selenium/selenium-api/2.53.0/src-html/org/openqa/selenium/remote/SessionNotFoundException.html