### PR TITLE
Remove "filters" from add-ons' manifests (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/alertReport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertReport/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -40,7 +40,6 @@
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesBeta.XXEPlugin</ascanrule>
 	</ascanrules>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.6.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/beanshell/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/beanshell/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>scripts/example.tree.bsh</file>
 	</files>

--- a/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
@@ -19,7 +19,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/diff/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/fuzz/ZapAddOn.xml
@@ -17,7 +17,6 @@
         <extension>org.zaproxy.zap.extension.fuzz.ExtensionFuzz</extension>
         <extension>org.zaproxy.zap.extension.fuzz.httpfuzzer.ExtensionHttpFuzzer</extension>
     </extensions>
-    <filters/>
     <files>
         <file>licenses/fuzz/dk.brics.automaton-license.txt</file>
         <file>scripts/templates/httpfuzzerprocessor/Fuzzer HTTP Processor default template.js</file>

--- a/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importurls/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/invoke/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files />
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/jruby/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jruby/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>scripts/templates/active/Active default template.rb</file>
 		<file>scripts/templates/authentication/Authentication default template.rb</file>

--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -16,7 +16,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>scripts/templates/active/Active default template.py</file>
 		<file>scripts/templates/authentication/Authentication default template.py</file>

--- a/src/org/zaproxy/zap/extension/plugnhack/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/plugnhack/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>fuzzers/PlugnHack DOM XSS Oracle</file>
 	</files>

--- a/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -29,7 +29,6 @@
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesBeta.ServletParameterPollutionScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesBeta.ViewstateScanner</pscanrule>
 	</pscanrules>
-	<filters/>
 	<files>
 		<file>xml/debug-error-messages.txt</file>
 		<file>xml/suspicious-comments.txt</file>

--- a/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
@@ -17,7 +17,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -19,7 +19,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>scripts/templates/extender/Add api call.js</file>
 		<file>scripts/templates/extender/Add history record menu.js</file>

--- a/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sqliplugin/ZapAddOn.xml
@@ -15,7 +15,6 @@
 		<ascanrule>org.zaproxy.zap.extension.sqliplugin.SQLInjectionPlugin</ascanrule>
 	</ascanrules>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/svndigger/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/svndigger/ZapAddOn.xml
@@ -13,7 +13,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>dirbuster/svndigger/Licence.txt</file>
 		<file>dirbuster/svndigger/ReadMe.txt</file>

--- a/src/org/zaproxy/zap/extension/tips/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tips/ZapAddOn.xml
@@ -11,7 +11,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tokengen/ZapAddOn.xml
@@ -20,7 +20,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.6.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/treetools/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>webdriver/linux/32/geckodriver</file>
 		<file>webdriver/linux/64/chromedriver</file>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>webdriver/macos/64/chromedriver</file>
 		<file>webdriver/macos/64/geckodriver</file>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>webdriver/windows/32/chromedriver.exe</file>
 		<file>webdriver/windows/32/geckodriver.exe</file>

--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -24,7 +24,6 @@
 	<extensions>
 		<extension>org.zaproxy.zap.extension.zest.ExtensionZest</extension>
 	</extensions>
-	<filters/>
 	<files>
 		<file>scripts/templates/active/Active default template.zst</file>
 		<file>scripts/templates/authentication/Authentication default template.zst</file>


### PR DESCRIPTION
Remove the filters entry from the ZapAddOn.xml files.

Related to zaproxy/zaproxy#4191 - Remove filter extension from core
functionality