### PR TITLE
Add Java 9 to Travis CI builds (beta)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ sudo: false
 
 jdk:
   - oraclejdk8
+  - oraclejdk9

--- a/build/build.xml
+++ b/build/build.xml
@@ -113,6 +113,8 @@
 				<exclude name="org/zaproxy/zap/extension/*/resources/Messages_*.properties" />
 			</fileset>
 		</copy>
+		<!-- Required by core (<= 2.7.0) on Java 9+ -->
+		<touch file="${test.build}/Messages.properties" />
 		<echo message="Running tests..." />
 		<junit printsummary="yes" haltonerror="true" failureproperty="TestsFailed">
 			<classpath>

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINFUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINFUnitTest.java
@@ -23,12 +23,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.httpclient.URIException;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -43,6 +46,15 @@ import fi.iki.elonen.NanoHTTPD.Response;
 public class SourceCodeDisclosureWEBINFUnitTest extends ActiveScannerTest<SourceCodeDisclosureWEBINF> {
 
     private static final String JAVA_LIKE_FILE_NAME_PATH = "/WEB-INF/classes/about/html.class";
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        // XXX Does not work with Java 9+ because of procyon-decompiler.
+        // Refs:
+        //  - https://github.com/zaproxy/zaproxy/issues/4038
+        //  - https://bitbucket.org/mstrobel/procyon/issues/320/java-9-sunmiscurlclasspath-and
+        assumeTrue(SystemUtils.IS_JAVA_1_8);
+    }
 
     @Override
     protected SourceCodeDisclosureWEBINF createScanner() {


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 9.
Change build.xml file to include a Messages.properties file on the
classpath as it's required by core.
Disable SourceCodeDisclosureWEBINFUnitTest on Java 9+ because of an
issue in the used library (i.e. zaproxy/zaproxy#4038).

Part of zaproxy/zaproxy#2602 - Java 9