### PR TITLE
Address warnings with Java 10 (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
+++ b/src/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
@@ -150,12 +150,14 @@ public class BruteForcePanel extends AbstractPanel implements BruteForceListenne
 	/**
 	 * This method initializes this
 	 */
+	@SuppressWarnings("deprecation")
 	private  void initialize() {
         this.setLayout(new CardLayout());
         this.setSize(474, 251);
         this.setName(Constant.messages.getString("bruteforce.panel.title"));
 		this.setIcon(new ImageIcon(BruteForcePanel.class.getResource(ExtensionBruteForce.HAMMER_ICON_RESOURCE)));
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("bruteforce.panel.mnemonic"));
 		this.add(getPanelCommand(), getPanelCommand().getName());

--- a/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/src/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -386,9 +386,11 @@ public class ExtensionFuzz extends ExtensionAdaptor {
         fuzzersController.stopAllScans();
     }
 
+    @SuppressWarnings("deprecation")
     private ZapMenuItem getMenuItemCustomScan() {
         if (menuItemCustomScan == null) {
             menuItemCustomScan = new ZapMenuItem("fuzz.menu.tools.fuzz",
+                    // TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
                     KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 
             menuItemCustomScan.addActionListener(new java.awt.event.ActionListener() {

--- a/src/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
+++ b/src/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
@@ -76,9 +76,11 @@ public class ExtensionImportUrls extends ExtensionAdaptor {
 	    extensionHook.addApiImplementor(api);
 	}
 
+	@SuppressWarnings("deprecation")
 	private ZapMenuItem getMenuImportUrls() {
         if (menuImportUrls == null) {
         	menuImportUrls = new ZapMenuItem("importurls.topmenu.tools.importurls",
+        			// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
         			KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
         	menuImportUrls.setToolTipText(Constant.messages.getString("importurls.topmenu.tools.importurls.tooltip"));
 

--- a/src/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
@@ -98,11 +98,13 @@ public class ClientsPanel extends AbstractPanel implements MonitoredPageListener
 	/**
 	 * This method initializes this
 	 */
+	@SuppressWarnings("deprecation")
 	private void initialize() {
         this.setLayout(new CardLayout());
         this.setSize(274, 251);
         this.setName(Constant.messages.getString("plugnhack.client.panel.title"));
 		this.setIcon(ExtensionPlugNHack.CLIENT_ACTIVE_ICON);
+		// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("plugnhack.client.panel.mnemonic"));
 

--- a/src/org/zaproxy/zap/extension/portscan/PortScanPanel.java
+++ b/src/org/zaproxy/zap/extension/portscan/PortScanPanel.java
@@ -61,11 +61,13 @@ public class PortScanPanel extends ScanPanel implements ScanListenner {
      * @param portScanParam 
      * 
      */
+    @SuppressWarnings("deprecation")
     public PortScanPanel(ExtensionPortScan extension, PortScanParam portScanParam) {
     	// 'picture list' icon
         super("ports", new ImageIcon(PortScanPanel.class.getResource("/resource/icon/16/187.png")), extension, portScanParam);
         
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("ports.panel.mnemonic"));
     }

--- a/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/portscan/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.5.0.<br>
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/src/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -127,9 +127,11 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
         return 0;
     }
 
+    @SuppressWarnings("deprecation")
     private ZapMenuItem getReplacerMenuItem() {
         if (replacerMenuItem == null) {
             replacerMenuItem = new ZapMenuItem(PREFIX + ".topmenu.tools.shortcut", 
+                    // TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
                     KeyStroke.getKeyStroke(KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
 
             replacerMenuItem.addActionListener(new java.awt.event.ActionListener() {

--- a/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -98,9 +98,11 @@ public class ConsolePanel extends AbstractPanel implements Tab {
 		initialize();
 	}
 
+	@SuppressWarnings("deprecation")
 	private void initialize() {
 		this.setIcon(new ImageIcon(ZAP.class.getResource("/resource/icon/16/059.png")));	// 'script' icon
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("scripts.panel.mnemonic"));
 		this.setLayout(new BorderLayout());

--- a/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/src/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -118,11 +118,13 @@ public class ScriptsListPanel extends AbstractPanel {
 		initialize();
 	}
 	
+	@SuppressWarnings("deprecation")
 	private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("scripts.list.panel.title"));
 		this.setIcon(ExtensionScriptsUI.ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("scripts.list.panel.mnemonic"));
 

--- a/src/org/zaproxy/zap/extension/tokengen/TokenPanel.java
+++ b/src/org/zaproxy/zap/extension/tokengen/TokenPanel.java
@@ -100,12 +100,14 @@ public class TokenPanel extends AbstractPanel {
 	/**
 	 * This method initializes this
 	 */
+	@SuppressWarnings("deprecation")
 	private  void initialize() {
         this.setLayout(new CardLayout());
         this.setSize(474, 251);
         this.setName(extension.getMessages().getString("tokengen.panel.title"));
 		this.setIcon(new ImageIcon(getClass().getResource("/resource/icon/fugue/barcode.png")));
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("tokengen.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());

--- a/src/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
@@ -62,11 +62,13 @@ public class ZestResultsPanel extends AbstractPanel {
 		initialize();
 	}
 	
+	@SuppressWarnings("deprecation")
 	private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("zest.results.panel.title"));
 		this.setIcon(ExtensionZest.ZEST_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_Z, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("zest.results.panel.mnemonic"));
 


### PR DESCRIPTION
Address compilation warning with usage of ToolKit.getMenuShortcutKeyMask
by suppressing it, the new method is only available in Java 10.
Update changes in ZapAddOn.xml files, where needed.