### PR TITLE
Add Method getPayloadAsString by replacing unmapped & malformed Chars

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketMessageDTO.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketMessageDTO.java
@@ -17,6 +17,7 @@
  */
 package org.zaproxy.zap.extension.websocket;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 
@@ -154,7 +155,7 @@ public class WebSocketMessageDTO implements Message {
 
 	/**
 	 * Assigns all values to given object.
-	 * 
+	 *
 	 * @param other
 	 */
 	public void copyInto(WebSocketMessageDTO other) {
@@ -183,7 +184,7 @@ public class WebSocketMessageDTO implements Message {
 	 * Returns content of {@link WebSocketMessageDTO#payload} directly if it is
 	 * of type {@link String}. Otherwise it tries to convert it.
 	 * @return readable representation of payload
-	 * @throws InvalidUtf8Exception 
+	 * @throws InvalidUtf8Exception
 	 */
 	public String getReadablePayload() throws InvalidUtf8Exception {
 		if (payload instanceof String) {
@@ -194,7 +195,23 @@ public class WebSocketMessageDTO implements Message {
 			return "";
 		}
 	}
-	
+
+	/**
+	 * Returns content of {@link WebSocketMessageDTO#payload} directly if it is
+	 * of type {@link String}. Otherwise tries to convert that by replacing unmapped
+	 * &amp; malformed characters.
+	 * @return readable representation of payload
+	 */
+	public String getPayloadAsString(){
+		if (payload instanceof String) {
+			return (String) payload;
+		} else if (payload instanceof byte[]){
+			return new String((byte[]) payload, StandardCharsets.UTF_8);
+		} else {
+			return "";
+		}
+	}
+
 	public boolean isForceIntercept() {
 		// Not currently supported for WebSockets
 		return false;

--- a/src/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewModel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewModel.java
@@ -224,19 +224,11 @@ public class WebSocketMessagesViewModel extends PagingTableModel<WebSocketMessag
 			value = message.payloadLength;
 			break;
 		case 5:
-			try {
-				String preview = message.getReadablePayload();
-				if (preview.length() > PAYLOAD_PREVIEW_LENGTH) {
-					value = preview.substring(0, PAYLOAD_PREVIEW_LENGTH - 1) + "...";
-				} else {
-					value = preview;
-				}
-			} catch (InvalidUtf8Exception e) {
-				if (message.opcode.equals(WebSocketMessage.OPCODE_BINARY)) {
-					value = emphasize(Constant.messages.getString("websocket.payload.unreadable_binary"));
-				} else {
-					value = emphasize(Constant.messages.getString("websocket.payload.invalid_utf8"));
-				}
+			String preview = message.getPayloadAsString();
+			if (preview.length() > PAYLOAD_PREVIEW_LENGTH) {
+				value = preview.substring(0, PAYLOAD_PREVIEW_LENGTH - 1) + "...";
+			} else {
+				value = preview;
 			}
 			break;
 		}

--- a/src/org/zaproxy/zap/extension/websocket/ui/httppanel/models/StringWebSocketPanelViewModel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/httppanel/models/StringWebSocketPanelViewModel.java
@@ -28,27 +28,30 @@ public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelV
 	
 	private static final Logger LOGGER = Logger.getLogger(StringWebSocketPanelViewModel.class);
 	private boolean isErrorMessage;
-
+	private boolean editable;
+    
     @Override
     public String getData() {
-    	String data;
+        String data;
         if (webSocketMessage == null || webSocketMessage.payload == null)  {
             data = "";
-        } else {
-	        try {
-				data = webSocketMessage.getReadablePayload();
-				isErrorMessage = false;
-			} catch (InvalidUtf8Exception e) {
-				isErrorMessage = true;
-				if (webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_BINARY)) {
-					data = Constant.messages.getString("websocket.payload.unreadable_binary");
-				} else {
-					data = Constant.messages.getString("websocket.payload.invalid_utf8");
-					if (LOGGER.isDebugEnabled()) {
-						LOGGER.debug("Unable to decode " + Arrays.toString((byte[]) webSocketMessage.payload) + " as UTF-8.", e);
-					}
-				}
-			}
+        }else if(editable){
+            try {
+                data = webSocketMessage.getReadablePayload();
+                isErrorMessage = false;
+            } catch (InvalidUtf8Exception e) {
+                isErrorMessage = true;
+                if (webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_BINARY)) {
+                    data = Constant.messages.getString("websocket.payload.unreadable_binary");
+                } else {
+                    data = Constant.messages.getString("websocket.payload.invalid_utf8");
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Unable to decode " + Arrays.toString((byte[]) webSocketMessage.payload) + " as UTF-8.", e);
+                    }
+                }
+            }
+        }else {
+            data = webSocketMessage.getPayloadAsString();
         }
         return data;
     }
@@ -77,4 +80,11 @@ public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelV
 			}
 		}
     }
+    
+	public void setEditable(boolean editableMessage) {
+		editable = editableMessage;
+		if(editableMessage){
+			fireDataChanged();
+		}
+	}
 }

--- a/src/org/zaproxy/zap/extension/websocket/ui/httppanel/views/WebSocketPanelTextView.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/httppanel/views/WebSocketPanelTextView.java
@@ -49,4 +49,10 @@ public class WebSocketPanelTextView extends HttpPanelTextView {
 		}
 		
 	}
+	
+	@Override
+	public void setEditable(boolean editable){
+		super.setEditable(editable);
+		((StringWebSocketPanelViewModel) getModel()).setEditable(editable);
+	}
 }

--- a/src/org/zaproxy/zap/extension/websocket/ui/httppanel/views/WebSocketSyntaxHighlightTextView.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/httppanel/views/WebSocketSyntaxHighlightTextView.java
@@ -76,6 +76,12 @@ public class WebSocketSyntaxHighlightTextView extends HttpPanelSyntaxHighlightTe
     protected WebSocketSyntaxHighlightTextArea createHttpPanelTextArea() {
         return new WebSocketSyntaxHighlightTextArea();
     }
+    
+    @Override
+    public void setEditable(boolean editable){
+        super.setEditable(editable);
+        ((StringWebSocketPanelViewModel) getModel()).setEditable(editable);
+    }
 
     @Override
     protected WebSocketSyntaxHighlightTextArea getHttpPanelTextArea() {


### PR DESCRIPTION
New Methods in order binary displayed payloads to be more informative

In current state when a payload contains unmapped or/end malformed characters, websocket panel display an informative message `<unreadable binary payload>`. Adding those methods we are able to get some info about payload.

Example Current State: 
![selection_008](https://user-images.githubusercontent.com/10010230/40544553-60e1d256-6031-11e8-98af-023f156fcdf8.png)

Example with replacing unmapped & malformed Chars
![selection_009](https://user-images.githubusercontent.com/10010230/40544584-7d4ffe54-6031-11e8-9d27-5bf5fc3caa0d.png)

I haven't yet replaced methods which make use of getReadablePayload because I would like your input about that.  