### PR TITLE
Add Java 9 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ sudo: false
 
 jdk:
   - oraclejdk8
+  - oraclejdk9

--- a/build/build.xml
+++ b/build/build.xml
@@ -101,6 +101,8 @@
 			</fileset>
 			<fileset dir="${test.src}/resources/" />
 		</copy>
+		<!-- Required by core (<= 2.7.0) on Java 9+ -->
+		<touch file="${test.build}/Messages.properties" />
 		<echo message="Running tests..." />
 		<junit printsummary="yes" haltonerror="true" failureproperty="TestsFailed">
 			<classpath>


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 9.
Change build.xml file to include a Messages.properties file on the
classpath as it's required by core.

Part of zaproxy/zaproxy#2602 - Java 9