### PR TITLE
scripts: remove misplaced word in help index

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/resources/help/index.xml
+++ b/src/org/zaproxy/zap/extension/scripts/resources/help/index.xml
@@ -3,7 +3,7 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Index Version 1.0//EN"
          "http://java.sun.com/products/javahelp/index_2_0.dtd">
 
-<index version="2.0">scripts
+<index version="2.0">
 	<indexitem text="script console" target="addon.scripts.scripts" />
 	<indexitem text="script console tab" target="addon.scripts.console" />
 	<indexitem text="scripts tree tab" target="addon.scripts.tree" />


### PR DESCRIPTION
Remove a misplaced word (since 2013?) in the help index.