### PR TITLE
Remove usage of java.awt.Event (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
+++ b/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.requester;
 
-import java.awt.Event;
 import java.awt.GridLayout;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -46,7 +45,7 @@ public class RequesterPanel extends AbstractPanel {
         this.setName(Constant.messages.getString("requester.panel.title"));
 		this.setIcon(ExtensionRequester.REQUESTER_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+				KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("requester.panel.mnemonic"));
 		this.setShowByDefault(true);
 		requesterNumberedTabbedPane = new RequesterNumberedTabbedPane();		

--- a/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
@@ -4,7 +4,7 @@
 	<description>Request numbered panel.</description>
 	<author>Surikato</author>
 	<url></url>
-	<changes>Minor code changes.</changes>
+	<changes>Code changes for Java 9 (Issue 2602).</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.requester.ExtensionRequester</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
+++ b/src/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
@@ -18,7 +18,6 @@ package org.zaproxy.zap.extension.tlsdebug;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-import java.awt.Event;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Toolkit;
@@ -79,7 +78,7 @@ public class TlsDebugPanel extends AbstractPanel implements Tab {
 
 		this.setIcon(TLSDEBUG_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C,
-				Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.SHIFT_MASK, false));
+				Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setLayout(new BorderLayout());
 
 		JPanel panelContent = new JPanel(new GridBagLayout());

--- a/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
@@ -1,10 +1,14 @@
 <zapaddon>
 	<name>TLS Debug</name>
-	<version>1</version>
+	<version>2</version>
 	<description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
 	<author>P.M.J. Roth</author>
 	<url></url>
-	<changes/>
+	<changes>
+	<![CDATA[
+	Code changes for Java 9 (Issue 2602).<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.tlsdebug.ExtensionTlsDebug</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.wappalyzer;
 
 import java.awt.CardLayout;
-import java.awt.Event;
 import java.awt.GridBagConstraints;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -71,7 +70,7 @@ public class TechPanel extends AbstractPanel {
         this.setName(Constant.messages.getString("wappalyzer.panel.title"));
 		this.setIcon(ExtensionWappalyzer.WAPPALYZER_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | Event.ALT_MASK | Event.SHIFT_MASK, false));
+				KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("wappalyzer.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
 	}


### PR DESCRIPTION
Replace usage of java.awt.Event with KeyEvent, the former is deprecated
in Java 9, also, update to recommended (non-deprecated) masks (e.g.
SHIFT_DOWN_MASK instead of SHIFT_MASK).
Update changes and bump version in ZapAddOn.xml files (where required).

Part of zaproxy/zaproxy#2602 - Java 9