### PR TITLE
soap: fix and tidy up tests

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -109,6 +109,7 @@
 				<exclude name="org/zaproxy/zap/extension/*/resources/help_*/**" />
 				<exclude name="org/zaproxy/zap/extension/*/resources/Messages_*.properties" />
 			</fileset>
+			<fileset dir="${test.src}" includes="org/zaproxy/zap/extension/*/resources/**" />
 		</copy>
 		<echo message="Running tests..." />
 		<junit printsummary="yes" haltonerror="true" failureproperty="TestsFailed">
@@ -128,6 +129,7 @@
 			<batchtest fork="yes" todir="${test.results.dir}">
 				<fileset dir="${test.build}">
 					<include name="**/*UnitTest.class" />
+					<include name="**/*TestCase.class" />
 					<exclude name="**/Abstract*Test.class" />
 				</fileset>
 			</batchtest>

--- a/src/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
@@ -136,7 +136,8 @@ public class SOAPActionSpoofingActiveScanner extends AbstractAppPlugin {
 		}	
 	}
 
-	private int scanResponse(HttpMessage msg, HttpMessage originalMsg){
+	// Relaxed accessibility for testing.
+	int scanResponse(HttpMessage msg, HttpMessage originalMsg){
 		if (msg.getResponseBody() == null) return EMPTY_RESPONSE;
 		String responseContent = new String(msg.getResponseBody().getBytes());
 		responseContent = responseContent.trim();

--- a/src/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/src/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -52,7 +52,7 @@ public class WSDLCustomParser {
 	private static final Logger log = Logger.getLogger(WSDLCustomParser.class);;
 	private static int keyIndex = -1;
 	private ImportWSDL wsdlSingleton = ImportWSDL.getInstance();
-	private static SOAPMsgConfig lastConfig; // Only used for unit testing purposes.
+	private SOAPMsgConfig lastConfig; // Only used for unit testing purposes.
 	
 	public WSDLCustomParser(){
 
@@ -75,12 +75,12 @@ public class WSDLCustomParser {
 	}	
 	
 	/* Method called from external classes to import a WSDL file specifying content. */
-	public void extContentWSDLImport(final String content){
-		parseWSDLContent(content);
+	public boolean extContentWSDLImport(final String content){
+		return parseWSDLContent(content);
 	}
 	
-	public void extContentWSDLImport(final String content, final boolean sendMessages){
-		parseWSDLContent(content, sendMessages);
+	public boolean extContentWSDLImport(final String content, final boolean sendMessages){
+		return parseWSDLContent(content, sendMessages);
 	}
 	
 	/* Method called from external classes to import a WSDL file from an URL. */
@@ -524,7 +524,7 @@ public class WSDLCustomParser {
 		}	
 	}
 	
-	public static SOAPMsgConfig getLastConfig(){
+	SOAPMsgConfig getLastConfig(){
 		return lastConfig;
 	}
 }

--- a/test/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
+++ b/test/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
@@ -1,50 +1,34 @@
 package org.zaproxy.zap.extension.soap;
 
-import static org.junit.Assert.*;
-
-import java.net.URL;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.zaproxy.zap.extension.ScannerTestUtils;
 
-public class ExtensionImportWSDLTestCase {
+public class ExtensionImportWSDLTestCase extends ScannerTestUtils {
 
 	ExtensionImportWSDL extension;
 	
 	@Before
 	public void setUp() {
 		extension = new ExtensionImportWSDL();
+		mockMessages(extension);
 	}
 	
 	@Test
 	public void getAuthorTest(){
-		try{
-			String author = extension.getAuthor();
-			assertNotNull(author);
-		}catch(NullPointerException e){
-			fail("Author could not be retrieved. If this parameter is set externally (e.g. messages.properties file), ignore this result.");
-		}
+		assertNotNull(extension.getAuthor());
 	}
 	
 	@Test
 	public void getDescriptionTest(){
-		try{
-			String description = extension.getDescription();
-			assertNotNull(description);
-		}catch(NullPointerException e){
-			fail("Description could not be retrieved. If this parameter is set externally (e.g. messages.properties file), ignore this result.");
-		}
-		
+		assertNotNull(extension.getDescription());
 	}
 	
 	@Test
 	public void getURLTest(){
-		try{
-			URL url = extension.getURL();
-			assertNotNull(url);
-		}catch(NullPointerException e){
-			fail("URL could not be retrieved. If this parameter is set externally (e.g. messages.properties file), ignore this result.");
-		}
+		assertNotNull(extension.getURL());
 	}
 
 }

--- a/test/org/zaproxy/zap/extension/soap/ImportWSDLTestCase.java
+++ b/test/org/zaproxy/zap/extension/soap/ImportWSDLTestCase.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.parosproxy.paros.network.HttpMessage;
@@ -28,6 +29,7 @@ public class ImportWSDLTestCase {
 	
 	@Before
 	public void setUp() throws URIException, NullPointerException{
+		ImportWSDL.destroy();
 		/* Retrieves singleton instance. */
 		singleton = ImportWSDL.getInstance();
 		
@@ -48,6 +50,11 @@ public class ImportWSDLTestCase {
 		soapConfig.setParams(new HashMap<String,String>());
 		soapConfig.setPort(new Port());
 		soapConfig.setBindOp(new BindingOperation());
+	}
+	
+	@After
+	public void teardown() {
+		ImportWSDL.destroy();
 	}
 	
 	@Test
@@ -75,6 +82,7 @@ public class ImportWSDLTestCase {
 		/* There are no requests in singleton's list. Response should be null. */
 		assertNull(result);
 		
+		singleton.putAction(WSDL_KEY, TEST_OP);
 		/* Test request. */
 		singleton.putRequest(WSDL_KEY, testRequest);
 		result = singleton.getSourceSoapActions(testRequest);

--- a/test/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScannerTestCase.java
+++ b/test/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScannerTestCase.java
@@ -2,15 +2,12 @@ package org.zaproxy.zap.extension.soap;
 
 import static org.junit.Assert.*;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class SOAPActionSpoofingActiveScannerTest {
+public class SOAPActionSpoofingActiveScannerTestCase {
 
 	private HttpMessage originalMsg = new HttpMessage();
 	private HttpMessage modifiedMsg = new HttpMessage();
@@ -29,29 +26,27 @@ public class SOAPActionSpoofingActiveScannerTest {
 
 	
 	@Test
-	public void scanResponseTest() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException, HttpMalformedHeaderException {
+	public void scanResponseTest() throws Exception {
 		SOAPActionSpoofingActiveScanner scanner = new SOAPActionSpoofingActiveScanner();
-		Method method = scanner.getClass().getDeclaredMethod("scanResponse", HttpMessage.class, HttpMessage.class);
-		method.setAccessible(true);
 		
 		/* Positive cases. */	
-		int result = (Integer) method.invoke(scanner, modifiedMsg, originalMsg);
+		int result = scanner.scanResponse(modifiedMsg, originalMsg);
 		assertTrue(result == SOAPActionSpoofingActiveScanner.SOAPACTION_EXECUTED);
 		
 		Sample.setOriginalResponse(modifiedMsg);
-		result = (Integer) method.invoke(scanner, modifiedMsg, originalMsg);
+		result = scanner.scanResponse(modifiedMsg, originalMsg);
 		assertTrue(result == SOAPActionSpoofingActiveScanner.SOAPACTION_IGNORED);
 		
 		/* Negative cases. */
-		result = (Integer) method.invoke(scanner, new HttpMessage(), originalMsg);
+		result = scanner.scanResponse(new HttpMessage(), originalMsg);
 		assertTrue(result == SOAPActionSpoofingActiveScanner.EMPTY_RESPONSE);
 		
 		Sample.setEmptyBodyResponse(modifiedMsg);
-		result = (Integer) method.invoke(scanner, modifiedMsg, originalMsg);
+		result = scanner.scanResponse(modifiedMsg, originalMsg);
 		assertTrue(result == SOAPActionSpoofingActiveScanner.EMPTY_RESPONSE);
 		
 		Sample.setInvalidFormatResponse(modifiedMsg);
-		result = (Integer) method.invoke(scanner, modifiedMsg, originalMsg);
+		result = scanner.scanResponse(modifiedMsg, originalMsg);
 		assertTrue(result == SOAPActionSpoofingActiveScanner.INVALID_FORMAT);
 	}
 

--- a/test/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/test/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -2,70 +2,53 @@ package org.zaproxy.zap.extension.soap;
 
 import static org.junit.Assert.*;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.junit.Before;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 import org.parosproxy.paros.network.HttpMessage;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WSDLCustomParserTestCase {
 
 	private String wsdlContent;
-	private WSDLCustomParser parser = new WSDLCustomParser();
+	private WSDLCustomParser parser;
 	
 	@Before
-	public void setUp() throws NullPointerException, IOException{
+	public void setUp() throws Exception {
 		/* Simple log configuration to prevent Log4j malfunction. */
 		BasicConfigurator.configure(); 
 		Logger rootLogger = Logger.getRootLogger();
 		rootLogger.setLevel(Level.OFF);
 		
 		/* Gets test wsdl file and retrieves its content as String. */
-		InputStream in = getClass().getResourceAsStream("resources/test.wsdl");
-		Reader fr = new InputStreamReader(in, "utf-8");
-		BufferedReader br = new BufferedReader(fr);		
-		StringBuilder sb = new StringBuilder();
-		String line = "";
-		line = br.readLine();	
-		do{		
-			sb.append(line+"\r\n");
-		}while((line = br.readLine()) != null);
-		wsdlContent = sb.toString();		
+		Path wsdlPath = Paths.get(getClass().getResource("resources/test.wsdl").toURI());
+		wsdlContent = new String(Files.readAllBytes(wsdlPath), StandardCharsets.UTF_8);
+
+		parser = new WSDLCustomParser();
 	}
 	
 	@Test
-	public void a_parseWSDLContentTest() {
-		try{
-			/* Positive case. Checks the method's return value. */
-			Method method = parser.getClass().getDeclaredMethod("parseWSDLContent", String.class, boolean.class);
-			method.setAccessible(true);
-			boolean result = (Boolean) method.invoke(parser, wsdlContent, false);
-			assertTrue(result);
-			
-			/* Negative cases. */
-			result = (Boolean) method.invoke(parser, "", false); //Empty content.
-			assertFalse(result);
-			
-			result = (Boolean) method.invoke(parser, "asdf", false); //Non-empty invalid content.
-			assertFalse(result);
-		}catch(Exception e){
-			fail("Could not call parseWSDLContent() method.");
-		}	
+	public void parseWSDLContentTest() {
+		/* Positive case. Checks the method's return value. */
+		boolean result = parser.extContentWSDLImport(wsdlContent, false);
+		assertTrue(result);
+		
+		/* Negative cases. */
+		result = parser.extContentWSDLImport("", false); //Empty content.
+		assertFalse(result);
+		
+		result = parser.extContentWSDLImport("asdf", false); //Non-empty invalid content.
+		assertFalse(result);
 	}	
 	
 	@Test
-	public void b_canBeWSDLparsedTest() {
+	public void canBeWSDLparsedTest() {
 		/* Positive case. */
 		boolean result = parser.canBeWSDLparsed(wsdlContent);
 		assertTrue(result);
@@ -77,13 +60,10 @@ public class WSDLCustomParserTestCase {
 	}
 	
 	@Test
-	public void c_createSoapRequestTest(){
-		if(WSDLCustomParser.getLastConfig() == null){
-			fail ("parseWSDLContentTest has not been able to save a proper configuration object to perform this test.");
-			return;
-		}
+	public void createSoapRequestTest(){
+		parser.extContentWSDLImport(wsdlContent, false);
 		/* Positive case. */
-		HttpMessage result = parser.createSoapRequest(WSDLCustomParser.getLastConfig());
+		HttpMessage result = parser.createSoapRequest(parser.getLastConfig());
 		assertNotNull(result);
 		/* Negative case. */
 		result = parser.createSoapRequest(new SOAPMsgConfig());


### PR DESCRIPTION
Fix failing tests in ImportWSDLTestCase (by not depending on the order
of the tests) and ExtensionImportWSDLTestCase (by loading the resource
messages).
Change WSDLCustomParserTestCase to not use reflection nor depend on the
order of the tests.
Rename SOAPActionSpoofingActiveScannerTest to have the same suffix as
the other tests ("TestCase", to use the same Ant include rule), also,
change it to not use reflection.
Tweak WSDLCustomParser and SOAPActionSpoofingActiveScanner to ease the
tests, by relaxing accessibility of the methods or return proper values.
Change build.xml file to run the soap tests (and copy its resources).