### PR TITLE
zest: don't re-wrap Zest scripts

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -1670,9 +1670,14 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 
 			logger.debug("Adding Zest script to tree");
 
-			ZestScriptWrapper zsw = new ZestScriptWrapper(script);
-			if (zsw.getName() == null) {
-				zsw.setName(script.getName());
+			ZestScriptWrapper zsw;
+			if (script instanceof ZestScriptWrapper) {
+				zsw = (ZestScriptWrapper) script;
+			} else {
+				zsw = new ZestScriptWrapper(script);
+				if (zsw.getName() == null) {
+					zsw.setName(script.getName());
+				}
 			}
 
 			ScriptNode parentNode = this.getExtScript().getTreeModel()

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Properly remove Zest scripts (Issue 3401).<br>
 	Allow to select the case on assign replacements.<br>
 	Show/select the correct script in the Edit Zest Action dialogue (Issue 3489).<br>
+	Ensure recorded Sequence scripts can be scanned through context menu (Issue 3536).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -56,14 +56,13 @@ public class ZestScriptWrapper extends ScriptWrapper {
 			Type ztype;
 			switch (script.getType().getName()) {
 			case ExtensionActiveScan.SCRIPT_TYPE_ACTIVE:
+			case "sequence": // ExtensionSequence.TYPE_SEQUENCE
 				ztype = Type.Active;
 				break;
 			case ExtensionPassiveScan.SCRIPT_TYPE_PASSIVE:
 				ztype = Type.Passive;
 				break;
 			case ExtensionScript.TYPE_TARGETED:
-				ztype = Type.Targeted;
-				break;
 			case ExtensionScript.TYPE_PROXY:
 				ztype = Type.Targeted;
 				break;


### PR DESCRIPTION
Change ExtensionZest to only wrap the script being added if it's not a
wrapper already (the wrapper does not allow to set the contents of the
script leading to an empty script for the Sequence scanning, thus not
perform any scanning at all).
Change ZestScriptWrapper to use the correct Zest type for Sequence
scripts, when recorded. Also, merge common case when choosing the type.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3536 - Sequence Addon "Active scan sequence" Doesn't
Work From Scripts Tree