### PR TITLE
Do not overwrite websocket messages with encoding error messages

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>WebSockets</name>
-	<version>14</version>
+	<version>15</version>
 	<status>release</status>
 	<description>Allows you to inspect WebSocket communication.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Do not set messages when switching views if text view shows an error message (Issue 4108)<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/ui/httppanel/models/StringWebSocketPanelViewModel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/httppanel/models/StringWebSocketPanelViewModel.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.websocket.utility.InvalidUtf8Exception;
 public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelViewModel {
 	
 	private static final Logger LOGGER = Logger.getLogger(StringWebSocketPanelViewModel.class);
+	private boolean isErrorMessage;
 
     @Override
     public String getData() {
@@ -36,7 +37,9 @@ public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelV
         } else {
 	        try {
 				data = webSocketMessage.getReadablePayload();
+				isErrorMessage = false;
 			} catch (InvalidUtf8Exception e) {
+				isErrorMessage = true;
 				if (webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_BINARY)) {
 					data = Constant.messages.getString("websocket.payload.unreadable_binary");
 				} else {
@@ -52,6 +55,14 @@ public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelV
 
     @Override
     public void setData(String data) {
+		if(isErrorMessage &&
+				((webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_BINARY)
+						&& data.equals(Constant.messages.getString("websocket.payload.unreadable_binary")))
+				||webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_TEXT)
+						&& data.equals(Constant.messages.getString("websocket.payload.invalid_utf8")))){
+			//do not set data if it is an error message and has not been modified
+			return;
+		}
     	if (webSocketMessage.opcode != null) {
 			if (webSocketMessage.opcode == WebSocketMessage.OPCODE_BINARY) {
 				webSocketMessage.payload = data.getBytes();


### PR DESCRIPTION
ensure switching between views in resender does not edit messages in some special cases
closes zaproxy/zaproxy#4108