### PR TITLE
pscanrulesBeta: fix exception with cookie scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScanner.java
@@ -139,7 +139,8 @@ public class CookieLooselyScopedScanner extends PluginPassiveScanner {
 		if (!cookieDomains[cookieDomains.length - 1].equalsIgnoreCase(hostDomains[hostDomains.length - 1])) {
 			return false;
 		}
-		if (!cookieDomains[cookieDomains.length - 2].equalsIgnoreCase(hostDomains[hostDomains.length - 2])) {
+		if (cookieDomains.length < 2 || hostDomains.length < 2
+				|| !cookieDomains[cookieDomains.length - 2].equalsIgnoreCase(hostDomains[hostDomains.length - 2])) {
 			return false;
 		}
 		return true;

--- a/test/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesBeta/CookieLooselyScopedScannerUnitTest.java
@@ -169,4 +169,30 @@ public class CookieLooselyScopedScannerUnitTest extends PassiveScannerTest {
 		// Then
 		assertThat(alertsRaised.size(), is(1));
 	}
+
+	@Test
+	public void shouldScanCookieDomainWithJustTld() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://example.com/ HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=com");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then = No exception.
+	}
+
+	@Test
+	public void shouldScanHostWithoutTld() throws Exception {
+		// Given
+		HttpMessage msg = createBasicMessage();
+		msg.setRequestHeader("GET http://intranet/ HTTP/1.1");
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "a=b;domain=subdomain.intranet");
+
+		// When
+		rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+		// Then = No exception.
+	}
 }


### PR DESCRIPTION
Change CookieLooselyScopedScanner to verify that the cookie domain and
hostname have the minimum length required when checking if same domain.
Add tests to assert the correct behaviour (i.e. no exceptions).

Fix zaproxy/zaproxy#3713 - CookieLooselyScopedScanner:
ArrayIndexOutOfBoundsException