### PR TITLE
Add APIs through the ExtensionHook

### DIFF
--- a/src/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
+++ b/src/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
@@ -41,9 +41,8 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionHookView;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.view.ZapToggleButton;
 
 public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
@@ -89,11 +88,12 @@ public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
 		extensionHook.addOptionsParamSet(revealParam);
 		
 		if (getView() != null) {
-			View.getSingleton().addMainToolbarButton(getRevealButton());
-			View.getSingleton().addMainToolbarSeparator(getToolBarSeparator());
+			ExtensionHookView extensionHookView = extensionHook.getHookView();
+			extensionHookView.addMainToolBarComponent(getRevealButton());
+			extensionHookView.addMainToolBarComponent(getToolBarSeparator());
 		}
 
-		API.getInstance().registerApiImplementor(revealAPI);
+		extensionHook.addApiImplementor(revealAPI);
 	}
 
 	@Override
@@ -101,18 +101,6 @@ public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
 		super.optionsLoaded();
 
 		setReveal(revealParam.isReveal());
-	}
-
-	@Override
-	public void unload() {
-		if (getView() != null) {
-			View.getSingleton().removeMainToolbarButton(getRevealButton());
-			View.getSingleton().removeMainToolbarSeparator(getToolBarSeparator());
-		}
-
-		API.getInstance().removeApiImplementor(revealAPI);
-
-		super.unload();
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
@@ -13,6 +13,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -59,7 +59,6 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.Version;
 import org.zaproxy.zap.extension.AddonFilesChangedListener;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.selenium.internal.BuiltInSingleWebDriverProvider;
 
 /**
@@ -197,7 +196,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
             extensionHook.getHookMenu().addPopupMenuItem(new PopupMenuOpenInBrowser(this));
         }
 
-        API.getInstance().registerApiImplementor(seleniumApi);
+        extensionHook.addApiImplementor(seleniumApi);
     }
 
     @Override
@@ -205,13 +204,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         return true;
     }
 
-    @Override
-    public void unload() {
-        super.unload();
-
-        API.getInstance().removeApiImplementor(seleniumApi);
-    }
-    
     @Override
     public void stop() {
         super.stop();

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -46,7 +46,6 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.model.Context;
@@ -110,7 +109,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 	public void hook(ExtensionHook extensionHook) {
 		super.hook(extensionHook);
 
-		API.getInstance().registerApiImplementor(ajaxSpiderApi);
+		extensionHook.addApiImplementor(ajaxSpiderApi);
 		extensionHook.addOptionsParamSet(getAjaxSpiderParam());
 
 		extensionHook.addSessionListener(new SpiderSessionChangedListener());
@@ -138,8 +137,6 @@ public class ExtensionAjax extends ExtensionAdaptor {
             
             getView().getMainFrame().getMainFooterPanel().removeFooterToolbarRightLabel(getSpiderPanel().getScanStatus().getCountLabel());
         }
-        
-        API.getInstance().removeApiImplementor(ajaxSpiderApi);
         
         super.unload();
     }

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Ajax Spider</name>
-	<version>21</version>
+	<version>22</version>
 	<status>release</status>
 	<description>Allows you to spider sites that make heavy use of JavaScript using Crawljax</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
-	Reset API scan also when in daemon mode (Issue 4163).<br>
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change ExtensionAjax, ExtensionReveal, and ExtensionSelenium to hook the
APIs instead of adding them through the API singleton, it avoids the
need to manually unload them. Also, hook tool bar components in
ExtensionReveal. For ExtensionReveal and ExtensionSelenium it allows to
completely remove the unload method.
Bump version, update changes and minimum ZAP version in ZapAddOn.xml
files, where needed.

Related to zaproxy/zaproxy#2785 - Allow to hook ApiImplementor