### PR TITLE
Update example ZapAddOn.xml with resource bundle

### DIFF
--- a/src/org/zaproxy/zap/extension/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ZapAddOn.xml
@@ -17,6 +17,7 @@
 			</addon>
 		</addons>
 	</dependencies>
+	<bundle prefix="example">com.example.Messages</bundle> <!-- Optional, declares a resource bundle to be automatically added/removed by core. The prefix attribute is used to add the bundle to Constant.messages. -->
 	<extensions>				<!-- Optional, to be used if this addon includes extensions -->
 		<extension/>			<!-- Full class name of the extension - can be multiple of these -->
 	</extensions>


### PR DESCRIPTION
Add example on how to declare a bundle.

Part of zaproxy/zaproxy#3841 - Allow add-ons without extensions to have
resource messages