### PR TITLE
jython: mention Jython version in the help

### DIFF
--- a/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jython/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Update the help to mention the bundled Jython version.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
+++ b/src/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
@@ -9,7 +9,8 @@ Python Scripting
 <BODY BGCOLOR="#ffffff">
 <H1>Python Scripting</H1>
 <p>
-	The Python Scripting add-on allow you to integrate Python scripts in ZAP.
+	The Python Scripting add-on allows you to integrate Python scripts in ZAP.<br>
+	It's bundled Jython 2.7.1.
 </p>
 <p>
 	When you create a new script you will be given the option to use Python, as well as the option to choose from various Python templates.


### PR DESCRIPTION
Add the Jython version bundled in the add-on to the help page, to inform
the user.
Update changes in ZapAddOn.xml file.