### PR TITLE
cmss: remove unnecessary call to finalize

### DIFF
--- a/src/org/zaproxy/zap/extension/cmss/FingerPrintingThread.java
+++ b/src/org/zaproxy/zap/extension/cmss/FingerPrintingThread.java
@@ -19,7 +19,6 @@ public class FingerPrintingThread extends Thread{
 	public void run() {
 		try {
 			resultList = FastFingerprinter.filterResults(this.targetUrl, wtfpList, this.POrAOption);
-			this.finalize();
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();


### PR DESCRIPTION
Remove unnecessary call to finalize in FingerPrintingThread, the method
should not be called directly and it's deprecated in Java 9+.