### PR TITLE
pscanrules: fix FP with mixed content and JS files

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules</name>
-	<version>19</version>
+	<version>20</version>
 	<status>release</status>
 	<description>The release quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Correct evidence of alerts raised by scanner "Application Error Disclosure".<br>
-	Fixed some false positives caused by scanner "Private Address Disclosure".<br>
-	Add support for cookie ignore rule.<br>
+	Fix false positive with Secure Pages Include Mixed Content and JavaScript files (Issue 3581).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrules/MixedContentScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/MixedContentScannerUnitTest.java
@@ -1,0 +1,189 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class MixedContentScannerUnitTest extends PassiveScannerTest {
+
+    @Override
+    protected MixedContentScanner createScanner() {
+        return new MixedContentScanner();
+    }
+
+    @Test
+    public void shouldNotRaiseAlertIfHttpResource() {
+        // Given
+        String uri = "http://example.com/";
+        HttpMessage msg = createHtmlResponse(uri, "<script src=\"https://example.com/script.js\"></script>");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertIfHttpsResourceContainsNoMixedContent() {
+        // Given
+        String uri = "https://example.com/";
+        HttpMessage msg = createHtmlResponse(uri, "<script src=\"https://example.com/script.js\"></script>");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertIfHttpsResourceIsEmpty() {
+        // Given
+        String uri = "https://example.com/";
+        HttpMessage msg = createHtmlResponse(uri, "");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertForNonHtmlContent() {
+        // Given
+        String uri = "https://example.com/script.js";
+        HttpMessage msg = createResponse(
+                uri,
+                "text/javascript",
+                // Extracted from: https://raw.githubusercontent.com/angular/angular.js/master/src/ng/directive/attrs.js
+                "/** <img src=\"http://www.gravatar.com/avatar/{{hash}}\" alt=\"Description\"/> */");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertIfHttpsResourceContainsMixedContentInUnknownAttribute() {
+        // Given
+        String attribute = "unknown";
+        String uri = "https://example.com/";
+        HttpMessage msg = createHtmlResponse(uri, "<tag " + attribute + "=\"http://example.com/file\" />");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldRaiseLowAlertIfHttpsResourceContainsMixedContentInKnownAttributes() {
+        for (String attribute : Arrays
+                .asList("src", "background", "classid", "codebase", "data", "icon", "usemap", "action", "formaction")) {
+            alertsRaised.clear();
+            // Given
+            String uri = "https://example.com/";
+            HttpMessage msg = createHtmlResponse(uri, "<tag " + attribute + "=\"http://example.com/file\" />");
+            // When
+            rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+            // Then
+            assertThat(alertsRaised.size(), is(1));
+            assertThat(alertsRaised.get(0).getEvidence(), is("http://example.com/file"));
+            assertThat(alertsRaised.get(0).getOtherInfo(), is("tag=tag " + attribute + "=http://example.com/file\n"));
+            assertThat(alertsRaised.get(0).getRisk(), is(Alert.RISK_LOW));
+            assertThat(alertsRaised.get(0).getConfidence(), is(Alert.CONFIDENCE_MEDIUM));
+        }
+    }
+
+    @Test
+    public void shouldNotRaiseAlertIfHttpsResourceContainsMixedContentInActionAndFormActionAttributesWhenInHighAlertTreshold() {
+        for (String attribute : Arrays.asList("action", "formaction")) {
+            // Given
+            String uri = "https://example.com/";
+            HttpMessage msg = createHtmlResponse(uri, "<tag " + attribute + "=\"http://example.com/file\" />");
+            rule.setLevel(AlertThreshold.HIGH);
+            // When
+            rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+            // Then
+            assertThat(alertsRaised.size(), is(0));
+        }
+    }
+
+    @Test
+    public void shouldRaiseMediumAlertIfHttpsResourceContainsMixedContentInScriptTag() {
+        // Given
+        String uri = "https://example.com/";
+        HttpMessage msg = createHtmlResponse(uri, "<script src=\"http://example.com/script.js\"></script>");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is("http://example.com/script.js"));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is("tag=script src=http://example.com/script.js\n"));
+        assertThat(alertsRaised.get(0).getRisk(), is(Alert.RISK_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), is(Alert.CONFIDENCE_MEDIUM));
+        // THC verify other info
+    }
+
+    @Test
+    public void shouldRaiseOneAlertForMultipleMixedContent() {
+        // Given
+        String uri = "https://example.com/";
+        HttpMessage msg = createHtmlResponse(
+                uri,
+                "<script src=\"http://example.com/script.js\"></script>\n" + "<img src=\"http://example.com/image.png\" />");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is("http://example.com/script.js"));
+        assertThat(
+                alertsRaised.get(0).getOtherInfo(),
+                is("tag=script src=http://example.com/script.js\ntag=img src=http://example.com/image.png\n"));
+    }
+
+    private static HttpMessage createHtmlResponse(String uri, String respBody) {
+        return createResponse(uri, "text/html", respBody);
+    }
+
+    private static HttpMessage createResponse(String uri, String respContentType, String respBody) {
+        HttpMessage msg = new HttpMessage();
+        try {
+            msg.setRequestHeader("GET " + uri + " HTTP/1.1");
+            msg.setResponseHeader("HTTP/1.1 200 OK\r\n");
+        } catch (HttpMalformedHeaderException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (StringUtils.isNotEmpty(respContentType)) {
+            msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, respContentType);
+        }
+
+        msg.getResponseBody().setBody(respBody);
+
+        return msg;
+    }
+}


### PR DESCRIPTION
Change MixedContentScanner to just check HTML files as the parser is
only for HTML content, attempting to use it with other files would lead
to misinterpreted results (e.g. a JavaScript file with HTML tags embeded
in comments). Also, remove redundant null check (the variable is never
null) and reorder statements to reduce the block statement depth.
Add tests to assert the expected behaviour.
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3581 - False Positive with Secure Pages Include
Mixed Content and JavaScript files

(Fix zaproxy/zaproxy#2788 as well.)