### PR TITLE
scripts: fix enabled checkbox with templates

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix an exception when installing extender scripts with errors.<br>
+	Correct state of Enabled checkbox when creating a script from templates.<br>
 	Allow to enable code folding in script text area.<br>
 	]]>
 	</changes>

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -98,7 +98,12 @@ public class NewScriptDialog extends StandardFieldsDialog {
 		this.addMultilineField(FIELD_DESC, desc);
 		this.addCheckBoxField(FIELD_LOAD, true);
 		this.addCheckBoxField(FIELD_ENABLED, false);
-		this.getField(FIELD_ENABLED).setEnabled(false);
+		if (template == null) {
+			this.getField(FIELD_ENABLED).setEnabled(false);
+		} else {
+			this.getField(FIELD_ENABLED).setEnabled(template.getType().isEnableable());
+			this.setFieldValue(FIELD_ENABLED, template.getType().isEnabledByDefault());
+		}
 
 		this.addFieldListener(FIELD_TYPE, new ActionListener() {
 			@Override


### PR DESCRIPTION
Correct state of Enabled checkbox when creating a script from templates,
it would be disabled even when the script type could be enabled.
Update changes in ZapAddOn.xml file.