### PR TITLE
websocket: don't try parse PINGs as API requests

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -169,6 +169,10 @@ public class WebSocketAPI extends ApiImplementor {
                         if (message.opcode == WebSocketMessage.OPCODE_CLOSE) {
                             return false;
                         }
+                        if (message.opcode == WebSocketMessage.OPCODE_PING) {
+                            // TODO send PONG.
+                            return false;
+                        }
                         JSONObject json = JSONObject.fromObject(message.getReadablePayload());
                         String component = json.getString("component");
                         String name = json.getString("name");


### PR DESCRIPTION
Change WebSocketAPI's WebSocketObserver to return immediately if the
message received is a PING, it's not an API request and attempting to
parse it as JSON would fail. Also, add a TODO to reply with a PONG..

---
The PONG reply is being added in #1618. 