### PR TITLE
fuzz: enable extensions for all DB types

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -152,6 +152,11 @@ public class ExtensionFuzz extends ExtensionAdaptor {
     }
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public void init() {
         super.init();
 

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
     <name>AdvFuzzer</name>
-    <version>10</version>
+    <version>11</version>
     <semver>2.0.1</semver>
     <status>beta</status>
     <description>Advanced fuzzer for manual testing</description>
@@ -8,7 +8,7 @@
     <url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsFuzzConcepts</url>
     <changes>
     <![CDATA[
-    Updated for 2.7.0.<br>
+    Enable the extensions for all DB types.<br>
     ]]>
     </changes>
     <extensions>

--- a/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/src/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -95,6 +95,11 @@ public class ExtensionHttpFuzzer extends ExtensionAdaptor {
     }
 
     @Override
+    public boolean supportsDb(String type) {
+        return true;
+    }
+
+    @Override
     public void init() {
         httpFuzzerHandler = new HttpFuzzerHandler();
 


### PR DESCRIPTION
Change all extensions (main and HTTP) to declare that they supports all
DB types (no custom tables added).
Bump version and update changes in ZapAddOn.xml file.