### PR TITLE
zest: correct dnd before stmt in loops

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -936,7 +936,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 			return child;
 		} else if (ZestZapUtils.getElement(parent) instanceof ZestLoop<?>) {
 			ZestLoop<?> zl = (ZestLoop<?>) ZestZapUtils.getElement(parent);
-			zl.add(zl.getIndex(existingChild) + 1, newChild);
+			zl.add(zl.getIndex(existingChild), newChild);
 			ScriptNode child = this.getZestTreeModel().addBeforeNode(parent, childNode, newChild);
 			this.updated(child);
 			this.display(child, false);

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Default 'load on start' to true in all cases.<br>
 	Re-enabled parameterize option.<br>
 	Cope with parameterizing strings in the URL.<br>
+	Correct drag-and-drop in loop statements.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change ExtensionZest.addBeforeRequest to not add one to the index when
pasting before the statement in a loop statement (otherwise it would add
it after).
Update changes in ZapAddOn.xml file.