### PR TITLE
replacer: ignore CFU messages

### DIFF
--- a/src/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
+++ b/src/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.replacer;
 
 import java.util.List;
 
+import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.utils.Enableable;
 
 class ReplacerParamRule extends Enableable {
@@ -122,6 +123,9 @@ class ReplacerParamRule extends Enableable {
     }
     
     public boolean appliesToInitiator(int initiator) {
+        if (initiator == HttpSender.CHECK_FOR_UPDATES_INITIATOR) {
+            return false;
+        }
         return appliesToAllInitiators() || initiators.contains(initiator);
     }
     

--- a/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
@@ -5,7 +5,12 @@
 	<description>Easy way to replace strings in requests and responses.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Tweak help page.</changes>
+	<changes>
+	<![CDATA[
+	Tweak help page.<br>
+	Ignore CFU HTTP messages.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.replacer.ExtensionReplacer</extension>
 	</extensions>


### PR DESCRIPTION
Change ReplacerParamRule to always return false when checking if the
rule applies to CFU messages, to not inadvertently break the check for
updates.
Update changes in ZapAddOn.xml file.

---
From a thread in the mailing list where a replacer rule was breaking the check for updates.