### PR TITLE
websocket: remove consumer on socket exception

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Register WebSocket Sender script type also in daemon mode.<br>
 	Fix an exception when dispatching events.<br>
 	Fix an exception while uninstalling the add-on with no GUI (Issue 4815).<br>
+	Remove event consumers when channel is no longer in expected state.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -21,6 +21,7 @@ ZAP Dev Team
 	<li>Register WebSocket Sender script type also in daemon mode.</li>
 	<li>Fix an exception when dispatching events.</li>
 	<li>Fix an exception while uninstalling the add-on with no GUI (Issue 4815).</li>
+	<li>Remove event consumers when channel is no longer in expected state.</li>
 </ul>
 
 <H3>Version 16 - 2018/06/05</H3>


### PR DESCRIPTION
Change WebSocketAPI to remove and unregister the event consumer on
socket exceptions (e.g. channel not cleanly closed) when dispatching the
events.
Update changes in ZapAddOn.xml and about.html.

Related to #1489.
Depends on zaproxy/zaproxy#4827 - Allow consumers to remove themselves
during events