### PR TITLE
quickstart: enable extensions for all DB types

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -75,6 +75,11 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
     public ExtensionQuickStart() {
         super(NAME);
 	}
+
+	@Override
+	public boolean supportsDb(String type) {
+		return true;
+	}
 	
 	@Override
 	public void hook(ExtensionHook extensionHook) {

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Quick Start</name>
-	<version>23</version>
+	<version>24</version>
 	<status>release</status>
 	<description>Provides a tab which allows you to quickly test a target application</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Update for 2.7.0.<br>
-	Stop the quick scan if the session is changed.<br>
-	Added toolbar button to launch the latest browser chosen.<br>
+	Enable the extensions for all DB types.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/src/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -106,6 +106,11 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor implements
     }
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
         this.api = new QuickStartLaunchAPI(this);

--- a/src/org/zaproxy/zap/extension/quickstart/pnh/ExtensionQuickStartPnH.java
+++ b/src/org/zaproxy/zap/extension/quickstart/pnh/ExtensionQuickStartPnH.java
@@ -75,6 +75,11 @@ public class ExtensionQuickStartPnH extends ExtensionAdaptor implements
     }
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 


### PR DESCRIPTION
Change all extensions to declare that they supports all DB types (no
custom tables added).
Bump version and update changes in ZapAddOn.xml file.