### PR TITLE
fuzz: use custom type for temporary HTTP messages

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzerResultsTableModel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzerResultsTableModel.java
@@ -88,7 +88,8 @@ public class HttpFuzzerResultsTableModel extends
             final HistoryReference href = result.getHttpMessage().getHistoryRef() != null ? result.getHttpMessage()
                     .getHistoryRef() : new HistoryReference(
                     Model.getSingleton().getSession(),
-                    HistoryReference.TYPE_TEMPORARY,
+                    // TODO Replace 20 with HistoryReference.TYPE_FUZZER_TEMPORARY once available.
+                    20,
                     result.getHttpMessage());
 
             EventQueue.invokeLater(new Runnable() {


### PR DESCRIPTION
Change HttpFuzzerResultsTableModel to use a custom history type for the
temporary messages created during fuzzing sessions, allowing to obtain
the messages through the ZAP API.

 ---
From talks in IRC channel.