### PR TITLE
Issue 2917 - Allow DOMXSS to target URL params

### DIFF
--- a/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>DOM XSS Active scanner rule</name>
-	<version>6</version>
+	<version>7</version>
 	<status>alpha</status>
 	<description>DOM XSS Active scanner rule</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
-	Add XSS Polyglot (Issue 2322).<br>
+	Issue 2918: Added an option to attack URL parameters.<br>
 	]]>
     </changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/domxss/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/domxss/resources/help/contents/about.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<TITLE>
+DOM XSS Active Scan Rule - About
+</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ffffff">
+<H1>DOM XSS Active Scan Rule - About</H1>
+
+<H2>Source Code</H2>
+<a href="https://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/domxss">https://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/domxss</a>
+
+<H2>Authors</H2>
+Aabha Biyani, and the ZAP Dev Team
+
+<H2>History</H2>
+
+<H3>Version 7</H3>
+<ul>
+	<li>Issue 2918: Added an option to attack URL parameters.</li>
+</ul>
+
+<H3>Version 6</H3>
+<ul>
+	<li>Minor code changes.</li>
+	<li>Add XSS Polyglot (Issue 2322).</li>
+</ul>
+
+<H3>Version 5</H3>
+<ul>
+	<li>Updated for 2.7.0.</li>
+</ul>
+
+<H3>Version 4</H3>
+<ul>
+	<li>Allow to use newer versions of Firefox (Issue 3396).</li>
+	<li>Provide the reason why the scanner was skipped.</li>
+</ul>
+
+</BODY>
+</HTML>

--- a/src/org/zaproxy/zap/extension/domxss/resources/help/contents/domxss.html
+++ b/src/org/zaproxy/zap/extension/domxss/resources/help/contents/domxss.html
@@ -19,13 +19,15 @@ This version only supports Firefox.<br>
 Future versions may support other browsers.
 </p>
 <p>
-The following Attack Strengths are supported, and related directly to the number of attack payloads used:
+The following Attack Strengths are supported, and related directly to the number of attack payloads used
+for URL fragment injections (eg: http://example.com/index.html?foo=bar#injection):
 <ul>
 <li>LOW: 3 attack payloads 
 <li>MEDIUM: 5 attack payloads 
 <li>HIGH: 7 attack payloads 
 <li>INSANE: 9 attack payloads 
 </ul>
+The scanner will also attempt URL/query parameter injections which are not impacted by the selected strength.
 </p>
 <p>
 The rule will only report one DOM XSS vulnerability per node, unless the LOW Alert threshold

--- a/src/org/zaproxy/zap/extension/domxss/resources/help/map.jhm
+++ b/src/org/zaproxy/zap/extension/domxss/resources/help/map.jhm
@@ -5,4 +5,5 @@
 
 <map version="1.0">
     <mapID target="domxss" url="contents/domxss.html" />
+    <mapID target="domxss.about" url="contents/about.html" />
 </map>

--- a/src/org/zaproxy/zap/extension/domxss/resources/help/toc.xml
+++ b/src/org/zaproxy/zap/extension/domxss/resources/help/toc.xml
@@ -6,7 +6,9 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="DOM XSS Active Scan Rule" target="domxss"/>
+			<tocitem text="DOM XSS Active Scan Rule" target="domxss">
+				<tocitem text="About" target="domxss.about"/>
+			</tocitem>
 		</tocitem>
 	</tocitem>
 </toc>


### PR DESCRIPTION
- TestDomXSS - Changed to AbstractAppParamPlugin and added functionality to handle param injection attempts.
- ZapAddOn.xml - Rolled version and updated changes section.
- about.html - Added.
- domxss.html - Updated to clarify implications of strength settings and URL fragment vs. parameter injections.

Fixes zaproxy/zaproxy#2917