### PR TITLE
Issue 3911 - Fix FP in Backup File Disclosure Scanner on 403s

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
@@ -346,6 +346,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 			//now request a different (and non-existent) parent directory, 
 			//to see whether a non-existent parent folder causes a 404 
 			String [] pathbreak = temppath.split("/");
+			HttpMessage nonexistparentmsg = null;
 			if (pathbreak.length > 2) {  //the file has a parent folder that is not the root folder (ie, there is a parent folder to mess with)
 				String [] temppathbreak =  pathbreak;
 				String parentfoldername = pathbreak[pathbreak.length - 2];
@@ -356,7 +357,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 				String randomparentpath= StringUtils.join(temppathbreak, "/");
 				
 				if (log.isDebugEnabled()) log.debug("Trying non-existent parent path: "+ randomparentpath);						
-				HttpMessage nonexistparentmsg= new HttpMessage (new URI(originalURI.getScheme(), originalURI.getAuthority(), randomparentpath, null, null));
+				nonexistparentmsg= new HttpMessage (new URI(originalURI.getScheme(), originalURI.getAuthority(), randomparentpath, null, null));
 				try {
 					nonexistparentmsg.setCookieParams(originalMessage.getCookieParams());
 					}
@@ -502,7 +503,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 				//but for a "Copy of" file, actually gives a 404 (for some unknown reason). We need to handle this case.
 				if ( 	( gives404s && requestStatusCode != HttpStatus.SC_NOT_FOUND) || 
 						(	(!gives404s) &&
-							requestStatusCode != HttpStatus.SC_NOT_FOUND &&
+								nonexistfilemsg .getResponseHeader().getStatusCode() != requestStatusCode &&
 							(! Arrays.equals(disclosedData, nonexistfilemsgdata)) 
 						)
 					) {
@@ -545,7 +546,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 
 				if ( 	( parentgives404s && requestStatusCode != HttpStatus.SC_NOT_FOUND) || 
 						(	(!parentgives404s) && 
-							requestStatusCode != HttpStatus.SC_NOT_FOUND && 
+								nonexistparentmsg.getResponseHeader().getStatusCode() != requestStatusCode && 
 							(! Arrays.equals(disclosedData, nonexistparentmsgdata)))
 					) {
 					bingo(	Alert.RISK_MEDIUM, 

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Changed XXE rule to use new callback extension.<br>
 	Notify of messages sent during Heartbleed scanning (Issue 2425).<br>
 	Fix false positive in Code Disclosure - CVE-2012-1823 on image content (Issue 3846).<br>
+	Fix false positive in Backup File Disclosure scanner on 403 responses (Issue 3911).<br>
     ]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureUnitTest.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesBeta;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+
+/**
+ * Unit test for {@link BackupFileDisclosure}.
+ */
+public class BackupFileDisclosureUnitTest extends ActiveScannerTest<BackupFileDisclosure> {
+
+    private static final String PATH_TOKEN = "@@@PATH@@@";
+    private static final String FORBIDDEN_RESPONSE_WITH_REQUESTED_PATH =
+            "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
+            + "<html><head>\n"
+            + "<title>403 Forbidden</title>\n"
+            + "</head><body>\n"
+            + "<h1>Forbidden</h1>\n"
+            + "<p>You don't have permission to access " + PATH_TOKEN + "\n"
+            + "on this server.</p>\n"
+            + "</body></html>";
+
+    @Override
+    protected BackupFileDisclosure createScanner() {
+        return new BackupFileDisclosure();
+    }
+
+    @Test
+    public void shouldNotAlertIfNonExistingBackupFileReturnsNon404Code() throws Exception {
+        // Given
+        String test = "/";
+        nano.addHandler(new ForbiddenResponseWithReqPath(test));
+        HttpMessage message = getHttpMessage(test + "sitemap.xml"); // 200 OK
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfOriginalFileNorBackupReturnsNon200Code() throws Exception {
+        // Given
+        String test = "/";
+        nano.addHandler(new ForbiddenResponseWithReqPath(test));
+        HttpMessage message = getHttpMessage(test + "sitemap.xml");
+        message.setResponseHeader("HTTP/1.1 403 Forbidden\r\n");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    private static class ForbiddenResponseWithReqPath extends NanoServerHandler {
+
+        public ForbiddenResponseWithReqPath(String name) {
+            super(name);
+        }
+
+        @Override
+        Response serve(IHTTPSession session) {
+            return new Response(
+                    Response.Status.FORBIDDEN,
+                    "text/html",
+                    FORBIDDEN_RESPONSE_WITH_REQUESTED_PATH.replace(PATH_TOKEN, session.getUri()));
+        }
+    }
+}


### PR DESCRIPTION
* BackupFileDisclosure.java > Updated to address FP.
* BackupFileDisclosureUnitTest.java > Added to test FP condition.
* ZapAddOn.xml > Added to change section.

Fixes zaproxy/zaproxy#3911