### PR TITLE
zest: validate cookie name not empty

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
+	Validate cookie name not empty.
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
@@ -87,7 +87,9 @@ public class ZestCookieDialog extends StandardFieldsDialog implements ZestDialog
 
 	@Override
 	public String validateFields() {
-		// Currently no validation - ok to let users mess up with these?
+		if (getStringValue(FIELD_PARAM_NAME).isEmpty()) {
+			return Constant.messages.getString("zest.dialog.cookies.error.cookie.name.empty");
+		}
 		return null;
 	}
 

--- a/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
@@ -220,6 +220,7 @@ zest.dialog.cookies.label.value			= Value:
 zest.dialog.cookies.label.path			= Path:
 zest.dialog.cookies.add.title			= Add Cookie
 zest.dialog.cookies.edit.title			= Edit Cookie
+zest.dialog.cookies.error.cookie.name.empty = Cookie name must not be empty.
 
 zest.dialog.fuzzfile.add.category		= Set a category for this fuzzer
 


### PR DESCRIPTION
Change ZestCookieDialog to validate that the cookie name is not empty.
Zest library requires a non-empty name:
 IllegalArgumentException: Cookie name may not be blank

Update changes in ZapAddOn.xml file.