### PR TITLE
requester: change tab's default accelerator

### DIFF
--- a/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
+++ b/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
@@ -45,7 +45,7 @@ public class RequesterPanel extends AbstractPanel {
         this.setName(Constant.messages.getString("requester.panel.title"));
 		this.setIcon(ExtensionRequester.REQUESTER_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
-				KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+				KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("requester.panel.mnemonic"));
 		this.setShowByDefault(true);
 		requesterNumberedTabbedPane = new RequesterNumberedTabbedPane();		

--- a/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
@@ -5,7 +5,12 @@
 	<description>Request numbered panel.</description>
 	<author>Surikato</author>
 	<url></url>
-	<changes>Minor code change to address deprecation.</changes>
+	<changes>
+	<![CDATA[
+	Maintenance changes.<br>
+	Change default accelerator for Requester tab.<br>
+	]]>
+	</changes>
 	<extensions>
 	    <extension>org.zaproxy.zap.extension.requester.ExtensionRequester</extension>
 	</extensions>


### PR DESCRIPTION
Change Requester tab to use a different accelerator than the WebSockets
tab.
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#3519 - Keyboard Shortcuts Issue