### PR TITLE
groovy: rename add-on for broader usage

### DIFF
--- a/src/org/zaproxy/zap/extension/groovy/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/groovy/ZapAddOn.xml
@@ -1,13 +1,14 @@
 <zapaddon>
-	<name>Groovy Scripting</name>
-	<version>3</version>
+	<name>Groovy Support</name>
+	<version>3.0.0</version>
 	<status>beta</status>
-	<description>Allows Groovy to be used for ZAP scripting - templates included</description>
+	<description>Adds Groovy support to ZAP</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
 	Promote to beta status.<br>
+	Change add-on name/description and update help.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/groovy/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/groovy/resources/Messages.properties
@@ -1,4 +1,4 @@
 # This file defines the default (English) variants of all of the internationalised messages
 
 groovy.name = Groovy Extension
-groovy.desc	= Allows Groovy to be used for ZAP scripting
+groovy.desc = Adds Groovy support to ZAP. Allows Groovy to be used for ZAP scripting - templates included - and to run add-ons written in Groovy.

--- a/src/org/zaproxy/zap/extension/groovy/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/groovy/resources/help/contents/about.html
@@ -2,11 +2,11 @@
 <HTML>
 <HEAD>
 <TITLE>
-Groovy Scripting - About
+Groovy Support - About
 </TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-<H1>Groovy Scripting - About</H1>
+<H1>Groovy Support - About</H1>
 
 <H2>Source Code</H2>
 <a href="https://github.com/zaproxy/zap-extensions/tree/master/src/org/zaproxy/zap/extension/groovy">https://github.com/zaproxy/zap-extensions/tree/master/src/org/zaproxy/zap/extension/groovy</a>
@@ -19,6 +19,7 @@ ZAP Dev Team
 <H3>Version 3 - TBD</H3>
 <ul>
 	<li>Promote to beta status</li>
+	<li>Change add-on name/description and update help</li>
 </ul>
 
 <H3>Version 2 - 2018-04-19</H3>

--- a/src/org/zaproxy/zap/extension/groovy/resources/help/contents/intro.html
+++ b/src/org/zaproxy/zap/extension/groovy/resources/help/contents/intro.html
@@ -3,15 +3,23 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-Groovy Scripting
+Groovy Support
 </TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-<H1>Groovy Scripting</H1>
+<H1>Groovy Support</H1>
 <p>
-    The Groovy Scripting add-on allows you to integrate Groovy scripts in ZAP.
+    The Groovy Support add-on allows Groovy to be used for ZAP scripting and to run add-ons written in Groovy.<br>
+    It's bundled Groovy 2.4 (2.4.14), core and all modules.
+
+<h2>Scripting</h2>
 <p>
-    When you create a new scripts you will be given the option to use Groovy, as well as the option to choose from various Groovy templates.
+    When you create a new script you will be given the option to use Groovy, as well as the option to choose from various Groovy templates.
+
+<h2>Add-ons</h2>
+<p>
+    It's recommended to depend on this add-on when creating Groovy add-ons, to reduce the overall size of the add-ons and memory used at runtime.
+
 
 </BODY>
 </HTML>

--- a/src/org/zaproxy/zap/extension/groovy/resources/help/helpset.hs
+++ b/src/org/zaproxy/zap/extension/groovy/resources/help/helpset.hs
@@ -3,7 +3,7 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
          "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
 <helpset version="2.0" xml:lang="en-GB">
-  <title>Groovy Scripting</title>
+  <title>Groovy Support</title>
 
   <maps>
      <homeID>top</homeID>

--- a/src/org/zaproxy/zap/extension/groovy/resources/help/index.xml
+++ b/src/org/zaproxy/zap/extension/groovy/resources/help/index.xml
@@ -4,5 +4,5 @@
          "http://java.sun.com/products/javahelp/index_2_0.dtd">
 
 <index version="2.0">
-    <indexitem text="groovy scripting" target="groovy.intro" />
+    <indexitem text="groovy" target="groovy.intro" />
 </index>

--- a/src/org/zaproxy/zap/extension/groovy/resources/help/toc.xml
+++ b/src/org/zaproxy/zap/extension/groovy/resources/help/toc.xml
@@ -6,7 +6,7 @@
 <toc version="2.0">
     <tocitem text="ZAP User Guide" tocid="toplevelitem">
         <tocitem text="Add Ons" tocid="addons">
-            <tocitem text="Groovy Scripting" image="groovy.icon" target="groovy.intro">
+            <tocitem text="Groovy Support" image="groovy.icon" target="groovy.intro">
                 <tocitem text="About" target="groovy.about" />
             </tocitem>
         </tocitem>


### PR DESCRIPTION
Change the add-on name (and description) to Groovy Support to not focus
just on scripting, the add-on is also useful as a dependency for add-ons
written in Groovy.
Update help to mention that use case and reflect the name/description
changes.
Change version to follow semantic versioning, to make it reliable for
other add-ons to depend on.
Update changes in ZapAddOn.xml file.