### PR TITLE
Update links to scanners.md

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
@@ -55,7 +55,7 @@ public class ExampleFileActiveScanner extends AbstractAppParamPlugin {
 	public int getId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/docs/scanners.md
 		 */
 		return 60101;
 	}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
@@ -49,7 +49,7 @@ public class ExampleSimpleActiveScanner extends AbstractAppParamPlugin {
 	public int getId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/docs/scanners.md
 		 */
 		return 60100;
 	}

--- a/src/org/zaproxy/zap/extension/communityScripts/files/community-scripts/httpsender/Alert on HTTP Response Code Errors.js
+++ b/src/org/zaproxy/zap/extension/communityScripts/files/community-scripts/httpsender/Alert on HTTP Response Code Errors.js
@@ -2,7 +2,7 @@
 // By default it will raise 'Info' level alerts for Client Errors (4xx) (apart from 404s) and 'Low' Level alerts for Server Errors (5xx)
 // But it can be easily changed.
 
-pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
+pluginid = 100000	// https://github.com/zaproxy/zaproxy/blob/develop/docs/scanners.md
 
 function sendingRequest(msg, initiator, helper) {
 	// Nothing to do

--- a/src/org/zaproxy/zap/extension/communityScripts/files/community-scripts/httpsender/Alert on Unexpected Content Types.js
+++ b/src/org/zaproxy/zap/extension/communityScripts/files/community-scripts/httpsender/Alert on Unexpected Content Types.js
@@ -6,7 +6,7 @@
 // and Java 8's Nashorn JS engine
 if (typeof println == 'undefined') this.println = print;
 
-var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
+var pluginid = 100001	// https://github.com/zaproxy/zaproxy/blob/develop/docs/scanners.md
 
 var extensionAlert = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension(
 		org.zaproxy.zap.extension.alert.ExtensionAlert.NAME)

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanner.java
@@ -160,7 +160,7 @@ public class ExampleFilePassiveScanner extends PluginPassiveScanner {
 	public int getPluginId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/docs/scanners.md
 		 */
 		return 60001;
 	}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanner.java
@@ -59,7 +59,7 @@ public class ExampleSimplePassiveScanner extends PluginPassiveScanner {
 	public int getPluginId() {
 		/*
 		 * This should be unique across all active and passive rules.
-		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/src/doc/scanners.md
+		 * The master list is https://github.com/zaproxy/zaproxy/blob/develop/docs/scanners.md
 		 */
 		return 60000;
 	}


### PR DESCRIPTION
Update the links to scanners.md in example scanners and community
scripts.

Part of zaproxy/zaproxy#4672 - Move (non-dist) doc files to top level
directory