### PR TITLE
Bump min ZAP version to 2.5.0 (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>
 	<changes>
 	<![CDATA[
-	Maintenance changes.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -39,6 +39,6 @@
 	<files>
 		<file>xml/example-ascan-file.txt</file>
 	</files>
-	<not-before-version>2.4.1</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/birtreports/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/birtreports/ZapAddOn.xml
@@ -13,6 +13,6 @@
     <ascanrules/>
     <pscanrules/>
     <files/>
-    <not-before-version>2.4.0</not-before-version>
+    <not-before-version>2.5.0</not-before-version>
     <not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/browserView/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/browserView/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>Browser View</name>
-	<version>5</version>
+	<version>6</version>
 	<status>alpha</status>
 	<description>Adds an option to render HTML responses like a browser</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Allow to properly scroll the rendered page.</changes>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.browserView.ExtensionHttpPanelBrowserView</extension>
 	</extensions>
@@ -13,7 +17,7 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>
 

--- a/src/org/zaproxy/zap/extension/callgraph/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/callgraph/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Call Graph</name>
-	<version>4</version>
+	<version>5</version>
 	<status>alpha</status>
 	<description>Allows the user to view a call graph of the selected resources</description>
 	<author>Colm O'Flaherty</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Finish internationalisation.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -17,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>WAFP Extension</name>
-	<version>2</version>
+	<version>3</version>
 	<status>alpha</status>
 	<description>Fingerprint web applications</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy</url>
-	<changes>Minor code changes.</changes>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.cmss.CMSSTopMenu</extension>
 	</extensions>
@@ -14,6 +18,6 @@
 	</pscanrules>
 	<filters></filters>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -17,6 +18,6 @@
 	<filters/>
 	<files>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
@@ -7,7 +7,7 @@
         <url></url>
         <changes>
         <![CDATA[
-        Maintenance changes.<br>
+        Update minimum ZAP version to 2.5.0.<br>
         ]]>
         </changes>
         <dependson/>
@@ -23,6 +23,6 @@
                 <file>xml/report.separated.html.xsl</file>
                 <file>xml/report.traditional.html.xsl</file>
         </files>
-        <not-before-version>2.4.0</not-before-version>
+        <not-before-version>2.5.0</not-before-version>
         <not-from-version></not-from-version>
 </zapaddon> 

--- a/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
@@ -5,7 +5,12 @@
 	<description>Allows you to highlight strings in the request and response tabs.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes>Fix help related exception in the Highlighter panel.</changes>
+	<changes>
+	<![CDATA[
+	Fix help related exception in the Highlighter panel.<br>
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.highlighter.ExtensionHighlighter</extension>
 	</extensions>
@@ -13,6 +18,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
     <name>SAML Extension</name>
-    <version>7</version>
+    <version>8</version>
     <status>alpha</status>
     <description>Detect, Show, Edit, Fuzz SAML requests</description>
     <author>ZAP Dev Team</author>
     <url>https://github.com/zaproxy/zaproxy</url>
 	<changes>
 	<![CDATA[
-	Minor code change to work with ZAP 2.5.0.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
     <dependson/>
@@ -19,6 +19,6 @@
     </pscanrules>
     <filters/>
     <files/>
-    <not-before-version>2.4.0</not-before-version>
+    <not-before-version>2.5.0</not-before-version>
     <not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
@@ -19,6 +19,6 @@
 	<files>
 		<file>example/ExampleFile.txt</file>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>Server-Sent Events</name>
-	<version>9</version>
+	<version>10</version>
 	<status>alpha</status>
 	<description>Allows you to view Server-Sent Events (SSE) communication.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
-	<changes></changes>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.sse.ExtensionServerSentEvents</extension>
 	</extensions>
@@ -13,6 +17,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
@@ -1,12 +1,12 @@
 <zapaddon>
 	<name>TLS Debug</name>
-	<version>2</version>
+	<version>3</version>
 	<description>Provides a tab which allows to quickly debug a TLS/SSL connection</description>
 	<author>P.M.J. Roth</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Code changes for Java 9 (Issue 2602).<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -16,6 +16,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url/>							
 	<changes>
 	<![CDATA[
-	Maintenance changes.<br>
+	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -17,6 +17,6 @@
 	<pscanrules/>				
 	<filters/>						
 	<files/>						
-	<not-before-version>2.4.0</not-before-version>		
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>			
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
@@ -1,10 +1,15 @@
 <zapaddon>
 	<name>VulnCheck Extension</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>list vulnerabilities from known databases </description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zaproxy</url>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.5.0.<br>
+	]]>
+	</changes>
 	<dependson></dependson>
 	<extensions>
 		<extension>org.zaproxy.zap.extension.vulncheck.VulnCheckTopMenu</extension>
@@ -14,6 +19,6 @@
 	</pscanrules>
 	<filters></filters>
 	<files/>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
@@ -14,6 +14,6 @@
 	<filters/>
 	<files>
 	</files>
-	<not-before-version>2.4.0</not-before-version>
+	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
Bump min ZAP version to 2.5.0 for add-ons targeting an older version.
Version 2.5.0 is the older version available in Maven Central and the
older one that the add-ons can use.
Bump version (where needed) and update changes in ZapAddOn.xml files.