### PR TITLE
Add APIs through the ExtensionHook (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
+++ b/src/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
@@ -38,14 +38,12 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionImportUrls extends ExtensionAdaptor {
@@ -75,18 +73,7 @@ public class ExtensionImportUrls extends ExtensionAdaptor {
 	    }
 	    
 	    this.api = new ImportUrlsAPI(this);
-	    API.getInstance().registerApiImplementor(api);
-	}
-
-	@Override
-	public void unload() {
-		super.unload();
-		Control control = Control.getSingleton();
-		ExtensionLoader extLoader = control.getExtensionLoader();
-	    if (getView() != null) {
-	    	extLoader.removeToolsMenuItem(getMenuImportUrls());
-	    }
-		API.getInstance().removeApiImplementor(api);
+	    extensionHook.addApiImplementor(api);
 	}
 
 	private ZapMenuItem getMenuImportUrls() {

--- a/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>Import files containing URLs</name>
-	<version>5</version>
+	<version>6</version>
 	<status>beta</status>
 	<description>Adds an option to import a file of URLs. The file must be plain text with one URL per line.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Updated for 2.7.0.</changes>
+	<changes>
+	<![CDATA[
+	Maintenance changes.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.importurls.ExtensionImportUrls</extension>
 	</extensions>

--- a/src/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
@@ -230,7 +230,7 @@ public class ExtensionPlugNHack extends ExtensionAdaptor implements ProxyListene
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 
-        API.getInstance().registerApiImplementor(api);
+        extensionHook.addApiImplementor(api);
         extensionHook.addProxyListener(this);
         extensionHook.addSessionListener(this);
 
@@ -324,8 +324,6 @@ public class ExtensionPlugNHack extends ExtensionAdaptor implements ProxyListene
         Database db = Model.getSingleton().getDb();
         db.removeDatabaseListener(clientTable);
         db.removeDatabaseListener(messageTable);
-
-        API.getInstance().removeApiImplementor(api);
     }
 
     private PopupMenuResend getPopupMenuResend() {


### PR DESCRIPTION
Change ExtensionImportUrls and ExtensionPlugNHack to hook the APIs
instead of adding them through the API singleton, it avoids the need to
manually unload them.
For ExtensionImportUrls it allows to completely remove the unload method
(the tool menu item was already being hooked).
Bump version and update changes in ZapAddOn.xml file, where needed.

Related to zaproxy/zaproxy#2785 - Allow to hook ApiImplementor