### PR TITLE
quickstart: update code to ZAP 2.7.0

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -74,6 +74,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 	}
 
 	private void initialize() {
+		this.setShowByDefault(true);
 		this.setIcon(new ImageIcon(BreakPanel.class.getResource("/resource/icon/16/147.png")));	// 'lightning' icon
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("quickstart.panel.mnemonic"));
@@ -303,15 +304,6 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 		default:
 			break;
 		}
-	}
-
-	/**
-	 * This should override (or use) the AbstractPanel class but cant do this until the relevant changes are
-	 * available in the zap-extensions trunk
-	 * @return
-	 */
-	public boolean isShowByDefault() {
-		return true;
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Quick Start</name>
-	<version>22</version>
+	<version>23</version>
 	<status>release</status>
 	<description>Provides a tab which allows you to quickly test a target application</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Code changes for Java 9 (Issue 2602).<br>
-	Updated to use new icon.<br>
-	Updated for the new default browser launch URL.<br>
+	Update for 2.7.0.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/src/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -151,7 +151,7 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor implements
         }
         
             
-        new Thread() {
+        new Thread("ZAP-LaunchPageFetcher") {
             @Override
             public void run() {
                 // Try to read the default launch page
@@ -282,9 +282,7 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor implements
                                 if (wd != null) {
                                     if (getQuickStartLaunchParam()
                                             .isZapStartPage()) {
-                                        // Use api instead of API due to a bug in the 2.6.0 core
-                                        // TODO use API once we've release 2.7.0
-                                        wd.get(api.getBaseURL(
+                                        wd.get(API.getInstance().getBaseURL(
                                                         API.Format.OTHER,
                                                         QuickStartLaunchAPI.API_PREFIX,
                                                         API.RequestType.other,
@@ -308,7 +306,7 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor implements
                                 LOGGER.error(e1.getMessage(), e1);
                             }
                         }
-                    }).start();
+                    }, "ZAP-BrowserLauncher").start();
                 }
             });
         }

--- a/src/org/zaproxy/zap/extension/quickstart/launch/QuickStartLaunchAPI.java
+++ b/src/org/zaproxy/zap/extension/quickstart/launch/QuickStartLaunchAPI.java
@@ -21,16 +21,11 @@ package org.zaproxy.zap.extension.quickstart.launch;
 
 import net.sf.json.JSONObject;
 
-import org.parosproxy.paros.core.proxy.ProxyParam;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.ApiOther;
-import org.zaproxy.zap.extension.api.API.RequestType;
-import org.zaproxy.zap.extension.api.OptionsParamApi;
 
 /**
  * The Quick Start Launch API.
@@ -89,38 +84,6 @@ public class QuickStartLaunchAPI extends ApiImplementor {
             }
         }
         throw new ApiException(ApiException.Type.BAD_OTHER, name);
-    }
-    
-    /**
-     * Methods copied (and tweaked) from the latest core to avoid bugs in the 2.6.0 core
-     * TODO Remove once we've release 2.7.0
-     */
-    protected String getBaseURL(API.Format format, String prefix, API.RequestType type, String name, boolean proxy) {
-        String apiPath = format.name() + "/" + prefix + "/" + type.name() + "/" + name + "/";
-        if (!RequestType.view.equals(type)) {
-            return getBaseURL(proxy) + apiPath + "?" + API.API_NONCE_PARAM + "=" + API.getInstance().getOneTimeNonce("/" + apiPath) + "&";
-        }
-        return getBaseURL(proxy) + apiPath;
-    }
-
-    private String getBaseURL(boolean proxy) {
-        OptionsParamApi apiOpts = Model.getSingleton().getOptionsParam().getApiParam();
-        ProxyParam proxyParams = Model.getSingleton().getOptionsParam().getProxyParam();
-        if (proxy) {
-            return apiOpts.isSecureOnly() ? API.API_URL_S : API.API_URL;
-        }
-
-        StringBuilder strBuilder = new StringBuilder(50);
-        strBuilder.append("http");
-        if (apiOpts.isSecureOnly()) {
-            strBuilder.append('s');
-        }
-        strBuilder.append("://")
-                .append(proxyParams.getProxyIp())
-                .append(':')
-                .append(proxyParams.getProxyPort())
-                .append('/');
-        return strBuilder.toString();
     }
 
 }


### PR DESCRIPTION
Change ExtensionQuickStartLaunch to use the API core method now that
the add-on is targeting 2.7.0. Set the name of the threads to be easier
to identify them.
Remove code no longer needed in QuickStartLaunchAPI per previous API
change.
Change QuickStartPanel to set the state that indicates the panel is
shown by default (instead of overriding the method).
Bump version and update changes in ZapAddOn.xml file.