### PR TITLE
domxss: use Selenium extension and add skip reason

### DIFF
--- a/src/org/zaproxy/zap/extension/domxss/ExtensionDomXSS.java
+++ b/src/org/zaproxy/zap/extension/domxss/ExtensionDomXSS.java
@@ -18,15 +18,60 @@
 
 package org.zaproxy.zap.extension.domxss;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.PluginFactory;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 
 /**
- * A null extension just to cause the message bundle and help file to get loaded 
+ * The extension responsible to add the DOM XSS active scanner.
+ * 
  * @author psiinon
- *
  */
 public class ExtensionDomXSS extends ExtensionAdaptor {
+
+	private static final List<Class<?>> DEPENDENCIES;
+
+	static {
+		List<Class<?>> dependencies = new ArrayList<>(1);
+		dependencies.add(ExtensionSelenium.class);
+
+		DEPENDENCIES = Collections.unmodifiableList(dependencies);
+	}
+
+	private TestDomXSS scanner;
+
+	@Override
+	public void init() {
+		super.init();
+
+		scanner = new TestDomXSS();
+		scanner.setStatus(getAddOn().getStatus());
+	}
+
+	@Override
+	public List<Class<?>> getDependencies() {
+		return DEPENDENCIES;
+	}
+
+	@Override
+	public void hook(ExtensionHook extensionHook) {
+		super.hook(extensionHook);
+
+		PluginFactory.loadedPlugin(scanner);
+	}
+
+	@Override
+	public void unload() {
+		super.unload();
+
+		PluginFactory.unloadedPlugin(scanner);
+	}
 
 	@Override
 	public String getAuthor() {

--- a/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
@@ -7,26 +7,26 @@
 	<url/>
 	<changes>
 	<![CDATA[
-	 <br>
+	Allow to use newer versions of Firefox (Issue 3396).<br>
+	Provide the reason why the scanner was skipped.<br>
 	]]>
     </changes>
 	<dependencies>
+		<javaversion>1.8</javaversion>
 		<addons>
 			<addon>
 				<id>selenium</id>
-				<not-before-version>7</not-before-version>
+				<semver>2.*</semver>
 			</addon>
 		</addons>
 	</dependencies>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.domxss.ExtensionDomXSS</extension>
 	</extensions>
-	<ascanrules>
-		<ascanrule>org.zaproxy.zap.extension.domxss.TestDomXSS</ascanrule>
-	</ascanrules>
+	<ascanrules />
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.1</not-before-version>
+	<not-before-version>2.6.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/domxss/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/domxss/resources/Messages.properties
@@ -4,3 +4,4 @@
 
 domxss.name				= Cross Site Scripting (DOM Based)
 domxss.desc				= DOM XSS Active Scan Rule
+domxss.skipped.reason.browsererror = failed to start or connect to the browser


### PR DESCRIPTION
Change ExtensionDomXSS to depend on ExtensionSelenium and to dynamically
add/remove the active scanner (TestDomXSS), to ensure the extension is
always available to the scanner.
Change TestDomXSS to use ExtensionSelenium to obtain the WebDriver,
which uses the latest/correct WebDriver implementation to connect to
Firefox (geckodriver/marionette instead of xpi add-on). Also, set the
reason why the scanner was skipped when failed to use the browser.
Update changes, minimum Java/ZAP version and Selenium add-on version in
ZapAddOn.xml file.

Fix zaproxy/zaproxy#3396 - Enhance DOM XSS scanner addon to use Selenium
addon
Related to zaproxy/zaproxy#3509 - Update Selenium library to version 3.x