### PR TITLE
ascanrulesAlpha: correct empty path handling

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
@@ -462,7 +462,7 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
 			//	- to bypass caching (if it's a random filename, if won't have been seen before, and won't be cached)
 			//	  yes, I know TRACK requests should *not* be cached, but not all servers are compliant.
 			String randompiece = RandomStringUtils.random(5, "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
-			trackRequestHeader.setURI(new URI(trackURI.getScheme() + "://" + trackURI.getAuthority()+ trackURI.getPath() + randompiece,true));
+			trackRequestHeader.setURI(new URI(trackURI.getScheme() + "://" + trackURI.getAuthority()+ getPath(trackURI) + randompiece,true));
 
 			trackRequestHeader.setVersion (HttpRequestHeader.HTTP11);	// 
 			trackRequestHeader.setSecure(trackRequestHeader.isSecure());
@@ -593,6 +593,14 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
 			//if it's in English, it's still better than not having it at all. 
 			log.error("An error occurred checking for proxy disclosure", e);
 		}
+	}
+
+	private String getPath(URI uri) {
+		String path = uri.getEscapedPath();
+		if (path != null) {
+			return path;
+		}
+		return "/";
 	}
 
 	private String getAttack() {

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
@@ -207,6 +207,13 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 	@Override
 	public void scan(HttpMessage originalmsg, String paramname, String paramvalue) {		
 		try {
+			URI uri = originalmsg.getRequestHeader().getURI();
+			String path = uri.getPath();
+			if (path == null || "/".equals(path)) {
+				// No path or empty path, no point continuing.
+				return;
+			}
+
 			if (log.isDebugEnabled()) {
 				log.debug("Attacking at Attack Strength: " + this.getAttackStrength());
 				log.debug("Checking [" + getBaseMsg().getRequestHeader().getMethod() + "] ["
@@ -237,7 +244,6 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 
 			//at this point, there was a sufficient difference between the random filename and the original parameter
 			//so lets try the various path names that might point at the source code for this URL
-			URI uri = originalmsg.getRequestHeader().getURI();
 			String pathMinusLeadingSlash = uri.getPath().substring(1);
 			String pathMinusApplicationContext = uri.getPath().substring( uri.getPath().indexOf("/", 1) + 1);
 

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -1,17 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules (alpha)</name>
-	<version>19</version>
+	<version>20</version>
 	<status>alpha</status>
 	<description>The alpha quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>
 	<changes>
 	<![CDATA[
-	Improve error handling in some scanners.<br>
-	Add MsSQL specific Injection scanner.<br>
-	Issue 3441: Add proper reference links to Proxy Discovery scanner.<br>
-	Issue 3279: Add ELMAH scanner.<br>
-	Issue 3280: Add trace.axd scanner.
+	Correct handling of messages with emtpy path.<br>
   	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change SourceCodeDisclosureFileInclusion to skip the scan if there's no
path to work with, preventing exceptions when handling it:
 StringIndexOutOfBoundsException: String index out of range: -2

Change ProxyDisclosureScanner to properly build the URI when the path is
empty (i.e. add "/" instead of "null"), which would lead to wrong host
being requested, e.g. "example.comnullIAACS".

Bump version and update changes in ZapAddOn.xml file.