### PR TITLE
websocket: fix NPE when dispatching events

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -468,6 +468,9 @@ public class WebSocketAPI extends ApiImplementor {
                 if (nodes != null) {
                     JSONArray jsonNodes = new JSONArray();
                     for (StructuralNode node : nodes) {
+                        if (node == null) {
+                            continue;
+                        }
                         jsonNodes.add(node.getURI().toString());
                     }
                     jsonTarget.put("target.nodes", jsonNodes);

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Fix an exception when dispatching events.
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -18,7 +18,7 @@ ZAP Dev Team
 
 <H3>Version 17 - TBD</H3>
 <ul>
-	<li></li>
+	<li>Fix an exception when dispatching events.</li>
 </ul>
 
 <H3>Version 16 - 2018/06/05</H3>


### PR DESCRIPTION
Change WebSocketAPI to check that the target node is non-null before
using it, the target might not have a node (e.g. spider started with a
URL not yet accessed).
Update changes in ZapAddOn.xml file and about help page.