### PR TITLE
pscanrulesAlpha: change ILS to scan "hidden" images

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ImageLocationScanner.java
@@ -27,6 +27,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -167,5 +168,14 @@ public class ImageLocationScanner extends PluginPassiveScanner {
     
     public String getAuthor() {
         return ILS.pluginAuthor;
+    }
+
+    @Override
+    public boolean appliesToHistoryType(int historyType) {
+        if (historyType == HistoryReference.TYPE_HIDDEN) {
+            // Scan hidden images, if the scanner is enabled it should scan.
+            return true;
+        }
+        return super.appliesToHistoryType(historyType);
     }
 }

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Minor code changes to comply with deprecations.<br>
 	Added passive PII Scanner (which currently looks for Credit Card # patterns).<br>
+	Change Image Location and Privacy Scanner to scan hidden images.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -95,17 +95,14 @@ Sun Java System Web Server<br>
 TornadoServer web server<br>
 WordPress<br>
 
-<H2>Image Location Scanner</H2>
+<H2>Image Location and Privacy Scanner</H2>
 <p>Passively scans for GPS location exposure in images during normal security
 assessments of websites.  Image Location Scanner assists in situations where
 end users may post profile images and possibly give away their home location,
 e.g. a dating site or children's chatroom.  A whitepaper on this can be found
 at http://veggiespam.com/ils/</p>
 
-<p>Note: In order for this plug-in to operate, ZAP must be configured to
-receive and process images.  To do this, go to the ZAP Options panel (Tools
-&rarr; Options), choose Display, and enable the checkbox for "Process images in
-HTTP requests/responses".  In addition, ZAP images cannot be filtered out via
+<p>Note: In order for this scanner to operate images cannot be filtered out via
 the settings "Global Exclude URL" or the Session Properties for "Exclude from
 Proxy". </p>
 


### PR DESCRIPTION
Change ImageLocationScanner to also scan "hidden" (proxied) images,
removing the requirement to enable another option to effectively use the
scanner, if the scanner is enabled it should scan.
Update help page to remove the requirement, also, update the name of the
scanner to reflect the latest name.
Update changes in ZapAddOn.xml file.