### PR TITLE
soap: dynamically unload the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/soap/WSDLSpider.java
+++ b/src/org/zaproxy/zap/extension/soap/WSDLSpider.java
@@ -14,15 +14,12 @@ public class WSDLSpider extends SpiderParser{
 	
 	private static final Logger log = Logger.getLogger(WSDLSpider.class);
 	
-	private static boolean isEnabled = false;
-	
 	@Override
 	public boolean parseResource(HttpMessage message, Source source, int depth) {
 		return parseResourceWSDL(message, source, depth, true);
 	}
 	
 	public boolean parseResourceWSDL(HttpMessage message, Source source, int depth, boolean sendRequests) {
-		if (!isEnabled) return false;
 		if (message == null) return false;
 		/* Only applied to wsdl files. */
 		log.info("WSDL custom spider called.");
@@ -82,13 +79,5 @@ public class WSDLSpider extends SpiderParser{
 		String baseURL = getURIfromMessage(message);
 		if(baseURL.endsWith(".wsdl")) return true;
 		else return false;
-	}
-	
-	public static void enable(){
-		isEnabled = true;
-	}
-	
-	public static void disable(){
-		isEnabled = false;
 	}
 }

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Internationalise file filter description.<br>
+	Dynamically unload the add-on.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/soap/WSDLSpiderTestCase.java
+++ b/test/org/zaproxy/zap/extension/soap/WSDLSpiderTestCase.java
@@ -27,7 +27,6 @@ public class WSDLSpiderTestCase {
 	
 	@Test
 	public void parseResourceTest() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-		WSDLSpider.enable();
 		WSDLSpider spider = new WSDLSpider();
 		
 		/* Positive case. */


### PR DESCRIPTION
Change ExtensionImportWSDL to remove the spider parser when unloaded and
declare that it can be unloaded (it was the last change need to
dynamically unload the add-on). Also, remove unnecessary log when adding
the parser, the presence of the spider already indicates if the parser
is added.
Remove code no longer needed in the spider parser and corresponding test
case, as the parser is removed it not longer needs to be enabled and
disabled.
Update changes in ZapAddOn.xml file.