### PR TITLE
webdriverlinux: rm download of ChromeDriver 32bits

### DIFF
--- a/src/org/zaproxy/zap/extension/webdriverlinux/WebdriverDownload.java
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/WebdriverDownload.java
@@ -72,10 +72,6 @@ public class WebdriverDownload {
 				srcdir, "files/webdriver/linux/64/geckodriver");
 
 		downloadDriver(
-				"https://github.com/" + repo + "/raw/master/files/webdriver/linux/32/chromedriver",
-				srcdir, "files/webdriver/linux/32/chromedriver");
-
-		downloadDriver(
 				"https://github.com/" + repo + "/raw/master/files/webdriver/linux/64/chromedriver",
 				srcdir, "files/webdriver/linux/64/chromedriver");
 		


### PR DESCRIPTION
Change WebdriverDownload to no longer download the ChromeDriver 32bits,
that's no longer available.

Related to #1274 - webdrivers: update ChromeDriver to v2.35