### PR TITLE
openapi: use UTF-8 and ignore BOM

### DIFF
--- a/src/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/src/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -187,7 +187,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
     public List<String> importOpenApiDefinition(final File file, boolean initViaUi) {
         try {
-            return importOpenApiDefinition(null, null, FileUtils.readFileToString(file), null, initViaUi);
+            return importOpenApiDefinition(null, null, FileUtils.readFileToString(file, "UTF-8"), null, initViaUi);
         } catch (IOException e) {
             if (initViaUi) {
                 View.getSingleton().showWarningDialog(Constant.messages.getString("openapi.io.error"));

--- a/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/openapi/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Ignore BOM when parsing and don't rely on default character encoding (Issue 4676).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/src/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -68,7 +68,8 @@ public class SwaggerConverter implements Converter {
         generators = new Generators(valueGenerator);
         operationHelper = new OperationHelper();
         requestConverter = new RequestModelConverter();
-        this.defn = defn;
+        // Remove BOM, if any. Swagger library checks the first char to decide if it should be parsed as JSON or YAML.
+        this.defn = defn.replace("\uFEFF", "");
     }
 
     public List<RequestModel> getRequestModels() throws SwaggerException {


### PR DESCRIPTION
Change ExtensionOpenApi to read the file with UTF-8 instead of relying
on the default charset.
Change SwaggerConverter to remove the BOM from the definition, the
Swagger library checks the first character to decide if the contents
should be parsed as JSON or YAML.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#4676 - openAPI import error