### PR TITLE
Bump min ZAP version to 2.5.0 (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/alertReport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertReport/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Report alert generator</name>
-	<version>14</version>
+	<version>15</version>
 	<status>beta</status>
 	<description>Allows you to generate reports for alerts you specify in pdf or odt format</description>
 	<author>Talsoft SRL</author>
 	<url>http://www.talsoft.com.ar</url>
 	<changes>
 	<![CDATA[
-	Fix an exception while generating the report (Issue 1612).<br>
-	Include Alert's evidence in report of ODT format.
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -18,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/beanshell/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/beanshell/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>BeanShell Console</name>
-	<version>6</version>
+	<version>7</version>
 	<status>beta</status>
 	<description>Provides a BeanShell Console</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Minor code changes.</changes>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.beanshell.ExtensionBeanShell</extension>
 	</extensions>
@@ -15,6 +19,6 @@
 	<files>
 		<file>scripts/example.tree.bsh</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>Port Scanner</name>
-	<version>8</version>
+	<version>9</version>
 	<status>beta</status>
 	<description>Allows to port scan a target server</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Code changes for Java 9 (Issue 2602).<br>
-	Issue 3513: Options panel UI fixes.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -18,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
@@ -1,12 +1,12 @@
 <zapaddon>
 	<name>Advanced SQLInjection Scanner</name>
-	<version>12</version>
+	<version>13</version>
 	<status>beta</status>
 	<description>An advanced active injection bundle for SQLi (derived by SQLMap)</description>
 	<author>Andrea Pompili (Yhawke)</author>
 	<url/>
 	<changes><![CDATA[
-	Minor code changes.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]></changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.sqliplugin.ExtensionSQLiPlugin</extension>
@@ -17,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.1</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/svndigger/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/svndigger/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>SVN Digger files</name>
-	<version>3</version>
+	<version>4</version>
 	<status>beta</status>
 	<description>SVN Digger files which can be used with ZAP forced browsing</description>
 	<author>ZAP Dev Team</author>
 	<url>http://www.mavitunasecurity.com/blog/svn-digger-better-lists-for-forced-browsing/</url>
-	<changes>Updated for ZAP 2.4</changes>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
@@ -70,6 +74,6 @@
 		<file>dirbuster/svndigger-context-setup.txt</file>
 		<file>dirbuster/svndigger-context-test.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>TreeTools</name>
-	<version>7</version>
+	<version>8</version>
 	<status>beta</status>
 	<description>Tools to add functionality to the tree view.</description>
 	<author>Carl Sampson</author>
 	<url/>
-	<changes>Code changes for Java 9 (Issue 2602)</changes>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.treetools.ExtensionTreeTools</extension>
 	</extensions>
@@ -13,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Update ChromeDriver to 2.36<br>
 	Update geckodriver to v0.20.1<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions/>
@@ -20,6 +21,6 @@
 		<file>webdriver/linux/64/chromedriver</file>
 		<file>webdriver/linux/64/geckodriver</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Update ChromeDriver to 2.36<br>
 	Update geckodriver to v0.20.1<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions/>
@@ -19,6 +20,6 @@
 		<file>webdriver/macos/64/chromedriver</file>
 		<file>webdriver/macos/64/geckodriver</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Update ChromeDriver to 2.36<br>
 	Update geckodriver to v0.20.1<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions/>
@@ -22,6 +23,6 @@
 		<file>webdriver/windows/64/geckodriver.exe</file>
 		<file>webdriver/windows/64/IEDriverServer.exe</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>


### PR DESCRIPTION
Bump min ZAP version to 2.5.0 for add-ons targeting an older version.
Version 2.5.0 is the older version available in Maven Central and the
older one that the add-ons can use.
Bump version (where needed) and update changes in ZapAddOn.xml files.