### PR TITLE
fix #4149 as suggested in comments

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
@@ -671,6 +671,7 @@ public class WebSocketProxyV13 extends WebSocketProxy {
 			payload.rewind();
 			byte[] bytes = new byte[payload.limit()];
 			payload.get(bytes);
+			payload.rewind();
 			return bytes;
 		}
 

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Remove usage of core filter functionality.<br>
 	Do not set messages when switching views if text view shows an error message (Issue 4108)<br>
+	Add rewind to fix issue #4149 <br>
 	]]>
 	</changes>
 	<classnames>


### PR DESCRIPTION
Tested to ensure Websocket message editing works manually as well as with Websocket sender scripts (zap-extensions/pull/971) and extender scripts. 