### PR TITLE
websocket: don't enable sender scripts by default

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -389,7 +389,6 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 						SCRIPT_TYPE_WEBSOCKET_SENDER,
 						"websocket.script.type.websocketsender",
 						WEBSOCKET_SENDER_SCRIPT_ICON,
-						true,
 						true);
 				extensionScript.registerScriptType(websocketSenderSciptType);
 				webSocketSenderScriptListener = new WebSocketSenderScriptListener();

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Tweak About help page.<br>
 	Remove event consumers when the channel is closed.<br>
+	Don't enable the sender scripts by default.<br>
 	]]>
 	</changes>
 	<classnames>


### PR DESCRIPTION
Change ExtensionWebSocket to not set the sender script type enabled by
default, the scripts are expected to be enabled by the user when needed.
Update changes in ZapAddOn.xml file.