### PR TITLE
jython: update template of passive rule

### DIFF
--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Python scripting</name>
-	<version>8</version>
+	<version>9</version>
 	<status>beta</status>
 	<description>Allows Python to be used for ZAP scripting - templates included</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Update Passive Rule template to include new function.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/jython/files/scripts/templates/passive/Passive default template.py
+++ b/src/org/zaproxy/zap/extension/jython/files/scripts/templates/passive/Passive default template.py
@@ -1,12 +1,35 @@
 """
-The scan function will be called for request/response made via ZAP, excluding some of the automated tools
-Passive scan rules should not make any requests 
+Passive scan rules should not make any requests.
 
 Note that new passive scripts will initially be disabled
 Right click the script in the Scripts tree and select "enable"
 """  
 
+from org.zaproxy.zap.extension.pscan import PluginPassiveScanner;
+
+
+def appliesToHistoryType(historyType):
+    """Tells whether or not the scanner applies to the given history type.
+
+    Args:
+        historyType (int): The type (ID) of the message to be scanned.
+
+    Returns:
+        True to scan the message, False otherwise.
+
+    """
+    return PluginPassiveScanner.getDefaultHistoryTypes().contains(historyType);
+
+
 def scan(ps, msg, src):
+  """Passively scans the message sent/received through ZAP.
+
+  Args:
+    ps (ScriptsPassiveScanner): The helper class to raise alerts and add tags to the message.
+    msg (HttpMessage): The HTTP message being scanned.
+    src (Source): The HTML source of the message (if any). 
+
+  """
   # Test the request and/or response here
   if (True):
     # Change to a test which detects the vulnerability


### PR DESCRIPTION
Change Passive default template.py to implement the new function
available in 2.7.0 that allows to choose which types of message are
passive scanned. Also, tweak/add docstrings.
Bump version and update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#3476 - Allow passive rules to choose the type
of msgs