### PR TITLE
Add APIs through the ExtensionHook (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
@@ -39,7 +39,6 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpResponseBody;
 
@@ -79,7 +78,7 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
         importLogAPI = new ImportLogAPI(null);
-        API.getInstance().registerApiImplementor(importLogAPI);
+        extensionHook.addApiImplementor(importLogAPI);
         if (getView() != null) {
             extensionHook.getHookMenu().addAnalyseMenuItem(getImportOption());
         }
@@ -89,13 +88,6 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
     @Override
     public boolean canUnload() {
         return true;
-    }
-
-    @Override
-    public void unload() {
-        super.unload();
-
-        API.getInstance().removeApiImplementor(importLogAPI);
     }
 
     private JMenuItem getImportOption() {

--- a/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
@@ -19,6 +19,6 @@
 	<pscanrules></pscanrules>
 	<filters></filters>
 	<files></files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/src/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -55,7 +55,6 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.model.ParameterParser;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.StructuralNode;
@@ -132,7 +131,7 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
 	    					Constant.messages.getString(PREFIX + ".popup.disable.title"), false));
 	    }
 
-	    API.getInstance().registerApiImplementor(revisitAPI);
+	    extensionHook.addApiImplementor(revisitAPI);
 	}
 	
 	@Override
@@ -155,8 +154,6 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
 
 			removeRevisitIconSiteNodes();
 		}
-
-		API.getInstance().removeApiImplementor(revisitAPI);
 	}
 
 	private void removeRevisitIconSiteNodes() {

--- a/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -37,7 +37,6 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -64,7 +63,7 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
 	public void hook(ExtensionHook extensionHook) {
 		super.hook(extensionHook);
 
-        API.getInstance().registerApiImplementor(new SoapAPI(this));
+		extensionHook.addApiImplementor(new SoapAPI(this));
 
 	    if (getView() != null) {
 	        extensionHook.getHookMenu().addToolsMenuItem(getMenuImportLocalWSDL());

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -22,6 +22,6 @@
 	</pscanrules>
 	<filters/>
 	<files/>
-	<not-before-version>2.5.0</not-before-version>
+	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
Change ExtensionImportLogFiles, ExtensionRevisit, and
ExtensionImportWSDL to hook the APIs instead of adding them through the
API singleton, it avoids the need to manually unload them.
For ExtensionImportLogFiles it allows to completely remove the unload
method.
Update minimum ZAP version in ZapAddOn.xml files, where needed.

Related to zaproxy/zaproxy#2785 - Allow to hook ApiImplementor