### PR TITLE
openapi: validate provided path and fix NPE

### DIFF
--- a/src/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
+++ b/src/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
@@ -61,7 +61,16 @@ public class OpenApiAPI extends ApiImplementor {
                 throw new ApiException(ApiException.Type.DOES_NOT_EXIST, file.getAbsolutePath());
             }
 
+            if (!file.isFile()) {
+                throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_FILE);
+            }
+
             List<String> errors = extension.importOpenApiDefinition(file, false);
+
+            if (errors == null) {
+                // A null list indicates that an exception occurred while parsing the file...
+                throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA, PARAM_FILE);
+            }
 
             ApiResponseList result = new ApiResponseList(name);
             for (String error : errors) {

--- a/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
@@ -1,17 +1,13 @@
 <zapaddon>
 	<name>OpenAPI Support</name>
-	<version>6</version>
+	<version>7</version>
 	<status>alpha</status>
 	<description>Imports and spiders Open API definitions.</description>
 	<author>ZAP Core Team plus Joanna Bona, Artur Grzesica, Michal Materniak and Marcin Spiewak</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-		Support optional host override.<br>
-		Detect and warn on potential loops.<br>
-		Allow add-on to be unloaded dynamically.<br>
-		Support user specified values when importing (Issue 3344).<br>
-		Support older swagger formats (Issue 3598).<br>
+		Correct validations when importing a file through the API.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change OpenApiAPI to validate that the provided path is a file (not just
that it exists) and check if the parsing succeeded at all.
Bump version and update changes in ZapAddOn.xml file.