### PR TITLE
Activescan Alpha help cleanup

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Add .htaccess scanner (Issue 3972).<br>
 	Modified trace.axd scanner to leverage new AbstractAppFilePlugin component.<br>
+	Remove unnecessary help entry.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -30,9 +30,6 @@ For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active
 This implements a very simple example active scan rule.<br>
 For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html
 
-<H2>Expression Language Injection</H2>
-The software constructs all or part of an expression language (EL) statement in a Java Server Page (JSP) using externally-influenced input from an upstream component, but it does not neutralize or incorrectly neutralizes special elements that could modify the intended EL statement before it is executed. In certain versions of Spring 3.0.5 and earlier, there was a vulnerability (CVE-2011-2730) in which Expression Language tags would be evaluated twice, which effectively exposed any application to EL injection. However, even for later versions, this weakness is still possible depending on configuration.
-
 <H2>GET for POST Scanner</H2>
 This scanner takes <code>application/x-www-form-urlencoded</code> POST requests, changes the parameters from POST to GET and resubmits the request. 
 If the GET response is the same as the original POST response then an alert is raised. While this does not necessarily


### PR DESCRIPTION
Remove redundant EL injection entry. ELi scanner has moved to beta
https://github.com/zaproxy/zap-extensions/blob/e8a0706d34e060daede4426b55918d14ee2da241/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html#L30-L33
Update manifest.