### PR TITLE
Normalise Source instantiations

### DIFF
--- a/src/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
+++ b/src/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
@@ -41,7 +41,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.api.API;
@@ -189,7 +188,7 @@ public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
 
 	private void revealFields(HttpMessage msg) {
 		boolean changed = false;
-		String response = msg.getResponseHeader().toString() + msg.getResponseBody().toString();
+		String response = msg.getResponseBody().toString();
 		Source src = new Source(response);
 		OutputDocument outputDocument = new OutputDocument(src);
 		
@@ -227,10 +226,7 @@ public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
 			}
 		}
 		if (changed) {
-			response = outputDocument.toString();
-			
-			int i = response.indexOf(HttpHeader.CRLF + HttpHeader.CRLF);
-			msg.setResponseBody(response.substring(i + (HttpHeader.CRLF + HttpHeader.CRLF).length()));
+			msg.setResponseBody(outputDocument.toString());
 		}
 	}
 

--- a/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>Reveal</name>
-	<version>2</version>
+	<version>3</version>
 	<status>release</status>
 	<description>Show hidden fields and enable disabled fields</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Code changes and API documentation.</changes>
+	<changes>Maintenance changes.</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.reveal.ExtensionReveal</extension>
 	</extensions>

--- a/test/org/zaproxy/zap/extension/pscanrules/PassiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/PassiveScannerTest.java
@@ -65,7 +65,7 @@ public abstract class PassiveScannerTest extends ScannerTestUtils {
     protected abstract PluginPassiveScanner createScanner();
     
     protected Source createSource(HttpMessage msg) {
-        return new Source(msg.getResponseHeader().toString() + msg.getResponseBody().toString());
+        return new Source(msg.getResponseBody().toString());
     }
 
 }


### PR DESCRIPTION
Change ExtensionReveal and PassiveScannerTest to just use the response
body when instantiating the Source, the header is not required (body
already using the expected charset).
Bump version and update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#4487.