### PR TITLE
birtreports: tidy up manifest

### DIFF
--- a/src/org/zaproxy/zap/extension/birtreports/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/birtreports/ZapAddOn.xml
@@ -1,33 +1,18 @@
 <zapaddon>
-        <name>birtreports</name>
-        <version>3</version>
-        <status>alpha</status>
-        <description>Alert reports using BIRT report API</description>
-        <author>Johanna Curiel And Rauf Butt</author>
-        <url/>
-	<changes>
+    <name>birtreports</name>
+    <version>3</version>
+    <status>alpha</status>
+    <description>Alert reports using BIRT report API</description>
+    <author>Johanna Curiel And Rauf Butt</author>
+    <url/>
+    <changes>
     <![CDATA[
-    Maintenance changes.<br>
     ]]>
     </changes>
-        <dependson>
-                <zapaddonid/>
-        </dependson>
-        <extensions>
-                <extension>org.zaproxy.zap.extension.birtreports</extension>
-        </extensions>
-        <ascanrules>
-                <ascanrule/>
-        </ascanrules>
-        <pscanrules>
-                <pscanrule/>
-        </pscanrules>
-        <filters>
-                <filter/>
-        </filters>
-        <files>
-                <file/>
-        </files>
-        <not-before-version>2.4.0</not-before-version>
-        <not-from-version/>
+    <extensions/>
+    <ascanrules/>
+    <pscanrules/>
+    <files/>
+    <not-before-version>2.4.0</not-before-version>
+    <not-from-version/>
 </zapaddon>


### PR DESCRIPTION
Indent and remove invalid/empty entries.
Remove old changes to leave them empty, the add-on is not ready for a
new release (zaproxy/zaproxy#2235).