### PR TITLE
accessControl: dynamically unload the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url />
 	<changes>
 	<![CDATA[
-	Minor code changes.<br>
+	Dynamically unload the add-on.<br>
 	]]> 
 	</changes>
 	<dependson />

--- a/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
+++ b/src/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
@@ -103,6 +103,12 @@ public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel imp
 	}
 
 	@Override
+	public void unload() {
+		super.unload();
+		reset();
+	}
+
+	@Override
 	public void scanResultObtained(int contextId, AccessControlResultEntry result) {
 		getResultsModel(contextId).addEntry(new AccessControlResultsTableEntry(result));
 	}

--- a/src/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
+++ b/src/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
@@ -256,6 +256,13 @@ public class ContextAccessControlPanel extends AbstractContextPropertiesPanel {
 		return "accessControl.contextOptions";
 	}
 
+	/**
+	 * Unloads the panel, to detach it from core (persistent) classes.
+	 */
+	public void unload() {
+		getUsersComboBox().unload();
+	}
+
 	private static ExtensionUserManagement getUsersManagementExtension() {
 		if (usersExtension == null) {
 			usersExtension = Control.getSingleton().getExtensionLoader()


### PR DESCRIPTION
Change ExtensionAccessControl to:
 - Hook the ContextDataFactory and ContextPanelFactory, to get them
 automatically removed when unloaded;
 - Unload the status/context panels and close the dialogue when the
 add-on is unloaded;
 - Unload the context panels when the context(s) are discard;
 - Declare that it can be unloaded.

Change AccessControlStatusPanel to also reset the panel when unloaded.
Change ContextAccessControlPanel to unload the users combo box.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#2380 - Dynamically unload "Access Control Testing"
add-on