### PR TITLE
ils: address compiler warning

### DIFF
--- a/src/com/veggiespam/imagelocationscanner/ILS.java
+++ b/src/com/veggiespam/imagelocationscanner/ILS.java
@@ -14,8 +14,6 @@ import com.drew.imaging.ImageProcessingException;
 import com.drew.metadata.Metadata;
 import com.drew.lang.GeoLocation;
 import com.drew.metadata.exif.GpsDirectory;
-import com.drew.metadata.xmp.XmpDirectory;
-import com.drew.metadata.xmp.XmpDescriptor;
 import com.drew.metadata.iptc.IptcDirectory;
 import com.drew.metadata.iptc.IptcDescriptor;
 import com.drew.metadata.exif.makernotes.PanasonicMakernoteDirectory;
@@ -172,6 +170,7 @@ public class ILS {
 	/** 
 	 * @deprecated Use the HTML / Text calls directly or use boolean construct.
 	 */
+	@Deprecated
 	public static String scanForLocationInImage(byte[] data)   {
 		return scanForLocationInImageHTML(data);
 	}

--- a/src/org/zaproxy/zap/extension/imagelocationscanner/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/imagelocationscanner/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Image Location and Privacy Scanner</name>
-	<version>1</version>
+	<version>2</version>
 	<status>beta</status>
 	<description>Image Location and Privacy Passive Scanner</description>
 	<author>Veggiespam and the ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-		Promoted to beta and separated from the passive scan alpha add-on.<br>
+		Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/imagelocationscanner/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/imagelocationscanner/resources/help/contents/about.html
@@ -17,7 +17,12 @@ Veggiespam and the ZAP Dev Team
 
 <H2>History</H2>
 
-<H3>Version 1</H3>
+<H3>Version 2 - TBD</H3>
+<ul>
+	<li>Maintenance changes.</li>
+</ul>
+
+<H3>Version 1 - 2018-02-27</H3>
 <ul>
 	<li>Image Location and Privacy Scanner separated from Passive Scan Rules Alpha and promoted to Beta.</li>
 </ul>


### PR DESCRIPTION
Add deprecated annotation to deprecated method (JavaDoc tag).
Remove unused imports.
Bump version and updated changes in ZapAddOn.xml file.
Update about.html page.

---
Upstream change veggiespam/ImageLocationScanner#13.
