### PR TITLE
zest: enable dnd after last statement

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
@@ -114,7 +114,7 @@ public class ZestTreeTransferHandler extends TransferHandler {
 		}
 
         // Configure for drop mode.
-        if(childIndex >= 0) {
+        if(childIndex >= 0 && childIndex < parent.getChildCount()) {
         	// prevent drop between shadow nodes
         	ScriptNode nextSibling = (ScriptNode) parent.getChildAt(childIndex);
         	if (nextSibling != null) {
@@ -178,15 +178,20 @@ public class ZestTreeTransferHandler extends TransferHandler {
         }
 
     	ScriptNode beforeChild = null;
+    	ScriptNode afterChild = null;
     	
         if (childIndex >= 0) {
-        	beforeChild = (ScriptNode) parent.getChildAt(childIndex);
+            if (childIndex == parent.getChildCount()) {
+                afterChild = (ScriptNode) parent.getChildAt(childIndex - 1);
+            } else {
+                beforeChild = (ScriptNode) parent.getChildAt(childIndex);
+            }
         }
     	
     	List<ScriptNode> nodes = new ArrayList<ScriptNode>();
     	nodes.add(dragNode);
     	
-		extension.pasteToNode((ScriptNode) parent, nodes, cut, beforeChild, null);
+		extension.pasteToNode((ScriptNode) parent, nodes, cut, beforeChild, afterChild);
     	return true;
     }
     	


### PR DESCRIPTION
Change ZestTreeTransferHandler to enable drag-and-drop after the last
statement (e.g. last statement of the script or in nested statements).
Required dnd events might not be generated with all Java versions, they
are with Java 9. (It also prevents an ArrayIndexOutOfBoundsException
while dragging the statements with Java 9.)