### PR TITLE
ascanrulesBeta: notify the msgs sent by Heartbleed

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
@@ -577,6 +577,8 @@ public class HeartBleedActiveScanner extends AbstractHostPlugin {
 					if (log.isDebugEnabled()) 
 						log.debug("Wrote the Client Hello");
 
+					getParent().notifyNewMessage(this);
+
 					//read through messages until we get a handshake message back from the server
 					try {
 						while (true) {
@@ -667,6 +669,8 @@ public class HeartBleedActiveScanner extends AbstractHostPlugin {
 		os.write(heartbeatRecordByte);
 		os.write(tlsVersionBuffer);
 		os.write(heartbeatBuffer);
+
+		getParent().notifyNewMessage(this);
 
 		if (log.isDebugEnabled()) log.debug("Wrote the dodgy heartbeat message");
 

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Fix FP in "Integer Overflow Error" on 500 error responses (Issue 3064).<br>
 	Support security annotations for forms that dont need anti-CSRF tokens.<br>
 	Changed XXE rule to use new callback extension.<br>
+	Notify of messages sent during Heartbleed scanning (Issue 2425).<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change HeartBleedActiveScanner to notify when sending SSL/TLS msg/data.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2425 - Change active scanners to notify that a
(non-HTTP) message was sent