### PR TITLE
accessControl: inform of running tests

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
+++ b/src/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
@@ -23,7 +23,9 @@ import java.awt.Dimension;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -151,6 +153,23 @@ public class ExtensionAccessControl extends ExtensionAdaptor implements SessionC
 		return true;
 	}
 
+	@Override
+	public List<String> getActiveActions() {
+		Collection<AccessControlScannerThread> scans = threadManager.getAllThreads();
+		if (scans.isEmpty()) {
+			return null;
+		}
+
+		String activeActionPrefix = Constant.messages.getString("accessControl.activeActionPrefix");
+		List<String> activeActions = new ArrayList<>(scans.size());
+		for (AccessControlScannerThread scan : scans) {
+			if (scan.isRunning()) {
+				activeActions.add(MessageFormat.format(activeActionPrefix, scan.getStartOptions().targetContext.getName()));
+			}
+		}
+		return activeActions;
+	}
+	
 	@Override
 	public String getAuthor() {
 		return Constant.ZAP_TEAM;

--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Dynamically unload the add-on.<br>
+	Inform of running tests (e.g. on session change, add-on uninstall).<br>
 	]]> 
 	</changes>
 	<dependson />

--- a/src/org/zaproxy/zap/extension/accessControl/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/accessControl/resources/Messages.properties
@@ -1,6 +1,7 @@
 # This file defines the default (English) variants of all of the internationalised messages
 
 accessControl.desc 								= Add-on that adds a set of tools for testing access control in web applications.
+accessControl.activeActionPrefix = Access Control: {0}
 accessControl.results.table.header.user 		= User
 accessControl.results.table.header.authorized	= Authorized
 accessControl.results.table.header.rule 		= Access Rule


### PR DESCRIPTION
Change ExtensionAccessControl to report the running tests so that the
user is informed when changing the session or uninstalling the add-on.
Update changes in ZapAddOn.xml file.