### PR TITLE
Remove redundant/unnecessary casts

### DIFF
--- a/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
@@ -662,7 +662,7 @@ public class BruteForcePanel extends AbstractPanel implements BruteForceListenne
 	protected ScanTarget createScanTarget(SiteNode node) {
 		if (node != null) {
 			while (node.getParent() != null && node.getParent().getParent() != null) {
-				node = (SiteNode) node.getParent();
+				node = node.getParent();
 			}
 
 			HistoryReference hRef = node.getHistoryReference();

--- a/src/org/zaproxy/zap/extension/bruteforce/PopupMenuBruteForceSite.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/PopupMenuBruteForceSite.java
@@ -59,7 +59,7 @@ public class PopupMenuBruteForceSite extends PopupMenuItemSiteNodeContainer {
 	public void performAction(SiteNode node) {
 		// Loop up to get the top parent
 		while (node.getParent() != null && node.getParent().getParent() != null) {
-			node = (SiteNode) node.getParent();
+			node = node.getParent();
 		}
 		extension.bruteForceSite(node);
 	}

--- a/src/org/zaproxy/zap/extension/portscan/PopupMenuPortScan.java
+++ b/src/org/zaproxy/zap/extension/portscan/PopupMenuPortScan.java
@@ -62,7 +62,7 @@ public class PopupMenuPortScan extends PopupMenuItemSiteNodeContainer {
 	public void performAction(SiteNode node) {
 		// Loop up to get the top parent
 		while (node.getParent() != null && node.getParent().getParent() != null) {
-			node = (SiteNode) node.getParent();
+			node = node.getParent();
 		}
 		extension.portScanSite(node);
 	}

--- a/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/src/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -978,7 +978,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener,
 	}
 
 	public void delete(ScriptNode node) {
-		ScriptNode parent = (ScriptNode) node.getParent();
+		ScriptNode parent = node.getParent();
 		this.getZestTreeModel().delete(node);
 		this.updated(parent);
 		this.display(parent, true);

--- a/src/org/zaproxy/zap/extension/zest/ZestTreeModel.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestTreeModel.java
@@ -237,7 +237,7 @@ public class ZestTreeModel {
 			if (ZestZapUtils.getShadowLevel(node) == 0) {
 				// Remove else node
 				parent.remove((ScriptNode) parent
-						.getChildAfter((ScriptNode) parent.getChildAfter(node)));
+						.getChildAfter(parent.getChildAfter(node)));
 				// Remove then node
 				parent.remove((ScriptNode) parent.getChildAfter(node));
 			}
@@ -270,7 +270,7 @@ public class ZestTreeModel {
 			}
 		} else if (parentZe instanceof ZestLoop<?>) {
 			ZestLoop<?> zl = (ZestLoop<?>) parentZe;
-			zl.getStatements().remove((ZestStatement) childZe);
+			zl.getStatements().remove(childZe);
 		} else if (parentZe instanceof ZestStructuredExpression) {
 			ZestStructuredExpression zse = (ZestStructuredExpression) parentZe;
 			zse.removeChildCondition((ZestExpressionElement) childZe);
@@ -304,7 +304,7 @@ public class ZestTreeModel {
 		if (node.getUserObject() instanceof ZestScriptWrapper) {
 			return (ZestScriptWrapper) node.getUserObject();
 		}
-		return this.getScriptWrapper((ScriptNode) node.getParent());
+		return this.getScriptWrapper(node.getParent());
 	}
 
 	public ScriptNode getScriptWrapperNode(ScriptNode node) {
@@ -314,7 +314,7 @@ public class ZestTreeModel {
 		if (node.getUserObject() instanceof ZestScriptWrapper) {
 			return node;
 		}
-		return this.getScriptWrapperNode((ScriptNode) node.getParent());
+		return this.getScriptWrapperNode(node.getParent());
 	}
 
 	public void update(ScriptNode node) {

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestCommentDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestCommentDialog.java
@@ -66,8 +66,7 @@ public class ZestCommentDialog extends StandardFieldsDialog implements ZestDialo
 			this.setTitle(Constant.messages.getString("zest.dialog.comment.edit.title"));
 		}
 
-		ZestComment za = (ZestComment) comment;
-		this.addMultilineField(FIELD_COMMENT, za.getComment());
+		this.addMultilineField(FIELD_COMMENT, comment.getComment());
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
@@ -170,7 +170,7 @@ public class ZestDialogManager extends AbstractPanel {
 							} else if (obj instanceof ZestExpression) {LinkedList<ScriptNode> nodes=new LinkedList<>();
 								nodes.add(sn);
 								showZestExpressionDialog(parent, nodes, null,
-										(ZestExpression) ((ZestExpression) obj), false, false, false);
+										(ZestExpression) obj, false, false, false);
 							} else if (obj instanceof ZestComment) {
 								showZestCommentDialog(parent, sn, null,
 										(ZestComment) obj, false);

--- a/src/org/zaproxy/zap/extension/zest/menu/ZestPopupNodePaste.java
+++ b/src/org/zaproxy/zap/extension/zest/menu/ZestPopupNodePaste.java
@@ -95,7 +95,7 @@ public class ZestPopupNodePaste extends ExtensionPopupMenuItem {
                 		// Start by just supporting one at a time..
                 		return false;
                 	}
-                    ScriptNode node = (ScriptNode) extension.getSelectedZestNode();
+                    ScriptNode node = extension.getSelectedZestNode();
                     ZestElement elmt = ZestZapUtils.getElement(node);
             		this.setEnabled(false);
             		


### PR DESCRIPTION
Remove redundant/unnecessary casts in bruteforce, portscan, and zest
classes.