### PR TITLE
spiderAjax: do not refresh table by default

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
@@ -251,9 +251,9 @@ public class AjaxSpiderResultsTableModel
                 refreshEntry(Integer.valueOf(event.getParameters().get(AlertEventPublisher.HISTORY_REFERENCE_ID)));
                 break;
             case AlertEventPublisher.ALL_ALERTS_REMOVED_EVENT:
-            default:
                 refreshEntries();
                 break;
+            default:
             }
         }
 

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Ajax Spider</name>
-	<version>20</version>
+	<version>21</version>
 	<status>release</status>
 	<description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Minor code changes.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change AjaxSpiderResultsTableModel to not refresh the table entries by
default when handling alert events, to avoid performance issues if new
(minor) alert events are added.
Bump version and update changes in ZapAddOn.xml file.