### PR TITLE
tokengen: allow to delay the requests

### DIFF
--- a/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
+++ b/src/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.Vector;
+import java.util.concurrent.TimeUnit;
 
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
@@ -318,6 +319,7 @@ public class ExtensionTokenGen extends ExtensionAdaptor {
 			gen.setHttpMessage(msg);
 			gen.setNumberTokens(numGen / numThreads);	// TODO what about remainder?
 			gen.setTargetToken(htmlParameterStats);
+			gen.setRequestDelay(getTokenParam().getRequestDelayInMs(), TimeUnit.MILLISECONDS);
 			gen.execute();
 			this.runningGenerators++;
 		}

--- a/src/org/zaproxy/zap/extension/tokengen/TokenGenerator.java
+++ b/src/org/zaproxy/zap/extension/tokengen/TokenGenerator.java
@@ -18,6 +18,7 @@
 package org.zaproxy.zap.extension.tokengen;
 
 import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.SwingWorker;
 
@@ -37,6 +38,8 @@ public class TokenGenerator extends SwingWorker<Void, Void> {
 	private ExtensionTokenGen extension = null;
 	private boolean stopGenerating = false;
 	private boolean paused = false;
+	private long requestDelayDuration;
+	private TimeUnit requestDelayTimeUnit;
     private static Logger log = Logger.getLogger(TokenGenerator.class);
 
 	private HttpSender getHttpSender() {
@@ -62,6 +65,8 @@ public class TokenGenerator extends SwingWorker<Void, Void> {
 			}
 
 			HttpMessage msg = this.httpMessage.cloneRequest();
+
+			requestDelayTimeUnit.sleep(requestDelayDuration);
 
 			try {
 				msg.getRequestHeader().setHeader(HttpHeader.COOKIE, null);
@@ -111,4 +116,11 @@ public class TokenGenerator extends SwingWorker<Void, Void> {
 		this.paused = paused;
 	}
 
+	public void setRequestDelay(long duration, TimeUnit timeUnit) {
+		if (timeUnit == null) {
+			throw new IllegalArgumentException("The parameter timeUnit must not be null.");
+		}
+		this.requestDelayDuration = duration;
+		this.requestDelayTimeUnit = timeUnit;
+	}
 }

--- a/src/org/zaproxy/zap/extension/tokengen/TokenOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/tokengen/TokenOptionsPanel.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
  * It allows to change the following options:
  * <ul>
  * <li>Number of threads for the token generation;</li>
+ * <li>The request delay;</li>
  * </ul>
  * 
  * @see TokenParam
@@ -53,15 +54,28 @@ public class TokenOptionsPanel extends AbstractParamPanel {
             .getString("tokengen.optionspanel.option.threadsperscan");
 
     /**
+     * The label for the request delay option.
+     */
+    private static final String REQUEST_DELAY_LABEL = Constant.messages.getString("tokengen.optionspanel.option.requestdelay");
+
+    /**
      * The number spinner for the number of threads per scan.
      */
     private ZapNumberSpinner threadsPerScanNumberSpinner;
+
+    /**
+     * The number spinner for the request delay.
+     */
+    private ZapNumberSpinner requestDelayNumberSpinner;
 
     public TokenOptionsPanel() {
         super();
 
         JLabel threadsPerScanLabel = new JLabel(THREADS_PER_SCAN_LABEL);
         threadsPerScanNumberSpinner = new ZapNumberSpinner(1, TokenParam.DEFAULT_THREADS_PER_SCAN, 50);
+
+        JLabel requestDelayLabel = new JLabel(REQUEST_DELAY_LABEL);
+        requestDelayNumberSpinner = new ZapNumberSpinner(0, TokenParam.DEFAULT_REQUEST_DELAY_IN_MS, Integer.MAX_VALUE);
 
         setName(NAME);
 
@@ -72,11 +86,26 @@ public class TokenOptionsPanel extends AbstractParamPanel {
         layout.setAutoCreateContainerGaps(true);
 
         layout.setHorizontalGroup(
-                layout.createSequentialGroup().addComponent(threadsPerScanLabel).addComponent(threadsPerScanNumberSpinner));
+                layout.createSequentialGroup()
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+                                        .addComponent(threadsPerScanLabel)
+                                        .addComponent(requestDelayLabel))
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                        .addComponent(threadsPerScanNumberSpinner)
+                                        .addComponent(requestDelayNumberSpinner)));
 
         layout.setVerticalGroup(
-                layout.createParallelGroup(GroupLayout.Alignment.BASELINE).addComponent(threadsPerScanLabel).addComponent(
-                        threadsPerScanNumberSpinner));
+                layout.createSequentialGroup()
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(threadsPerScanLabel)
+                                        .addComponent(threadsPerScanNumberSpinner))
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(requestDelayLabel)
+                                        .addComponent(requestDelayNumberSpinner)));
     }
 
     @Override
@@ -84,6 +113,7 @@ public class TokenOptionsPanel extends AbstractParamPanel {
         TokenParam options = ((OptionsParam) obj).getParamSet(TokenParam.class);
 
         threadsPerScanNumberSpinner.setValue(options.getThreadsPerScan());
+        requestDelayNumberSpinner.setValue(options.getRequestDelayInMs());
     }
 
     @Override
@@ -91,6 +121,7 @@ public class TokenOptionsPanel extends AbstractParamPanel {
         TokenParam options = ((OptionsParam) obj).getParamSet(TokenParam.class);
 
         options.setThreadsPerScan(threadsPerScanNumberSpinner.getValue());
+        options.setRequestDelayInMs(requestDelayNumberSpinner.getValue());
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/tokengen/TokenParam.java
+++ b/src/org/zaproxy/zap/extension/tokengen/TokenParam.java
@@ -25,11 +25,14 @@ import org.zaproxy.zap.common.VersionedAbstractParam;
  * It allows to change, programmatically, the following options:
  * <ul>
  * <li>Number of threads for the token generation;</li>
+ * <li>The request delay;</li>
  * </ul>
  */
 public class TokenParam extends VersionedAbstractParam {
 
     protected static final int DEFAULT_THREADS_PER_SCAN = 5;
+
+    protected static final int DEFAULT_REQUEST_DELAY_IN_MS = 0;
 
     /**
      * The version of the configurations. Used to keep track of configurations changes between releases, if updates are needed.
@@ -45,7 +48,11 @@ public class TokenParam extends VersionedAbstractParam {
 
     private static final String THREADS_PER_SCAN = PARAM_BASE_KEY + ".threadsPerScan";
 
+    private static final String REQUEST_DELAY_IN_MS = PARAM_BASE_KEY + ".requestDelayInMs";
+
     private int threadsPerScan = DEFAULT_THREADS_PER_SCAN;
+
+    private int requestDelayInMs = DEFAULT_REQUEST_DELAY_IN_MS;
 
     public TokenParam() {
     }
@@ -68,6 +75,8 @@ public class TokenParam extends VersionedAbstractParam {
     @Override
     protected void parseImpl() {
         setThreadsPerScanImpl(getConfig().getInt(THREADS_PER_SCAN, DEFAULT_THREADS_PER_SCAN));
+
+        requestDelayInMs = getConfig().getInt(REQUEST_DELAY_IN_MS, DEFAULT_REQUEST_DELAY_IN_MS);
     }
 
     private void setThreadsPerScanImpl(int threadsPerScan) {
@@ -83,4 +92,12 @@ public class TokenParam extends VersionedAbstractParam {
         getConfig().setProperty(THREADS_PER_SCAN, this.threadsPerScan);
     }
 
+    public int getRequestDelayInMs() {
+        return requestDelayInMs;
+    }
+
+    public void setRequestDelayInMs(int requestDelayInMs) {
+        this.requestDelayInMs = requestDelayInMs;
+        getConfig().setProperty(REQUEST_DELAY_IN_MS, this.requestDelayInMs);
+    }
 }

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Respect the current mode and react to changes.<br>
 	Inform of running test (e.g. on session change, add-on uninstall).<br>
 	Allow to configure the number of threads.<br>
+	Allow to delay the requests.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/tokengen/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/tokengen/resources/Messages.properties
@@ -51,6 +51,7 @@ tokengen.panel.mnemonic			= t
 tokengen.panel.title            = Token Gen
 tokengen.optionspanel.name = Token Generator
 tokengen.optionspanel.option.threadsperscan = Number of Threads:
+tokengen.optionspanel.option.requestdelay = Request Delay (in milliseconds):
 tokengen.results.table.header.timestamp.request = Req. Timestamp
 tokengen.results.table.header.method       = Method
 tokengen.results.table.header.url          = URL

--- a/src/org/zaproxy/zap/extension/tokengen/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/tokengen/resources/help/contents/options.html
@@ -26,6 +26,18 @@
             <td align="center">5</td>
             <td>Key: <code>tokengen.threadsPerScan</code><br>Value: a non-negative integer.</td>
         </tr>
+        <tr>
+            <td>Request Delay (in milliseconds)</td>
+            <td>
+                The time to wait before sending each request, to avoid overloading the target server.
+                <p>
+                <strong>Note:</strong> Given the high number of requests sent during the Token
+                Generation increasing the delay might have a high impact on the time that the
+                generation will take to complete.
+            </td>
+            <td align="center">0</td>
+            <td>Key: <code>tokengen.requestDelayInMs</code><br>Value: a non-negative integer.</td>
+        </tr>
     </table>
 
 </BODY>


### PR DESCRIPTION
Add a new option (in options panel) that allows to configure the time
(in milliseconds) to wait before sending each request.

Split from #1147.

---
Note that I changed the default to 0ms (instead of the suggested 51ms) to keep the same behaviour (also, 51ms * 20k reqs = +17min).
The option was added to main Options panel instead of the Generate Tokens dialogue (as there's already another option), we can change the latter dialogue to have an advanced tab (like Spider, Active Scan) to tweak the extra options.