### PR TITLE
scripts: mention new access to script variables

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
@@ -65,6 +65,12 @@ org.zaproxy.zap.extension.script.ScriptVars.getScriptVar(this.context, "var.name
 </code>
 <br/>
 Note that these methods are only usable from scripting languages that provide access to the ScriptContext (like Javascript).
+For other scripting languages (in ZAP versions after 2.7.0) the variables can be accessed/set by manually specifying
+the name of the script:<br/><br/>
+<code>
+org.zaproxy.zap.extension.script.ScriptVars.setScriptVar("ScriptName", "var.name","value")<br/>
+org.zaproxy.zap.extension.script.ScriptVars.getScriptVar("ScriptName", "var.name")<br/>
+</code>
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
Mention in the help how other scripting languages (than the ones that
have access to the ScriptContext) can access/set script variables.

Related to zaproxy/zaproxy#4185 - Expose global and script variables