### PR TITLE
Add Java 9 to Travis CI builds (alpha)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ sudo: false
 
 jdk:
   - oraclejdk8
+  - oraclejdk9

--- a/build/build.xml
+++ b/build/build.xml
@@ -92,6 +92,7 @@
 				<pathelement location="${build}" />
 				<fileset dir="${dist.lib.dir}">
 					<include name="**/*.jar" />
+					<include name="**/*.zap" />
 				</fileset>
 				<fileset dir="${test.lib}">
 					<include name="**/*.jar" />
@@ -111,6 +112,8 @@
 			</fileset>
 			<fileset dir="${test.src}/resources/" />
 		</copy>
+		<!-- Required by core (<= 2.7.0) on Java 9+ -->
+		<touch file="${test.build}/Messages.properties" />
 		<echo message="Running tests..." />
 		<junit printsummary="yes" haltonerror="true" failureproperty="TestsFailed">
 			<classpath>

--- a/test/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScannerTestCase.java
+++ b/test/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScannerTestCase.java
@@ -1,8 +1,11 @@
 package org.zaproxy.zap.extension.soap;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -12,6 +15,13 @@ public class SOAPActionSpoofingActiveScannerTestCase {
 	private HttpMessage originalMsg = new HttpMessage();
 	private HttpMessage modifiedMsg = new HttpMessage();
 	
+	@BeforeClass
+	public static void setUpBeforeClass() {
+		// XXX Does not work with Java 9+ because of used classes (e.g. javax.xml.soap.SOAPException).
+		// Ref: https://github.com/zaproxy/zaproxy/issues/4037
+		assumeTrue(SystemUtils.IS_JAVA_1_8);
+	}
+
 	@Before
 	public void setUp() throws HttpMalformedHeaderException{
 		/* Original. */


### PR DESCRIPTION
Change .travis.yml to also run the build with Java 9.
Change build.xml file to include a Messages.properties file on the
classpath as it's required by core, also, include add-ons in test
classpath to include helper class (SystemUtils, from commons-lang3).
Disable SOAPActionSpoofingActiveScannerTestCase on Java 9+ because of
class used (i.e. zaproxy/zaproxy#4037).

Part of zaproxy/zaproxy#2602 - Java 9