### PR TITLE
ascanrulesAlpha: do not resend "base" message

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SlackerCookieDetector.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SlackerCookieDetector.java
@@ -44,20 +44,14 @@ public class SlackerCookieDetector extends AbstractAppPlugin {
 	@Override
 	public void scan() {
 
-		HttpMessage msg = getBaseMsg();
-		try {
-			sendAndReceive(msg, false);
-		} catch (IOException io) {
-			log.debug("Blew up trying to do BASE request :(");
-		}
-
-		int baseResponseLength = msg.getResponseBody().length();
-		Set<HtmlParameter> cookies = msg.getCookieParams();
+		int baseResponseLength = getBaseMsg().getResponseBody().length();
+		Set<HtmlParameter> cookies = getBaseMsg().getCookieParams();
 
 		Set<String> cookiesThatMakeADifference = new HashSet<String>();
 		Set<String> cookiesThatDoNOTMakeADifference = new HashSet<String>();
 
 		boolean thereAreSlackCookies = false;
+		HttpMessage msg = getNewMsg();
 
 		for (HtmlParameter oneCookie : cookies) {
 			thereAreSlackCookies = repeatRequestWithoutOneCookie(msg, baseResponseLength, cookies,

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
@@ -59,7 +59,6 @@ public class TestUserAgent extends AbstractAppPlugin {
             I_PHONE_3
     };
 
-    private HttpMessage originalMsg;
     private int originalResponseBodyHash;
 
     @Override
@@ -103,11 +102,7 @@ public class TestUserAgent extends AbstractAppPlugin {
 
     @Override
     public void scan() {
-        setOriginalMessageAndResponseBodyHash();
-        if(originalMsg == null){
-            log.warn("Aborting due to empty original message leads to false positives");
-            return;
-        }
+        originalResponseBodyHash = getBaseMsg().getResponseBody().hashCode();
 
         for(String userAgent: USER_AGENTS){
             if (isStop()) {
@@ -115,32 +110,6 @@ public class TestUserAgent extends AbstractAppPlugin {
             }
             attack(userAgent);
         }
-    }
-
-    private void setOriginalMessageAndResponseBodyHash() {
-        originalMsg = getOriginalMessage();
-        if(originalMsg != null){
-            originalResponseBodyHash = originalMsg.getResponseBody().hashCode();
-        }
-    }
-
-    private HttpMessage getOriginalMessage(){
-        HttpMessage baseMsg = getBaseMsg();
-        if(baseMsg.getResponseHeader().isEmpty()){
-            return resendBaseMessage();
-        }
-        return baseMsg;
-    }
-
-    private HttpMessage resendBaseMessage(){
-        try {
-            HttpMessage newMsg = getNewMsg();
-            sendAndReceive(newMsg);
-            return newMsg;
-        }catch(IOException e){
-            log.warn(e.getMessage(), e);
-        }
-        return null;
     }
 
     private void attack(String userAgent){
@@ -172,7 +141,7 @@ public class TestUserAgent extends AbstractAppPlugin {
     }
 
     private boolean isStatusCodeDifferent(HttpMessage newMsg) {
-        return originalMsg.getResponseHeader().getStatusCode() != newMsg.getResponseHeader().getStatusCode();
+        return getBaseMsg().getResponseHeader().getStatusCode() != newMsg.getResponseHeader().getStatusCode();
     }
 
     private boolean isBodyDifferent(HttpMessage newMsg) {

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>
 	<changes>
 	<![CDATA[
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change SlackerCookieDetector and TestUserAgent to not resend the "base"
message (for the latter scanner it was a new message), it should not be
modified and it's no longer needed (the base message is now guaranteed
to have response).
Update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#1964 - ZAP should ensure response in base
message before passing them to scanners