### PR TITLE
tokengen: inform of running test

### DIFF
--- a/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
+++ b/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
@@ -112,6 +112,17 @@ public class ExtensionTokenGen extends ExtensionAdaptor {
         super.unload();
     }
 
+    @Override
+    public List<String> getActiveActions() {
+        if (runningGenerators == 0) {
+            return null;
+        }
+
+        List<String> activeActions = new ArrayList<>(1);
+        activeActions.add(Constant.messages.getString("tokengen.activeAction"));
+        return activeActions;
+    }
+
 	private TokenPanel getTokenPanel() {
 		if (tokenPanel == null) {
 			tokenPanel = new TokenPanel(this, this.getTokenParam());

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+	Inform of running test (e.g. on session change, add-on uninstall).<br>
 	Maintenance changes.<br>
 	]]>
 	</changes>

--- a/src/org/zaproxy/zap/extension/tokengen/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/tokengen/resources/Messages.properties
@@ -2,6 +2,7 @@
 #
 # This file defines the default (English) variants of all of the internationalised messages
 
+tokengen.activeAction = Token Generator
 tokengen.analyse.button.save    = Save Analysis
 tokengen.analyse.detail.maxentropy = Maximum theoretical entropy:
 tokengen.analyse.save.error=Failed to write to file, see log for detail.


### PR DESCRIPTION
Change ExtensionTokenGen to report the running test so that the user is
informed when changing the session or uninstalling the add-on.
Update changes in ZapAddOn.xml file.