### PR TITLE
scripts: do not show empty choice if tmpl required

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Correct extender script, Add history record menu.js, to show the info dialogue.<br>
 	Invoke script on selected message(s) (Issue 4085).<br>
 	Update extender scripts to use just Nashorn (Java 8).<br>
+	Do not show empty choice when the script engine requires a template.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -199,16 +199,17 @@ public class NewScriptDialog extends StandardFieldsDialog {
 
 	private List<String> getTemplates() {
 		ArrayList<String> list = new ArrayList<String>();
+		ScriptEngineWrapper selectedEngine = getSelectedEngine();
 		for (ScriptWrapper template : extension.getExtScript().getTreeModel().getTemplates(
 				this.nameToType(this.getStringValue(FIELD_TYPE)))) {
 			
 			if (template.getEngine() != null
-					&& (getSelectedEngine() == null || template.getEngine().equals(getSelectedEngine()))) {
+					&& (selectedEngine == null || template.getEngine().equals(selectedEngine))) {
 				list.add(template.getName());
 			}
 		}
-		if (list.size() > 1) {
-			// Only give an empty choice if theres more than one
+		if (list.size() > 1 && (selectedEngine == null || selectedEngine.isSupportsMissingTemplates())) {
+			// Only give an empty choice if theres more than one (and the engine does not require template)
 			list.add("");
 		}
 		return list;


### PR DESCRIPTION
Change NewScriptDialog to not show an empty choice if the selected
script engine requires a template (e.g. Zest engine).
Update changes in ZapAddOn.xml file.