### PR TITLE
zest: update Content-Length of proxied responses

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
+	Update Content-Length of proxied responses (Issue 4613).<br>
 	Added input for Variable Name in Client Element Assign dialog.<br>
 	Allow to clear the Zest panel.<br>
 	Allow to access the options through Zest panel.<br>

--- a/src/org/zaproxy/zap/extension/zest/ZestProxyRunner.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestProxyRunner.java
@@ -124,6 +124,7 @@ public class ZestProxyRunner extends ZestZapRunner implements ProxyScript {
 			if (msg.getResponseHeader().isText()) {
 				// Dont currently support changing binary response body
 				msg.setResponseBody(this.getVariable(ZestVariables.RESPONSE_BODY));
+				msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
 			}
 
 		} catch (Exception e) {


### PR DESCRIPTION
Change ZestProxyRunner to update the Content-Length of the response.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#4613 - Zest "Replace in response-body" doesn't
update the Content-Length header