### PR TITLE
Remove usage of java.awt.Event (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.bruteforce;
 
 import java.awt.CardLayout;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -155,7 +154,7 @@ public class BruteForcePanel extends AbstractPanel implements BruteForceListenne
         this.setName(Constant.messages.getString("bruteforce.panel.title"));
 		this.setIcon(new ImageIcon(BruteForcePanel.class.getResource(ExtensionBruteForce.HAMMER_ICON_RESOURCE)));
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("bruteforce.panel.mnemonic"));
 		this.add(getPanelCommand(), getPanelCommand().getName());
         

--- a/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Forced Browse</name>
-	<version>6</version>
+	<version>7</version>
 	<status>beta</status>
 	<description>Forced browsing of files and directories using code from the OWASP DirBuster tool</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Allow to set higher number of threads (Issue 2912).<br>
-	Fix issue with multiple concurrent scans.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.fuzz;
 
-import java.awt.Event;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
@@ -385,7 +384,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
     private ZapMenuItem getMenuItemCustomScan() {
         if (menuItemCustomScan == null) {
             menuItemCustomScan = new ZapMenuItem("fuzz.menu.tools.fuzz",
-                    KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK, false));
+                    KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 
             menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {
                 @Override

--- a/src/org/zaproxy/zap/extension/fuzz/FuzzersStatusPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzersStatusPanel.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.fuzz;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.event.KeyEvent;
 
@@ -61,7 +60,7 @@ public class FuzzersStatusPanel extends ScanPanel2<Fuzzer<?>, FuzzersController>
 
         this.fuzzerOptions = fuzzerOptions;
 
-        setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, Event.CTRL_MASK | Event.SHIFT_MASK, false));
+        setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
         setMnemonic(Constant.messages.getString("fuzz.panel.mnemonic").charAt(0));
     }
 

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -8,6 +8,7 @@
     <url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</url>
     <changes>
     <![CDATA[
+    Code changes for Java 9 (Issue 2602).<br>
     Ignore empty payloads when highlighting or detecting reflections.<br>
     Contains new number generator payload.<br>
     Add null/empty payload generator.<br>

--- a/src/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
@@ -19,7 +19,6 @@ package org.zaproxy.zap.extension.plugnhack;
 
 import java.awt.CardLayout;
 import java.awt.Dimension;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Rectangle;
@@ -103,7 +102,7 @@ public class ClientsPanel extends AbstractPanel implements MonitoredPageListener
         this.setSize(274, 251);
         this.setName(Constant.messages.getString("plugnhack.client.panel.title"));
 		this.setIcon(ExtensionPlugNHack.CLIENT_ACTIVE_ICON);
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("plugnhack.client.panel.mnemonic"));
 
         this.add(getClientsPanel(), getClientsPanel().getName());

--- a/src/org/zaproxy/zap/extension/plugnhack/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/plugnhack/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Plug-n-Hack Configuration</name>
-	<version>10</version>
+	<version>11</version>
 	<status>beta</status>
 	<description>Supports the Mozilla Plug-n-Hack standard: https://developer.mozilla.org/en-US/docs/Plug-n-Hack.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://developer.mozilla.org/en-US/docs/Plug-n-Hack</url>
 	<changes>
 	<![CDATA[
-	Make breakpoint dialogues modal.<br>
-	Changed to use api nonces and include new fx_pnh.xpi (still unsigned).<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/portscan/PortScanPanel.java
+++ b/src/org/zaproxy/zap/extension/portscan/PortScanPanel.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.portscan;
 
-import java.awt.Event;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.List;
@@ -67,7 +66,7 @@ public class PortScanPanel extends ScanPanel implements ScanListenner {
         super("ports", new ImageIcon(PortScanPanel.class.getResource("/resource/icon/16/187.png")), extension, portScanParam);
         
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("ports.panel.mnemonic"));
     }
 

--- a/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	Issue 3513: Options panel UI fixes.<br>
 	]]>
 	</changes>

--- a/src/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.scripts;
 
 import java.awt.BorderLayout;
-import java.awt.Event;
 import java.awt.GridBagLayout;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -80,7 +79,7 @@ public class ConsolePanel extends AbstractPanel implements Tab {
 	private void initialize() {
 		this.setIcon(new ImageIcon(ZAP.class.getResource("/resource/icon/16/059.png")));	// 'script' icon
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("scripts.panel.mnemonic"));
 		this.setLayout(new BorderLayout());
 

--- a/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.scripts;
 import java.awt.CardLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -115,7 +114,7 @@ public class ScriptsListPanel extends AbstractPanel {
         this.setName(Constant.messages.getString("scripts.list.panel.title"));
 		this.setIcon(ExtensionScriptsUI.ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("scripts.list.panel.mnemonic"));
 
         this.add(getListPanel(), getListPanel().getName());

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
+	Code changes for Java 9 (Issue 2602).<br>
 	Inform when the script contains invalid char sequences (related to Issue 3377).<br>
 	Invoke Scripts tree context menu once.<br>
 	Title caps adjustments (related to Issue 2000).<br>

--- a/src/org/zaproxy/zap/extension/tokengen/TokenPanel.java
+++ b/src/org/zaproxy/zap/extension/tokengen/TokenPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.tokengen;
 
 import java.awt.CardLayout;
-import java.awt.Event;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
@@ -104,7 +103,7 @@ public class TokenPanel extends AbstractPanel {
         this.setName(extension.getMessages().getString("tokengen.panel.title"));
 		this.setIcon(new ImageIcon(getClass().getResource("/resource/icon/fugue/barcode.png")));
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+				KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("tokengen.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
         

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Issue 2338: Allow dynamic timeout adjustment to combat read timeout issues.<br>
 	Ensure initial dialog is properly sized.<br>
 	Issue 2000: Title caps adjustments.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Validate cookie name not empty.
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.zest;
 
 import java.awt.CardLayout;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.Toolkit;
@@ -63,7 +62,7 @@ public class ZestResultsPanel extends AbstractPanel {
         this.setName(Constant.messages.getString("zest.results.panel.title"));
 		this.setIcon(ExtensionZest.ZEST_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_Z, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+				KeyEvent.VK_Z, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("zest.results.panel.mnemonic"));
 
         this.add(getZestPanel(), getZestPanel().getName());


### PR DESCRIPTION
Replace usage of java.awt.Event with KeyEvent, the former is deprecated
in Java 9, also, update to recommended (non-deprecated) masks (e.g.
SHIFT_DOWN_MASK instead of SHIFT_MASK).
Update changes (and bump version, where required) in ZapAddOn.xml files
of the corresponding add-ons.

Part of zaproxy/zaproxy#2602 - Java 9