### PR TITLE
Fix Issue 1640 False Negative on Double Encoding

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -7,7 +7,8 @@
 	<url/>
 	<changes>
 	<![CDATA[
-	Issue 1852: Fix Reflected XSS false negative with poor quality HTML filtering.<br/>
+	Issue 1852: Fix reflected XSS false negative with poor quality HTML filtering.<br/>
+	Issue 1640: Fix reflected XSS false negative with double decoded output.<br/>
 	]]>
     </changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
@@ -61,6 +61,7 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 //import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ClassLoaderUtil;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public abstract class ActiveScannerTest<T extends AbstractPlugin> extends ScannerTestUtils {
 
@@ -89,6 +90,7 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
 
     protected T rule;
     protected HostProcess parent;
+    protected ScannerParam scannerParam;
 
     /**
      * The alerts raised during the scan.
@@ -153,7 +155,8 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
         
         ConnectionParam connectionParam = new ConnectionParam();
         
-        ScannerParam scannerParam = new ScannerParam();
+        scannerParam = new ScannerParam();
+        scannerParam.load(new ZapXmlConfiguration());
         RuleConfigParam ruleConfigParam = new RuleConfigParam();
         Scanner parentScanner =
                 new Scanner(scannerParam, connectionParam, scanPolicy, ruleConfigParam);


### PR DESCRIPTION
- TestCrossSiteScriptV2 - Updated with new logic to check for double decoded injections. Also made a constant to represent and reuse a simple script alert injection.
- TestCrossSiteScriptV2 - Updated with new unit tests to cover the new check when GET and POST (one test assets that other input variants are ignored).
- ActiveScannerTest - Expose scannerParams so that unit tests can set specific input variants.
- ZapAddOn.xml - Add to changes section, and made a slight tweak of the existing changes message (for Issue 1852).

Fixes zaproxy/zaproxy#1640