### PR TITLE
openapi: add versions supported to help page

### DIFF
--- a/src/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/src/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -8,7 +8,7 @@ Open API Specification Support
 </HEAD>
 <BODY BGCOLOR="#ffffff">
 <H1>Open API Specification Support</H1>
-This add-on allows you to spider and import OpenAPI (Swagger) definitions.
+This add-on allows you to spider and import OpenAPI (Swagger) definitions (versions 1.2 and 2.0).
 <br><br>
 The add-on will automatically detect any Open API definitions and spider them as long as they are in scope.
 


### PR DESCRIPTION
Add the supported OpenAPI Specification versions to the help page.