### PR TITLE
pscanrules: fix FP with X-Content-Type-Options

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanner.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
+import java.util.Locale;
 import java.util.Vector;
 
 import net.htmlparser.jericho.Source;
@@ -70,7 +71,7 @@ public class XContentTypeOptionsScanner extends PluginPassiveScanner {
 			} else {
 				for (String xContentTypeOptionsDirective : xContentTypeOptions) {
 					//'nosniff' is currently the only defined value for this header, so this logic is ok
-					if (xContentTypeOptionsDirective.toLowerCase().indexOf("nosniff") < 0) {
+					if (xContentTypeOptionsDirective.toLowerCase(Locale.ROOT).indexOf("nosniff") < 0) {
 						this.raiseAlert(msg, id, xContentTypeOptionsDirective);
 					}
 				}

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Fix false positive with Secure Pages Include Mixed Content and JavaScript files (Issue 3581).<br>
 	Fix false positive with Private IP Disclosure when target is a private IP on a non-standard port (Issue 3549).<br>
+	Fix false positive with X-Content-Type-Options Header Missing with certain system locales.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change XContentTypeOptionsScanner to check if the header value is
present in a locale insensitive manner, in some locales it could lead to
an alert even if the header had the correct value.
Update changes in ZapAddOn.xml file.