### PR TITLE
openapi: fix NPE with RefParameter

### DIFF
--- a/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 		Update Swagger/OpenAPI parser (Issue 3479).<br>
+		Fix exception with ref parameters.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/openapi/generators/FormGenerator.java
+++ b/src/org/zaproxy/zap/extension/openapi/generators/FormGenerator.java
@@ -44,7 +44,7 @@ public class FormGenerator {
                 continue;
             }
             String parameterType = parameter.getIn();
-            if (parameterType.equals("formData")) {
+            if ("formData".equals(parameterType)) {
                 String type = ((AbstractSerializableParameter<?>) parameter).getType();
                 FormDataItem item = new FormDataItem();
                 item.setIsFile(type != null && type.equals("file"));


### PR DESCRIPTION
Change FormGenerator to cope with null "in" value, as with RefParameter.
Update changes in ZapAddOn.xml file.