### PR TITLE
Install ant-optional in Travis CI builds (beta)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ language: java
 script: ant -buildfile build/build.xml test
 sudo: false
 
+# Issue travis-ci/travis-ci#7706
+addons:
+  apt:
+    packages:
+      - ant-optional 
+
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Change .travis.yml to install the package ant-optional, required to run
the tests with newer dist trusty.