### PR TITLE
tokengen: set parent window to results dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/tokengen/AnalyseTokensDialog.java
+++ b/src/org/zaproxy/zap/extension/tokengen/AnalyseTokensDialog.java
@@ -75,7 +75,7 @@ public class AnalyseTokensDialog extends AbstractDialog implements TokenAnalyser
      * @throws HeadlessException
      */
     public AnalyseTokensDialog(ResourceBundle messages) throws HeadlessException {
-        super();
+        super(View.getSingleton().getMainFrame(), false);
         this.messages = messages;
         initialize();
     }

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -14,6 +14,7 @@
 	Ensure initial dialog is properly sized.<br>
 	Issue 2000: Title caps adjustments.<br>
 	Code changes for Java 9 (Issue 2602).<br>
+	Ensure Analyse Token dialogue is shown in front of main window.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change AnalyseTokensDialog to use the main ZAP window as its parent, it
avoids the dialogue from being hidden by main window when the focus is
changed.
Update changes in ZapAddOn.xml file.