### PR TITLE
Change TestParameterTamper to set evidence field

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
@@ -26,6 +26,7 @@
 // ZAP: 2013/01/25 Removed the "(non-Javadoc)" comments.
 // ZAP: 2013/03/03 Issue 546: Remove all template Javadoc comments
 // ZAP: 2016/02/02 Add isStop() checks
+// ZAP: 2017/05/19 Correct data set in the raised alerts
 package org.zaproxy.zap.extension.ascanrules;
 
 import java.net.SocketException;
@@ -179,22 +180,25 @@ public class TestParameterTamper extends AbstractAppParamPlugin {
 
         StringBuilder sb = new StringBuilder();
 
+        boolean issueFound = false;
+        int confidence = Alert.CONFIDENCE_MEDIUM;
         if (matchBodyPattern(msg, patternErrorJava1, sb) && matchBodyPattern(msg, patternErrorJava2, null)) {
-
-            bingo(Alert.RISK_MEDIUM, Alert.CONFIDENCE_MEDIUM, null, param, attack, sb.toString(), msg);
-            return true;
+            issueFound = true;
         } else if (matchBodyPattern(msg, patternErrorVBScript, sb)
                 || matchBodyPattern(msg, patternErrorODBC1, sb)
                 || matchBodyPattern(msg, patternErrorODBC2, sb)
                 || matchBodyPattern(msg, patternErrorJet, sb)
                 || matchBodyPattern(msg, patternErrorTomcat, sb)
                 || matchBodyPattern(msg, patternErrorPHP, sb)) {
-            bingo(Alert.RISK_MEDIUM, Alert.CONFIDENCE_LOW, "", param, sb.toString(), attack, msg);
-
-            return true;
+            issueFound = true;
+            confidence = Alert.CONFIDENCE_LOW;
         }
 
-        return false;
+        if (issueFound) {
+            bingo(Alert.RISK_MEDIUM, confidence, null, param, attack, "", sb.toString(), msg);
+        }
+
+        return issueFound;
 
     }
 

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Issue 1365: Additional Path Traversal detection.<br>
+	Correct alert's evidence/attack of Parameter Tampering (Issue 3524).<br>
 	]]>
     </changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrules/TestParameterTamperUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestParameterTamperUnitTest.java
@@ -1,0 +1,229 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+
+/**
+ * Unit test for {@link TestParameterTamper}.
+ */
+public class TestParameterTamperUnitTest extends ActiveScannerTest<TestParameterTamper> {
+
+    @Override
+    protected TestParameterTamper createScanner() {
+        return new TestParameterTamper();
+    }
+
+    @Test
+    public void shouldNotContinueScanningIfFirstResponseIsNotOK() throws Exception {
+        // Given
+        rule.init(getHttpMessage("/"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(1));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldContinueScanningIfFirstResponseIsOK() throws Exception {
+        // Given
+        nano.addHandler(new NanoServerHandler("/") {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "");
+            }
+        });
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfAttackResponseIsAlwaysTheSame() throws Exception {
+        // Given
+        nano.addHandler(new NanoServerHandler("/") {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "Default Response");
+            }
+        });
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfAttackResponseIsNotOkNorServerError() throws Exception {
+        // Given
+        nano.addHandler(new NanoServerHandler("/") {
+
+            private boolean showDefaultResponse = true;
+
+            @Override
+            Response serve(IHTTPSession session) {
+                if (showDefaultResponse) {
+                    showDefaultResponse = false;
+                    return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "Default Response");
+                }
+                return new Response(Response.Status.NOT_FOUND, NanoHTTPD.MIME_HTML, "404 Not Found");
+            }
+        });
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfAttackResponseIsServerErrorWithUnknownErrorMessage() throws Exception {
+        // Given
+        ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/");
+        nano.addHandler(serverErrorOnAttack);
+        serverErrorOnAttack.setError("Not an error message the scanner knows...");
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertIfAttackResponseContainsJavaServletError() throws Exception {
+        // Given
+        ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/", 2);
+        nano.addHandler(serverErrorOnAttack);
+        serverErrorOnAttack.setError("javax.servlet.Class invoke exception");
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(4));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("javax.servlet.Class")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo("p")));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo("@")));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldNotAlertIfAttackResponseDoesNotContainsJavaServletError() throws Exception {
+        // Given
+        ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/");
+        nano.addHandler(serverErrorOnAttack);
+        serverErrorOnAttack.setError("javax.servlet.NotAnException");
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertWithLowConfidenceIfAttackResponseContainsOtherKnownServerErrors() throws Exception {
+        ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/");
+        nano.addHandler(serverErrorOnAttack);
+
+        String[] serverErrors = {
+                "Microsoft VBScript error",
+                "Microsoft OLE DB Provider for ODBC Drivers error",
+                "ODBC Drivers error",
+                "Microsoft JET Database Engine error",
+                " on line <b>",
+                "Apache Tomcat/8.0.27 - Error report</title> ... <h1>HTTP Status 500 - Internal Server Error" };
+
+        for (String serverError : serverErrors) {
+            // Given
+            serverErrorOnAttack.setError(serverError);
+            rule.init(getHttpMessage("/?p=v"), parent);
+            // When
+            rule.scan();
+            // Then
+            assertThat(serverError, httpMessagesSent, hasSize(2));
+            assertThat(serverError, alertsRaised, hasSize(1));
+            assertThat(serverError, alertsRaised.get(0).getEvidence(), is(equalTo(serverError)));
+            assertThat(serverError, alertsRaised.get(0).getParam(), is(equalTo("p")));
+            assertThat(serverError, alertsRaised.get(0).getAttack(), is(equalTo(null))); // Parameter absent, no attack value.
+            assertThat(serverError, alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+            assertThat(serverError, alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
+            assertThat(serverError, alertsRaised.get(0).getOtherInfo(), is(equalTo("")));
+
+            // Clean up for next error
+            rule = createScanner();
+            httpMessagesSent.clear();
+            alertsRaised.clear();
+        }
+    }
+
+    private static class ServerErrorOnAttack extends NanoServerHandler {
+
+        private final int totalAttacks;
+        private int count = 0;
+        private String error;
+
+        public ServerErrorOnAttack(String path) {
+            this(path, 0);
+        }
+
+        public ServerErrorOnAttack(String path, int totalAttacks) {
+            super(path);
+            this.totalAttacks = totalAttacks;
+        }
+
+        public void setError(String error) {
+            this.error = error;
+            this.count = 0;
+        }
+
+        @Override
+        Response serve(IHTTPSession session) {
+            if (count <= totalAttacks) {
+                count++;
+                return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "Default Response");
+            }
+            return new Response(Response.Status.INTERNAL_ERROR, NanoHTTPD.MIME_HTML, error);
+        }
+    }
+}


### PR DESCRIPTION
Change TestParameterTamper to include the evidence in the evidence field
instead of Other Info field, also, correctly set the attack in the
attack field (previously set as Other Info).
Add tests to assert the expected behaviour and alert data.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3524 - 'Parameter Tampering' alert has an invalid
'otherinfo' field value equals @