### PR TITLE
pscanrulesAlpha: leave attack fields empty

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -236,7 +236,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
 								Constant.messages.getString("pscanalpha.base64disclosure.viewstate.desc"), 
 								msg.getRequestHeader().getURI().toString(), 
 								"", //param
-								viewstatexml.substring(0, Math.min(32000, viewstatexml.length())), //TODO: this should be the the attack (NULL).  Set this field to NULL, once Zap allows mutiple alerts on the same URL, with just different evidence 
+								"", // attack 
 								Constant.messages.getString("pscanalpha.base64disclosure.viewstate.extrainfo", viewstatexml), //other info
 								Constant.messages.getString("pscanalpha.base64disclosure.viewstate.soln"), 
 								Constant.messages.getString("pscanalpha.base64disclosure.viewstate.refs"), 
@@ -254,7 +254,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
 									Constant.messages.getString("pscanalpha.base64disclosure.viewstatewithoutmac.desc"), 
 									msg.getRequestHeader().getURI().toString(), 
 									"", //param
-									viewstatexml.substring(0, Math.min(32000, viewstatexml.length())), //TODO: this should be the the attack (NULL).  Set this field to NULL, once Zap allows mutiple alerts on the same URL, with just different evidence 
+									"", // attack 
 									Constant.messages.getString("pscanalpha.base64disclosure.viewstatewithoutmac.extrainfo", viewstatexml), //other info
 									Constant.messages.getString("pscanalpha.base64disclosure.viewstatewithoutmac.soln"), 
 									Constant.messages.getString("pscanalpha.base64disclosure.viewstatewithoutmac.refs"), 

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
@@ -193,7 +193,7 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 								getDescription() + " - "+ hashType, 
 								msg.getRequestHeader().getURI().toString(), 
 								"", //param
-								evidence, //TODO: this should be the the attack (NULL).  Set this field to NULL, once Zap allows mutiple alerts on the same URL, with just different evidence 
+								"",  // attack 
 								getExtraInfo(msg, evidence),  //other info
 								getSolution(), 
 								getReference(), 

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
@@ -156,7 +156,7 @@ public class TimestampDisclosureScanner extends PluginPassiveScanner {
 									getDescription() + " - "+ timestampType, 
 									msg.getRequestHeader().getURI().toString(), 
 									"", //param
-									evidence, //TODO: this should be the the attack (NULL).  Set this field to NULL, once Zap allows mutiple alerts on the same URL, with just different evidence 
+									"", // attack
 									getExtraInfo(msg, evidence, timestamp),  //other info
 									getSolution(), 
 									getReference(), 

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Correct typo in XCOLD alert description (Issue 3997).<br>
+	Do not set a value in the attack fields.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Leave the attack field empty in alerts ASP.NET ViewState Disclosure,
ASP.NET ViewState Integrity, Hash Disclosure, and Timestamp Disclosure.
The attack is no longer needed to keep the alerts unique (per changes
done in zaproxy/zaproxy#2509 the evidence is enough to differentiate
them), also, it addresses the TODOs.
Update changes in ZapAddOn.xml file.