### PR TITLE
JSON view with basic features: indenting, highlighting, folding

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -421,6 +421,7 @@
 		<build-addon name="highlighter" />
 		<build-addon name="httpsinfo" addonid="httpsInfo" />
 		<build-addon name="importLogFiles" />
+		<build-addon name="jsonview"/>
 		<build-addon name="jxbrowser" />
 		<build-addon name="jxbrowserlinux64" />
 		<build-addon name="jxbrowsermacos" />
@@ -623,6 +624,10 @@
 	
 	<target name="deploy-importLogFiles" description="deploy the importLogFiles extension">
 		<build-deploy-addon name="importLogFiles" />
+	</target>
+	
+	<target name="deploy-jsonview" description="deploy the jsonview extension">
+		<build-deploy-addon name="jsonview" />
 	</target>
 
 	<target name="download-jxbrowser" depends="compile" description="download the jxbrowser files">

--- a/src/org/zaproxy/zap/extension/jsonview/ExtensionHttpPanelJsonView.java
+++ b/src/org/zaproxy/zap/extension/jsonview/ExtensionHttpPanelJsonView.java
@@ -1,0 +1,215 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.jsonview;
+
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.extension.httppanel.component.split.response.ResponseSplitComponent;
+import org.zaproxy.zap.extension.httppanel.component.split.request.RequestSplitComponent;
+import org.zaproxy.zap.extension.httppanel.view.HttpPanelDefaultViewSelector;
+import org.zaproxy.zap.extension.httppanel.view.HttpPanelView;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestBodyStringHttpPanelViewModel;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.response.ResponseBodyStringHttpPanelViewModel;
+import org.zaproxy.zap.view.HttpPanelManager;
+import org.zaproxy.zap.view.HttpPanelManager.HttpPanelDefaultViewSelectorFactory;
+import org.zaproxy.zap.view.HttpPanelManager.HttpPanelViewFactory;
+
+import java.util.Locale;
+
+public class ExtensionHttpPanelJsonView extends ExtensionAdaptor {
+
+	public static final String NAME = "ExtensionHttpPanelJsonView";
+
+	@Override
+	public String getAuthor() {
+		return "Juha Kivekäs";
+	}
+
+	public ExtensionHttpPanelJsonView() {
+		super(NAME);
+	}
+
+	@Override
+	public void hook(ExtensionHook extensionHook) {
+		super.hook(extensionHook);
+
+		if (getView() != null) {
+			HttpPanelManager panelManager = HttpPanelManager.getInstance();
+			//add the view factories for http requests and responses
+			panelManager.addRequestViewFactory(RequestSplitComponent.NAME, new RequestJsonViewFactory());
+			panelManager.addResponseViewFactory(ResponseSplitComponent.NAME, new ResponseJsonViewFactory());
+			//add default view selectors
+			panelManager.addRequestDefaultViewSelectorFactory(RequestSplitComponent.NAME,
+					new JsonDefaultViewSelectorFactory(RequestSplitComponent.NAME, RequestSplitComponent.ViewComponent.BODY));
+			panelManager.addResponseDefaultViewSelectorFactory(ResponseSplitComponent.NAME,
+					new JsonDefaultViewSelectorFactory(ResponseSplitComponent.NAME, ResponseSplitComponent.ViewComponent.BODY));
+		}
+	}
+
+	@Override
+	public boolean canUnload() {
+		return true;
+	}
+
+	@Override
+	public void unload() {
+		if (getView() != null) {
+			HttpPanelManager panelManager = HttpPanelManager.getInstance();
+			//remove views and their factories
+			panelManager.removeRequestViewFactory(RequestSplitComponent.NAME, RequestJsonViewFactory.NAME);
+			panelManager.removeRequestViews(RequestSplitComponent.NAME, HttpPanelJsonView.NAME, RequestSplitComponent.ViewComponent.BODY);
+			panelManager.removeResponseViewFactory(ResponseSplitComponent.NAME, ResponseJsonViewFactory.NAME);
+			panelManager.removeResponseViews(ResponseSplitComponent.NAME, HttpPanelJsonView.NAME, ResponseSplitComponent.ViewComponent.BODY);
+			//remove default view selectors and their factories
+			panelManager.removeRequestDefaultViewSelectorFactory(
+					RequestSplitComponent.NAME,
+					JsonDefaultViewSelectorFactory.NAME);
+			panelManager.removeRequestDefaultViewSelectors(
+					RequestSplitComponent.NAME,
+					JsonDefaultViewSelector.NAME,
+					RequestSplitComponent.ViewComponent.BODY);
+			panelManager.removeResponseDefaultViewSelectorFactory(
+					ResponseSplitComponent.NAME,
+					JsonDefaultViewSelectorFactory.NAME);
+			panelManager.removeResponseDefaultViewSelectors(
+					ResponseSplitComponent.NAME,
+					JsonDefaultViewSelector.NAME,
+					ResponseSplitComponent.ViewComponent.BODY);
+		}
+		super.unload();
+	}
+
+	private static final class RequestJsonViewFactory implements HttpPanelViewFactory {
+		public static final String NAME = "RequestJsonViewFactory";
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+
+		@Override
+		public HttpPanelView getNewView() {
+			return new HttpPanelJsonView(new RequestBodyStringHttpPanelViewModel());
+		}
+
+		@Override
+		public Object getOptions() {
+			return RequestSplitComponent.ViewComponent.BODY;
+		}
+	}
+
+	private static final class ResponseJsonViewFactory implements HttpPanelViewFactory {
+		public static final String NAME = "ResponseJsonViewFactory";
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+
+		@Override
+		public HttpPanelView getNewView() {
+			return new HttpPanelJsonView(new ResponseBodyStringHttpPanelViewModel());
+		}
+
+		@Override
+		public Object getOptions() {
+			return ResponseSplitComponent.ViewComponent.BODY;
+		}
+	}
+
+	private static final class JsonDefaultViewSelector implements HttpPanelDefaultViewSelector {
+		private static final String NAME = "JsonDefaultViewSelector";
+		private Object options;
+
+		JsonDefaultViewSelector(Object options) {
+			this.options = options;
+		}
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+
+		@Override
+		public boolean matchToDefaultView(Message message) {
+			if (message == null) {
+				//called with null when deleting the view, ie. when changing from split to combined view
+				return false;
+			}
+			if (message instanceof HttpMessage) {
+				HttpMessage httpMessage = (HttpMessage) message;
+				HttpHeader header;
+				if (this.options == RequestSplitComponent.NAME) {
+					header = httpMessage.getRequestHeader();
+				} else if (this.options == ResponseSplitComponent.NAME) {
+					header = httpMessage.getResponseHeader();
+				} else {
+					return false;
+				}
+				String contentType = header.getHeader(HttpHeader.CONTENT_TYPE);
+				if (contentType == null) {
+					return false;
+				}
+				if (contentType.toLowerCase(Locale.ROOT).contains("application/json")) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		@Override
+		public String getViewName() {
+			return HttpPanelJsonView.NAME;
+		}
+
+		@Override
+		public int getOrder() {
+			return 0;
+		}
+	}
+
+	private static final class JsonDefaultViewSelectorFactory implements HttpPanelDefaultViewSelectorFactory {
+		public static final String NAME = "JsonDefaultViewSelector";
+		private Object selectorOptions;
+		private Object factoryOptions;
+
+		JsonDefaultViewSelectorFactory(Object selectorOptions, Object factoryOptions) {
+			this.factoryOptions = factoryOptions;
+			this.selectorOptions = selectorOptions;
+		}
+
+		@Override
+		public String getName() {
+			return NAME;
+		}
+
+		@Override
+		public HttpPanelDefaultViewSelector getNewDefaultViewSelector() {
+			return new JsonDefaultViewSelector(this.selectorOptions);
+		}
+
+		@Override
+		public Object getOptions() {
+			return this.factoryOptions;
+		}
+	}
+}
+

--- a/src/org/zaproxy/zap/extension/jsonview/HttpPanelJsonArea.java
+++ b/src/org/zaproxy/zap/extension/jsonview/HttpPanelJsonArea.java
@@ -1,0 +1,50 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.jsonview;
+
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextArea;
+import org.zaproxy.zap.extension.search.SearchMatch;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class HttpPanelJsonArea extends HttpPanelSyntaxHighlightTextArea {
+
+	private static final long serialVersionUID = 1L;
+
+	public HttpPanelJsonArea() {
+		setSyntaxEditingStyle(SyntaxConstants.SYNTAX_STYLE_JSON);
+		setCodeFoldingEnabled(true);
+	}
+
+	@Override
+	public void search(Pattern pattern, List<SearchMatch> list) {
+
+	}
+
+	@Override
+	public void highlight(SearchMatch searchMatch) {
+
+	}
+
+	@Override
+	protected CustomTokenMakerFactory getTokenMakerFactory() {
+		return null;
+	}
+}

--- a/src/org/zaproxy/zap/extension/jsonview/HttpPanelJsonView.java
+++ b/src/org/zaproxy/zap/extension/jsonview/HttpPanelJsonView.java
@@ -1,0 +1,189 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+package org.zaproxy.zap.extension.jsonview;
+
+import java.awt.BorderLayout;
+
+
+import net.sf.json.*;
+import org.apache.commons.configuration.FileConfiguration;
+import org.fife.ui.rtextarea.RTextScrollPane;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.extension.httppanel.view.*;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.request.RequestBodyStringHttpPanelViewModel;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.response.ResponseBodyStringHttpPanelViewModel;
+
+import javax.swing.JPanel;
+import javax.swing.JComponent;
+
+public class HttpPanelJsonView implements HttpPanelView, HttpPanelViewModelListener {
+
+	/**
+	 * Default name used for {@code MessageContainer}.
+	 *
+	 * @see org.zaproxy.zap.view.messagecontainer.MessageContainer
+	 */
+	public static final String NAME = "HttpPanelJsonView";
+	private static final String CAPTION_NAME = "Json";
+
+	private HttpPanelJsonArea httpPanelJsonArea;
+	private JPanel mainPanel;
+
+	private AbstractStringHttpPanelViewModel model;
+
+	public HttpPanelJsonView(AbstractStringHttpPanelViewModel model) {
+		httpPanelJsonArea = new HttpPanelJsonArea();
+		RTextScrollPane scrollPane = new RTextScrollPane(httpPanelJsonArea);
+		scrollPane.setLineNumbersEnabled(false);
+		mainPanel = new JPanel(new BorderLayout());
+		mainPanel.add(scrollPane, BorderLayout.CENTER);
+		this.model = model;
+		model.addHttpPanelViewModelListener(this);
+	}
+
+	@Override
+	public void setSelected(boolean selected) {
+		if (selected) {
+			httpPanelJsonArea.requestFocusInWindow();
+		}
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getCaptionName() {
+		return CAPTION_NAME;
+	}
+
+	@Override
+	public String getTargetViewName() {
+		return "";
+	}
+
+	@Override
+	public int getPosition() {
+		return 0;
+	}
+
+	@Override
+	public boolean isEnabled(Message message) {
+		String jsonString;
+		if (message instanceof HttpMessage) {
+			HttpMessage httpMessage = ((HttpMessage) message);
+			if (this.model instanceof RequestBodyStringHttpPanelViewModel) {
+				jsonString = httpMessage.getRequestBody().toString();
+			} else if (this.model instanceof ResponseBodyStringHttpPanelViewModel) {
+				jsonString = httpMessage.getResponseBody().toString();
+			} else {
+				return false;
+			}
+		} else {
+			return false;
+		}
+		try {
+			toJson(jsonString);
+			return true;
+		} catch (JSONException e) {
+			return false;
+		}
+	}
+
+	@Override
+	public boolean hasChanged() {
+		return true;
+	}
+
+	@Override
+	public JComponent getPane() {
+		return mainPanel;
+	}
+
+	@Override
+	public boolean isEditable() {
+		return httpPanelJsonArea.isEditable();
+	}
+
+	@Override
+	public void setEditable(boolean editable) {
+		httpPanelJsonArea.setEditable(editable);
+	}
+
+	@Override
+	public HttpPanelViewModel getModel() {
+		return model;
+	}
+
+	@Override
+	public void save() {
+		//we intentionally want to let the user give broken data
+		this.model.setData(httpPanelJsonArea.getText());
+	}
+
+	@Override
+	public void setParentConfigurationKey(String configurationKey) {
+	}
+
+	@Override
+	public void loadConfiguration(FileConfiguration fileConfiguration) {
+	}
+
+	@Override
+	public void saveConfiguration(FileConfiguration fileConfiguration) {
+	}
+
+	@Override
+	public void dataChanged(HttpPanelViewModelEvent e) {
+		String body = ((AbstractStringHttpPanelViewModel) e.getSource()).getData();
+		try {
+			JSON json = toJson(body);
+			if (json instanceof JSONNull) {
+				//avoid the string "null" for empty bodies
+				httpPanelJsonArea.setText("");
+			} else {
+				httpPanelJsonArea.setText(json.toString(2));
+			}
+		} catch (JSONException ex) {
+			httpPanelJsonArea.setText(body);
+		}
+		if (!isEditable()) {
+			httpPanelJsonArea.discardAllEdits();
+		}
+		// TODO: scrolling to top when new message is opened
+		//httpPanelJsonArea.setCaretPosition(0);
+	}
+
+	private static JSON toJson(String s) throws JSONException {
+		JSON object;
+		s = s.trim();
+
+		if (s.isEmpty()) {
+			object = JSONNull.getInstance();
+		} else if (s.startsWith("{")) {
+			object = JSONObject.fromObject(s);
+		} else if (s.startsWith("[")) {
+			object = JSONArray.fromObject(s);
+		} else {
+			throw new JSONException("Expected a '{', '[', or an empty message");
+		}
+		return object;
+	}
+}

--- a/src/org/zaproxy/zap/extension/jsonview/README.md
+++ b/src/org/zaproxy/zap/extension/jsonview/README.md
@@ -1,0 +1,25 @@
+Json view
+=========
+A simple Json indenter and beautifier.
+Built after months of API testing on mobile applications that caused huge amounts of copy-pasting to jq.
+Currently a very crude, yet helpful addon.
+
+### ExtensionHttpPanelJsonView
+The extension loader and handler, this is here mainly because nobody wants addons to touch the core code so it has to extend dynamically.
+Contains some classes to manage the view enabling and selection too.
+
+### HttpPanelJsonView
+Controls the view, model, and Json data parsing.
+
+### HttpPanelJsonArea
+The syntax highlighted editable text area used for viewing and editing.
+
+## Edge cases
+application/json with empty body
+	sometimes renders null into the sent body :(
+application/json with huge data
+	large request view not defaulted, causes loading delays in either
+		identification/parsing
+		rendering
+	
+

--- a/src/org/zaproxy/zap/extension/jsonview/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jsonview/ZapAddOn.xml
@@ -1,0 +1,19 @@
+<zapaddon>
+	<name>Json view</name>
+	<version>1</version>
+	<status>alpha</status>
+	<description>Adds a view that shows JSON messages nicely formatted</description>
+	<author>Juha Kivekäs</author>
+	<url></url>
+	<changes>Initial release</changes>
+	<extensions>
+	    <extension>org.zaproxy.zap.extension.jsonview.ExtensionHttpPanelJsonView</extension>
+	</extensions>
+	<ascanrules/>
+	<pscanrules/>
+	<filters/>
+	<files/>
+	<not-before-version>2.6.0</not-before-version>
+	<not-from-version></not-from-version>
+</zapaddon>
+


### PR DESCRIPTION
I keep copying stuff to jq while doing API assessments and decided to make my life easier with this addon. Useful for manual testing of JSON APIs of mobile applications, especially when responses grow into a few kilobytes.

Tested mainly this week during an assessment, and a few issues already fixed after that. Changing between view methods (split and combined), breakpoints, repeating messages, unloading the plugin, and default view selection all seem to work without throwing exceptions.