### PR TITLE
ascanrulesBeta - Issue 1354

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
@@ -166,6 +166,9 @@ public class Csrftokenscan extends AbstractAppPlugin {
 	 */
 	@Override
 	public void scan() {
+		if (AlertThreshold.HIGH.equals(getAlertThreshold()) && !getBaseMsg().isInScope()) {
+			return; // At HIGH threshold return if the msg isn't in scope
+		}
 
 		boolean vuln = false;
 		Map<String, String> tagsMap = new HashMap<>();

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -1,20 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules (beta)</name>
-	<version>22</version>
+	<version>23</version>
 	<status>beta</status>
 	<description>The beta quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Fix FP in "Source Code Disclosure - /WEB-INF folder" on successful responses (Issue 3048).<br>
-	Fix FP in "Integer Overflow Error" on 500 error responses (Issue 3064).<br>
-	Support security annotations for forms that dont need anti-CSRF tokens.<br>
-	Changed XXE rule to use new callback extension.<br>
-	Notify of messages sent during Heartbleed scanning (Issue 2425).<br>
-	Fix false positive in Code Disclosure - CVE-2012-1823 on image content (Issue 3846).<br>
-	Fix false positive in Backup File Disclosure scanner on 403 responses (Issue 3911).<br>
-	CsrfTokenScan : Keep session cookies instead of deleting all of them<br>
+	At HIGH threshold only perform CSRF checks for inScope messages (Issue 1354).<br>
     ]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -21,6 +21,7 @@ SilverLight's clientaccesspolicy.xml.
 <H2>CSRF Token</H2>
 Scans for the existence of Anti-CSRF tokens. <br>
 Alerts on requests which do not appear to contain Anti-CSRF tokens.<br>
+At HIGH alert threshold only scans messages which are in scope.<br>
 Post 2.5.0 you can specify a comma separated list of identifiers in the 
 <code>rules.csrf.ignorelist</code> parameter via the Options 'Rule configuration' panel.
 Any FORMs with a name or ID that matches one of these identifiers will be ignored when scanning for missing Anti-CSRF tokens.


### PR DESCRIPTION
Csrftokenscan - At HIGH threshold only check messages inScope.
ascanbeta.html - Added this detail to the help content.
ZapAddOn.xml - Version incremented and changes updated.

Related to zaproxy/zaproxy#1354

pscanrulesBeta will be similarly updated after https://github.com/zaproxy/zap-extensions/pull/1190 is accepted. (I'll add the fix tag in that forth coming PR.)