### PR TITLE
scripts: use component pop up menus in text areas

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -21,14 +21,12 @@ package org.zaproxy.zap.extension.scripts;
 
 import java.awt.CardLayout;
 import java.awt.Component;
-import java.awt.event.InputEvent;
 import java.awt.event.KeyListener;
 
 import javax.swing.JScrollPane;
 
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.parosproxy.paros.extension.AbstractPanel;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.scripts.autocomplete.ScriptAutoCompleteKeyListener;
 import org.zaproxy.zap.utils.FontUtils;
 
@@ -81,26 +79,8 @@ public class CommandPanel extends AbstractPanel {
 		if (this.syntaxTxtArea == null) {
 			this.syntaxTxtArea = new SyntaxHighlightTextArea();
 			
-			this.syntaxTxtArea.addMouseListener(new java.awt.event.MouseAdapter() { 
+			this.syntaxTxtArea.setComponentPopupMenu(ZapPopupMenu.INSTANCE);
 
-				@Override
-				public void mousePressed(java.awt.event.MouseEvent e) {
-					mouseAction(e);
-				}
-					
-				@Override
-				public void mouseReleased(java.awt.event.MouseEvent e) {
-					mouseAction(e);
-				}
-				
-				public void mouseAction(java.awt.event.MouseEvent e) {
-					// right mouse button action
-					if ((e.getModifiers() & InputEvent.BUTTON3_MASK) != 0 || e.isPopupTrigger()) {
-						View.getSingleton().getPopupMenu().show(e.getComponent(), e.getX(), e.getY());
-					}
-				}
-				
-			});
 			this.autocompleteListener = new ScriptAutoCompleteKeyListener(this.syntaxTxtArea);
 			this.syntaxTxtArea.addKeyListener(this.autocompleteListener);
 			if (listener != null) {

--- a/src/org/zaproxy/zap/extension/scripts/OutputPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/OutputPanel.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.scripts;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.EventQueue;
-import java.awt.event.InputEvent;
 
 import javax.script.ScriptException;
 import javax.swing.ImageIcon;
@@ -35,7 +34,6 @@ import javax.swing.text.DefaultCaret;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapTextArea;
@@ -193,26 +191,7 @@ public class OutputPanel extends AbstractPanel {
 			txtOutput.setLineWrap(true);
 			txtOutput.setFont(FontUtils.getFont("Dialog"));
 			txtOutput.setName("");
-			txtOutput.addMouseListener(new java.awt.event.MouseAdapter() { 
-
-				@Override
-				public void mousePressed(java.awt.event.MouseEvent e) {
-					mouseAction(e);
-				}
-					
-				@Override
-				public void mouseReleased(java.awt.event.MouseEvent e) {
-					mouseAction(e);
-				}
-				
-				public void mouseAction(java.awt.event.MouseEvent e) {
-					// right mouse button action
-					if ((e.getModifiers() & InputEvent.BUTTON3_MASK) != 0 || e.isPopupTrigger()) {
-						View.getSingleton().getPopupMenu().show(e.getComponent(), e.getX(), e.getY());
-					}
-				}
-				
-			});
+			txtOutput.setComponentPopupMenu(ZapPopupMenu.INSTANCE);
 		}
 		return txtOutput;
 	}

--- a/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.scripts;
 
 import java.awt.CardLayout;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -41,7 +40,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
-import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTree;
 import javax.swing.KeyStroke;
@@ -494,15 +492,7 @@ public class ScriptsListPanel extends AbstractPanel {
 					return super.getPopupLocation(event);
 				}
 			};
-			tree.setComponentPopupMenu(new JPopupMenu() {
-
-				private static final long serialVersionUID = 1L;
-
-				@Override
-				public void show(Component invoker, int x, int y) {
-					View.getSingleton().getPopupMenu().show(tree, x, y);
-				}
-			});
+			tree.setComponentPopupMenu(ZapPopupMenu.INSTANCE);
 			tree.setModel(extension.getExtScript().getTreeModel());
 			tree.setName(TREE);
 			tree.setShowsRootHandles(true);

--- a/src/org/zaproxy/zap/extension/scripts/ZapPopupMenu.java
+++ b/src/org/zaproxy/zap/extension/scripts/ZapPopupMenu.java
@@ -1,0 +1,41 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2017 The ZAP Development Team
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.scripts;
+
+import java.awt.Component;
+
+import javax.swing.JPopupMenu;
+
+import org.parosproxy.paros.view.View;
+
+public class ZapPopupMenu extends JPopupMenu {
+
+    public static final ZapPopupMenu INSTANCE = new ZapPopupMenu();
+
+    private static final long serialVersionUID = -3110110234622733751L;
+
+    private ZapPopupMenu() {
+    }
+
+    @Override
+    public void show(Component invoker, int x, int y) {
+        View.getSingleton().getPopupMenu().show(invoker, x, y);
+    }
+}


### PR DESCRIPTION
Change OutputPanel and CommandPanel to set a pop up menu, ZapPopupMenu,
into the text areas instead of listening for mouse clicks, as the former
works with mouse and keyboard.
Add a JPopupMenu (ZapPopupMenu) that invokes the main/core pop menu.
Change ScriptsListPanel to also use the new class, ZapPopupMenu.

These changes also address deprecation warnings with Java 9, by removing
usage of MouseEvent.getModifiers() and InputEvent.BUTTON3_MASK.
Related to zaproxy/zaproxy#2602 - Java 9