### PR TITLE
jython: fix path module loading and UI hang

### DIFF
--- a/src/org/zaproxy/zap/extension/jython/JythonEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/jython/JythonEngineWrapper.java
@@ -27,12 +27,17 @@ import javax.script.ScriptEngine;
 import javax.swing.ImageIcon;
 
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.python.core.Py;
 import org.zaproxy.zap.extension.script.DefaultEngineWrapper;
 
 public class JythonEngineWrapper extends DefaultEngineWrapper {
 
-	public JythonEngineWrapper(ScriptEngine engine) {
+	private final JythonOptionsParam options;
+
+	public JythonEngineWrapper(JythonOptionsParam options, ScriptEngine engine) {
 		super(engine);
+
+		this.options = options;
 	}
 
 	@Override
@@ -57,4 +62,10 @@ public class JythonEngineWrapper extends DefaultEngineWrapper {
 		return false;
 	}
 
+	@Override
+	public ScriptEngine getEngine() {
+		ScriptEngine engine = super.getEngine();
+		Py.getSystemState().path.append(Py.newString(options.getModulePath()));
+		return engine;
+	}
 }

--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -1,5 +1,5 @@
 <zapaddon>
-	<name>Python scripting</name>
+	<name>Python Scripting</name>
 	<version>10</version>
 	<status>beta</status>
 	<description>Allows Python to be used for ZAP scripting - templates included</description>
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Correctly set path module defined in the options and address UI hang (Issue 4651).<br>
 	Minor tweak in extender template.<br>
 	Add default template for Script Input Vector.<br>
 	]]>


### PR DESCRIPTION
Change ExtensionJython to no longer set the module path to the "default"
system state, the script engines use their own (new each time).
Change JythonEngineWrapper to set the path on the system state of the
engine (which is set to the current thread after its creation).
Update changes in ZapAddOn.xml file and capitalise the add-on name.

Fix zaproxy/zaproxy#4651 - UI hang during start after setting module
path for Python Scripting