### PR TITLE
travis-ci: remove ant-optional workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,5 @@ language: java
 script: ant -buildfile build/build.xml test
 sudo: false
 
-# Issue travis-ci/travis-ci#7706
-addons:
-  apt:
-    packages:
-      - ant-optional 
-
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Change .travis.yml to remove the manual installation of the package
ant-optional, it's now (update 2017-09-06) installed by default.