### PR TITLE
scripts: update links in help page

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
@@ -11,10 +11,10 @@ The ZAP Script Add-on allows you to run scripts that can be embedded within ZAP 
 It supports any scripting language that supports JSR 223 (http://www.jcp.org/en/jsr/detail?id=223) , including:
 <ul>
 <li>ECMAScript / Javascript (included by default)</li>
-<li>Zest https://developer.mozilla.org/en-US/docs/zest (included by default)</li>
-<li>Groovy http://groovy.codehaus.org/</li>
-<li>Python http://www.jython.org</li>
-<li>Ruby - http://jruby.org/</li>
+<li>Zest <a href="https://developer.mozilla.org/en-US/docs/zest">https://developer.mozilla.org/en-US/docs/zest</a> (included by default)</li>
+<li>Groovy <a href="http://groovy-lang.org/">http://groovy-lang.org/</a></li>
+<li>Python <a href="http://www.jython.org">http://www.jython.org</a></li>
+<li>Ruby - <a href="http://jruby.org/">http://jruby.org/</a></li>
 <li>and many more...</li> 
 </ul>
 
@@ -81,11 +81,11 @@ Note that these methods are only usable from scripting languages that provide ac
 <table>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-	<td>https://github.com/zaproxy/zaproxy/wiki/InternalDetails</td>
+	<td><a href="https://github.com/zaproxy/zaproxy/wiki/InternalDetails">https://github.com/zaproxy/zaproxy/wiki/InternalDetails</a></td>
 	<td>ZAP internal objects</td></tr>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-	<td>https://github.com/zaproxy/zaproxy/wiki/JavaDocs</td>
+	<td><a href="https://javadoc.io/doc/org.zaproxy/zap">https://javadoc.io/doc/org.zaproxy/zap</a></td>
 	<td>ZAP javadocs</td>
 </tr>
 </table>


### PR DESCRIPTION
Update outdated links (Groovy and JavaDoc) and make all of them
hyperlinks (a tags), ZAP help can open them in an external browser.