### PR TITLE
scripts: make null engine not visible

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/NullScriptEngineWrapper.java
+++ b/src/org/zaproxy/zap/extension/scripts/NullScriptEngineWrapper.java
@@ -48,4 +48,9 @@ public class NullScriptEngineWrapper extends DefaultEngineWrapper {
 		return Collections.emptyList();
 	}
 
+	// TODO Uncomment the annotation once targeting newer core version.
+	// @Override
+	public boolean isVisible() {
+		return false;
+	}
 }

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
@@ -108,6 +108,7 @@ public class LoadScriptDialog extends StandardFieldsDialog {
 	private List<String> getEngines() {
 		ArrayList<String> list = new ArrayList<String>();
 		list.addAll(extension.getExtScript().getScriptingEngines());
+		// TODO Remove the following workaround once targeting core version that respects ScriptEngineWrapper.isVisible.
 		// Remove the null scripting engine - unfortunately there is no easy way to do this
 		// and ExtensionScript.LANG_ENGINE_SEP (" : ") is private
 		list.remove(" : " + NullScriptEngineWrapper.NAME);

--- a/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/src/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -169,6 +169,7 @@ public class NewScriptDialog extends StandardFieldsDialog {
 			list.add("");
 		}
 		list.addAll(extension.getExtScript().getScriptingEngines());
+		// TODO Remove the following workaround once targeting core version that respects ScriptEngineWrapper.isVisible.
 		// Remove the null scripting engine - unfortunately there is no easy way to do this
 		// and ExtensionScript.LANG_ENGINE_SEP (" : ") is private
 		list.remove(" : " + NullScriptEngineWrapper.NAME);


### PR DESCRIPTION
Change NullScriptEngineWrapper to declare that it's not visible.
Add tasks to NewScriptDialog and LoadScriptDialog to remove the
workaround when targeting newer core version.

Related to zaproxy/zaproxy#4680 - Ignore null script engine when listing
engines