### PR TITLE
accessControl: use core method to display messages

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Access Control Testing</name>
-	<version>4</version>
+	<version>5</version>
 	<status>alpha</status>
 	<description>Adds a set of tools for testing access control in web applications.</description>
 	<author>ZAP Dev Team</author>
 	<url />
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Minor code changes.<br>
 	]]> 
 	</changes>
 	<dependson />

--- a/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
+++ b/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
@@ -161,21 +161,7 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel imp
 	}
 
 	protected void displayMessageInHttpPanel(final HttpMessage msg) {
-		if (msg == null) {
-			return;
-		}
-
-		if (msg.getRequestHeader().isEmpty()) {
-			View.getSingleton().getRequestPanel().clearView(true);
-		} else {
-			View.getSingleton().getRequestPanel().setMessage(msg);
-		}
-
-		if (msg.getResponseHeader().isEmpty()) {
-			View.getSingleton().getResponsePanel().clearView(false);
-		} else {
-			View.getSingleton().getResponsePanel().setMessage(msg, true);
-		}
+		View.getSingleton().displayMessage(msg);
 	}
 
 	@Override


### PR DESCRIPTION
Change AccessControlStatusPanel to use core method to display the HTTP
messages instead of manually setting up the request/response panels.
Bump version and update changes in ZapAddOn.xml file.