### PR TITLE
websocket: add missing error message

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Remove event consumers when the channel is closed.<br>
 	Don't enable the sender scripts by default.<br>
 	Fix send of CLOSE messages with message editor (Issue 4657).<br>
+	Add missing error message.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/websocket/resources/Messages.properties
@@ -49,6 +49,7 @@ websocket.fuzz.success                          = Successful
 websocket.manual_send.fail                      = Unable to send crafted message!
 websocket.manual_send.fail.disconnected_channel = Selected WebSocket channel is not connected.
 websocket.manual_send.fail.invalid_channel      = Invalid WebSocket channel selected.
+websocket.manual_send.fail.invalid_direction_client_mode = Selected WebSocket channel is not connected to the client.
 websocket.manual_send.fail.invalid_opcode       = Invalid WebSocket opcode selected.
 websocket.manual_send.menu                      = WebSocket Message Editor
 websocket.manual_send.menu.mnemonic				= w

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -22,6 +22,7 @@ ZAP Dev Team
 	<li>Remove event consumers when the channel is closed.</li>
 	<li>Don't enable the sender scripts by default.</li>
 	<li>Fix send of CLOSE messages with message editor (Issue 4657).</li>
+	<li>Add missing error message.</li>
 </ul>
 
 <H3>Version 15</H3>


### PR DESCRIPTION
Add missing error message shown when attempting to send a message to the
client and no connection is established.
Update changes in ZapAddOn.xml file and about help page.