### PR TITLE
zest: fix NPE when editing action invoke

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Zest - Graphical Security Scripting Language</name>
-	<version>26</version>
+	<version>27</version>
 	<status>beta</status>
 	<description>A graphical security scripting language, ZAPs macro language on steroids</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
-	Use custom plugin ID for fail actions.<br>
-	Updated for 2.7.0.<br>
+	Fix exception when editing Action - Script with unsaved scripts.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
@@ -170,7 +170,7 @@ public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog
 		}
 
 		for (ScriptWrapper script : this.extension.getExtScript().getScripts(ExtensionScript.TYPE_STANDALONE)) {
-			if (filePath.equals(script.getFile().getAbsolutePath())) {
+			if (script.getFile() != null && filePath.equals(script.getFile().getAbsolutePath())) {
 				return script.getName();
 			}
 		}


### PR DESCRIPTION
Change ZestActionDialog to check if the stand alone scripts available
have a file before using it, preventing the NullPointerException. The
NPE would happen when editing an action invoke with unsaved scripts.
Bump version and update changes in ZapAddOn.xml file.