### PR TITLE
invoke: log/report when application fails to start

### DIFF
--- a/src/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
+++ b/src/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
@@ -30,6 +30,7 @@ import javax.swing.SwingWorker;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
@@ -112,7 +113,15 @@ public class InvokeAppWorker extends SwingWorker<Void, Void> {
 			pb.directory(workingDir);
 		}
 		pb.redirectErrorStream(true);
-		Process proc = pb.start();
+		Process proc;
+		try {
+			proc = pb.start();
+		} catch (final Exception e) {
+			View.getSingleton().getOutputPanel().append(
+					Constant.messages.getString("invoke.error") + e.getLocalizedMessage() + "\n");
+			logger.warn("Failed to start the process: " + e.getMessage(), e);
+			return null;
+		}
 
 		if (captureOutput) {
 			try (BufferedReader brOut = new BufferedReader(new InputStreamReader(proc.getInputStream()))) {

--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Invoke Applications</name>
-	<version>6</version>
+	<version>7</version>
 	<status>beta</status>
 	<description>Invoke external applications passing context related information such as URLs and parameters</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Properly split application arguments.
+	Report/log when the application fails to start (related to Issue 3960).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/invoke/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/invoke/resources/Messages.properties
@@ -32,3 +32,4 @@ invoke.options.table.header.ouput                 = Output
 invoke.options.table.header.toNote                 = To Note
 invoke.options.title            = Applications
 invoke.site.popup               = Run application
+invoke.error = Failed to start/invoke the application:\n


### PR DESCRIPTION
Change InvokeAppWorker to report (to Output tab) and log when the
application fails to start because of an exception (previously it would
fail silently).
Bump version and update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#3960 - Output from invoked application not
captured in macOS