### PR TITLE
Bump min ZAP version to 2.5.0

### DIFF
--- a/src/org/zaproxy/zap/extension/directorylistv1/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv1/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Directory List v1.0</name>
-	<version>3</version>
+	<version>4</version>
 	<status>release</status>
 	<description>List of directory names to be used with "Forced Browse" add-on.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://owasp.org/index.php/DirBuster</url>
 	<changes>
 	<![CDATA[
-	Removed repeated files.<br>
-	Added strings for version control directories of Git, Mercurial, SVN, CVS, Bazaar.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions/>
@@ -18,6 +17,6 @@
 	<files>
 		<file>fuzzers/dirbuster/directory-list-1.0.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/directorylistv2_3/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv2_3/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Directory List v2.3</name>
-	<version>3</version>
+	<version>4</version>
 	<status>release</status>
 	<description>Lists of directory names to be used with "Forced Browse" add-on.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://owasp.org/index.php/DirBuster</url>
 	<changes>
 	<![CDATA[
-	Removed repeated files.<br>
-	Added strings for version control directories of Git, Mercurial, SVN, Bazaar.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]></changes>
 	<extensions/>
 	<ascanrules/>
@@ -19,6 +18,6 @@
 		<file>fuzzers/dirbuster/directory-list-2.3-medium.txt</file>
 		<file>fuzzers/dirbuster/directory-list-2.3-big.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/directorylistv2_3_lc/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv2_3_lc/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Directory List v2.3 LC</name>
-	<version>3</version>
+	<version>4</version>
 	<status>release</status>
 	<description>Lists of lower case directory names to be used with "Forced Browse" add-on.</description>
 	<author>ZAP Dev Team</author>
 	<url>https://owasp.org/index.php/DirBuster</url>
 	<changes>
 	<![CDATA[
-	Added strings for version control directories of Git, Mercurial, SVN, Bazaar.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]></changes>
 	<extensions/>
 	<ascanrules/>
@@ -18,6 +18,6 @@
 		<file>fuzzers/dirbuster/directory-list-lowercase-2.3-medium.txt</file>
 		<file>fuzzers/dirbuster/directory-list-lowercase-2.3-big.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/fuzzdb/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzzdb/ZapAddOn.xml
@@ -1,11 +1,11 @@
 <zapaddon>
 	<name>FuzzDB files</name>
-	<version>4</version>
+	<version>5</version>
 	<status>release</status>
 	<description>FuzzDB files which can be used with the ZAP fuzzer</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/fuzzdb-project/fuzzdb/</url>
-	<changes>Update FuzzDB files.</changes>
+	<changes>Update minimum ZAP version to 2.5.0.</changes>
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
@@ -361,6 +361,6 @@
 		<file>fuzzers/fuzzdb/wordlists-user-passwd/unix-os/unix_passwords.txt</file>
 		<file>fuzzers/fuzzdb/wordlists-user-passwd/unix-os/unix_users.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>


### PR DESCRIPTION
Bump min ZAP version to 2.5.0 for add-ons targeting an older version.
Version 2.5.0 is the older version available in Maven Central and the
older one that the add-ons can use.
Bump version and update changes in ZapAddOn.xml files.