### PR TITLE
spiderAjax: reset API scan also in daemon mode

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -113,8 +113,9 @@ public class ExtensionAjax extends ExtensionAdaptor {
 		API.getInstance().registerApiImplementor(ajaxSpiderApi);
 		extensionHook.addOptionsParamSet(getAjaxSpiderParam());
 
+		extensionHook.addSessionListener(new SpiderSessionChangedListener());
+
 		if (getView() != null) {
-			extensionHook.addSessionListener(new SpiderSessionChangedListener());
 
 			extensionHook.getHookView().addStatusPanel(getSpiderPanel());
 			extensionHook.getHookView().addOptionPanel(getOptionsSpiderPanel());

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Reset API scan also when in daemon mode (Issue 4163).<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change ExtensionAjax to add/hook the session listener even if there's no
view, it should also be executed in daemon mode to reset the API scan.
Update changes in ZapAddOn.xml file (remove the old change, no longer
relevant).

Fix zaproxy/zaproxy#4163 - ajaxSpider.number_of_results is not cleared
when a new session is created