### PR TITLE
Remove "filters" from add-ons' manifests

### DIFF
--- a/src/org/zaproxy/zap/extension/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ZapAddOn.xml
@@ -26,9 +26,6 @@
 	<pscanrules>				<!-- Optional, to be used if this addon includes passive scan rules -->
 		<pscanrule/>			<!-- Full class name of the passive scan rule - can be multiple of these -->
 	</pscanrules>
-	<filters>					<!-- Optional, to be used if this addon includes filters -->
-		<filter/>				<!-- Full class name of the filter - can be multiple of these -->
-	</filters>
 	<files>						<!-- Optional, to be used if this addon includes raw files -->
 		<file/>					<!-- Relative file name (to this package, and the users directory) - can be multiple of these -->
 	</files>

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -32,7 +32,6 @@
 		<ascanrule>org.zaproxy.zap.extension.ascanrules.TestSQLInjection</ascanrule>
 	</ascanrules>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/coreLang/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/coreLang/ZapAddOn.xml
@@ -16,7 +16,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<!-- Note: the declaration order of the file(s) is important in this add-on, see ExtensionCoreLanguages.postInstall() -->
 		<file>lang/ZAP_2.7.0_language_pack.2.zaplang</file>

--- a/src/org/zaproxy/zap/extension/directorylistv1/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv1/ZapAddOn.xml
@@ -13,7 +13,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>fuzzers/dirbuster/directory-list-1.0.txt</file>
 	</files>

--- a/src/org/zaproxy/zap/extension/directorylistv2_3/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv2_3/ZapAddOn.xml
@@ -12,7 +12,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>fuzzers/dirbuster/directory-list-2.3-small.txt</file>
 		<file>fuzzers/dirbuster/directory-list-2.3-medium.txt</file>

--- a/src/org/zaproxy/zap/extension/directorylistv2_3_lc/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/directorylistv2_3_lc/ZapAddOn.xml
@@ -12,7 +12,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>fuzzers/dirbuster/directory-list-lowercase-2.3-small.txt</file>
 		<file>fuzzers/dirbuster/directory-list-lowercase-2.3-medium.txt</file>

--- a/src/org/zaproxy/zap/extension/fuzzdb/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzzdb/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>fuzzers/fuzzdb/README.md</file>
 		<file>fuzzers/fuzzdb/_copyright.txt</file>

--- a/src/org/zaproxy/zap/extension/gettingStarted/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/gettingStarted/ZapAddOn.xml
@@ -11,7 +11,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>lang/ZAPGettingStartedGuide-2.7-es_ES.pdf</file>
 		<file>lang/ZAPGettingStartedGuide-2.7-fil_PH.pdf</file>

--- a/src/org/zaproxy/zap/extension/groovy/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/groovy/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>scripts/templates/standalone/LoopThroughHistoryTable.groovy</file>
 		<file>scripts/templates/standalone/StandaloneDefaultTemplate.groovy</file>

--- a/src/org/zaproxy/zap/extension/help/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_fil_PH/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_fil_PH/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_id_ID/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_id_ID/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_pt_BR/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_pt_BR/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_tr_TR/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_tr_TR/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_zh_CN/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_zh_CN/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -28,7 +28,6 @@
 		<pscanrule>org.zaproxy.zap.extension.pscanrules.XContentTypeOptionsScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrules.XFrameOptionScanner</pscanrule>
 	</pscanrules>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -42,7 +42,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/reveal/ZapAddOn.xml
@@ -11,7 +11,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/saverawmessage/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saverawmessage/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -17,7 +17,6 @@
 	</extensions>
 	<ascanrules />
 	<pscanrules />
-	<filters />
 	<files />
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -23,7 +23,6 @@
 	</extensions>
 	<ascanrules></ascanrules>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/todo/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/todo/ZapAddOn.xml
@@ -11,7 +11,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.6.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -34,7 +34,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>scripts/templates/websocketfuzzerprocessor/Fuzzer WebSocket Processor default template.js</file>
 		<file>scripts/templates/websocketsender/WebsocketSender Default Template.js</file>


### PR DESCRIPTION
Remove the filters entry from the ZapAddOn.xml files, the filters are no
longer supported.

Related to zaproxy/zaproxy#4191 - Remove filter extension from core
functionality