### PR TITLE
accessControl: display correct msg when sorting

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Fix exception that occurred with Java 9 (Issue 3934).<br>
 	Allow to copy multiple results and copy correct value from the result column.<br>
+	Display correct message when the table is sorted.<br>
 	]]> 
 	</changes>
 	<dependson />

--- a/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
+++ b/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
@@ -338,7 +338,7 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel imp
 	public HistoryReference getSelectedHistoryReference() {
 		final int selectedRow = resultsTable.getSelectedRow();
 		if (selectedRow != -1 && currentResultsModel != null) {
-			return currentResultsModel.getEntry(selectedRow).getHistoryReference();
+			return currentResultsModel.getEntry(resultsTable.convertRowIndexToModel(selectedRow)).getHistoryReference();
 		}
 		return null;
 	}


### PR DESCRIPTION
Change AccessControlStatusPanel to convert the view index to model index
to display the correct message when the table is sorted.
Update changes in ZapAddOn.xml file.