### PR TITLE
websocket: address npe during installation

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -315,7 +315,7 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 			hookMenu.addPopupMenuItem(new ExcludeFromWebSocketsMenuItem(this));
 
 			// setup Session Properties
-			sessionExcludePanel =  new SessionExcludeFromWebSocket(this);
+			sessionExcludePanel =  new SessionExcludeFromWebSocket(this, config);
 			getView().getSessionDialog().addParamPanel(new String[]{}, sessionExcludePanel, false);
 			
 			// setup Breakpoints

--- a/src/org/zaproxy/zap/extension/websocket/ui/SessionExcludeFromWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/SessionExcludeFromWebSocket.java
@@ -26,7 +26,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.websocket.ExtensionWebSocket;
@@ -41,10 +40,12 @@ public class SessionExcludeFromWebSocket extends AbstractParamPanel {
 	private MultipleRegexesOptionsPanel regexesPanel;
 	
 	private ExtensionWebSocket extWs;
+	private OptionsParamWebSocket config;
 
-	public SessionExcludeFromWebSocket(ExtensionWebSocket extWs) {
+	public SessionExcludeFromWebSocket(ExtensionWebSocket extWs, OptionsParamWebSocket config) {
 		super();
 		this.extWs = extWs;
+		this.config = config;
 		initialize();
 	}
 	
@@ -92,11 +93,7 @@ public class SessionExcludeFromWebSocket extends AbstractParamPanel {
 	@Override
 	public void initParam(Object obj) {
 		regexesPanel.setRegexes(extWs.getChannelIgnoreList());
-		regexesPanel.setRemoveWithoutConfirmation(!getOptions().isConfirmRemoveProxyExcludeRegex());
-	}
-
-	private static OptionsParamWebSocket getOptions() {
-		return Model.getSingleton().getOptionsParam().getParamSet(OptionsParamWebSocket.class);
+		regexesPanel.setRemoveWithoutConfirmation(!config.isConfirmRemoveProxyExcludeRegex());
 	}
 
 	@Override
@@ -106,7 +103,7 @@ public class SessionExcludeFromWebSocket extends AbstractParamPanel {
 
 	@Override
 	public void saveParam(Object obj) throws WebSocketException {
-		getOptions().setConfirmRemoveProxyExcludeRegex(!regexesPanel.isRemoveWithoutConfirmation());
+		config.setConfirmRemoveProxyExcludeRegex(!regexesPanel.isRemoveWithoutConfirmation());
 		extWs.setChannelIgnoreList(regexesPanel.getRegexes());
 	}
 


### PR DESCRIPTION
Fix a NullPointerException during installation if the Session dialogue
was already initialised (caused by missing OptionsParamWebSocket, which
was not yet added to core).