### PR TITLE
tokengen: bump minimum ZAP version to 2.6.0

### DIFF
--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Inform of running test (e.g. on session change, add-on uninstall).<br>
 	Allow to configure the number of threads.<br>
 	Allow to delay the requests.<br>
+	Update minimum ZAP version to 2.6.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -21,6 +22,6 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.5.0</not-before-version>
+	<not-before-version>2.6.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>


### PR DESCRIPTION
The add-on is already using newer features from 2.6.0.