### PR TITLE
Address compilation errors with Java 9 (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
@@ -49,6 +49,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JToggleButton;
 import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
+import javax.swing.tree.TreeNode;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
@@ -678,9 +679,9 @@ public class BruteForcePanel extends AbstractPanel implements BruteForceListenne
 		SiteNode rootNode = (SiteNode) siteTree.getRoot();
 		
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = rootNode.children();
+		Enumeration<TreeNode> en = rootNode.children();
 		while (en.hasMoreElements()) {
-			SiteNode sn = en.nextElement();
+			SiteNode sn = (SiteNode) en.nextElement();
 			ScanTarget snScanTarget = createScanTarget(sn);
 			if (snScanTarget != null && snScanTarget.equals(scanTarget)) {
 				return sn;

--- a/src/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
@@ -25,6 +25,8 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.List;
 
+import javax.swing.tree.TreeNode;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
@@ -173,9 +175,9 @@ public class ExtensionBruteForce extends ExtensionAdaptor
 		// Add new hosts
 		SiteNode root = (SiteNode)session.getSiteTree().getRoot();
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = root.children();
+		Enumeration<TreeNode> en = root.children();
 		while (en.hasMoreElements()) {
-			HistoryReference hRef = en.nextElement().getHistoryReference();
+			HistoryReference hRef = ((SiteNode) en.nextElement()).getHistoryReference();
 			if (hRef != null) {
 				this.getBruteForcePanel().addSite(hRef.getURI());
 			}

--- a/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
@@ -47,6 +47,7 @@ import javax.swing.KeyStroke;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.DefaultTreeSelectionModel;
+import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 
 import org.jdesktop.swingx.JXFindBar;
@@ -379,9 +380,9 @@ public class FuzzerPayloadGeneratorUIHandler implements
                 String defaultCategory = extensionFuzz.getFuzzOptions().getDefaultCategoryName();
                 root = (DefaultMutableTreeNode) fileFuzzersCheckBoxTree.getModel().getRoot();
                 @SuppressWarnings("unchecked")
-                Enumeration<DefaultMutableTreeNode> nodes = root.breadthFirstEnumeration();
+                Enumeration<TreeNode> nodes = root.breadthFirstEnumeration();
                 while (nodes.hasMoreElements()) {
-                    DefaultMutableTreeNode node = nodes.nextElement();
+                    DefaultMutableTreeNode node = (DefaultMutableTreeNode) nodes.nextElement();
                     Object object = node.getUserObject();
                     if (object instanceof FuzzerPayloadCategory) {
                         if (defaultCategory.equals(((FuzzerPayloadCategory) object).getFullName())) {
@@ -492,9 +493,9 @@ public class FuzzerPayloadGeneratorUIHandler implements
             List<FuzzerPayloadSource> selections = new ArrayList<>(fileFuzzers);
             DefaultMutableTreeNode root = (DefaultMutableTreeNode) getFileFuzzersCheckBoxTree().getModel().getRoot();
             @SuppressWarnings("unchecked")
-            Enumeration<DefaultMutableTreeNode> nodes = root.depthFirstEnumeration();
+            Enumeration<TreeNode> nodes = root.depthFirstEnumeration();
             while (!selections.isEmpty() && nodes.hasMoreElements()) {
-                DefaultMutableTreeNode node = nodes.nextElement();
+                DefaultMutableTreeNode node = (DefaultMutableTreeNode) nodes.nextElement();
                 if (selections.remove(node.getUserObject())) {
                     TreePath path = new TreePath(node.getPath());
                     getFileFuzzersCheckBoxTree().check(path, true);
@@ -615,9 +616,9 @@ public class FuzzerPayloadGeneratorUIHandler implements
 
                 DefaultMutableTreeNode rootNode = (DefaultMutableTreeNode) tree.getModel().getRoot();
                 @SuppressWarnings("unchecked")
-                Enumeration<DefaultMutableTreeNode> nodes = rootNode.preorderEnumeration();
+                Enumeration<TreeNode> nodes = rootNode.preorderEnumeration();
                 for (int i = 0; nodes.hasMoreElements(); i++) {
-                    rows.put(i, new TreePath(nodes.nextElement().getPath()));
+                    rows.put(i, new TreePath(((DefaultMutableTreeNode) nodes.nextElement()).getPath()));
                 }
             }
 

--- a/src/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
+++ b/src/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
+import javax.swing.tree.TreeNode;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control.Mode;
@@ -147,9 +149,9 @@ public class ExtensionPortScan extends ExtensionAdaptor
         // Add new hosts
         SiteNode root = (SiteNode) session.getSiteTree().getRoot();
         @SuppressWarnings("unchecked")
-        Enumeration<SiteNode> en = root.children();
+        Enumeration<TreeNode> en = root.children();
         while (en.hasMoreElements()) {
-            this.getPortScanPanel().addSite(en.nextElement().getNodeName(), false);
+            this.getPortScanPanel().addSite(((SiteNode) en.nextElement()).getNodeName(), false);
         }
     }
 

--- a/src/org/zaproxy/zap/extension/treetools/PopupMenuTreeTools.java
+++ b/src/org/zaproxy/zap/extension/treetools/PopupMenuTreeTools.java
@@ -59,7 +59,7 @@ public class PopupMenuTreeTools extends ExtensionPopupMenuItem {
 		TreeNode tn = (TreeNode) parent.getLastPathComponent();
 		
 		if (tn.getChildCount() > 0) {
-			for (Enumeration<TreeNode> e = tn.children(); e.hasMoreElements();) {
+			for (Enumeration<? extends TreeNode> e = tn.children(); e.hasMoreElements();) {
 				  TreePath path = parent.pathByAddingChild(e.nextElement());
 				  expandOrCollapseFromNode(path, expand);
 			}

--- a/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
@@ -5,7 +5,7 @@
 	<description>Tools to add functionality to the tree view.</description>
 	<author>Carl Sampson</author>
 	<url/>
-	<changes>Minor code changes.</changes>
+	<changes>Code changes for Java 9 (Issue 2602)</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.treetools.ExtensionTreeTools</extension>
 	</extensions>


### PR DESCRIPTION
Address compilation errors related to change in return type of method
TreeNode.children​() and depthFirstEnumeration​(), with Java 9 it returns
`Enumeration<TreeNode>`.
Update changes in ZapAddOn.xml file (where required).

Part of zaproxy/zaproxy#2602 - Java 9