### PR TITLE
fuzz: allow to choose null/empty payload generator

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -82,6 +82,8 @@ import org.zaproxy.zap.extension.fuzz.payloads.processor.TrimStringProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.URLDecodeProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.processor.URLEncodeProcessor;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUIHandlersRegistry;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.DefaultEmptyPayloadGeneratorUIHandler;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.DefaultEmptyPayloadGeneratorUIHandler.DefaultEmptyPayloadGenerator;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.DefaultStringPayloadGeneratorUIHandler;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.FileStringPayloadGeneratorUIHandler;
 import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.NumberPayloadGeneratorAdapterUIHandler;
@@ -225,6 +227,8 @@ public class ExtensionFuzz extends ExtensionAdaptor {
         // payloadGeneratorsUIRegistry.registerPayloadUI(ProcessPayloadGenerator.class, new ProcessPayloadGeneratorUIHandler());
         payloadGeneratorsUIRegistry.registerPayloadUI(RegexPayloadGenerator.class, new RegexPayloadGeneratorUIHandler());
 
+        payloadGeneratorsUIRegistry
+                .registerPayloadUI(DefaultEmptyPayloadGenerator.class, new DefaultEmptyPayloadGeneratorUIHandler());
         payloadGeneratorsUIRegistry.registerPayloadUI(NumberPayloadGenerator.class, new NumberPayloadGeneratorAdapterUIHandler());
 
         PayloadProcessorUIHandlersRegistry payloadProcessorsUIRegistry = PayloadProcessorUIHandlersRegistry.getInstance();

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -9,6 +9,7 @@
     <changes>
     <![CDATA[
     Contains new number generator payload.<br>
+    Add null/empty payload generator.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/generator/EmptyPayloadGenerator.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/generator/EmptyPayloadGenerator.java
@@ -51,7 +51,7 @@ public class EmptyPayloadGenerator<T extends Payload> implements PayloadGenerato
 
     @Override
     public PayloadGenerator<T> copy() {
-        return new EmptyPayloadGenerator<>(value, numberOfPayloads);
+        return this;
     }
 
     private static class ValueRepeaterIterator<E extends Payload> implements ResettableAutoCloseableIterator<E> {

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultEmptyPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/DefaultEmptyPayloadGeneratorUIHandler.java
@@ -1,0 +1,201 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.payloads.ui.impl;
+
+import java.text.MessageFormat;
+
+import javax.swing.GroupLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.fuzz.payloads.DefaultPayload;
+import org.zaproxy.zap.extension.fuzz.payloads.generator.EmptyPayloadGenerator;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUI;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUIHandler;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.PayloadGeneratorUIPanel;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.DefaultEmptyPayloadGeneratorUIHandler.DefaultEmptyPayloadGenerator;
+import org.zaproxy.zap.extension.fuzz.payloads.ui.impl.DefaultEmptyPayloadGeneratorUIHandler.DefaultEmptyPayloadGeneratorUI;
+import org.zaproxy.zap.model.MessageLocation;
+import org.zaproxy.zap.utils.ZapNumberSpinner;
+
+public class DefaultEmptyPayloadGeneratorUIHandler
+        implements PayloadGeneratorUIHandler<DefaultPayload, DefaultEmptyPayloadGenerator, DefaultEmptyPayloadGeneratorUI> {
+
+    private static final String PAYLOAD_GENERATOR_NAME = Constant.messages.getString("fuzz.payloads.generator.empty.name");
+    private static final String PAYLOAD_GENERATOR_DESC = Constant.messages
+            .getString("fuzz.payloads.generator.empty.description");
+
+    @Override
+    public String getName() {
+        return PAYLOAD_GENERATOR_NAME;
+    }
+
+    @Override
+    public Class<DefaultEmptyPayloadGeneratorUI> getPayloadGeneratorUIClass() {
+        return DefaultEmptyPayloadGeneratorUI.class;
+    }
+
+    @Override
+    public Class<DefaultEmptyPayloadGeneratorUIPanel> getPayloadGeneratorUIPanelClass() {
+        return DefaultEmptyPayloadGeneratorUIPanel.class;
+    }
+
+    @Override
+    public DefaultEmptyPayloadGeneratorUIPanel createPanel() {
+        return new DefaultEmptyPayloadGeneratorUIPanel();
+    }
+
+    public static class DefaultEmptyPayloadGeneratorUI
+            implements PayloadGeneratorUI<DefaultPayload, DefaultEmptyPayloadGenerator> {
+
+        private final String value;
+        private final int repetitions;
+
+        public DefaultEmptyPayloadGeneratorUI(String value, int repetitions) {
+            this.value = value;
+            this.repetitions = repetitions;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public int getRepetitions() {
+            return repetitions;
+        }
+
+        @Override
+        public Class<DefaultEmptyPayloadGenerator> getPayloadGeneratorClass() {
+            return DefaultEmptyPayloadGenerator.class;
+        }
+
+        @Override
+        public String getName() {
+            return PAYLOAD_GENERATOR_NAME;
+        }
+
+        @Override
+        public String getDescription() {
+            return MessageFormat.format(PAYLOAD_GENERATOR_DESC, repetitions);
+        }
+
+        @Override
+        public long getNumberOfPayloads() {
+            return repetitions;
+        }
+
+        @Override
+        public DefaultEmptyPayloadGenerator getPayloadGenerator() {
+            return new DefaultEmptyPayloadGenerator(new DefaultPayload(value), repetitions);
+        }
+
+        @Override
+        public DefaultEmptyPayloadGeneratorUI copy() {
+            return this;
+        }
+
+    }
+
+    public static class DefaultEmptyPayloadGeneratorUIPanel
+            implements PayloadGeneratorUIPanel<DefaultPayload, DefaultEmptyPayloadGenerator, DefaultEmptyPayloadGeneratorUI> {
+
+        private static final String NUMBER_REPETITIONS_FIELD_LABEL = Constant.messages
+                .getString("fuzz.payloads.generator.empty.repetitions.label");
+
+        private static final int DEFAULT_NUMBER_REPETITIONS = 10;
+
+        private JPanel fieldsPanel;
+
+        private ZapNumberSpinner repetitionsNumberSpinner;
+
+        private String payloadValue;
+
+        public DefaultEmptyPayloadGeneratorUIPanel() {
+            fieldsPanel = new JPanel();
+
+            GroupLayout layout = new GroupLayout(fieldsPanel);
+            fieldsPanel.setLayout(layout);
+            layout.setAutoCreateGaps(true);
+
+            JLabel valueLabel = new JLabel(NUMBER_REPETITIONS_FIELD_LABEL);
+            valueLabel.setLabelFor(getRepetitionsNumberSpinner());
+
+            layout.setHorizontalGroup(
+                    layout.createSequentialGroup().addComponent(valueLabel).addComponent(getRepetitionsNumberSpinner()));
+
+            layout.setVerticalGroup(
+                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                            .addComponent(valueLabel)
+                            .addComponent(getRepetitionsNumberSpinner()));
+        }
+
+        private ZapNumberSpinner getRepetitionsNumberSpinner() {
+            if (repetitionsNumberSpinner == null) {
+                repetitionsNumberSpinner = new ZapNumberSpinner(1, DEFAULT_NUMBER_REPETITIONS, Integer.MAX_VALUE);
+            }
+            return repetitionsNumberSpinner;
+        }
+
+        @Override
+        public void init(MessageLocation messageLocation) {
+            payloadValue = messageLocation.getValue();
+        }
+
+        @Override
+        public JPanel getComponent() {
+            return fieldsPanel;
+        }
+
+        @Override
+        public void setPayloadGeneratorUI(DefaultEmptyPayloadGeneratorUI payloadGeneratorUI) {
+            getRepetitionsNumberSpinner().setValue(payloadGeneratorUI.getRepetitions());
+        }
+
+        @Override
+        public DefaultEmptyPayloadGeneratorUI getPayloadGeneratorUI() {
+            return new DefaultEmptyPayloadGeneratorUI(payloadValue, getRepetitionsNumberSpinner().getValue());
+        }
+
+        @Override
+        public void clear() {
+            getRepetitionsNumberSpinner().setValue(DEFAULT_NUMBER_REPETITIONS);
+        }
+
+        @Override
+        public boolean validate() {
+            return true;
+        }
+
+        @Override
+        public String getHelpTarget() {
+            return "addon.fuzzer.payloads";
+        }
+
+    }
+
+    public static class DefaultEmptyPayloadGenerator extends EmptyPayloadGenerator<DefaultPayload> {
+
+        public DefaultEmptyPayloadGenerator(DefaultPayload value, int numberOfPayloads) {
+            super(value, numberOfPayloads);
+        }
+
+    }
+}

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -288,6 +288,9 @@ fuzz.payloads.generator.numbers.from.label = From:
 fuzz.payloads.generator.numbers.to.label = To: 
 fuzz.payloads.generator.numbers.increment.label = Increment: 
 
+fuzz.payloads.generator.empty.name = Empty/Null
+fuzz.payloads.generator.empty.description = Repeat {0} time(s)
+fuzz.payloads.generator.empty.repetitions.label = Number Repetitions
 
 fuzz.payload.processor.charset.charset.label = Character Encoding:
 

--- a/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/payloads.html
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/help/contents/payloads.html
@@ -14,6 +14,7 @@ Payload generators generate the raw attacks that the fuzzer submits to the targe
 <br><br>
 The following types of generators are provided by default:
 <ul>
+<li>Empty/Null - generates the selected payload multiple times, leaving the message without changes. This payload generator is useful to send multiple messages that are later processed, for example, with a <a href="httpmessageprocessors.html">Fuzzer HTTP Processor (Script)</a>.</li>
 <li>File - select any local file for one off attacks</li>
 <li>File Fuzzers - select any combination of the fuzzing files registered with ZAP, eg via add-ons like fuzzdb</li>
 <li>Numberzz - allows to easily generate a sequence of numbers, with custom increment</li>


### PR DESCRIPTION
Allow to choose the null/empty payload generator which allows to send
the message multiple times without changes, for later processing with
a processor script.
Update changes in ZapAddOn.xml file.