### PR TITLE
zest: select correct script when editing actions

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Allow to loop files even if fuzzers.jbrf does not exist (Issue 3400).<br>
 	Properly remove Zest scripts (Issue 3401).<br>
 	Allow to select the case on assign replacements.<br>
+	Show/select the correct script in the Edit Zest Action dialogue (Issue 3489).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
@@ -25,7 +25,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -150,12 +149,7 @@ public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog
 		} else if (action instanceof ZestActionInvoke) {
 			ZestActionInvoke za = (ZestActionInvoke) action;
 			
-			String fileName = "";
-			if (za.getScript() != null) {
-				fileName = new File(za.getScript()).getName();
-			}
-
-			this.addComboField(FIELD_SCRIPT, this.getScriptNames(), fileName);
+			this.addComboField(FIELD_SCRIPT, this.getScriptNames(), getScriptName(za.getScript()));
 			this.addTextField(FIELD_VARIABLE, za.getVariableName());
 
 	        this.getParamsModel().setValues(za.getParameters());
@@ -168,6 +162,19 @@ public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog
 	        this.addTableField(FIELD_PARAMS, this.getParamsTable(), buttons);
 		}
 		this.addPadding();
+	}
+
+	private String getScriptName(String filePath) {
+		if (filePath == null) {
+			return "";
+		}
+
+		for (ScriptWrapper script : this.extension.getExtScript().getScripts(ExtensionScript.TYPE_STANDALONE)) {
+			if (filePath.equals(script.getFile().getAbsolutePath())) {
+				return script.getName();
+			}
+		}
+		return "";
 	}
 	
     private JButton getAddButton () {


### PR DESCRIPTION
Change ZestActionDialog to select the correct script of the action by
using the name of the script instead of the file path. If the script no
longer exists (that is, added to ZAP) it's selected an existing one.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3489 - Zest script execution UI does not show the
correct configuration