### PR TITLE
Server Header Info Leak LOW Threshold Alert

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ServerHeaderInfoLeakScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ServerHeaderInfoLeakScanner.java
@@ -28,6 +28,7 @@ import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -39,7 +40,6 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  */
 public class ServerHeaderInfoLeakScanner extends PluginPassiveScanner{
 
-	private static final String MESSAGE_PREFIX = "pscanalpha.serverheaderversioninfoleak.";
 	private static final int PLUGIN_ID = 10036;
 	
 	private PassiveScanThread parent = null;
@@ -69,21 +69,19 @@ public class ServerHeaderInfoLeakScanner extends PluginPassiveScanner{
 				if (matched) { //See if there's any version info.
 					//While an alpha string might be the server type (Apache, Netscape, IIS, etc) 
 					//that's much less of a head-start than actual version details.
-					Alert alert = new Alert(getPluginId(), Alert.RISK_LOW, Alert.CONFIDENCE_MEDIUM, //PluginID, Risk, Reliability
-						getName()); 
-		    			alert.setDetail(
-		    					getDescription(), //Description
-		    					msg.getRequestHeader().getURI().toString(), //URI
-		    					"",	// Param
-		    					"", // Attack
-		    					"", // Other info
-		    					getSolution(), //Solution
-		    					getReference(), //References
-		    					serverDirective,	// Evidence - Return the Server Header info
-		    					200, // CWE Id 
-		    					13,	// WASC Id 
-		    					msg); //HttpMessage
-		    		parent.raiseAlert(id, alert);
+					raiseAlert(Alert.RISK_LOW, Alert.CONFIDENCE_HIGH,
+							Constant.messages.getString("pscanalpha.serverheaderversioninfoleak.name"),
+							Constant.messages.getString("pscanalpha.serverheaderversioninfoleak.desc"),
+							Constant.messages.getString("pscanalpha.serverheaderinfoleak.general.soln"),
+							Constant.messages.getString("pscanalpha.serverheaderinfoleak.general.refs"),
+							serverDirective, msg, id);
+				} else if (Plugin.AlertThreshold.LOW.equals(this.getLevel())) {
+					raiseAlert(Alert.RISK_INFO, Alert.CONFIDENCE_HIGH,
+							Constant.messages.getString("pscanalpha.serverheaderinfoleak.name"),
+							Constant.messages.getString("pscanalpha.serverheaderinfoleak.desc"),
+							Constant.messages.getString("pscanalpha.serverheaderinfoleak.general.soln"),
+							Constant.messages.getString("pscanalpha.serverheaderinfoleak.general.refs"),
+							serverDirective, msg, id);
 				}
 			}
 		}
@@ -99,19 +97,24 @@ public class ServerHeaderInfoLeakScanner extends PluginPassiveScanner{
 	
 	@Override
 	public String getName(){
-		return Constant.messages.getString(MESSAGE_PREFIX + "name");
+		return Constant.messages.getString("pscanalpha.serverheader.scanner.name");
 	}
 	
-	private String getDescription() {
-		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-	}
-
-	private String getSolution() {
-		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-	}
-
-	private String getReference() {
-		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+	private void raiseAlert(int risk, int confidence, String name, String desc, String soln, String refs, String evidence, HttpMessage msg, int id) {
+		Alert alert = new Alert(getPluginId(), risk, confidence, // PluginID, Risk, Reliability
+				name);
+		alert.setDetail(desc, // Description
+				msg.getRequestHeader().getURI().toString(), // URI
+				"", // Param
+				"", // Attack
+				"", // Other info
+				soln, // Solution
+				refs, // References
+				evidence, // Evidence - Return the Server Header info
+				200, // CWE Id
+				13, // WASC Id
+				msg); // HttpMessage
+		parent.raiseAlert(id, alert);
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+	HTTP "Server" response header, report any "Server" header if Threshold is LOW.<br> 
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -128,12 +128,13 @@ pscanalpha.crossdomain.soln=Ensure that sensitive data is not available in an un
 pscanalpha.crossdomain.refs=http://www.hpenterprisesecurity.com/vulncat/en/vulncat/vb/html5_overly_permissive_cors_policy.html
 pscanalpha.crossdomain.extrainfo=The CORS misconfiguration on the web server permits cross-domain read requests from arbitrary third party domains, using unauthenticated APIs on this domain. Web browser implementations do not permit arbitrary third parties to read the response from authenticated APIs, however. This reduces the risk somewhat. This misconfiguration could be used by an attacker to access data that is available in an unauthenticated manner, but which uses some other form of security, such as IP address white-listing.
 
+pscanalpha.serverheader.scanner.name=HTTP Server Response Header Scanner
 pscanalpha.serverheaderversioninfoleak.name=Server Leaks Version Information via "Server" HTTP Response Header Field
 pscanalpha.serverheaderversioninfoleak.desc=The web/application server is leaking version information via the "Server" HTTP response header. Access to such information may facilitate attackers identifying other vulnerabilities your web/application server is subject to.
-pscanalpha.serverheaderversioninfoleak.refs=http://httpd.apache.org/docs/current/mod/core.html#servertokens\nhttp://msdn.microsoft.com/en-us/library/ff648552.aspx#ht_urlscan_007\nhttp://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx\nhttp://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html
-pscanalpha.serverheaderversioninfoleak.soln=Ensure that your web server, application server, load balancer, etc. is configured to suppress the "Server" header or provide generic details.
-pscanalpha.serverheaderversioninfoleak.exploit=
-pscanalpha.serverheaderversioninfoleak.extrainfo=
+pscanalpha.serverheaderinfoleak.name=Server Leaks its Webserver Application via "Server" HTTP Response Header Field
+pscanalpha.serverheaderinfoleak.desc=The web/application server is leaking the application it uses as a webserver via the "Server" HTTP response header. Access to such information may facilitate attackers identifying other vulnerabilities your web/application server is subject to. This information alone, i.e. without a version string, is not very dangerous for the security of a server, nevertheless this information in the response header field is almost always useless and thus just an obsolete attacking vector.
+pscanalpha.serverheaderinfoleak.general.refs=http://httpd.apache.org/docs/current/mod/core.html#servertokens\nhttp://msdn.microsoft.com/en-us/library/ff648552.aspx#ht_urlscan_007\nhttp://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx\nhttp://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html
+pscanalpha.serverheaderinfoleak.general.soln=Ensure that your web server, application server, load balancer, etc. is configured to suppress the "Server" header or provide generic details.
 
 pscanalpha.stricttransportsecurity.scanner.name=Strict-Transport-Security Header Scanner
 pscanalpha.stricttransportsecurity.name=Strict-Transport-Security Header Not Set

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -112,8 +112,9 @@ Proxy". </p>
 <H2>Open Redirect</H2>
 Open redirects are one of the OWASP 2010 Top Ten vulnerabilities. This check looks at user-supplied input in query string parameters and POST data to identify where open redirects might be possible. Open redirects occur when an application allows user-supplied input (e.g. http://nottrusted.com) to control an offsite redirect. This is generally a pretty accurate way to find where 301 or 302 redirects could be exploited by spammers or phishing attacks
 
-<H2>Server Header Version Information Leak</H2>
+<H2>HTTP Server Response Header Scanner</H2>
 This checks response headers for the presence of a server header that contains version details.
+At LOW Threshold will raise an alert based on presence of the header field whether or not a version string is detected.
 
 <H2>Source Code Disclosure</H2>
 Application Source Code was disclosed by the web server


### PR DESCRIPTION
In follow-up to https://github.com/zaproxy/zap-extensions/pull/879, recreate changes and apply at LOW threshold (more tolerant to false positives).

Updated manifest changes section, it does not appear that v16 of the add-on has been released yet.

Thanks @rain0r