### PR TITLE
pscanrulesBeta: fix typo in scanner name

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix typo and correct term in help page.<br>
+	Fix typo in scanner name.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -36,7 +36,7 @@ pscanbeta.informationdisclosuredebugerrors.name=Information Disclosure - Debug E
 pscanbeta.informationdisclosuredebugerrors.desc=The response appeared to contain common error messages returned by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure the list of common debug messages.
 pscanbeta.informationdisclosuredebugerrors.soln=Disable debugging messages before pushing to production.
 
-pscanbeta.informationdisclosureinurl.name=Information Disclosure - Sensitive Informations in URL
+pscanbeta.informationdisclosureinurl.name=Information Disclosure - Sensitive Information in URL
 pscanbeta.informationdisclosureinurl.desc=The request appeared to contain sensitive information leaked in the URL. This can violate PCI and most organizational compliance policies. You can configure the list of strings for this check to add or remove values specific to your environment.
 pscanbeta.informationdisclosureinurl.otherinfo.sensitiveinfo=The URL contains potentially sensitive information.
 pscanbeta.informationdisclosureinurl.otherinfo.cc=The URL appears to contain credit card information.


### PR DESCRIPTION
Fix typo in scanner name, per changes done in zaproxy/zaproxy#4744.
Update changes in ZapAddOn.xml file.