### PR TITLE
zest: add exact case option for assign replace

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Allow to loop files even if fuzzers.jbrf does not exist (Issue 3400).<br>
 	Properly remove Zest scripts (Issue 3401).<br>
+	Allow to select the case on assign replacements.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
@@ -58,6 +58,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
 	private static final String FIELD_OPERAND_B = "zest.dialog.assign.label.operandb";
 	private static final String FIELD_OPERATION = "zest.dialog.assign.label.operation";
 	private static final String FIELD_REGEX = "zest.dialog.assign.label.regex";
+	private static final String FIELD_EXACT = "zest.dialog.assign.label.exact";
 	private static final String FIELD_REGEX_PREFIX = "zest.dialog.assign.label.rgxprefix";
 	private static final String FIELD_REGEX_POSTFIX = "zest.dialog.assign.label.rgxpostfix";
 	private static final String FIELD_REPLACE = "zest.dialog.assign.label.replace";
@@ -153,6 +154,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
 			this.addTextField(FIELD_REPLACE, za.getReplace());
 			this.addTextField(FIELD_REPLACEMENT, za.getReplacement());
 			this.addCheckBoxField(FIELD_REGEX, za.isRegex());
+			this.addCheckBoxField(FIELD_EXACT, za.isCaseExact());
 
 			// Enable right click menus
 			this.addFieldListener(FIELD_REPLACE, ZestZapUtils.stdMenuAdapter()); 
@@ -265,7 +267,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
 			za.setReplace(this.getStringValue(FIELD_REPLACE));
 			za.setReplacement(this.getStringValue(FIELD_REPLACEMENT));
 			za.setRegex(this.getBoolValue(FIELD_REGEX));
-			// TODO support caseexact
+			za.setCaseExact(this.getBoolValue(FIELD_EXACT));
 		} else if (assign instanceof ZestAssignCalc) {
 			ZestAssignCalc za = (ZestAssignCalc) assign;
 			za.setOperandA(this.getStringValue(FIELD_OPERAND_A));

--- a/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
@@ -104,6 +104,7 @@ zest.dialog.assign.error.variable		= You must supply a name which starts with a 
 zest.dialog.assign.error.value			= You must supply a Value to compare with
 zest.dialog.assign.label.location		= Location:
 zest.dialog.assign.label.regex			= Regex:
+zest.dialog.assign.label.exact			= Case exact:
 zest.dialog.assign.label.replace		= Replace:
 zest.dialog.assign.label.replacement	= With:
 zest.dialog.assign.label.rgxprefix		= Prefix Regex:


### PR DESCRIPTION
Add a field, to Add Assignment dialogue, for "assign replace" to control
the case when matching the value to be replaced.
Update changes in ZapAddOn.xml file.

Related to mozilla/zest#93 - Implement exact case replacement when
assigning