### PR TITLE
websocket: restore binary compatibility

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -953,6 +953,22 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 	 * @return the specified messages
 	 * @throws DatabaseException
 	 */
+	public List<WebSocketMessageDTO> getWebsocketMessages(WebSocketMessageDTO criteria, List<Integer> opcodes, List<Integer> inScopeChannelIds, int offset, int limit, int payloadPreviewLength) throws DatabaseException {
+		return this.table.getMessages(criteria, opcodes, inScopeChannelIds, offset, limit, payloadPreviewLength);
+	}
+
+	/**
+	 * Returns the specified messages
+	 * @param criteria the criteria to use for the messages to include
+	 * @param opcodes the opcodes to return, use null for any
+	 * @param inScopeChannelIds the channel ids for which messages should be included, use null for all
+	 * @param payloadFilter the payload filter
+	 * @param offset the offset of the first message
+	 * @param limit the number of messages to return
+	 * @param payloadPreviewLength the maximum size of the payload to include (for a preview)
+	 * @return the specified messages
+	 * @throws DatabaseException
+	 */
 	public List<WebSocketMessageDTO> getWebsocketMessages(WebSocketMessageDTO criteria, List<Integer> opcodes, List<Integer> inScopeChannelIds, WebSocketMessagesPayloadFilter payloadFilter, int offset, int limit, int payloadPreviewLength) throws DatabaseException {
 		return this.table.getMessages(criteria, opcodes, inScopeChannelIds,payloadFilter, offset, limit, payloadPreviewLength);
 	}

--- a/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/db/TableWebSocket.java
@@ -206,25 +206,34 @@ public class TableWebSocket extends ParosAbstractTable {
     }
 
     /**
-	 * Prepares a {@link PreparedStatement} instance on the fly.
+	 * Gets the number of messages for the given criteria and opcodes.
 	 * 
 	 * @param criteria
 	 * @param opcodes Null when all opcodes should be retrieved.
 	 * @return number of message that fulfill given template
 	 * @throws SQLException
 	 */
+	public synchronized int getMessageCount(WebSocketMessageDTO criteria, List<Integer> opcodes) throws DatabaseException {
+		return getMessageCount(criteria, opcodes, -1);
+	}
+
 	public synchronized int getMessageCount(WebSocketMessageDTO criteria, List<Integer> opcodes, int payloadLength) throws DatabaseException {
 		return getMessageCount(criteria, opcodes, null,null, payloadLength);
 	}
 	
 	/**
-	 * Prepares a {@link PreparedStatement} instance on the fly.
+	 * Gets the number of messages for the given criteria, opcodes, and channel IDs.
+	 * 
 	 * @param criteria
 	 * @param opcodes Null when all opcodes should be retrieved.
 	 * @param inScopeChannelIds 
 	 * @return number of message that fulfill given template
 	 * @throws DatabaseException
 	 */
+	public synchronized int getMessageCount(WebSocketMessageDTO criteria, List<Integer> opcodes, List<Integer> inScopeChannelIds) throws DatabaseException {
+		return getMessageCount(criteria, opcodes, inScopeChannelIds, null, -1);
+	}
+
 	public synchronized int getMessageCount(WebSocketMessageDTO criteria, List<Integer> opcodes, List<Integer> inScopeChannelIds,
 											WebSocketMessagesPayloadFilter payloadFilter, int payloadLength) throws DatabaseException {
 		if (payloadFilter != null) {
@@ -365,6 +374,10 @@ public class TableWebSocket extends ParosAbstractTable {
 	 * @return Messages that fulfill given template.
 	 * @throws DatabaseException
 	 */
+	public synchronized List<WebSocketMessageDTO> getMessages(WebSocketMessageDTO criteria, List<Integer> opcodes, List<Integer> inScopeChannelIds, int offset, int limit, int payloadPreviewLength) throws DatabaseException {
+		return getMessages(criteria, opcodes, inScopeChannelIds, null, offset, limit, payloadPreviewLength);
+	}
+
 	public synchronized List<WebSocketMessageDTO> getMessages(WebSocketMessageDTO criteria, List<Integer> opcodes, List<Integer> inScopeChannelIds, WebSocketMessagesPayloadFilter payloadFilter, int offset, int limit, int payloadPreviewLength) throws DatabaseException {
 		try {
 			String query = "SELECT m.message_id, m.channel_id, m.timestamp, m.opcode, m.payload_length, m.is_outgoing, "

--- a/src/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewModel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewModel.java
@@ -154,6 +154,15 @@ public class WebSocketMessagesViewModel extends PagingTableModel<WebSocketMessag
 		}
 	}
 
+	/**
+	 * @return the IDs of the channels in scope, or {@code null} for all.
+	 * @deprecated Use {@link #getCriterionInScope()} instead.
+	 */
+	@Deprecated
+	protected List<Integer> getCriterianInScope() {
+		return getCriterionInScope();
+	}
+
 	protected List<Integer> getCriterionInScope() {
 		if (filter != null && filter.getShowJustInScope()) {
 			List<Integer> inScopeChannelIds = new ArrayList<>();


### PR DESCRIPTION
Add methods back to restore binary compatibility and deprecate replaced
method (typo in its name).
Tweak JavaDoc of some restored methods.