### PR TITLE
scripts: prompt for charset on load (if needed)

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix GUI freeze on script addition/removal through the API (Issue 4302).<br>
+	Prompt for a charset when failed to read the script file (Issue 3383).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -85,7 +85,11 @@ scripts.runscript.popup					= Invoke with Script...
 scripts.popup.useForContextAs			= Use for Context as...
 scripts.popup.scriptBasedAuth			= {0} : Script-Based Authentication Script
 
-scripts.script.load.error.charset = Unable to read the script, it contains invalid character sequence.\nThe script is expected to be in UTF-8.
+scripts.script.load.charset.confirmbutton = Load Script
+scripts.script.load.charset.label = Character Encoding:
+scripts.script.load.charset.title = Load Script With Character Encoding
+scripts.script.load.charset.message = Unable to read the script with default character encoding(s):\n{0}\nIt contains invalid character sequence(s).\nYou can select other character encoding.
+scripts.script.load.charset.selected.error = Unable to properly read the script with the selected character encoding.
 
 scripts.type.extender					= Extender
 scripts.type.extender.desc				= Extender scripts add new functionality, including graphical elements and new API end points.\n\n\


### PR DESCRIPTION
Change ScriptsListPanel to show a dialogue prompting for a charset if
the default charsets (UTF-8 and JVM default) don't properly decode the
script.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#3383 - Prompt the user for a charset when failed to
read the script file