### PR TITLE
added fingerprinting header passive scan rule

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/FingerprintingHeadersScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/FingerprintingHeadersScanner.java
@@ -1,0 +1,118 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+import net.htmlparser.jericho.Source;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+
+/**
+ * a scanner to passively scan for the presence of the server HTTP response header
+ */
+public class FingerprintingHeadersScanner extends PluginPassiveScanner {
+
+    /**
+     * Prefix for internationalised messages used by this rule
+     */
+    private static final String MESSAGE_PREFIX = "pscanrules.fingerprintingheaderscanner.";
+
+    private PassiveScanThread parent = null;
+
+    private final List<String> fingerprintingHeaders = new ArrayList<String>();
+
+    public FingerprintingHeadersScanner() {
+        fingerprintingHeaders.add("Server");
+        fingerprintingHeaders.add("X-Powered-By");
+        fingerprintingHeaders.add("X-AspNet-Version");
+        fingerprintingHeaders.add("X-AspNetMvc-Version");
+    }
+
+    @Override
+    public void setParent(PassiveScanThread parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public void scanHttpRequestSend(HttpMessage msg, int id) {
+
+    }
+
+    @Override
+    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (AlertThreshold.LOW.equals(this.getLevel())) {
+            return;
+        }
+        boolean headerPresent = false;
+        List<String> fingerprintingHeadersFound = new ArrayList<String>();
+
+        for (String header :
+                fingerprintingHeaders) {
+            Vector<String> found = msg.getResponseHeader().getHeaders(header);
+
+            if (found != null){
+                fingerprintingHeadersFound.add(header + ":" + found.firstElement());
+            }
+        }
+
+        if (fingerprintingHeadersFound.isEmpty()) {
+            return;
+        }
+
+        this.raiseAlert(msg, id, String.join(",", fingerprintingHeadersFound) );
+    }
+
+    private void raiseAlert(HttpMessage msg, int id, String foundFingerprintingHeaders) {
+        Alert alert = new Alert(getPluginId(), Alert.RISK_LOW, Alert.CONFIDENCE_HIGH,  getName());
+        alert.setDetail(
+                Constant.messages.getString(MESSAGE_PREFIX + "desc"),
+                msg.getRequestHeader().getURI().toString(),
+                "Headers", //parameter
+                "", 					//attack
+                Constant.messages.getString(MESSAGE_PREFIX + "extrainfo"),		//other info
+                Constant.messages.getString(MESSAGE_PREFIX + "soln"),			//solution
+                Constant.messages.getString(MESSAGE_PREFIX + "refs"),			//refs
+                (foundFingerprintingHeaders), 	//evidence, if any
+                933, //CWE-933: OWASP Top Ten 2013 Category A5 - Security Misconfiguration
+                14,  //WASC-14: Server Misconfiguration
+                msg);
+
+        parent.raiseAlert(id, alert);
+    }
+
+    @Override
+    public int getPluginId() {
+        return 1078;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+}

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -85,3 +85,9 @@ pscanrules.testinfosessionidurl.refs = http://seclists.org/lists/webappsec/2002/
 pscanrules.testinfosessionidurl.referrer.alert = Referer Exposes Session ID
 pscanrules.testinfosessionidurl.referrer.desc = A hyperlink pointing to anther host name was found. As session ID URL rewrite is used, it may be disclosed in referer header to external hosts.
 pscanrules.testinfosessionidurl.referrer.soln = This is a risk if the session ID is sensitive and the hyperlink refers to an external or third party host. For secure content, put session ID in secured session cookie.
+
+pscanrules.fingerprintingheaderscanner.name = Fingerprinting Headers
+pscanrules.fingerprintingheaderscanner.desc = Headers that can leak information to an attacker about the technology stack used by the server found.
+pscanrules.fingerprintingheaderscanner.soln = Configure the server so it will not return those headers.
+pscanrules.fingerprintingheaderscanner.extrainfo = An attacker can used this information to exploit known vulnerabilities.
+pscanrules.fingerprintingheaderscanner.refs = https://www.troyhunt.com/shhh-dont-let-your-response-headers/

--- a/test/org/zaproxy/zap/extension/pscanrules/FingerprintingHeadersScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/FingerprintingHeadersScannerUnitTest.java
@@ -1,0 +1,150 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class FingerprintingHeadersScannerUnitTest extends PassiveScannerTest {
+
+    @Override
+    protected FingerprintingHeadersScanner createScanner() {
+        return new FingerprintingHeadersScanner();
+    }
+
+    @Test
+    public void hasServerHeader() throws HttpMalformedHeaderException {
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: Apache-Coyote/1.1\r\n" +
+                        "Content-Type: text/html;charset=ISO-8859-1\r\n" +
+                        "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("Headers"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Server:Apache-Coyote/1.1"));
+    }
+
+    @Test
+    public void hasXPoweredByHeader() throws HttpMalformedHeaderException {
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                        "X-Powered-By: Apache-Coyote/1.1\r\n" +
+                        "Content-Type: text/html;charset=ISO-8859-1\r\n" +
+                        "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("Headers"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("X-Powered-By:Apache-Coyote/1.1"));
+    }
+
+    @Test
+    public void hasXAspNetVersionHeader() throws HttpMalformedHeaderException {
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                        "X-AspNet-Version: 1\r\n" +
+                        "Content-Type: text/html;charset=ISO-8859-1\r\n" +
+                        "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("Headers"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("X-AspNet-Version:1"));
+    }
+
+    @Test
+    public void hasXAspNetMvcVersionHeader() throws HttpMalformedHeaderException {
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                        "X-AspNetMvc-Version: 1\r\n" +
+                        "Content-Type: text/html;charset=ISO-8859-1\r\n" +
+                        "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("Headers"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("X-AspNetMvc-Version:1"));
+    }
+
+    @Test
+    public void noFingerprintingHeader() throws HttpMalformedHeaderException {
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                        "X-XSS-Protection: \r\n" +
+                        "Content-Type: text/html;charset=ISO-8859-1\r\n" +
+                        "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void alertThresholdLow() throws HttpMalformedHeaderException {
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                        "Server: Apache-Coyote/1.1\r\n" +
+                        "X-XSS-Protection: 0\r\n" +
+                        "Content-Type: text/html;charset=ISO-8859-1\r\n" +
+                        "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        rule.setLevel(AlertThreshold.LOW);
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+}


### PR DESCRIPTION
I noticed that currently there is a rule for `X-Powered-By`, but not for other headers like `Server` - this scan rule should fix it.