### PR TITLE
openapi: open previously chosen dir

### DIFF
--- a/src/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/src/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -124,6 +124,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                     final JFileChooser chooser = new JFileChooser(Model.getSingleton().getOptionsParam().getUserDirectory());
                     int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
                     if (rc == JFileChooser.APPROVE_OPTION) {
+                        Model.getSingleton().getOptionsParam().setUserDirectory(chooser.getCurrentDirectory());
                         importOpenApiDefinition(chooser.getSelectedFile(), true);
                     }
 

--- a/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 		Include exception message in warning dialog when a parse error occurs (Issue 4667).<br>
+		Open previously chosen directory when importing local file.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionOpenApi to save the directory chosen when importing
local file, to not require to navigate to the same directory if the file
needs to be imported again.
Update changes in ZapAddOn.xml file.