### PR TITLE
scripts: tweak script console tab help page

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/resources/help/contents/console.html
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/contents/console.html
@@ -11,8 +11,8 @@ The Scripts Console allows you to write scripts which run within ZAP.<br/>
 It is made up of:
 <ul>
 <li>A toolbar</li>
-<li>An area in which you can write your scripts</li>
-<li>A area for debug and error messages</li>
+<li>A text area (top) in which you can write your scripts</li>
+<li>An output text area (bottom) for debug and error messages, with "print" statements.</li>
 </ul>
 You can run 'Stand alone' scripts from within this tab using the 'Run' button on the tab toolbar.<br/>
 All other types of scripts will be run when enabled or if explicitly invoked.<br/><br/>


### PR DESCRIPTION
Mention that the output of "print" statements is shown in the (bottom)
text area of the script console tab.