### PR TITLE
Tweak README for correct term usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-This project contains extensions for the [OWASP Zed Attack Proxy](https://github.com/zaproxy/zaproxy) (ZAP).
+This project contains add-ons for the [OWASP Zed Attack Proxy](https://github.com/zaproxy/zaproxy) (ZAP).
 
-If you are using the latest version of ZAP  then you can browse and download addons from within ZAP by clicking on this button in the toolbar:
+If you are using the latest version of ZAP then you can browse and download add-ons from within ZAP by clicking on this button in the toolbar:
 
 ![Image](https://github.com/zaproxy/zap-extensions/wiki/images/zap-screenshot-browse-addons.png)
 
-You can also import add-ons you have downloaded manually from https://github.com/zaproxy/zap-extensions/releases via the "File / Load Add-on file..." menu option.
+You can also import add-ons you have downloaded manually from https://github.com/zaproxy/zap-extensions/releases via the "File / Load Add-on File..." menu option.
 
 Please see the [wiki](https://github.com/zaproxy/zap-extensions/wiki) for more details.


### PR DESCRIPTION
Use "add-ons" (instead of "extensions") when referring to add-ons.
Also, correct the case of the menu item to match the one in ZAP and
remove two consecutive spaces.

Part of zaproxy/zaproxy#4732 - Correct/normalise terms used throughout
the docs