### PR TITLE
plugnhack: remove unnecessary throws clause

### DIFF
--- a/src/org/zaproxy/zap/extension/plugnhack/manualsend/ClientMessagePanelSender.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/manualsend/ClientMessagePanelSender.java
@@ -18,8 +18,6 @@
 
 package org.zaproxy.zap.extension.plugnhack.manualsend;
 
-import javax.xml.ws.WebServiceException;
-
 import org.parosproxy.paros.extension.manualrequest.MessageSender;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httppanel.Message;
@@ -39,7 +37,7 @@ public class ClientMessagePanelSender implements MessageSender {
     }
     
     @Override
-    public void handleSendMessage(Message aMessage) throws WebServiceException {
+    public void handleSendMessage(Message aMessage) {
         this.extension.resend((ClientMessage)aMessage);
     }
     


### PR DESCRIPTION
Change ClientMessagePanelSender to remove the throws clause from a
method, it does not throw the exception.