### PR TITLE
highlighter: correct resizing of main panel

### DIFF
--- a/src/org/zaproxy/zap/extension/highlighter/HighlighterPanel.java
+++ b/src/org/zaproxy/zap/extension/highlighter/HighlighterPanel.java
@@ -11,6 +11,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.zaproxy.zap.view.HighlightSearchEntry;
@@ -48,31 +49,17 @@ public class HighlighterPanel extends AbstractPanel implements ActionListener {
 		this.setName("Highlighter");
 		
 		// mainPanel
-		mainPanel = new JPanel();
-	    mainPanel.setLayout(new GridBagLayout());
-	    GridBagConstraints c = new GridBagConstraints();
-	    this.add(mainPanel, BorderLayout.CENTER);
+		mainPanel = new JPanel(new BorderLayout());
+	    this.add(mainPanel);
 
 	    // 0: button panel
 	    initButtonPanel();
-		c.fill = GridBagConstraints.HORIZONTAL;
-	    c.gridx = 0;
-	    c.weightx = 1.0;
-	    c.gridy = 0;
-	    c.anchor = GridBagConstraints.PAGE_START;
-	    mainPanel.add(buttonPanel, c);
+	    mainPanel.add(buttonPanel, BorderLayout.PAGE_START);
 	    
 	    // 1: userPanel
-		userPanel = new JPanel(new GridBagLayout());
+		userPanel = new JPanel(new BorderLayout());
 		reinit();
-	    c.gridy = 1;
-	    mainPanel.add(userPanel, c);
-	    
-	    // 2: finishpanel
-	    JPanel finishPanel = new JPanel();
-	    c.weighty = 1.0;
-	    c.gridy = 2;
-	    mainPanel.add(finishPanel, c);
+	    mainPanel.add(new JScrollPane(userPanel));
 	}
 	
 	private void initButtonPanel() {
@@ -86,17 +73,10 @@ public class HighlighterPanel extends AbstractPanel implements ActionListener {
 	}
 	
 	private void reinit() {
-		GridBagConstraints c = new GridBagConstraints();
-		
-		c.fill = GridBagConstraints.HORIZONTAL;
-	    c.gridx = 0;
-	    c.weightx = 1.0;
-	    c.gridy = 0;
-	    c.anchor = GridBagConstraints.PAGE_START;
-		
 		userPanel.removeAll();
-		userPanel.add(initUserPanel(), c);
-		this.invalidate();
+		userPanel.add(initUserPanel(), BorderLayout.PAGE_START);
+		mainPanel.validate();
+		mainPanel.repaint();
 	}
 	
 	private JPanel initUserPanel() {

--- a/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/highlighter/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix help related exception in the Highlighter panel.<br>
+	Correct resizing of Highlighter panel.<br>
 	Update minimum ZAP version to 2.5.0.<br>
 	]]>
 	</changes>


### PR DESCRIPTION
Change HighlighterPanel to use a scroll panel for its internal panel to
allow to scroll/resize the panel, instead of expanding it each time a
new highlight entry is added. Also, remove unused/empty panel and use
BorderLayout instead of GridBagLayout to simplify the layout, where
possible.
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#232 - String Highlighter