### PR TITLE
scripts: correct default font used with macOS

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
+++ b/src/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
@@ -28,6 +28,7 @@ import javax.swing.Action;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JViewport;
+import javax.swing.UIManager;
 
 import org.apache.commons.configuration.FileConfiguration;
 import org.fife.ui.rsyntaxtextarea.AbstractTokenMakerFactory;
@@ -37,6 +38,7 @@ import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.FontUtils;
 
@@ -117,12 +119,22 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
 		setClearWhitespaceLinesEnabled(false);
 		
 		Font font = FontUtils.getFont(Font.PLAIN);
-		if (font.getName().isEmpty()) {
+		// TODO Replace isDefaultFontSet() with FontUtils.isDefaultFontSet() when available.
+		if (!isDefaultFontSet()) {
 			// Use default RSyntaxTextArea font instead but with correct font size.
 			font = FontUtils.getFont(this.getFont().getFontName());
 		}
 		this.setFont(font);
 
+	}
+
+	private static boolean isDefaultFontSet() {
+		Object defaultFont = UIManager.getLookAndFeelDefaults().get("defaultFont");
+		if (defaultFont == null) {
+			return false;
+		}
+		String fontName = Model.getSingleton().getOptionsParam().getViewParam().getFontName();
+		return fontName != null && !fontName.isEmpty();
 	}
 	
 	@Override


### PR DESCRIPTION
Change SyntaxHighlightTextArea to correct the detection of default font
set.

Fix zaproxy/zaproxy#3939 - Default font in script console is
non-monospaced on OSX