### PR TITLE
Add Passive Scan Alpha Unit Tests

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledHTMLAttributesScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledHTMLAttributesScanner.java
@@ -183,6 +183,7 @@ public class UserControlledHTMLAttributesScanner extends PluginPassiveScanner {
 	            for (String s: attrValue.split("[;=,]")) {
 	                if (s.equals(paramValue)) {
 	                    raiseAlert(msg, id, htmlElement, attribute, param, attrValue);
+	                    return; //Only need one alert
 	                }
 	            }
 	        }
@@ -235,7 +236,7 @@ public class UserControlledHTMLAttributesScanner extends PluginPassiveScanner {
 				getName());				    
 
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), "content-type", getExploitMessage(msg), 
+				.getURI().toString(), param.getName(), getExploitMessage(msg), 
 				getExtraInfoMessage(msg, htmlElement.getName(), 
 						htmlAttribute.getName(), param, userControlledValue),
 				getSolutionMessage(), getReferenceMessage(),  

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,8 @@
 	<changes>
 	<![CDATA[
 	Help documentation improvements and cleanup.<br>
+	Prevent User Controlled HTML Attribute scanner from sometimes raising duplicate alerts.<br>
+	User Controlled HTML Attribute scanner now properly reports the parameter name in alerts.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/cspscanner/ContentSecurityPolicyScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/cspscanner/ContentSecurityPolicyScannerUnitTest.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.cspscanner;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -37,8 +36,8 @@ public class ContentSecurityPolicyScannerUnitTest extends PassiveScannerTest {
         return new ContentSecurityPolicyScanner();
     }
 
-    @BeforeClass
-    public static void beforeClass() {
+    @Override
+    protected void setUpMessages() {
         mockMessages(new ExtensionContentSecurityPolicyScanner());
     }
 

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/DirectoryBrowsingScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/DirectoryBrowsingScannerUnitTest.java
@@ -1,0 +1,96 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class DirectoryBrowsingScannerUnitTest extends PassiveScannerTest {
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("http://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new DirectoryBrowsingScanner();
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseBodyIsEmpty() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+	
+	@Test
+	public void shouldNotRaiseAlertIfResponseBodyIsIrrelevant() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("<html><H1>Some Title</H1></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+	
+
+	@Test
+	public void shouldRaiseAlertIfResponseContainsApacheStyleIndex() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("<html><title>Index of /htdocs</title></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+	}
+	
+	@Test
+	public void shouldRaiseAlertIfResponseContainsIisStyleIndex() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("<html><head><title>somesite.net - /site/</title></head><body><H1>somesite.net - /site/</H1><hr><pre><A HREF=\"/\">[To Parent Directory]</A><br><br> 6/12/2014  3:25 AM        &lt;dir&gt; <A HREF=\"/site/file.ext/\">file.ext</A><br></pre><hr></body></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormLoadScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormLoadScannerUnitTest.java
@@ -1,0 +1,119 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class InsecureFormLoadScannerUnitTest extends PassiveScannerTest {
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("http://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new InsecureFormLoadScanner();
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsHttps() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setSecure(true);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotStatusOk() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotHtml() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+	
+	@Test
+	public void shouldNotRaiseAlertIfResponseContentTypeIsNull() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfFormActionIsSecure() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("<html><form name=\"someform\" action=\"https://example.com/processform\"></form</html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfFormActionIsInsecure() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("<html><form name=\"someform\" action=\"http://example.com/processform\"></form</html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormPostScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormPostScannerUnitTest.java
@@ -1,0 +1,119 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class InsecureFormPostScannerUnitTest extends PassiveScannerTest {
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("https://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new InsecureFormPostScanner();
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotHttps() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setSecure(false);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotStatusOk() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotHtml() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+	
+	@Test
+	public void shouldNotRaiseAlertIfResponseContentTypeIsNull() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseFormIsSecure() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("<html><form name=\"someform\" action=\"https://example.com/processform\"></form</html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseFormIsInsecure() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("<html><form name=\"someform\" action=\"http://example.com/processform\"></form</html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/RetrievedFromCacheScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/RetrievedFromCacheScannerUnitTest.java
@@ -1,0 +1,158 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class RetrievedFromCacheScannerUnitTest extends PassiveScannerTest {
+
+	private static final String X_CACHE = "X-Cache";
+	private static final String AGE = "Age";
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("http://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new RetrievedFromCacheScanner();
+	}
+
+	@Test
+	public void scannerNameShouldMatch() {
+		// Quick test to verify scanner name which is used in the policy dialog but not
+		// alerts
+
+		// Given
+		PluginPassiveScanner thisScanner = createScanner();
+		// Then
+		assertThat(thisScanner.getName(), equalTo("Retrieved from Cache"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfXCacheWasMiss() throws URIException {
+		// Given
+		String xCacheValue = "MISS";
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(X_CACHE, xCacheValue);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfXCacheWasEmpty() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(X_CACHE, "");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfXCacheWasHit() throws URIException {
+		// Given
+		String xCacheValue = "HIT";
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(X_CACHE, xCacheValue);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo(xCacheValue));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfXCacheWasHitWithServerDetails() throws URIException {
+		// Given
+		String xCacheValue = "HIT from cache.kolich.local";
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(X_CACHE, xCacheValue);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo(xCacheValue));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfXCacheWasHitWithMultipleServerDetails() throws URIException {
+		// Given
+		String xCacheValue = "HIT from proxy.domain.tld, MISS from proxy.local";
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(X_CACHE, xCacheValue);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo("HIT from proxy.domain.tld"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfAgeWasEmpty() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(AGE, "");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfAgePresentWithValue() throws URIException {
+		// Given
+		String ageValue = "24";
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(AGE, ageValue);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo(AGE + ": " + ageValue));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/ServerHeaderInfoLeakScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/ServerHeaderInfoLeakScannerUnitTest.java
@@ -1,0 +1,111 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class ServerHeaderInfoLeakScannerUnitTest extends PassiveScannerTest {
+
+	private static final String SERVER = "Server";
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("http://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new ServerHeaderInfoLeakScanner();
+	}
+
+	@Test
+	public void scannerNameShouldMatch() {
+		// Quick test to verify scanner name which is used in the policy dialog but not
+		// alerts
+
+		// Given
+		PluginPassiveScanner thisScanner = createScanner();
+		// Then
+		assertThat(thisScanner.getName(), equalTo("HTTP Server Response Header Scanner"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasRelevantHeader() throws URIException {
+		// Given
+		String apacheHeader = "Apache/2.4.1 (Unix)";
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(SERVER, apacheHeader);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertEquals(apacheHeader, alertsRaised.get(0).getEvidence());
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasRelevantContentButNoVersion() throws URIException {
+		// Given - Default threshold (MEDIUM)
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(SERVER, "Apache");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfThresholdLowResponseHasRelevantContentButNoVersion() throws URIException {
+		// Given
+		String bareApacheHeader = "Apache";
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(SERVER, bareApacheHeader);
+		((ServerHeaderInfoLeakScanner) rule).setAlertThreshold(AlertThreshold.LOW);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertEquals(bareApacheHeader, alertsRaised.get(0).getEvidence());
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScannerUnitTest.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class SourceCodeDisclosureScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new SourceCodeDisclosureScanner();
+	}
+
+	@Test
+	public void scannerNameShouldMatch() {
+		// Quick test to verify scanner name which is used in the policy dialog but not 
+		// alone in alerts
+
+		// Given
+		PluginPassiveScanner thisScanner = createScanner();
+		// Then
+		assertThat(thisScanner.getName(), equalTo("Source Code Disclosure"));
+	}
+	
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/StrictTransportSecurityScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/StrictTransportSecurityScannerUnitTest.java
@@ -1,0 +1,205 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class StrictTransportSecurityScannerUnitTest extends PassiveScannerTest {
+
+	private static final String STS_HEADER = "Strict-Transport-Security";
+	private static final String HEADER_VALUE = "max-age=31536000";// 1 year
+	private static final String SHORT_VALUE = "max-age=86400";
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("https://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new StrictTransportSecurityScanner();
+	}
+
+	@Test
+	public void scannerNameShouldMatch() {
+		// Quick test to verify scanner name which is used in the policy dialog but not
+		// alerts
+
+		// Given
+		PluginPassiveScanner thisScanner = createScanner();
+		// Then
+		assertThat(thisScanner.getName(), equalTo("Strict-Transport-Security Header Scanner"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponsIsNotHttps() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setSecure(false);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseMissingHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Header Not Set"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasWelformedHeaderAndValue() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(STS_HEADER, SHORT_VALUE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasMultipleHeaders() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(STS_HEADER, SHORT_VALUE);
+		msg.getResponseHeader().addHeader(STS_HEADER, HEADER_VALUE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Multiple Header Entries (Non-compliant with Spec)"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasStsDisablingHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(STS_HEADER, "max-age=0");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Disabled"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasStsHeaderWithBlankValue() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(STS_HEADER, "");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Missing Max-Age (Non-compliant with Spec)"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfHeaderValueHasJunkContent() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(STS_HEADER, SHORT_VALUE + "”");// Append curly quote
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Malformed Content (Non-compliant with Spec)"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfHeaderValueHasImproperQuotes() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(STS_HEADER, "\"max-age=84600\"");// Quotes before max
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Max-Age Malformed (Non-compliant with Spec)"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfThresholdLowNonSecureResponseWithHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setSecure(false);
+		msg.getResponseHeader().addHeader(STS_HEADER, HEADER_VALUE);
+		((StrictTransportSecurityScanner) rule).setAlertThreshold(AlertThreshold.LOW);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Header on Plain HTTP Response"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfThresholdLowNonSecureResponseNoHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setSecure(false);
+		((StrictTransportSecurityScanner) rule).setAlertThreshold(AlertThreshold.LOW);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseContainsStsHeaderAndMeta() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(STS_HEADER, HEADER_VALUE);
+		msg.setResponseBody(
+				"<html><meta http-equiv=\"Strict-Transport-Security\" content=\"max-age=31536000\" /></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getName(),
+				equalTo("Strict-Transport-Security Defined via META (Non-compliant with Spec)"));
+	}
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCharsetScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCharsetScannerUnitTest.java
@@ -1,0 +1,193 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+import net.htmlparser.jericho.Source;
+
+public class UserControlledCharsetScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new UserControlledCharsetScanner();
+	}
+
+	public HttpMessage createMessage() {
+		HttpMessage msg = new HttpMessage();
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		try {
+			requestHeader.setURI(new URI("http://example.com/i.php", false));
+		} catch (URIException | NullPointerException e) {
+		}
+		requestHeader.setMethod(HttpRequestHeader.GET);
+
+		msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+		return msg;
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+		// Given
+		HttpMessage msg = createMessage();
+		// WHen
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotHtmlNorXml() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseCharsetIsEmpty() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html; charset=");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamsAppearAsCharsetValue() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html; charset=utf-8");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("cs"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseMetaCharsetIsEmpty() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
+		msg.setResponseBody("<html><META http-equiv=\"Content-Type\" content=\"text/html; charset=\"></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseMetaIsNotContentType() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
+		msg.setResponseBody("<html><META http-equiv=\"info\" content=\"Someinfo\"></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamAppearAsMetaCharsetValue() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
+		msg.setResponseBody("<html><META http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("cs"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfXmlResponseCharsetIsEmpty() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/xml");
+		msg.setResponseBody("<?xml version='1.0' encoding=?>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamsAppearAsXmlCharsetValue() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/xml");
+		msg.setResponseBody("<?xml version='1.0' encoding='utf-8'?>");
+		Source source = createSource(msg);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, source);
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("cs"));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCookieScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCookieScannerUnitTest.java
@@ -1,0 +1,159 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.TreeSet;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HtmlParameter;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class UserControlledCookieScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new UserControlledCookieScanner();
+	}
+
+	public HttpMessage createMessage() {
+		HttpMessage msg = new HttpMessage();
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		try {
+			requestHeader.setURI(new URI("http://example.com/i.php", false));
+		} catch (URIException | NullPointerException e) {
+		}
+		requestHeader.setMethod(HttpRequestHeader.GET);
+
+		msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+		return msg;
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseDoesntSetCookie() {
+		// Given
+		HttpMessage msg = createMessage();
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+		// Given
+		HttpMessage msg = createMessage();
+		// WHen
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "Set-Cookie: aCookie=aValue; Secure");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfCookieHasNoValue() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "Set-Cookie: aCookie=\"\"; Secure");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfCookieIsEmpty() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamsAppearAsCookieValue() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "Set-Cookie: aCookie=fred; Secure");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamsAppearWithinCookieValue() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
+		msg.getResponseHeader().setHeader(HttpResponseHeader.SET_COOKIE, "Set-Cookie: aCookie=freddy; Secure");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfCookieBasedOnGetParamDuringPost() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=evil", false));
+		msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
+		TreeSet<HtmlParameter> formParams = new TreeSet<HtmlParameter>();
+		formParams.add(new HtmlParameter(HtmlParameter.Type.form, "name", "jane"));
+		msg.setFormParams(formParams);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.FOUND);
+		msg.getResponseHeader().setHeader(HttpHeader.SET_COOKIE, "Set-Cookie: aCookie=evil; Secure");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("place"));
+	}
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledHTMLAttributesScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledHTMLAttributesScannerUnitTest.java
@@ -1,0 +1,215 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class UserControlledHTMLAttributesScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new UserControlledHTMLAttributesScanner();
+	}
+
+	public HttpMessage createMessage() {
+		HttpMessage msg = new HttpMessage();
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		try {
+			requestHeader.setURI(new URI("http://example.com/i.php", false));
+		} catch (URIException | NullPointerException e) {
+		}
+		requestHeader.setMethod(HttpRequestHeader.GET);
+
+		msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+		return msg;
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotHtml() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasNoContentType() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseHeader(new HttpResponseHeader());
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+		// Given
+		HttpMessage msg = createMessage();
+		// WHen
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseContainsNoAttributes() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><H1>Title</H1></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInAttribute() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><img src=\"x.jpg\" alt=\"Some image (x)\")></img></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInMetaAttribute() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><meta name=\"description\" content=\"UnitTest Content\"></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamValuesUsedInMetaAttribute() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><meta name=\"description\" content=\"fred\"></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInMetaRefresh() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><meta http-equiv=\"refresh\" content=\"0; url=http://example.com/\"></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamValuesUsedInMetaRefresh() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=http://example.com/", false));
+		msg.setResponseBody("<html><meta http-equiv=\"refresh\" content=\"0; url=http://example.com/\"></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("place"));
+	}
+
+	@Test
+	public void shouldRaiseMultipleAlertsIfRequestParamValuesUsedInAttributes() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=http://example.com/&name=fred", false));
+		msg.setResponseBody(
+				"<html><meta http-equiv=\"refresh\" content=\"0; url=http://example.com/\"><img src=\"x.jpg\" alt=fred></img></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(2));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("place"));
+		assertThat(alertsRaised.get(1).getParam(), equalTo("name"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamsValuesUsedInAttributes() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><img src=\"x.jpg\" alt=\"fred, here\")></img></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledJavascriptEventScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledJavascriptEventScannerUnitTest.java
@@ -1,0 +1,148 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class UserControlledJavascriptEventScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new UserControlledJavascriptEventScanner();
+	}
+
+	public HttpMessage createMessage() {
+		HttpMessage msg = new HttpMessage();
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		try {
+			requestHeader.setURI(new URI("http://example.com/i.php", false));
+		} catch (URIException | NullPointerException e) {
+		}
+		requestHeader.setMethod(HttpRequestHeader.GET);
+
+		msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+		return msg;
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotHtml() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+	
+	@Test
+	public void shouldNotRaiseAlertIfResponsehasNoContentType() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, ""); // Removed when value set empty
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+		// Given
+		HttpMessage msg = createMessage();
+		// WHen
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInJsEvent() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><img src=\"x.jpg\" onerror=alert(\"Error\")></img></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasUnknownJsEvent() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><img src=\"x.jpg\" onblah=fred></img></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfRequestParamValuesUsedInJsEvent() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
+		msg.setResponseBody("<html><img src=\"x.jpg\" onerror=fred></img></html>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("name"));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledOpenRedirectScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledOpenRedirectScannerUnitTest.java
@@ -1,0 +1,186 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.TreeSet;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HtmlParameter;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class UserControlledOpenRedirectScannerUnitTest extends PassiveScannerTest {
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new UserControlledOpenRedirectScanner();
+	}
+
+	public HttpMessage createMessage() {
+		HttpMessage msg = new HttpMessage();
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		try {
+			requestHeader.setURI(new URI("http://example.com/i.php", false));
+		} catch (URIException | NullPointerException e) {
+		}
+		requestHeader.setMethod(HttpRequestHeader.GET);
+
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		return msg;
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsNotRedirect() {
+		// Given
+		HttpMessage msg = createMessage();
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsRedirectButHasNoLocationHeader() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsRedirectHasEmptyLocationHeader() {
+		// Given
+		HttpMessage msg = createMessage();
+		TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
+		params.add(new HtmlParameter(HtmlParameter.Type.url, "place", "http://evil.com"));
+		msg.setGetParams(params);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
+		msg.getResponseHeader().setHeader(HttpHeader.LOCATION, "");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderNoParam() {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
+		msg.getResponseHeader().setHeader(HttpHeader.LOCATION, "http://evil.com");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderEmptyParam() {
+		// Given
+		HttpMessage msg = createMessage();
+		TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
+		params.add(new HtmlParameter(HtmlParameter.Type.url, "place", ""));
+		msg.setGetParams(params);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
+		msg.getResponseHeader().setHeader(HttpHeader.LOCATION, "http://evil.com");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderIrrelevantParam() {
+		// Given
+		HttpMessage msg = createMessage();
+		TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
+		params.add(new HtmlParameter(HtmlParameter.Type.url, "place", "fred"));
+		msg.setGetParams(params);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
+		msg.getResponseHeader().setHeader(HttpHeader.LOCATION, "http://evil.com");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseIsRedirectHasLocationHeaderBasedOnParam() {
+		// Given
+		HttpMessage msg = createMessage();
+		TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
+		params.add(new HtmlParameter(HtmlParameter.Type.url, "place", "http://evil.com"));
+		msg.setGetParams(params);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
+		msg.getResponseHeader().setHeader(HttpHeader.LOCATION, "http://evil.com");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("place"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseIsTempRedirectHasLocationHeaderBasedOnParam() {
+		// Given
+		HttpMessage msg = createMessage();
+		TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
+		params.add(new HtmlParameter(HtmlParameter.Type.url, "place", "http://evil.com"));
+		msg.setGetParams(params);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.FOUND);
+		msg.getResponseHeader().setHeader(HttpHeader.LOCATION, "http://evil.com");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("place"));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseIsTempRedirectHasLocationHeaderBasedOnGetParamDuringPost() throws Exception {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=evil.com", false));
+		msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
+		TreeSet<HtmlParameter> formParams = new TreeSet<HtmlParameter>();
+		formParams.add(new HtmlParameter(HtmlParameter.Type.form, "name", "jane"));
+		msg.setFormParams(formParams);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.FOUND);
+		msg.getResponseHeader().setHeader(HttpHeader.LOCATION, "http://evil.com");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getParam(), equalTo("place"));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/XBackendServerInformationLeakUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/XBackendServerInformationLeakUnitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class XBackendServerInformationLeakUnitTest extends PassiveScannerTest {
+
+	private static final String XBS_HEADER = "X-Backend-Server";
+	private static final String HEADER_VALUE = "developer1.webapp.scl3.mozilla.com";
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("http://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new XBackendServerInformationLeak();
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasRelevantContent() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(XBS_HEADER, HEADER_VALUE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// THen
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo(HEADER_VALUE));
+	}
+
+}

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/XChromeLoggerDataInfoLeakScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/XChromeLoggerDataInfoLeakScannerUnitTest.java
@@ -1,0 +1,119 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.extension.encoder.Base64;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class XChromeLoggerDataInfoLeakScannerUnitTest extends PassiveScannerTest {
+
+	private static final String XCLD = "X-ChromeLogger-Data";
+	private static final String XCPD = "X-ChromePhp-Data";
+	private static final String XCLD_VALUE = "eyJ2ZXJzaW9uIjoiNC4wIiwiY29sdW"
+			+ "1ucyI6WyJsYWJlbCIsImxvZyIsImJhY2t0cmFjZSIsInR5cGUiXSwicm93cyI"
+			+ "6W1sicmVxdWVzdCIsIk1hdGNoZWQgcm91dGUgXCJhcHBfc2VjdXJpdHlfbG9n"
+			+ "aW5cIiAocGFyYW1ldGVyczogXCJfY29udHJvbGxlclwiOiBcIkJhY2tFbmRcX"
+			+ "EFwcEJ1bmRsZVxcQ29udHJvbGxlclxcU2VjdXJpdHlDb250cm9sbGVyOjpsb2"
+			+ "dpbkFjdGlvblwiLCBcIl9yb3V0ZVwiOiBcImFwcF9zZWN1cml0eV9sb2dpblw"
+			+ "iKSIsInVua25vd24iLCJpbmZvIl0sWyJzZWN1cml0eSIsIlBvcHVsYXRlZCBT"
+			+ "ZWN1cml0eUNvbnRleHQgd2l0aCBhbiBhbm9ueW1vdXMgVG9rZW4iLCJ1bmtub"
+			+"3duIiwiaW5mbyJdXSwicmVxdWVzdF91cmkiOiJcL2xvZ2luIn0=";
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("http://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new XChromeLoggerDataInfoLeakScanner();
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseBody("Some text <h1>Some Title Element</h1>");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasRelevantHeader() throws IOException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(XCLD, XCLD_VALUE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo(XCLD_VALUE));
+		String otherInfo = "The following represents an attempt to base64 decode the value:\n"
+				+ new String(Base64.decode(XCLD_VALUE), StandardCharsets.UTF_8);
+		assertThat(alertsRaised.get(0).getOtherInfo(), equalTo(otherInfo));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasAlternateRelevantHeader() throws IOException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.getResponseHeader().addHeader(XCPD, XCLD_VALUE);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo(XCLD_VALUE));
+		String otherInfo = "The following represents an attempt to base64 decode the value:\n"
+				+ new String(Base64.decode(XCLD_VALUE), StandardCharsets.UTF_8);
+		assertThat(alertsRaised.get(0).getOtherInfo(), equalTo(otherInfo));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasAlternateRelevantHeaderEvenWithInvalidEncoding() throws IOException {
+		// Given
+		HttpMessage msg = createMessage();
+		String malformedEncodedValue = "ê"+XCLD_VALUE;
+		msg.getResponseHeader().addHeader(XCPD, malformedEncodedValue);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo(malformedEncodedValue));
+		String otherInfo = "Header value could not be base64 decoded: " + malformedEncodedValue;
+		assertThat(alertsRaised.get(0).getOtherInfo(), equalTo(otherInfo));
+	}
+}


### PR DESCRIPTION
Added Unit Tests:
- DirectoryBrowsingScannerUnitTest.java
- InsecureFormLoadScannerUnitTest.java
- InsecureFormPostScannerUnitTest.java
- RetrievedFromCacheScannerUnitTest.java
- ServerHeaderInfoLeakScannerUnitTest.java
- SourceCodeDisclosureScannerUnitTest.java
- StrictTransportSecurityScannerUnitTest.java
- UserControlledCharsetScannerUnitTest.java
- UserControlledCookieScannerUnitTest.java
- UserControlledHTMLAttributesScannerUnitTest.java
- UserControlledJavascriptEventScannerUnitTest.java
- UserControlledOpenRedirectScannerUnitTest.java
- XBackendServerInformationLeakUnitTest.java
- XChromeLoggerDataInfoLeakScannerUnitTest.java

PassiveScannerTest.java > Updated with some functionality from the active scan test packages in order to handle logging etc. This first became necessary while working on the UserControlledOpenRedirectScannerUnitTest.

UserControlledHTMLAttributesScanner > Updated to prevent raising of duplicate alerts, and to properly return the param name in the Alerts. (Including update of associated manifest file).