### PR TITLE
jython: change icon init and add new initiator

### DIFF
--- a/src/org/zaproxy/zap/extension/jython/ExtensionJython.java
+++ b/src/org/zaproxy/zap/extension/jython/ExtensionJython.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.View;
 import org.python.core.Py;
 import org.python.google.common.base.Strings;
 import org.python.jsr223.PyScriptEngineFactory;
@@ -46,8 +47,7 @@ import org.zaproxy.zap.extension.script.ExtensionScript;
 public class ExtensionJython extends ExtensionAdaptor implements OptionsChangedListener {
 
 	public static final String NAME = "ExtensionJython";
-	public static final ImageIcon PYTHON_ICON = new ImageIcon(
-			ExtensionJython.class.getResource("/org/zaproxy/zap/extension/jython/resources/python.png"));
+	public static final ImageIcon PYTHON_ICON;
 
 	private static final Logger LOGGER = Logger.getLogger(ExtensionJython.class);
 
@@ -57,6 +57,10 @@ public class ExtensionJython extends ExtensionAdaptor implements OptionsChangedL
 		List<Class<?>> dependencies = new ArrayList<>(1);
 		dependencies.add(ExtensionScript.class);
 		EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
+
+		PYTHON_ICON = View.isInitialised()
+				? new ImageIcon(ExtensionJython.class.getResource("/org/zaproxy/zap/extension/jython/resources/python.png"))
+				: null;
 	}
 
 	private ExtensionScript extScript = null;

--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -1,11 +1,16 @@
 <zapaddon>
 	<name>Python scripting</name>
-	<version>6</version>
+	<version>7</version>
 	<status>beta</status>
 	<description>Allows Python to be used for ZAP scripting - templates included</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Update Jython from 2.5.3 to 2.7.1</changes>
+	<changes>
+	<![CDATA[
+	Do not initialise java.awt.Toolkit when in daemon.<br>
+	Update HTTP Sender template with initiator ID of AJAX Spider.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jython.ExtensionJython</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/jython/files/scripts/templates/httpsender/HttpSender default template.py
+++ b/src/org/zaproxy/zap/extension/jython/files/scripts/templates/httpsender/HttpSender default template.py
@@ -15,6 +15,7 @@
 #      7   CHECK_FOR_UPDATES_INITIATOR
 #      8   BEAN_SHELL_INITIATOR
 #      9   ACCESS_CONTROL_SCANNER_INITIATOR
+#     10   AJAX_SPIDER_INITIATOR
 # For the latest list of values see the HttpSender class:
 # https://github.com/zaproxy/zaproxy/blob/master/src/org/parosproxy/paros/network/HttpSender.java
 # 'helper' just has one method at the moment: helper.getHttpSender() which


### PR DESCRIPTION
Change ExtensionJython to not create the icon if the view is not
initialised. (Related to zaproxy/zaproxy#3798 - java.awt.Toolkit
initialised in daemon mode)
Update HttpSender default template to include the initiator ID of AJAX
Spider.
Bump version and update changes in ZapAddOn.xml file.