### PR TITLE
Address remaining Java 9 compilation issues

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -697,8 +697,8 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 				try {
 					//is it an integer type?
 					//ZAP: removed URLDecoding because on Variants
-					//int paramAsInt = new Integer (TestSQLInjection.getURLDecode(origParamValue));
-					int paramAsInt = new Integer(origParamValue);
+					//int paramAsInt = Integer.parseInt(TestSQLInjection.getURLDecode(origParamValue));
+					int paramAsInt = Integer.parseInt(origParamValue);
 
 					if (this.debugEnabled) {
 						log.debug("The parameter value [" + origParamValue + "] is of type Integer");

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Issue 1365: Additional Path Traversal detection.<br>
 	Correct alert's evidence/attack of Parameter Tampering (Issue 3524).<br>
 	Fix Path Traversal false positives when etc is a substring (Issue 3735).<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
     </changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import javax.swing.ImageIcon;
 import javax.swing.KeyStroke;
+import javax.swing.tree.TreeNode;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -320,9 +321,9 @@ public class ExtensionAjax extends ExtensionAdaptor {
 
 	private static URI findFirstUriInContext(Context context, SiteNode node) {
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = node.children();
+		Enumeration<TreeNode> en = node.children();
 		while (en.hasMoreElements()) {
-			SiteNode childNode = en.nextElement();
+			SiteNode childNode = (SiteNode) en.nextElement();
 			if (context.isInContext(childNode)) {
 				return URI.create(childNode.getHistoryReference().getURI().toString());
 			}


### PR DESCRIPTION
Address compilation error in ExtensionAjax caused by the change of the
return type of DefaultMutableTreeNode.children​().
Address deprecation warning in TestSQLInjection, replace the usage of
constructor Integer(String) with Integer.parseInt(String).
Update changes in ZapAddOn.xml file (of ascanrules, where required).

Part of zaproxy/zaproxy#2602 - Java 9