### PR TITLE
scripts: invoke context menu once

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Inform when the script contains invalid char sequences (related to Issue 3377).<br>
+	Invoke Scripts tree context menu once.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ScriptsListPanel to set the context menu into the Scripts tree
instead of manually invoking it with a MouseListener, the latter could
lead to the context menu being invoked twice leading to duplicated
menu items. Also, remove the KeyListener, the context menu set can be
already invoked with keyboard shortcuts.
Update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#2106 - Zest - script context menu has
duplicated items