### PR TITLE
websocket: normalise session properties panel

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Fix/correct help buttons.<br>
 	Set fuzzer script type enabled by default (Issue 2997).<br>
+	Normalise the Session Properties panel Exclude from WebSockets.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
@@ -57,7 +57,6 @@ websocket.payload.invalid_utf8                  = <invalid utf8 payload>
 websocket.payload.unreadable_binary             = <unreadable binary payload>
 websocket.session.exclude.title                 = Exclude from WebSockets
 websocket.session.label.ignore                  = URLs where WebSocket traffic will be forwarded but not further processed. 
-websocket.session.table.header.ignore           = URL Regexes
 websocket.table.header.direction                = \u2194
 websocket.table.header.fuzz                     = Fuzz
 websocket.table.header.id                       = Channel

--- a/src/org/zaproxy/zap/extension/websocket/ui/OptionsParamWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/OptionsParamWebSocket.java
@@ -26,10 +26,12 @@ public class OptionsParamWebSocket extends AbstractParam {
 	public static final String FORWARD_ALL = "websocket.forwardAll";
 	public static final String BREAK_ON_PING_PONG = "websocket.breakOnPingPong";
 	public static final String BREAK_ON_ALL = "websocket.breakOnAll";
+	private static final String CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY = "websocket.confirmRemoveProxyExcludeRegex";
 
 	private boolean isForwardAll;
 	private boolean isBreakOnPingPong;
 	private boolean isBreakOnAll;
+	private boolean confirmRemoveProxyExcludeRegex;
 
     @Override
     protected void parse() {
@@ -37,6 +39,7 @@ public class OptionsParamWebSocket extends AbstractParam {
     	isForwardAll = cfg.getBoolean(FORWARD_ALL, false);
     	isBreakOnPingPong = cfg.getBoolean(BREAK_ON_PING_PONG, false);
     	isBreakOnAll = cfg.getBoolean(BREAK_ON_ALL, false);
+    	confirmRemoveProxyExcludeRegex = cfg.getBoolean(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, false);
     }
 
     /**
@@ -101,5 +104,14 @@ public class OptionsParamWebSocket extends AbstractParam {
 	public void setBreakOnAll(boolean isBreakOnAll) {
 		this.isBreakOnAll = isBreakOnAll;
 		getConfig().setProperty(BREAK_ON_ALL, isBreakOnAll);
+	}
+
+	public boolean isConfirmRemoveProxyExcludeRegex() {
+		return this.confirmRemoveProxyExcludeRegex;
+	}
+
+	public void setConfirmRemoveProxyExcludeRegex(boolean confirmRemove) {
+		this.confirmRemoveProxyExcludeRegex = confirmRemove;
+		getConfig().setProperty(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, Boolean.valueOf(confirmRemove));
 	}
 }


### PR DESCRIPTION
Change SessionExcludeFromWebSocket to use the same table as the other
exclude panels (to allow to manage the excluded URLs more easily).
Update changes in ZapAddOn.xml file.