### PR TITLE
zest: use custom plugin ID for fail actions

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -1,19 +1,13 @@
 <zapaddon>
 	<name>Zest - Graphical Security Scripting Language</name>
-	<version>25</version>
+	<version>26</version>
 	<status>beta</status>
 	<description>A graphical security scripting language, ZAPs macro language on steroids</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
-	Address exception when adding calc assign statement.<br>
-	Validate cookie name not empty.<br>
-	Code changes for Java 9 (Issue 2602).<br>
-	Default 'load on start' to true in all cases.<br>
-	Re-enabled parameterize option.<br>
-	Cope with parameterizing strings in the URL.<br>
-	Correct drag-and-drop in loop statements.<br>
+	Use custom plugin ID for fail actions.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -65,8 +65,8 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 
     private static final Logger log = Logger.getLogger(ZestZapRunner.class);
 
-	// TODO Replace the value (12) with HistoryReference.TYPE_ZEST_SCRIPT once released with core
-	private static final int ZEST_HISTORY_REFERENCE_TYPE = 12;
+	private static final int ZEST_HISTORY_REFERENCE_TYPE = HistoryReference.TYPE_ZEST_SCRIPT;
+	private static final int FAIL_ACTION_PLUGIN_ID = 50004;
 	
 	private ExtensionZest extension;
 	private ZestScriptWrapper wrapper = null;
@@ -191,7 +191,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 			} else if (ZestActionFail.Priority.HIGH.name().equals(zaf.getPriority())) {
 				risk = Alert.RISK_HIGH;
 			}
-			Alert alert = new Alert(getID(), risk, Alert.CONFIDENCE_MEDIUM, e.getMessage());
+			Alert alert = new Alert(FAIL_ACTION_PLUGIN_ID, risk, Alert.CONFIDENCE_MEDIUM, e.getMessage());
 			
 			if (lastHref != null) {
 				alert.setHistoryRef(lastHref);
@@ -222,11 +222,6 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 
 	private static boolean hasSameScriptType(ZestScript script, ZestScript.Type type) {
 		return type.name().equalsIgnoreCase(script.getType());
-	}
-	
-	private int getID() {
-		// TODO Auto-generated method stub
-		return 0;
 	}
 
 	private void notifyAssignFailed(ZestAssignFailException e) {


### PR DESCRIPTION
Change ZestZapRunner to use other plugin ID when creating alerts from
the failed actions. Also, address a TODO by using a core constant
(already targeting required core version).
Bump version and update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#3963.