### PR TITLE
added STS to timestamp rule ignored headers

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
@@ -73,7 +73,7 @@ public class TimestampDisclosureScanner extends PluginPassiveScanner {
 	/**
 	 * ignore the following response headers for the purposes of the comparison, since they cause false positives
 	 */
-	private static final String [] RESPONSE_HEADERS_TO_IGNORE = {HttpHeader._KEEP_ALIVE, HttpHeader.CACHE_CONTROL, "ETag", "Age"};  
+	private static final String [] RESPONSE_HEADERS_TO_IGNORE = {HttpHeader._KEEP_ALIVE, HttpHeader.CACHE_CONTROL, "ETag", "Age", "Strict-Transport-Security"};
 
 	/**
 	 * gets the name of the scanner

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2012 The ZAP development team
+ * Copyright 2017 The ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Code changes for Java 9 (Issue 2602).<br>
+	Bug fix - Added Strict-Transport-Security to the ignored header on Timestamp Disclosure scanner. <br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScannerUnitTest.java
@@ -1,3 +1,23 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2017 The ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import org.apache.commons.httpclient.URI;
@@ -12,10 +32,6 @@ import static org.junit.Assert.assertEquals;
 
 public class TimestampDisclosureScannerUnitTest extends PassiveScannerTest  {
     private HttpMessage msg;
-
-    // Hashes in lower case for "guest" without quotes
-    private static final String GUEST_MD5 = "084e0343a0486ff05530df6c705c8bb4";
-    private static final String GUEST_SHA1 = "84983c60f7daadc1cb8698621f802c0d9f9a3c3c295c810748fb048115c186ec";
 
     @Before
     public void before() throws URIException {

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScannerUnitTest.java
@@ -1,0 +1,44 @@
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Before;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+import static org.junit.Assert.assertEquals;
+
+public class TimestampDisclosureScannerUnitTest extends PassiveScannerTest  {
+    private HttpMessage msg;
+
+    // Hashes in lower case for "guest" without quotes
+    private static final String GUEST_MD5 = "084e0343a0486ff05530df6c705c8bb4";
+    private static final String GUEST_SHA1 = "84983c60f7daadc1cb8698621f802c0d9f9a3c3c295c810748fb048115c186ec";
+
+    @Before
+    public void before() throws URIException {
+        HttpRequestHeader requestHeader = new HttpRequestHeader();
+        requestHeader.setURI(new URI("http://example.com", false));
+
+        msg = new HttpMessage();
+        msg.setRequestHeader(requestHeader);
+    }
+
+    @Override
+    protected PluginPassiveScanner createScanner() {
+        return new TimestampDisclosureScanner();
+    }
+
+    @Test
+    public void shouldNotRaiseAlertOnSTSHeader() throws Exception {
+        // Given
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Server: Apache-Coyote/1.1\r\n" + "Strict-Transport-Security: max-age=15552000; includeSubDomains\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertEquals(alertsRaised.size(), 0);
+    }
+
+}


### PR DESCRIPTION
The following request would raise an alert:
```
Strict-Transport-Security: max-age=15552000; includeSubDomains
X-Download-Options: noopen
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
X-Powered-By: Express
Content-Type: application/json; charset=utf-8
Content-Length: 978
```
because of the `max-age`.