### PR TITLE
Correct loading of test resources

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry excluding="org/zaproxy/zap/extension/*/files/" kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" path="test/resources"/>
+	<classpathentry excluding="resources/" kind="src" path="test"/>
 	<classpathentry kind="lib" path="lib/commons-collections-3.2.2.jar"/>
 	<classpathentry kind="lib" path="lib/commons-configuration-1.9.jar"/>
 	<classpathentry kind="lib" path="lib/commons-httpclient-3.1.jar"/>

--- a/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
@@ -23,9 +23,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.ServerSocket;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -87,8 +89,6 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
      * {@link org.parosproxy.paros.core.scanner.Plugin.AttackStrength#HIGH AttackStrength.HIGH}, per parameter being scanned.
      */
     protected static final int NUMBER_MSGS_ATTACK_STRENGTH_HIGH = 24;
-
-    private static final String BASE_RESOURCE_DIR = "/org/zaproxy/zap/extension/ascanrules/";
 
     @ClassRule
     public static TemporaryFolder zapDir = new TemporaryFolder();
@@ -277,7 +277,7 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
     }
 
     public String getHtml(String name, Map<String, String> params) {
-        File file = new File(getClass().getResource(BASE_RESOURCE_DIR + this.getClass().getSimpleName() + "/" + name).getPath());
+        File file = getResourceFile(name);
         try {
             String html = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
             if (params != null) {
@@ -289,6 +289,15 @@ public abstract class ActiveScannerTest<T extends AbstractPlugin> extends Scanne
             return html;
         } catch (IOException e) {
             System.err.println("Failed to read file " + file.getAbsolutePath());
+            throw new RuntimeException(e);
+        }
+    }
+
+    private File getResourceFile(String name) {
+        try {
+            String resourcePath = getClass().getSimpleName() + "/" + name;
+            return Paths.get(getClass().getResource(resourcePath).toURI()).toFile();
+        } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Correct the path of the test resources to be properly loaded on Windows
and to not require the hardcoded path (just rely on the class package).
Correct Eclipse classpath to find/load the test resources.