### PR TITLE
alertFilters: clear filters on session changes

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -302,6 +302,10 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 
 	@Override
 	public void discardContexts() {
+		clearAlertFiltersState();
+	}
+
+	private void clearAlertFiltersState() {
 		this.contextManagers.clear();
 		this.alertFilterPanelsMap.clear();
 	}
@@ -479,7 +483,7 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 
 	@Override
 	public void sessionAboutToChange(Session session) {
-		// Ignore
+		clearAlertFiltersState();
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Dynamically unload the add-on.<br>
+	Clear filters on session changes (Issue 3683).<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionAlertFilters to clear the state of the alert filters
when the session is about to change.
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3683 - NPE in ExtensionAlertFilters