### PR TITLE
websocket: correct position of close frame payload

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
@@ -546,6 +546,7 @@ public class WebSocketProxyV13 extends WebSocketProxy {
 				newPayload.put(ArrayUtils.subarray(payload.array(), 4, payload.limit()), 2, payload.limit() - 4);
 			}
 			newPayload.put(newCloseCodeByte, 0, 2);
+			newPayload.position(0);
 			
 			return newPayload;
 		}

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Tweak About help page.<br>
 	Remove event consumers when the channel is closed.<br>
 	Don't enable the sender scripts by default.<br>
+	Fix send of CLOSE messages with message editor (Issue 4657).<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -20,6 +20,8 @@ ZAP Dev Team
 <ul>
 	<li>Tweak About help page.</li>
 	<li>Remove event consumers when the channel is closed.</li>
+	<li>Don't enable the sender scripts by default.</li>
+	<li>Fix send of CLOSE messages with message editor (Issue 4657).</li>
 </ul>
 
 <H3>Version 15</H3>


### PR DESCRIPTION
Change WebSocketProxyV13 to set the position of the close frame buffer
back to 0, so that it can be properly copied.
Updatge about page with the changes.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#4657 - Websocket Message Editor Fails to send Close
Opcode