### PR TITLE
selenium: mention config keys in options help page

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	<changes>
 	<![CDATA[
 	Enable the extension for all DB types.<br>
+	Mention the configuration keys in the options help page.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
@@ -12,44 +12,50 @@
 	<h2>Configuration option explanation</h2>
 	<table border="2">
 		<tr>
-			<th colspan="3">Configuration Options</th>
+			<th colspan="4">Configuration Options</th>
 		</tr>
 		<tr>
 			<th>Field</th>
 			<th>Details</th>
 			<th>Default</th>
+			<th>Config File</th>
 		</tr>
 		<tr>
-			<th colspan="3">WebDrivers</th>
+			<th colspan="4">WebDrivers</th>
 		</tr>
 		<tr>
 			<td>ChromeDriver</td>
 			<td>This allows you to select the location of ChromeDriver.</td>
 			<td align="center">The path to the bundled WebDriver, if available.</td>
+			<td>Key: <code>selenium.chromeDriver</code><br>Value: file system path to the ChromeDriver</td>
 		</tr>
 		<tr>
 			<td>geckodriver</td>
 			<td>This allows you to select the location of geckodriver (Firefox driver).</td>
 			<td align="center">The path to the bundled WebDriver, if available.</td>
+			<td>Key: <code>selenium.firefoxDriver</code><br>Value: file system path to the geckodriver</td>
 		</tr>
 		<tr>
 			<td>IEDriverServer</td>
 			<td>This allows you to select the location of IEDriverServer.</td>
 			<td align="center">The path to the bundled WebDriver, if available.</td>
+			<td>Key: <code>selenium.ieDriver</code><br>Value: file system path to the IEDriverServer</td>
 		</tr>
 		<tr>
-			<th colspan="3">Binaries</th>
+			<th colspan="4">Binaries</th>
 		</tr>
 		<tr>
 			<td>Firefox</td>
 			<td>This allows you to select the location of Firefox binary (for example, to use
 				a version other than the system default).</td>
 			<td align="center">(None)</td>
+			<td>Key: <code>selenium.firefoxBinary</code><br>Value: file system path to the Firefox binary</td>
 		</tr>
 		<tr>
 			<td>PhantomJS</td>
 			<td>This allows you to select the location of PhantomJS binary.</td>
 			<td align="center">(None)</td>
+			<td>Key: <code>selenium.phantomJsBinary</code><br>Value: file system path to the PhantomJS binary</td>
 		</tr>
 	</table>
 	<strong>Note:</strong> It's also possible to set the above locations (binaries and


### PR DESCRIPTION
Mention the configuration keys in the options help page.
Update changes in ZapAddOn.xml file.