### PR TITLE
alertFilters: address compiler warning

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
@@ -161,7 +161,7 @@ public class AlertFilterAPI extends ApiImplementor {
 		fields.put(PARAM_URL_IS_REGEX, Boolean.toString(af.isRegex()));
 		fields.put(PARAM_PARAMETER, af.getParameter());
 		fields.put(PARAM_ENABLED, Boolean.toString(af.isEnabled()));
-		ApiResponseSet response = new ApiResponseSet("alertFilter", fields);
+		ApiResponseSet<String> response = new ApiResponseSet<>("alertFilter", fields);
 		return response;
 	}
 }

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Context Alert Filters</name>
-	<version>7</version>
+	<version>8</version>
 	<status>beta</status>
 	<description>Allows you to automate the changing of alert risk levels.</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Fix an exception when running ZAP in daemon mode (Issue 4405).<br>
+	Maintenance changes.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Add missing type arguments to ApiResponseSet in AlertFilterAPI.
Bump version and update changes in ZapAddOn.xml file.