### PR TITLE
Add GET for POST Scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/GetForPostScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/GetForPostScanner.java
@@ -1,0 +1,149 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.util.TreeSet;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HtmlParameter;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+
+/**
+ * Active scan rule which checks whether or not POST requests with parameters
+ * are accepted as GET equivalent requests.
+ * 
+ * @author kingthorin+owaspzap@gmail.com
+ */
+public class GetForPostScanner extends AbstractAppPlugin {
+
+	private static final Logger LOG = Logger.getLogger(GetForPostScanner.class);
+	private static final String MESSAGE_PREFIX = "ascanalpha.getforpostscanner.";
+	private static final int PLUGIN_ID = 10058; 
+
+	@Override
+	public int getId() {
+		return PLUGIN_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "name");
+	}
+
+	@Override
+	public String getDescription() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+	}
+
+	@Override
+	public int getCategory() {
+		return Category.MISC;
+	}
+
+	@Override
+	public String getSolution() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+	}
+	
+	@Override
+	public String getReference() {
+		return null;
+	}
+
+	@Override
+	public void init() {
+
+	}
+
+	@Override
+	public void scan() {
+		// Check if the user stopped things. One request per URL so check before
+		// sending the request
+		if (isStop()) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Scanner " + getName() + " Stopping.");
+			}
+			return;
+		}
+		
+		HttpMessage baseMsg = getBaseMsg();
+		TreeSet<HtmlParameter> postParams = baseMsg.getFormParams();
+		if (!baseMsg.getRequestHeader().getMethod().equalsIgnoreCase(HttpRequestHeader.POST)
+				|| postParams.isEmpty()) {
+			return; //Not a POST or no form params, no reason to continue
+		}
+		
+		HttpMessage newRequest = getNewMsg();
+		newRequest.getRequestHeader().setMethod(HttpRequestHeader.GET);
+		newRequest.setFormParams(new TreeSet<HtmlParameter>());
+		for (HtmlParameter param : postParams) {
+			param.setType(HtmlParameter.Type.url);
+		}
+		newRequest.getRequestHeader().setGetParams(postParams);
+		
+		try {
+			sendAndReceive(newRequest);
+		} catch (IOException e) {
+			LOG.warn("An error occurred while checking [" + newRequest.getRequestHeader().getMethod() + "] ["
+					+ newRequest.getRequestHeader().getURI().toString() + "] for " + getName() + " Caught "
+					+ e.getClass().getName() + " " + e.getMessage());
+			return;
+		}
+		
+		if (newRequest.getResponseBody().equals(baseMsg.getResponseBody())) {
+			bingo(getRisk(), // Risk
+					Alert.CONFIDENCE_HIGH, // Confidence
+					getName(), // Name
+					getDescription(), // Description
+					baseMsg.getRequestHeader().getURI().toString(), // URI
+					null, // Param
+					"", // Attack
+					"", // OtherInfo
+					getSolution(), // Solution
+					newRequest.getRequestHeader().getPrimeHeader(), // Evidence
+					getCweId(), // CWE ID
+					getWascId(), // WASC ID
+					newRequest); // HTTPMessage
+		}
+		
+	}
+	
+	@Override
+	public int getRisk() {
+		return Alert.RISK_INFO;
+	}
+
+	@Override
+	public int getCweId() {
+		return 16;//Configuration
+	}
+
+	@Override
+	public int getWascId() {
+		return 20; //Improper Input Handling
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Correct handling of messages with emtpy path.<br>
+	Add Get for Post Scanner.<br>
   	]]>
 	</changes>
 	<extensions>
@@ -18,6 +19,7 @@
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleSimpleActiveScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleFileActiveScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ElmahScanner</ascanrule>
+		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.GetForPostScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.HttpOnlySite</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.HttpoxyScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.HttpsAsHttpScanner</ascanrule>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -31,6 +31,10 @@ ascanalpha.examplefile.other=This is for information that doesnt fit in any of t
 ascanalpha.examplefile.soln=A general description of how to solve the problem
 ascanalpha.examplefile.refs=http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html
 
+ascanalpha.getforpostscanner.name=GET for POST
+ascanalpha.getforpostscanner.desc=A request that was originally observed as a POST was also accepted as a GET. This issue does not represent a security weakness unto itself, however, it may facilitate simplification of other attacks. For example if the original POST is subject to Cross-Site Scripting (XSS), then this finding may indicate that a simplified (GET based) XSS may also be possible.
+ascanalpha.getforpostscanner.soln=Ensure that only POST is accepted where POST is expected.
+
 ascanalpha.httponlysite.name = HTTP Only Site
 ascanalpha.httponlysite.desc = The site is only served under HTTP and not HTTPS.
 ascanalpha.httponlysite.soln = Configure your web or application server to use SSL (https).

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -33,6 +33,12 @@ For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active
 <H2>Expression Language Injection</H2>
 The software constructs all or part of an expression language (EL) statement in a Java Server Page (JSP) using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended EL statement before it is executed. In certain versions of Spring 3.0.5 and earlier, there was a vulnerability (CVE-2011-2730) in which Expression Language tags would be evaluated twice, which effectively exposed any application to EL injection. However, even for later versions, this weakness is still possible depending on configuration.
 
+<H2>GET for POST Scanner</H2>
+This scanner takes <code>application/x-www-form-urlencoded</code> POST requests, changes the parameters from POST to GET and resubmits the request. 
+If the GET response is the same as the original POST response then an alert is raised. While this does not necessarily
+represent a security weakness unto itself it may indicate that other attacks or weaknesses can be expanded or simplified.
+(Such as a POST based Cross-Site Scripting (XSS) attack being changed to GET.)
+
 <H2>HTTP Only Site</H2>
 This active scanner checks whether an HTTP site is served under HTTPS.
 


### PR DESCRIPTION
Added a new active scanner that repeats POST requests as GET requests and raises an informational alert if the responses are the same.
Help updated, i18n message keys added, manifest changes and ascanrule sections updated.

Tested with XAMPP, based on the following PHP page:
```php
<?php
if (isset($_REQUEST['name']))
	//Displays the data that was received from the input box named name in the form
	echo ($_REQUEST['name']);
 ?>
 <hr>
 <!-- This is the html form that creates the input box and submit button -->
 <!-- The method for the form is in the line below -->
 <form action="test.php" method=POST>
 	Name:<br><input type="text" name="name"><br>
 	<input type="submit" value="Submit">
 </form>
```