### PR TITLE
zest: correct script type comparisons

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -207,7 +207,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 		
 		if (View.isInitialised()) {
 			if (scriptUI != null && scriptUI.isScriptDisplayed(wrapper)) {
-				if (! ZestScript.Type.Passive.name().equals(wrapper.getZestScript().getType())) {
+				if (! hasSameScriptType(wrapper.getZestScript(), ZestScript.Type.Passive)) {
 					// Dont try to update passive scripts - they cant make requests so the 
 					// last request wont be in the results list
 					extension.failLastResult(e);
@@ -219,6 +219,10 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 			System.out.println("Action: failed: " + e.getMessage());
 		}
 	}
+
+	private static boolean hasSameScriptType(ZestScript script, ZestScript.Type type) {
+		return type.name().equalsIgnoreCase(script.getType());
+	}
 	
 	private int getID() {
 		// TODO Auto-generated method stub
@@ -229,7 +233,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     	log.debug("notifyAssignFailed", e);
 		if (View.isInitialised()) {
 			if (scriptUI != null && scriptUI.isScriptDisplayed(wrapper)) {
-				if (! ZestScript.Type.Passive.equals(wrapper.getZestScript().getType())) {
+				if (! hasSameScriptType(wrapper.getZestScript(), ZestScript.Type.Passive)) {
 					// Dont try to update passive scripts - they cant make requests so the 
 					// last request wont be in the results list
 					extension.failLastResult(e);

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -203,7 +203,7 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
         if (this.isServerSide()) {
     		scriptWrapper.setRecording(true);
 
-    		if (ZestScript.Type.StandAlone.equals(getSelectedType())) {
+    		if (ZestScript.Type.StandAlone.name().equalsIgnoreCase(script.getType())) {
                 scriptWrapper.setIncStatusCodeAssertion(this.getBoolValue(FIELD_STATUS));
                 scriptWrapper.setIncLengthAssertion(this.getBoolValue(FIELD_LENGTH));
                 scriptWrapper.setLengthApprox(this.getIntValue(FIELD_APPROX));


### PR DESCRIPTION
Change ZestRecordScriptDialog and ZestZapRunner to correct script type
comparisons (they were using different types which would yield always
false).