### PR TITLE
pscanrulesAlpha: do not rely on system's charset

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -119,7 +119,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
 
 		//get the body contents as a String, so we can match against it
 		String responseheader = msg.getResponseHeader().getHeadersAsString();
-		String responsebody = new String (msg.getResponseBody().getBytes());
+		String responsebody = msg.getResponseBody().toString();
 		String [] responseparts = {responseheader, responsebody};
 
 		//for each pattern..

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/DirectoryBrowsingScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/DirectoryBrowsingScanner.java
@@ -89,7 +89,7 @@ public class DirectoryBrowsingScanner extends PluginPassiveScanner {
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 		//get the body contents as a String, so we can match against it
-		String responsebody = new String (msg.getResponseBody().getBytes());
+		String responsebody = msg.getResponseBody().toString();
 		
 		//try each of the patterns in turn against the response.
 		String evidence = null;

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
@@ -139,7 +139,7 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 		
 		//get the request contents as an array of Strings, so we can match against them
 		String requestheader = msg.getRequestHeader().getHeadersAsString();
-		String requestbody = new String (msg.getRequestBody().getBytes());
+		String requestbody = msg.getRequestBody().toString();
 		String [] requestparts = {requestheader, requestbody};
 		
 		checkForHashes (msg, id, requestparts);
@@ -158,7 +158,7 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 		
 		//get the response contents as an array of Strings, so we can match against them
 		String responseheader = msg.getResponseHeader().getHeadersAsString();
-		String responsebody = new String (msg.getResponseBody().getBytes());
+		String responsebody = msg.getResponseBody().toString();
 		String [] responseparts = {responseheader, responsebody};
 		
 		checkForHashes (msg, id, responseparts);

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
@@ -318,7 +318,7 @@ public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 		//get the body contents as a String, so we can match against it
-		String responsebody = new String (msg.getResponseBody().getBytes());
+		String responsebody = msg.getResponseBody().toString();
 		
 		//try each of the patterns in turn against the response.
 		//we deliberately do not assume that only status 200 responses will contain source code.

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/TimestampDisclosureScanner.java
@@ -123,7 +123,7 @@ public class TimestampDisclosureScanner extends PluginPassiveScanner {
 				} 
 			}
 
-			String responsebody = new String (msg.getResponseBody().getBytes());
+			String responsebody = msg.getResponseBody().toString();
 			String [] responseparts = {filteredResponseheaders.toString(), responsebody};
 
 			//try each of the patterns in turn against the response.				

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Correct typo in XCOLD alert description (Issue 3997).<br>
 	Do not set a value in the attack fields.<br>
+	Do not rely on system's charset to create request/response bodies.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change the scanners to use the method toString() of the request/response
bodies instead of creating manually the String, which relies on the
system's charset (might not be correct, different from the one defined
in the HTTP header).
Update changes in ZapAddOn.xml file.