### PR TITLE
websocket: remove event consumer if channel closed

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Tweak About help page.<br>
+	Remove event consumers when the channel is closed.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -19,6 +19,7 @@ ZAP Dev Team
 <H3>Version 16</H3>
 <ul>
 	<li>Tweak About help page.</li>
+	<li>Remove event consumers when the channel is closed.</li>
 </ul>
 
 <H3>Version 15</H3>


### PR DESCRIPTION
Change WebSocketAPI to remove and unregister the event consumer when the
channel is closed, no longer needs to be notified.
Update changes in ZapAddOn.xml and about.html.