### PR TITLE
ascanrules: path traversal, skip msg with evidence

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
@@ -517,6 +517,10 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
      * @throws IOException
      */
     private boolean sendAndCheckPayload(String param, String newValue, ContentsMatcher contentsMatcher) throws IOException {
+        if (contentsMatcher.match(getContentsToMatch(getBaseMsg())) != null) {
+            // Evidence already present, no point sending the payload/attack.
+            return false;
+        }
 
         // get a new copy of the original message (request only)
         // and set the specific pattern

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -8,7 +8,7 @@
 	<changes>
 	<![CDATA[
 	Issue 1366: Allow SSI detection patterns to include new lines, and pre-check the original response for detection patterns to reduce false positives.<br/>
-	Issue 4230: Pre-check the original response for detection patterns.<br/>
+	Issue 4168 and 4230: Pre-check the original response for detection patterns.<br/>
 	]]>
     </changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
@@ -177,6 +177,25 @@ public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTravers
         assertThat(alertsRaised, hasSize(0));
     }
 
+    @Test
+    public void shouldNotAlertIfOriginalResponseAlreadyContainsTheEvidence() throws Exception {
+        // Given
+        String filePath = "/static-file";
+        String fileContent = ListWinDirsOnAttack.DIRS_LISTING;
+        nano.addHandler(new NanoServerHandler(filePath) {
+
+            @Override
+            Response serve(IHTTPSession session) {
+                return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, fileContent);
+            }
+        });
+        rule.init(getHttpMessage("GET", filePath, fileContent), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
     private static abstract class ListDirsOnAttack extends NanoServerHandler {
 
         private final String param;


### PR DESCRIPTION
Change TestPathTraversal to skip the messages which already have the
evidence of a successful attack present in the response.
Add test to assert the new behaviour.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#4168.