### PR TITLE
alertFilters: add description to API endpoints

### DIFF
--- a/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
+++ b/src/org/zaproxy/zap/extension/alertFilters/AlertFilterAPI.java
@@ -66,15 +66,23 @@ public class AlertFilterAPI extends ApiImplementor {
 		super();
 		this.extension = extension;
 
-		this.addApiView(new ApiView(VIEW_ALERT_FILTER_LIST, new String[] { PARAM_CONTEXT_ID }));
+		ApiView alertFilterList = new ApiView(VIEW_ALERT_FILTER_LIST, new String[] { PARAM_CONTEXT_ID });
+		alertFilterList.setDescriptionTag("alertFilters.api.view.alertFilterList");
+		this.addApiView(alertFilterList);
 
-		this.addApiAction(new ApiAction(ACTION_ADD_ALERT_FILTER, 
+		ApiAction addAlertFilter = new ApiAction(
+				ACTION_ADD_ALERT_FILTER,
 				new String[] { PARAM_CONTEXT_ID, PARAM_RULE_ID, PARAM_NEW_LEVEL },
-				new String[] { PARAM_URL, PARAM_URL_IS_REGEX, PARAM_PARAMETER, PARAM_ENABLED}));
-		this.addApiAction(new ApiAction(ACTION_REMOVE_ALERT_FILTER, 
-				new String[] { PARAM_CONTEXT_ID, PARAM_RULE_ID, PARAM_NEW_LEVEL },
-				new String[] { PARAM_URL, PARAM_URL_IS_REGEX, PARAM_PARAMETER, PARAM_ENABLED}));
+				new String[] { PARAM_URL, PARAM_URL_IS_REGEX, PARAM_PARAMETER, PARAM_ENABLED });
+		addAlertFilter.setDescriptionTag("alertFilters.api.action.addAlertFilter");
+		this.addApiAction(addAlertFilter);
 
+		ApiAction removeAlertFilter = new ApiAction(
+				ACTION_REMOVE_ALERT_FILTER,
+				new String[] { PARAM_CONTEXT_ID, PARAM_RULE_ID, PARAM_NEW_LEVEL },
+				new String[] { PARAM_URL, PARAM_URL_IS_REGEX, PARAM_PARAMETER, PARAM_ENABLED });
+		removeAlertFilter.setDescriptionTag("alertFilters.api.action.removeAlertFilter");
+		this.addApiAction(removeAlertFilter);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/alertFilters/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Correct required state of an API parameter.<br>
+	Add description to API endpoints.<br>
 	]]>
     </changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/alertFilters/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/alertFilters/resources/Messages.properties
@@ -2,6 +2,10 @@
 #
 # This file defines the default (English) variants of all of the internationalised messages
 
+alertFilters.api.view.alertFilterList = Lists the alert filters of the context with the given ID.
+alertFilters.api.action.addAlertFilter = Adds a new alert filter for the context with the given ID. 
+alertFilters.api.action.removeAlertFilter = Removes an alert filter from the context with the given ID.
+
 alertFilters.desc					= Context alert rules filter
 
 alertFilters.dialog.add.title		= Add Alert Filter


### PR DESCRIPTION
Add basic description to endpoints.
Change AlertFilterAPI to set a custom description tag to the endpoints,
since the API uses a different prefix than the extension ("alertFilter"
vs "alertFilters").
Update changes in ZapAddOn.xml file.