### PR TITLE
Normalise Source instantiations (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/viewstate/ViewStateModel.java
+++ b/src/org/zaproxy/zap/extension/viewstate/ViewStateModel.java
@@ -294,7 +294,7 @@ public class ViewStateModel extends AbstractHttpByteHttpPanelViewModel {
 				return msg.getRequestBody().toString();
 			}
 		} else {
-			return msg.getResponseHeader().toString() + msg.getResponseBody().toString();
+			return msg.getResponseBody().toString();
 		}
 	}
 	

--- a/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>ViewState</name>
-	<version>1</version>			<!-- Integer than increments with each (released) change -->
+	<version>2</version>			<!-- Integer than increments with each (released) change -->
 	<status>alpha</status>			<!-- alpha/beta/release -->
 	<description>ASP/JSF ViewState Decoder and Editor</description>
 	<author>Calum Hutton</author>
 	<url/>							
-	<changes/>					
+	<changes>
+	<![CDATA[
+	Maintenance changes.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.viewstate.ExtensionHttpPanelViewStateView</extension>	
 	</extensions>				

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
@@ -64,7 +64,7 @@ public abstract class PassiveScannerTest extends ScannerTestUtils {
 	protected abstract PluginPassiveScanner createScanner();
 
 	protected Source createSource(HttpMessage msg) {
-		return new Source(msg.getResponseHeader().toString() + msg.getResponseBody().toString());
+		return new Source(msg.getResponseBody().toString());
 	}
 
 }


### PR DESCRIPTION
Change instantiations of Source class to only use the response body, the
header is not required, the body is already using the expected charset.
Bump version and update changes in ZapAddOn.xml file (viewstate).

Related to zaproxy/zaproxy#4487.