### PR TITLE
replacer: tweak help page

### DIFF
--- a/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Replacer</name>
-	<version>5</version>
+	<version>6</version>
 	<status>beta</status>
 	<description>Easy way to replace strings in requests and responses.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Fix exception during ZAP start up.</changes>
+	<changes>Tweak help page.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.replacer.ExtensionReplacer</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/src/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -61,8 +61,8 @@ The new string that will replace the specified selection.
 <h3>Enable</h3>
 If not set then the rule will not apply.
 
-<h3>Advanced</h3>
-If set then an additional tab will be show which allows you to specify which 'initiators' the rule should apply to.
+<h3>Initiators tab</h3>
+Allows you to specify which 'initiators' the rule should apply to.
 Each ZAP component which can send and receive messages is a separate initiator, so this gives you a very fine grain
 control over exactly when the rule should apply.
 


### PR DESCRIPTION
Remove reference to an inexistent option/checkbox, the Initiators tab is
always shown.
Bump version and update changes in ZapAddOn.xml file.