### PR TITLE
replacer: allow to invoke from scripts

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+ - Allow to manage the replacer rules programmatically, for example, through ZAP scripts.
+
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Maintenance changes.

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -89,7 +89,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
         return optionsReplacerPanel;
     }
 
-    protected ReplacerParam getParams() {
+    public ReplacerParam getParams() {
         if (params == null) {
             params = new ReplacerParam();
         }

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.utils.Enableable;
 
-class ReplacerParamRule extends Enableable {
+public class ReplacerParamRule extends Enableable {
 
     public enum MatchType {
         REQ_HEADER,


### PR DESCRIPTION
```python
extReplacer = Control.getSingleton().getExtensionLoader().getExtension(ExtensionReplacer.NAME)
initiators = [ ]
replacer_rule = ReplacerParamRule(description=TOKEN_RULE_NAME,enabled=True,initiators=[],matchRegex=False,matchString="AuthenticationToken",matchType=MatchType.REQ_HEADER,replacement=token_value)
extReplacer.getParams().addRule(replacer_rule)
```