### PR TITLE
Fix false positives in Path Traversal

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
@@ -612,7 +612,13 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
         @Override
         public String match(String contents) {
             if (contents.contains("etc") && contents.contains("bin") && contents.contains("boot")) {
-                return "etc";
+                Pattern nixDoubleCheckPattern = Pattern.compile("\\betc\\b");
+                Matcher nixDoubleCheckMatcher = nixDoubleCheckPattern.matcher(contents);
+
+                if (nixDoubleCheckMatcher.find())
+                {
+                    return "etc";
+                }
             }
 
             if (contents.contains("Windows") && Pattern.compile("Program\\sFiles").matcher(contents).find()) {

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Issue 1365: Additional Path Traversal detection.<br>
 	Correct alert's evidence/attack of Parameter Tampering (Issue 3524).<br>
+	Fix Path Traversal false positives when etc is a substring (Issue 3735).<br>
 	]]>
     </changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
@@ -154,6 +154,18 @@ public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTravers
     }
 
     @Test
+    public void shouldNotAlertIfAttackResponseListsBogusLinuxDirectories() throws Exception {
+        // Given
+        nano.addHandler(new ListBogusLinuxDirsOnAttack("/", "p", "/"));
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+
+    }
+    
+    @Test
     public void shouldNotAlertIfLocalFilePathTraversalDoesNotExist() throws Exception {
         // Given
         nano.addHandler(new LocalFileHandler("/", "p", ""));
@@ -210,6 +222,22 @@ public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTravers
                 + "<td><a href=\"/boot/\">boot</a></td>";
 
         public ListLinuxDirsOnAttack(String path, String param, String attack) {
+            super(path, param, attack);
+        }
+
+        @Override
+        protected String getDirs() {
+            return DIRS_LISTING;
+        }
+    }
+    
+    private static class ListBogusLinuxDirsOnAttack extends ListDirsOnAttack {
+
+        private static final String DIRS_LISTING = "<td><a href=\"/bin/\">bin</a></td>"
+                + "<td><a href=\"/getChoice/\">getChoice</a></td>" // Matches etc but isn't etc 
+                + "<td><a href=\"/boot/\">boot</a></td>";
+
+        public ListBogusLinuxDirsOnAttack(String path, String param, String attack) {
             super(path, param, attack);
         }
 


### PR DESCRIPTION
Add a secondary check that ensures "etc" is not a substring of a larger word (for example: getChoice).
Add a unit test for the same.

Fixes zaproxy/zaproxy#3735