### PR TITLE
alertReport: address deprecations

### DIFF
--- a/src/org/zaproxy/zap/extension/alertReport/AlertReportExportMenuItem.java
+++ b/src/org/zaproxy/zap/extension/alertReport/AlertReportExportMenuItem.java
@@ -73,7 +73,7 @@ public class AlertReportExportMenuItem extends ExtensionPopupMenuItem {
 					alerts.add(extension.getAlertsSelected(alertAllAlerts));
 					for (int j = 0; j < allAlerts.size(); j++) {
 						Alert alertToCompare= allAlerts.get(j);
-						if (alertAllAlerts.getAlert().equals(alertToCompare.getAlert())){
+						if (alertAllAlerts.getName().equals(alertToCompare.getName())){
 							allAlerts.remove(j);
 							j = 0;
 						}

--- a/src/org/zaproxy/zap/extension/alertReport/AlertReportExportODT.java
+++ b/src/org/zaproxy/zap/extension/alertReport/AlertReportExportODT.java
@@ -279,7 +279,7 @@ public class AlertReportExportODT {
 		Border border = new Border(Color.BLACK, 0,
 				StyleTypeDefinitions.SupportedLinearMeasure.PT);
 		cell.setBorders(CellBordersType.NONE, border);
-		cell.setStringValue(alert.getAlert());
+		cell.setStringValue(alert.getName());
 		cell.setFont(fontTitleBold);
 		String color = Color.toSixDigitHexRGB("#87cefa");
 		cell.setCellBackgroundColor(Color.valueOf(color));

--- a/src/org/zaproxy/zap/extension/alertReport/AlertReportExportPDF.java
+++ b/src/org/zaproxy/zap/extension/alertReport/AlertReportExportPDF.java
@@ -495,7 +495,7 @@ public class AlertReportExportPDF {
         //Point2D.Float textInsertionPoint = new Point2D.Float(page.findMediaBox().getLowerLeftX() + marginPoints, page.findMediaBox().getUpperRightY() - marginPoints);
         Point2D.Float textInsertionPoint = getPageInitialInsertionPoint ();
                 
-        textInsertionPoint = addText (alertCategoryLabelFormatting, alert.getAlert(), textInsertionPoint);
+        textInsertionPoint = addText (alertCategoryLabelFormatting, alert.getName(), textInsertionPoint);
         
         textInsertionPoint = addText (alertLabelFormatting, labelDescription, textInsertionPoint);
         textInsertionPoint = addText (alertTextFormatting, getFieldAlertProperty(alert.getPluginId(),"description", alert.getDescription(), extensionExport),textInsertionPoint);

--- a/src/org/zaproxy/zap/extension/alertReport/ExtensionAlertReportExport.java
+++ b/src/org/zaproxy/zap/extension/alertReport/ExtensionAlertReportExport.java
@@ -244,7 +244,7 @@ public class ExtensionAlertReportExport extends ExtensionAdaptor  {
 		List<Alert> alerts = new ArrayList<>();
 		for (int i = 0; i < alertsDB.size(); i++) {
 			Alert alert = alertsDB.get(i);
-			if (alertSelected.getAlert().equals(alert.getAlert()))
+			if (alertSelected.getName().equals(alert.getName()))
 				alerts.add(alert);
 		}
 		


### PR DESCRIPTION
Use Alert.getName() (instead of getAlert()) to obtain the name of the
alert.