### PR TITLE
help: tweak add-on names

### DIFF
--- a/src/org/zaproxy/zap/extension/help_fil_PH/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_fil_PH/ZapAddOn.xml
@@ -1,5 +1,5 @@
 <zapaddon>
-	<name>Help Filipino</name>
+	<name>Help - Filipino</name>
 	<version>2</version>
 	<status>alpha</status>
 	<description>Filipino version of the ZAP help file.</description>

--- a/src/org/zaproxy/zap/extension/help_id_ID/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_id_ID/ZapAddOn.xml
@@ -1,5 +1,5 @@
 <zapaddon>
-	<name>Help Indonesian</name>
+	<name>Help - Indonesian</name>
 	<version>2</version>
 	<status>beta</status>
 	<description>Indonesian version of the ZAP help file.</description>

--- a/src/org/zaproxy/zap/extension/help_zh_CN/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_zh_CN/ZapAddOn.xml
@@ -1,5 +1,5 @@
 <zapaddon>
-	<name>Help Chinese Simplified</name>
+	<name>Help - Chinese Simplified</name>
 	<version>1</version>
 	<status>beta</status>
 	<description>Chinese Simplified version of the ZAP help file.</description>


### PR DESCRIPTION
Tweak the names of the help add-ons (fil_PH, id_ID, and zh_CN) so that
all of them use the same pattern ("Help - \<language>").