### PR TITLE
Implemented dialog for testing regular expressions

### DIFF
--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this add-on will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## Unreleased
+
+- Initial Release.
+

--- a/addOns/regextester/regextester.gradle.kts
+++ b/addOns/regextester/regextester.gradle.kts
@@ -3,7 +3,7 @@ description = "Allows to test Regular Expressions"
 
 zapAddOn {
     addOnName.set("Regular Expression Tester")
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.8.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/regextester/regextester.gradle.kts
+++ b/addOns/regextester/regextester.gradle.kts
@@ -1,0 +1,11 @@
+version = "1"
+description = "Allows to test Regular Expressions"
+
+zapAddOn {
+    addOnName.set("Regular Expression Tester")
+    zapVersion.set("2.7.0")
+
+    manifest {
+        author.set("ZAP Dev Team")
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ExtensionRegExTester.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ExtensionRegExTester.java
@@ -1,0 +1,102 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.regextester.ui.RegexDialog;
+import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
+import org.zaproxy.zap.view.ZapMenuItem;
+
+public class ExtensionRegExTester extends ExtensionAdaptor {
+    public static final String NAME = "ExtensionRegExTester";
+    public static final int EXTENSION_ORDER = 85;
+
+    private ZapMenuItem menuItemRegExTester = null;
+
+    public ExtensionRegExTester() {
+        super(NAME);
+        this.setOrder(EXTENSION_ORDER);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+        if (getView() != null) {
+            extensionHook.getHookMenu().addToolsMenuItem(getMenuItemCustomScan());
+            extensionHook.getHookMenu().addPopupMenuItem(new RegExTesterPopupMenuItem(this));
+        }
+    }
+
+    private ZapMenuItem getMenuItemCustomScan() {
+        if (menuItemRegExTester == null) {
+            menuItemRegExTester = new ZapMenuItem("regextester.menu.tools.name");
+            menuItemRegExTester.addActionListener(e -> showDialog());
+        }
+        return menuItemRegExTester;
+    }
+
+    public RegexDialog showDialog() {
+        return showDialog("", "");
+    }
+
+    public RegexDialog showDialog(String regex, String text) {
+        RegexDialog dialog = new RegexDialog(new RegexModel(regex, text));
+        dialog.setVisible(true);
+        return dialog;
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("regextester.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("regextester.desc");
+    }
+
+    @Override
+    public URL getURL() {
+        try {
+            return new URL(Constant.ZAP_HOMEPAGE);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ExtensionRegExTester.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ExtensionRegExTester.java
@@ -43,12 +43,12 @@ public class ExtensionRegExTester extends ExtensionAdaptor {
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
         if (getView() != null) {
-            extensionHook.getHookMenu().addToolsMenuItem(getMenuItemCustomScan());
+            extensionHook.getHookMenu().addToolsMenuItem(getMenuItemRegExTester());
             extensionHook.getHookMenu().addPopupMenuItem(new RegExTesterPopupMenuItem(this));
         }
     }
 
-    private ZapMenuItem getMenuItemCustomScan() {
+    private ZapMenuItem getMenuItemRegExTester() {
         if (menuItemRegExTester == null) {
             menuItemRegExTester = new ZapMenuItem("regextester.menu.tools.name");
             menuItemRegExTester.addActionListener(e -> showDialog());
@@ -69,11 +69,6 @@ public class ExtensionRegExTester extends ExtensionAdaptor {
     @Override
     public boolean canUnload() {
         return true;
-    }
-
-    @Override
-    public void unload() {
-        super.unload();
     }
 
     @Override

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegExTesterPopupMenuItem.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegExTesterPopupMenuItem.java
@@ -1,0 +1,160 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
+import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
+
+public class RegExTesterPopupMenuItem extends PopupMenuHttpMessageContainer {
+    private static final long serialVersionUID = 1L;
+
+    private static final String POPUP_MENU_LABEL =
+            Constant.messages.getString("regextester.popup.option");
+    private static final String POPUP_MENU_ALL =
+            Constant.messages.getString("regextester.popup.option.all");
+    private static final String POPUP_MENU_BODY =
+            Constant.messages.getString("regextester.popup.option.body");
+    private static final String POPUP_MENU_HEADER =
+            Constant.messages.getString("regextester.popup.option.header");
+    private static final String POPUP_MENU_REQUEST =
+            Constant.messages.getString("regextester.popup.option.request");
+    private static final String POPUP_MENU_RESPONSE =
+            Constant.messages.getString("regextester.popup.option.response");
+
+    private ExtensionRegExTester extension;
+
+    public RegExTesterPopupMenuItem(ExtensionRegExTester extension) {
+        super(POPUP_MENU_LABEL);
+        this.extension = extension;
+        setButtonStateOverriddenByChildren(false);
+        add(createRequestMenu());
+        add(createResponseMenu());
+    }
+
+    private PopupMenuHttpMessageContainer createRequestMenu() {
+        PopupMenuHttpMessageContainer request =
+                new PopupMenuHttpMessageContainer(POPUP_MENU_REQUEST);
+
+        request.add(
+                new SubMenuItem(
+                        POPUP_MENU_HEADER,
+                        m -> !m.getRequestHeader().isEmpty(),
+                        m -> showDialog(m.getRequestHeader().toString())));
+
+        request.add(
+                new SubMenuItem(
+                        POPUP_MENU_BODY,
+                        m -> m.getRequestBody().length() != 0,
+                        m -> showDialog(m.getRequestBody().toString())));
+
+        request.addSeparator();
+
+        request.add(
+                new SubMenuItem(
+                        POPUP_MENU_ALL,
+                        m -> !m.getRequestHeader().isEmpty() && m.getRequestBody().length() != 0,
+                        m ->
+                                showDialog(
+                                        m.getRequestHeader().toString()
+                                                + m.getRequestBody().toString())));
+
+        return request;
+    }
+
+    private PopupMenuHttpMessageContainer createResponseMenu() {
+        PopupMenuHttpMessageContainer request =
+                new PopupMenuHttpMessageContainer(POPUP_MENU_RESPONSE);
+
+        request.add(
+                new SubMenuItem(
+                        POPUP_MENU_HEADER,
+                        m -> !m.getResponseHeader().isEmpty(),
+                        m -> showDialog(m.getResponseHeader().toString())));
+
+        request.add(
+                new SubMenuItem(
+                        POPUP_MENU_BODY,
+                        m -> m.getResponseBody().length() != 0,
+                        m -> showDialog(m.getResponseBody().toString())));
+
+        request.addSeparator();
+
+        request.add(
+                new SubMenuItem(
+                        POPUP_MENU_ALL,
+                        m -> !m.getResponseHeader().isEmpty() && m.getResponseBody().length() != 0,
+                        m ->
+                                showDialog(
+                                        m.getResponseHeader().toString()
+                                                + m.getResponseBody().toString())));
+
+        return request;
+    }
+
+    private void showDialog(String value) {
+        extension.showDialog("", value);
+    }
+
+    @Override
+    public boolean precedeWithSeparator() {
+        return true;
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+
+    private static class SubMenuItem extends PopupMenuItemHttpMessageContainer {
+
+        private static final long serialVersionUID = 1L;
+
+        private Function<HttpMessage, Boolean> isEnabled;
+        private Consumer<HttpMessage> performAction;
+
+        public SubMenuItem(
+                String label,
+                Function<HttpMessage, Boolean> isEnabled,
+                Consumer<HttpMessage> performAction) {
+            super(label);
+            this.isEnabled = isEnabled;
+            this.performAction = performAction;
+        }
+
+        @Override
+        public boolean isButtonEnabledForSelectedHttpMessage(HttpMessage httpMessage) {
+            return isEnabled.apply(httpMessage);
+        }
+
+        @Override
+        public void performAction(HttpMessage httpMessage) {
+            performAction.accept(httpMessage);
+        }
+
+        @Override
+        public boolean isSafe() {
+            return true;
+        }
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTest.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTest.java
@@ -1,0 +1,96 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexTest {
+
+    public RegexTestResult test(RegexTestInput input) {
+        try {
+            return testInternal(input);
+        } catch (Exception e) {
+            return new RegexTestResult(false, false, e.getMessage(), "");
+        }
+    }
+
+    private RegexTestResult testInternal(RegexTestInput input) {
+        Pattern compiledPattern = Pattern.compile(input.getPattern());
+        Matcher matcher = compiledPattern.matcher(input.getText());
+        boolean match = matcher.matches();
+        boolean lookingAt = matcher.lookingAt();
+
+        List<RegexTestResult.RegexTestHighlight> highlights = new ArrayList<>();
+        Matcher findMatcher = compiledPattern.matcher(input.getText());
+        StringBuilder capture = new StringBuilder();
+        int findIndex = 1;
+        boolean matcherFound = false;
+        while (findMatcher.find()) {
+            highlights.add(
+                    new RegexTestResult.RegexTestHighlight(findMatcher.start(), findMatcher.end()));
+            appendFind(findMatcher, findIndex, capture);
+            appendAllGroups(findMatcher, findIndex, capture);
+            capture.append("\n");
+            findIndex++;
+            matcherFound = true;
+        }
+
+        if (!matcherFound) {
+            return new RegexTestResult(match, lookingAt, "No findings.", "");
+        }
+
+        return new RegexTestResult(
+                match, lookingAt, input.getText(), capture.toString().trim(), highlights);
+    }
+
+    private void appendFind(Matcher matcher, int findIndex, StringBuilder capture) {
+        capture.append(findIndex)
+                .append("   ")
+                .append("[")
+                .append(matcher.start())
+                .append(",")
+                .append(matcher.end())
+                .append("]")
+                .append("\t")
+                .append(matcher.group())
+                .append("\n");
+    }
+
+    private void appendAllGroups(Matcher matcher, int findIndex, StringBuilder capture) {
+        for (int i = 1; i <= matcher.groupCount(); i++) {
+            capture.append("")
+                    .append(findIndex)
+                    .append(".")
+                    .append(i)
+                    .append(" ")
+                    .append("[")
+                    .append(matcher.start(i))
+                    .append(",")
+                    .append(matcher.end(i))
+                    .append("]")
+                    .append("\t")
+                    .append(matcher.group(i))
+                    .append("\n");
+        }
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestInput.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestInput.java
@@ -22,8 +22,8 @@ package org.zaproxy.zap.extension.regextester;
 import java.util.Objects;
 
 public class RegexTestInput {
-    private String pattern;
-    private String text;
+    private final String pattern;
+    private final String text;
 
     public RegexTestInput(String pattern, String text) {
         Objects.requireNonNull(pattern, "pattern is null");

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestInput.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestInput.java
@@ -1,0 +1,43 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester;
+
+import java.util.Objects;
+
+public class RegexTestInput {
+    private String pattern;
+    private String text;
+
+    public RegexTestInput(String pattern, String text) {
+        Objects.requireNonNull(pattern, "pattern is null");
+        Objects.requireNonNull(text, "text is null");
+
+        this.pattern = pattern;
+        this.text = text;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestResult.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestResult.java
@@ -19,40 +19,32 @@
  */
 package org.zaproxy.zap.extension.regextester;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public class RegexTestResult {
-    private boolean match;
-    private boolean lookingAt;
-    private String result;
-    private String capture;
-    private List<RegexTestHighlight> highlights;
+    private final boolean match;
+    private final boolean lookingAt;
+    private final String result;
+    private final String capture;
+    private final List<Group> groups;
 
     public RegexTestResult(boolean match, boolean lookingAt, String result, String capture) {
-        this(match, lookingAt, result, capture, new ArrayList<>());
+        this(match, lookingAt, result, capture, Collections.emptyList());
     }
 
     public RegexTestResult(
-            boolean match,
-            boolean lookingAt,
-            String result,
-            String capture,
-            List<RegexTestHighlight> highlights) {
+            boolean match, boolean lookingAt, String result, String capture, List<Group> groups) {
         Objects.requireNonNull(result, "result is null");
-        Objects.requireNonNull(result, "capture is null");
-        Objects.requireNonNull(result, "highlights is null");
+        Objects.requireNonNull(capture, "capture is null");
+        Objects.requireNonNull(groups, "groups is null");
 
         this.match = match;
         this.lookingAt = lookingAt;
         this.capture = capture;
         this.result = result;
-        this.highlights = highlights;
-    }
-
-    public void add(RegexTestHighlight highlight) {
-        this.highlights.add(highlight);
+        this.groups = groups;
     }
 
     public boolean isMatch() {
@@ -71,16 +63,16 @@ public class RegexTestResult {
         return capture;
     }
 
-    public List<RegexTestHighlight> getHighlights() {
-        return highlights;
+    public List<Group> getGroups() {
+        return groups;
     }
 
-    public static class RegexTestHighlight {
+    public static class Group {
 
-        private int start;
-        private int end;
+        private final int start;
+        private final int end;
 
-        public RegexTestHighlight(int start, int end) {
+        public Group(int start, int end) {
             this.start = start;
             this.end = end;
         }

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestResult.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegexTestResult.java
@@ -1,0 +1,96 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class RegexTestResult {
+    private boolean match;
+    private boolean lookingAt;
+    private String result;
+    private String capture;
+    private List<RegexTestHighlight> highlights;
+
+    public RegexTestResult(boolean match, boolean lookingAt, String result, String capture) {
+        this(match, lookingAt, result, capture, new ArrayList<>());
+    }
+
+    public RegexTestResult(
+            boolean match,
+            boolean lookingAt,
+            String result,
+            String capture,
+            List<RegexTestHighlight> highlights) {
+        Objects.requireNonNull(result, "result is null");
+        Objects.requireNonNull(result, "capture is null");
+        Objects.requireNonNull(result, "highlights is null");
+
+        this.match = match;
+        this.lookingAt = lookingAt;
+        this.capture = capture;
+        this.result = result;
+        this.highlights = highlights;
+    }
+
+    public void add(RegexTestHighlight highlight) {
+        this.highlights.add(highlight);
+    }
+
+    public boolean isMatch() {
+        return match;
+    }
+
+    public boolean isLookingAt() {
+        return lookingAt;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public String getCapture() {
+        return capture;
+    }
+
+    public List<RegexTestHighlight> getHighlights() {
+        return highlights;
+    }
+
+    public static class RegexTestHighlight {
+
+        private int start;
+        private int end;
+
+        public RegexTestHighlight(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        public int getStart() {
+            return start;
+        }
+
+        public int getEnd() {
+            return end;
+        }
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/MatchPanel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/MatchPanel.java
@@ -32,9 +32,9 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.DefaultHighlighter;
 import javax.swing.text.Highlighter;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.extension.regextester.RegexTest;
 import org.zaproxy.zap.extension.regextester.RegexTestInput;
 import org.zaproxy.zap.extension.regextester.RegexTestResult;
+import org.zaproxy.zap.extension.regextester.RegexTester;
 import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
 
 public class MatchPanel extends JPanel {
@@ -118,8 +118,7 @@ public class MatchPanel extends JPanel {
         }
 
         RegexTestInput input = new RegexTestInput(regexModel.getRegex(), regexModel.getTestValue());
-        RegexTest tester = new RegexTest();
-        RegexTestResult result = tester.test(input);
+        RegexTestResult result = RegexTester.test(input);
 
         matchField.setText(String.format(MATCHES_LABEL, result.isMatch()));
         lookingAtField.setText(String.format(LOOKING_AT_LABEL, result.isLookingAt()));
@@ -128,10 +127,9 @@ public class MatchPanel extends JPanel {
         captureField.setCaretPosition(0);
 
         Highlighter highlighter = resultField.getHighlighter();
-        for (RegexTestResult.RegexTestHighlight highlight : result.getHighlights()) {
+        for (RegexTestResult.Group group : result.getGroups()) {
             try {
-                highlighter.addHighlight(
-                        highlight.getStart(), highlight.getEnd(), highlightPainter);
+                highlighter.addHighlight(group.getStart(), group.getEnd(), highlightPainter);
             } catch (BadLocationException ignore) {
             }
         }

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/MatchPanel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/MatchPanel.java
@@ -1,0 +1,139 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSplitPane;
+import javax.swing.JTextArea;
+import javax.swing.SwingUtilities;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultHighlighter;
+import javax.swing.text.Highlighter;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.regextester.RegexTest;
+import org.zaproxy.zap.extension.regextester.RegexTestInput;
+import org.zaproxy.zap.extension.regextester.RegexTestResult;
+import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
+
+public class MatchPanel extends JPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String MATCHES_LABEL =
+            Constant.messages.getString("regextester.dialog.matches");
+    private static final String LOOKING_AT_LABEL =
+            Constant.messages.getString("regextester.dialog.lookingat");
+    private static final String MATCH_RESULT_HEADER =
+            Constant.messages.getString("regextester.dialog.matchresultheader");
+    private static final String FIND_RESULT_HEADER =
+            Constant.messages.getString("regextester.dialog.findresultheader");
+    private static final String FIND_CAPTURE_HEADER =
+            Constant.messages.getString("regextester.dialog.findcaptureheader");
+
+    private final DefaultHighlighter.DefaultHighlightPainter highlightPainter =
+            new DefaultHighlighter.DefaultHighlightPainter(null);
+    private final JTextArea resultField;
+    private final JTextArea captureField;
+    private final JLabel matchField;
+    private final JLabel lookingAtField;
+    private RegexModel regexModel;
+
+    public MatchPanel(RegexModel regexModel) {
+        super(new BorderLayout());
+        this.regexModel = regexModel;
+
+        resultField = createTextArea();
+        captureField = createTextArea();
+        matchField = new JLabel();
+        matchField.setText(String.format(MATCHES_LABEL, ""));
+        lookingAtField = new JLabel();
+        lookingAtField.setText(String.format(LOOKING_AT_LABEL, ""));
+
+        JPanel matchPanel = createPanel(MATCH_RESULT_HEADER);
+        matchPanel.add(matchField, BorderLayout.NORTH);
+        matchPanel.add(lookingAtField, BorderLayout.SOUTH);
+        matchPanel.setPreferredSize(new Dimension(0, 80));
+
+        JPanel findPanel = createPanel(resultField, FIND_RESULT_HEADER);
+        JPanel capturePanel = createPanel(captureField, FIND_CAPTURE_HEADER);
+
+        JSplitPane findSplit = new JSplitPane(JSplitPane.VERTICAL_SPLIT, findPanel, capturePanel);
+        findSplit.setResizeWeight(0.35);
+        findSplit.setBorder(BorderFactory.createEmptyBorder());
+
+        add(matchPanel, BorderLayout.NORTH);
+        add(findSplit, BorderLayout.CENTER);
+    }
+
+    private JPanel createPanel(JTextArea resultField, String title) {
+        JPanel resultPanel = createPanel(title);
+        resultPanel.add(new JScrollPane(resultField), BorderLayout.CENTER);
+        return resultPanel;
+    }
+
+    private JPanel createPanel(String title) {
+        JPanel resultPanel = new JPanel(new BorderLayout());
+        resultPanel.setBorder(RegexDialog.createBorder(title));
+        return resultPanel;
+    }
+
+    private JTextArea createTextArea() {
+        JTextArea textArea = new JTextArea();
+        textArea.setFont(RegexDialog.monoFont);
+        textArea.setLineWrap(true);
+        textArea.setWrapStyleWord(true);
+        textArea.setEditable(false);
+        return textArea;
+    }
+
+    public void updateFromModel() {
+        SwingUtilities.invokeLater(() -> update());
+    }
+
+    private void update() {
+        if (regexModel.getRegex() == null || regexModel.getTestValue() == null) {
+            return;
+        }
+
+        RegexTestInput input = new RegexTestInput(regexModel.getRegex(), regexModel.getTestValue());
+        RegexTest tester = new RegexTest();
+        RegexTestResult result = tester.test(input);
+
+        matchField.setText(String.format(MATCHES_LABEL, result.isMatch()));
+        lookingAtField.setText(String.format(LOOKING_AT_LABEL, result.isLookingAt()));
+        resultField.setText(result.getResult());
+        captureField.setText(result.getCapture());
+        captureField.setCaretPosition(0);
+
+        Highlighter highlighter = resultField.getHighlighter();
+        for (RegexTestResult.RegexTestHighlight highlight : result.getHighlights()) {
+            try {
+                highlighter.addHighlight(
+                        highlight.getStart(), highlight.getEnd(), highlightPainter);
+            } catch (BadLocationException ignore) {
+            }
+        }
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/RegexDialog.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/RegexDialog.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester.ui;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Font;
+import javax.swing.BorderFactory;
+import javax.swing.JSplitPane;
+import javax.swing.border.Border;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.TitledBorder;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.AbstractFrame;
+import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
+import org.zaproxy.zap.utils.FontUtils;
+
+public class RegexDialog extends AbstractFrame {
+    private static final long serialVersionUID = 1L;
+
+    public static final Font monoFont = FontUtils.getFont("Monospaced");
+    private static final String DIALOG_TITLE =
+            Constant.messages.getString("regextester.dialog.title");
+
+    private RegexPanel regexPanel;
+    private MatchPanel matchPanel;
+    private TestValuePanel testValuePanel;
+
+    public RegexDialog(RegexModel regexModel) {
+        setTitle(DIALOG_TITLE);
+        this.regexPanel = new RegexPanel(regexModel, () -> somethingChanged());
+        this.testValuePanel = new TestValuePanel(regexModel, () -> somethingChanged());
+        this.matchPanel = new MatchPanel(regexModel);
+
+        setPreferredSize(new Dimension(1024, 768));
+
+        JSplitPane centerSplit =
+                new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, testValuePanel, matchPanel);
+        centerSplit.setResizeWeight(0.5);
+        centerSplit.setBorder(BorderFactory.createEmptyBorder());
+
+        getContentPane().add(regexPanel, BorderLayout.NORTH);
+        getContentPane().add(centerSplit, BorderLayout.CENTER);
+    }
+
+    private void somethingChanged() {
+        matchPanel.updateFromModel();
+    }
+
+    public static Border createBorder(String title) {
+        TitledBorder titledBorder = BorderFactory.createTitledBorder(title);
+        titledBorder.setBorder(BorderFactory.createEmptyBorder());
+
+        return BorderFactory.createCompoundBorder(
+                new EmptyBorder(10, 5, 5, 5),
+                BorderFactory.createCompoundBorder(
+                        titledBorder, BorderFactory.createEmptyBorder(5, 5, 5, 5)));
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/RegexPanel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/RegexPanel.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester.ui;
+
+import java.awt.BorderLayout;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
+import org.zaproxy.zap.extension.regextester.ui.util.SimpleDocumentListener;
+
+public class RegexPanel extends JPanel {
+    private static final long serialVersionUID = 1L;
+
+    private static final String REGEX_HEADER =
+            Constant.messages.getString("regextester.dialog.regexheader");
+
+    private final JTextField regexField;
+    private final SimpleDocumentListener documentListener =
+            (SimpleDocumentListener) this::updateToModel;
+    private RegexModel regexModel;
+    private Runnable onRegexChanged;
+
+    public RegexPanel(RegexModel regexModel, Runnable onRegexChanged) {
+        super(new BorderLayout());
+        this.regexModel = regexModel;
+        this.onRegexChanged = onRegexChanged;
+        regexField = new JTextField();
+        regexField.setFont(RegexDialog.monoFont);
+        regexField.setText(regexModel.getRegex());
+        regexField.getDocument().addDocumentListener(documentListener);
+
+        JPanel regexPanel = new JPanel(new BorderLayout());
+        regexPanel.add(regexField, BorderLayout.CENTER);
+        add(regexPanel, BorderLayout.CENTER);
+        setBorder(RegexDialog.createBorder(REGEX_HEADER));
+    }
+
+    private void updateToModel() {
+        regexModel.setRegex(regexField.getText());
+        onRegexChanged.run();
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/TestValuePanel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/TestValuePanel.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester.ui;
+
+import java.awt.BorderLayout;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
+import org.zaproxy.zap.extension.regextester.ui.util.SimpleDocumentListener;
+
+public class TestValuePanel extends JPanel {
+    private static final long serialVersionUID = 1L;
+
+    private static final String TEST_VALUE_HEADER =
+            Constant.messages.getString("regextester.dialog.testvalueheader");
+
+    private final JTextArea testValueField;
+    private final SimpleDocumentListener documentListener =
+            (SimpleDocumentListener) this::updateToModel;
+    private RegexModel regexModel;
+    private Runnable onTestValueChanged;
+
+    public TestValuePanel(RegexModel regexModel, Runnable onTestValueChanged) {
+        super(new BorderLayout());
+        this.regexModel = regexModel;
+        this.onTestValueChanged = onTestValueChanged;
+        testValueField = new JTextArea();
+        testValueField.setFont(RegexDialog.monoFont);
+        testValueField.setLineWrap(true);
+        testValueField.setWrapStyleWord(true);
+        testValueField.setText(regexModel.getTestValue());
+        testValueField.getDocument().addDocumentListener(documentListener);
+        add(new JScrollPane(testValueField), BorderLayout.CENTER);
+        setBorder(RegexDialog.createBorder(TEST_VALUE_HEADER));
+    }
+
+    private void updateToModel() {
+        regexModel.setTestValue(testValueField.getText());
+        onTestValueChanged.run();
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/model/RegexModel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/model/RegexModel.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester.ui.model;
+
+public class RegexModel {
+
+    private String regex;
+    private String testValue;
+
+    public RegexModel(String regex, String testValue) {
+        this.regex = regex;
+        this.testValue = testValue;
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    public String getTestValue() {
+        return testValue;
+    }
+
+    public void setTestValue(String testValue) {
+        this.testValue = testValue;
+    }
+}

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/util/SimpleDocumentListener.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/util/SimpleDocumentListener.java
@@ -1,0 +1,41 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.regextester.ui.util;
+
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+public interface SimpleDocumentListener extends DocumentListener {
+
+    void onInsertOrRemove();
+
+    @Override
+    default void insertUpdate(DocumentEvent e) {
+        onInsertOrRemove();
+    }
+
+    @Override
+    default void removeUpdate(DocumentEvent e) {
+        onInsertOrRemove();
+    }
+
+    @Override
+    default void changedUpdate(DocumentEvent e) {}
+}

--- a/addOns/regextester/src/main/resources/org/zaproxy/zap/extension/regextester/resources/Messages.properties
+++ b/addOns/regextester/src/main/resources/org/zaproxy/zap/extension/regextester/resources/Messages.properties
@@ -1,0 +1,24 @@
+# This file defines the default (English) variants of all of the internationalised messages
+
+regextester.name = Regular Expression Tester
+regextester.desc = Allows to test Regular Expressions
+
+regextester.dialog.title = Regular Expression Tester
+regextester.dialog.matchresultheader = Match Result
+regextester.dialog.matches = Matches: %s
+regextester.dialog.lookingat = LookingAt: %s
+regextester.dialog.findresultheader = Find Result
+regextester.dialog.findcaptureheader = Find Captures
+regextester.dialog.regexheader = Regular Expression
+regextester.dialog.testvalueheader = Test String
+
+regextester.menu.tools.name = Regular Expression Tester
+
+regextester.popup.option = Regular Expression Tester
+regextester.popup.option.all = All
+regextester.popup.option.body = Body
+regextester.popup.option.header = Header
+regextester.popup.option.request = Request
+regextester.popup.option.response = Response
+
+

--- a/addOns/regextester/src/main/resources/org/zaproxy/zap/extension/regextester/resources/Messages.properties
+++ b/addOns/regextester/src/main/resources/org/zaproxy/zap/extension/regextester/resources/Messages.properties
@@ -21,4 +21,4 @@ regextester.popup.option.header = Header
 regextester.popup.option.request = Request
 regextester.popup.option.response = Response
 
-
+regextester.result.none = No Findings.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,6 +60,7 @@ var addOns = listOf(
     "pscanrulesAlpha",
     "pscanrulesBeta",
     "quickstart",
+    "regextester",
     "replacer",
     "requester",
     "reveal",


### PR DESCRIPTION
You can open this dialog via ToolMenu. Then the dialog is empty
![regex1](https://user-images.githubusercontent.com/3629463/37995702-9c6b67f0-3215-11e8-9b01-f2b3cc6c89b1.png)

Furthermore you can open this dialog via ContextMenu  and choose the part  of the request/response that should prefill the dialog
![regex2](https://user-images.githubusercontent.com/3629463/37995829-fe6dec5c-3215-11e8-8ae2-f9abeb77c388.jpg)

If this is merged I like to implement, that textboxes containing regular expressions can launch this dialog. It could be prefilled with the regex and an example of the possible value or the user can choose a "real value" from the NodeSelectDialog.



