### PR TITLE
websocket: remove extensions header by default

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -16,6 +16,7 @@
 	Focus WebSockets tab just once (Issue 3747).<br>
 	Minor code adjustment to align with core changes.<br>
 	Code changes for Java 9 (Issue 2602).<br>
+	Remove header Sec-WebSocket-Extensions (Issue 3324).<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
@@ -47,6 +47,11 @@ websocket.manual_send.resend.menu               = Open/Resend with Message Edito
 websocket.options.break_on_all                  = Break on enabled 'all request/response break buttons'.
 websocket.options.break_on_ping_pong            = Break on Ping & Pong messages on implicit breakpoints.
 websocket.options.forward_all                   = Forward all WebSockets communication (no storage nor UI).
+websocket.options.remove_extensions = Remove Sec-WebSocket-Extensions header.
+websocket.options.remove_extensions.tooltip = <html>Allows to remove the HTTP header Sec-WebSocket-Extensions from handshake messages, <br>\
+so no transformations are done to the WebSocket messages sent/received.<br>\
+This option should always be enabled unless the client or the server under test requires them.<br>\
+The WebSocket messages might not be correctly processed by ZAP when extensions are used.</html>
 websocket.panel.component.all.tooltip           = Display for WebSocket message
 websocket.panel.title                           = WebSockets
 websocket.panel.mnemonic                        = w

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/options.html
@@ -39,5 +39,11 @@ If this option is disabled no <i>PING</i> or <i>PONG</i> message is caught when 
 </ul>
 This setting does not affect breakpoints that are set explicitly on <i>PING</i> or <i>PONG</i> messages. You can view such explicit breakpoints in the <i>Breakpoints tab</i>.
 
+<h3>Remove <code>Sec-WebSocket-Extensions</code> header</h3>
+Allows to remove the HTTP header <code>Sec-WebSocket-Extensions</code> from handshake messages, so no transformations are done
+to the WebSocket messages sent/received.<br>
+This option should always be enabled unless the client or the server under test requires them. The WebSocket
+messages might not be correctly processed by ZAP when extensions are used.
+
 </BODY>
 </HTML>

--- a/src/org/zaproxy/zap/extension/websocket/ui/OptionsParamWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/OptionsParamWebSocket.java
@@ -27,11 +27,23 @@ public class OptionsParamWebSocket extends AbstractParam {
 	public static final String BREAK_ON_PING_PONG = "websocket.breakOnPingPong";
 	public static final String BREAK_ON_ALL = "websocket.breakOnAll";
 	private static final String CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY = "websocket.confirmRemoveProxyExcludeRegex";
+	private static final String REMOVE_EXTENSIONS_HEADER_KEY = "websocket.removeExtensionsHeader";
 
 	private boolean isForwardAll;
 	private boolean isBreakOnPingPong;
 	private boolean isBreakOnAll;
 	private boolean confirmRemoveProxyExcludeRegex;
+
+	/**
+	 * Flag that controls whether or not the header {@code Sec-WebSocket-Extensions} should be removed from the handshake
+	 * messages.
+	 * <p>
+	 * Default is {@code true}.
+	 * 
+	 * @see #REMOVE_EXTENSIONS_HEADER_KEY
+	 * @see #setRemoveExtensionsHeader(boolean)
+	 */
+	private boolean removeExtensionsHeader = true;
 
     @Override
     protected void parse() {
@@ -40,6 +52,7 @@ public class OptionsParamWebSocket extends AbstractParam {
     	isBreakOnPingPong = cfg.getBoolean(BREAK_ON_PING_PONG, false);
     	isBreakOnAll = cfg.getBoolean(BREAK_ON_ALL, false);
     	confirmRemoveProxyExcludeRegex = cfg.getBoolean(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, false);
+    	removeExtensionsHeader = cfg.getBoolean(REMOVE_EXTENSIONS_HEADER_KEY, true);
     }
 
     /**
@@ -113,5 +126,31 @@ public class OptionsParamWebSocket extends AbstractParam {
 	public void setConfirmRemoveProxyExcludeRegex(boolean confirmRemove) {
 		this.confirmRemoveProxyExcludeRegex = confirmRemove;
 		getConfig().setProperty(CONFIRM_REMOVE_PROXY_EXCLUDE_REGEX_KEY, Boolean.valueOf(confirmRemove));
+	}
+
+	/**
+	 * Sets whether or not the header {@code Sec-WebSocket-Extensions} should be removed from the handshake messages.
+	 *
+	 * @param remove {@code true} if the header should be removed, {@code false} otherwise
+	 * @see #isRemoveExtensionsHeader()
+	 */
+	public void setRemoveExtensionsHeader(boolean remove) {
+		if (removeExtensionsHeader != remove) {
+			this.removeExtensionsHeader = remove;
+			getConfig().setProperty(REMOVE_EXTENSIONS_HEADER_KEY, Boolean.valueOf(removeExtensionsHeader));
+		}
+	}
+
+	/**
+	 * Tells whether or not the header {@code Sec-WebSocket-Extensions} should be removed from the handshake messages.
+	 * <p>
+	 * When enabled it allows ZAP to properly process the WebSocket messages, as no further (and unsupported) transformation is
+	 * done to them (for example, compression).
+	 *
+	 * @return {@code true} if the header should be removed, {@code false} otherwise
+	 * @see #setRemoveExtensionsHeader(boolean)
+	 */
+	public boolean isRemoveExtensionsHeader() {
+		return removeExtensionsHeader;
 	}
 }

--- a/src/org/zaproxy/zap/extension/websocket/ui/OptionsWebSocketPanel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/OptionsWebSocketPanel.java
@@ -40,6 +40,8 @@ import org.parosproxy.paros.view.AbstractParamPanel;
  * <li>Break on All - react on breakpoints set for all requests/responses.</li>
  * <li>Break on Ping/Pong - react on Ping & Pong messages that arrive while
  * stepping or waiting for all requests/responses.</li>
+ * <li>Remove header {@code Sec-WebSocket-Extensions} - when enabled it allows to properly process the WebSocket messages, as no
+ * further (and unsupported) transformation is done to them (for example, compression).</li>
  * </ul>
  * </p>
  */
@@ -55,6 +57,8 @@ public class OptionsWebSocketPanel extends AbstractParamPanel {
     private static final String LABEL_FORWARD_ALL = Constant.messages.getString("websocket.options.forward_all");
     private static final String LABEL_BREAK_ON_PING_PONG = Constant.messages.getString("websocket.options.break_on_ping_pong");
     private static final String LABEL_BREAK_ON_ALL = Constant.messages.getString("websocket.options.break_on_all");
+    private static final String LABEL_REMOVE_EXTENSIONS_HEADER = Constant.messages.getString("websocket.options.remove_extensions");
+    private static final String TOOLTIP_REMOVE_EXTENSIONS_HEADER = Constant.messages.getString("websocket.options.remove_extensions.tooltip");
 
     /**
 	 * Represents the model containing current values. Is able to save back to
@@ -65,6 +69,7 @@ public class OptionsWebSocketPanel extends AbstractParamPanel {
 	private JCheckBox checkBoxForwardAll;
 	private JCheckBox checkBoxBreakOnPingPong;
 	private JCheckBox checkBoxBreakOnAll;
+	private JCheckBox checkBoxRemoveExtensionsHeader;
 	
     public OptionsWebSocketPanel(OptionsParamWebSocket wsParams) {
         super();
@@ -100,6 +105,12 @@ public class OptionsWebSocketPanel extends AbstractParamPanel {
         gbc.insets = new Insets(2,2,2,2);
         panel.add(getCheckBoxBreakOnPingPong(), gbc);
         
+        gbc = new GridBagConstraints();
+        gbc.gridy = 3;
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.insets = new Insets(2,2,2,2);
+        panel.add(getCheckcheckBoxRemoveExtensionsHeader(), gbc);
+
         return panel;
 	}
 
@@ -123,12 +134,21 @@ public class OptionsWebSocketPanel extends AbstractParamPanel {
         }
         return checkBoxBreakOnPingPong;
     }
+
+    private JCheckBox getCheckcheckBoxRemoveExtensionsHeader() {
+        if (checkBoxRemoveExtensionsHeader == null) {
+            checkBoxRemoveExtensionsHeader = new JCheckBox(LABEL_REMOVE_EXTENSIONS_HEADER);
+            checkBoxRemoveExtensionsHeader.setToolTipText(TOOLTIP_REMOVE_EXTENSIONS_HEADER);
+        }
+        return checkBoxRemoveExtensionsHeader;
+    }
     
     @Override
     public void initParam(Object obj) {
         checkBoxForwardAll.setSelected(wsParams.isForwardAll());
         checkBoxBreakOnAll.setSelected(wsParams.isBreakOnAll());
         checkBoxBreakOnPingPong.setSelected(wsParams.isBreakOnPingPong());
+        checkBoxRemoveExtensionsHeader.setSelected(wsParams.isRemoveExtensionsHeader());
     }
 
     @Override
@@ -141,6 +161,7 @@ public class OptionsWebSocketPanel extends AbstractParamPanel {
     	wsParams.setForwardAll(checkBoxForwardAll.isSelected());
     	wsParams.setBreakOnAll(checkBoxBreakOnAll.isSelected());
     	wsParams.setBreakOnPingPong(checkBoxBreakOnPingPong.isSelected());
+    	wsParams.setRemoveExtensionsHeader(checkBoxRemoveExtensionsHeader.isSelected());
     }
     
     @Override


### PR DESCRIPTION
Add a new option, enabled by default, that allows to control whether or
not the HTTP header Sec-WebSocket-Extensions should be removed from the
handshake messages. This disables any extensions that could prevent ZAP
from properly process the WebSocket messages sent/received.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3324 - invalid utf-8 in payload when connecting
using a simple websocket client in firefox + chrome