### PR TITLE
Issue 3008 - Session ID In URL Rewrite False Negative

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix a typo in the description of Referer Exposes Session ID.<br>
+	Address false negative on jsessionid in URL Rewrite when preceded by a semi-colon and potentially followed by parameters (Issue 3008).<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
- TestInfoSessionIdURL.java > Updated to include a supplemental check for situations like:
`http://tld.gtld/fred;jsessionid=1A530637289A03B07199A44E8D531427?foo=bar`
- ZapAddOn.xml > Updated changes section.

Fixes zaproxy/zaproxy#3008