### PR TITLE
zest: skip (keyboard) paste of statements

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
@@ -157,6 +157,10 @@ public class ZestTreeTransferHandler extends TransferHandler {
     @Override
     public boolean importData(TransferHandler.TransferSupport support) {
     	logger.debug("importData " + support.getComponent().getClass().getCanonicalName());
+
+        if (!support.isDrop()) {
+            return false;
+        }
     	
     	JTree tree = (JTree) support.getComponent();
     	


### PR DESCRIPTION
Change ZestTreeTransferHandler.importData to skip the import if not a
drag-and-drop action, thus avoiding the exception when pasting the
statements with keyboard shortcut.

Related to zaproxy/zaproxy#2300 - Zest - Pasting statements with
keyboard shortcut leads to an exception