### PR TITLE
websocket: fix NPE while uninstalling

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/src/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -24,11 +24,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Vector;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
@@ -420,9 +418,8 @@ public class ExtensionWebSocket extends ExtensionAdaptor implements
 		ExtensionLoader extLoader = control.getExtensionLoader();
 		
 		// clear up Breakpoints
-		ExtensionBreak extBreak = (ExtensionBreak) extLoader.getExtension(ExtensionBreak.NAME);
-		if (extBreak != null) {
-			extBreak.removeBreakpointsUiManager(getBrkManager());
+		if (brkManager != null) {
+			extLoader.getExtension(ExtensionBreak.class).removeBreakpointsUiManager(brkManager);
 		}
 		
 		// clear up manualrequest extension

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -7,7 +7,8 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Fix an exception when dispatching events.
+	Fix an exception when dispatching events.<br>
+	Fix an exception while uninstalling the add-on with no GUI (Issue 4815).<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -19,6 +19,7 @@ ZAP Dev Team
 <H3>Version 17 - TBD</H3>
 <ul>
 	<li>Fix an exception when dispatching events.</li>
+	<li>Fix an exception while uninstalling the add-on with no GUI (Issue 4815).</li>
 </ul>
 
 <H3>Version 16 - 2018/06/05</H3>


### PR DESCRIPTION
Change ExtensionWebSocket to not try to remove the breakpoint UI manager
when uninstalling if not initialised, preventing the NPE.
Remove unused imports in ExtensionWebSocket.
Update changes in ZapAddOn.xml file and about help page.

Fix zaproxy/zaproxy#4815 - NullPointerException while uninstalling
WebSockets add-on with ZAP without GUI