### PR TITLE
pscanrulesAlpha: fix NPE in blank link scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/BlankLinkTargetScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/BlankLinkTargetScanner.java
@@ -79,7 +79,7 @@ public class BlankLinkTargetScanner extends PluginPassiveScanner {
     }
 
     private boolean isLinkFromOtherDomain (String host, String link, List<Context> contextList){
-        if (!link.startsWith("//") && (link.startsWith("/") || link.startsWith("./") || link.startsWith("../"))) {
+        if (link == null || !link.startsWith("//") && (link.startsWith("/") || link.startsWith("./") || link.startsWith("../"))) {
             return false;
         }
         boolean otherDomain = false;

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Change Image Location and Privacy Scanner to escape HTML inside of embedded image comments.<br>
 	Bump jar version of Image Location and Privacy Scanner dependancy xmpcore.<br>
 	Update Image Location and Privacy Scanner to version 1.0.<br>
+	Fix exception in blank link target scanner.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/BlankLinkTargetScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/BlankLinkTargetScannerUnitTest.java
@@ -406,4 +406,26 @@ public class BlankLinkTargetScannerUnitTest extends PassiveScannerTest {
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo("<a href=\"http://www.example3.com/\" target=\"_blank\">link</a>"));
     }
+
+    @Test
+    public void shouldNotFailIfLinkOrAreaDoesNotHaveHref() throws Exception {
+        // Mock the model and session
+        Model model = Mockito.mock(Model.class);
+        Session session = Mockito.mock(Session.class);
+        Context context = Mockito.mock(Context.class);
+        when(context.isInContext(Matchers.anyString())).thenReturn(true);
+        ArrayList<Context> contexts = new ArrayList<>();
+        contexts.add(context);
+        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
+        when(model.getSession()).thenReturn(session);
+        ((BlankLinkTargetScanner) rule).setModel(model);
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
+        msg.setResponseBody("<html><a>link</a><area>area</area></html>");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then = no exception.
+    }
 }


### PR DESCRIPTION
Change BlankLinkTargetScanner to handle the absence of href attribute in
the elements a and area, preventing a NullPointerException.
Add test to assert the expected behaviour.
Bump version and update changes in ZapAddOn.xml file.

(Spotted while working on #1377)