### PR TITLE
Issue 3997 - XCOLD Resource Message Typo

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (alpha)</name>
-	<version>17</version>
+	<version>18</version>
 	<status>alpha</status>
 	<description>The alpha quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Code changes for Java 9 (Issue 2602).<br>
-	Bug fix - Added Strict-Transport-Security to the ignored header on Timestamp Disclosure scanner. <br>
-	Add X-AspNet-Version Header scanner - detecting information disclosure via HTTP headers. <br>
+	Correct typo in XCOLD alert description (Issue 3997).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -256,7 +256,7 @@ pscanalpha.xaspnetversioncanner.extrainfo = An attacker can use this information
 pscanalpha.xaspnetversioncanner.refs = https://www.troyhunt.com/shhh-dont-let-your-response-headers/\nhttps://blogs.msdn.microsoft.com/varunm/2013/04/23/remove-unwanted-http-response-headers/
 
 pscanalpha.xchromeloggerdata.name=X-ChromeLogger-Data (XCOLD) Header Information Leak
-pscanalpha.xchromeloggerdata.desc=The server is leaking information through the X-ChromeLogger-Data (or X-ChromePhp-Date) response header. The content of such headers can be customized by the developer, however it is not uncommon to find: server file system locations, vhost declarations, etc.
+pscanalpha.xchromeloggerdata.desc=The server is leaking information through the X-ChromeLogger-Data (or X-ChromePhp-Data) response header. The content of such headers can be customized by the developer, however it is not uncommon to find: server file system locations, vhost declarations, etc.
 pscanalpha.xchromeloggerdata.refs=https://craig.is/writing/chrome-logger
 pscanalpha.xchromeloggerdata.soln=Disable this functionality in Production when it might leak information that could be leveraged by an attacker. Alternatively ensure that use of the functionality is tied to a strong authorization check and only available to administrators or support personnel for troubleshooting purposes not general users.
 pscanalpha.xchromeloggerdata.otherinfo.msg=The following represents an attempt to base64 decode the value:


### PR DESCRIPTION
Correct typo and update manifest (version & changes).

Fixes zaproxy/zaproxy#3997