### PR TITLE
soap: change default accelerator for import file

### DIFF
--- a/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -95,7 +95,7 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
 	private ZapMenuItem getMenuImportLocalWSDL() {
 		if (menuImportLocalWSDL == null) {
 			menuImportLocalWSDL = new ZapMenuItem("soap.topmenu.tools.importWSDL",
-					KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
+					KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 			menuImportLocalWSDL.setToolTipText(Constant.messages.getString("soap.topmenu.tools.importWSDL.tooltip"));
 
 			menuImportLocalWSDL.addActionListener(new java.awt.event.ActionListener() {

--- a/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/soap/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Internationalise file filter description.<br>
 	Dynamically unload the add-on.<br>
 	Various fixes (related to Issue 4832 and other testing).<br>
+	Change default accelerator for "Import a WSDL file from local file system".<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionImportWSDL to use a different accelerator than the one
already in use by Import files containing URLs add-on.
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#3519 - Keyboard Shortcuts Issue