### PR TITLE
jxbrowser: mention JxBrowser version in the help

### DIFF
--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
@@ -1,14 +1,13 @@
 <zapaddon>
 	<name>JxBrowser (core)</name>
-	<version>8</version>
+	<version>9</version>
 	<status>alpha</status>
 	<description>An embedded browser based on Chromium, you must also install the relevant platform specific add-on</description>
 	<author>ZAP Dev Team</author>
 	<url></url>
 	<changes>
 	<![CDATA[
-		Minor code change to address deprecations.<br>
-		Updated to JxBrowser 6.18.<br>
+		Update the help to mention the bundled JxBrowser version.<br>
 	]]>
 	</changes>
 	<dependencies/>

--- a/src/org/zaproxy/zap/extension/jxbrowser/resources/help/contents/jxbrowser.html
+++ b/src/org/zaproxy/zap/extension/jxbrowser/resources/help/contents/jxbrowser.html
@@ -8,7 +8,7 @@ JxBrowser
 </HEAD>
 <BODY BGCOLOR="#ffffff">
 <H1>JxBrowser</H1>
-JxBrowser is an embedded browser based on Chromium. It has no other external dependencies so you can be sure that it will work out of the box.<br>
+JxBrowser is an embedded browser based on Chromium. It has no other external dependencies so you can be sure that it will work out of the box. It's bundled JxBrowser 6.18 (in the OS specific add-ons).<br>
 You can launch as many instances as you like and they will all be automatically configured to proxy via ZAP.<br>
 It also now accepts 'invalid' certificates by default, which includes the ZAP root certificate.
 <p>


### PR DESCRIPTION
Add the JxBrowser version bundled (in the specific OS add-ons) to the
help page, to inform the user.
Bump version and up changes in ZapAddOn.xml file.