### PR TITLE
accessControl: correct resource loading

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Access Control Testing</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>Adds a set of tools for testing access control in web applications.</description>
 	<author>ZAP Dev Team</author>
 	<url />
 	<changes>
 	<![CDATA[
-	Fix an exception when cancelling the "Save" access control report dialogue.<br>
-	Do not allow to dynamically uninstall, not yet supported.<br>
+	Fix exception that occurred with Java 9 (Issue 3934).<br>
 	]]> 
 	</changes>
 	<dependson />

--- a/src/org/zaproxy/zap/extension/accessControl/widgets/SiteNodeIcons.java
+++ b/src/org/zaproxy/zap/extension/accessControl/widgets/SiteNodeIcons.java
@@ -20,31 +20,28 @@
 package org.zaproxy.zap.extension.accessControl.widgets;
 
 import javax.swing.ImageIcon;
-import javax.swing.tree.DefaultTreeCellRenderer;
 
 public final class SiteNodeIcons {
 	public static final ImageIcon ROOT_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/16/094.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/16/094.png"));
 	public static final ImageIcon LEAF_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/document.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/document.png"));
 	public static final ImageIcon FOLDER_OPEN_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-open.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/folder-horizontal-open.png"));
 	public static final ImageIcon FOLDER_CLOSED_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/folder-horizontal.png"));
 	public static final ImageIcon LEAF_ICON_CHECK = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/document-check.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/document-check.png"));
 	public static final ImageIcon FOLDER_OPEN_ICON_CHECK = new ImageIcon(
-			DefaultTreeCellRenderer.class
-					.getResource("/resource/icon/fugue/folder-horizontal-open-check.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/folder-horizontal-open-check.png"));
 	public static final ImageIcon FOLDER_CLOSED_ICON_CHECK = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-check.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/folder-horizontal-check.png"));
 	public static final ImageIcon LEAF_ICON_CROSS = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/document-cross.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/document-cross.png"));
 	public static final ImageIcon FOLDER_OPEN_ICON_CROSS = new ImageIcon(
-			DefaultTreeCellRenderer.class
-					.getResource("/resource/icon/fugue/folder-horizontal-open-cross.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/folder-horizontal-open-cross.png"));
 	public static final ImageIcon FOLDER_CLOSED_ICON_CROSS = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-cross.png"));
+			SiteNodeIcons.class.getResource("/resource/icon/fugue/folder-horizontal-cross.png"));
 
 	private SiteNodeIcons() {
 		// Utility class

--- a/src/org/zaproxy/zap/extension/accessControl/widgets/SiteTreeNodeCellRenderer.java
+++ b/src/org/zaproxy/zap/extension/accessControl/widgets/SiteTreeNodeCellRenderer.java
@@ -33,13 +33,13 @@ public class SiteTreeNodeCellRenderer extends DefaultTreeCellRenderer {
 	private static final long serialVersionUID = -6714631438207624613L;
 
 	protected static final ImageIcon ROOT_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/16/094.png"));
+			SiteTreeNodeCellRenderer.class.getResource("/resource/icon/16/094.png"));
 	protected static final ImageIcon LEAF_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/document.png"));
+			SiteTreeNodeCellRenderer.class.getResource("/resource/icon/fugue/document.png"));
 	protected static final ImageIcon FOLDER_OPEN_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-open.png"));
+			SiteTreeNodeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal-open.png"));
 	protected static final ImageIcon FOLDER_CLOSED_ICON = new ImageIcon(
-			DefaultTreeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal.png"));
+			SiteTreeNodeCellRenderer.class.getResource("/resource/icon/fugue/folder-horizontal.png"));
 
 	/**
 	 * Sets custom tree node icons.


### PR DESCRIPTION
Change SiteNodeIcons and SiteTreeNodeCellRenderer (the latter class is
currently unused) to use the classes themselves to load the resources,
which ensures it's used the correct class loader to load the resource.
Bump version and update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#2602 - Java 9
Reported in zaproxy/zaproxy#3934.