### PR TITLE
webdrivers: update geckodriver to v0.20.0

### DIFF
--- a/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update ChromeDriver to 2.35<br>
+	Update geckodriver to v0.20.0<br>
 	]]>
 	</changes>
 	<extensions/>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update ChromeDriver to 2.35<br>
+	Update geckodriver to v0.20.0<br>
 	]]>
 	</changes>
 	<extensions/>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update ChromeDriver to 2.35<br>
+	Update geckodriver to v0.20.0<br>
 	]]>
 	</changes>
 	<extensions/>


### PR DESCRIPTION
Update geckodriver to v0.20.0.
Update changes in ZapAddOn.xml files.

---
Depends on zaproxy/zap-libs#15.