### PR TITLE
Replace use of regex in TestPathTraversal dir test

### DIFF
--- a/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
@@ -19,13 +19,21 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
 
 /**
  * Unit test for {@link TestPathTraversal}.
@@ -97,5 +105,104 @@ public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTravers
         // Then
         assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(75))); // No recommendation, use an arbitrary value.
         assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfAttackResponseDoesNotListDirectories() throws Exception {
+        // Given
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertIfAttackResponseListsWindowsDirectories() throws Exception {
+        // Given
+        nano.addHandler(new ListWinDirsOnAttack("/", "p", "c:/"));
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("Windows")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo("p")));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo("c:/")));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+    }
+
+    @Test
+    public void shouldAlertIfAttackResponseListsLinuxDirectories() throws Exception {
+        // Given
+        nano.addHandler(new ListLinuxDirsOnAttack("/", "p", "/"));
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("etc")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo("p")));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo("/")));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+    }
+
+    private static abstract class ListDirsOnAttack extends NanoServerHandler {
+
+        private final String param;
+        private final String attack;
+
+        public ListDirsOnAttack(String path, String param, String attack) {
+            super(path);
+
+            this.param = param;
+            this.attack = attack;
+        }
+
+        protected abstract String getDirs();
+
+        @Override
+        Response serve(IHTTPSession session) {
+            String value = session.getParms().get(param);
+            if (attack.equals(value)) {
+                return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, getDirs());
+            }
+            return new Response(Response.Status.NOT_FOUND, NanoHTTPD.MIME_HTML, "404 Not Found");
+        }
+    }
+
+    private static class ListWinDirsOnAttack extends ListDirsOnAttack {
+
+        private static final String DIRS_LISTING = "<td><a href=\"Windows/\">Windows</a></td>"
+                + "<td><a href=\"Program Files/\">Program Files</a></td>";
+
+        public ListWinDirsOnAttack(String path, String param, String attack) {
+            super(path, param, attack);
+        }
+
+        @Override
+        protected String getDirs() {
+            return DIRS_LISTING;
+        }
+    }
+
+    private static class ListLinuxDirsOnAttack extends ListDirsOnAttack {
+
+        private static final String DIRS_LISTING = "<td><a href=\"/bin/\">bin</a></td>" + "<td><a href=\"/etc/\">etc</a></td>"
+                + "<td><a href=\"/boot/\">boot</a></td>";
+
+        public ListLinuxDirsOnAttack(String path, String param, String attack) {
+            super(path, param, attack);
+        }
+
+        @Override
+        protected String getDirs() {
+            return DIRS_LISTING;
+        }
     }
 }


### PR DESCRIPTION
Change TestPathTraversal to simply search for the directory names
instead of using a regular expression, while with the regular expression
the evidence included all the directory names it was not efficient with
bigger responses (new behaviour returns one of the directory names).
For example, with a 76k chars response the regex took 153s to complete
but less than 1s with the simple search.
Add tests to assert the expected behaviour when testing for directory
listings.

Fix zaproxy/zaproxy#3468 - PathTraversal rule performance issue