### PR TITLE
scripts: allow to set new/loaded script as enabled

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Inform when the script contains invalid char sequences (related to Issue 3377).<br>
 	Invoke Scripts tree context menu once.<br>
 	Title caps adjustments (related to Issue 2000).<br>
+	Allow to configure the enabled state of new/loaded scripts (Issue 2996).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
@@ -42,6 +42,7 @@ public class LoadScriptDialog extends StandardFieldsDialog {
 	private static final String FIELD_DESC = "scripts.dialog.script.label.desc";
 	private static final String FIELD_TYPE = "scripts.dialog.script.label.type";
 	private static final String FIELD_LOAD = "scripts.dialog.script.label.load";
+	private static final String FIELD_ENABLED = "scripts.dialog.script.label.enabled";
 
 	private static final long serialVersionUID = 1L;
 
@@ -64,6 +65,8 @@ public class LoadScriptDialog extends StandardFieldsDialog {
 		this.addComboField(FIELD_TYPE, this.getTypes(), "");
 		this.addMultilineField(FIELD_DESC, "");
 		this.addCheckBoxField(FIELD_LOAD, true);
+		this.addCheckBoxField(FIELD_ENABLED, false);
+		this.getField(FIELD_ENABLED).setEnabled(false);
 		this.addFieldListener(FIELD_ENGINE, new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -80,6 +83,24 @@ public class LoadScriptDialog extends StandardFieldsDialog {
 				}
 			}});
 
+		this.addFieldListener(FIELD_TYPE, new ActionListener() {
+
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				boolean scriptEnableable = false;
+				boolean scriptEnabledByDefault = false;
+
+				if (!isEmptyField(FIELD_TYPE)) {
+					ScriptType scriptType = nameToType(getStringValue(FIELD_TYPE));
+					if (scriptType != null) {
+						scriptEnableable = scriptType.isEnableable();
+						scriptEnabledByDefault = scriptType.isEnabledByDefault();
+					}
+				}
+				getField(FIELD_ENABLED).setEnabled(scriptEnableable);
+				setFieldValue(FIELD_ENABLED, scriptEnabledByDefault);
+			}
+		});
 		this.addPadding();
 	}
 	
@@ -105,6 +126,7 @@ public class LoadScriptDialog extends StandardFieldsDialog {
 		script.setDescription(this.getStringValue(FIELD_DESC));
 		script.setType(this.nameToType(this.getStringValue(FIELD_TYPE)));
 		script.setLoadOnStart(this.getBoolValue(FIELD_LOAD));
+		script.setEnabled(getBoolValue(FIELD_ENABLED));
 		script.setEngine(extension.getExtScript().getEngineWrapper(this.getStringValue(FIELD_ENGINE)));
 
 		extension.getExtScript().addScript(script);

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -41,6 +41,7 @@ public class NewScriptDialog extends StandardFieldsDialog {
 	private static final String FIELD_TEMPLATE = "scripts.dialog.script.label.template";
 	private static final String FIELD_TYPE = "scripts.dialog.script.label.type";
 	private static final String FIELD_LOAD = "scripts.dialog.script.label.load";
+	private static final String FIELD_ENABLED = "scripts.dialog.script.label.enabled";
 
 	private static final long serialVersionUID = 1L;
 
@@ -96,17 +97,31 @@ public class NewScriptDialog extends StandardFieldsDialog {
 		this.addComboField(FIELD_TEMPLATE, this.getTemplates(), templateName);
 		this.addMultilineField(FIELD_DESC, desc);
 		this.addCheckBoxField(FIELD_LOAD, true);
+		this.addCheckBoxField(FIELD_ENABLED, false);
+		this.getField(FIELD_ENABLED).setEnabled(false);
 
 		this.addFieldListener(FIELD_TYPE, new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
+				boolean scriptEnableable = false;
+				boolean scriptEnabledByDefault = false;
+
 				if (isEmptyField(FIELD_TYPE)) {
 					// Unset the template, otherwise it just resets the type again ;)
 					if (!isEmptyField(FIELD_ENGINE)) {
 						setFieldValue(FIELD_ENGINE, "");
 					}
 					setFieldValue(FIELD_TEMPLATE, "");
+				} else {
+					ScriptType scriptType = nameToType(getStringValue(FIELD_TYPE));
+					if (scriptType != null) {
+						scriptEnableable = scriptType.isEnableable();
+						scriptEnabledByDefault = scriptType.isEnabledByDefault();
+					}
 				}
+				getField(FIELD_ENABLED).setEnabled(scriptEnableable);
+				setFieldValue(FIELD_ENABLED, scriptEnabledByDefault);
+
 				resetTemplates();
 			}});
 
@@ -213,6 +228,7 @@ public class NewScriptDialog extends StandardFieldsDialog {
 		script.setName(this.getStringValue(FIELD_NAME));
 		script.setDescription(this.getStringValue(FIELD_DESC));
 		script.setLoadOnStart(this.getBoolValue(FIELD_LOAD));
+		script.setEnabled(getBoolValue(FIELD_ENABLED));
 		
 		extension.getExtScript().addScript(script);
 	}

--- a/src/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -71,6 +71,7 @@ scripts.dialog.script.label.desc		= Description:
 scripts.dialog.script.label.engine		= Script Engine:
 scripts.dialog.script.label.file		= File:
 scripts.dialog.script.label.load		= Load on Start:
+scripts.dialog.script.label.enabled = Enabled:
 scripts.dialog.script.label.template	= Template:
 scripts.dialog.script.label.type		= Type:
 scripts.dialog.script.new.title			= New Script


### PR DESCRIPTION
Change NewScriptDialog and LoadScriptDialog to allow to set the enabled
state of the script (based on the selected script type).
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2996 - Allow to configure the enabled state of
new/loaded scripts