### PR TITLE
selenium: tweak error message

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	<![CDATA[
 	Enable the extension for all DB types.<br>
 	Mention the configuration keys in the options help page.<br>
+	Tweak error message shown when failed to start/connect to the browser.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -24,7 +24,7 @@ selenium.options.label.firefox.driver = geckodriver:
 selenium.options.label.driver.ie = IEDriverServer:
 selenium.options.label.phantomjs.binary = PhantomJS:
 
-selenium.warn.message.failed.start.browser = Failed to start ''{0}'', is the browser installed/available?
+selenium.warn.message.failed.start.browser = Failed to start/connect to ''{0}'', is the browser available/supported?
 selenium.warn.message.failed.start.browser.chrome = Failed to start Chrome browser.\nMake sure that Chrome and ChromeDriver are available.\nFor more details refer to "Options Selenium screen" help page.
 selenium.warn.message.failed.start.browser.ie = Failed to start Internet Explorer.\nMake sure that both Internet Explorer and IEDriverServer are available.\nFor more details refer to "Options Selenium screen" help page.
 selenium.warn.message.failed.start.browser.phantomjs = Failed to start PhantomJS.\nMake sure that the PhantomJS binary is available.\nFor more details refer to "Options Selenium screen" help page.


### PR DESCRIPTION
Tweak message shown when failed to start or connect to the browser, to
be more clear that while the browser might have started it might have
failed to connect to it.
Update changes in ZapAddOn.xml file.