### PR TITLE
bugtracker: add task to generate the wiki

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -516,6 +516,10 @@
         <build-deploy-addon name="bugtracker" />
     </target>
     
+    <target name="generate-wiki-bugtracker" description="Generates the wiki of Bug Tracker add-on">
+        <generate-wiki addon="bugtracker" />
+    </target>
+
 	<target name="generate-wiki-browserView" description="Generates the wiki of browser extension">
 		<generate-wiki addon="browserView" />
 	</target>


### PR DESCRIPTION
Add a new task to build.xml file to generate the wiki of the add-on.