### PR TITLE
Bugfix in ZestScript Ui. 

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -654,6 +654,11 @@
 		<build-deploy-addon name="zest" />
 	</target>
 
+	<target name="deploy-zest-without-help-indexes" description="deploy the zest extension, without building help indexes">
+		<!-- To facilitate quick Dev builds -->
+		<build-deploy-addon-without-help-indexes name="zest" />
+	</target>
+
 	 <target name="generate-wiki-zest" description="Generates the wiki of zest">
 		<generate-wiki-core addon="zest" />
 	</target>

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
+	Bugfix in ZestScript Ui: When more than one 'Assign variable to a form field' node is below a RequestNode then the RequestNode is now correctly determined.<br>
 	Correct operation set in calc assigns.<br>
 	Allow to loop files even if fuzzers.jbrf does not exist (Issue 3400).<br>
 	Properly remove Zest scripts (Issue 3401).<br>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
@@ -115,6 +115,18 @@ public class ZestDialogManager extends AbstractPanel {
 		initialize();
 	}
 
+	private static ZestRequest getPreviousZestRequest(ScriptNode currentNode){
+		ScriptNode previous = (ScriptNode)currentNode.getPreviousSibling();
+		while(previous != null){
+			Object element = ZestZapUtils.getElement(previous);
+			if(element instanceof ZestRequest){
+				return (ZestRequest)element;
+			}
+			previous = (ScriptNode)previous.getPreviousSibling();
+		}
+		return null;
+	}
+
 	private void initialize() {
 		this.setLayout(new CardLayout());
 		this.setName(Constant.messages.getString("zest.scripts.panel.title"));
@@ -150,16 +162,8 @@ public class ZestDialogManager extends AbstractPanel {
 								showZestAssertionDialog(parent, sn,
 										(ZestAssertion) obj, false);
 							} else if (obj instanceof ZestAssignment) {
-								ScriptNode prev = (ScriptNode) sn
-										.getPreviousSibling();
-								ZestRequest req = null;
-								if (prev != null
-										&& ZestZapUtils.getElement(prev) instanceof ZestRequest) {
-									req = (ZestRequest) ZestZapUtils
-											.getElement(prev);
-								}
-								showZestAssignDialog(parent, sn, req,
-										(ZestAssignment) obj, false);
+								ZestRequest req = getPreviousZestRequest(sn);
+								showZestAssignDialog(parent, sn, req, (ZestAssignment) obj, false);
 							} else if (obj instanceof ZestAction) {
 								showZestActionDialog(parent, sn, null,
 										(ZestAction) obj, false);


### PR DESCRIPTION
When more than one 'Assign variable to a form field' Node is below a RequestNode then the RequestNode is now is correctly determined.