### PR TITLE
websocket: set fuzzer script enabled by default

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix/correct help buttons.<br>
+	Set fuzzer script type enabled by default (Issue 2997).<br>
 	]]>
 	</changes>
 	<classnames>
@@ -36,6 +37,6 @@
 	<files>
 		<file>scripts/templates/websocketfuzzerprocessor/Fuzzer WebSocket Processor default template.js</file>
 	</files>
-	<not-before-version>2.4.3</not-before-version>
+	<not-before-version>2.6.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
+++ b/src/org/zaproxy/zap/extension/websocket/fuzz/ExtensionWebSocketFuzzer.java
@@ -107,6 +107,7 @@ public class ExtensionWebSocketFuzzer extends ExtensionAdaptor {
                     WebSocketFuzzerProcessorScript.TYPE_NAME,
                     "websocket.fuzzer.script.type.fuzzerprocessor",
                     WEBSOCKET_FUZZER_PROCESSOR_SCRIPT_ICON,
+                    true,
                     true);
             extensionScript.registerScriptType(scriptType);
 


### PR DESCRIPTION
Change ExtensionWebSocketFuzzer to set the custom script type enabled by
default.
Bump minimum ZAP version (to 2.6.0, required by the new feature) and
update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#2997 - Change fuzzer related script types to be
enabled by default