### PR TITLE
scripts: clear syntax on non-script node selection

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -25,6 +25,7 @@ import java.awt.event.KeyListener;
 
 import javax.swing.JScrollPane;
 
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.fife.ui.rtextarea.RTextScrollPane;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.zaproxy.zap.extension.scripts.autocomplete.ScriptAutoCompleteKeyListener;
@@ -103,6 +104,7 @@ public class CommandPanel extends AbstractPanel {
 	public void clear() {
 	    getTxtOutput().setText("");
 	    getTxtOutput().discardAllEdits();
+	    setSyntax(SyntaxConstants.SYNTAX_STYLE_NONE);
 	}
 
 	public String getCommandScript() {

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Execute Targeted scripts in other thread than GUI thread.<br>
+	Clear highlighting syntax when a non-script node is selected.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change CommandPanel to clear the highlighting syntax when a non-script
node is selected.
Update changes in ZapAddOn.xml file.