### PR TITLE
scripts: correct menu item extender template

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
+	Correct extender script, Add history record menu.js, to show the info dialogue.<br>
 	Invoke script on selected message(s) (Issue 4085).<br>
 	]]>
 	</changes>

--- a/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add history record menu.js
+++ b/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add history record menu.js
@@ -13,10 +13,13 @@ var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHisto
 var menuitem = new popupmenuitemtype("Example history reference menu") {
       performAction: function(href) {
         print("Example menu called with " + href.getHttpMessage().getRequestHeader().getURI().toString());
-        helper.getView().showMessageDialog(
+        view.showMessageDialog(
           "Example menu called with " + href.getHttpMessage().getRequestHeader().getURI().toString());
       }
     }
+
+// View to be used in the menu item (initialised when installing the script).
+var view;
 
 /**
  * This function is called when the script is enabled.
@@ -30,6 +33,7 @@ var menuitem = new popupmenuitemtype("Example history reference menu") {
 function install(helper) {
   if (helper.getView()) {
     helper.getView().getPopupMenu().addMenu(menuitem);
+    view = helper.getView();
   }
 }
 


### PR DESCRIPTION
Correct example extender script Add history record menu.js, by keeping a
reference to the view to be later used in the menu item. It was leading
to an error when triggering the menu item:
 <eval>:16 ReferenceError: "helper" is not defined

Update changes in ZapAddOn.xml file.