### PR TITLE
Add WebSocket Sender script interface

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketSenderScript.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketSenderScript.java
@@ -1,0 +1,27 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.zaproxy.zap.extension.websocket;
+
+import javax.script.ScriptException;
+
+public interface WebSocketSenderScript {
+	void onMessageFrame(WebSocketMessage msg, WebSocketSenderScriptHelper helper) throws ScriptException;
+}

--- a/src/org/zaproxy/zap/extension/websocket/WebSocketSenderScriptHelper.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketSenderScriptHelper.java
@@ -1,0 +1,41 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.zaproxy.zap.extension.websocket;
+
+import org.zaproxy.zap.extension.websocket.WebSocketProxy.Initiator;
+
+public class WebSocketSenderScriptHelper {
+	private final int channelId;
+	private final Initiator initiator;
+
+	WebSocketSenderScriptHelper(int channelId, Initiator initiator) {
+		this.channelId = channelId;
+		this.initiator = initiator;
+	}
+
+	public int getChannelId() {
+		return channelId;
+	}
+
+	public Initiator getInitiator() {
+		return initiator;
+	}
+}

--- a/src/org/zaproxy/zap/extension/websocket/WebSocketSenderScriptListener.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketSenderScriptListener.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.websocket;
+
+import java.util.List;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.zaproxy.zap.extension.script.ExtensionScript;
+import org.zaproxy.zap.extension.script.ScriptWrapper;
+import org.zaproxy.zap.extension.websocket.WebSocketProxy.Initiator;
+import org.zaproxy.zap.extension.websocket.WebSocketProxy.State;
+
+/**
+ * @author Juha Kivekas
+ *
+ */
+public class WebSocketSenderScriptListener implements WebSocketSenderListener {
+	
+	private ExtensionScript extensionScript;
+
+	WebSocketSenderScriptListener(){
+		extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+	}
+
+	@Override
+	public int getListenerOrder() {
+		return 0;
+	}
+
+	@Override
+	public void onMessageFrame(int channelId, WebSocketMessage message,
+			Initiator initiator) {
+		List<ScriptWrapper> scripts = extensionScript.getScripts(ExtensionWebSocket.SCRIPT_TYPE_WEBSOCKET_SENDER);
+		WebSocketSenderScriptHelper helper = new WebSocketSenderScriptHelper(channelId, initiator);
+		for (ScriptWrapper script : scripts) {
+			try {
+				if (script.isEnabled()) {
+					WebSocketSenderScript s = extensionScript.getInterface(script, WebSocketSenderScript.class);
+					if (s != null) {
+						s.onMessageFrame(message, helper);
+					} else {
+						extensionScript.handleFailedScriptInterface(
+							script,
+							Constant.messages.getString("websocket.script.error.websocketsender", script.getName()));
+					}
+				}
+			} catch (Exception e) {
+				extensionScript.handleScriptException(script, e);
+			}
+		}
+	}
+
+	@Override
+	public void onStateChange(State state, WebSocketProxy proxy) { }
+}

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Remove usage of core filter functionality.<br>
 	Do not set messages when switching views if text view shows an error message (Issue 4108)<br>
 	Add rewind to fix issue #4149 <br>
+	Added Websocket Sender script interface <br>
 	]]>
 	</changes>
 	<classnames>
@@ -37,6 +38,7 @@
 	<filters/>
 	<files>
 		<file>scripts/templates/websocketfuzzerprocessor/Fuzzer WebSocket Processor default template.js</file>
+		<file>scripts/templates/websocketsender/WebsocketSender Default Template.js</file>
 	</files>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/websocket/files/scripts/templates/websocketsender/WebsocketSender Default Template.js
+++ b/src/org/zaproxy/zap/extension/websocket/files/scripts/templates/websocketsender/WebsocketSender Default Template.js
@@ -1,0 +1,12 @@
+// Note that new WebSocketSender scripts will initially be disabled
+// Right click the script in the Scripts tree and select "enable"  
+
+/**
+ * Called before forwarding the WebSocket message frame to the server or client.
+ * 
+ * @param {WebSocketMessage} msg - The message frame being sent or received.
+ * @param {WebSocketSenderScriptHelper} helper - Gives access to the websocket connection Initiator and the channelId.
+ */
+function onMessageFrame(msg, helper){
+	print(msg.getReadablePayload())
+}

--- a/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
@@ -93,3 +93,6 @@ websocket.fuzzer.processor.scriptProcessor.name = Fuzzer WebSocket Processor (Sc
 websocket.fuzzer.processor.scriptProcessor.panel.script.label = Script:
 websocket.fuzzer.processor.scriptProcessor.panel.warnNoScript.message = No script selected, a script must be selected first.
 websocket.fuzzer.processor.scriptProcessor.panel.warnNoScript.title = No Script Selected
+
+websocket.script.type.websocketsender = WebSocket Sender
+websocket.script.error.websocketsender = Error in WebSocket Sender script


### PR DESCRIPTION
This adds a feature to the websocket extension that provides a way to edit messages by calling scripts. The new WebSocket Sender script interface practically exposes the `onMessageFrame` to the user so that quick processing, logging or modification of WebSocket messages can be performed more easily.

This might not be a commonly wanted functionality, but even if this is not merged, I'd gladly take some comments with later contributions in mind.