### PR TITLE
jruby: mention JRuby version in the help

### DIFF
--- a/src/org/zaproxy/zap/extension/jruby/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jruby/ZapAddOn.xml
@@ -1,5 +1,5 @@
 <zapaddon>
-	<name>Ruby scripting</name>
+	<name>Ruby Scripting</name>
 	<version>7</version>
 	<status>beta</status>
 	<description>Allows Ruby to be used for ZAP scripting - templates included</description>
@@ -7,7 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Maintenance changes.<br>
+	Update the help to mention the bundled JRuby version.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/jruby/resources/help/contents/jruby.html
+++ b/src/org/zaproxy/zap/extension/jruby/resources/help/contents/jruby.html
@@ -9,7 +9,8 @@ Ruby Scripting
 <BODY BGCOLOR="#ffffff">
 <H1>Ruby Scripting</H1>
 <p>
-	The Ruby Scripting add-on allow you to integrate Ruby scripts in ZAP.
+	The Ruby Scripting add-on allows you to integrate Ruby scripts in ZAP.<br>
+	It's bundled JRuby 1.7.4.
 </p>
 <p>
 	When you create a new script you will be given the option to use Ruby, as well as the option to choose from various Ruby templates.


### PR DESCRIPTION
Add the JRuby version bundled in the add-on to the help page, to inform
the user.
Update changes and capitalise add-on name in ZapAddOn.xml file.