### PR TITLE
scripts: use selected font in script text area

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
+++ b/src/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.scripts;
 
 import java.awt.Component;
+import java.awt.Font;
 import java.util.List;
 import java.util.Vector;
 
@@ -115,8 +116,12 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
 		setCloseMarkupTags(false);
 		setClearWhitespaceLinesEnabled(false);
 		
-		// Correct the font size
-		this.setFont(FontUtils.getFont(this.getFont().getFontName()));
+		Font font = FontUtils.getFont(Font.PLAIN);
+		if (font.getName().isEmpty()) {
+			// Use default RSyntaxTextArea font instead but with correct font size.
+			font = FontUtils.getFont(this.getFont().getFontName());
+		}
+		this.setFont(font);
 
 	}
 	

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Invoke Scripts tree context menu once.<br>
 	Title caps adjustments (related to Issue 2000).<br>
 	Allow to configure the enabled state of new/loaded scripts (Issue 2996).<br>
+	Use selected font in script text area.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change SyntaxHighlightTextArea to use the font selected in the options
or use default font of the component (e.g. monospaced).
Update changes in ZapAddOn.xml file.