### PR TITLE
Tweak accessibility of test server handler

### DIFF
--- a/test/org/zaproxy/zap/extension/ascanrules/HTTPDTestServer.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/HTTPDTestServer.java
@@ -31,7 +31,7 @@ public class HTTPDTestServer extends NanoHTTPD {
     
     private NanoServerHandler handler404 = new NanoServerHandler(""){
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             return new Response(
                     Response.Status.NOT_FOUND, MIME_HTML, 
                     "<html><head><title>404</title></head><body>404 Not Found</body></html>");

--- a/test/org/zaproxy/zap/extension/ascanrules/NanoServerHandler.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/NanoServerHandler.java
@@ -39,7 +39,7 @@ public abstract class NanoServerHandler {
         return name;
     }
     
-    abstract Response serve(IHTTPSession session);
+    protected abstract Response serve(IHTTPSession session);
 
     /**
      * Consumes the request body.

--- a/test/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest.java
@@ -56,7 +56,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -89,7 +89,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -122,7 +122,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -155,7 +155,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -191,7 +191,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -224,7 +224,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -257,7 +257,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -290,7 +290,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -323,7 +323,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -356,7 +356,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -392,7 +392,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -425,7 +425,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String color = session.getParms().get("color");
                 String response;
                 if (color != null) {
@@ -461,7 +461,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String color = session.getParms().get("color");
                 String response;
                 if (color != null) {
@@ -495,7 +495,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String color = session.getParms().get("color");
                 String response;
                 if (color != null) {
@@ -530,7 +530,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -565,7 +565,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -600,7 +600,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
 
         NanoServerHandler handler = new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String url = session.getUri();
                 if (session.getQueryParameterString() != null) {
                     try {
@@ -643,7 +643,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
 
         NanoServerHandler handler = new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String url = session.getUri();
                 if (session.getQueryParameterString() != null) {
                     try {
@@ -682,7 +682,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
 
         NanoServerHandler handler = new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String url = session.getUri();
                 if (session.getQueryParameterString() != null) {
                     try {
@@ -720,7 +720,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
 
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -752,7 +752,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -789,7 +789,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -830,7 +830,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String name = session.getParms().get("name");
                 String response;
                 if (name != null) {
@@ -865,7 +865,7 @@ public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSi
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
             	String sess = getBody(session);
                 String name = sess.split("=")[1];
                 String response;

--- a/test/org/zaproxy/zap/extension/ascanrules/TestParameterTamperUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestParameterTamperUnitTest.java
@@ -59,7 +59,7 @@ public class TestParameterTamperUnitTest extends ActiveScannerTest<TestParameter
         nano.addHandler(new NanoServerHandler("/") {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "");
             }
         });
@@ -77,7 +77,7 @@ public class TestParameterTamperUnitTest extends ActiveScannerTest<TestParameter
         nano.addHandler(new NanoServerHandler("/") {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "Default Response");
             }
         });
@@ -97,7 +97,7 @@ public class TestParameterTamperUnitTest extends ActiveScannerTest<TestParameter
             private boolean showDefaultResponse = true;
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 if (showDefaultResponse) {
                     showDefaultResponse = false;
                     return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "Default Response");
@@ -218,7 +218,7 @@ public class TestParameterTamperUnitTest extends ActiveScannerTest<TestParameter
         }
 
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             if (count <= totalAttacks) {
                 count++;
                 return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "Default Response");

--- a/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
@@ -185,7 +185,7 @@ public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTravers
         nano.addHandler(new NanoServerHandler(filePath) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, fileContent);
             }
         });
@@ -211,7 +211,7 @@ public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTravers
         protected abstract String getDirs();
 
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             String value = session.getParms().get(param);
             if (attack.equals(value)) {
                 return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, getDirs());
@@ -279,7 +279,7 @@ public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTravers
         }
 
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             String value = session.getParms().get(param);
             if (ArrayUtils.contains(existingFiles, value)) {
                 return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, "File Found");

--- a/test/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
@@ -219,7 +219,7 @@ public class TestSQLInjectionUnitTest extends ActiveScannerTest<TestSQLInjection
         }
 
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             String value = session.getParms().get(param);
             if (isValidValue(value)) {
                 return new Response(Response.Status.OK, NanoHTTPD.MIME_HTML, getContent(value));


### PR DESCRIPTION
Change NanoServerHandler.serve accessibility from package to protected,
to allow classes in other packages to implement it.