### PR TITLE
scripts: do not run targeted scripts in EDT

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -537,9 +537,11 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 
     public void invokeTargetedScript(ScriptWrapper script, HttpMessage msg) {
     	if (View.isInitialised()) {
-    		this.displayScript(script);
-			this.getConsolePanel().getOutputPanel().preScriptInvoke();
-			this.getConsolePanel().setTabFocus();
+			executeInEdt(() -> {
+				this.displayScript(script);
+				this.getConsolePanel().getOutputPanel().preScriptInvoke();
+				this.getConsolePanel().setTabFocus();
+			});
     	}
    		this.getExtScript().invokeTargetedScript(script, msg);
     }

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Script Console</name>
-	<version>24</version>
+	<version>25</version>
 	<status>beta</status>
 	<description>Supports all JSR 223 scripting languages</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy/wiki/ScriptConsole</url>
 	<changes>
 	<![CDATA[
-	Fix GUI freeze on script addition/removal through the API (Issue 4302).<br>
-	Prompt for a charset when failed to read the script file (Issue 3383).<br>
+	Execute Targeted scripts in other thread than GUI thread.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change InvokeScriptWithHttpMessageMenu to use a new thread to execute
the targeted script, to not block the EDT.
Change ExtensionScriptsUI to execute UI related statements, done before
executing the targeted script, in the EDT to avoid threading issues.
Bump version and update changes in ZapAddOn.xml file.