### PR TITLE
pscanrules: fix typo in alert description

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules</name>
-	<version>22</version>
+	<version>23</version>
 	<status>release</status>
 	<description>The release quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Retired the password auto-complete passive scan rule (Issue 4215).<br>
+	Fix a typo in the description of Referer Exposes Session ID.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -78,5 +78,5 @@ pscanrules.testinfosessionidurl.desc = URL rewrite is used to track user session
 pscanrules.testinfosessionidurl.soln = For secure content, put session ID in a cookie. To be even more secure consider using a combination of cookie and URL rewrite.
 pscanrules.testinfosessionidurl.refs = http://seclists.org/lists/webappsec/2002/Oct-Dec/0111.html
 pscanrules.testinfosessionidurl.referrer.alert = Referer Exposes Session ID
-pscanrules.testinfosessionidurl.referrer.desc = A hyperlink pointing to anther host name was found. As session ID URL rewrite is used, it may be disclosed in referer header to external hosts.
+pscanrules.testinfosessionidurl.referrer.desc = A hyperlink pointing to another host name was found. As session ID URL rewrite is used, it may be disclosed in referer header to external hosts.
 pscanrules.testinfosessionidurl.referrer.soln = This is a risk if the session ID is sensitive and the hyperlink refers to an external or third party host. For secure content, put session ID in secured session cookie.


### PR DESCRIPTION
Fix a typo in the description of Referer Exposes Session ID.
Bump version and update changes in ZapAddOn.xml file.