### PR TITLE
Issue 2452 Add X-Debug-Token Passive Scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/XDebugTokenScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/XDebugTokenScanner.java
@@ -1,0 +1,162 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.htmlparser.jericho.Source;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+/**
+ * X-Debug-Token passive scan rule
+ * https://github.com/zaproxy/zaproxy/issues/2452
+ * 
+ * @author kingthorin+owaspzap@gmail.com
+ */
+public class XDebugTokenScanner extends PluginPassiveScanner {
+
+	private static final String MESSAGE_PREFIX = "pscanalpha.xdebugtoken.";
+	private static final int PLUGIN_ID = 10056;
+
+	private PassiveScanThread parent = null;
+	private static final Logger LOGGER = Logger.getLogger(XDebugTokenScanner.class);
+
+	private static final String X_DEBUG_TOKEN_HEADER = "X-Debug-Token";
+	private static final String X_DEBUG_TOKEN_LINK_HEADER = "X-Debug-Token-Link";
+
+	@Override
+	public void setParent(PassiveScanThread parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public void scanHttpRequestSend(HttpMessage msg, int id) {
+		// Only checking the response for this plugin
+	}
+
+	@Override
+	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+		long start = System.currentTimeMillis();
+
+		//Check "Link" variant first as it's of greater concern/convenience.
+		if (responseHasHeader(msg, X_DEBUG_TOKEN_LINK_HEADER)) {
+			for (String xdtl : getHeaders(msg, X_DEBUG_TOKEN_LINK_HEADER)) {
+				parent.raiseAlert(id, getAlert(msg, xdtl));
+				return; // No need to continue
+			}
+		}
+		// Check non-Link variant
+		if (responseHasHeader(msg, X_DEBUG_TOKEN_HEADER)) {
+			for (String xdt : getHeaders(msg, X_DEBUG_TOKEN_HEADER)) {
+				parent.raiseAlert(id, getAlert(msg, xdt));
+				return; // No need to continue
+			}
+		}
+		
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("\tScan of record " + id + " took " + (System.currentTimeMillis() - start) + " ms");
+		}
+	}
+	
+	private Alert getAlert(HttpMessage msg, String evidence) {
+		Alert alert = new Alert(getPluginId(), Alert.RISK_LOW, Alert.CONFIDENCE_HIGH, // PluginID, Risk, Reliability
+				getName());
+		alert.setDetail(getDescription(), // Description
+				msg.getRequestHeader().getURI().toString(), // URI
+				"", // Param
+				"", // Attack
+				getOtherInfo(), // Other info
+				getSolution(), // Solution
+				getReference(), // References
+				evidence, // Evidence
+				200, // CWE-200: Information Exposure
+				13, // WASC Id
+				msg); // HttpMessage
+		return alert;
+	}
+
+	/**
+	 * Checks if there is a relevant header
+	 * @param msg Response Http message
+	 * @param header the name of the header field being looked for
+	 * @return boolean status of existence
+	 */
+	private boolean responseHasHeader(HttpMessage msg, String header) {
+		return null != msg.getResponseHeader().getHeaders(header);
+	}
+
+	/**
+	 * Extracts the list of headers, and returns them without changing their cases.
+	 * @param msg Response Http message
+	 * @param header the name of the header field(s) to be collected
+	 * @return list of the matched headers
+	 */
+	private List<String> getHeaders(HttpMessage msg, String header) {
+		List<String> matchedHeaders = new ArrayList<>();
+		String headers = msg.getResponseHeader().toString();
+		String[] headerElements = headers.split("\\r\\n");
+		Pattern pattern = Pattern.compile("^" + header + ".*", Pattern.CASE_INSENSITIVE);
+		for (String hdr : headerElements) {
+			Matcher matcher = pattern.matcher(hdr);
+			if (matcher.find()) {
+				String match = matcher.group();
+				matchedHeaders.add(match);
+			}
+		}
+		return matchedHeaders;
+	}
+	
+	@Override
+	public int getPluginId() {
+		return PLUGIN_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "name");
+	}
+	
+	private String getOtherInfo() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo");
+	}
+
+	private String getDescription() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+	}
+
+	private String getSolution() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+	}
+
+	private String getReference() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -7,7 +7,8 @@
 	<url/>
 	<changes>
 	<![CDATA[
-		Report missing CSP header as LOW even if CSP Report header present.
+		Report missing CSP header as LOW even if CSP Report header present.<br>
+		Added X-Debug-Token Scanner (Issue 2452).<br>
 	]]>
 	</changes>
 	<extensions>
@@ -42,6 +43,7 @@
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.UserControlledOpenRedirectScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XBackendServerInformationLeak</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XChromeLoggerDataInfoLeakScanner</pscanrule>
+		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XDebugTokenScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XPoweredByHeaderInfoLeakScanner</pscanrule>
 	</pscanrules>
 	<filters/>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -248,3 +248,9 @@ pscanalpha.xchromeloggerdata.refs=https://craig.is/writing/chrome-logger
 pscanalpha.xchromeloggerdata.soln=Disable this functionality in Production when it might leak information that could be leveraged by an attacker. Alternatively ensure that use of the functionality is tied to a strong authorization check and only available to administrators or support personnel for troubleshooting purposes not general users.
 pscanalpha.xchromeloggerdata.otherinfo.msg=The following represents an attempt to base64 decode the value:
 pscanalpha.xchromeloggerdata.otherinfo.error=Header value could not be base64 decoded:
+
+pscanalpha.xdebugtoken.name=X-Debug-Token Information Leak
+pscanalpha.xdebugtoken.desc=The response contained an X-Debug-Token or X-Debug-Token-Link header. This indicates that Symfony's Profiler may be in use and exposing sensitive data.
+pscanalpha.xdebugtoken.otherinfo=By accessing a URL in the form http://target_host/_profiler/token_value (i.e.: http://example.com/_profiler_/123ab4), you may gain access to the profiler and further leaked information.
+pscanalpha.xdebugtoken.refs=https://symfony.com/doc/current/cookbook/profiler/profiling_data.html\nhttps://symfony.com/blog/new-in-symfony-2-4-quicker-access-to-the-profiler-when-working-on-an-api
+pscanalpha.xdebugtoken.soln=Limit access to Symfony's Profiler, either via authentication/authorization or limiting inclusion of the header to specific clients (by IP etc).

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -162,5 +162,9 @@ A large redirect response may indicate that although a redirect has taken place 
 <H2>X-ChromeLogger-Data Header Information Leak</H2>
 This checks response headers for the presence of X-ChromeLogger-Data or X-ChromePhp-Data details.
 
+<H2>X-Debug-Token Information Leak</H2>
+This checks response headers for the presence of X-Debug-Token and X-Debug-Token-Link details.
+Which indicates the use/exposure of Symfony's Profiler. Symfony's Profiler provides access to a significant amount of information of interest to malicious individuals and Security Testers.
+
 </BODY>
 </HTML>

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/XDebugTokenScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/XDebugTokenScannerUnitTest.java
@@ -1,0 +1,103 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import org.junit.Test;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class XDebugTokenScannerUnitTest extends PassiveScannerTest {
+	
+	private static final String X_DEBUG_TOKEN_HEADER = "X-Debug-Token";
+	private static final String X_DEBUG_TOKEN_LINK_HEADER = "X-Debug-Token-Link";
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new XDebugTokenScanner();
+	}
+	
+	private HttpMessage createMessage() throws HttpMalformedHeaderException {
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+		msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n");
+
+		return msg;
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfThereIsNoRelevantHeader() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(0));
+	}
+
+	@Test
+	public void shouldRaiseAnAlertIfFindsXDebugToken() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(X_DEBUG_TOKEN_HEADER, "9687e6");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+		assertThat(alertsRaised.get(0).getEvidence(), is("X-Debug-Token: 9687e6"));
+	}
+	
+	@Test
+	public void shouldRaiseAnAlertIfFindsXDebugTokenLink() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(X_DEBUG_TOKEN_LINK_HEADER, "/_profiler/97b958");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+		assertThat(alertsRaised.get(0).getEvidence(), is("X-Debug-Token-Link: /_profiler/97b958"));
+	}
+
+	@Test
+	public void shouldRaiseOnlyOneAlertIfBothHeaderVariantsFound() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(X_DEBUG_TOKEN_LINK_HEADER, "https://www.example.com/_profiler/9687e6");
+		msg.getResponseHeader().setHeader(X_DEBUG_TOKEN_HEADER, "9687e6");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then
+		assertThat(alertsRaised.size(), is(1));
+		assertThat(alertsRaised.get(0).getEvidence(), is("X-Debug-Token-Link: https://www.example.com/_profiler/9687e6"));
+	}
+
+}


### PR DESCRIPTION
XDebugTokenScanner - The new scanner.
Messages.properties - Add necessary i18n keys and values.
pscanalpha.html - Add new help entry.
ZapAddOn.xml - Add new change entry, and include the new scanner in the
pscanrules section.
XDebugTokenScannerUnitTest - The unit tests for the new scanner.

Fixes zaproxy/zaproxy#2452