### PR TITLE
scripts: show script types in alphabetical order

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
+	Show script types in alphabetical order in dialogues New and Load Script.<br>
 	Fix an exception when installing extender scripts with errors.<br>
 	Allow to enable code folding in script text area.<br>
 	]]>

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
@@ -24,6 +24,7 @@ import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.parosproxy.paros.Constant;
@@ -109,6 +110,7 @@ public class LoadScriptDialog extends StandardFieldsDialog {
 		for (ScriptType type : extension.getExtScript().getScriptTypes()) {
 			list.add(Constant.messages.getString(type.getI18nKey()));
 		}
+		Collections.sort(list);
 		return list;
 	}
 	

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -24,6 +24,7 @@ import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.parosproxy.paros.Constant;
@@ -171,6 +172,7 @@ public class NewScriptDialog extends StandardFieldsDialog {
 		for (ScriptType type : extension.getExtScript().getScriptTypes()) {
 			list.add(Constant.messages.getString(type.getI18nKey()));
 		}
+		Collections.sort(list);
 		return list;
 	}
 	


### PR DESCRIPTION
Change New and Load Script dialogues to show the types in alphabetical
order, easier to search the script types.
Update changes in ZapAddOn.xml file.