### PR TITLE
spiderAjax: address tasks

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -235,11 +235,11 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 
 		switch (Control.getSingleton().getMode()) {
 		case safe:
-			throw new ApiException(getModeViolationType());
+			throw new ApiException(ApiException.Type.MODE_VIOLATION);
 		case protect:
 			if ((validateUrl && !Model.getSingleton().getSession().isInScope(url))
 					|| (context != null && !context.isInScope())) {
-				throw new ApiException(getModeViolationType());
+				throw new ApiException(ApiException.Type.MODE_VIOLATION);
 			}
 			// No problem
 			break;
@@ -270,15 +270,6 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 			new Thread(spiderThread, "ZAP-AjaxSpiderApi").start();
 		} catch (Exception e) {
 			logger.error(e);
-		}
-	}
-
-	// XXX replace calls with ApiException.Type.MODE_VIOLATION once targeting newer ZAP version (>= 2.5.0)
-	private static ApiException.Type getModeViolationType() {
-		try {
-			return ApiException.Type.valueOf("MODE_VIOLATION");
-		} catch (IllegalArgumentException e) {
-			return ApiException.Type.ILLEGAL_PARAMETER;
 		}
 	}
 

--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
@@ -342,7 +342,7 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
      */
     @Override
     public void save() {
-    	AjaxSpiderParam params = this.extension.getAjaxSpiderParam().clone();
+    	AjaxSpiderParam params = (AjaxSpiderParam) this.extension.getAjaxSpiderParam().clone();
     	
         String selectedBrowser = getSelectedBrowser();
         if (selectedBrowser != null) {

--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -22,9 +22,7 @@ package org.zaproxy.zap.extension.spiderAjax;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.configuration.FileConfiguration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.log4j.Logger;
 import org.zaproxy.zap.common.VersionedAbstractParam;
@@ -281,19 +279,6 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
             // Remove old version element, from now on the version is saved as an attribute of root element
             getConfig().clearProperty(OLD_CONFIG_VERSION_KEY);
         }
-    }
-
-    // TODO remove the override once AbstractParam is released with the clone method fixed (see Issue 2151).
-    @Override
-    public AjaxSpiderParam clone() {
-        try {
-            AjaxSpiderParam clone = new AjaxSpiderParam();
-            clone.load((FileConfiguration) ConfigurationUtils.cloneConfiguration(getConfig()));
-            return clone;
-        } catch (Exception e) {
-            logger.error(e.getMessage(), e);
-        }
-        return null;
     }
 
     public int getNumberOfBrowsers() {

--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
@@ -246,11 +246,9 @@ public class AjaxSpiderResultsTableModel
         public void eventReceived(Event event) {
             switch (event.getEventType()) {
             case AlertEventPublisher.ALERT_ADDED_EVENT:
-                // TODO Replace once available in the zap.jar AlertEventPublisher.ALERT_CHANGED_EVENT
-            case "alert.changed":
+            case AlertEventPublisher.ALERT_CHANGED_EVENT:
             case AlertEventPublisher.ALERT_REMOVED_EVENT:
-                // TODO Replace once available in the zap.jar AlertEventPublisher.HISTORY_REFERENCE_ID
-                refreshEntry(Integer.valueOf(event.getParameters().get("historyId")));
+                refreshEntry(Integer.valueOf(event.getParameters().get(AlertEventPublisher.HISTORY_REFERENCE_ID)));
                 break;
             case AlertEventPublisher.ALL_ALERTS_REMOVED_EVENT:
             default:
@@ -289,7 +287,6 @@ public class AjaxSpiderResultsTableModel
             });
         }
 
-        // TODO Remove once available in the zap.jar.
         public void refreshEntryRows() {
             if (getRowCount() == 0) {
                 return;

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -1,14 +1,12 @@
 <zapaddon>
 	<name>Ajax Spider</name>
-	<version>18</version>
+	<version>19</version>
 	<status>release</status>
 	<description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
-	Update to support Selenium version 3.4.0 (Issue 3509).<br>
-	Fix WebDriver process leak (Issue 3155).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Address pending tasks that required newer version of ZAP (already
targeting 2.6.0).
Bump version and remove old changes from ZapAddOn.xml file.