### PR TITLE
selenium: correct insecure certs capability

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -568,6 +568,10 @@ public class ExtensionSelenium extends ExtensionAdaptor {
 
     private static WebDriver getWebDriverImpl(Browser browser, String proxyAddress, int proxyPort) {
         DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
+        // W3C capability
+        capabilities.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
+
         if (proxyAddress != null) {
             String httpProxy = proxyAddress + ":" + proxyPort;
             Proxy proxy = new Proxy();
@@ -602,12 +606,13 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                 options.addPreference("network.proxy.ssl_port", proxyPort);
                 options.addPreference("network.proxy.share_proxy_settings", true);
                 options.addPreference("network.proxy.no_proxies_on", "");
+                // And remove the PROXY capability:
+                capabilities.setCapability(CapabilityType.PROXY, (Object) null);
             }
 
-            // Since Firefox 53, https://bugzilla.mozilla.org/show_bug.cgi?id=1103196
-            options.addPreference("acceptInsecureCerts", true);
+            options.addTo(capabilities);
 
-            return new FirefoxDriver(options.toCapabilities());
+            return new FirefoxDriver(capabilities);
         case HTML_UNIT:
             return new HtmlUnitDriver(DesiredCapabilities.htmlUnit().merge(capabilities));
         case INTERNET_EXPLORER:


### PR DESCRIPTION
Change ExtensionSelenium to set the insecure cert capability as an
actual capability instead of as a preference of Firefox (broken when
changing for Selenium 3), also, set it to all browsers to ensure all of
them accept the insecure certs (e.g. ZAP's Root CA cert).