### PR TITLE
Tweak accessibility of test server handler (alpha)

### DIFF
--- a/test/org/zaproxy/zap/extension/openapi/HTTPDTestServer.java
+++ b/test/org/zaproxy/zap/extension/openapi/HTTPDTestServer.java
@@ -31,7 +31,7 @@ public class HTTPDTestServer extends NanoHTTPD {
     
     private NanoServerHandler handler404 = new NanoServerHandler(""){
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             return new Response(
                     Response.Status.NOT_FOUND, MIME_HTML, 
                     "<html><head><title>404</title></head><body>404 Not Found</body></html>");

--- a/test/org/zaproxy/zap/extension/openapi/NanoServerHandler.java
+++ b/test/org/zaproxy/zap/extension/openapi/NanoServerHandler.java
@@ -39,7 +39,7 @@ public abstract class NanoServerHandler {
         return name;
     }
     
-    abstract Response serve(IHTTPSession session);
+    protected abstract Response serve(IHTTPSession session);
 
     /**
      * Consumes the request body.

--- a/test/org/zaproxy/zap/extension/openapi/OpenApiPre2dot0UnitTest.java
+++ b/test/org/zaproxy/zap/extension/openapi/OpenApiPre2dot0UnitTest.java
@@ -45,7 +45,7 @@ public class OpenApiPre2dot0UnitTest extends ServerBasedTest {
         
         this.nano.addHandler(new NanoServerHandler(test) {
             @Override
-            Response serve(IHTTPSession session) {
+            protected Response serve(IHTTPSession session) {
                 String response;
                 String uri = session.getUri();
                 if (uri.endsWith("defn.json")) {

--- a/test/org/zaproxy/zap/extension/openapi/OpenApiUnitTest.java
+++ b/test/org/zaproxy/zap/extension/openapi/OpenApiUnitTest.java
@@ -451,7 +451,7 @@ public class OpenApiUnitTest extends ServerBasedTest {
         }
 
         @Override
-        Response serve(IHTTPSession session) {
+        protected Response serve(IHTTPSession session) {
             String response;
             if (session.getUri().endsWith(defnName)) {
                 response = getHtml(defnFileName);


### PR DESCRIPTION
Change NanoServerHandler.serve accessibility from package to protected,
to allow classes in other packages to implement it.