### PR TITLE
zest: fix NPE on assign calc statement

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
+	Address exception when adding calc assign statement.<br>
 	Validate cookie name not empty.<br>
 	Code changes for Java 9 (Issue 2602).<br>
 	Re-enabled parameterize option.<br>

--- a/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -970,6 +970,8 @@ public class ZestZapUtils {
 
 	/**
 	 * Gets the label for the given calc operation.
+	 * <p>
+	 * If the given operation is {@code null} it returns the label of the default operation (addition).
 	 *
 	 * @param operation the calc operation.
 	 * @return the label of the operation.
@@ -977,6 +979,10 @@ public class ZestZapUtils {
 	 * @see #labelToCalcOperation(String)
 	 */
 	public static String calcOperationToLabel(String operation) {
+		if (operation == null) {
+			return Constant.messages.getString("zest.dialog.assign.oper.add");
+		}
+
 		switch (operation) {
 		case ZestAssignCalc.OPERAND_ADD:
 		default:


### PR DESCRIPTION
Change ZestZapUtils.calcOperationToLabel to handle null operation,
preventing a NullPointerException.
Update changes in ZapAddOn.xml file.