### PR TITLE
Allow circular redirects in ZestScriptRequests. 

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.params.HttpClientParams;
 import org.apache.log4j.Logger;
 import org.mozilla.zest.core.v1.ZestAction;
 import org.mozilla.zest.core.v1.ZestActionFail;
@@ -94,6 +96,10 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     	
 	    this.setStopOnAssertFail(false);
 	    this.setStopOnTestFail(false);
+
+		HttpClient httpClient = new HttpClient();
+		httpClient.getParams().setBooleanParameter(HttpClientParams.ALLOW_CIRCULAR_REDIRECTS, true);
+		this.setHttpClient(httpClient);
 	    // Always proxy via ZAP
 		this.setProxy(Model.getSingleton().getOptionsParam().getProxyParam().getProxyIp(),
 				Model.getSingleton().getOptionsParam().getProxyParam().getProxyPort());


### PR DESCRIPTION
Because the detection of a circular redirect happens even if url-parameters are modified.