### PR TITLE
pscanrulesAlpha: fix NPE in username hash scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UsernameIdorScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UsernameIdorScanner.java
@@ -21,6 +21,7 @@
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,9 +65,11 @@ public class UsernameIdorScanner extends PluginPassiveScanner {
 			return testUsers;
 		}
 		
-		List<User> usersList = null;
-		extUserMgmt = getExtensionUserManagement();
-		usersList = new ArrayList<User>();
+		if (getExtensionUserManagement() == null) {
+			return Collections.emptyList();
+		}
+
+		List<User> usersList = new ArrayList<>();
 
 		for (Context context : Model.getSingleton().getSession().getContexts()) {
 			usersList.addAll(extUserMgmt.getContextUserAuthManager(context.getIndex()).getUsers());

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Bump jar version of Image Location and Privacy Scanner dependancy xmpcore.<br>
 	Update Image Location and Privacy Scanner to version 1.0.<br>
 	Fix exception in blank link target scanner.<br>
+	Fix exception in Username Hash Found scanner.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change UsernameIdorScanner to check if the HTTP Sessions extension is
enabled (non-null) before using it, preventing a NullPointerException.
Update changes in ZapAddOn.xml file.