### PR TITLE
scripts: update extender templates to Java 8

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Invoke script on selected message(s) (Issue 4085).<br>
+	Update extender scripts to use just Nashorn (Java 8).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add api call.js
+++ b/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add api call.js
@@ -5,10 +5,6 @@
 // Any functionality added in the install function should be removed in the uninstall method.
 // See the other templates for examples on how to do add different functionality. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // Script variable to use when uninstalling
 var apiimpltype = Java.type("org.zaproxy.zap.extension.api.ApiImplementor");
 var apiimpl = new apiimpltype() {

--- a/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add history record menu.js
+++ b/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add history record menu.js
@@ -4,10 +4,6 @@
 // Any functionality added in the install function should be removed in the uninstall method.
 // See the other templates for examples on how to do add different functionality. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // Script variable to use when uninstalling
 var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer");
 var menuitem = new popupmenuitemtype("Example history reference menu") {

--- a/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add toolbar button.js
+++ b/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add toolbar button.js
@@ -4,10 +4,6 @@
 // Any functionality added in the install function should be removed in the uninstall method.
 // See the other templates for examples on how to do add different functionality. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // Script variable to use when uninstalling
 var jbutton = Java.type("javax.swing.JButton");
 var button = new jbutton();

--- a/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add tools menu.js
+++ b/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Add tools menu.js
@@ -4,10 +4,6 @@
 // Any functionality added in the install function should be removed in the uninstall method.
 // See the other templates for examples on how to do add different functionality. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 // Script variable to use when uninstalling
 var menuitem
 

--- a/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Copy as curl command menu.js
+++ b/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Copy as curl command menu.js
@@ -3,9 +3,6 @@
 // Any functionality added in the install function should be removed in the uninstall method.
 // See the other templates for examples on how to do add different functionality. 
 
-// This script will not work with Rhino
-var usingNashorn = typeof importClass !== "function";
-
 // Script variable to use when uninstalling
 var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer");
 var curlmenuitem = new popupmenuitemtype("Copy as curl command") {
@@ -25,11 +22,6 @@ var curlmenuitem = new popupmenuitemtype("Copy as curl command") {
  */
 function install(helper) {
 	if (helper.getView()) {
-		if (! usingNashorn) {
-			helper.getView().showWarningDialog(
-				'This script will only work with Java 8+ \nThe next version of ZAP will require a minimum of Java 8\nso you are recommended to upgrade asap.');
-			return;
-		}
 		helper.getView().getPopupMenu().addMenu(curlmenuitem);
 	}
 }

--- a/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Extender default template.js
+++ b/src/org/zaproxy/zap/extension/scripts/files/scripts/templates/extender/Extender default template.js
@@ -3,10 +3,6 @@
 // Any functionality added in the install function should be removed in the uninstall method.
 // See the other templates for examples on how to do add different functionality. 
 
-// The following handles differences in printing between Java 7's Rhino JS engine
-// and Java 8's Nashorn JS engine
-if (typeof println == 'undefined') this.println = print;
-
 /**
  * This function is called when the script is enabled.
  * 


### PR DESCRIPTION
Update extender JavaScript templates to Nashorn (e.g. remove println
workaround and other specific Rhino code).
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#3470 - Move to using Java 8