### PR TITLE
fuzz: set script types enabled by default

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -271,6 +271,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
                     ScriptStringPayloadGenerator.TYPE_NAME,
                     "fuzz.payloads.script.type.payloadgenerator",
                     SCRIPT_PAYLOAD_GENERATOR_ICON,
+                    true,
                     true);
             extensionScript.registerScriptType(scriptTypeGenerator);
             payloadGeneratorsUIRegistry.registerPayloadUI(
@@ -281,6 +282,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
                     ScriptStringPayloadProcessor.TYPE_NAME,
                     "fuzz.payloads.script.type.payloadprocessor",
                     SCRIPT_PAYLOAD_PROCESSOR_ICON,
+                    true,
                     true);
             extensionScript.registerScriptType(scriptTypeProcessor);
             payloadProcessorsUIRegistry.registerProcessorUIHandler(

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -12,6 +12,7 @@
     Contains new number generator payload.<br>
     Add null/empty payload generator.<br>
     Issue 3557: Backport export changes.<br>    
+    Set fuzzer script types enabled by default (Issue 2997).<br>
     ]]>
     </changes>
     <extensions>
@@ -26,6 +27,6 @@
         <file>scripts/templates/payloadprocessor/Payload Processor default template.js</file>
         <file>jbrofuzz/fuzzers.jbrf</file>
     </files>
-    <not-before-version>2.4.0</not-before-version>
+    <not-before-version>2.6.0</not-before-version>
     <not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -110,6 +110,7 @@ public class ExtensionHttpFuzzer extends ExtensionAdaptor {
                     HttpFuzzerProcessorScript.TYPE_NAME,
                     "fuzz.httpfuzzer.script.type.fuzzerprocessor",
                     HTTP_FUZZER_PROCESSOR_SCRIPT_ICON,
+                    true,
                     true);
             extensionScript.registerScriptType(scriptType);
 


### PR DESCRIPTION
Change ExtensionFuzz and ExtensionHttpFuzzer to set the custom script
types enabled by default.
Bump minimum ZAP version (to 2.6.0, required by the new feature) and
update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#2997 - Change fuzzer related script types to be
enabled by default