### PR TITLE
pscanrules: remove N/A from alert parameter

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/TestInfoSessionIdURL.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/TestInfoSessionIdURL.java
@@ -27,6 +27,7 @@
 // ZAP: 2013/10/12 Issue 809: Converted to a passive scan rule and added some new features
 // ZAP: 2014/11/09 Issue 1396: Add min length check to reduce false positives
 // ZAP: 2015/09/23 Issue 1594: Change matching mechanism
+// ZAP: 2017/11/10 Remove N/A from alert parameter.
 package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.List;
@@ -271,7 +272,7 @@ public class TestInfoSessionIdURL extends PluginPassiveScanner {
                     alert.setDetail(
                             getRefererDescription(),
                             msg.getRequestHeader().getURI().getURI(),
-                            "N/A",
+                            "",
                             linkHostName,
                             "",
                             getRefererSolution(),

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Fix false positive with Private IP Disclosure when target is a private IP on a non-standard port (Issue 3549).<br>
 	Fix false positive with X-Content-Type-Options Header Missing with certain system locales.<br>
 	Fix X-Content-Type-Options help content (Issue 3986).<br>
+	Remove N/A value from parameter of alert Session ID in URL Rewrite.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change TestInfoSessionIdURL to remove "N/A" value from the alert
parameter, if there's no parameter it should be left empty.
Update changes in ZapAddOn.xml file.