### PR TITLE
Remove "filters" from add-ons' manifests (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -18,7 +18,6 @@
 	</extensions>
 	<ascanrules />
 	<pscanrules />
-	<filters />
 	<files>
 		<file>xml/reportAccessControl.html.xsl</file>
 	</files>

--- a/src/org/zaproxy/zap/extension/amf/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/amf/ZapAddOn.xml
@@ -17,7 +17,6 @@
     <ascanrules/>
     <pscanrules>
     </pscanrules>
-    <filters/>
     <files/>
     <not-before-version>2.7.0</not-before-version>
     <not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -35,7 +35,6 @@
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.HtAccessScanner</ascanrule>
 	</ascanrules>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>xml/example-ascan-file.txt</file>
 	</files>

--- a/src/org/zaproxy/zap/extension/authstats/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/authstats/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/browserView/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/browserView/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/bugtracker/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/bugtracker/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/callgraph/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/callgraph/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
@@ -16,7 +16,6 @@
 	<ascanrules/>
 	<pscanrules>
 	</pscanrules>
-	<filters></filters>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/codedx/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 	</files>
 	<not-before-version>2.5.0</not-before-version>

--- a/src/org/zaproxy/zap/extension/communityScripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/communityScripts/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>community-scripts/README.md</file>
 		<file>community-scripts/active/README.md</file>

--- a/src/org/zaproxy/zap/extension/cspscanner/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/cspscanner/ZapAddOn.xml
@@ -16,7 +16,6 @@
 	<pscanrules>
 		<pscanrule>org.zaproxy.zap.extension.cspscanner.ContentSecurityPolicyScanner</pscanrule>
 	</pscanrules>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/customreport/ZapAddOn.xml
@@ -16,7 +16,6 @@
         </extensions>
         <ascanrules/>
         <pscanrules/>
-        <filters/>
         <files>
                 <file>xml/mergeAlertitems.xml.xsl</file>
                 <file>xml/report.concise.html.xsl</file>

--- a/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/domxss/ZapAddOn.xml
@@ -23,7 +23,6 @@
 	</extensions>
 	<ascanrules />
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/exportreport/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/exportreport/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>exportreport/merge.xml.xsl</file>
 		<file>exportreport/report.html.xsl</file>

--- a/src/org/zaproxy/zap/extension/formhandler/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/formhandler/ZapAddOn.xml
@@ -11,7 +11,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 	</files>
 	<not-before-version>2.6.0</not-before-version>

--- a/src/org/zaproxy/zap/extension/help_bs_BA/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_bs_BA/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_es_ES/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_es_ES/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_fr_FR/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_fr_FR/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/help_ja_JP/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/help_ja_JP/ZapAddOn.xml
@@ -9,7 +9,6 @@
 	<extensions/>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
@@ -16,7 +16,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/httpsinfo/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/httpsinfo/ZapAddOn.xml
@@ -16,7 +16,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/imagelocationscanner/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/imagelocationscanner/ZapAddOn.xml
@@ -17,7 +17,6 @@
 	<pscanrules>
 		<pscanrule>org.zaproxy.zap.extension.imagelocationscanner.ImageLocationScanner</pscanrule>
 	</pscanrules>
-	<filters/>
 	<files>
 		<file>licenses/metadata-extractor-license.txt</file>
 		<file>licenses/xmpcore-license.txt</file>

--- a/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ZapAddOn.xml
@@ -17,7 +17,6 @@
 	</extensions>
 	<ascanrules></ascanrules>
 	<pscanrules></pscanrules>
-	<filters></filters>
 	<files></files>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/jsonview/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jsonview/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
@@ -17,7 +17,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/ZapAddOn.xml
@@ -39,7 +39,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/jxbrowsermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowsermacos/ZapAddOn.xml
@@ -36,7 +36,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/ZapAddOn.xml
@@ -36,7 +36,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
@@ -17,7 +17,6 @@
 	</ascanrules>
 	<pscanrules>
 	</pscanrules>
-	<filters/>
 	<files/>
 	<not-before-version>2.6.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -50,7 +50,6 @@
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XPoweredByHeaderInfoLeakScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.XAspNetVersionScanner</pscanrule>
 	</pscanrules>
-	<filters/>
 	<files>
 		<file>xml/example-pscan-file.txt</file>
 		<file>vulnerabilities.db</file>

--- a/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
@@ -11,7 +11,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>		
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/revisit/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -17,7 +17,6 @@
     <ascanrules/>
     <pscanrules>
     </pscanrules>
-    <filters/>
     <files/>
     <not-before-version>2.5.0</not-before-version>
     <not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sequence/ZapAddOn.xml
@@ -22,7 +22,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>scripts/templates/sequence/sequence.zst</file>
 	</files>

--- a/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/simpleExample/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 		<file>example/ExampleFile.txt</file>
 	</files>

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -21,7 +21,6 @@
 	<pscanrules>
 	    <pscanrule>org.zaproxy.zap.extension.soap.WSDLFilePassiveScanner</pscanrule>
 	</pscanrules>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>

--- a/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
@@ -15,7 +15,6 @@
 	</extensions>				
 	<ascanrules/>					
 	<pscanrules/>				
-	<filters/>						
 	<files/>						
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version/>			

--- a/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
@@ -17,7 +17,6 @@
 	<ascanrules/>
 	<pscanrules>
 	</pscanrules>
-	<filters></filters>
 	<files/>
 	<not-before-version>2.5.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wappalyzer/ZapAddOn.xml
@@ -16,7 +16,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files/>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>

--- a/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/wavsepRpt/ZapAddOn.xml
@@ -11,7 +11,6 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<filters/>
 	<files>
 	</files>
 	<not-before-version>2.5.0</not-before-version>


### PR DESCRIPTION
Remove the filters entry from the ZapAddOn.xml files.

Related to zaproxy/zaproxy#4191 - Remove filter extension from core
functionality