### PR TITLE
websocket: focus WebSockets tab just once

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Normalise the Session Properties panel Exclude from WebSockets.<br>
 	Implements WebSocketSenderListener.<br>
 	Use JRE decoder for UTF-8 conversions and log (debug) invalid payloads (related to Issue 3324).<br>
+	Focus WebSockets tab just once (Issue 3747).<br>
 	]]>
 	</changes>
 	<classnames>


### PR DESCRIPTION
Change ExtensionWebSocket to focus the WebSockets tab just once, when
the first handshake is received.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3747 - Websocket tab focuses on every handshake
message