### PR TITLE
websocket: register script type also in daemon

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -116,6 +116,15 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 		PersistentConnectionListener, SessionChangedListener, SiteMapListener {
     
 	private static final Logger logger = Logger.getLogger(ExtensionWebSocket.class);
+
+	/**
+	 * The script icon.
+	 * <p>
+	 * Lazily initialised.
+	 * 
+	 * @see #getScriptIcon()
+	 */
+	private static ImageIcon scriptIcon;
 	
 	public static final int HANDSHAKE_LISTENER = 10;
 	
@@ -128,12 +137,6 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 	 * Used to identify the type of Websocket sender scripts
 	 */
 	public static final String SCRIPT_TYPE_WEBSOCKET_SENDER = "websocketsender";
-
-	/**
-	 * Icon to be shown in script tab for sender scripts
-	 */
-	private static final ImageIcon WEBSOCKET_SENDER_SCRIPT_ICON = new ImageIcon(
-			ExtensionWebSocket.class.getResource("/org/zaproxy/zap/extension/websocket/resources/script-plug.png"));
 
 	/**
 	 * Used to shorten the time, a listener is started on a WebSocket channel.
@@ -382,18 +385,18 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 					httpSendEditor.addPersistentConnectionListener(this);
 				}
 			}
-			// setup sender script interface
-			ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
-			if (extensionScript != null) {
-				websocketSenderSciptType = new ScriptType(
-						SCRIPT_TYPE_WEBSOCKET_SENDER,
-						"websocket.script.type.websocketsender",
-						WEBSOCKET_SENDER_SCRIPT_ICON,
-						true);
-				extensionScript.registerScriptType(websocketSenderSciptType);
-				webSocketSenderScriptListener = new WebSocketSenderScriptListener();
-				addAllChannelSenderListener(webSocketSenderScriptListener);
-			}
+		}
+		// setup sender script interface
+		ExtensionScript extensionScript = Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
+		if (extensionScript != null) {
+			websocketSenderSciptType = new ScriptType(
+					SCRIPT_TYPE_WEBSOCKET_SENDER,
+					"websocket.script.type.websocketsender",
+					getView() != null ? getScriptIcon() : null,
+					true);
+			extensionScript.registerScriptType(websocketSenderSciptType);
+			webSocketSenderScriptListener = new WebSocketSenderScriptListener();
+			addAllChannelSenderListener(webSocketSenderScriptListener);
 		}
 	}
 	
@@ -472,6 +475,21 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 	@Override
 	public String getDescription() {
 		return Constant.messages.getString("websocket.desc");
+	}
+
+	/**
+	 * Gets the icon for scripts types.
+	 * <p>
+	 * Should be called/used only when in view mode.
+	 * 
+	 * @return the script icon, never {@code null}.
+	 */
+	private static ImageIcon getScriptIcon() {
+		if (scriptIcon == null) {
+			scriptIcon = new ImageIcon(
+					ExtensionWebSocket.class.getResource("/org/zaproxy/zap/extension/websocket/resources/script-plug.png"));
+		}
+		return scriptIcon;
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Register WebSocket Sender script type also in daemon mode.<br>
 	Fix an exception when dispatching events.<br>
 	Fix an exception while uninstalling the add-on with no GUI (Issue 4815).<br>
 	]]>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -18,6 +18,7 @@ ZAP Dev Team
 
 <H3>Version 17 - TBD</H3>
 <ul>
+	<li>Register WebSocket Sender script type also in daemon mode.</li>
 	<li>Fix an exception when dispatching events.</li>
 	<li>Fix an exception while uninstalling the add-on with no GUI (Issue 4815).</li>
 </ul>


### PR DESCRIPTION
Change ExtensionWebSocket to also register the script type in daemon
mode, the scripts can be used without UI. Also, don't create the script
icon if in daemon to prevent initialisation of UI classes (which might
fail if in headless environment).
Update changes in ZapAddOn.xml file and about help page.