### PR TITLE
Fix Issue 4210 Error Disclosure False Positive

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/InformationDisclosureDebugErrors.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/InformationDisclosureDebugErrors.java
@@ -31,6 +31,7 @@ import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpBody;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
@@ -53,6 +54,10 @@ public class InformationDisclosureDebugErrors extends PluginPassiveScanner {
 
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+		//At medium or high exclude javascript responses
+		if (!AlertThreshold.LOW.equals(this.getAlertThreshold()) && msg.getResponseHeader().isJavaScript()) {
+			return;
+		}
 		if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isText()) {
 			String parameter;
 			if ((parameter = doesResponseContainsDebugErrorMessage(msg.getResponseBody())) != null) {

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Minor code changes to address deprecation.<br/>
 	At HIGH threshold only perform CSRF checks for in scope messages (Issue 1354).<br/>
+		Exclude JavaScript response types from the InformationDisclosureDebugErrors scanner unless threshold is Low (Issue 4210).<br/>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -47,7 +47,8 @@ Only use this feature to ignore FORMs that you know are safe, for example search
 <H2>Information Disclosure: Debug Errors</H2>
 This passive scanner checks the content of web responses for known Debug Error message fragments.
 Access to such details may provide a malicious individual with means by which to further abuse the web site.
-They may also leak data not specifically meant for end user consumption.
+They may also leak data not specifically meant for end user consumption.<br>
+Note: Javascript responses are only assessed at LOW thresehold.
 
 <H2>Information Disclosure: In URL</H2>
 Attempts to identify the existence of sensitive details within the visited URIs themselves 


### PR DESCRIPTION
InformationDisclosureDebugErrors.java > Updated to ignore javascript responses at medium and high thresholds.
InformationDisclosureDebugErrorsUnitTest.java > Updated with tests for the new behavior.
ZapAddOn.xml > Updated changes section.
pscanbeta.html > Added a note to help content.

Fixes zaproxy/zaproxy#4210