### PR TITLE
authstats: check if context has an auth method

### DIFF
--- a/src/org/zaproxy/zap/extension/authstats/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/authstats/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Authentication Statistics</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>Records logged in/out statistics for all contexts in scope.</description>
 	<author>ZAP Core Team</author>
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAuthstatsAuthStats</url>
 	<changes>
 	<![CDATA[
-	First version<br>
+	Code change for future ZAP versions.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/authstats/resources/help/contents/authStats.html
+++ b/src/org/zaproxy/zap/extension/authstats/resources/help/contents/authStats.html
@@ -11,6 +11,7 @@ Authentication Statistics
 This add-on records authentication related statistics for all contexts that are in scope.<br>
 The statistics are recorded on a per site basis and cover:
 <table>
+<tr><td>stats.auth.<i>component</i>.state.noauth</td><td>The context does not have an authentication method</td></tr>
 <tr><td>stats.auth.<i>component</i>.state.nothtml</td><td>Non HTML responses (which are unlikely to have logged in/out indicators)</td></tr>
 <tr><td>stats.auth.<i>component</i>.state.notsuccess</td><td>Unsuccessful HTML responses (which are unlikely to have logged in/out indicators)</td></tr>
 <tr><td>stats.auth.<i>component</i>.state.noindicator</td><td>No logged in/out indicators have been defined</td></tr>


### PR DESCRIPTION
Change ExtensionAuthStats to check if the context has an authentication
method, in future ZAP versions the context might not have one. Also,
extract a method to reduce statement nesting.
Update help page to mention the new stat, that indicates the context
does not have the authentication method.
Bump version and update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#2620 - Allow to add/remove authentication and
session management methods