### PR TITLE
travis-ci: remove ant-optional workaround (alpha)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,3 @@ sudo: false
 
 jdk:
   - oraclejdk8
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - ant
-      - ant-optional


### PR DESCRIPTION
Change .travis.yml to remove the manual installation of the package
ant-optional, it's now (update 2017-09-06) installed by default.