### PR TITLE
Address deprecations and correct import

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
@@ -793,12 +793,12 @@ public class HeartBleedActiveScanner extends AbstractHostPlugin {
 			if (read != -1 )
 				remainingtoread -= read;
 			else
-				throw new IOException ("Failed to read " + length +" bytes. Read " + new Integer (length - remainingtoread) + " bytes");
+				throw new IOException ("Failed to read " + length +" bytes. Read " + (length - remainingtoread) + " bytes");
 			currentTime = System.currentTimeMillis();
 		}
 		//did we time out?
 		if (currentTime >= timeoutTime)
-			throw new IOException ("Failed to read " + length +" bytes in "+ timeoutMs +"ms due to a timeout. Read " + new Integer (length - remainingtoread) + " bytes");
+			throw new IOException ("Failed to read " + length +" bytes in "+ timeoutMs +"ms due to a timeout. Read " + (length - remainingtoread) + " bytes");
 		return buffer;	
 	}
 	/**

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
@@ -24,7 +24,7 @@ import org.apache.commons.httpclient.ProxyClient.ConnectResponse;
 import org.apache.commons.httpclient.StatusLine;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;

--- a/src/org/zaproxy/zap/extension/sqliplugin/SQLiUnionEngine.java
+++ b/src/org/zaproxy/zap/extension/sqliplugin/SQLiUnionEngine.java
@@ -721,7 +721,7 @@ public class SQLiUnionEngine {
     private int orderByTechnique() {
         int found = -1;
         
-        if (orderByTest(1) && !orderByTest(new Integer(SQLiPayloadManager.randomInt()))) {
+        if (orderByTest(1) && !orderByTest(Integer.parseInt(SQLiPayloadManager.randomInt()))) {
             if (log.isDebugEnabled()) {
                 log.debug("ORDER BY technique seems to be usable. "
                         + "This should reduce the time needed "


### PR DESCRIPTION
Change HeartBleedActiveScanner and SQLiUnionEngine to not use the
Integer constructors (deprecated in Java 9+), not needed in string
concatenation and when parsing (use parseInt instead).
Change import in InsecureHTTPMethod from Commons Lang 3 to Lang 2.x, the
former version is not bundled in the targeted ZAP version (2.7.0).

(The latter was spotted while building with Gradle.)