### PR TITLE
Address warnings with Java 10

### DIFF
--- a/src/org/zaproxy/zap/extension/onlineMenu/ExtensionOnlineMenu.java
+++ b/src/org/zaproxy/zap/extension/onlineMenu/ExtensionOnlineMenu.java
@@ -62,7 +62,9 @@ public class ExtensionOnlineMenu extends ExtensionAdaptor {
 	    
 	    if (getView() != null) {
 			// Homepage
+			@SuppressWarnings("deprecation")
 			ZapMenuItem menuHomepage = new ZapMenuItem("onlineMenu.home",
+					// TODO Use getMenuShortcutKeyMaskEx() (and remove warn suppression) when targeting Java 10+
 					KeyStroke.getKeyStroke(KeyEvent.VK_Z, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
 			menuHomepage.setEnabled(DesktopUtils.canOpenUrlInBrowser());
 			menuHomepage.addActionListener(new java.awt.event.ActionListener() { 

--- a/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/onlineMenu/ZapAddOn.xml
@@ -1,13 +1,13 @@
 <zapaddon>
 	<name>Online menus</name>
-	<version>6</version>
+	<version>7</version>
 	<status>release</status>
 	<description>ZAP Online menu items</description>
 	<author>ZAP Dev Team</author>
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsOnlineMenuOnlineMenu</url>
 	<changes>
 	<![CDATA[
-	Updated for 2.7.0.<br>
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -73,9 +73,11 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 		initialize();
 	}
 
+	@SuppressWarnings("deprecation")
 	private void initialize() {
 		this.setShowByDefault(true);
 		this.setIcon(new ImageIcon(BreakPanel.class.getResource("/resource/icon/16/147.png")));	// 'lightning' icon
+		// TODO Use getMenuShortcutKeyMaskEx() (and remove warn suppression) when targeting Java 10+
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("quickstart.panel.mnemonic"));
 		this.setLayout(new BorderLayout());

--- a/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -188,12 +188,14 @@ public class ExtensionAjax extends ExtensionAdaptor {
 		return popupMenuSpiderSite;
 	}
 
+	@SuppressWarnings("deprecation")
 	private ZapMenuItem getMenuItemCustomScan() {
 		if (menuItemCustomScan == null) {
 			menuItemCustomScan = new ZapMenuItem(
 					"spiderajax.menu.tools.label",
 					KeyStroke.getKeyStroke(
 							KeyEvent.VK_X,
+							// TODO Use getMenuShortcutKeyMaskEx() (and remove warn suppression) when targeting Java 10+
 							Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK,
 							false));
 			menuItemCustomScan.setEnabled(Control.getSingleton().getMode() != Mode.safe);

--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -93,6 +93,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
 	 * This method initializes this class and its attributes
 	 * 
 	 */
+	@SuppressWarnings("deprecation")
 	private  void initialize() {
 		this.setLayout(new BorderLayout());
 	    if (Model.getSingleton().getOptionsParam().getViewParam().getWmUiHandlingOption() == 0) {
@@ -105,6 +106,7 @@ public class SpiderPanel extends AbstractPanel implements SpiderListener {
         					this.extension.getMessages().getString("spiderajax.panel.title"));
         
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Use getMenuShortcutKeyMaskEx() (and remove warn suppression) when targeting Java 10+
 				KeyEvent.VK_J, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("spiderajax.panel.mnemonic"));
         

--- a/src/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
+++ b/src/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
@@ -169,8 +169,10 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
 	/**
 	 * Sets up the graphical representation of this tab.
 	 */
+	@SuppressWarnings("deprecation")
 	private void initializePanel() {
 		setName(Constant.messages.getString("websocket.panel.title"));
+		// TODO Use getMenuShortcutKeyMaskEx() (and remove warn suppression) when targeting Java 10+
 		setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		setMnemonic(Constant.messages.getChar("websocket.panel.mnemonic"));
 


### PR DESCRIPTION
Address warnings with usage of ToolKit.getMenuShortcutKeyMask by
suppressing them, the new method is only available in Java 10.
Update version and changes in ZapAddOn.xml file, where needed.