### PR TITLE
Issue 3978 - Handle reflected XSS in JSON response

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Issue 3979: Fix reflected XSS in PUT response.<br>
+	Issue 3978: Handle relfected XSS in JSON response.<br>
 	]]>
     </changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -23,6 +23,8 @@ ascanrules.formatstring.error3 = Potential Format String Error.  The script clos
 
 
 ascanrules.testscrosssitescriptv2.name = Cross Site Scripting (Reflected)
+ascanrules.testscrosssitescriptv2.json.name = Cross Site Scripting Weakness (Reflected in JSON Response)
+ascanrules.testscrosssitescriptv2.json.desc = A XSS attack was reflected in a JSON response, this might leave content consumers vulnerable to attack if they don't appropriately handle the data (response).
 ascanrules.testscrosssitescriptv2.otherinfo.nothtml = Raised with LOW confidence as the Content-Type is not HTML
 
 ascanrules.testpersistentxssattack.name=Cross Site Scripting (Persistent)

--- a/src/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/src/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -43,8 +43,10 @@ This rule checks the headers of secure pages and reports an alert if they allow 
 
 This rule starts by submitting a 'safe' value and analyzing all of the locations in which this value occurs in the response (if any). <br>
 It then performs a series of attacks specifically targeted at the location in which each of the instances occurs, 
-including tag attributes, URL attributes, attributes in tags which support src attributes, html comments etc. (This rule only scans 
-HTTP PUT requests at LOW threshold.)
+including tag attributes, URL attributes, attributes in tags which support src attributes, html comments etc. <br>
+Note: <br>
+This rule only scans HTTP PUT requests at LOW threshold.<br>
+If an XSS injection is located in a JSON response a LOW risk and LOW confidence alert is raised.
 
 <H2>Cross Site Scripting (persistent)</H2>
 

--- a/test/resources/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest/example.json
+++ b/test/resources/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest/example.json
@@ -1,0 +1,1 @@
+{ "name":"@@@name@@@", "age":30, "car":null } 


### PR DESCRIPTION
* TestCrossSiteScriptV2 - Add handling for simple XSS in JSON responses.
* Messages.properties - Add supporting keys and messages.
* ascanrules.html - Add relevant note to the help content.
* TestCrossSiteScriptV2UnitTest - Add unit test to cover the new behavior.
* example.json - New resource file to support the unit test.
* ZapAddOn.xml - Updated changes section.

Fixes zaproxy/zaproxy#3978