### PR TITLE
fuzz: correct payload count for random regex

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/payloads/generator/RegexPayloadGenerator.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/generator/RegexPayloadGenerator.java
@@ -79,7 +79,7 @@ public class RegexPayloadGenerator implements StringPayloadGenerator {
         validateValid(regex);
         this.generator = new Generex(regex);
         this.maxPayloads = maxPayloads;
-        this.numberOfPayloads = calculateNumberOfPayloadsImpl(generator, limitCalculationPayloads);
+        this.numberOfPayloads = calculateNumberOfPayloadsImpl(generator, limitCalculationPayloads, randomOrder);
         this.randomOrder = randomOrder;
     }
 
@@ -181,15 +181,41 @@ public class RegexPayloadGenerator implements StringPayloadGenerator {
      * @return the number of payloads that would be produced by the given regular expression
      * @throws IllegalArgumentException if the given {@code regex} is {@code null} or not valid
      * @see #DEFAULT_LIMIT_CALCULATION_PAYLOADS
+     * @see #calculateNumberOfPayloads(String, int, boolean)
      * @see #isInfinite(String, int)
      * @see #isValid(String)
      */
     public static int calculateNumberOfPayloads(String regex, int limit) {
-        validateValid(regex);
-        return calculateNumberOfPayloadsImpl(new Generex(regex), limit);
+        return calculateNumberOfPayloads(regex, limit, false);
     }
 
-    private static int calculateNumberOfPayloadsImpl(Generex generator, int limit) {
+    /**
+     * Calculates the number of payloads that the given regular expression would produce, limiting up to the given {@code limit}
+     * (if positive) and whether it's random.
+     * <p>
+     * If the payloads should be generated in random order the limit would be the number of payloads, otherwise, if the regular
+     * expression is infinite and no limit is provided it returns {@code DEFAULT_LIMIT_CALCULATION_PAYLOADS}.
+     *
+     * @param regex the regular expression that will be used to calculate the number of payloads generated
+     * @param limit if positive, the maximum number of payloads that are allowed, otherwise, negative or zero, for no limit
+     * @param randomOrder {@code true} if the payloads are generated randomly, {@code false} otherwise.
+     * @return the number of payloads that would be produced by the given regular expression
+     * @throws IllegalArgumentException if the given {@code regex} is {@code null} or not valid
+     * @see #DEFAULT_LIMIT_CALCULATION_PAYLOADS
+     * @see #calculateNumberOfPayloads(String, int)
+     * @see #isInfinite(String, int)
+     * @see #isValid(String)
+     */
+    public static int calculateNumberOfPayloads(String regex, int limit, boolean randomOrder) {
+        validateValid(regex);
+        return calculateNumberOfPayloadsImpl(new Generex(regex), limit, randomOrder);
+    }
+
+    private static int calculateNumberOfPayloadsImpl(Generex generator, int limit, boolean randomOrder) {
+        if (randomOrder) {
+            return Math.max(0, limit);
+        }
+
         long max = limit;
         if (max <= 0 || max == DEFAULT_LIMIT_CALCULATION_PAYLOADS) {
             if (isInfiniteImpl(generator, 0)) {

--- a/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/RegexPayloadGeneratorUIHandler.java
+++ b/src/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/RegexPayloadGeneratorUIHandler.java
@@ -414,7 +414,17 @@ public class RegexPayloadGeneratorUIHandler implements
                 getRegexTextField().requestFocusInWindow();
                 return false;
             }
-            if (getMaxPayloadsNumberSpinner().getValue().intValue() == 0 && RegexPayloadGenerator.isInfinite(regex, 0)) {
+            if (getRandomOrderCheckbox().isSelected()) {
+                if (getMaxPayloadsNumberSpinner().getValue().intValue() == 0) {
+                    JOptionPane.showMessageDialog(
+                            null,
+                            Constant.messages.getString("fuzz.payloads.generator.regex.warnNoRandomPayloads.message"),
+                            Constant.messages.getString("fuzz.payloads.generator.regex.warnNoRandomPayloads.title"),
+                            JOptionPane.INFORMATION_MESSAGE);
+                    getMaxPayloadsNumberSpinner().requestFocusInWindow();
+                    return false;
+                }
+            } else if (getMaxPayloadsNumberSpinner().getValue().intValue() == 0 && RegexPayloadGenerator.isInfinite(regex, 0)) {
                 if (JOptionPane.showConfirmDialog(
                         null,
                         Constant.messages.getString("fuzz.payloads.generator.regex.warnInfiniteRegex.message"),
@@ -438,10 +448,14 @@ public class RegexPayloadGeneratorUIHandler implements
         private int calculateNumberOfPayloads(String regex) {
             return RegexPayloadGenerator.calculateNumberOfPayloads(
                     regex,
-                    getMaximumForPayloadCalculation(getMaxPayloadsNumberSpinner().getValue().intValue()));
+                    getMaximumForPayloadCalculation(getMaxPayloadsNumberSpinner().getValue().intValue()),
+                    getRandomOrderCheckbox().isSelected());
         }
 
-        private static int getMaximumForPayloadPersistence(int limit) {
+        private int getMaximumForPayloadPersistence(int limit) {
+            if (getRandomOrderCheckbox().isSelected()) {
+                return limit;
+            }
             if (limit == 0) {
                 return MAX_NUMBER_PAYLOADS_PERSISTENCE;
             }

--- a/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -271,6 +271,8 @@ fuzz.payloads.generator.regex.warnInvalidRegex.message = The syntax of the speci
 fuzz.payloads.generator.regex.warnInvalidRegex.title = Invalid Regular Expression
 fuzz.payloads.generator.regex.warnInvalidRegexTimeCost.message = The specified regular expression can not be used, it takes too much time to be processed.
 fuzz.payloads.generator.regex.warnInvalidRegexTimeCost.title = Invalid Regular Expression
+fuzz.payloads.generator.regex.warnNoRandomPayloads.message = The selected maximum does not allow for generation of any random payloads.
+fuzz.payloads.generator.regex.warnNoRandomPayloads.title = No Random Payloads
 fuzz.payloads.generator.regex.warnMaxNumberOfPayloads.message = The specified regular expression generates a large number of payloads (>= 10M).\nIt will be used a fixed maximum for calculation of the progress.
 fuzz.payloads.generator.regex.warnMaxNumberOfPayloads.title = Large Number of Payloads
 fuzz.payloads.generator.regex.warnNoRegex.message = No regular expression specified, a regular expression must be specified first.


### PR DESCRIPTION
Change RegexPayloadGenerator to take into account the random state when
calculating the number of payloads that are generated (with random it
generates into the limit specified).
Change RegexPayloadGeneratorUIHandler to prevent setting the max/limit
to 0 when random, as that prevents the generation of any payload. Also,
take into account the random state when calculating the maximum number
of payloads that should be persisted and when previewing the payloads.