### PR TITLE
fuzz: ignore empty payloads for reflections

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -8,6 +8,7 @@
     <url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</url>
     <changes>
     <![CDATA[
+    Ignore empty payloads when highlighting or detecting reflections.<br>
     Contains new number generator payload.<br>
     ]]>
     </changes>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/HttpFuzzerReflectionDetector.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/HttpFuzzerReflectionDetector.java
@@ -62,10 +62,12 @@ public class HttpFuzzerReflectionDetector implements HttpFuzzerMessageProcessor 
         String fuzzedResponseBody = httpMessage.getResponseBody().toString();
         for (Object payload : payloads) {
             String strPayload = payload.toString();
-            int pos = originalResponseBody.indexOf(strPayload);
-            if (fuzzedResponseBody.indexOf(strPayload, pos) != -1) {
-                reflected.add(strPayload);
-                break;
+            if (!strPayload.isEmpty()) {
+                int pos = originalResponseBody.indexOf(strPayload);
+                if (fuzzedResponseBody.indexOf(strPayload, pos) != -1) {
+                    reflected.add(strPayload);
+                    break;
+                }
             }
         }
         return reflected;

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzerResultsTable.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzerResultsTable.java
@@ -120,6 +120,10 @@ public class HttpFuzzerResultsTable extends HistoryReferencesTable {
 
                     for (Object payload : ((HttpFuzzerResultsTableModel) getModel()).getPayloads(hRef.getHistoryId())) {
                         String strPayload = payload.toString();
+                        if (strPayload.isEmpty()) {
+                            continue;
+                        }
+
                         int startIndex = httpMessage.getResponseBody().toString().indexOf(strPayload);
                         if (startIndex >= 0) {
                             // Found the exact pattern - highlight it


### PR DESCRIPTION
Change HttpFuzzerResultsTable to not highlighting empty payloads and
change HttpFuzzerReflectionDetector to ignore empty payloads when
detecting reflections, in both cases the empty payload would always
match highlight nothing and adding useless reflections.
Update changes in ZapAddOn.xml file.