### PR TITLE
tokengen: address compiler warnings

### DIFF
--- a/src/com/fasteasytrade/JRandTest/Algo/DES.java
+++ b/src/com/fasteasytrade/JRandTest/Algo/DES.java
@@ -106,7 +106,7 @@ public class DES extends FileAlgoRandomStream {
 		//System.out.println("outAlgoBuffer length = " + outAlgoBuffer.length);
 
 		if (false) {
-			Set s = java.security.Security.getAlgorithms("Cipher");
+			Set<String> s = java.security.Security.getAlgorithms("Cipher");
 			Object[] o = s.toArray();
 			for (int i = 0; i < o.length; i++)
 				System.out.println(o[i].toString());

--- a/src/com/fasteasytrade/JRandTest/Algo/MT19937Prng.java
+++ b/src/com/fasteasytrade/JRandTest/Algo/MT19937Prng.java
@@ -225,7 +225,7 @@ public class MT19937Prng extends Cipher {
 	 * generates a random number on [0,0x7fffffff]-interval
 	 */
 	long genrand_int31() {
-		return (long) (genrand_int32() >>> 1);
+		return genrand_int32() >>> 1;
 	}
 
 	/**

--- a/src/com/fasteasytrade/JRandTest/Algo/RSA.java
+++ b/src/com/fasteasytrade/JRandTest/Algo/RSA.java
@@ -117,7 +117,7 @@ public class RSA extends FileAlgoRandomStream {
 		}
 
 		if (outAlgoBufferIx == outAlgoBuffer.length) {
-			BigInteger z = (BigInteger) (algo.encrypt(algoBuffer).elementAt(0));
+			BigInteger z = algo.encrypt(algoBuffer).elementAt(0);
 			outAlgoBuffer = z.toByteArray();
 			outAlgoBufferIx = 0;
 		}

--- a/src/com/fasteasytrade/JRandTest/Algo/RSACrypt.java
+++ b/src/com/fasteasytrade/JRandTest/Algo/RSACrypt.java
@@ -112,7 +112,7 @@ public class RSACrypt extends Cipher {
 	/**
 	 * encrypt byte[] and returns vector of bigintegers.
 	 */
-	public Vector encrypt(byte[] message) {
+	public Vector<BigInteger> encrypt(byte[] message) {
 		return encrypt(message, message.length);
 	}
 	
@@ -125,13 +125,13 @@ public class RSACrypt extends Cipher {
 	 * byte 1 - 4 = random number
 	 * byte 5 .. getMessageLen-1 = data
 	 */
-	public Vector encrypt(byte[] message, int mlen) {
+	public Vector<BigInteger> encrypt(byte[] message, int mlen) {
 		if (mlen < 1)
 			return null;
 		int numMsgs = 1 + (mlen-1) / (getMessageLength() - 5);
 		int rest = mlen % (getMessageLength() - 5);
 		
-		Vector rslt = new Vector();
+		Vector<BigInteger> rslt = new Vector<>();
 		byte[] tmp = new byte[getMessageLength()];
 		int i,x ;
 		int j = 0;	// read from message buffer
@@ -170,10 +170,10 @@ public class RSACrypt extends Cipher {
 				break;		// End of encryption
 			
 			out.writeInt(len);	// write length of data
-			Vector vec = encrypt(buffer);
+			Vector<BigInteger> vec = encrypt(buffer);
 			if (vec.size() != 1)	// We expect 1 biginteger! 
 				throw new IOException("encrypt does not return a biginteger!");
-			write((BigInteger)vec.elementAt(0), out);	// write biginteger
+			write(vec.elementAt(0), out);	// write biginteger
 		}
 		
 		out.writeInt(-1);	// write "dummy" EOF - no more bigintegers
@@ -222,10 +222,10 @@ public class RSACrypt extends Cipher {
 				break;		// End of encryption
 			
 			write(len, out);	// write length of data
-			Vector vec = encrypt(buffer);
+			Vector<BigInteger> vec = encrypt(buffer);
 			if (vec.size() != 1)	// We expect 1 biginteger! 
 				throw new IOException("encrypt does not return a biginteger!");
-			write((BigInteger)vec.elementAt(0), out);	// write biginteger
+			write(vec.elementAt(0), out);	// write biginteger
 		}
 		
 		write(-1, out);		// write "dummy" EOF - no more bigintegers
@@ -420,9 +420,9 @@ public class RSACrypt extends Cipher {
 				"Sonnet 18, William Shakespeare\n"+
 				"";
 		byte[] mymsgb = mymsg.getBytes();
-		Vector v = rsa.encrypt( mymsgb );
+		Vector<BigInteger> v = rsa.encrypt( mymsgb );
 		for (int i = 0; i < v.size(); i++) {
-			BigInteger t = (BigInteger)v.elementAt(i);
+			BigInteger t = v.elementAt(i);
 			System.out.print(new String(rsa.decrypt(t).toByteArray()));
 		}
 	}

--- a/src/com/fasteasytrade/JRandTest/Algo/TripleDES.java
+++ b/src/com/fasteasytrade/JRandTest/Algo/TripleDES.java
@@ -106,7 +106,7 @@ public class TripleDES extends FileAlgoRandomStream {
 		outAlgoBuffer = new byte[outAlgoBufferIx]; // output of encryption
 
 		if (false) {
-			Set s = java.security.Security.getAlgorithms("Cipher");
+			Set<String> s = java.security.Security.getAlgorithms("Cipher");
 			Object[] o = s.toArray();
 			for (int i = 0; i < o.length; i++)
 				System.out.println(o[i].toString());

--- a/src/com/fasteasytrade/JRandTest/IO/HttpGetUrlRandomStream.java
+++ b/src/com/fasteasytrade/JRandTest/IO/HttpGetUrlRandomStream.java
@@ -113,11 +113,11 @@ public class HttpGetUrlRandomStream implements RandomStream {
 			 */
 			System.out.println(" headers for url: " + url);
 			System.out.println(" lengthOfData = " + lengthOfData);
-			Map m = con.getHeaderFields();
-			Set s = m.keySet();
-			Iterator i = s.iterator();
+			Map<String, List<String>> m = con.getHeaderFields();
+			Set<String> s = m.keySet();
+			Iterator<String> i = s.iterator();
 			while (i.hasNext()) {
-				String x = (String) i.next();
+				String x = i.next();
 				Object o = m.get(x);
 				String y = null;
 				if (o instanceof String)

--- a/src/com/fasteasytrade/JRandTest/Tests/Base.java
+++ b/src/com/fasteasytrade/JRandTest/Tests/Base.java
@@ -102,7 +102,7 @@ public class Base {
 	}
 
 	public double sqrt(int a) {
-		return Math.sqrt((double) a);
+		return Math.sqrt(a);
 	}
 
 	public double exp(double a) {
@@ -110,7 +110,7 @@ public class Base {
 	}
 
 	public double exp(int a) {
-		return Math.exp((double) a);
+		return Math.exp(a);
 	}
 
 	public double log(double a) {
@@ -355,7 +355,7 @@ public class Base {
 	public static double r2_double(double[] data) {
 		// k is the length
 		int k = data.length;
-		double n = (double) k - 1.0;
+		double n = k - 1.0;
 		double sumx = 0;
 		double sumsqx = 0;
 		double sumy = 0;
@@ -364,8 +364,8 @@ public class Base {
 		double p, p1;
 
 		for (int i = 1; i < k; i++) {
-			p = (double) (data[i]);
-			p1 = (double) (data[i - 1]);
+			p = data[i];
+			p1 = data[i - 1];
 			sumx += p;
 			sumsqx += p * p;
 			sumy += p1;
@@ -430,7 +430,7 @@ public class Base {
 
 		double result = 1 - Chisq(dgf, chi_fit);
 
-		double[] resultVec = { (double) dgf, chi_fit, result };
+		double[] resultVec = { dgf, chi_fit, result };
 		return resultVec;
 	}
 
@@ -463,9 +463,9 @@ public class Base {
 
 		OutputDestination od = null;
 
-		for (Enumeration e = vecOutputDestinations.elements(); e
+		for (Enumeration<OutputDestination> e = vecOutputDestinations.elements(); e
 				.hasMoreElements();) {
-			od = (OutputDestination) e.nextElement();
+			od = e.nextElement();
 			od.printf(s);
 		}
 
@@ -491,7 +491,7 @@ public class Base {
 		}
 	}
 
-	Vector vecOutputDestinations = new Vector();
+	Vector<OutputDestination> vecOutputDestinations = new Vector<>();
 
 	/**
 	 * register output destination in vector of output destinations. printf and

--- a/src/com/fasteasytrade/JRandTest/Tests/Squeeze.java
+++ b/src/com/fasteasytrade/JRandTest/Tests/Squeeze.java
@@ -173,7 +173,7 @@ public class Squeeze extends Base
 		 */
 		for (i = 0; i < 43; ++i)
 		{
-			tmp = (double) (f[i] - Ef[i]) / sqrt(Ef[i]);
+			tmp = (f[i] - Ef[i]) / sqrt(Ef[i]);
 			chsq += tmp * tmp;
 			printf("\t% " + d4(tmp) + "  ");
 			if ((i + 1) % 6 == 0)


### PR DESCRIPTION
Remove redundant casts, address raw type warnings, and unchecked calls
in JRandTest code to compile the add-on with all lint checks and with
warnings as error.