### PR TITLE
zest: allow to clear the Zest panel

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Zest - Graphical Security Scripting Language</name>
-	<version>27</version>
+	<version>28</version>
 	<status>beta</status>
 	<description>A graphical security scripting language, ZAPs macro language on steroids</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
-	Fix exception when editing Action - Script with unsaved scripts.<br>
-	Allow to select more HTTP methods in Zest Request dialogue.<br>
+	Allow to clear the Zest panel.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
@@ -19,22 +19,25 @@
  */
 package org.zaproxy.zap.extension.zest;
 
+import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.GridBagConstraints;
-import java.awt.Insets;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.util.List;
 
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JToolBar;
 import javax.swing.KeyStroke;
 
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
-import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
 public class ZestResultsPanel extends AbstractPanel {
@@ -46,6 +49,7 @@ public class ZestResultsPanel extends AbstractPanel {
 	@SuppressWarnings("unused")
 	private ExtensionZest extension = null;
 
+	private JToolBar toolBar;
 	private javax.swing.JPanel zestPanel = null;
 	private JScrollPane jScrollPane = null;
 	private HistoryReferencesTable resultsTable = null;
@@ -69,14 +73,29 @@ public class ZestResultsPanel extends AbstractPanel {
 			
 	}
 
+	private JToolBar getToolBar() {
+		if (toolBar == null) {
+			toolBar = new JToolBar();
+			toolBar.setFloatable(false);
+			toolBar.setRollover(true);
+
+			JButton clearButton = new JButton(
+					Constant.messages.getString("zest.results.panel.button.clear"),
+					DisplayUtils.getScaledIcon(
+							new ImageIcon(ZestResultsPanel.class.getResource("/resource/icon/fugue/broom.png"))));
+			clearButton.addActionListener(e -> model.clear());
+
+			toolBar.add(clearButton);
+		}
+		return toolBar;
+	}
+
 	private javax.swing.JPanel getZestPanel() {
 		if (zestPanel == null) {
-
-			zestPanel = new javax.swing.JPanel();
-			zestPanel.setLayout(new java.awt.GridBagLayout());
+			zestPanel = new JPanel(new BorderLayout());
 			zestPanel.setName("ZestResultsPanel");
-			zestPanel.add(getJScrollPane(), 
-					LayoutHelper.getGBC(0, 1, 1, 1.0, 1.0, GridBagConstraints.BOTH, new Insets(2,2,2,2)));
+			zestPanel.add(getToolBar(), BorderLayout.PAGE_START);
+			zestPanel.add(getJScrollPane(), BorderLayout.CENTER);
 
 		}
 		return zestPanel;

--- a/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
@@ -489,6 +489,7 @@ zest.redact.popup						= Zest: Redact text...
 zest.request.popup						= Add Request
 zest.results.panel.title				= Zest Results
 zest.results.panel.mnemonic				= z
+zest.results.panel.button.clear = Clear
 zest.results.table.header.result		= Result
 zest.return.popup						= Add Return statement 
 zest.runscript.popup					= Run with Zest Script...


### PR DESCRIPTION
Change ZestResultsPanel to show a button that clears the results of an
executed script.
Bump version and update changes in ZapAddOn.xml file.