### PR TITLE
amf: update for ZAP 2.7.0

### DIFF
--- a/src/org/zaproxy/zap/extension/amf/ExtensionAMF.java
+++ b/src/org/zaproxy/zap/extension/amf/ExtensionAMF.java
@@ -84,7 +84,10 @@ public class ExtensionAMF extends ExtensionAdaptor {
                     RequestAMFTextView.NAME,
                     RequestSplitComponent.ViewComponent.BODY);
 
-            panelManager.removeRequestDefaultViewSelectorFactoryAndDefaultViewSelectorsAdded(
+            panelManager.removeRequestDefaultViewSelectorFactory(
+                    RequestSplitComponent.NAME,
+                    RequestAMFTextViewDefaultViewSelectorFactory.NAME);
+            panelManager.removeRequestDefaultViewSelectors(
                     RequestSplitComponent.NAME,
                     RequestAMFTextViewDefaultViewSelector.NAME,
                     RequestSplitComponent.ViewComponent.BODY);

--- a/src/org/zaproxy/zap/extension/amf/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/amf/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
     <name>AMF</name>
-    <version>2</version>
+    <version>3</version>
     <status>alpha</status>
     <description>Adds support for AMF messages</description>
     <author>ZAP Dev Team</author>
     <url/>
     <changes>
     <![CDATA[
-    Deserialise the AMF request.
+    Update for ZAP 2.7.0.<br>
     ]]>
     </changes>
     <dependson/>
@@ -19,6 +19,6 @@
     </pscanrules>
     <filters/>
     <files/>
-    <not-before-version>2.4.0</not-before-version>
+    <not-before-version>2.7.0</not-before-version>
     <not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
Change ExtensionAMF to use the newer core method that allows to properly
remove (request) default view selectors.
Bump add-on and minimum ZAP version (to 2.7.0) and update changes in
ZapAddOn.xml file.