### PR TITLE
Update to use java 8

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -2,7 +2,7 @@
 	<description>Build ZAP extensions</description>
 
 	<property name="src" location="../src" />
-	<property name="src.version" value="1.7" />
+	<property name="src.version" value="1.8" />
 	<property name="test.src" location="../test" />
 	<property name="test.lib" location="../testlib" />
 	<property name="test.build" location="buildtest" />


### PR DESCRIPTION
For https://github.com/zaproxy/zaproxy/issues/4032
Dont merge yet - we'll do that just before generating 2.7.0 in case there are any last minute add-on releases required on 2.6.0