### PR TITLE
Tweak accessibility of test server handler (beta)

### DIFF
--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureUnitTest.java
@@ -83,7 +83,7 @@ public class BackupFileDisclosureUnitTest extends ActiveScannerTest<BackupFileDi
         }
 
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             return new Response(
                     Response.Status.FORBIDDEN,
                     "text/html",

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/HTTPDTestServer.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/HTTPDTestServer.java
@@ -31,7 +31,7 @@ public class HTTPDTestServer extends NanoHTTPD {
     
     private NanoServerHandler handler404 = new NanoServerHandler(""){
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             return new Response(
                     Response.Status.NOT_FOUND, MIME_HTML, 
                     "<html><head><title>404</title></head><body>404 Not Found</body></html>");

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/NanoServerHandler.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/NanoServerHandler.java
@@ -39,7 +39,7 @@ public abstract class NanoServerHandler {
         return name;
     }
     
-    abstract Response serve(IHTTPSession session);
+    protected abstract Response serve(IHTTPSession session);
 
     /**
      * Consumes the request body.

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823UnitTest.java
@@ -81,7 +81,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest<Re
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 consumeBody(session);
                 return new Response("Nothing echoed...");
             }
@@ -114,7 +114,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest<Re
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 consumeBody(session);
                 return new Response("Nothing echoed...");
             }
@@ -134,7 +134,7 @@ public class RemoteCodeExecutionCVE20121823UnitTest extends ActiveScannerTest<Re
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 consumeBody(session);
 
                 StringBuilder strBuilder = new StringBuilder("Nothing echoed...\n");

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823UnitTest.java
@@ -139,7 +139,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         nano.addHandler(new NanoServerHandler("shouldScanUrlsWithoutPath") {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 return new Response("No Source Code here!");
             }
         });
@@ -158,7 +158,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 return new Response("No Source Code here!");
             }
         });
@@ -177,7 +177,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 return new Response("No Source Code here!");
             }
         });
@@ -196,7 +196,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String encodedPhpCode = StringEscapeUtils.escapeHtml4(PHP_SOURCE_TAGS);
                 return new Response("<html><body>" + encodedPhpCode + "</body></html>");
             }
@@ -222,7 +222,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String encodedPhpCode = StringEscapeUtils.escapeHtml4(PHP_SOURCE_TAGS);
                 return new Response(
                         Response.Status.INTERNAL_ERROR,
@@ -246,7 +246,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String encodedPhpCode = StringEscapeUtils.escapeHtml4(PHP_SOURCE_ECHO_TAG);
                 return new Response("<html><body>" + encodedPhpCode + "</body></html>");
             }
@@ -272,7 +272,7 @@ public class SourceCodeDisclosureCVE20121823UnitTest extends ActiveScannerTest<S
         nano.addHandler(new NanoServerHandler(test) {
 
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String encodedPhpCode = StringEscapeUtils.escapeHtml4(PHP_SOURCE_ECHO_TAG);
                 return new Response(
                         Response.Status.INTERNAL_ERROR,


### PR DESCRIPTION
Change NanoServerHandler.serve accessibility from package to protected,
to allow classes in other packages to implement it.