### PR TITLE
Tweak ImportURLs Help Content

### DIFF
--- a/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Import files containing URLs</name>
-	<version>3</version>
+	<version>4</version>
 	<status>beta</status>
 	<description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Issue 1643: Add an API end point for importing URLs from file.</changes>
+	<changes>Minor change to help content.</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.importurls.ExtensionImportUrls</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/importurls/resources/help/contents/importUrls.html
+++ b/src/org/zaproxy/zap/extension/importurls/resources/help/contents/importUrls.html
@@ -7,7 +7,7 @@ Import URLs
 </HEAD>
 <BODY BGCOLOR="#ffffff">
 <H1>Import URLs</H1>
-This add-on adds an option to import a file of URLs. The file must be plain text with one URL per line.
+This add-on adds an option to import a file of URLs  via the 'Tools' menu. The file must be plain text with one URL per line.
 </p>
 This add-on also exposes a ZAP API endpoint <tt>/importurls/importurls (filePath*)</tt> to facilitate programmatic 
 use of the functionality.


### PR DESCRIPTION
Help content updated to align with
https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsImporturlsImportUrls/_compare/8973b94%5E...8973b94

Manifest version rolled and changes element updated.