### PR TITLE
pscanrulesBeta: tweak help page

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -1,15 +1,13 @@
 <zapaddon>
 	<name>Passive scanner rules (beta)</name>
-	<version>18</version>
+	<version>19</version>
 	<status>beta</status>
 	<description>The beta quality Passive Scanner rules</description>
 	<author>ZAP Dev Team</author>
 	<url/>
 	<changes>
 	<![CDATA[
-	Minor code changes to address deprecation.<br/>
-	At HIGH threshold only perform CSRF checks for in scope messages (Issue 1354).<br/>
-		Exclude JavaScript response types from the InformationDisclosureDebugErrors scanner unless threshold is Low (Issue 4210).<br/>
+	Fix typo and correct term in help page.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -35,7 +35,7 @@ Further reference:<br>
 Cookies can be scoped by domain or path. This check is only concerned with domain scope.The domain scope applied to a cookie determines which domains can access it. For example, a cookie can be scoped strictly to a subdomain e.g. www.nottrusted.com, or loosely scoped to a parent domain e.g. nottrusted.com. In the latter case, any subdomain of nottrusted.com can access the cookie. Loosely scoped cookies are common in mega-applications like google.com and live.com.
 
 <H2>CSRF Countermeasures</H2>
-The CSRFCountermeasures plugin identifies "potential" vulnerabilities with the lack of known CSRF 
+This scanner identifies "potential" vulnerabilities with the lack of known CSRF 
 countermeasures in pages with forms.<br>
 At HIGH alert threshold only scans messages which are in scope.<br>
 Post 2.5.0 you can specify a comma separated list of identifiers in the 
@@ -48,7 +48,7 @@ Only use this feature to ignore FORMs that you know are safe, for example search
 This passive scanner checks the content of web responses for known Debug Error message fragments.
 Access to such details may provide a malicious individual with means by which to further abuse the web site.
 They may also leak data not specifically meant for end user consumption.<br>
-Note: Javascript responses are only assessed at LOW thresehold.
+Note: Javascript responses are only assessed at LOW threshold.
 
 <H2>Information Disclosure: In URL</H2>
 Attempts to identify the existence of sensitive details within the visited URIs themselves 


### PR DESCRIPTION
Fix typo and correct term (`scanner` instead of `plugin`) in help page.
Bump version and update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#4732 - Correct/normalise terms used throughout
the docs