### PR TITLE
scripts: invoke script with selected HTTP messages

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -99,7 +99,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 	private OutputPanelWriter stdOutputPanelWriter = null;
 	private OutputPanelWriter displayedScriptOutputPanelWriter = null;
 
-	private InvokeScriptWithNodePopupMenu popupInvokeScriptWithNodeMenu = null;
+	private InvokeScriptWithHttpMessagePopupMenu popupInvokeScriptWithHttpMessageMenu = null;
 	private PopupEnableDisableScript popupEnableDisableScript = null;
 	private PopupRemoveScript popupRemoveScript = null;
 	private PopupInstantiateTemplate popupInstantiateTemplate = null;
@@ -144,7 +144,7 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 	    	extensionHook.getHookView().addSelectPanel(getScriptsPanel());
 	    	extensionHook.addSessionListener(new ViewSessionChangedListener());
 	        extensionHook.getHookView().addWorkPanel(getConsolePanel());
-			extensionHook.getHookMenu().addPopupMenuItem(getPopupInvokeScriptWithNodeMenu());
+			extensionHook.getHookMenu().addPopupMenuItem(getPopupInvokeScriptWithHttpMessageMenu());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupEnableDisableScript());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupRemoveScript());
             extensionHook.getHookMenu().addPopupMenuItem(getPopupInstantiateTemplate());
@@ -298,11 +298,11 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 	}
 	
 
-	private InvokeScriptWithNodePopupMenu getPopupInvokeScriptWithNodeMenu() {
-		if (popupInvokeScriptWithNodeMenu == null) {
-			popupInvokeScriptWithNodeMenu = new InvokeScriptWithNodePopupMenu(this);
+	private InvokeScriptWithHttpMessagePopupMenu getPopupInvokeScriptWithHttpMessageMenu() {
+		if (popupInvokeScriptWithHttpMessageMenu == null) {
+			popupInvokeScriptWithHttpMessageMenu = new InvokeScriptWithHttpMessagePopupMenu(this);
 		}
-		return popupInvokeScriptWithNodeMenu;
+		return popupInvokeScriptWithHttpMessageMenu;
 	}
 	
 	private PopupEnableDisableScript getPopupEnableDisableScript() {

--- a/src/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessageMenu.java
+++ b/src/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessageMenu.java
@@ -21,22 +21,21 @@ package org.zaproxy.zap.extension.scripts;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
-import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
+import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
-public class InvokeScriptWithNodeMenu extends PopupMenuItemSiteNodeContainer {
+public class InvokeScriptWithHttpMessageMenu extends PopupMenuItemHttpMessageContainer {
 
 	private static final long serialVersionUID = 2282358266003940700L;
-    private static Logger logger = Logger.getLogger(InvokeScriptWithNodeMenu.class);
+    private static Logger logger = Logger.getLogger(InvokeScriptWithHttpMessageMenu.class);
 
 	private ExtensionScriptsUI extension;
 	private ScriptWrapper script;
 	
-	public InvokeScriptWithNodeMenu(ExtensionScriptsUI extension, ScriptWrapper script) {
+	public InvokeScriptWithHttpMessageMenu(ExtensionScriptsUI extension, ScriptWrapper script) {
 		super(script.getName(), true);
 		this.extension = extension;
 		this.script = script;
@@ -53,17 +52,14 @@ public class InvokeScriptWithNodeMenu extends PopupMenuItemSiteNodeContainer {
     }
 
 	@Override
-	public void performAction(SiteNode sn) {
-		if (sn != null && sn.getHistoryReference() != null) {
-			logger.debug("Invoke script with " + sn.getNodeName());
-			try {
-				HttpMessage msg = sn.getHistoryReference().getHttpMessage();
-				extension.invokeTargetedScript(script, msg);
-					
-			} catch (Exception e) {
-				logger.debug("Script " + script.getName() + " failed with error: " + e.toString());
-				extension.showError(e);
-			}
+	public void performAction(HttpMessage msg) {
+		logger.debug("Invoke script with " + msg.getRequestHeader().getURI());
+		try {
+			extension.invokeTargetedScript(script, msg);
+				
+		} catch (Exception e) {
+			logger.debug("Script " + script.getName() + " failed with error: " + e.toString());
+			extension.showError(e);
 		}
 	}
 	

--- a/src/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessagePopupMenu.java
+++ b/src/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessagePopupMenu.java
@@ -25,13 +25,14 @@ import javax.swing.JMenuItem;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
-import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
-import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
+import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
+import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
-public class InvokeScriptWithNodePopupMenu extends PopupMenuItemSiteNodeContainer {
+public class InvokeScriptWithHttpMessagePopupMenu extends PopupMenuItemHttpMessageContainer {
 
 	private static final long serialVersionUID = 2282358266003940700L;
 
@@ -41,7 +42,7 @@ public class InvokeScriptWithNodePopupMenu extends PopupMenuItemSiteNodeContaine
 	 * This method initializes 
 	 * 
 	 */
-	public InvokeScriptWithNodePopupMenu(ExtensionScriptsUI extension) {
+	public InvokeScriptWithHttpMessagePopupMenu(ExtensionScriptsUI extension) {
 		super("ScriptsInvokeX", true);
 		this.extension = extension;
 	}
@@ -60,14 +61,19 @@ public class InvokeScriptWithNodePopupMenu extends PopupMenuItemSiteNodeContaine
     public boolean isDummyItem () {
     	return true;
     }
-	    
-	@Override
-	public void performAction(SiteNode sn) {
-		// Do nothing
+
+    @Override
+    protected void performActions(HttpMessageContainer httpMessageContainer) {
+		// Do nothing (avoids calling performAction for each message).
 	}
 
 	@Override
-    public boolean isButtonEnabledForSiteNode (SiteNode sn) {
+	protected void performAction(HttpMessage message) {
+		// Nothing to do.
+	}
+
+	@Override
+	protected boolean isButtonEnabledForSelectedMessages(HttpMessageContainer httpMessageContainer) {
 		reCreateSubMenu();
 		
     	return false;
@@ -84,7 +90,7 @@ public class InvokeScriptWithNodePopupMenu extends PopupMenuItemSiteNodeContaine
 	}
 
     private ExtensionPopupMenuItem createPopupAddToScriptMenu(ScriptWrapper script) {
-    	return new InvokeScriptWithNodeMenu(extension, script);
+    	return new InvokeScriptWithHttpMessageMenu(extension, script);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Script Console</name>
-	<version>22</version>
+	<version>23</version>
 	<status>beta</status>
 	<description>Supports all JSR 223 scripting languages</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Invoke script on selected message(s) (Issue 4085).<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change Invoke with Script pop up menus to extend HTTP Message container
menus, to invoke the scripts on the selected HTTP message(s) (instead of
the (first) HTTP message of the corresponding site node).
Rename pop up menus to reflect the new inheritance.
Bump version and update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#4085 - Invoking with script invokes with wrong
message