### PR TITLE
Address compilation errors with Java 9 (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ContextAccessRulesManager.java
+++ b/src/org/zaproxy/zap/extension/accessControl/ContextAccessRulesManager.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.swing.tree.TreeNode;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -325,11 +327,11 @@ public class ContextAccessRulesManager {
 
 		// We make a traversal of the context site tree and remove all nodes from the map
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteTreeNode> en = contextSiteTree.getRoot().depthFirstEnumeration();
+		Enumeration<TreeNode> en = contextSiteTree.getRoot().depthFirstEnumeration();
 		while (en.hasMoreElements()) {
 			// Unfortunately the enumeration isn't genericized so we need to downcast when calling
 			// nextElement():
-			SiteTreeNode node = en.nextElement();
+			SiteTreeNode node = (SiteTreeNode) en.nextElement();
 			rules.remove(node);
 		}
 

--- a/src/org/zaproxy/zap/extension/accessControl/widgets/SiteTree.java
+++ b/src/org/zaproxy/zap/extension/accessControl/widgets/SiteTree.java
@@ -23,6 +23,8 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
 
+import javax.swing.tree.TreeNode;
+
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
@@ -123,10 +125,10 @@ public class SiteTree {
 
 	private SiteTreeNode findChild(SiteTreeNode parent, String nodeName) {
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteTreeNode> children = parent.children();
+		Enumeration<TreeNode> children = parent.children();
 
 		while (children.hasMoreElements()) {
-			SiteTreeNode child = children.nextElement();
+			SiteTreeNode child = (SiteTreeNode) children.nextElement();
 			if (child.getNodeName().equals(nodeName)) {
 				return child;
 			}

--- a/src/org/zaproxy/zap/extension/accessControl/widgets/SiteTreeNode.java
+++ b/src/org/zaproxy/zap/extension/accessControl/widgets/SiteTreeNode.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.accessControl.widgets;
 import java.util.Enumeration;
 
 import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeNode;
 
 import org.apache.commons.httpclient.URI;
 
@@ -51,10 +52,10 @@ public class SiteTreeNode extends DefaultMutableTreeNode {
 			return null;
 
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteTreeNode> children = this.children();
+		Enumeration<TreeNode> children = this.children();
 
 		while (children.hasMoreElements()) {
-			SiteTreeNode child = children.nextElement();
+			SiteTreeNode child = (SiteTreeNode) children.nextElement();
 			if (child.getNodeName().equals(nodeName)) {
 				return child;
 			}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
@@ -363,7 +363,7 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
 					
 					HttpMessage msgDelay = getNewMsg();
 					String newTimeBasedInjectionValue = SQL_SQLITE_TIME_REPLACEMENTS[timeBasedSQLindex].replace ("<<<<ORIGINALVALUE>>>>", originalParamValue);
-					newTimeBasedInjectionValue = newTimeBasedInjectionValue.replace ("<<<<NUMBLOBBYTES>>>>", new Long(numBlobsToCreate).toString());
+					newTimeBasedInjectionValue = newTimeBasedInjectionValue.replace ("<<<<NUMBLOBBYTES>>>>", Long.toString(numBlobsToCreate));
 					setParameter(msgDelay, paramName, newTimeBasedInjectionValue);
 					
 					if ( this.debugEnabled ) log.debug("\nTrying '"+newTimeBasedInjectionValue + "'. The number of Sequential Increases already is "+ numberOfSequentialIncreases); 

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>
 	<changes>
 	<![CDATA[
+	Code changes for Java 9 (Issue 2602).<br>
 	Correct handling of messages with emtpy path.<br>
 	Add Get for Post Scanner.<br>
   	]]>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ViewStateDecoder.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ViewStateDecoder.java
@@ -140,7 +140,7 @@ public class ViewStateDecoder {
 			int intsize = readLittleEndianBase128Number (bb);
 			representation.append(getIndentation(this.indentationlevel));
 			representation.append ("<uint32>");
-			representation.append (new Integer(intsize));
+			representation.append (intsize);
 			representation.append ("</uint32>\n");
 			return representation;
 		case 0x03:
@@ -265,7 +265,7 @@ public class ViewStateDecoder {
 			int stringref = readLittleEndianBase128Number (bb);
 			representation.append(getIndentation(this.indentationlevel));
 			representation.append ("<stringreference>");			
-			representation.append (new Integer(stringref));
+			representation.append (stringref);
 			representation.append ("</stringreference>\n");
 			return representation;
 		case 0x18:

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>16</version>
+	<version>17</version>
 	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	HTTP "Server" response header, report any "Server" header if Threshold is LOW.<br> 
-	Update Image Location Scanner (passive rule) to leverage 0.4 of the code and 2.10.1 of the library it depends on.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/src/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 
+import javax.swing.tree.TreeNode;
+
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -161,9 +163,9 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
 		SiteMap siteMap = Model.getSingleton().getSession().getSiteTree();
 		SiteNode root = (SiteNode) siteMap.getRoot();
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = root.breadthFirstEnumeration();
+		Enumeration<TreeNode> en = root.breadthFirstEnumeration();
 		while (en.hasMoreElements()) {
-			en.nextElement().removeCustomIcon(ICON_RESOURCE);
+			((SiteNode) en.nextElement()).removeCustomIcon(ICON_RESOURCE);
 		}
 	}
 

--- a/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import javax.swing.ImageIcon;
+import javax.swing.tree.TreeNode;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -484,9 +485,9 @@ public class ExtensionWappalyzer extends ExtensionAdaptor implements SessionChan
 		// TODO Repopulate
 		SiteNode root = (SiteNode)session.getSiteTree().getRoot();
 		@SuppressWarnings("unchecked")
-		Enumeration<SiteNode> en = root.children();
+		Enumeration<TreeNode> en = root.children();
 		while (en.hasMoreElements()) {
-			String site = en.nextElement().getNodeName();
+			String site = ((SiteNode) en.nextElement()).getNodeName();
 			if (site.indexOf("//") >= 0) {
 				site = site.substring(site.indexOf("//") + 2);
 			}

--- a/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Updated Wappalyzer github link in help content.<br>
+	Code changes for Java 9 (Issue 2602).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
+++ b/test/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
@@ -226,6 +226,6 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
         ServerSentEvent event = proxy.processEvent(eventStream);
         
         // Then
-        assertThat(event.getReconnectionTime(), is(new Integer(10000)));
+        assertThat(event.getReconnectionTime(), is(Integer.valueOf(10000)));
     }
 }


### PR DESCRIPTION
Address compilation errors related to change in return type of method
TreeNode.children​() and depthFirstEnumeration​(), with Java 9 it returns
`Enumeration<TreeNode>`.
Remove/replace usage of Integer and Long constructors.
Update changes and bump version in ZapAddOn.xml files (where required).

Part of zaproxy/zaproxy#2602 - Java 9