### PR TITLE
Issue 3449 CSRFcountermeasures scanner handling multiple forms

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Minor changes to InsecureJFSViewStatePassiveScanner (check response contains JSF viewstate or if it's server stored).<br/>
 	Improve the domain matching in CookieLooselyScopedScanner.<br/>
+	Issue 3449: CSRFcountermeasures passive scanner now raises alerts on a per-form basis on pages with multiple forms.</br> 
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -69,7 +69,7 @@ pscanbeta.insecurejsfviewstate.extrainfo=JSF ViewState [{0}] is insecure
 
 pscanbeta.noanticsrftokens.name=Absence of Anti-CSRF Tokens
 pscanbeta.noanticsrftokens.desc=No Anti-CSRF tokens were found in a HTML submission form.
-pscanbeta.noanticsrftokens.alert.extrainfo=No known Anti-CSRF tokens {0} were found in the following HTML forms: {1}.
+pscanbeta.noanticsrftokens.alert.extrainfo=No known Anti-CSRF token {0} was found in the following HTML form: {1}.
 pscanbeta.noanticsrftokens.extrainfo.annotation=This is an informational alert as the form has a security annotation indicating that it does not need an anti-CSRF Token. This should be tested manually to ensure the annotation is correct.
 
 pscanbeta.servletparameterpollutionscanner.name=HTTP Parameter Override

--- a/test/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasuresUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasuresUnitTest.java
@@ -140,7 +140,7 @@ public class CSRFCountermeasuresUnitTest extends PassiveScannerTest {
 	}
 
 	@Test
-	public void shouldNotRaiseAlertWhenSecondFormHasAKnownCSRFToken() {
+	public void shouldRaiseOneAlertForOneFormWhenSecondFormHasAKnownCSRFToken() {
 		//Given
 		msg.setResponseBody("<html><head></head><body>"
 				+ "<form id=\"second_form\"><input type=\"text\" name=\"name\"/><input type=\"submit\"/></form>"
@@ -149,7 +149,38 @@ public class CSRFCountermeasuresUnitTest extends PassiveScannerTest {
 		//When
 		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
 		//Then
-		assertEquals(0, alertsRaised.size());
+		assertEquals(1, alertsRaised.size());
+		assertEquals(alertsRaised.get(0).getEvidence(), "<form id=\"second_form\">");
+	}
+	
+	@Test
+	public void shouldRaiseOneAlertForOneFormWhenFirstFormOfTwoHasAKnownCSRFToken() {
+		//Given
+		msg.setResponseBody("<html><head></head><body>"
+				+ "<form id=\"first_form\"><input type=\"text\" name=\"csrfToken\"/><input type=\"submit\"/></form>"
+				+ "<form id=\"second_form\"><input type=\"text\" name=\"name\"/><input type=\"submit\"/></form>"
+				+ "</body></html>");
+		//When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		//Then
+		assertEquals(1, alertsRaised.size());
+		assertEquals(alertsRaised.get(0).getEvidence(), "<form id=\"second_form\">");
+	}
+	
+	@Test
+	public void shouldRaiseTwoAlertsForTwoFormsWhenOneOfThreeHasAKnownCSRFToken() {
+		//Given
+		msg.setResponseBody("<html><head></head><body>"
+				+ "<form id=\"zeroth_form\" action=\"someaction\"><input type=\"text\" name=\"zero\"/><input type=\"submit\"/></form>"
+				+ "<form id=\"first_form\"><input type=\"text\" name=\"csrfToken\"/><input type=\"submit\"/></form>"
+				+ "<form id=\"second_form\"><input type=\"text\" name=\"name\"/><input type=\"submit\"/></form>"
+				+ "</body></html>");
+		//When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		//Then
+		assertEquals(2, alertsRaised.size());
+		assertEquals(alertsRaised.get(0).getEvidence(), "<form id=\"zeroth_form\" action=\"someaction\">");
+		assertEquals(alertsRaised.get(1).getEvidence(), "<form id=\"second_form\">");
 	}
 
 	@Test


### PR DESCRIPTION
* Alerts are now raised on a per-form basis.
* Unit tests updated.
* Messages.properties resource message updated to align with new behavior.
* ZapAddOn.xml updated changes section.

Fixes zaproxy/zaproxy#3449