### PR TITLE
build: use status declared in add-ons' manifest

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -12,8 +12,7 @@
 	<property name="temp" location="temp" />
 	<property name="dist" location="zap-exts" />
 	<property name="dist.lib.dir" location="../lib" />
-	<property name="status" value="release" />
-	<property name="versions.file" location="${dist}/ZapVersions-${status}.xml" />
+	<property name="versions.file" location="${dist}/ZapVersions.xml" />
 	<property name="wiki.dir" location="../../zap-extensions-wiki" />
 	<property name="wiki.zapcorehelp.dir" location="../../zap-core-help-wiki" />
 	<!-- This assumes you also have the zaproxy project -->
@@ -188,8 +187,10 @@
 		<sequential>
 			<local name="zapaddon.version" />
 			<xmlproperty file="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml"/>
+			<local name="zapaddon.status" />
+			<xmlproperty file="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml"/>
 			<local name="file" />
-			<property name="file" value="@{name}-${status}-${zapaddon.version}.zap" />
+			<property name="file" value="@{name}-${zapaddon.status}-${zapaddon.version}.zap" />
 
 			<generatejavahelpsearchindexes jhalljar="${build.lib.dir}/jhall.jar"
 				helpcontentsdirname="contents" helpsetfilename="helpset*.hs">
@@ -256,7 +257,7 @@
 			</tstamp>
 
 			<appendzapaddonfile from="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml" to="${versions.file}"
-				addonid="@{name}" filename="${file}" status="${status}" size="${length}" hash="${hash}" date="${yyyymmdd}"
+				addonid="@{name}" filename="${file}" status="${zapaddon.status}" size="${length}" hash="${hash}" date="${yyyymmdd}"
 				url="${zap.download.url}/${file}" />
 
 		</sequential>
@@ -268,8 +269,10 @@
 			<sequential>
 				<local name="zapaddon.version" />
 				<xmlproperty file="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml"/>
+				<local name="zapaddon.status" />
+				<xmlproperty file="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml"/>
 				<local name="file" />
-				<property name="file" value="@{name}-${status}-${zapaddon.version}.zap" />
+				<property name="file" value="@{name}-${zapaddon.status}-${zapaddon.version}.zap" />
 
 				<local name="addon.libs.zip" />
 				<property name="addon.libs.zip" value="${temp}/libs-@{name}.zip" />
@@ -320,7 +323,7 @@
 				</tstamp>
 
 				<appendzapaddonfile from="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml" to="${versions.file}"
-					addonid="@{name}" filename="${file}" status="${status}" size="${length}" hash="${hash}" date="${yyyymmdd}"
+					addonid="@{name}" filename="${file}" status="${zapaddon.status}" size="${length}" hash="${hash}" date="${yyyymmdd}"
 					url="${zap.download.url}/${file}" />
 
 			</sequential>
@@ -332,8 +335,10 @@
 		<sequential>
 			<local name="zapaddon.version" />
 			<xmlproperty file="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml" />
+			<local name="zapaddon.status" />
+			<xmlproperty file="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml" />
 			<local name="file" />
-			<property name="file" value="@{name}-${status}-${zapaddon.version}.zap" />
+			<property name="file" value="@{name}-${zapaddon.status}-${zapaddon.version}.zap" />
 
 			<local name="addon.libs.zip" />
 			<property name="addon.libs.zip" value="${temp}/libs-@{name}.zip" />
@@ -367,7 +372,7 @@
 			</tstamp>
 
 			<appendzapaddonfile from="${src}/org/zaproxy/zap/extension/@{name}/ZapAddOn.xml" to="${versions.file}"
-				addonid="@{name}" filename="${file}" status="${status}" size="${length}" hash="${hash}" date="${yyyymmdd}"
+				addonid="@{name}" filename="${file}" status="${zapaddon.status}" size="${length}" hash="${hash}" date="${yyyymmdd}"
 				url="${zap.download.url}/${file}" />
 
 		</sequential>
@@ -603,19 +608,19 @@
 		<antcall target="build-all" />
 		<copy todir="${zap.plugin.dir}">
 			<fileset dir="${dist}">
-				<include name="ascanrules-${status}-*.zap"/>
-				<include name="coreLang-${status}-*.zap"/>
-				<include name="directorylistv1-${status}-*.zap"/>
-				<include name="gettingStarted-${status}-*.zap"/>
-				<include name="help-${status}-*.zap"/>
-				<include name="onlineMenu-${status}-*.zap"/>
-				<include name="pscanrules-${status}-*.zap"/>
-				<include name="quickstart-${status}-*.zap"/>
-				<include name="reveal-${status}-*.zap"/>
-				<include name="saverawmessage-${status}-*.zap"/>
-				<include name="selenium-${status}-*.zap"/>
-				<include name="spiderAjax-${status}-*.zap"/>
-				<include name="websocket-${status}-*.zap"/>
+				<include name="ascanrules-*.zap"/>
+				<include name="coreLang-*.zap"/>
+				<include name="directorylistv1-*.zap"/>
+				<include name="gettingStarted-*.zap"/>
+				<include name="help-*.zap"/>
+				<include name="onlineMenu-*.zap"/>
+				<include name="pscanrules-*.zap"/>
+				<include name="quickstart-*.zap"/>
+				<include name="reveal-*.zap"/>
+				<include name="saverawmessage-*.zap"/>
+				<include name="selenium-*.zap"/>
+				<include name="spiderAjax-*.zap"/>
+				<include name="websocket-*.zap"/>
 			</fileset>
 		</copy>
 	</target>
@@ -627,19 +632,19 @@
 		<antcall target="build-all" />
 		<copy todir="${zap.plugin.dir}">
 			<fileset dir="${dist}">
-				<include name="ascanrules-${status}-*.zap"/>
-				<include name="coreLang-${status}-*.zap"/>
-				<include name="directorylistv1-${status}-*.zap"/>
-				<include name="gettingStarted-${status}-*.zap"/>
-				<include name="help-${status}-*.zap"/>
-				<include name="onlineMenu-${status}-*.zap"/>
-				<include name="pscanrules-${status}-*.zap"/>
-				<include name="quickstart-${status}-*.zap"/>
-				<include name="reveal-${status}-*.zap"/>
-				<include name="saverawmessage-${status}-*.zap"/>
-				<include name="selenium-${status}-*.zap"/>
-				<include name="spiderAjax-${status}-*.zap"/>
-				<include name="websocket-${status}-*.zap"/>
+				<include name="ascanrules-*.zap"/>
+				<include name="coreLang-*.zap"/>
+				<include name="directorylistv1-*.zap"/>
+				<include name="gettingStarted-*.zap"/>
+				<include name="help-*.zap"/>
+				<include name="onlineMenu-*.zap"/>
+				<include name="pscanrules-*.zap"/>
+				<include name="quickstart-*.zap"/>
+				<include name="reveal-*.zap"/>
+				<include name="saverawmessage-*.zap"/>
+				<include name="selenium-*.zap"/>
+				<include name="spiderAjax-*.zap"/>
+				<include name="websocket-*.zap"/>
 			</fileset>
 		</copy>
 	</target>


### PR DESCRIPTION
Change build.xml to use the status declared in the add-ons' manifest
(ZapAddOn.xml) when creating its file name. Allows add-ons of any status
to be in the same branch.