### PR TITLE
bugtracker: remove unused resource message

### DIFF
--- a/src/org/zaproxy/zap/extension/bugtracker/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/bugtracker/ZapAddOn.xml
@@ -1,12 +1,14 @@
 <zapaddon>
 	<name>Bug Tracker</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>Bug Tracker extension.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
-	Added help for the add-on
+	<![CDATA[
+	Remove unused resource message.<br>
+	]]>
 	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.bugtracker.ExtensionBugTracker</extension>

--- a/src/org/zaproxy/zap/extension/bugtracker/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/bugtracker/resources/Messages.properties
@@ -8,7 +8,6 @@ bugtracker.trackers.list                    = Choose a Bug Tracker
 bugtracker.trackers.github.tab 				= Github
 bugtracker.trackers.bugzilla.tab 			= Bugzilla
 bugtracker.trackers.jira.tab 				= JIRA
-bugtracker.trackers.atlassan.tab     		= Atlassan
 bugtracker.trackers.github.issue.repo 		= Repository URL (owner/repo)
 bugtracker.trackers.github.issue.title 		= Title
 bugtracker.trackers.github.issue.body 		= Body


### PR DESCRIPTION
Remove unused resource message (which had a typo, reported in Crowdin).
Bump version and update changes in ZapAddOn.xml file.