### PR TITLE
alertFilters: correct required state of API param

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
@@ -66,7 +66,7 @@ public class AlertFilterAPI extends ApiImplementor {
 		super();
 		this.extension = extension;
 
-		this.addApiView(new ApiView(VIEW_ALERT_FILTER_LIST, null, new String[] { PARAM_CONTEXT_ID }));
+		this.addApiView(new ApiView(VIEW_ALERT_FILTER_LIST, new String[] { PARAM_CONTEXT_ID }));
 
 		this.addApiAction(new ApiAction(ACTION_ADD_ALERT_FILTER, 
 				new String[] { PARAM_CONTEXT_ID, PARAM_RULE_ID, PARAM_NEW_LEVEL },

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Maintenance changes.<br>
+	Correct required state of an API parameter.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Change AlertFilterAPI to set the parameter "contextId" of the view as
required (the view requires it).
Update changes in ZapAddOn.xml file.