### PR TITLE
jsonview: bump minimum ZAP version to 2.7.0

### DIFF
--- a/src/org/zaproxy/zap/extension/jsonview/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jsonview/ZapAddOn.xml
@@ -1,11 +1,15 @@
 <zapaddon>
 	<name>Json view</name>
-	<version>1</version>
+	<version>2</version>
 	<status>alpha</status>
 	<description>Adds a view that shows JSON messages nicely formatted</description>
 	<author>Juha Kivekäs</author>
 	<url></url>
-	<changes>Initial release</changes>
+	<changes>
+	<![CDATA[
+	Update minimum ZAP version to 2.7.0.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.jsonview.ExtensionHttpPanelJsonView</extension>
 	</extensions>
@@ -13,7 +17,7 @@
 	<pscanrules/>
 	<filters/>
 	<files/>
-	<not-before-version>2.6.0</not-before-version>
+	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>
 


### PR DESCRIPTION
The add-on is already using newer features from 2.7.0.
Bump version and update changes in ZapAddOn.xml file.