### PR TITLE
spiderAjax: address internal error in API

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -98,6 +98,8 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 	public AjaxSpiderAPI(ExtensionAjax extension) {
 		this.extension = extension;
 		this.historyReferences = Collections.emptyList();
+		this.resourcesOutOfScope = Collections.emptyList();
+		this.resourcesError = Collections.emptyList();
 
 		ApiAction scan = new ApiAction(ACTION_START_SCAN, null, new String[] { PARAM_URL, PARAM_IN_SCOPE, PARAM_CONTEXT_NAME, PARAM_SUBTREE_ONLY });
 		scan.setDescriptionTag("spiderajax.api.action.scan");

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Code changes for Java 9 (Issue 2602).<br>
+	Fix "Internal Error" when accessing the full results API view.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change AjaxSpiderAPI to initialise all results, to prevent a NPE when
creating the full results response (when no scan was previously started
in daemon mode).
Update changes in ZapAddOn.xml file.