### PR TITLE
Update webdriver add-ons for new versions

### DIFF
--- a/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
@@ -1,15 +1,14 @@
 <zapaddon>
 	<name>Linux WebDrivers</name>
-	<version>2</version>
+	<version>3</version>
 	<status>beta</status>
 	<description>Linux WebDrivers for Firefox and Chrome.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Update geckodriver to v0.14.0<br>
-	Download files from zap-libs repo<br>
-	Promote to beta<br>
+	Update geckodriver to v0.18.0<br>
+	Update chromedriver to 2.31<br>
 	]]>
 	</changes>
 	<extensions/>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
@@ -1,15 +1,14 @@
 <zapaddon>
 	<name>MacOS WebDrivers</name>
-	<version>2</version>
+	<version>3</version>
 	<status>beta</status>
 	<description>MacOS WebDrivers for Firefox and Chrome.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Update geckodriver to v0.14.0<br>
-	Download files from zap-libs repo<br>
-	Promote to beta<br>
+	Update geckodriver to v0.18.0<br>
+	Update chromedriver to 2.31<br>
 	]]>
 	</changes>
 	<extensions/>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
@@ -1,15 +1,15 @@
 <zapaddon>
 	<name>Windows WebDrivers</name>
-	<version>2</version>
+	<version>3</version>
 	<status>beta</status>
 	<description>Windows WebDrivers for Firefox, Chrome and IE.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Update geckodriver to v0.14.0<br>
-	Download files from zap-libs repo<br>
-	Promote to beta<br>
+	Update geckodriver to v0.18.0<br>
+	Update chromedriver to 2.31<br>
+	Update IEDriverServer to 3.4.0<br>
 	]]>
 	</changes>
 	<extensions/>


### PR DESCRIPTION
Driver file updated via https://github.com/zaproxy/zap-libs/pull/8
Part of https://github.com/zaproxy/zaproxy/issues/3789