### PR TITLE
websocket: ignore all control frames in the API

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -166,11 +166,7 @@ public class WebSocketAPI extends ApiImplementor {
                         return true;
                     }
                     try {
-                        if (message.opcode == WebSocketMessage.OPCODE_CLOSE) {
-                            return false;
-                        }
-                        if (message.opcode == WebSocketMessage.OPCODE_PING) {
-                            // TODO send PONG.
+                        if (WebSocketMessage.isControl(message.opcode)) {
                             return false;
                         }
                         JSONObject json = JSONObject.fromObject(message.getReadablePayload());


### PR DESCRIPTION
Change WebSocketAPI's WebSocketObserver to return immediately if the
message received is a control frame (not just Ping or Close), none of
those frames are API requests.
Remove TODO task added previously, the Pong should be handled by the
WebSocketProxy instead.