### PR TITLE
Issue 3846 FP Source Code Disclosure - CVE-2012-1823 on image content

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823.java
@@ -135,6 +135,10 @@ public class SourceCodeDisclosureCVE20121823 extends AbstractAppPlugin {
 	@Override
 	public void scan() {
 		try {
+			
+			if (!getBaseMsg().getResponseHeader().isText()) {
+				return;//Ignore images, pdfs, etc.
+			}
 			//at Low or Medium strength, do not attack URLs which returned "Not Found"
 			AttackStrength attackStrength = getAttackStrength();
 			if ( (attackStrength==AttackStrength.LOW||attackStrength==AttackStrength.MEDIUM) 

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Support security annotations for forms that dont need anti-CSRF tokens.<br>
 	Changed XXE rule to use new callback extension.<br>
 	Notify of messages sent during Heartbleed scanning (Issue 2425).<br>
+	Fix false positive in Code Disclosure - CVE-2012-1823 on image content (Issue 3846).<br>
     ]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -68,7 +68,8 @@ The first is a simple reflected attack and the second is a time based attack.<br
 Post 2.5.0 you can change the length of time used for the attack by changing the <code>rules.common.sleep</code> parameter via the Options 'Rule configuration' panel.
 
 <H2>Source Code Disclosure - CVE-2012-1823</H2>
-Exploit CVE-2012-1823 to disclose server-side PHP source code on a PHP-CGI based web server.
+Exploit CVE-2012-1823 to disclose server-side PHP source code on a PHP-CGI based web server.<br>
+Only analyzes responses that are text based (HTML, JS, JSON, XML, etc), in order to avoid false positives which may occur with image or other binary content.
 
 <H2>Source Code Disclosure - SVN</H2>
 Uses Subversion source code repository metadata to scan for files containing source code on the web server.

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
@@ -41,7 +42,7 @@ import fi.iki.elonen.NanoHTTPD.Response;
  */
 public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<SourceCodeDisclosureCVE20121823> {
 
-    private static final String RESPONSE_HEADER_404_NOT_FOUND = "HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n";
+    private static final String RESPONSE_HEADER_404_NOT_FOUND = "HTTP/1.1 404 Not Found\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n";
     private static final String PHP_SOURCE_TAGS = "<?php $x=0; echo '<h1>Welcome!</h1>'; ?>";
     private static final String PHP_SOURCE_ECHO_TAG = "<?= '<h1>Welcome!</h1>' ?>";
 
@@ -70,6 +71,18 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         boolean targets = rule.targets(techSet);
         // Then
         assertThat(targets, is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldIgnoreNonTextResponses() throws Exception {
+        // Given
+        HttpMessage message = getHttpMessage("/");
+        message.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "image/jpeg");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(0));
     }
 
     @Test


### PR DESCRIPTION
* SourceCodeDisclosureCVE20121823 - Modified to ignore non-text responses.
* SourceCodeDisclosureCVE20121823UnitTest - Added unit test to validate handling of image type responses.
* ascanbeta.html - Added a note about response content type handling and reasoning.
* ZapAddOn.xml - Added changes element.

Fixes zaproxy/zaproxy#3846