### PR TITLE
tlsdebug: change tab's default accelerator

### DIFF
--- a/src/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
+++ b/src/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
@@ -77,8 +77,8 @@ public class TlsDebugPanel extends AbstractPanel implements Tab {
 	private void initialize() {
 
 		this.setIcon(TLSDEBUG_ICON);
-		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C,
-				Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
+		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D,
+				Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 		this.setLayout(new BorderLayout());
 
 		JPanel panelContent = new JPanel(new GridBagLayout());

--- a/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/tlsdebug/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.5.0.<br>
+	Change default accelerator for TLS Debug tab.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change TLS Debug tab to use a different accelerator than Clients tab.
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#3519 - Keyboard Shortcuts Issue