### PR TITLE
Add console listener to jxBrowser

### DIFF
--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>JxBrowser (core)</name>
-	<version>5</version>
+	<version>6</version>
 	<status>alpha</status>
 	<description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-		Updated for JxBrowser 6.14.2.<br>
-		Added method to allow caller to tell if the BrowserFrame has been closed.<br>
+		Added console debug logger.<br>
 	]]>
 	</changes>
 	<dependencies/>
@@ -22,4 +21,3 @@
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>
-

--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapBrowserPanel.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapBrowserPanel.java
@@ -40,6 +40,8 @@ import org.zaproxy.zap.view.NodeSelectDialog;
 import com.teamdev.jxbrowser.chromium.Browser;
 import com.teamdev.jxbrowser.chromium.BrowserContext;
 import com.teamdev.jxbrowser.chromium.BrowserContextParams;
+import com.teamdev.jxbrowser.chromium.events.ConsoleEvent;
+import com.teamdev.jxbrowser.chromium.events.ConsoleListener;
 import com.teamdev.jxbrowser.chromium.CustomProxyConfig;
 
 public class ZapBrowserPanel extends BrowserPanel {
@@ -86,6 +88,15 @@ public class ZapBrowserPanel extends BrowserPanel {
                 LOGGER.error(e.getMessage(), e);
                 browser = new Browser();
             }
+
+            browser.addConsoleListener(new ConsoleListener() {
+                @Override
+                public void onMessage(ConsoleEvent event) {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("jxBrowser Console Event - Level: " + event.getLevel() + " - Message: " + event.getMessage());
+                    }
+                }
+            });
         }
         return browser;
     }


### PR DESCRIPTION
Adds a [console listener](https://www.teamdev.com/downloads/jxbrowser/javadoc/com/teamdev/jxbrowser/chromium/Browser.html#addConsoleListener-com.teamdev.jxbrowser.chromium.events.ConsoleListener-) to the jxbrowser instance for debugging.

Tested that adding an executeJavascript does log to the zap log as described in https://jxbrowser.support.teamdev.com/support/solutions/articles/9000013060-console-messages

e.g.

```
2017-09-19 11:55:44,231 [Browser Events Thread] INFO  ZapBrowserPanel - jxBrowser Console Event - Level: ERROR - Message: Error message
2017-09-19 11:55:44,231 [Browser Events Thread] INFO  ZapBrowserPanel - jxBrowser Console Event - Level: ERROR - Message: Error message
```

Note that it looks like getBrowser is being called four times (maybe once for each of the jxbrowser platform addons), but I don't think that is related to this change.