### PR TITLE
Sequence Depend on Zest

### DIFF
--- a/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
@@ -9,8 +9,16 @@
 	<![CDATA[
 	Correct error message to include the script name.<br>
 	Add help content (Issue 2191).<br>
+	Depend on Zest extension, since it is currently the only script option for Sequence scripts.<br>
 	]]>
 	</changes>
+	<dependencies>
+		<addons>
+			<addon>
+				<id>zest</id>
+			</addon>
+		</addons>
+	</dependencies>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.sequence.ExtensionSequence</extension>
 	</extensions>


### PR DESCRIPTION
Make Sequence addon depend on Zest extension, since it is currently the only script option for Sequence scripts.