### PR TITLE
exportreport: unload API when uninstalling

### DIFF
--- a/src/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
+++ b/src/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
@@ -36,7 +36,6 @@ import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.exportreport.export.ExportReport;
 import org.zaproxy.zap.extension.exportreport.filechooser.FileList;
 import org.zaproxy.zap.extension.exportreport.filechooser.Utils;
@@ -136,7 +135,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
         if (getView() != null) {
             extensionHook.getHookMenu().addReportMenuItem(getMenuExportReport());
         }
-        API.getInstance().registerApiImplementor(exportReportAPI);
+        extensionHook.addApiImplementor(exportReportAPI);
         extensionHook.addCommandLine(getCommandLineArguments());
     }
 

--- a/src/org/zaproxy/zap/extension/exportreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/exportreport/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Export Report</name>
-	<version>5</version>
+	<version>6</version>
 	<status>alpha</status>
 	<description>Report Export module that allows users to customize content and export in a desired format.</description>
 	<author>Goran Sarenkapa - JordanGS</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Change where XSL files are deployed to avoid clashes (Issue 4206).<br>
+	Remove API when uninstalling.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -21,6 +21,6 @@
 		<file>exportreport/report.html.xsl</file>
 		<file>licenses/SpringUtilities-license.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
Change ExtensionExportReport to hook the API implementor instead of
adding it "manually" to ensure it's (automatically) removed when
uninstalled.
Bump version, update minimum ZAP version (to 2.7.0) and replace changes
in ZapAddOn.xml file.