### PR TITLE
brutefoce: tweak logging levels

### DIFF
--- a/src/org/zaproxy/zap/extension/bruteforce/BruteForce.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/BruteForce.java
@@ -74,7 +74,9 @@ public class BruteForce extends Thread implements BruteForceListenner {
 		this.onlyUnderDirectory = false;
 
 		this.tableModel = new BruteForceTableModel();
-		log.info("BruteForce : " + target.getURI() + "/" + directory + " threads: " + threads);
+		if (log.isDebugEnabled()) {
+			log.debug("BruteForce : " + target.getURI() + "/" + directory + " threads: " + threads);
+		}
 
 		manager = new DirBusterManager(this);
 		

--- a/src/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
@@ -41,7 +41,7 @@ public class DirBusterManager extends Manager {
 	@Override
     public synchronized void foundError(URL url, String reason) {
     	super.foundError(url, reason);
-    	log.error("DirBusterManager.foundError " + url.toString() + " reason:" + reason);
+    	log.warn("DirBusterManager.foundError " + url.toString() + " reason:" + reason);
     }
 	
 	@Override


### PR DESCRIPTION
Change BruteForce to log the creation of the instance with debug level,
not of much interest.
Change DirBusterManager to log errors with warn level, the errors do not
represent a bug or other serious issue (e.g. extracted a URL that's not
valid).