### PR TITLE
selenium: enable extension for all DB types

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -149,6 +149,11 @@ public class ExtensionSelenium extends ExtensionAdaptor {
     }
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public void init() {
         super.init();
 

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
 	<name>Selenium</name>
-	<version>13</version>
+	<version>14</version>
 	<semver>2.0.0</semver><!-- This version should be kept in sync with the one of the extension. -->
 	<status>release</status>
 	<description>WebDriver provider and includes HtmlUnit browser</description>
@@ -9,7 +9,7 @@
 	<dependencies/>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Enable the extension for all DB types.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionSelenium to declare that it supports all DB types (no
custom tables added).
Bump version and update changes in ZapAddOn.xml file.