### PR TITLE
Added example 'about' help page

### DIFF
--- a/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Simple Example</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>A simple extension example.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>First version</changes>
+	<changes>Updated to include example 'about' page.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.simpleExample.ExtensionSimpleExample</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/simpleExample/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/simpleExample/resources/help/contents/about.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<TITLE>
+Simple Example - About
+</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ffffff">
+<H1>Simple Example - About</H1>
+
+<H2>Source Code</H2>
+<a href="https://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/simpleExample">https://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/simpleExample</a>
+
+<H2>Authors</H2>
+ZAP Dev Team
+
+<H2>History</H2>
+
+<H3>Version 2</H3>
+Updated to include example 'about' page.
+
+<H3>Version 1</H3>
+First Version
+
+</BODY>
+</HTML>

--- a/src/org/zaproxy/zap/extension/simpleExample/resources/help/map.jhm
+++ b/src/org/zaproxy/zap/extension/simpleExample/resources/help/map.jhm
@@ -6,4 +6,5 @@
 <map version="1.0">
 	<mapID target="simple-icon" url="contents/images/cake.png" />
     <mapID target="simple" url="contents/simple.html" />
+    <mapID target="simple.about" url="contents/about.html" />
 </map>

--- a/src/org/zaproxy/zap/extension/simpleExample/resources/help/toc.xml
+++ b/src/org/zaproxy/zap/extension/simpleExample/resources/help/toc.xml
@@ -6,7 +6,9 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="Simple Example" image="simple-icon" target="simple"/>
+			<tocitem text="Simple Example" image="simple-icon" target="simple">
+				<tocitem text="About" target="simple.about"/>
+			</tocitem>
 		</tocitem>
 	</tocitem>
 </toc>


### PR DESCRIPTION
This is proposed as a standard for all add-ons.
The structure should be standard but can be extended, eg to link to author's home pages etc.
We dont have to change them all to use it right now but can gradually add such pages over time as add-ons are updated.
I think it will help people see what changes have been made and find the source code more easily.
I also think we should have standard help pages for API and cmdline support, but this addon doesnt have either ;)
Note that the about page is deliberately not in the index as I dont think that will be so useful, but happy to be convinced otherwise.