### PR TITLE
pscanrulesAlpha: remove misleading comments

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UsernameIdorScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UsernameIdorScanner.java
@@ -129,7 +129,7 @@ public class UsernameIdorScanner extends PluginPassiveScanner {
 				getOtherinfo(hashType, evidence), // Other info
 				getSolution(), // Solution
 				getReference(), // References
-				evidence, // Evidence - Return the Server Header info
+				evidence, // Evidence
 				284, // CWE-284: Improper Access Control
 				02, // WASC-02: Insufficient Authorization
 				msg); // HttpMessage

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/XBackendServerInformationLeak.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/XBackendServerInformationLeak.java
@@ -72,7 +72,7 @@ public class XBackendServerInformationLeak extends PluginPassiveScanner{
 		    					"", // Other info
 		    					getSolution(), //Solution
 		    					getReference(), //References
-		    					xbsDirective,	// Evidence - Return the Server Header info
+		    					xbsDirective,	// Evidence
 		    					200, // CWE Id 
 		    					13,	// WASC Id 
 		    					msg); //HttpMessage


### PR DESCRIPTION
Remove misleading code comment when setting the evidence in the scanner
UsernameIdorScanner and XBackendServerInformationLeak (it's not setting
the Server header in those scanners).