### PR TITLE
alertFilters: dynamically unload the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -52,7 +52,6 @@ import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.alert.AlertEventPublisher;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.PolicyManager;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
@@ -170,16 +169,28 @@ public class ExtensionAlertFilters extends ExtensionAdaptor implements ContextPa
 	    extensionHook.addSessionListener(this);
 	    
 		// Register this as a context data factory
-		Model.getSingleton().addContextDataFactory(this);
+		extensionHook.addContextDataFactory(this);
 
 		if (getView() != null) {
 			// Factory for generating Session Context alertFilters panels
-			getView().addContextPanelFactory(this);
+			extensionHook.getHookView().addContextPanelFactory(this);
 		}
 
 		this.api = new AlertFilterAPI(this);
-		API.getInstance().registerApiImplementor(api);
+		extensionHook.addApiImplementor(api);
 
+	}
+
+	@Override
+	public boolean canUnload() {
+		return true;
+	}
+
+	@Override
+	public void unload() {
+		super.unload();
+
+		ZAP.getEventBus().unregisterConsumer(this, AlertEventPublisher.getPublisher().getPublisherName());
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Context Alert Filters</name>
-	<version>4</version>
+	<version>5</version>
 	<status>beta</status>
 	<description>Allows you to automate the changing of alert risk levels.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Minor functional improvement.<br>
+	Dynamically unload the add-on.<br>
 	]]>
     </changes>
 	<extensions>
@@ -17,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.2</not-before-version>
+	<not-before-version>2.6.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
Change ExtensionAlertFilters to add the components through the provided
hook (instead of adding them directly to the core components, so that
they are automatically unloaded when the add-on is uninstalled) and
declare that the extension can be unloaded.
Bump minimum ZAP version and version of the add-on and update changes in
ZapAddOn.xml file.