### PR TITLE
Fix Issue 4230 - Pre-check the original message against the detection

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -421,9 +421,12 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
         // the response content
         // -----------------------------------------------
         for(int i = 0; it.hasNext() && (i < targetCount); i++) {
-
-            HttpMessage msg = getNewMsg();
             payload = it.next();
+            if (osPayloads.get(payload).matcher(getBaseMsg().getResponseBody().toString()).find()) {
+                continue; // The original matches the detection so continue to next
+            }
+            
+            HttpMessage msg = getNewMsg();
             paramValue = value + payload;
             setParameter(msg, paramName, paramValue);
 

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Issue 1366: Allow SSI detection patterns to include new lines, and pre-check the original response for detection patterns to reduce false positives.<br/>
+	Issue 4230: Pre-check the original response for detection patterns.<br/>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Before sending a new message with the injection pre-check `getBaseMsg()` for the detection pattern, if it's found skip (continue) to the next pattern. Thus reducing false positives.

Fixes zaproxy/zaproxy#4230