### PR TITLE
HttpsInfo UI Tweak

### DIFF
--- a/src/org/zaproxy/zap/extension/httpsinfo/ExtensionHttpsInfo.java
+++ b/src/org/zaproxy/zap/extension/httpsinfo/ExtensionHttpsInfo.java
@@ -101,7 +101,16 @@ public class ExtensionHttpsInfo extends ExtensionAdaptor implements SessionChang
 	
 	protected TabbedPanel2 getHttpsInfoTabsPanel() {
 		if (httpsInfoTabsPanel == null) {
-			httpsInfoTabsPanel = new TabbedPanel2();
+			httpsInfoTabsPanel = new TabbedPanel2() {
+				private static final long serialVersionUID = -1422894398829082869L;
+
+				@Override
+				public void setVisible(Component component, boolean visible) {
+					if (!visible) {
+						removeTab((AbstractPanel) component);
+					}
+				}
+			};
 		}
 		return httpsInfoTabsPanel;
 	}


### PR DESCRIPTION
This minor change changes the tab close functionality so that tabs are actually removed not just hidden. As this is related to the previous PR I have not included any further "changes" in the manifest.

I decided to go ahead with this changes as the 5.1.0beta integration has been stalled due to some performance issues that I've had to go back to the author with and am now waiting on a new build.