### PR TITLE
ascanrulesBeta: skip WEB-INF disclosure on Java 9+

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINF.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureWEBINF.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
+import org.apache.commons.lang.SystemUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
@@ -151,6 +152,11 @@ public class SourceCodeDisclosureWEBINF extends AbstractHostPlugin {
 
 	@Override
 	public void init() {		
+		// Does not work with Java 9+
+		// https://github.com/zaproxy/zaproxy/issues/4038
+		if (SystemUtils.isJavaVersionAtLeast(1.9f)) {
+			getParent().pluginSkipped(this, Constant.messages.getString("ascanbeta.sourcecodedisclosurewebinf.skipJava9"));
+		}
 	}
 
 

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Issue 1142: Logic and alert risk ratings modified.<br>
 	Correct timeout per attack strength in Heartbleed OpenSSL Vulnerability scanner.<br>
 	Issue 174: Added further method checks to the Insecure HTTP Methods Scanner.<br>
+	Skip "Source Code Disclosure - /WEB-INF folder" on Java 9+ (Issue 4038).<br>
     ]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -167,6 +167,7 @@ ascanbeta.sourcecodedisclosure.svnbased.extrainfo = The source code for [{0}] wa
 ascanbeta.sourcecodedisclosurewebinf.name = Source Code Disclosure - /WEB-INF folder
 ascanbeta.sourcecodedisclosurewebinf.desc = Java source code was disclosed by the web server in Java class files in the WEB-INF folder. The class files can be dis-assembled to produce source code which very closely matches the original source code.  
 ascanbeta.sourcecodedisclosurewebinf.soln = The web server should be configured to not serve the /WEB-INF folder or its contents to web browsers, since it contains sensitive information such as compiled Java source code and properties files which may contain credentials. Java classes deployed with the application should be obfuscated, as an additional layer of defence in a "defence-in-depth" approach.
+ascanbeta.sourcecodedisclosurewebinf.skipJava9 = not supported on Java 9+
 
 ascanbeta.sourcecodedisclosurewebinf.propertiesfile.name = Properties File Disclosure - /WEB-INF folder
 ascanbeta.sourcecodedisclosurewebinf.propertiesfile.desc = A Java class in the /WEB-INF folder disclosed the presence of the properties file. Properties file are not intended to be publicly accessible, and typically contain configuration information, application credentials, or cryptographic keys.   

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -76,7 +76,8 @@ Only analyzes responses that are text based (HTML, JS, JSON, XML, etc), in order
 Uses Subversion source code repository metadata to scan for files containing source code on the web server.
 
 <H2>Source Code Disclosure - /WEB-INF</H2>
-Exploit the presence of an unprotected /WEB-INF folder to download and decompile Java classes, to disclose Java source code.
+Exploit the presence of an unprotected /WEB-INF folder to download and decompile Java classes, to disclose Java source code.<br>
+<strong>Note:</strong> Currently not supported on Java 9 and above.
 
 <H2>SQL Injection - Hypersonic (Time Based)</H2>
 


### PR DESCRIPTION
Change SourceCodeDisclosureWEBINF to skip on Java 9+, it does not work.
Add a note to the help of the scanner.
Update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#4038 Source Code Disclosure (WEB-INF folder)
fails with Java 9