### PR TITLE
jython: add options help page

### DIFF
--- a/src/org/zaproxy/zap/extension/jython/JythonOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/jython/JythonOptionsPanel.java
@@ -82,7 +82,7 @@ public class JythonOptionsPanel extends AbstractParamPanel {
 
 	@Override
 	public String getHelpIndex() {
-		return null;
+		return "jython.options";
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Minor tweak in extender template.<br>
 	Add default template for Script Input Vector.<br>
+	Add help page for the options.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
+++ b/src/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
@@ -13,7 +13,8 @@ Python Scripting
 </p>
 <p>
 	When you create a new script you will be given the option to use Python, as well as the option to choose from various Python templates.
-</p>
+<p>
+	Python Scripting is configured using the <a href="options.html">Options Jython screen</a>.<br />
 
 </BODY>
 </HTML>

--- a/src/org/zaproxy/zap/extension/jython/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/jython/resources/help/contents/options.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Options Jython screen</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ffffff">
+	<H1>Options Jython screen</H1>
+	<p>
+		This screen allows you to configure the <a href="jython.html">Python Scripting</a> add-on.
+	<table border="2">
+		<tr>
+			<th colspan="4">Configuration Options</th>
+		</tr>
+		<tr>
+			<th>Field</th>
+			<th>Details</th>
+			<th>Default</th>
+			<th>Config File</th>
+		</tr>
+		<tr>
+			<td>Additional Python modules path</td>
+			<td>The path to the directory with additional modules/libraries for Python scripting.</td>
+			<td align="center">(none)</td>
+			<td>Key: <code>jython.modulepath</code><br>Values: file system path to the directory</td>
+		</tr>
+	</table>
+
+</BODY>
+</HTML>

--- a/src/org/zaproxy/zap/extension/jython/resources/help/index.xml
+++ b/src/org/zaproxy/zap/extension/jython/resources/help/index.xml
@@ -6,4 +6,5 @@
 <index version="2.0">
     <!-- index entries are merged (sorted) into core index -->
 	<indexitem text="jython" target="jython" />
+	<indexitem text="jython options" target="jython.options" />
 </index>

--- a/src/org/zaproxy/zap/extension/jython/resources/help/map.jhm
+++ b/src/org/zaproxy/zap/extension/jython/resources/help/map.jhm
@@ -6,4 +6,5 @@
 <map version="1.0">
 	<mapID target="python-logo" url="contents/images/python.png" />
     <mapID target="jython" url="contents/jython.html" />
+    <mapID target="jython.options" url="contents/options.html" />
 </map>

--- a/src/org/zaproxy/zap/extension/jython/resources/help/toc.xml
+++ b/src/org/zaproxy/zap/extension/jython/resources/help/toc.xml
@@ -6,7 +6,9 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="Python Scripting" image="python-logo" target="jython"/>
+			<tocitem text="Python Scripting" image="python-logo" target="jython">
+				<tocitem text="Options" target="jython.options" />
+			</tocitem>
 		</tocitem>
 	</tocitem>
 </toc>


### PR DESCRIPTION
Add help page for Jython options panel.
Add the help key to JythonOptionsPanel.
Update changes in ZapAddOn.xml file.