### PR TITLE
customreport: show dialogue, always

### DIFF
--- a/src/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
+++ b/src/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
@@ -90,11 +90,11 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
                 menuCustomHtmlReport.addActionListener(new java.awt.event.ActionListener() {
                 @Override
                 public void actionPerformed(java.awt.event.ActionEvent e) {
-                    if (optionDialog != null) {
-                        optionDialog.requestFocusInWindow();
-                        return;
-                    }
-                	getNewOptionFrame();
+                    optionDialog = new OptionDialog(
+                            ExtensionCustomReport.this,
+                            getScopeTab(),
+                            getAlertsTab(getAlertTypes()),
+                            getAlertDetailsTab());
                 	optionDialog.setVisible(true);
                 	optionDialog.centerFrame();
                 }
@@ -102,12 +102,6 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
         }
         return menuCustomHtmlReport;
     }// zap menu item
-        
-        public void getNewOptionFrame(){
-        	//optionframe.setPreferredSize( new Dimension(530,320) );
-        	List<String> alertTypes = getAlertTypes();
-        	optionDialog = new OptionDialog(this, getScopeTab(),getAlertsTab( alertTypes ), getAlertDetailsTab() );
-        }
         
         private List<String> getAlertTypes() {
         	ExtensionAlert extAlert = (ExtensionAlert) Control.getSingleton().getExtensionLoader().getExtension(ExtensionAlert.NAME);
@@ -127,7 +121,6 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
             ReportLastScan report = new ReportLastScan();
             
 		    report.generateReport(this.getView(), this.getModel(), this  );
-		    this.emitFrame();
         }
 
 		private ScopePanel getScopeTab(){
@@ -219,9 +212,7 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
                 }
         }
 
-		public void emitFrame() {
-			optionDialog.setVisible(false);
-			optionDialog.dispose();
+		void dialogClosed() {
 			optionDialog = null;
 		}
 		

--- a/src/org/zaproxy/zap/extension/customreport/OptionDialog.java
+++ b/src/org/zaproxy/zap/extension/customreport/OptionDialog.java
@@ -21,6 +21,8 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 import javax.swing.JButton;
 import javax.swing.JPanel;
@@ -52,6 +54,14 @@ public class OptionDialog extends AbstractFrame{
         optiondialog.add(mainpane, BorderLayout.NORTH );
         optiondialog.add(buttonpane, BorderLayout.SOUTH );
         
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        this.addWindowListener(new WindowAdapter() {
+
+            @Override
+            public void windowClosed(WindowEvent e) {
+                extension.dialogClosed();
+            }
+        });
         this.setTitle(Constant.messages.getString("customreport.menu.title"));
         this.add(optiondialog);
         this.pack();
@@ -60,13 +70,7 @@ public class OptionDialog extends AbstractFrame{
 	
 	private JButton getCancelButton(){
 		JButton cancelbutton = new JButton(Constant.messages.getString("customreport.cancel"));
-		cancelbutton.addActionListener(
-				new ActionListener() {
-		            @Override
-		            public void actionPerformed(ActionEvent e) {
-		               extension.emitFrame();
-		            }
-		        });
+		cancelbutton.addActionListener(e -> dispose());
 		return cancelbutton;
 	}
 	
@@ -77,6 +81,7 @@ public class OptionDialog extends AbstractFrame{
 		            @Override
 		            public void actionPerformed(ActionEvent e) {
 		                extension.generateReport();
+		                dispose();
 		            }
 		        });
 		return generatebutton;


### PR DESCRIPTION
Change OptionDialog to always (on cancel, accept, and close) clear its
own reference in ExtensionCustomReport to ensure that it's always shown
when invoked through the menu, otherwise if closed through the window
decorations it will not be shown anymore.
Change ExtensionCustomReport to not expose the method that clears the
reference to the dialogue as that's handled internally also create the
dialogue when invoked through the menu (instead of using a public
method).