### PR TITLE
pscanrulesAlpha: update minimum ZAP version

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,13 +1,12 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>15</version>
+	<version>16</version>
 	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-		Added scanner that looks for simple hashes of usernames based on context user configuration details.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -53,6 +52,6 @@
 		<file>licenses/metadata-extractor-license.txt</file>
 		<file>licenses/xmpcore-license.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.6.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
Bump version of the add-on and minimum ZAP version (to 2.6.0, latest),
it doesn't run correctly in 2.4.0 (missing commons-codec classes).