### PR TITLE
replacer: fix NPE during start up

### DIFF
--- a/src/org/zaproxy/zap/extension/replacer/ReplacerParam.java
+++ b/src/org/zaproxy/zap/extension/replacer/ReplacerParam.java
@@ -50,7 +50,7 @@ public class ReplacerParam extends AbstractParam {
 
     private static ArrayList<ReplacerParamRule> defaultList = new ArrayList<ReplacerParamRule>();
 
-    private List<ReplacerParamRule> rules = null;
+    private List<ReplacerParamRule> rules = new ArrayList<>();
 
     private boolean confirmRemoveToken = true;
 

--- a/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Replacer</name>
-	<version>4</version>
+	<version>5</version>
 	<status>beta</status>
 	<description>Easy way to replace strings in requests and responses.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for 2.7.0.</changes>
+	<changes>Fix exception during ZAP start up.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.replacer.ExtensionReplacer</extension>
 	</extensions>


### PR DESCRIPTION
Change ReplacerParam to initialise the list of rules, to prevent a
NullPointerException during start up (caused by a request from
ExtensionQuickStartLaunch).
Bump version and update changes in ZapAddOn.xml file.