### PR TITLE
Fix Issue 1852 False Negative

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
@@ -395,6 +395,17 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
            								"", contexts2.get(0).getTarget(), contexts2.get(0).getMsg());
         						attackWorked = true;
             	            }
+        	            } else {
+                            // Try an img tag
+                            List<HtmlContext> contextsA = performAttack (msg, param, 
+                                    "<img src=x onerror=alert(1);>", 
+                                    context, HtmlContext.IGNORE_IN_SCRIPT);
+                            if (contextsA != null && contextsA.size() > 0) {
+           						bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM, null, param, contextsA.get(0).getTarget(), 
+           								"", contextsA.get(0).getTarget(), contextsA.get(0).getMsg());
+        						attackWorked = true;
+        						break;
+            	            }
         	            }
             		} else {
             			// Last chance - is the payload reflected outside of any tags

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules</name>
-	<version>30</version>
+	<version>31</version>
 	<status>release</status>
 	<description>The release quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 1366: Allow SSI detection patterns to include new lines, and pre-check the original response for detection patterns to reduce false positives.<br/>
-	Issue 4168 and 4230: Pre-check the original response for detection patterns.<br/>
+	Issue 1852: Fix Reflected XSS false negative with poor quality HTML filtering.<br/>
 	]]>
     </changes>
 	<extensions>

--- a/test/resources/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest/InputInsideDiv.html
+++ b/test/resources/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest/InputInsideDiv.html
@@ -1,0 +1,11 @@
+<html>
+	<table>
+		<tr>
+			<td valign='top'>
+			  <div id='0'>
+				@@@name@@@
+			  </div>
+			</td>
+		</tr>
+	</table>
+</html>


### PR DESCRIPTION
TestCrossSiteScriptV2 > Add handling for img onerror injections when poor quality input filtering is in play.
TestCrossSiteScriptV2UnitTest > Add new unit test.
InputInsideDiv.html > Supports the new unit test.
ZapAddOn.xml > Rolled version and updated changes.

Fixes zaproxy/zaproxy#1852