### PR TITLE
Remove usage of java.awt.Event

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.quickstart;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -76,7 +75,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 
 	private void initialize() {
 		this.setIcon(new ImageIcon(BreakPanel.class.getResource("/resource/icon/16/147.png")));	// 'lightning' icon
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("quickstart.panel.mnemonic"));
 		this.setLayout(new BorderLayout());
 

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Quick Start</name>
-	<version>21</version>
+	<version>22</version>
 	<status>release</status>
 	<description>Provides a tab which allows you to quickly test a target application</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Add option to launch a browser via selenium (v20).<br>
-	Fix to the default launch page url for 2.6.0.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -17,7 +17,6 @@
  */
 package org.zaproxy.zap.extension.spiderAjax;
 
-import java.awt.Event;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.net.MalformedURLException;
@@ -195,7 +194,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 					"spiderajax.menu.tools.label",
 					KeyStroke.getKeyStroke(
 							KeyEvent.VK_X,
-							Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK,
+							Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK,
 							false));
 			menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);
 

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -18,7 +18,6 @@
 package org.zaproxy.zap.extension.spiderAjax;
 
 import java.awt.BorderLayout;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -106,7 +105,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
         					this.extension.getMessages().getString("spiderajax.panel.title"));
         
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_J, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+				KeyEvent.VK_J, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("spiderajax.panel.mnemonic"));
         
         if (View.isInitialised()) {

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -15,6 +15,7 @@
 	Use JRE decoder for UTF-8 conversions and log (debug) invalid payloads (related to Issue 3324).<br>
 	Focus WebSockets tab just once (Issue 3747).<br>
 	Minor code adjustment to align with core changes.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
@@ -19,7 +19,6 @@ package org.zaproxy.zap.extension.websocket.ui;
 
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -173,7 +172,7 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
 	 */
 	private void initializePanel() {
 		setName(Constant.messages.getString("websocket.panel.title"));
-		setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		setMnemonic(Constant.messages.getChar("websocket.panel.mnemonic"));
 
 		


### PR DESCRIPTION
Replace usage of java.awt.Event with KeyEvent, the former is deprecated
in Java 9, also, update to recommended (non-deprecated) masks (e.g.
SHIFT_DOWN_MASK instead of SHIFT_MASK).
Update changes (and bump version, where required) in ZapAddOn.xml files
of the corresponding add-ons.

Part of #2602 - Java 9