### PR TITLE
highlighter: fix exception in Highlighter panel

### DIFF
--- a/src/org/zaproxy/zap/extension/highlighter/ExtensionHighlighter.java
+++ b/src/org/zaproxy/zap/extension/highlighter/ExtensionHighlighter.java
@@ -4,19 +4,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.extension.ExtensionHookView;
-import org.parosproxy.paros.extension.SessionChangedListener;
-import org.parosproxy.paros.model.Session;
-import org.zaproxy.zap.extension.help.ExtensionHelp;
 
 /*
  * Implements the Extension Interface for HighlighterManager and HighlighterPanel
  */
-public class ExtensionHighlighter extends ExtensionAdaptor
-implements SessionChangedListener /*ProxyListener, */ {
+public class ExtensionHighlighter extends ExtensionAdaptor {
 
 	public static final String NAME = "ExtensionHighlighter";
 	private HighlighterPanel highlighterPanel;
@@ -24,32 +18,17 @@ implements SessionChangedListener /*ProxyListener, */ {
 	public ExtensionHighlighter() {
 		this.setName(NAME);
 		this.setOrder(69);
-		//API.getInstance().registerApiImplementor(new ParamsAPI(this));
-	}
-	
-	@Override
-	public void sessionChanged(Session session) {
-		// TODO Auto-generated method stub
-		
 	}
 
 	@Override
 	public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
-        extensionHook.addSessionListener(this);
         
         if (getView() != null) {
-            @SuppressWarnings("unused")
-            ExtensionHookView pv = extensionHook.getHookView();
             extensionHook.getHookView().addStatusPanel(getHighlighterPanel());
 
-//            extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuParamSearch());
- //           extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAddAntiCSRF());
- //           extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuRemoveAntiCSRF());
- //           extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuAddSession());
- //           extensionHook.getHookMenu().addPopupMenuItem(getPopupMenuRemoveSession());
-//
-            ExtensionHelp.enableHelpKey(getHighlighterPanel(), "ui.tabs.hilighter");
+            // TODO enable (and correct the key) once the add-on provides help
+            // ExtensionHelp.enableHelpKey(getHighlighterPanel(), "ui.tabs.hilighter");
         }
     }
 	
@@ -63,60 +42,7 @@ implements SessionChangedListener /*ProxyListener, */ {
         	highlighterPanel = new HighlighterPanel(this);
         }
         return highlighterPanel;
-}
-    
-	/*
-    private PopupMenuParamSearch getPopupMenuParamSearch() {
-            if (popupMenuSearch == null) {
-                    popupMenuSearch = new PopupMenuParamSearch();
-                    popupMenuSearch.setExtension(this);
-            }
-            return popupMenuSearch;
     }
-    
-    private PopupMenuAddAntiCSRF getPopupMenuAddAntiCSRF() {
-            if (popupMenuAddAntiCsrf == null) {
-                    popupMenuAddAntiCsrf = new PopupMenuAddAntiCSRF();
-                    popupMenuAddAntiCsrf.setExtension(this);
-            }
-            return popupMenuAddAntiCsrf;
-    }
-
-    private PopupMenuRemoveAntiCSRF getPopupMenuRemoveAntiCSRF() {
-            if (popupMenuRemoveAntiCsrf == null) {
-                    popupMenuRemoveAntiCsrf = new PopupMenuRemoveAntiCSRF();
-                    popupMenuRemoveAntiCsrf.setExtension(this);
-            }
-            return popupMenuRemoveAntiCsrf;
-    }
-
-    private PopupMenuAddSession getPopupMenuAddSession() {
-            if (popupMenuAddSession == null) {
-                    popupMenuAddSession = new PopupMenuAddSession();
-                    popupMenuAddSession.setExtension(this);
-            }
-            return popupMenuAddSession;
-    }
-
-    private PopupMenuRemoveSession getPopupMenuRemoveSession() {
-            if (popupMenuRemoveSession == null) {
-                    popupMenuRemoveSession = new PopupMenuRemoveSession();
-                    popupMenuRemoveSession.setExtension(this);
-            }
-            return popupMenuRemoveSession;
-    }
-
-    protected ParamsPanel getParamsPanel() {
-            if (paramsPanel == null) {
-                    paramsPanel = new ParamsPanel(this);
-            }
-            return paramsPanel;
-    }
-    */
-	
-	@Override
-	public void sessionAboutToChange(Session session) {
-	}
 	
 	@Override
 	public String getAuthor() {
@@ -130,14 +56,6 @@ implements SessionChangedListener /*ProxyListener, */ {
 		} catch (MalformedURLException e) {
 			return null;
 		}
-	}
-
-	@Override
-	public void sessionModeChanged(Mode arg0) {
-	}
-
-	@Override
-	public void sessionScopeChanged(Session arg0) {
 	}
 
 }

--- a/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Highlighter</name>
-	<version>6</version>
+	<version>7</version>
 	<status>alpha</status>
 	<description>Allows you to highlight strings in the request and response tabs.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for ZAP 2.4</changes>
+	<changes>Fix help related exception in the Highlighter panel.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.highlighter.ExtensionHighlighter</extension>
 	</extensions>


### PR DESCRIPTION
Change ExtensionHighlighter to not enable the help for the Highlighter
panel, the help is not yet available. Also, remove unused and commented
code.
Bump version and update changes in ZapAddOn.xml file.