### PR TITLE
Fix typo in example ZapAddOn.xml file

### DIFF
--- a/src/org/zaproxy/zap/extension/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ZapAddOn.xml
@@ -1,6 +1,6 @@
 <zapaddon>
 	<name>Short text name (no HTML)</name>
-	<version></version>			<!-- Integer than increments with each (released) change -->
+	<version></version>			<!-- Integer that increments with each (released) change -->
 	<semver></semver>			<!-- Optional, semantic version of the add-on -->
 	<description>Longer test description (no HTML), but not too long!</description>
 	<author>Author (no HTML)</author>


### PR DESCRIPTION
Fix a typo in the description of the version.