### PR TITLE
Normalise Source instantiations (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
@@ -18,7 +18,6 @@
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
@@ -175,7 +174,7 @@ public class Csrftokenscan extends AbstractAppPlugin {
 		Source s1;
 		try {		
 			// We parse the HTML of the response
-			s1 = new Source(new StringReader(getBaseMsg().getResponseBody().toString()));
+			s1 = new Source(getBaseMsg().getResponseBody().toString());
 
 			List<Element> formElements = s1.getAllElements(HTMLElementName.FORM);
 			
@@ -234,7 +233,7 @@ public class Csrftokenscan extends AbstractAppPlugin {
 				sendAndReceive(newMsg);
 	
 				// We parse the HTML of the response
-				Source s2 = new Source(new StringReader(newMsg.getResponseBody().toString()));
+				Source s2 = new Source(newMsg.getResponseBody().toString());
 				List<Element> form2Elements = s2.getAllElements(HTMLElementName.FORM);
 				if (form2Elements.size() > formIdx) {
 					

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
@@ -18,7 +18,6 @@
 
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
-import java.io.StringReader;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -145,7 +144,7 @@ public class HPP extends AbstractAppPlugin {
 			List<String> vulnLinks = new ArrayList<String>();
 
 			// We parse the HTML of the response and get all its parameters
-			Source s = new Source(new StringReader(getBaseMsg().getResponseBody().toString()));
+			Source s = new Source(getBaseMsg().getResponseBody().toString());
 			List<Element> inputTags = s.getAllElements(HTMLElementName.INPUT);
 			TreeSet<HtmlParameter> tags = this.getParams(s, inputTags);
 			
@@ -167,7 +166,7 @@ public class HPP extends AbstractAppPlugin {
 					}
 					
 					// We check all the links of the response to find our payload
-					s = new Source(new StringReader(newMsg.getResponseBody().toString()));
+					s = new Source(newMsg.getResponseBody().toString());
 					List<Element> links = s.getAllElements(HTMLElementName.A);
 					if (!links.isEmpty()) {
 						vulnLinks = this.findPayload(s, inputTags, vulnLinks);

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Active scanner rules (beta)</name>
-	<version>23</version>
+	<version>24</version>
 	<status>beta</status>
 	<description>The beta quality Active Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	At HIGH threshold only perform CSRF checks for inScope messages (Issue 1354).<br>
+	Maintenance changes.<br>
     ]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
+++ b/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
@@ -128,8 +128,7 @@ public class ExtensionTokenGen extends ExtensionAdaptor {
 
 	// TODO This method is also in ExtensionAntiCSRF - put into a helper class?
 	public String getTokenValue(HttpMessage tokenMsg, String tokenName) {
-		String response = tokenMsg.getResponseHeader().toString() + tokenMsg.getResponseBody().toString();
-		Source source = new Source(response);
+		Source source = new Source(tokenMsg.getResponseBody().toString());
 		List<Element> formElements = source.getAllElements(HTMLElementName.FORM);
 		
 		if (formElements != null && formElements.size() > 0) {
@@ -157,8 +156,7 @@ public class ExtensionTokenGen extends ExtensionAdaptor {
 	}
 
 	public Vector<String> getFormInputFields(HttpMessage tokenMsg) {
-		String response = tokenMsg.getResponseHeader().toString() + tokenMsg.getResponseBody().toString();
-		Source source = new Source(response);
+		Source source = new Source(tokenMsg.getResponseBody().toString());
 		List<Element> formElements = source.getAllElements(HTMLElementName.FORM);
 		Vector<String> fifs = new Vector<>();
 		

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -1,21 +1,13 @@
 <zapaddon>
 	<name>Token generation and analysis</name>
-	<version>11</version>
+	<version>12</version>
 	<status>beta</status>
 	<description>Allows you to generate and analyze pseudo random tokens, such as those used for session handling or CSRF protection</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Use custom HTTP Sender initiator ID.<br>
-	Show same cookies once in Generate Tokens dialogue (Issue 2116).<br>
-	Fix exception when no tokens are found (Issue 2116).<br>
-	Added help file.<br>
-	Issue 2338: Allow dynamic timeout adjustment to combat read timeout issues.<br>
-	Ensure initial dialog is properly sized.<br>
-	Issue 2000: Title caps adjustments.<br>
-	Code changes for Java 9 (Issue 2602).<br>
-	Ensure Analyse Token dialogue is shown in front of main window.<br>
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -716,8 +716,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 
 				if (getExtACSRF() != null) {
 					// Create assignments for any ACSRF tokens
-					Source src = new Source(msg.getResponseHeader().toString()
-							+ msg.getResponseBody().toString());
+					Source src = new Source(msg.getResponseBody().toString());
 					List<AntiCsrfToken> acsrfTokens = getExtACSRF()
 							.getTokensFromResponse(msg, src);
 					for (AntiCsrfToken acsrf : acsrfTokens) {

--- a/test/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
@@ -64,7 +64,7 @@ public abstract class PassiveScannerTest extends ScannerTestUtils {
     protected abstract PluginPassiveScanner createScanner();
     
     protected Source createSource(HttpMessage msg) {
-        return new Source(msg.getResponseHeader().toString() + msg.getResponseBody().toString());
+        return new Source(msg.getResponseBody().toString());
     }
 
 }


### PR DESCRIPTION
Change instantiations of Source class to only use the response body (and
to use the body directly), the header is not required, body is already
using the expected charset.
Bump versions and update changes in ZapAddOn.xml files, where needed.

Related to zaproxy/zaproxy#4487.