### PR TITLE
Add Java 11 to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ sudo: false
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - openjdk11


### PR DESCRIPTION
Change .travis.yml to run the build with Java 11, also, remove Java 9 as
it's already superseded.