### PR TITLE
ascanrulesBeta: correct timeout in heartbleed

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
@@ -498,12 +498,16 @@ public class HeartBleedActiveScanner extends AbstractHostPlugin {
 		switch (this.getAttackStrength()) {
 		case LOW:
 			this.timeoutMs=1000;  //1 second
+			break;
 		case MEDIUM:
 			this.timeoutMs=3000; //3 seconds
+			break;
 		case HIGH:
 			this.timeoutMs=6000;  //6 seconds
+			break;
 		case INSANE:
 			this.timeoutMs=12000;  //12 seconds
+			break;
 		case DEFAULT:
 			this.timeoutMs=5000;  //5 seconds
 		}

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Maintenance changes.<br>
 	Issue 1142: Logic and alert risk ratings modified.<br>
+	Correct timeout per attack strength in Heartbleed OpenSSL Vulnerability scanner.<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Correct timeout per attack strength in heartbleed scanner, by not
falling-through into the following cases.
Update changes in ZapAddOn.xml file.