### PR TITLE
selenium: update known working browser versions

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
@@ -26,7 +26,8 @@
 		<tr>
 			<td>Chrome</td>
 			<td>chrome</td>
-			<td>Requires ChromeDriver, if not on the system's PATH, it can be set in the
+			<td>The following versions are known to work: 59 and 60 (older versions might work
+				too). Requires ChromeDriver, if not on the system's PATH, it can be set in the
 				options. For more information on ChromeDriver and how to obtain it refer to the <a
 				href="https://sites.google.com/a/chromium.org/chromedriver/">ChromeDriver website</a>.
 			</td>
@@ -34,8 +35,8 @@
 		<tr>
 			<td>Firefox</td>
 			<td>firefox</td>
-			<td>The following versions are known to work: 45 (ESR), 46 and 47.0.1 (older
-				version might work too). Some versions are known to not work, for example, 47.0. Newer
+			<td>The following versions are known to work: 45 (ESR), 46, 47.0.1, 54, and 55 (older
+				versions might work too). Some versions are known to not work, for example, 47.0. Newer
 				versions (&ge; 48) require geckodriver, it can be set in the options. For more
 				information on geckodriver and how to obtain it refer to the <a
 				href="https://github.com/mozilla/geckodriver">geckodriver website</a> (see footer note
@@ -50,8 +51,9 @@
 		<tr>
 			<td>Internet Explorer</td>
 			<td>ie</td>
-			<td>Requires IEDriverServer, if not on the system's PATH, it can be set in the
-				options. For more information on IEDriverServer refer to the <a
+			<td>The following version is known to work: 11 (older versions might work too).
+				Requires IEDriverServer, if not on the system's PATH, it can be set in the options.
+				For more information on IEDriverServer refer to the <a
 				href="https://code.google.com/p/selenium/wiki/InternetExplorerDriver">IEDriverServer
 					website</a> (see footer note for caveat when using Internet Explorer).
 			</td>
@@ -59,13 +61,14 @@
 		<tr>
 			<td>Opera</td>
 			<td>opera</td>
-			<td>&nbsp;</td>
+			<td>Temporarily not working.</td>
 		</tr>
 		<tr>
 			<td>PhantomJS</td>
 			<td>phantomjs</td>
-			<td>requires PhantomJS binary, if not on the system's PATH, it can be set in the
-				options. For more information on PhantomJS and how to obtain it refer to the <a
+			<td>The following version is known to work: 2.1.1 (older versions might work too).
+				Requires PhantomJS binary, if not on the system's PATH, it can be set in the options.
+				For more information on PhantomJS and how to obtain it refer to the <a
 				href="http://phantomjs.org/">PhantomJS website</a> (see footer note for caveat when
 				using PhantomJS).
 			</td>


### PR DESCRIPTION
Change Selenium help page to add the newer versions known to work with
bundled WebDrivers.