### PR TITLE
webdrivers: update geckodriver to v0.21.0

### DIFF
--- a/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Add help.<br>
+	Update geckodriver to v0.21.0.<br>
 	]]>
 	</changes>
 	<extensions/>

--- a/src/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -10,7 +10,7 @@
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
 <li>Chrome - ChromeDriver 2.40</li>
-<li>Firefox - geckodriver 0.20.1</li>
+<li>Firefox - geckodriver 0.21.0</li>
 </ul>
 
 </BODY>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Add help.<br>
+	Update geckodriver to v0.21.0.<br>
 	]]>
 	</changes>
 	<extensions/>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -10,7 +10,7 @@
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
 <li>Chrome - ChromeDriver 2.40</li>
-<li>Firefox - geckodriver 0.20.1</li>
+<li>Firefox - geckodriver 0.21.0</li>
 </ul>
 
 </BODY>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Add help.<br>
+	Update geckodriver to v0.21.0.<br>
 	]]>
 	</changes>
 	<extensions/>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -10,7 +10,7 @@
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
 <li>Chrome - ChromeDriver 2.40</li>
-<li>Firefox - geckodriver 0.20.1</li>
+<li>Firefox - geckodriver 0.21.0</li>
 <li>Internet Explorer - IEDriverServer 3.7.0</li>
 </ul>
 


### PR DESCRIPTION
Update geckodriver to v0.21.0.
Update help pages.
Update changes in ZapAddOn.xml files.

Part of zaproxy/zaproxy#4770 - Update geckodriver to 0.21.0

---
Depends on zaproxy/zap-libs#25.