### PR TITLE
scripts: tweak help

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
@@ -2,12 +2,12 @@
 <HTML>
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
-<TITLE>Scripts</TITLE>
+<TITLE>Script Console</TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-<H1>Scripts</H1>
+<H1>Script Console</H1>
 <p>
-The ZAP Script Add-on allows you to run scripts that can be embedded within ZAP and can access internal ZAP data structures.<br/>
+The Script Console add-on allows you to run scripts that can be embedded within ZAP and can access internal ZAP data structures.<br/>
 It supports any scripting language that supports JSR 223 (http://www.jcp.org/en/jsr/detail?id=223) , including:
 <ul>
 <li>ECMAScript / Javascript (using <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/">Nashorn engine</a>, included by default)</li>
@@ -20,7 +20,7 @@ It supports any scripting language that supports JSR 223 (http://www.jcp.org/en/
 
 <b>WARNING - scripts run with the same permissions as ZAP, so do not run any scripts that you do not trust!</b>
 
-<H2>Script types</H2>
+<H2>Script Types</H2>
 Different types of scripts are supported:
 <ul>
 <li>Stand Alone - scripts that are self contained and are only run when your start them manually</li>
@@ -45,7 +45,6 @@ Targeted scripts can be invoked by right clicking on a record in the Sites or Hi
 All scripting languages can be used for all script types, but only those languages that have been downloaded from the ZAP Marketplace
 will typically have templates. However you may well be able to adapt a template for another language.<br/>
 If your favourite language is not available on the Marketplace then please raise a new issue via the "Online/Report an issue" menu item.<br/>
-In the meantime you can just place the relevant jars in the 'lib' directory (not the 'plugin' directory) and restart ZAP.<br/>
 </p>
 
 <H2>Global Variables</H2>

--- a/src/org/zaproxy/zap/extension/scripts/resources/help/helpset.hs
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/helpset.hs
@@ -3,7 +3,7 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
          "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
 <helpset version="2.0" xml:lang="en-GB">
-  <title>Port Scan | ZAP Extension</title>
+  <title>Script Console</title>
 
   <maps>
      <homeID>top</homeID>

--- a/src/org/zaproxy/zap/extension/scripts/resources/help/index.xml
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/index.xml
@@ -4,7 +4,7 @@
          "http://java.sun.com/products/javahelp/index_2_0.dtd">
 
 <index version="2.0">scripts
-	<indexitem text="scripts" target="addon.scripts.scripts" />
+	<indexitem text="script console" target="addon.scripts.scripts" />
 	<indexitem text="script console tab" target="addon.scripts.console" />
 	<indexitem text="scripts tree tab" target="addon.scripts.tree" />
 </index>

--- a/src/org/zaproxy/zap/extension/scripts/resources/help/toc.xml
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/toc.xml
@@ -6,7 +6,7 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="Scripts" image="addon.scripts.icon" target="addon.scripts.scripts">
+			<tocitem text="Script Console" image="addon.scripts.icon" target="addon.scripts.scripts">
 				<tocitem text="Console" target="addon.scripts.console" />
 				<tocitem text="Tree" target="addon.scripts.tree" />
 			</tocitem>


### PR DESCRIPTION
Remove recommendation to copy JARs to lib directory, that will not work
by default with newer ZAP versions (the classpath needs to be changed to
include them).
Change the TOC, index, headers, and titles to use Script Console instead
of Scripts, so they match the add-on name (as with other add-ons).

Related to zaproxy/zaproxy#4755 - Stop relying on ClassLoaderUtil