### PR TITLE
pscanrulesAlpha: properly fix NPE in username hash

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UsernameIdorScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UsernameIdorScanner.java
@@ -178,7 +178,7 @@ public class UsernameIdorScanner extends PluginPassiveScanner {
 
 	protected ExtensionUserManagement getExtensionUserManagement() {
 		if (extUserMgmt == null) {
-			return Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
+			extUserMgmt = Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 		}
 		return extUserMgmt;
 	}


### PR DESCRIPTION
Change UsernameIdorScanner to assign the extension when obtaining it,
with the previous change (#1395) it no longer assigned the extension
(thus causing a NPE when it was enabled), also, the extension is Users
not HTTP Sessions...

Sorry for the mess up.