### PR TITLE
Fix Issue 3979 Reflected XSS in PUT Response

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.httputils.HtmlContext;
 import org.zaproxy.zap.httputils.HtmlContextAnalyser;
 import org.zaproxy.zap.model.Vulnerabilities;
@@ -135,6 +136,9 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
     	
     @Override
     public void scan(HttpMessage msg, String param, String value) {
+        if (!AlertThreshold.LOW.equals(getAlertThreshold()) && HttpRequestHeader.PUT.equals(msg.getRequestHeader().getMethod())) {
+            return;
+        }
     	
 		try {
 	    	// Inject the 'safe' eyecatcher and see where it appears

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules</name>
-	<version>28</version>
+	<version>29</version>
 	<status>release</status>
 	<description>The release quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Issue 3979: Fix reflected XSS in PUT response.<br>
 	]]>
     </changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/src/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -43,7 +43,8 @@ This rule checks the headers of secure pages and reports an alert if they allow 
 
 This rule starts by submitting a 'safe' value and analyzing all of the locations in which this value occurs in the response (if any). <br>
 It then performs a series of attacks specifically targeted at the location in which each of the instances occurs, 
-including tag attributes, URL attributes, attributes in tags which support src attributes, html comments etc. 
+including tag attributes, URL attributes, attributes in tags which support src attributes, html comments etc. (This rule only scans 
+HTTP PUT requests at LOW threshold.)
 
 <H2>Cross Site Scripting (persistent)</H2>
 


### PR DESCRIPTION
Ignore testing the request if the method is PUT.
Update UnitTest to check the new behavior.

Fixes zaproxy/zaproxy#3979