### PR TITLE
bruteforce: enable start button on file selection

### DIFF
--- a/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
@@ -552,6 +552,7 @@ public class BruteForcePanel extends AbstractPanel implements BruteForceListenne
 	private JComboBox<ForcedBrowseFile> getFileSelect() {
 		if (fileSelect == null) {
 			fileSelect = new JComboBox<>();
+			fileSelect.addItemListener(e -> updateSiteSelection());
 			this.refreshFileList();
 		}
 		return fileSelect;
@@ -563,21 +564,18 @@ public class BruteForcePanel extends AbstractPanel implements BruteForceListenne
 			siteSelect.addItem(noSelectionScanTarget);
 			siteSelect.setSelectedIndex(0);
 
-			siteSelect.addActionListener(new java.awt.event.ActionListener() { 
-
-				@Override
-				public void actionPerformed(java.awt.event.ActionEvent e) {    
-
-				    ScanTarget item = (ScanTarget) siteSelect.getSelectedItem();
-				    if (item != null && siteSelect.getSelectedIndex() > 0) {
-				        siteSelected(item, false);
-				    } else {
-				        siteSelected(null, false);
-				    }
-				}
-			});
+			siteSelect.addActionListener(e -> updateSiteSelection());
 		}
 		return siteSelect;
+	}
+
+	private void updateSiteSelection() {
+		ScanTarget item = (ScanTarget) siteSelect.getSelectedItem();
+		if (item != null && siteSelect.getSelectedIndex() > 0) {
+			siteSelected(item, false);
+		} else {
+			siteSelected(null, false);
+		}
 	}
 	
 	public void addSite(URI site) {

--- a/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/bruteforce/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	The other option allows the user to specify fail case string.<br>
 	Inform of running scans (e.g. on session change, add-on uninstall).<br>
 	Issue 2000 - Updated strings shown in attack menu with title caps.<br>
+	Enable start button on file selection.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change BruteForcePanel to also enable the start button when a file is
selected, to allow to start the scan without the need to change the
target.
Update changes in ZapAddOn.xml file.