### PR TITLE
websocket: include stack trace in channel setup

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -643,7 +643,7 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 					logger.warn(e.getMessage(), e1);
 				}
 			}
-			logger.error("Adding WebSockets channel failed due to: '" + e.getClass() + "' " + e.getMessage());
+			logger.error("Adding WebSockets channel failed due to: '" + e.getClass() + "' " + e.getMessage(), e);
 			return;
 		}
 	}


### PR DESCRIPTION
Change ExtensionWebSocket to also include the exception's stack trace
when logging errors during the channel setup. Gives more information
about the actual issue, instead of just:
 Adding WebSockets channel failed due to: 'class NullPointerException'
 null