### PR TITLE
diff: address compiler warnings

### DIFF
--- a/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Diff</name>
-	<version>8</version>
+	<version>9</version>
 	<status>beta</status>
 	<description>Displays a dialog showing the differences between 2 requests or responses. It uses diffutils and diff_match_patch</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
+++ b/src/org/zaproxy/zap/extension/diff/ZapDiffRowGenerator.java
@@ -372,7 +372,7 @@ public class ZapDiffRowGenerator {
   */
  public static LinkedList<String> wrapInTag(LinkedList<String> sequence, int startPosition,
          int endPosition, String tag, String cssClass) {
-     LinkedList<String> result = (LinkedList<String>) sequence.clone();
+     LinkedList<String> result = new LinkedList<>(sequence);
      StringBuilder tagBuilder = new StringBuilder();
      tagBuilder.append("<");
      tagBuilder.append(tag);

--- a/src/org/zaproxy/zap/extension/diff/diff_match_patch.java
+++ b/src/org/zaproxy/zap/extension/diff/diff_match_patch.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -2364,6 +2365,11 @@ public class diff_match_patch {
       } catch (ClassCastException e) {
         return false;
       }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operation, text);
     }
   }
 


### PR DESCRIPTION
Use copy constructor instead of clone (which does not require unchecked
cast) in ZapDiffRowGenerator and implement Diff.hashCode.
Bump version and update changes in ZapAddOn.xml file.