### PR TITLE
Implemented a new Extension CustomPayloads. 

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+ - Add dependency on Custom Payloads add-on. The payloads of the Test User Agent scanner are now customizable.
 
 - Maintenance changes.
 - Added XSLT Injection Scanner (issue 3572).

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,10 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-### Added
- - Add dependency on Custom Payloads add-on. The payloads of the Test User Agent scanner are now customizable.
 
-- Maintenance changes.
+### Added
+- Add dependency on Custom Payloads add-on. The payloads of the Test User Agent scanner are now customizable.
 - Added XSLT Injection Scanner (issue 3572).
 
 ## [25] - 2019-07-11

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -3,15 +3,23 @@ description = "The alpha quality Active Scanner rules"
 
 zapAddOn {
     addOnName.set("Active scanner rules (alpha)")
-    zapVersion.set("2.6.0")
+    zapVersion.set("2.8.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha")
-
-        dependencies {
-            addOns {
-                register("custompayloads")
+        extensions {
+            register("org.zaproxy.zap.extension.ascanrulesAlpha.payloader.ExtensionPayloader") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.zap.extension.ascanrulesAlpha.payloader"))
+                }
+                dependencies {
+                    addOns {
+                        register("custompayloads") {
+                            version.set("1.*")
+                        }
+                    }
+                }
             }
         }
     }
@@ -19,7 +27,7 @@ zapAddOn {
 
 dependencies {
     implementation("org.jsoup:jsoup:1.7.2")
-        compileOnly(parent!!.childProjects.get("custompayloads")!!)
+    compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -8,11 +8,19 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha")
+
+        dependencies {
+            addOns {
+                register("custompayloads")
+            }
+        }
     }
 }
 
 dependencies {
     implementation("org.jsoup:jsoup:1.7.2")
+        compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
+    testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
@@ -21,18 +21,24 @@ package org.zaproxy.zap.extension.ascanrulesAlpha;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.custompayloads.CustomPayloadModel;
+import org.zaproxy.zap.extension.custompayloads.ExtensionCustomPayloads;
+import org.zaproxy.zap.extension.custompayloads.PluginWithConfigurablePayload;
 
 /** @author kniepdennis@gmail.com */
-public class TestUserAgent extends AbstractAppPlugin {
+public class TestUserAgent extends AbstractAppPlugin implements PluginWithConfigurablePayload {
 
     private static final Logger log = Logger.getLogger(TestUserAgent.class);
 
@@ -64,6 +70,7 @@ public class TestUserAgent extends AbstractAppPlugin {
         YAHOO_SLURP,
         I_PHONE_3
     };
+    public static final String USER_AGENT_PAYLOAD_CATEGORY = "User-Agent";
 
     private int originalResponseBodyHash;
 
@@ -75,6 +82,11 @@ public class TestUserAgent extends AbstractAppPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public String[] getDependency() {
+        return null;
     }
 
     @Override
@@ -98,15 +110,31 @@ public class TestUserAgent extends AbstractAppPlugin {
     }
 
     @Override
+    public void init() {}
+
+    @Override
     public void scan() {
         originalResponseBodyHash = getBaseMsg().getResponseBody().hashCode();
 
-        for (String userAgent : USER_AGENTS) {
+        for (CustomPayloadModel userAgentPayload : getUserAgentPayloads()) {
             if (isStop()) {
                 return;
             }
-            attack(userAgent);
+            attack(userAgentPayload.getPayload());
         }
+    }
+
+    private List<CustomPayloadModel> getUserAgentPayloads() {
+        ExtensionCustomPayloads extension =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionCustomPayloads.class);
+
+        if (extension != null) {
+            return extension.getPayloadsByCategory(USER_AGENT_PAYLOAD_CATEGORY);
+        }
+
+        return getDefaultPayloads();
     }
 
     private void attack(String userAgent) {
@@ -155,5 +183,14 @@ public class TestUserAgent extends AbstractAppPlugin {
                 userAgent,
                 "",
                 newMsg);
+    }
+
+    @Override
+    public List<CustomPayloadModel> getDefaultPayloads() {
+        List<CustomPayloadModel> payloads = new ArrayList<>();
+        for (String userAgent : USER_AGENTS) {
+            payloads.add(new CustomPayloadModel(USER_AGENT_PAYLOAD_CATEGORY, userAgent));
+        }
+        return payloads;
     }
 }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/payloader/ExtensionPayloader.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/payloader/ExtensionPayloader.java
@@ -1,0 +1,107 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.payloader;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.ascanrulesAlpha.TestUserAgent;
+import org.zaproxy.zap.extension.custompayloads.ExtensionCustomPayloads;
+import org.zaproxy.zap.extension.custompayloads.PayloadCategory;
+
+public class ExtensionPayloader extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtensionPayloader";
+    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static ExtensionCustomPayloads ecp;
+    private PayloadCategory category;
+
+    static {
+        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
+        dependencies.add(ExtensionCustomPayloads.class);
+        DEPENDENCIES = Collections.unmodifiableList(dependencies);
+    }
+
+    public ExtensionPayloader() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        ecp =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionCustomPayloads.class);
+        category =
+                new PayloadCategory(
+                        TestUserAgent.USER_AGENT_PAYLOAD_CATEGORY, TestUserAgent.USER_AGENTS);
+        ecp.addPayloadCategory(category);
+        TestUserAgent.setPayloadProvider(() -> category.getPayloadsIterator());
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        TestUserAgent.setPayloadProvider(null);
+        ecp.removePayloadCategory(category);
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+
+    @Override
+    public URL getURL() {
+        try {
+            return new URL(Constant.ZAP_HOMEPAGE);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("ascanalpha.payloader.desc");
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("ascanalpha.payloader.name");
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -96,6 +96,9 @@ ascanalpha.ldapinjection.booleanbased.alert.extrainfo=parameter [{0}] on [{1}] [
 ascanalpha.ldapinjection.alert.attack=parameter [{0}] set to [{1}]
 ascanalpha.ldapinjection.booleanbased.alert.attack=Equivalent LDAP expression: [{0}]. Random parameter: [{1}].
 
+ascanalpha.payloader.desc=Provides support for custom payloads in scan rules.
+ascanalpha.payloader.name=Active Scan Rules Alpha Custom Payloads
+
 ascanalpha.proxydisclosure.name=Proxy Disclosure
 ascanalpha.proxydisclosure.desc={0} proxy server(s) were detected or fingerprinted. This information helps a potential attacker to determine \n - A list of targets for an attack against the application.\n - Potential vulnerabilities on the proxy servers that service the application.\n - The presence or absence of any proxy-based components that might cause attacks against the application to be detected, prevented, or mitigated. 
 ascanalpha.proxydisclosure.soln=Disable the 'TRACE' method on the proxy servers, as well as the origin web/application server.\nDisable the 'OPTIONS' method on the proxy servers, as well as the origin web/application server, if it is not required for other purposes, such as 'CORS' (Cross Origin Resource Sharing).\nConfigure the web and application servers with custom error pages, to prevent 'fingerprintable' product-specific error pages being leaked to the user in the event of HTTP errors, such as 'TRACK' requests for non-existent pages.\nConfigure all proxies, application servers, and web servers to prevent disclosure of the technology and version information in the 'Server' and 'X-Powered-By' HTTP response headers.\n

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this add-on will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## Unreleased
+
+- First version.
+

--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -1,9 +1,9 @@
-version = "1"
+version = "1.0.0"
 description = "Ability to add, edit or remove payloads that are used i.e. by active scanners"
 
 zapAddOn {
     addOnName.set("Custom Payloads")
-    zapVersion.set("2.6.0")
+    zapVersion.set("2.8.0")
 
     manifest {
         author.set("ZAP Core Team")

--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -1,0 +1,11 @@
+version = "1"
+description = "Ability to add, edit or remove payloads that are used i.e. by active scanners"
+
+zapAddOn {
+    addOnName.set("Custom Payloads")
+    zapVersion.set("2.6.0")
+
+    manifest {
+        author.set("ZAP Core Team")
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnDialog.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnDialog.java
@@ -1,0 +1,161 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.awt.Dimension;
+import java.awt.Window;
+import java.util.ArrayList;
+import java.util.List;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AbstractColumnDialog<T> extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+    private List<Column<T>> columns;
+    private T model;
+    private boolean saved;
+
+    public AbstractColumnDialog(Window owner, String title, List<Column<T>> columns, T model) {
+        this(owner, title, columns, model, DisplayUtils.getScaledDimension(500, 350));
+    }
+
+    public AbstractColumnDialog(
+            Window owner, String title, List<Column<T>> columns, T model, Dimension dimension) {
+        this(owner, title, columns, model, dimension, true);
+    }
+
+    public AbstractColumnDialog(
+            Window owner,
+            String title,
+            List<Column<T>> columns,
+            T model,
+            Dimension dimension,
+            boolean modal) {
+        super(owner, title, dimension, modal);
+        this.columns = columns;
+        this.model = model;
+        initFields();
+    }
+
+    private void initFields() {
+        this.removeAllFields();
+        for (Column<T> column : columns) {
+            addField(column);
+        }
+    }
+
+    private void addField(Column<T> column) {
+        if (column.getColumnClass() == String.class) {
+            createStringFieldForColumn(column);
+        } else if (column.getColumnClass() == Boolean.class) {
+            createBooleanFieldForColumn(column);
+        } else if (column.getColumnClass() == Integer.class) {
+            createIntFieldForColumn(column);
+        }
+        setFieldEnabledStateByColumnType(column);
+    }
+
+    private void createBooleanFieldForColumn(Column<T> column) {
+        Boolean value = column.<Boolean>getTypedValue(model);
+        this.addCheckBoxField(column.getNameKey(), value);
+    }
+
+    private void createStringFieldForColumn(Column<T> column) {
+        if (column instanceof EditableSelectColumn) {
+            createStringComboFieldForColumn(column);
+        } else {
+            createStringTextFieldForColumn(column);
+        }
+    }
+
+    private void createStringTextFieldForColumn(Column<T> column) {
+        String value = column.getTypedValue(model);
+        this.addTextField(column.getNameKey(), value);
+    }
+
+    private void createStringComboFieldForColumn(Column<T> column) {
+        EditableSelectColumn<T> selectColumn = (EditableSelectColumn<T>) column;
+        String value = column.getTypedValue(model);
+        ArrayList<String> selectableValues = selectColumn.getTypedSelectableValues(model);
+        this.addComboField(column.getNameKey(), selectableValues, value);
+    }
+
+    private void createIntFieldForColumn(Column<T> column) {
+        Integer value = column.<Integer>getTypedValue(model);
+        this.addNumberField(column.getNameKey(), -1, Integer.MAX_VALUE, value);
+    }
+
+    private void setFieldEnabledStateByColumnType(Column<T> column) {
+        boolean enabled = isEditable(column);
+        this.getField(column.getNameKey()).setEnabled(enabled);
+    }
+
+    private boolean isEditable(Column<T> column) {
+        return column.isEditable(model) && column instanceof EditableColumn;
+    }
+
+    @Override
+    public void save() {
+        for (Column<T> column : columns) {
+            if (isEditable(column)) {
+                EditableColumn<T> editableColumn = (EditableColumn<T>) column;
+                Object value = getValueByColumn(editableColumn);
+                editableColumn.setValue(model, value);
+            }
+        }
+        saved = true;
+    }
+
+    @Override
+    public void cancelPressed() {
+        super.cancelPressed();
+        saved = false;
+    }
+
+    private Object getValueByColumn(EditableColumn<T> column) {
+        if (column.getColumnClass() == String.class) {
+            return getStringValueByColumn(column);
+        }
+
+        if (column.getColumnClass() == Boolean.class) {
+            return getBoolValueByColumn(column);
+        }
+
+        return null;
+    }
+
+    private String getStringValueByColumn(EditableColumn<T> column) {
+        return this.getStringValue(column.getNameKey());
+    }
+
+    private Boolean getBoolValueByColumn(EditableColumn<T> column) {
+        return getBoolValue(column.getNameKey());
+    }
+
+    @Override
+    public String validateFields() {
+        return null;
+    }
+
+    public boolean isSaved() {
+        return saved;
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnTableModel.java
@@ -29,7 +29,7 @@ public class AbstractColumnTableModel<T> extends AbstractTableModel {
 
     public AbstractColumnTableModel(List<Column<T>> columns) {
         super();
-        this.tableModel = new AbstractTableModelAsAbstractColumnTableModelWrapper<T>(this, columns);
+        this.tableModel = new AbstractTableModelAsAbstractColumnTableModelWrapper<>(this, columns);
     }
 
     @Override

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnTableModel.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+
+public class AbstractColumnTableModel<T> extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+    private final AbstractTableModelAsAbstractColumnTableModelWrapper<T> tableModel;
+
+    public AbstractColumnTableModel(List<Column<T>> columns) {
+        super();
+        this.tableModel = new AbstractTableModelAsAbstractColumnTableModelWrapper<T>(this, columns);
+    }
+
+    @Override
+    public int getColumnCount() {
+        return tableModel.getColumnCount();
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return tableModel.getColumnName(column);
+    }
+
+    @Override
+    public int getRowCount() {
+        return tableModel.getRowCount();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        return tableModel.getValueAt(row, col);
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        return tableModel.getColumnClass(columnIndex);
+    }
+
+    public T getModelAt(int rowIndex) {
+        return tableModel.getModelAt(rowIndex);
+    }
+
+    public List<T> getModels() {
+        return tableModel.getModels();
+    }
+
+    public Column<T> getColumnAt(int columnIndex) {
+        return tableModel.getColumnAt(columnIndex);
+    }
+
+    public void addModels(final List<T> models) {
+        tableModel.addModels(models);
+    }
+
+    public void addModel(final T model) {
+        tableModel.addModel(model);
+    }
+
+    public void removeAllModels() {
+        tableModel.removeAllModels();
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        return tableModel.isCellEditable(row, col);
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+        tableModel.setValueAt(aValue, rowIndex, columnIndex);
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractMultipleOptionsColumnTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractMultipleOptionsColumnTableModel.java
@@ -1,0 +1,88 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.List;
+import org.zaproxy.zap.utils.EnableableInterface;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
+
+public class AbstractMultipleOptionsColumnTableModel<T extends EnableableInterface>
+        extends AbstractMultipleOptionsTableModel<T> {
+
+    private static final long serialVersionUID = 1L;
+    private final AbstractTableModelAsAbstractColumnTableModelWrapper<T> tableModel;
+
+    public AbstractMultipleOptionsColumnTableModel(List<Column<T>> columns) {
+        super();
+        tableModel = new AbstractTableModelAsAbstractColumnTableModelWrapper<>(this, columns);
+    }
+
+    @Override
+    public List<T> getElements() {
+        return tableModel.getModels();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return tableModel.getColumnCount();
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return tableModel.getColumnName(column);
+    }
+
+    @Override
+    public int getRowCount() {
+        return tableModel.getRowCount();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        return tableModel.getValueAt(row, col);
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        return tableModel.getColumnClass(columnIndex);
+    }
+
+    @Override
+    public boolean isCellEditable(int row, int col) {
+        return tableModel.isCellEditable(row, col);
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+        tableModel.setValueAt(aValue, rowIndex, columnIndex);
+    }
+
+    public void addModels(final List<T> models) {
+        tableModel.addModels(models);
+    }
+
+    public void addModel(final T model) {
+        tableModel.addModel(model);
+    }
+
+    public void removeAllModels() {
+        tableModel.removeAllModels();
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractTableModelAsAbstractColumnTableModelWrapper.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractTableModelAsAbstractColumnTableModelWrapper.java
@@ -1,0 +1,157 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.awt.EventQueue;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+
+public class AbstractTableModelAsAbstractColumnTableModelWrapper<T> {
+
+    private final AbstractTableModel abstractTableModel;
+    private final ArrayList<Column<T>> columns;
+    private ArrayList<T> models;
+
+    public AbstractTableModelAsAbstractColumnTableModelWrapper(
+            AbstractTableModel abstractTableModel, List<Column<T>> columns) {
+        super();
+        this.abstractTableModel = abstractTableModel;
+        this.columns = new ArrayList<>(columns);
+        this.models = new ArrayList<>();
+    }
+
+    public int getColumnCount() {
+        return columns.size();
+    }
+
+    public String getColumnName(int column) {
+        String nameKey = columns.get(column).getNameKey();
+        return Constant.messages.getString(nameKey);
+    }
+
+    public int getRowCount() {
+        return models.size();
+    }
+
+    public Object getValueAt(int row, int col) {
+        if (row >= models.size() || col >= columns.size()) {
+            return null;
+        }
+
+        T model = getModelAt(row);
+        return columns.get(col).getValue(model);
+    }
+
+    public Class<?> getColumnClass(int columnIndex) {
+        if (columnIndex >= columns.size()) {
+            return null;
+        }
+
+        return getColumnAt(columnIndex).getColumnClass();
+    }
+
+    public T getModelAt(int rowIndex) {
+        return models.get(rowIndex);
+    }
+
+    public List<T> getModels() {
+        return models;
+    }
+
+    public Column<T> getColumnAt(int columnIndex) {
+        return columns.get(columnIndex);
+    }
+
+    public void addModels(final List<T> models) {
+        if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+            EventQueue.invokeLater(
+                    new Runnable() {
+
+                        @Override
+                        public void run() {
+                            addModels(models);
+                        }
+                    });
+
+            return;
+        }
+
+        int startIndex = this.models.size() - 1;
+        for (T model : models) {
+            this.models.add(model);
+        }
+        int lastIndex = this.models.size() - 1;
+        abstractTableModel.fireTableRowsInserted(startIndex, lastIndex);
+    }
+
+    public void addModel(final T model) {
+        if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+            EventQueue.invokeLater(
+                    new Runnable() {
+
+                        @Override
+                        public void run() {
+                            addModel(model);
+                        }
+                    });
+
+            return;
+        }
+        models.add(model);
+        int index = models.size() - 1;
+        abstractTableModel.fireTableRowsInserted(index, index);
+    }
+
+    public void removeAllModels() {
+        if (View.isInitialised() && !EventQueue.isDispatchThread()) {
+            EventQueue.invokeLater(
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            removeAllModels();
+                        }
+                    });
+            return;
+        }
+
+        int lastIndex = Math.max(models.size() - 1, 0);
+        models.clear();
+        models.trimToSize();
+        abstractTableModel.fireTableRowsDeleted(0, lastIndex);
+    }
+
+    public boolean isCellEditable(int row, int col) {
+        T model = getModelAt(row);
+        Column<T> column = getColumnAt(col);
+        return column.isEditable(model);
+    }
+
+    public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+        T model = getModelAt(rowIndex);
+        Column<T> column = getColumnAt(columnIndex);
+        if (column.isEditable(model) && column instanceof EditableColumn) {
+            EditableColumn<T> editColumn = (EditableColumn<T>) column;
+            editColumn.setValue(model, aValue);
+        }
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/Column.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/Column.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+public abstract class Column<T> {
+    Class<?> columnClass;
+    String nameKey;
+
+    public Column(Class<?> columnClass, String nameKey) {
+        this.columnClass = columnClass;
+        this.nameKey = nameKey;
+    }
+
+    public Class<?> getColumnClass() {
+        return columnClass;
+    }
+
+    public String getNameKey() {
+        return nameKey;
+    }
+
+    public boolean isEditable(T model) {
+        return false;
+    }
+
+    public abstract Object getValue(T model);
+
+    public <V> V getTypedValue(T model) {
+        Object value = getValue(model);
+        return getTypedObject(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <V> V getTypedObject(Object value) {
+        if (value == null) {
+            return null;
+        }
+
+        Class<?> type = getColumnClass();
+        if (value.getClass() != type) {
+            return null;
+        }
+        return (V) value;
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayload.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayload.java
@@ -21,22 +21,22 @@ package org.zaproxy.zap.extension.custompayloads;
 
 import org.zaproxy.zap.utils.EnableableInterface;
 
-public class CustomPayloadModel implements EnableableInterface {
+public class CustomPayload implements EnableableInterface {
 
     private int id;
     private boolean enabled;
     private String category;
     private String payload;
 
-    public CustomPayloadModel(String category, String payload) {
+    public CustomPayload(String category, String payload) {
         this(true, category, payload);
     }
 
-    public CustomPayloadModel(boolean enabled, String category, String payload) {
+    public CustomPayload(boolean enabled, String category, String payload) {
         this(-1, enabled, category, payload);
     }
 
-    public CustomPayloadModel(int id, boolean enabled, String category, String payload) {
+    public CustomPayload(int id, boolean enabled, String category, String payload) {
         this.id = id;
         this.enabled = enabled;
         this.category = category;
@@ -55,6 +55,7 @@ public class CustomPayloadModel implements EnableableInterface {
         this.payload = payload;
     }
 
+    @Override
     public boolean isEnabled() {
         return enabled;
     }
@@ -76,7 +77,7 @@ public class CustomPayloadModel implements EnableableInterface {
         return id;
     }
 
-    public CustomPayloadModel clone() {
-        return new CustomPayloadModel(id, enabled, category, payload);
+    public CustomPayload copy() {
+        return new CustomPayload(id, enabled, category, payload);
     }
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadCategoryColumn.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadCategoryColumn.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.ArrayList;
+import org.parosproxy.paros.control.Control;
+
+public class CustomPayloadCategoryColumn extends EditableSelectColumn<CustomPayloadModel> {
+
+    private ArrayList<String> defaultCategories;
+
+    public CustomPayloadCategoryColumn() {
+        super(String.class, "custompayloads.options.dialog.category");
+    }
+
+    @Override
+    public void setValue(CustomPayloadModel model, Object value) {
+        model.setCategory((String) value);
+    }
+
+    @Override
+    public Object getValue(CustomPayloadModel model) {
+        return model.getCategory();
+    }
+
+    @Override
+    public ArrayList<Object> getSelectableValues(CustomPayloadModel model) {
+        ArrayList<String> categories = getDefaultCategories();
+
+        ArrayList<Object> categoryObjects = new ArrayList<>();
+        boolean containsCategoryFromModel = false;
+        for (String category : categories) {
+            categoryObjects.add(category);
+            if (category.equals(model.getCategory())) {
+                containsCategoryFromModel = true;
+            }
+        }
+
+        if (!containsCategoryFromModel
+                && model.getCategory() != null
+                && !model.getCategory().isEmpty()) {
+            categoryObjects.add(model.getCategory());
+        }
+
+        return categoryObjects;
+    }
+
+    private ArrayList<String> getDefaultCategories() {
+        if (defaultCategories == null) {
+            defaultCategories = new ArrayList<>();
+            for (CustomPayloadModel defaultModel : getExtension().getDefaultPayloads()) {
+                if (!defaultCategories.contains(defaultModel.getCategory())) {
+                    defaultCategories.add(defaultModel.getCategory());
+                }
+            }
+        }
+        return defaultCategories;
+    }
+
+    private ExtensionCustomPayloads getExtension() {
+        return Control.getSingleton()
+                .getExtensionLoader()
+                .getExtension(ExtensionCustomPayloads.class);
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadCategoryColumn.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadCategoryColumn.java
@@ -20,58 +20,45 @@
 package org.zaproxy.zap.extension.custompayloads;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import org.parosproxy.paros.control.Control;
 
-public class CustomPayloadCategoryColumn extends EditableSelectColumn<CustomPayloadModel> {
-
-    private ArrayList<String> defaultCategories;
+public class CustomPayloadCategoryColumn extends EditableSelectColumn<CustomPayload> {
 
     public CustomPayloadCategoryColumn() {
         super(String.class, "custompayloads.options.dialog.category");
     }
 
     @Override
-    public void setValue(CustomPayloadModel model, Object value) {
-        model.setCategory((String) value);
+    public void setValue(CustomPayload payload, Object value) {
+        payload.setCategory((String) value);
     }
 
     @Override
-    public Object getValue(CustomPayloadModel model) {
-        return model.getCategory();
+    public Object getValue(CustomPayload payload) {
+        return payload.getCategory();
     }
 
     @Override
-    public ArrayList<Object> getSelectableValues(CustomPayloadModel model) {
-        ArrayList<String> categories = getDefaultCategories();
+    public ArrayList<Object> getSelectableValues(CustomPayload payload) {
+        Collection<String> categories = getExtension().getParam().getCategoriesNames();
 
         ArrayList<Object> categoryObjects = new ArrayList<>();
-        boolean containsCategoryFromModel = false;
+        boolean containsCategoryFromPayload = false;
         for (String category : categories) {
             categoryObjects.add(category);
-            if (category.equals(model.getCategory())) {
-                containsCategoryFromModel = true;
+            if (category.equals(payload.getCategory())) {
+                containsCategoryFromPayload = true;
             }
         }
 
-        if (!containsCategoryFromModel
-                && model.getCategory() != null
-                && !model.getCategory().isEmpty()) {
-            categoryObjects.add(model.getCategory());
+        if (!containsCategoryFromPayload
+                && payload.getCategory() != null
+                && !payload.getCategory().isEmpty()) {
+            categoryObjects.add(payload.getCategory());
         }
 
         return categoryObjects;
-    }
-
-    private ArrayList<String> getDefaultCategories() {
-        if (defaultCategories == null) {
-            defaultCategories = new ArrayList<>();
-            for (CustomPayloadModel defaultModel : getExtension().getDefaultPayloads()) {
-                if (!defaultCategories.contains(defaultModel.getCategory())) {
-                    defaultCategories.add(defaultModel.getCategory());
-                }
-            }
-        }
-        return defaultCategories;
     }
 
     private ExtensionCustomPayloads getExtension() {

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadColumns.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadColumns.java
@@ -24,8 +24,8 @@ import java.util.List;
 
 public final class CustomPayloadColumns {
 
-    public static List<Column<CustomPayloadModel>> createColumns() {
-        ArrayList<Column<CustomPayloadModel>> columns = new ArrayList<>();
+    public static List<Column<CustomPayload>> createColumns() {
+        ArrayList<Column<CustomPayload>> columns = new ArrayList<>();
         columns.add(createEnabledColumn());
         columns.add(createIdColumn());
         columns.add(createCategoryColumn());
@@ -33,8 +33,8 @@ public final class CustomPayloadColumns {
         return columns;
     }
 
-    public static List<Column<CustomPayloadModel>> createColumnsForOptionsTable() {
-        ArrayList<Column<CustomPayloadModel>> columns = new ArrayList<>();
+    public static List<Column<CustomPayload>> createColumnsForOptionsTable() {
+        ArrayList<Column<CustomPayload>> columns = new ArrayList<>();
         columns.add(createEnabledColumn());
         columns.add(createIdColumn());
         columns.add(createCategoryColumn().AsReadonly());
@@ -42,47 +42,47 @@ public final class CustomPayloadColumns {
         return columns;
     }
 
-    private static EditableColumn<CustomPayloadModel> createEnabledColumn() {
-        return new EditableColumn<CustomPayloadModel>(
+    private static EditableColumn<CustomPayload> createEnabledColumn() {
+        return new EditableColumn<CustomPayload>(
                 Boolean.class, "custompayloads.options.dialog.enabled") {
             @Override
-            public void setValue(CustomPayloadModel model, Object value) {
-                model.setEnabled((Boolean) value);
+            public void setValue(CustomPayload payload, Object value) {
+                payload.setEnabled((Boolean) value);
             }
 
             @Override
-            public Object getValue(CustomPayloadModel model) {
-                return model.isEnabled();
+            public Object getValue(CustomPayload payload) {
+                return payload.isEnabled();
             }
         };
     }
 
-    private static Column<CustomPayloadModel> createIdColumn() {
-        return new Column<CustomPayloadModel>(Integer.class, "custompayloads.options.dialog.id") {
+    private static Column<CustomPayload> createIdColumn() {
+        return new Column<CustomPayload>(Integer.class, "custompayloads.options.dialog.id") {
 
             @Override
-            public Object getValue(CustomPayloadModel model) {
-                return model.getId();
+            public Object getValue(CustomPayload payload) {
+                return payload.getId();
             }
         };
     }
 
-    private static EditableColumn<CustomPayloadModel> createPayloadColumn() {
-        return new EditableColumn<CustomPayloadModel>(
+    private static EditableColumn<CustomPayload> createPayloadColumn() {
+        return new EditableColumn<CustomPayload>(
                 String.class, "custompayloads.options.dialog.payload") {
             @Override
-            public void setValue(CustomPayloadModel model, Object value) {
-                model.setPayload((String) value);
+            public void setValue(CustomPayload payload, Object value) {
+                payload.setPayload((String) value);
             }
 
             @Override
-            public Object getValue(CustomPayloadModel model) {
-                return model.getPayload();
+            public Object getValue(CustomPayload payload) {
+                return payload.getPayload();
             }
         };
     }
 
-    private static EditableColumn<CustomPayloadModel> createCategoryColumn() {
+    private static EditableColumn<CustomPayload> createCategoryColumn() {
         return new CustomPayloadCategoryColumn();
     }
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadColumns.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadColumns.java
@@ -1,0 +1,88 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class CustomPayloadColumns {
+
+    public static List<Column<CustomPayloadModel>> createColumns() {
+        ArrayList<Column<CustomPayloadModel>> columns = new ArrayList<>();
+        columns.add(createEnabledColumn());
+        columns.add(createIdColumn());
+        columns.add(createCategoryColumn());
+        columns.add(createPayloadColumn());
+        return columns;
+    }
+
+    public static List<Column<CustomPayloadModel>> createColumnsForOptionsTable() {
+        ArrayList<Column<CustomPayloadModel>> columns = new ArrayList<>();
+        columns.add(createEnabledColumn());
+        columns.add(createIdColumn());
+        columns.add(createCategoryColumn().AsReadonly());
+        columns.add(createPayloadColumn().AsReadonly());
+        return columns;
+    }
+
+    private static EditableColumn<CustomPayloadModel> createEnabledColumn() {
+        return new EditableColumn<CustomPayloadModel>(
+                Boolean.class, "custompayloads.options.dialog.enabled") {
+            @Override
+            public void setValue(CustomPayloadModel model, Object value) {
+                model.setEnabled((Boolean) value);
+            }
+
+            @Override
+            public Object getValue(CustomPayloadModel model) {
+                return model.isEnabled();
+            }
+        };
+    }
+
+    private static Column<CustomPayloadModel> createIdColumn() {
+        return new Column<CustomPayloadModel>(Integer.class, "custompayloads.options.dialog.id") {
+
+            @Override
+            public Object getValue(CustomPayloadModel model) {
+                return model.getId();
+            }
+        };
+    }
+
+    private static EditableColumn<CustomPayloadModel> createPayloadColumn() {
+        return new EditableColumn<CustomPayloadModel>(
+                String.class, "custompayloads.options.dialog.payload") {
+            @Override
+            public void setValue(CustomPayloadModel model, Object value) {
+                model.setPayload((String) value);
+            }
+
+            @Override
+            public Object getValue(CustomPayloadModel model) {
+                return model.getPayload();
+            }
+        };
+    }
+
+    private static EditableColumn<CustomPayloadModel> createCategoryColumn() {
+        return new CustomPayloadCategoryColumn();
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadDialog.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadDialog.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.awt.Window;
+import org.zaproxy.zap.utils.DisplayUtils;
+
+public class CustomPayloadDialog extends AbstractColumnDialog<CustomPayloadModel> {
+
+    private static final long serialVersionUID = 1L;
+
+    public CustomPayloadDialog(Window owner, String title, CustomPayloadModel model) {
+        super(
+                owner,
+                title,
+                CustomPayloadColumns.createColumns(),
+                model,
+                DisplayUtils.getScaledDimension(400, 180));
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadDialog.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadDialog.java
@@ -22,16 +22,16 @@ package org.zaproxy.zap.extension.custompayloads;
 import java.awt.Window;
 import org.zaproxy.zap.utils.DisplayUtils;
 
-public class CustomPayloadDialog extends AbstractColumnDialog<CustomPayloadModel> {
+public class CustomPayloadDialog extends AbstractColumnDialog<CustomPayload> {
 
     private static final long serialVersionUID = 1L;
 
-    public CustomPayloadDialog(Window owner, String title, CustomPayloadModel model) {
+    public CustomPayloadDialog(Window owner, String title, CustomPayload payload) {
         super(
                 owner,
                 title,
                 CustomPayloadColumns.createColumns(),
-                model,
+                payload,
                 DisplayUtils.getScaledDimension(400, 180));
     }
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadModel.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import org.zaproxy.zap.utils.EnableableInterface;
+
+public class CustomPayloadModel implements EnableableInterface {
+
+    private int id;
+    private boolean enabled;
+    private String category;
+    private String payload;
+
+    public CustomPayloadModel(String category, String payload) {
+        this(true, category, payload);
+    }
+
+    public CustomPayloadModel(boolean enabled, String category, String payload) {
+        this(-1, enabled, category, payload);
+    }
+
+    public CustomPayloadModel(int id, boolean enabled, String category, String payload) {
+        this.id = id;
+        this.enabled = enabled;
+        this.category = category;
+        this.payload = payload;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public void setEnabled(boolean flag) {
+        enabled = flag;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public CustomPayloadModel clone() {
+        return new CustomPayloadModel(id, enabled, category, payload);
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.ArrayList;
+
+public class CustomPayloadMultipleOptionsTableModel
+        extends AbstractMultipleOptionsColumnTableModel<CustomPayloadModel> {
+
+    private static final long serialVersionUID = 1L;
+    private ArrayList<CustomPayloadModel> defaultPayloads;
+    private int nextPayloadId;
+
+    public CustomPayloadMultipleOptionsTableModel() {
+        super(CustomPayloadColumns.createColumnsForOptionsTable());
+    }
+
+    public void setDefaultPayloads(ArrayList<CustomPayloadModel> defaultPayloads) {
+        this.defaultPayloads = defaultPayloads;
+    }
+
+    public void setNextPayloadId(int nextPayloadId) {
+        this.nextPayloadId = nextPayloadId;
+    }
+
+    public int getNextPayloadId() {
+        return nextPayloadId;
+    }
+
+    public void resetPayloadIds() {
+        nextPayloadId = 1;
+        for (CustomPayloadModel model : getElements()) {
+            setNextIdToPayload(model);
+        }
+        fireTableRowsUpdated(0, getElements().size() - 1);
+    }
+
+    public void resetToDefaults() {
+        clear();
+        for (CustomPayloadModel defaultPayload : defaultPayloads) {
+            CustomPayloadModel newModel = defaultPayload.clone();
+            setNextIdToPayload(newModel);
+            addModel(newModel);
+        }
+    }
+
+    public void setNextIdToPayload(CustomPayloadModel payload) {
+        payload.setId(nextPayloadId++);
+    }
+
+    public void addMissingDefaultPayloads() {
+        for (CustomPayloadModel defaultPayload : defaultPayloads) {
+            boolean alreadyExisting = false;
+            for (CustomPayloadModel existingPayload : getElements()) {
+                if (defaultPayload.getCategory().equalsIgnoreCase(existingPayload.getCategory())
+                        && defaultPayload.getPayload().equals(existingPayload.getPayload())) {
+                    alreadyExisting = true;
+                    break;
+                }
+            }
+
+            if (!alreadyExisting) {
+                CustomPayloadModel newModel = defaultPayload.clone();
+                setNextIdToPayload(newModel);
+                addModel(newModel);
+            }
+        }
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
@@ -19,20 +19,20 @@
  */
 package org.zaproxy.zap.extension.custompayloads;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class CustomPayloadMultipleOptionsTableModel
-        extends AbstractMultipleOptionsColumnTableModel<CustomPayloadModel> {
+        extends AbstractMultipleOptionsColumnTableModel<CustomPayload> {
 
     private static final long serialVersionUID = 1L;
-    private ArrayList<CustomPayloadModel> defaultPayloads;
+    private List<CustomPayload> defaultPayloads;
     private int nextPayloadId;
 
     public CustomPayloadMultipleOptionsTableModel() {
         super(CustomPayloadColumns.createColumnsForOptionsTable());
     }
 
-    public void setDefaultPayloads(ArrayList<CustomPayloadModel> defaultPayloads) {
+    public void setDefaultPayloads(List<CustomPayload> defaultPayloads) {
         this.defaultPayloads = defaultPayloads;
     }
 
@@ -46,29 +46,31 @@ public class CustomPayloadMultipleOptionsTableModel
 
     public void resetPayloadIds() {
         nextPayloadId = 1;
-        for (CustomPayloadModel model : getElements()) {
-            setNextIdToPayload(model);
+        for (CustomPayload payload : getElements()) {
+            setNextIdToPayload(payload);
         }
-        fireTableRowsUpdated(0, getElements().size() - 1);
+        if (this.getRowCount() > 0) {
+            fireTableRowsUpdated(0, getElements().size() - 1);
+        }
     }
 
     public void resetToDefaults() {
         clear();
-        for (CustomPayloadModel defaultPayload : defaultPayloads) {
-            CustomPayloadModel newModel = defaultPayload.clone();
-            setNextIdToPayload(newModel);
-            addModel(newModel);
+        for (CustomPayload defaultPayload : defaultPayloads) {
+            CustomPayload newPayload = defaultPayload.copy();
+            setNextIdToPayload(newPayload);
+            addModel(newPayload);
         }
     }
 
-    public void setNextIdToPayload(CustomPayloadModel payload) {
+    public void setNextIdToPayload(CustomPayload payload) {
         payload.setId(nextPayloadId++);
     }
 
     public void addMissingDefaultPayloads() {
-        for (CustomPayloadModel defaultPayload : defaultPayloads) {
+        for (CustomPayload defaultPayload : defaultPayloads) {
             boolean alreadyExisting = false;
-            for (CustomPayloadModel existingPayload : getElements()) {
+            for (CustomPayload existingPayload : getElements()) {
                 if (defaultPayload.getCategory().equalsIgnoreCase(existingPayload.getCategory())
                         && defaultPayload.getPayload().equals(existingPayload.getPayload())) {
                     alreadyExisting = true;
@@ -77,9 +79,9 @@ public class CustomPayloadMultipleOptionsTableModel
             }
 
             if (!alreadyExisting) {
-                CustomPayloadModel newModel = defaultPayload.clone();
-                setNextIdToPayload(newModel);
-                addModel(newModel);
+                CustomPayload newPayload = defaultPayload.copy();
+                setNextIdToPayload(newPayload);
+                addModel(newPayload);
             }
         }
     }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
 public class CustomPayloadsMultipleOptionsTablePanel
-        extends AbstractMultipleOptionsTablePanel<CustomPayloadModel> {
+        extends AbstractMultipleOptionsTablePanel<CustomPayload> {
 
     private static final long serialVersionUID = 1L;
     private static final String REMOVE_DIALOG_TITLE =
@@ -105,8 +105,8 @@ public class CustomPayloadsMultipleOptionsTablePanel
     }
 
     @Override
-    public CustomPayloadModel showAddDialogue() {
-        CustomPayloadModel payload = new CustomPayloadModel(-1, false, "", "");
+    public CustomPayload showAddDialogue() {
+        CustomPayload payload = new CustomPayload(-1, true, "", "");
         if (showDialog(payload)) {
             tableModel.setNextIdToPayload(payload);
             return payload;
@@ -114,25 +114,25 @@ public class CustomPayloadsMultipleOptionsTablePanel
         return null;
     }
 
-    private boolean showDialog(CustomPayloadModel model) {
+    private boolean showDialog(CustomPayload payload) {
         CustomPayloadDialog dialog =
                 new CustomPayloadDialog(
                         (Window) View.getSingleton().getOptionsDialog(null),
                         "custompayloads.options.dialog.title",
-                        model);
+                        payload);
         dialog.pack();
         dialog.setVisible(true);
         return dialog.isSaved();
     }
 
     @Override
-    public CustomPayloadModel showModifyDialogue(CustomPayloadModel payload) {
+    public CustomPayload showModifyDialogue(CustomPayload payload) {
         showDialog(payload);
         return payload;
     }
 
     @Override
-    public boolean showRemoveDialogue(CustomPayloadModel payload) {
+    public boolean showRemoveDialogue(CustomPayload payload) {
         getTable().packAll();
         JCheckBox removeWithoutConfirmationCheckBox = new JCheckBox(REMOVE_DIALOG_CHECKBOX_LABEL);
         Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsMultipleOptionsTablePanel.java
@@ -1,0 +1,159 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JOptionPane;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
+
+public class CustomPayloadsMultipleOptionsTablePanel
+        extends AbstractMultipleOptionsTablePanel<CustomPayloadModel> {
+
+    private static final long serialVersionUID = 1L;
+    private static final String REMOVE_DIALOG_TITLE =
+            Constant.messages.getString("custompayloads.options.dialog.remove.title");
+    private static final String REMOVE_DIALOG_TEXT =
+            Constant.messages.getString("custompayloads.options.dialog.remove.text");
+
+    private static final String RESET_BUTTON =
+            Constant.messages.getString("custompayloads.options.button.reset");
+    private static final String RESET_ID_BUTTON =
+            Constant.messages.getString("custompayloads.options.button.resetIds");
+    private static final String ADD_MISSING_DEFAULTS_BUTTON =
+            Constant.messages.getString("custompayloads.options.button.addMissingDefaults");
+
+    private static final String REMOVE_DIALOG_CONFIRM_BUTTON_LABEL =
+            Constant.messages.getString("custompayloads.options.dialog.remove.button.confirm");
+    private static final String REMOVE_DIALOG_CANCEL_BUTTON_LABEL =
+            Constant.messages.getString("custompayloads.options.dialog.remove.button.cancel");
+
+    private static final String REMOVE_DIALOG_CHECKBOX_LABEL =
+            Constant.messages.getString("custompayloads.options.dialog.remove.label");
+    private JButton resetButton;
+    private JButton resetButtonId;
+    private JButton addMissingDefaultsButton;
+    private CustomPayloadMultipleOptionsTableModel tableModel;
+
+    public CustomPayloadsMultipleOptionsTablePanel(
+            CustomPayloadMultipleOptionsTableModel tableModel) {
+        super(tableModel);
+        this.tableModel = tableModel;
+        addButtonSpacer();
+        addMissingDefaultsButton();
+        addResetButton();
+        addResetIdButton();
+        getTable().setHorizontalScrollEnabled(true);
+    }
+
+    private void addMissingDefaultsButton() {
+        addMissingDefaultsButton = new JButton(ADD_MISSING_DEFAULTS_BUTTON);
+        addMissingDefaultsButton.addActionListener(
+                new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent evt) {
+                        tableModel.addMissingDefaultPayloads();
+                    }
+                });
+        addButton(addMissingDefaultsButton);
+    }
+
+    private void addResetIdButton() {
+        resetButtonId = new JButton(RESET_ID_BUTTON);
+        resetButtonId.addActionListener(
+                new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent evt) {
+                        tableModel.resetPayloadIds();
+                    }
+                });
+        addButton(resetButtonId);
+    }
+
+    private void addResetButton() {
+        resetButton = new JButton(RESET_BUTTON);
+        resetButton.addActionListener(
+                new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent evt) {
+                        tableModel.resetToDefaults();
+                    }
+                });
+        addButton(resetButton);
+    }
+
+    @Override
+    public CustomPayloadModel showAddDialogue() {
+        CustomPayloadModel payload = new CustomPayloadModel(-1, false, "", "");
+        if (showDialog(payload)) {
+            tableModel.setNextIdToPayload(payload);
+            return payload;
+        }
+        return null;
+    }
+
+    private boolean showDialog(CustomPayloadModel model) {
+        CustomPayloadDialog dialog =
+                new CustomPayloadDialog(
+                        (Window) View.getSingleton().getOptionsDialog(null),
+                        "custompayloads.options.dialog.title",
+                        model);
+        dialog.pack();
+        dialog.setVisible(true);
+        return dialog.isSaved();
+    }
+
+    @Override
+    public CustomPayloadModel showModifyDialogue(CustomPayloadModel payload) {
+        showDialog(payload);
+        return payload;
+    }
+
+    @Override
+    public boolean showRemoveDialogue(CustomPayloadModel payload) {
+        getTable().packAll();
+        JCheckBox removeWithoutConfirmationCheckBox = new JCheckBox(REMOVE_DIALOG_CHECKBOX_LABEL);
+        Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};
+        int option =
+                JOptionPane.showOptionDialog(
+                        View.getSingleton().getMainFrame(),
+                        messages,
+                        REMOVE_DIALOG_TITLE,
+                        JOptionPane.OK_CANCEL_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        new String[] {
+                            REMOVE_DIALOG_CONFIRM_BUTTON_LABEL, REMOVE_DIALOG_CANCEL_BUTTON_LABEL
+                        },
+                        null);
+
+        if (option == JOptionPane.OK_OPTION) {
+            setRemoveWithoutConfirmation(removeWithoutConfirmationCheckBox.isSelected());
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsOptionsPanel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsOptionsPanel.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import javax.swing.JLabel;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+
+public class CustomPayloadsOptionsPanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = 1L;
+    private static final String OPTIONS_TITLE =
+            Constant.messages.getString("custompayloads.options.title");
+    CustomPayloadsMultipleOptionsTablePanel tablePanel;
+    CustomPayloadMultipleOptionsTableModel tableModel;
+
+    public CustomPayloadsOptionsPanel() {
+        this.tableModel = new CustomPayloadMultipleOptionsTableModel();
+        this.tablePanel = new CustomPayloadsMultipleOptionsTablePanel(tableModel);
+        this.setName(OPTIONS_TITLE);
+        this.setLayout(new GridBagLayout());
+
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridx = 0;
+        gbc.weightx = 1.0;
+        gbc.anchor = GridBagConstraints.LINE_START;
+        gbc.fill = GridBagConstraints.BOTH;
+
+        this.add(new JLabel(OPTIONS_TITLE), gbc);
+        gbc.weighty = 1.0;
+        this.add(tablePanel, gbc);
+    }
+
+    @Override
+    public void initParam(Object obj) {
+        OptionsParam optionsParam = (OptionsParam) obj;
+        CustomPayloadsParam param = optionsParam.getParamSet(CustomPayloadsParam.class);
+        tableModel.clear();
+        tableModel.addModels(param.getPayloads());
+        tableModel.setDefaultPayloads(param.getDefaultPayloads());
+        tableModel.setNextPayloadId(param.getNextPayloadId());
+        tablePanel.setRemoveWithoutConfirmation(param.isConfirmRemoveToken());
+    }
+
+    @Override
+    public void saveParam(Object obj) throws Exception {
+        OptionsParam optionsParam = (OptionsParam) obj;
+        CustomPayloadsParam param = optionsParam.getParamSet(CustomPayloadsParam.class);
+        param.setPayloads(tableModel.getElements());
+        param.setNextPayloadId(tableModel.getNextPayloadId());
+        param.setConfirmRemoveToken(tablePanel.isRemoveWithoutConfirmation());
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParam.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadsParam.java
@@ -1,0 +1,181 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.parosproxy.paros.common.AbstractParam;
+import org.zaproxy.zap.extension.api.ZapApiIgnore;
+
+public class CustomPayloadsParam extends AbstractParam {
+
+    private static final String ASCAN_ALPHA_BASE_KEY = "acanalpha";
+    private static final String ALL_PAYLOADS_KEY = ASCAN_ALPHA_BASE_KEY + ".payload_list";
+
+    private static final String PAYLOAD_ID_KEY = "id";
+    private static final String PAYLOAD_KEY = "payload";
+    private static final String PAYLOAD_CATEGORY_KEY = "category";
+    private static final String PAYLOAD_ENABLED_KEY = "enabled";
+
+    private static final String CONFIRM_REMOVE_PAYLOAD_KEY =
+            ASCAN_ALPHA_BASE_KEY + ".confirmRemoveToken";
+    private static final String NEXT_PAYLOAD_ID_KEY = ASCAN_ALPHA_BASE_KEY + ".nextPayloadId";
+
+    private ExtensionCustomPayloads extensionCustomPayloads;
+    private ArrayList<CustomPayloadModel> payloads;
+    private boolean confirmRemoveToken;
+    private int nextPayloadId = 1;
+
+    public CustomPayloadsParam(ExtensionCustomPayloads extensionCustomPayloads) {
+        this.extensionCustomPayloads = extensionCustomPayloads;
+    }
+
+    @Override
+    protected void parse() {
+        loadFromConfig();
+    }
+
+    private void loadFromConfig() {
+        HierarchicalConfiguration rootConfig = (HierarchicalConfiguration) getConfig();
+        loadPayloadsFromConfig(rootConfig);
+        loadConfirmRemoveTokenFromConfig(rootConfig);
+        loadNextPayloadIdFromConfig(rootConfig);
+        initializeWithDefaultsIfPayloadsAreEmpty();
+    }
+
+    private void initializeWithDefaultsIfPayloadsAreEmpty() {
+        if (payloads.size() == 0) {
+            ArrayList<CustomPayloadModel> newModels = new ArrayList<>();
+            for (CustomPayloadModel defaultPayload : getDefaultPayloads()) {
+                CustomPayloadModel newModel = defaultPayload.clone();
+                newModel.setId(nextPayloadId++);
+                newModels.add(newModel);
+            }
+            setPayloads(newModels);
+            setNextPayloadId(nextPayloadId);
+        }
+    }
+
+    private void loadPayloadsFromConfig(HierarchicalConfiguration rootConfig) {
+        List<HierarchicalConfiguration> fields = rootConfig.configurationsAt(ALL_PAYLOADS_KEY);
+        payloads = new ArrayList<>(fields.size());
+        for (HierarchicalConfiguration sub : fields) {
+            int id = sub.getInt(PAYLOAD_ID_KEY);
+            boolean isEnabled = sub.getBoolean(PAYLOAD_ENABLED_KEY);
+            String category = sub.getString(PAYLOAD_CATEGORY_KEY, "");
+            String payload = sub.getString(PAYLOAD_KEY, "");
+            payloads.add(new CustomPayloadModel(id, isEnabled, category, payload));
+        }
+    }
+
+    private void loadConfirmRemoveTokenFromConfig(HierarchicalConfiguration rootConfig) {
+        confirmRemoveToken = rootConfig.getBoolean(CONFIRM_REMOVE_PAYLOAD_KEY, true);
+    }
+
+    private void loadNextPayloadIdFromConfig(HierarchicalConfiguration rootConfig) {
+        int maxUsedPayloadId = getMaxUsedPayloadId();
+        nextPayloadId = rootConfig.getInteger(NEXT_PAYLOAD_ID_KEY, 1);
+        if (nextPayloadId <= maxUsedPayloadId) {
+            setNextPayloadId(maxUsedPayloadId + 1);
+        }
+    }
+
+    public int getNextPayloadId() {
+        return nextPayloadId;
+    }
+
+    public void setNextPayloadId(int id) {
+        nextPayloadId = id;
+        saveNextPayloadId();
+    }
+
+    private void saveNextPayloadId() {
+        getConfig().setProperty(NEXT_PAYLOAD_ID_KEY, Integer.valueOf(nextPayloadId));
+    }
+
+    private int getMaxUsedPayloadId() {
+        int maxUsedPayloadId = 0;
+        for (CustomPayloadModel payload : payloads) {
+            if (maxUsedPayloadId < payload.getId()) {
+                maxUsedPayloadId = payload.getId();
+            }
+        }
+        return maxUsedPayloadId;
+    }
+
+    public List<CustomPayloadModel> getPayloads() {
+        ArrayList<CustomPayloadModel> clonedPayloads = new ArrayList<>();
+        for (CustomPayloadModel model : payloads) {
+            clonedPayloads.add(model.clone());
+        }
+        return clonedPayloads;
+    }
+
+    public void setPayloads(List<CustomPayloadModel> payloads) {
+        this.payloads = new ArrayList<>(payloads);
+        savePayloadsToConfig();
+    }
+
+    private void savePayloadsToConfig() {
+        ((HierarchicalConfiguration) getConfig()).clearTree(ALL_PAYLOADS_KEY);
+        for (int i = 0, size = payloads.size(); i < size; ++i) {
+            String elementBaseKey = ALL_PAYLOADS_KEY + "(" + i + ").";
+            CustomPayloadModel payload = payloads.get(i);
+            getConfig()
+                    .setProperty(elementBaseKey + PAYLOAD_ID_KEY, Integer.valueOf(payload.getId()));
+            getConfig()
+                    .setProperty(
+                            elementBaseKey + PAYLOAD_ENABLED_KEY,
+                            Boolean.valueOf(payload.isEnabled()));
+            getConfig().setProperty(elementBaseKey + PAYLOAD_CATEGORY_KEY, payload.getCategory());
+            getConfig().setProperty(elementBaseKey + PAYLOAD_KEY, payload.getPayload());
+        }
+    }
+
+    @ZapApiIgnore
+    public boolean isConfirmRemoveToken() {
+        return this.confirmRemoveToken;
+    }
+
+    @ZapApiIgnore
+    public void setConfirmRemoveToken(boolean confirmRemove) {
+        this.confirmRemoveToken = confirmRemove;
+        saveConfirmRemoveToken();
+    }
+
+    private void saveConfirmRemoveToken() {
+        getConfig().setProperty(CONFIRM_REMOVE_PAYLOAD_KEY, Boolean.valueOf(confirmRemoveToken));
+    }
+
+    public List<CustomPayloadModel> getPayloadsByCategory(String category) {
+        ArrayList<CustomPayloadModel> payloadsByCategory = new ArrayList<>();
+        for (CustomPayloadModel payload : payloads) {
+            if (payload.isEnabled() && payload.getCategory().equalsIgnoreCase(category)) {
+                payloadsByCategory.add(payload);
+            }
+        }
+        return payloadsByCategory;
+    }
+
+    public ArrayList<CustomPayloadModel> getDefaultPayloads() {
+        return extensionCustomPayloads.getDefaultPayloads();
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableColumn.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableColumn.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+public abstract class EditableColumn<T> extends Column<T> {
+
+    public EditableColumn(Class<?> columnClass, String name) {
+        super(columnClass, name);
+    }
+
+    @Override
+    public boolean isEditable(T model) {
+        return true;
+    }
+
+    public abstract void setValue(T model, Object value);
+
+    public Column<T> AsReadonly() {
+        return new Column<T>(this.columnClass, this.nameKey) {
+
+            @Override
+            public Object getValue(T model) {
+                return EditableColumn.this.getValue(model);
+            }
+        };
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableSelectColumn.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/EditableSelectColumn.java
@@ -1,0 +1,43 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.ArrayList;
+
+public abstract class EditableSelectColumn<T> extends EditableColumn<T> {
+
+    public EditableSelectColumn(Class<?> columnClass, String name) {
+        super(columnClass, name);
+    }
+
+    public abstract ArrayList<Object> getSelectableValues(T model);
+
+    public <V> ArrayList<V> getTypedSelectableValues(T model) {
+        ArrayList<Object> values = getSelectableValues(model);
+
+        ArrayList<V> typedValues = new ArrayList<>();
+        for (Object value : values) {
+            V typedValue = getTypedObject(value);
+            typedValues.add(typedValue);
+        }
+
+        return typedValues;
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/ExtensionCustomPayloads.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/ExtensionCustomPayloads.java
@@ -19,21 +19,15 @@
  */
 package org.zaproxy.zap.extension.custompayloads;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.core.scanner.Plugin;
-import org.parosproxy.paros.core.scanner.PluginFactory;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.AbstractParamPanel;
-import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public class ExtensionCustomPayloads extends ExtensionAdaptor {
 
     private CustomPayloadsParam params;
     private CustomPayloadsOptionsPanel optionsPanel;
-    private ArrayList<CustomPayloadModel> defaultPayloads;
 
     public ExtensionCustomPayloads() {
         super();
@@ -78,33 +72,18 @@ public class ExtensionCustomPayloads extends ExtensionAdaptor {
         return optionsPanel;
     }
 
-    public CustomPayloadsParam getParam() {
+    protected CustomPayloadsParam getParam() {
         if (params == null) {
-            params = new CustomPayloadsParam(this);
+            params = new CustomPayloadsParam();
         }
         return params;
     }
 
-    public ArrayList<CustomPayloadModel> getDefaultPayloads() {
-        if (defaultPayloads == null) {
-            ArrayList<CustomPayloadModel> payloads = new ArrayList<>();
-            PluginFactory factory = new PluginFactory();
-            ZapXmlConfiguration conf = new ZapXmlConfiguration();
-            factory.loadAllPlugin(conf);
-            List<Plugin> scanners = factory.getAllPlugin();
-            for (Plugin scanner : scanners) {
-                if (scanner instanceof PluginWithConfigurablePayload) {
-                    PluginWithConfigurablePayload scannerWithConfigurablePayload =
-                            (PluginWithConfigurablePayload) scanner;
-                    payloads.addAll(scannerWithConfigurablePayload.getDefaultPayloads());
-                }
-            }
-            defaultPayloads = payloads;
-        }
-        return defaultPayloads;
+    public void addPayloadCategory(PayloadCategory payloadCategory) {
+        getParam().addPayloadCategory(payloadCategory);
     }
 
-    public List<CustomPayloadModel> getPayloadsByCategory(String category) {
-        return getParam().getPayloadsByCategory(category);
+    public void removePayloadCategory(PayloadCategory payloadCategory) {
+        getParam().removePayloadCategory(payloadCategory);
     }
 }

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/ExtensionCustomPayloads.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/ExtensionCustomPayloads.java
@@ -1,0 +1,110 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.core.scanner.PluginFactory;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+public class ExtensionCustomPayloads extends ExtensionAdaptor {
+
+    private CustomPayloadsParam params;
+    private CustomPayloadsOptionsPanel optionsPanel;
+    private ArrayList<CustomPayloadModel> defaultPayloads;
+
+    public ExtensionCustomPayloads() {
+        super();
+        this.setI18nPrefix("custompayloads");
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("custompayloads.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("custompayloads.desc");
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        extensionHook.addOptionsParamSet(getParam());
+
+        if (getView() != null) {
+            extensionHook.getHookView().addOptionPanel(getOptionsPanel());
+        }
+    }
+
+    private AbstractParamPanel getOptionsPanel() {
+        if (optionsPanel == null) {
+            optionsPanel = new CustomPayloadsOptionsPanel();
+        }
+        return optionsPanel;
+    }
+
+    public CustomPayloadsParam getParam() {
+        if (params == null) {
+            params = new CustomPayloadsParam(this);
+        }
+        return params;
+    }
+
+    public ArrayList<CustomPayloadModel> getDefaultPayloads() {
+        if (defaultPayloads == null) {
+            ArrayList<CustomPayloadModel> payloads = new ArrayList<>();
+            PluginFactory factory = new PluginFactory();
+            ZapXmlConfiguration conf = new ZapXmlConfiguration();
+            factory.loadAllPlugin(conf);
+            List<Plugin> scanners = factory.getAllPlugin();
+            for (Plugin scanner : scanners) {
+                if (scanner instanceof PluginWithConfigurablePayload) {
+                    PluginWithConfigurablePayload scannerWithConfigurablePayload =
+                            (PluginWithConfigurablePayload) scanner;
+                    payloads.addAll(scannerWithConfigurablePayload.getDefaultPayloads());
+                }
+            }
+            defaultPayloads = payloads;
+        }
+        return defaultPayloads;
+    }
+
+    public List<CustomPayloadModel> getPayloadsByCategory(String category) {
+        return getParam().getPayloadsByCategory(category);
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/PayloadCategory.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/PayloadCategory.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class PayloadCategory {
+
+    private final String name;
+    private final List<CustomPayload> defaultPayloads;
+    private List<CustomPayload> payloads;
+
+    public PayloadCategory(String name, List<String> defaultPayloads) {
+        this(name, defaultPayloads, Collections.emptyList());
+    }
+
+    PayloadCategory(String name, List<String> defaultPayloads, List<CustomPayload> payloads) {
+        this.name = Objects.requireNonNull(name);
+        this.defaultPayloads = createDefaultPayloads(name, defaultPayloads);
+        this.payloads = Objects.requireNonNull(payloads);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public PayloadIterator getPayloadsIterator() {
+        return new PayloadIterator(this);
+    }
+
+    List<CustomPayload> getPayloads() {
+        return payloads;
+    }
+
+    void setPayloads(List<CustomPayload> payloads) {
+        this.payloads = payloads;
+    }
+
+    List<CustomPayload> getDefaultPayloads() {
+        return defaultPayloads;
+    }
+
+    private static List<CustomPayload> createDefaultPayloads(String name, List<String> payloads) {
+        Objects.requireNonNull(payloads);
+
+        if (payloads.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<CustomPayload> defaultPayloads = new ArrayList<>(payloads.size());
+        for (String payload : payloads) {
+            defaultPayloads.add(new CustomPayload(name, payload));
+        }
+        return defaultPayloads;
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/PayloadIterator.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/PayloadIterator.java
@@ -1,0 +1,63 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class PayloadIterator implements Iterable<String> {
+
+    private final PayloadCategory category;
+
+    public PayloadIterator(PayloadCategory category) {
+        this.category = category;
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return new IteratorImpl(category.getPayloads());
+    }
+
+    private static class IteratorImpl implements Iterator<String> {
+
+        private final Iterator<CustomPayload> iterator;
+        private CustomPayload currentPayload;
+
+        public IteratorImpl(List<CustomPayload> payloads) {
+            this.iterator = payloads.iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            while (iterator.hasNext()) {
+                currentPayload = iterator.next();
+                if (currentPayload.isEnabled()) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String next() {
+            return currentPayload.getPayload();
+        }
+    }
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/PluginWithConfigurablePayload.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/PluginWithConfigurablePayload.java
@@ -1,0 +1,26 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.custompayloads;
+
+import java.util.List;
+
+public interface PluginWithConfigurablePayload {
+    List<CustomPayloadModel> getDefaultPayloads();
+}

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/ScanRulePayloadsProvider.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/ScanRulePayloadsProvider.java
@@ -21,6 +21,6 @@ package org.zaproxy.zap.extension.custompayloads;
 
 import java.util.List;
 
-public interface PluginWithConfigurablePayload {
-    List<CustomPayloadModel> getDefaultPayloads();
+public interface ScanRulePayloadsProvider {
+    List<CustomPayload> getDefaultPayloads();
 }

--- a/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
+++ b/addOns/custompayloads/src/main/resources/org/zaproxy/zap/extension/custompayloads/resources/Messages.properties
@@ -1,0 +1,23 @@
+# CustomPayloads
+#
+# This file defines the default (English) variants of all of the internationalised messages
+
+custompayloads.name = Custom Payloads
+custompayloads.desc = Ability to add, edit or remove payloads that are used i.e. by active scanners
+
+custompayloads.options.title = Custom Payloads
+custompayloads.options.dialog.title = Custom Payload
+custompayloads.options.dialog.enabled = Enabled
+custompayloads.options.dialog.id = ID
+custompayloads.options.dialog.payload = Payload
+custompayloads.options.dialog.category = Category
+
+custompayloads.options.button.reset = Reset to Defaults
+custompayloads.options.button.resetIds = Reset IDs
+custompayloads.options.button.addMissingDefaults = Add Missing Defaults
+
+custompayloads.options.dialog.remove.title = Remove Payload
+custompayloads.options.dialog.remove.text = Are you sure you want to remove this payload?
+custompayloads.options.dialog.remove.button.confirm = Remove
+custompayloads.options.dialog.remove.button.cancel = Cancel
+custompayloads.options.dialog.remove.label = Do not show this message again

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ var addOns = listOf(
     "cmss",
     "codedx",
     "coreLang",
+    "custompayloads",
     "customreport",
     "diff",
     "directorylistv1",


### PR DESCRIPTION
It provides the ability to add, edit or remove payloads that are used by active scanners. I added an example how to use the new extension in the alpha active scanner TestUserAgent.

The whole idea is that scanners provide default payloads via implementing the interface `PluginWithConfigurablePayload`. The payloads which are used during the scan are retrieved by the `ExtensionCustomPayloads` class from the method` getPayloadsByCategory(String category)`. The scanners ask the `ExtensionCustomPayloads` for payloads of a particular category.
This enables the user to add, modify or remove payloads as he like.

Once the PR #1072 "First implementation of scanner that uses callbacks for identifying XSS vulnerabilities" is merged I will change the new `XssByCallbackScanner.java ` to use CustomPayloads.

Furthermore I tried to make life easier if you would like to add new tables or in this particular case a new options dialog with an editable table. If you like this generic approach maybe we could integrate it to the zap core codebase.

@psiinon maybe we can improve this first implementation with the thoughts from that issue https://github.com/zaproxy/zaproxy/issues/1703#issuecomment-121591931

