### PR TITLE
scripts: address NPE on script errors

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -831,6 +831,9 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 		ExtenderScript ec;
 		try {
 			ec = extScript.getInterface(script, ExtenderScript.class);
+			if (ec == null) {
+				return;
+			}
 			ec.install(getExtensionScriptHelper());
 			this.installedExtenderScripts.put(script.getName(), ec);
 			script.setError(false);

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Script Console</name>
-	<version>20</version>
+	<version>21</version>
 	<status>beta</status>
 	<description>Supports all JSR 223 scripting languages</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
-	Added extender script type and examples.<br>
+	Fix an exception when installing extender scripts with errors.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionScriptsUI to not attempt to use the ExtenderScript if
failed to obtain it from the script (e.g. syntax errors) preventing the
NullPointerException.
Bump version and update changes in ZapAddOn.xml file.