### PR TITLE
Issue 178 - Add In Page Banner Info Leak Scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanner.java
@@ -1,0 +1,129 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ * 
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2018 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at 
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0 
+ *   
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License. 
+ */
+
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import net.htmlparser.jericho.Source;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+/**
+ * In Page Banner Information Leak passive scan rule
+ * https://github.com/zaproxy/zaproxy/issues/178
+ * 
+ * @author kingthorin+owaspzap@gmail.com
+ */
+public class InPageBannerInfoLeakScanner extends PluginPassiveScanner {
+
+	private static final Logger LOGGER = Logger.getLogger(InPageBannerInfoLeakScanner.class);
+	private static final int PLUGIN_ID = 10009;
+	private static final String MESSAGE_PREFIX = "pscanalpha.inpagebanner.";
+	
+
+	private PassiveScanThread parent = null;
+
+	@Override
+	public void setParent(PassiveScanThread parent) {
+		this.parent = parent;
+	}
+
+	@Override
+	public void scanHttpRequestSend(HttpMessage msg, int id) {
+		// Only checking the response for this plugin
+	}
+
+	@Override
+	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+		long start = System.currentTimeMillis();
+
+		int statusCode = msg.getResponseHeader().getStatusCode();
+		// If LOW and 200 then check or if isClientError or isServerError check
+		if ((this.getAlertThreshold().equals(AlertThreshold.LOW) && HttpStatusCode.isSuccess(statusCode))
+				|| (HttpStatusCode.isClientError(statusCode) || HttpStatusCode.isServerError(statusCode))) {
+			for (BannerPattern patt : BannerPattern.values()) {
+				Matcher bannerMatcher = patt.getPattern().matcher(msg.getResponseBody().toString());
+				boolean found = bannerMatcher.find();
+				if (found) {
+					raiseAlert(Alert.RISK_LOW, Alert.CONFIDENCE_HIGH, bannerMatcher.group(), msg, id);
+					break;
+				}
+			}
+		}
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("\tScan of record " + id + " took " + (System.currentTimeMillis() - start) + " ms");
+		}
+	}
+
+	@Override
+	public int getPluginId() {
+		return PLUGIN_ID;
+	}
+
+	@Override
+	public String getName() {
+		return Constant.messages.getString(MESSAGE_PREFIX + "name");
+	}
+
+	private void raiseAlert(int risk, int confidence, String evidence, HttpMessage msg, int id) {
+		Alert alert = new Alert(getPluginId(), risk, confidence, // PluginID, Risk, Reliability
+				getName());
+		alert.setDetail(Constant.messages.getString(MESSAGE_PREFIX + "desc"), // Description
+				msg.getRequestHeader().getURI().toString(), // URI
+				"", // Param
+				"", // Attack
+				Constant.messages.getString(MESSAGE_PREFIX + "other"), // Other info
+				Constant.messages.getString(MESSAGE_PREFIX + "soln"), // Solution
+				Constant.messages.getString(MESSAGE_PREFIX + "refs"), // References
+				evidence, // Evidence - Return the in page banner
+				200, // CWE Id: 200 - Information Exposure
+				13, // WASC Id: 13 - Information Leakage
+				msg); // HttpMessage
+		parent.raiseAlert(id, alert);
+	}
+
+	public enum BannerPattern {
+		TOMCAT_PATTERN(Pattern.compile("Tomcat\\/\\d\\.\\d\\.\\d{1,2}", Pattern.CASE_INSENSITIVE)),
+		APACHE_PATTERN(Pattern.compile("Apache\\/\\d\\.\\d\\.\\d{1,2}", Pattern.CASE_INSENSITIVE)),
+		NGINX_PATTERN(Pattern.compile("nginx\\/\\d\\.\\d{1,2}\\.\\d{1,2}", Pattern.CASE_INSENSITIVE)),
+		JETTY_PATTERN(Pattern.compile("Jetty:\\/\\/\\d\\.\\d{1,2}", Pattern.CASE_INSENSITIVE)),
+		SQUID_PATTERN(Pattern.compile("squid\\/\\d\\.\\d{1,2}", Pattern.CASE_INSENSITIVE));
+		
+		private Pattern pattern;
+		
+		private BannerPattern(Pattern pattern) {
+			this.pattern=pattern;
+		}
+		
+		public Pattern getPattern() {
+			return pattern;
+		}
+	}
+
+}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Help documentation improvements and cleanup.<br>
 	Prevent User Controlled HTML Attribute scanner from sometimes raising duplicate alerts.<br>
 	User Controlled HTML Attribute scanner now properly reports the parameter name in alerts.<br>
+	Add In Page Banner Info Leak scanner (Issue 178).<br>
 	]]>
 	</changes>
 	<extensions>
@@ -28,6 +29,7 @@
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.ExampleSimplePassiveScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.HashDisclosureScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.HeartBleedScanner</pscanrule>
+		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.InPageBannerInfoLeakScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.InsecureComponentScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.InsecureFormLoadScanner</pscanrule>
 		<pscanrule>org.zaproxy.zap.extension.pscanrulesAlpha.InsecureFormPostScanner</pscanrule>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -15,6 +15,12 @@ pscanalpha.examplefile.other=This is for information that doesnt fit in any of t
 pscanalpha.examplefile.soln=A general description of how to solve the problem
 pscanalpha.examplefile.refs=http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
 
+pscanalpha.inpagebanner.name=In Page Banner Information Leak
+pscanalpha.inpagebanner.desc=The server returned a version banner string in the response content. Such information leaks may allow attackers to further target specific issues impacting the product and version in use.
+pscanalpha.inpagebanner.other=There is a chance that the highlight in the finding is on a value in the headers, versus the actual matched string in the response body.
+pscanalpha.inpagebanner.soln=Configure the server to prevent such information leaks. For example:\nUnder Tomcat this is done via the "server" directive and implementation of custom error pages.\nUnder Apache this is done via the "ServerSignature" and "ServerTokens" directives.
+pscanalpha.inpagebanner.refs=https://www.owasp.org/index.php/Testing_for_Error_Code_(OTG-ERR-001)
+
 pscanalpha.insecureformload.name=HTTP to HTTPS Insecure Transition in Form Post
 pscanalpha.insecureformload.desc=This check looks for insecure HTTP pages that host HTTPS forms. The issue is that an insecure HTTP page can easily be hijacked through MITM and the secure HTTPS form can be replaced or spoofed.
 pscanalpha.insecureformload.refs=

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -76,6 +76,11 @@ This check looks for insecure HTTP pages that host HTTPS forms. The issue is tha
 <H2>HTTPS to HTTP Insecure Transition in Form Post</H2>
 This check identifies secure HTTPS pages that host insecure HTTP forms. The issue is that a secure page is transitioning to an insecure page when data is uploaded through a form. The user may think they're submitting data to a secure page when in fact they are not.
 
+<H2>In Page Banner Information Leak</H2>
+Analyzes response body content for the presence of web or application server banners (when the responses have error status codes).<br>
+If the Threshold is Low then status 200 - Ok responses are analyzed as well.<br>
+The presence of such banners may facilitate more targeted attacks against known vulnerabilities.
+
 <H2>Insecure Component</H2>
 Passively scans the server response headers and body generator content for product versions, which are then cross-referenced against a list of product versions known to be vulnerable to various CVEs. 
 A list of ranked CVEs and CVSS severity scores is output for each product noted to be vulnerable. 

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScannerUnitTest.java
@@ -1,0 +1,101 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class InPageBannerInfoLeakScannerUnitTest extends PassiveScannerTest {
+
+	private HttpMessage createMessage(String banner) throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setURI(new URI("http://example.com", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_FOUND);
+		msg.setResponseBody("<html><body>" + banner + "</body></html>");
+		return msg;
+	}
+
+	@Override
+	protected PluginPassiveScanner createScanner() {
+		return new InPageBannerInfoLeakScanner();
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseIsRedirect() throws URIException {
+		// Given
+		HttpMessage msg = createMessage("");
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.TEMPORARY_REDIRECT);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfResponseHasRelevanContent() throws URIException {
+		// Given
+		String squidBanner = "Squid/2.5.STABLE4";
+		HttpMessage msg = createMessage(squidBanner);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo("Squid/2.5"));
+	}
+
+	@Test
+	public void shouldNotRaiseAlertIfResponseHasRelevantContentWithStatusOk() throws URIException {
+		// Given - Default threshold (MEDIUM)
+		String apacheBanner = "Apache/2.4.17";
+		HttpMessage msg = createMessage(apacheBanner);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(0));
+	}
+
+	@Test
+	public void shouldRaiseAlertIfThresholdLowResponseHasRelevantContentWithStatusOk() throws URIException {
+		// Given
+		String jettyBanner = "Jetty://9.4z-SNAPSHOT";
+		HttpMessage msg = createMessage(jettyBanner);
+		msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+		((InPageBannerInfoLeakScanner) rule).setAlertThreshold(AlertThreshold.LOW);
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+		assertThat(alertsRaised.get(0).getEvidence(), equalTo("Jetty://9.4"));
+	}
+
+}


### PR DESCRIPTION
Add new passive scanner (InPageBannerInfoLeakScanner), test (InPageBannerInfoLeakScannerUnitTest), update addon manifest (ZapAddOn.xml), help content (pscanalpha.html), and add supporting resources messages (Messages.properties).

Fixes zaproxy/zaproxy#178