### PR TITLE
zest: correct drop location check

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
@@ -126,7 +126,7 @@ public class ZestTreeTransferHandler extends TransferHandler {
         		}
         	}
         }
-    	if (childIndex == dragNode.getParent().getIndex(dragNode)) {
+    	if (parent == dragNode.getParent() && childIndex == dragNode.getParent().getIndex(dragNode)) {
         	//logger.debug("canImport cant paste into the same location");
     		return false;
     	}


### PR DESCRIPTION
Change ZestTreeTransferHandler.canImport to also check the parent
statement/node when checking if it's the same drop location, otherwise
it would prevent moving the statement if it occupied the same location
in the target (parent) statement/node.