### PR TITLE
replacer: allow to select token gen messages

### DIFF
--- a/src/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
+++ b/src/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
@@ -61,6 +61,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
     protected static final String INIT_TYPE_AUTH_FIELD = "replacer.label.init.auth";
     protected static final String INIT_TYPE_AC_FIELD = "replacer.label.init.ac";
     protected static final String INIT_TYPE_USER_FIELD = "replacer.label.init.user";
+    protected static final String INIT_TYPE_TOKEN_GEN_FIELD = "replacer.label.init.tokengen";
 
     private ReplacerParam replacerParam;
     private ReplacerParamRule rule;
@@ -113,6 +114,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         this.addCheckBoxField(1, INIT_TYPE_AUTH_FIELD, false);
         this.addCheckBoxField(1, INIT_TYPE_AC_FIELD, false);
         this.addCheckBoxField(1, INIT_TYPE_USER_FIELD, false);
+        this.addCheckBoxField(1, INIT_TYPE_TOKEN_GEN_FIELD, false);
         this.addPadding(1);
 
         // Set before adding the listener so we don't get in a loop
@@ -152,6 +154,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         getField(INIT_TYPE_AUTH_FIELD).setEnabled(bool);
         getField(INIT_TYPE_AC_FIELD).setEnabled(bool);
         getField(INIT_TYPE_USER_FIELD).setEnabled(bool);
+        getField(INIT_TYPE_TOKEN_GEN_FIELD).setEnabled(bool);
     }
 
     public ReplacerParamRule getRule() {
@@ -206,6 +209,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
                         INIT_TYPE_AC_FIELD,
                         rule.getInitiators().contains(HttpSender.ACCESS_CONTROL_SCANNER_INITIATOR));
                 this.setFieldValue(INIT_TYPE_USER_FIELD, rule.getInitiators().contains(HttpSender.MANUAL_REQUEST_INITIATOR));
+                this.setFieldValue(INIT_TYPE_TOKEN_GEN_FIELD, rule.getInitiators().contains(HttpSender.TOKEN_GENERATOR_INITIATOR));
             }
         }
         setUpInitiatorFields();
@@ -248,6 +252,9 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
             }
             if (getBoolValue(INIT_TYPE_USER_FIELD)) {
                 initiators.add(HttpSender.MANUAL_REQUEST_INITIATOR);
+            }
+            if (getBoolValue(INIT_TYPE_TOKEN_GEN_FIELD)) {
+                initiators.add(HttpSender.TOKEN_GENERATOR_INITIATOR);
             }
         }
 

--- a/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Tweak help page.<br>
 	Ignore CFU HTTP messages.<br>
+	Allow to (explicitly) select Token Generator messages.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/replacer/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/replacer/resources/Messages.properties
@@ -40,6 +40,7 @@ replacer.label.init.spiderajax	= Ajax spider messages:
 replacer.label.init.auth		= Authentication messages:
 replacer.label.init.ac			= Access controller messages:
 replacer.label.init.user		= Manual Request messages:
+replacer.label.init.tokengen = Token Generator messages:
 
 
 replacer.matchtype.req_header		= Request Header (will add if not present)


### PR DESCRIPTION
Allow to explicitly select token generator messages.
Update changes in ZapAddOn.xml file.