### PR TITLE
Wappalyzer Update Help Content Link

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -403,14 +403,7 @@
 		<build-addon name="jxbrowsermacos" />
 		<build-addon name="jxbrowserwindows" />
 		<build-addon name="openapi" />
-		<build-addon name="pscanrulesAlpha" >
-				<!-- Add the extra classes required -->
-				<jar jarfile="${dist}/${file}" update="true" compress="true">
-					<zipfileset dir="${build}" prefix="">
-						<include name="com/veggiespam/imagelocationscanner/**"/>
-					</zipfileset>
-				</jar>
-			</build-addon>
+		<build-pscanrulesalpha-addon />
 		<build-addon name="requester" />
 		<build-addon name="revisit" />
 		<build-addon name="saml" />
@@ -655,13 +648,41 @@
 		<build-deploy-addon name="onlineMenu" />
 	</target>
 
-	<target name="deploy-pscanrulesAlpha" description="deploy the passive scan rules">
-		<build-deploy-addon name="pscanrulesAlpha" />
+	<macrodef name="build-pscanrulesalpha-addon" description="Builds passive scan rules add-on">
+		<sequential>
+			<build-addon name="pscanrulesAlpha">
+				<!-- Add the extra classes required -->
+				<jar jarfile="${dist}/${file}" update="true" compress="true">
+					<zipfileset dir="${build}" prefix="">
+						<include name="com/veggiespam/imagelocationscanner/**" />
+					</zipfileset>
+				</jar>
+			</build-addon>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="build-pscanrulesalpha-addon-without-help-indexes" description="Builds passive scan rules add-on">
+		<sequential>
+			<build-addon-without-help-indexes name="pscanrulesAlpha">
+				<!-- Add the extra classes required -->
+				<jar jarfile="${dist}/${file}" update="true" compress="true">
+					<zipfileset dir="${build}" prefix="">
+						<include name="com/veggiespam/imagelocationscanner/**" />
+					</zipfileset>
+				</jar>
+			</build-addon-without-help-indexes>
+		</sequential>
+	</macrodef>
+
+	<target name="deploy-pscanrulesAlpha" depends="clean, compile" description="deploy the passive scan rules">
+		<build-pscanrulesalpha-addon />
+		<deploy-addon name="pscanrulesAlpha" />
 	</target>
 
-	<target name="deploy-pscanrulesAlpha-without-help-indexes" description="deploy the passive scan rules">
+	<target name="deploy-pscanrulesAlpha-without-help-indexes" depends="clean, compile" description="deploy the passive scan rules">
 		<!-- To facilitate quick Dev builds -->
-		<build-deploy-addon-without-help-indexes name="pscanrulesAlpha" />
+		<build-pscanrulesalpha-addon-without-help-indexes />
+		<deploy-addon name="pscanrulesAlpha" />
 	</target>
 	
 	<target name="deploy-openapi" description="deploy the openapi add-on">

--- a/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Technology detection using Wappalyzer</name>
-	<version>8</version>
+	<version>9</version>
 	<status>alpha</status>
 	<description>Technology detection using Wappalyzer: wappalyzer.com</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Remove the use of passive scan rule.<br>
-	Minor code cleanup.<br>
-	Add support for wappalyzer META tag checks.<br>
+	Updated Wappalyzer github link in help content.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/src/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -28,7 +28,7 @@ Selecting a regex will switch to the 'Search' tab and search through the history
 	<td>The Wappalyzer Homepage</td></tr>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-	<td><a href="https://github.com/ElbertF/Wappalyzer/">https://github.com/ElbertF/Wappalyzer/</a></td>
+	<td><a href="https://github.com/AliasIO/Wappalyzer">https://github.com/AliasIO/Wappalyzer</a></td>
 	<td>The Wappalyzer Repository</td>
 </tr>
 </table>


### PR DESCRIPTION
Updated github link in the Wappalyzer addon help content.
Rolled version in manifest file and updated changes section.