### PR TITLE
websocket: properly remove pop up menu items

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Don't enable the sender scripts by default.<br>
 	Fix send of CLOSE messages with message editor (Issue 4657).<br>
 	Add missing error message.<br>
+	Fix removal of pop up menu items.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -23,6 +23,7 @@ ZAP Dev Team
 	<li>Don't enable the sender scripts by default.</li>
 	<li>Fix send of CLOSE messages with message editor (Issue 4657).</li>
 	<li>Add missing error message.</li>
+	<li>Fix removal of pop up menu items.</li>
 </ul>
 
 <H3>Version 15</H3>

--- a/src/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketFromContextMenu.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketFromContextMenu.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.ContextExcludePanel;
+import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 
 public class PopupExcludeWebSocketFromContextMenu extends ExtensionPopupMenuItem {
 
@@ -119,5 +120,10 @@ public class PopupExcludeWebSocketFromContextMenu extends ExtensionPopupMenuItem
 			return false;
 		}
     	return true;
+    }
+
+    @Override
+    public void dismissed(ExtensionPopupMenuComponent selectedMenuComponent) {
+        View.getSingleton().getPopupList().remove(this);
     }
 }

--- a/src/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.ContextIncludePanel;
+import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 
 public class PopupIncludeWebSocketInContextMenu extends ExtensionPopupMenuItem {
 
@@ -133,5 +134,10 @@ public class PopupIncludeWebSocketInContextMenu extends ExtensionPopupMenuItem {
 			return false;
 		}
     	return true;
+    }
+
+    @Override
+    public void dismissed(ExtensionPopupMenuComponent selectedMenuComponent) {
+        View.getSingleton().getPopupList().remove(this);
     }
 }


### PR DESCRIPTION
Remove the pop up menu items when no longer needed, to prevent them from
staying in the main pop up menu after the add-on has been uninstalled
or updated, which would lead to exceptions (ClassCastException) as the
old menu items tried to use classes of the newer version.
Update changes in ZapAddOn.xml file and about help page.