### PR TITLE
websocket: don't wait forever for persisted msg

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -617,12 +617,15 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 			
 			// wait until HistoryReference is saved to database
 			if (! wsProxy.isServerMode()) {
-				while (handshakeMessage.getHistoryRef() == null) {
+				// TODO Remove the wait once targeting the newer core version that saves the message synchronously.
+				int count = 0;
+				while (handshakeMessage.getHistoryRef() == null && count < 10) {
 					try {
-						Thread.sleep(5);
+						Thread.sleep(100);
 					} catch (InterruptedException e) {
 						logger.warn(e.getMessage(), e);
 					}
+					count++;
 				}
 			}
 			wsProxy.setHandshakeReference(handshakeMessage.getHistoryRef());


### PR DESCRIPTION
Change ExtensionWebSocket to not wait forever for the persisted hanshake
message, if the message is not persisted the proxy thread would hang
forever. It will now wait at most 1 second, which should be enough time
(if not it simply doesn't show the handshake message). Also, core is now
persisting the message synchronously (zaproxy/zaproxy#4586) which makes
the wait obsolete.