### PR TITLE
Address compilation warns in beta test code

### DIFF
--- a/test/org/zaproxy/zap/extension/ScannerTestUtils.java
+++ b/test/org/zaproxy/zap/extension/ScannerTestUtils.java
@@ -125,7 +125,7 @@ public abstract class ScannerTestUtils {
 
             @Override
             public boolean matches(Object actualValue) {
-                return ((Alert) actualValue).getAlert().equals(Constant.messages.getString(key));
+                return ((Alert) actualValue).getName().equals(Constant.messages.getString(key));
             }
 
             @Override
@@ -135,7 +135,7 @@ public abstract class ScannerTestUtils {
 
             @Override
             public void describeMismatch(Object item, Description description) {
-                description.appendText("was ").appendValue(((Alert) item).getAlert());
+                description.appendText("was ").appendValue(((Alert) item).getName());
             }
         };
     }
@@ -152,7 +152,7 @@ public abstract class ScannerTestUtils {
 
             @Override
             public boolean matches(Object actualValue) {
-                return ((Alert) actualValue).getAlert().contains(Constant.messages.getString(key));
+                return ((Alert) actualValue).getName().contains(Constant.messages.getString(key));
             }
 
             @Override
@@ -162,7 +162,7 @@ public abstract class ScannerTestUtils {
 
             @Override
             public void describeMismatch(Object item, Description description) {
-                description.appendText("was ").appendValue(((Alert) item).getAlert());
+                description.appendText("was ").appendValue(((Alert) item).getName());
             }
         };
     }

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
@@ -55,6 +55,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ScannerTestUtils;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.utils.ClassLoaderUtil;
@@ -132,11 +133,9 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
         ConnectionParam connectionParam = new ConnectionParam();
 
         ScannerParam scannerParam = new ScannerParam();
-        // Will need this once we go to the release after 2.5.0
-        // RuleConfigParam ruleConfigParam = new RuleConfigParam();
+        RuleConfigParam ruleConfigParam = new RuleConfigParam();
         Scanner parentScanner =
-                new Scanner(scannerParam, connectionParam, scanPolicy);
-        //, ruleConfigParam);
+                new Scanner(scannerParam, connectionParam, scanPolicy, ruleConfigParam);
 
         int port = 9090;
         nano = new HTTPDTestServer(port);
@@ -149,8 +148,8 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
                 parentScanner, 
                 scannerParam, 
                 connectionParam, 
-                scanPolicy) {
-                //ruleConfigParam) {
+                scanPolicy,
+                ruleConfigParam) {
             @Override
             public void alertFound(Alert arg1) {
                 alertsRaised.add(arg1);
@@ -163,15 +162,15 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
                 countMessagesSent++;
             }
 
+            @Override
             public void notifyNewMessage(Plugin plugin) {
-                // TODO for 2.5.0:
-                // super.notifyNewMessage(plugin);
+                super.notifyNewMessage(plugin);
                 countMessagesSent++;
             }
 
+            @Override
             public void notifyNewMessage(Plugin plugin, HttpMessage msg) {
-                // TODO for 2.5.0:
-                // super.notifyNewMessage(plugin, msg);
+                super.notifyNewMessage(plugin, msg);
                 httpMessagesSent.add(msg);
                 countMessagesSent++;
             }

--- a/test/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpResponseTagCreatorUnitTest.java
+++ b/test/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpResponseTagCreatorUnitTest.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class HttpResponseTagCreatorUnitTest {
@@ -117,7 +119,7 @@ public class HttpResponseTagCreatorUnitTest {
 
         List<String> newTagList = tagCreator.create();
 
-        assertThat(newTagList, containsInAnyOrder());
+        assertThat(newTagList, is(empty()));
     }
 
     @Test
@@ -157,7 +159,7 @@ public class HttpResponseTagCreatorUnitTest {
 
         List<String> newTagList = tagCreator.create();
 
-        assertThat(newTagList, containsInAnyOrder());
+        assertThat(newTagList, is(empty()));
     }
 
     @Test
@@ -167,6 +169,6 @@ public class HttpResponseTagCreatorUnitTest {
 
         List<String> newTagList = tagCreator.create();
 
-        assertThat(newTagList, containsInAnyOrder());
+        assertThat(newTagList, is(empty()));
     }
 }

--- a/test/org/zaproxy/zap/extension/pscanrulesBeta/CharsetMismatchScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesBeta/CharsetMismatchScannerUnitTest.java
@@ -43,7 +43,7 @@ public class CharsetMismatchScannerUnitTest extends PassiveScannerTest {
     
     @Before
     public void before() throws HttpMalformedHeaderException {
-        rule.setLevel(AlertThreshold.LOW);
+        rule.setAlertThreshold(AlertThreshold.LOW);
         
         msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");

--- a/test/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
@@ -51,7 +51,7 @@ public abstract class PassiveScannerTest extends ScannerTestUtils {
     @Before
     public void setUp() throws Exception {
         alertsRaised = new ArrayList<>();
-        parent = new PassiveScanThread(null, null, new ExtensionAlert()) {
+        parent = new PassiveScanThread(null, null, new ExtensionAlert(), null) {
             @Override
             public void raiseAlert(int arg0, Alert arg1) {
                 alertsRaised.add(arg1);


### PR DESCRIPTION
Update ActiveScannerTest, CharsetMismatchScannerUnitTest,
PassiveScannerTest, and ScannerTestUtils to use latest (non-deprecated)
core code.
Address unchecked warnings in HttpResponseTagCreatorUnitTest.