### PR TITLE
quickstart: stop the quick scan on session changes

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/src/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -37,8 +37,10 @@ import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.extension.spider.SpiderScan;
 import org.zaproxy.zap.model.Target;
 
 public class AttackThread extends Thread {
@@ -100,14 +102,15 @@ public class AttackThread extends Thread {
 			sleep(1500);
 			
 			try {
+				SpiderScan spiderScan = extSpider.getScan(spiderId);
 				 // Wait for the spider to complete
-				while (! extSpider.getScan(spiderId).isStopped()) { 
+				while (! spiderScan.isStopped()) { 
 					sleep (500);
 					if (this.stopAttack) {
 						extSpider.stopScan(spiderId);
 						break;
 					}
-					extension.notifyProgress(Progress.spider, extSpider.getScan(spiderId).getProgress());
+					extension.notifyProgress(Progress.spider, spiderScan.getProgress());
 				}
 			} catch (InterruptedException e) {
 				// Ignore
@@ -146,13 +149,14 @@ public class AttackThread extends Thread {
 			}
 		
 			try {
+				ActiveScan ascan = extAscan.getScan(scanId);
 				 // Wait for the active scanner to complete
-				while (! extAscan.getScan(scanId).isStopped()) { 
+				while (! ascan.isStopped()) { 
 					sleep (500);
 					if (this.stopAttack) {
 						extAscan.stopScan(scanId);
 					}
-					extension.notifyProgress(Progress.ascan, extAscan.getScan(scanId).getProgress());
+					extension.notifyProgress(Progress.ascan, ascan.getProgress());
 				}
 			} catch (InterruptedException e) {
 				// Ignore

--- a/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -209,6 +209,7 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
 	public void stopAttack() {
 		if (attackThread != null) {
 			attackThread.stopAttack();
+			attackThread = null;
 		}
 	}
 
@@ -230,7 +231,7 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
 
 	@Override
 	public void sessionAboutToChange(Session arg0) {
-		// Ignore
+		stopAttack();
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update for 2.7.0.<br>
+	Stop the quick scan if the session is changed.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionQuickStart to stop the scan if the session is changed.
Change AttackThread to keep a reference to the spider and active scans,
to prevent NullPointerException(s) when the scans are stopped and
removed because of session changes.
Update changes in ZapAddOn.xml file.