### PR TITLE
pscanBeta - CSRFCountermessures High Threshold Only In Scope

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
@@ -105,6 +106,10 @@ public class CSRFCountermeasures extends PluginPassiveScanner {
 	 */
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+		if (AlertThreshold.HIGH.equals(getAlertThreshold()) && !msg.isInScope()) {
+			return; // At HIGH threshold return if the msg isn't in scope
+		}
+		
 		//need to do this if we are to be able to get an element's parent. Do it as early as possible in the logic 
 		source.fullSequentialParse();
 		

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Minor code changes to address deprecation.<br/>
+	At HIGH threshold only perform CSRF checks for in scope messages (Issue 1354).<br/>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -37,6 +37,7 @@ Cookies can be scoped by domain or path. This check is only concerned with domai
 <H2>CSRF Countermeasures</H2>
 The CSRFCountermeasures plugin identifies "potential" vulnerabilities with the lack of known CSRF 
 countermeasures in pages with forms.<br>
+At HIGH alert threshold only scans messages which are in scope.<br>
 Post 2.5.0 you can specify a comma separated list of identifiers in the 
 <code>rules.csrf.ignorelist</code> parameter via the Options 'Rule configuration' panel.
 Any FORMs with a name or ID that matches one of these identifiers will be ignored when scanning for missing Anti-CSRF tokens.


### PR DESCRIPTION
CSRFCountermeasures - Add alert threshold and scope check.
CSRFCountermeasuresUnitTest - Updated to test the new behavior.
pscanbeta.html - Updated help content.
ZapAddOn.xml - Updated changes section.

Fixes zaproxy/zaproxy#1354