### PR TITLE
XSS In Span UnitTests

### DIFF
--- a/test/resources/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest/InputInSpan.html
+++ b/test/resources/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest/InputInSpan.html
@@ -1,0 +1,6 @@
+<html>
+<td style="HEIGHT: 31px" vAlign="bottom"><span id="lblSearchCreteria" class="clsSubTitle"
+style="display:inline-block;font-weight:bold;height:26px;width:100%;" >Page Accessed:
+General; Date Range: 01/01/2011 to 02/01/2011; User last name contains @@@name@@@</span>
+</td>
+</html>


### PR DESCRIPTION
* TestCrossSiteScriptV2UnitTest.java > Removed `@Ignore` annotation on `shouldReportXssInReflectedUrl` since the requirement for core post 2.5.0 is fulfilled. Added `shouldReportXssInSpanContent` test method to
assert the behavior expected (as consistent with discussion in zaproxy/zaproxy#1222)
* InputInSpan.html > Resource file supporting the `shouldReportXssInSpanContent` test method.