### PR TITLE
tokengen: use custom initiator ID in HttpSender

### DIFF
--- a/src/org/zaproxy/zap/extension/tokengen/TokenGenerator.java
+++ b/src/org/zaproxy/zap/extension/tokengen/TokenGenerator.java
@@ -41,8 +41,8 @@ public class TokenGenerator extends SwingWorker<Void, Void> {
 
 	private HttpSender getHttpSender() {
 		if (httpSender == null) {
-			//TODO: is HttpSender.ACTIVE_SCANNER_INITIATOR really the right option here??
-			httpSender = new HttpSender(Model.getSingleton().getOptionsParam().getConnectionParam(), true, HttpSender.ACTIVE_SCANNER_INITIATOR);
+			//TODO Replace with HttpSender.TOKEN_GENERATOR_INITIATOR when available.
+			httpSender = new HttpSender(Model.getSingleton().getOptionsParam().getConnectionParam(), true, 12);
 		}
 		return httpSender;
 	}

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+	Use custom HTTP Sender initiator ID.<br>
 	Show same cookies once in Generate Tokens dialogue (Issue 2116).<br>
 	Fix exception when no tokens are found (Issue 2116).<br>
 	Added help file.<br>


### PR DESCRIPTION
Change TokenGenerator to use a custom initiator ID, to differentiate its
requests from the active scanner.
Update changes in ZapAddOn.xml file.

--- 
Constant defined in zaproxy/zaproxy#4058 - Add initiator constant for Token Gen requests