### PR TITLE
Issue 4211 - Fix FormatString ascan false positive

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/FormatString.java
@@ -163,6 +163,11 @@ public class FormatString extends AbstractAppParamPlugin  {
 						"\n The target may have replied with a poorly formed redirect due to our input.");
 				return; //Something went wrong, no point continuing
 			}
+			
+			if (HttpStatusCode.INTERNAL_SERVER_ERROR == msg.getResponseHeader().getStatusCode()) {
+				return; // Initial message returned error, subsequent requests are likely to as well
+			}
+			
 			HttpResponseBody initialResponseBody= msg.getResponseBody();
 			int initialResponseLength = initialResponseBody.length();
 		//  The following section of the code attacks GNU and generic C compiler format 

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Issue 3979: Fix reflected XSS in PUT response.<br>
 	Issue 3978: Handle relfected XSS in JSON response.<br>
+	Issue 4211: Fix false positive in FormatString scanner.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
FormatString.java > Add a check after the submission of the initial modified message, if the response is 500 then bail (since further manipulation is also likely to result in a 500 and thus false positive).
ZapAddOn.xml > Updated changes section.

Fixes zaproxy/zaproxy#4211