### PR TITLE
Fix the QuickStart default browser

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/src/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.swing.ComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
@@ -113,6 +114,27 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor implements
     }
 
     @Override
+    public void postInit() {
+        if (getView() != null) {
+            // Plugable browsers (like JxBrowser) can be added after this add-ons 
+            // options have been loaded
+            String def = this.getQuickStartLaunchParam().getDefaultBrowser();
+            if (def == null || def.length() == 0) {
+                // no default
+                return;
+            }
+            ComboBoxModel<ProvidedBrowserUI> model = this.getBrowserComboBox().getModel();
+            for (int idx = 0; idx < model.getSize(); idx++) {
+                ProvidedBrowserUI el = model.getElementAt(idx);
+                if (el.getName().equals(def)) {
+                    model.setSelectedItem(el);
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
     public void optionsLoaded() {
         super.optionsLoaded();
         if (View.isInitialised()) {
@@ -120,9 +142,6 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor implements
             // later
             defaultLaunchContent = Constant.messages
                     .getString("quickstart.launch.html");
-    
-            getBrowserComboBox().setSelectedItem(
-                    this.getQuickStartLaunchParam().getDefaultBrowser());
         }
 
         if (!getQuickStartLaunchParam().isZapStartPage()) {
@@ -283,6 +302,7 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor implements
                                                     getBrowserComboBox()
                                                             .getSelectedItem()
                                                             .toString());
+                                    getQuickStartLaunchParam().getConfig().save();
                                 }
                             } catch (Exception e1) {
                                 LOGGER.error(e1.getMessage(), e1);

--- a/src/org/zaproxy/zap/extension/quickstart/launch/QuickStartLaunchParam.java
+++ b/src/org/zaproxy/zap/extension/quickstart/launch/QuickStartLaunchParam.java
@@ -41,8 +41,10 @@ public class QuickStartLaunchParam extends AbstractParam {
 
     private static final String BLANK_START_PAGE = "BLANK";
 
+    private static final String DEFAULT_BROWSER = "JxBrowser";   // The default default ;)
+
     private String startPage;
-    private String defaultBrowser = "JxBrowser"; // The default default ;)
+    private String defaultBrowser = DEFAULT_BROWSER;
 
     @Override
     protected void parse() {
@@ -52,7 +54,7 @@ public class QuickStartLaunchParam extends AbstractParam {
             LOGGER.error("Failed to load the \"Start Page\" configuration", e);
         }
         try {
-            defaultBrowser = getConfig().getString(PARAM_DEFAULT_BROWSER, "");
+            defaultBrowser = getConfig().getString(PARAM_DEFAULT_BROWSER, DEFAULT_BROWSER);
         } catch (Exception e) {
             LOGGER.error(
                     "Failed to load the \"Default Browser\" configuration", e);


### PR DESCRIPTION
It wasnt getting initialised correctly - it just defaulted to the first one every time.
It should now default initially to JxBrowser (if installed) and then to whichever browser was last launched (not just selected).
Note that the selenium changes arent actually needed, but they might be useful for other add-ons