### PR TITLE
Address warnings with Java 10 (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
+++ b/src/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
@@ -252,9 +252,11 @@ public class ManualHttpRequestEditorPanel extends ManualRequestEditorPanel {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	public ZapMenuItem getMenuItem() {
 		if (menuItem == null) {
 			menuItem = new ZapMenuItem("menu.tools.manReq",
+					// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 					KeyStroke.getKeyStroke(KeyEvent.VK_M, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
 			menuItem.addActionListener(new ActionListener() {
 				@Override

--- a/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
+++ b/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
@@ -38,6 +38,7 @@ public class RequesterPanel extends AbstractPanel {
 	
 	private RequesterNumberedTabbedPane requesterNumberedTabbedPane = null; 
 
+	@SuppressWarnings("deprecation")
 	public RequesterPanel(ExtensionRequester extension) {
         super();
         this.setLayout(new GridLayout(1, 1));
@@ -45,6 +46,7 @@ public class RequesterPanel extends AbstractPanel {
         this.setName(Constant.messages.getString("requester.panel.title"));
 		this.setIcon(ExtensionRequester.REQUESTER_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("requester.panel.mnemonic"));
 		this.setShowByDefault(true);

--- a/src/org/zaproxy/zap/extension/requester/RightClickMsgMenuRequester.java
+++ b/src/org/zaproxy/zap/extension/requester/RightClickMsgMenuRequester.java
@@ -34,9 +34,11 @@ public class RightClickMsgMenuRequester extends PopupMenuItemHttpMessageContaine
 	/**
      * @param label
      */
+    @SuppressWarnings("deprecation")
     public RightClickMsgMenuRequester(String label) {
         super(label);
         this.setAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
     }
 	

--- a/src/org/zaproxy/zap/extension/requester/ToolsMenuItemRequester.java
+++ b/src/org/zaproxy/zap/extension/requester/ToolsMenuItemRequester.java
@@ -33,8 +33,10 @@ public class ToolsMenuItemRequester extends ZapMenuItem {
 	private static final long serialVersionUID = 1L;
 	private ExtensionRequester extension = null;   
 		
+    @SuppressWarnings("deprecation")
     public ToolsMenuItemRequester(ExtensionRequester extension) {
         super("requester", Constant.messages.getString("requester.toolsmenu.label"), KeyStroke.getKeyStroke(
+        		// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
         		KeyEvent.VK_W, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
         this.extension = extension;
         

--- a/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/src/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -92,9 +92,11 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
 	}
 
 	/* Menu option to import a local WSDL file. */
+	@SuppressWarnings("deprecation")
 	private ZapMenuItem getMenuImportLocalWSDL() {
 		if (menuImportLocalWSDL == null) {
 			menuImportLocalWSDL = new ZapMenuItem("soap.topmenu.tools.importWSDL",
+					// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 					KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK, false));
 			menuImportLocalWSDL.setToolTipText(Constant.messages.getString("soap.topmenu.tools.importWSDL.tooltip"));
 
@@ -119,9 +121,11 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
 	}
 
 	/* Menu option to import a WSDL file from a given URL. */
+	@SuppressWarnings("deprecation")
 	private ZapMenuItem getMenuImportUrlWSDL() {
 		if (menuImportUrlWSDL == null) {
 			menuImportUrlWSDL = new ZapMenuItem("soap.topmenu.tools.importRemoteWSDL",
+					// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 					KeyStroke.getKeyStroke(KeyEvent.VK_J, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(), false));
 			menuImportUrlWSDL
 					.setToolTipText(Constant.messages.getString("soap.topmenu.tools.importRemoteWSDL.tooltip"));

--- a/src/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
+++ b/src/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
@@ -74,10 +74,12 @@ public class TlsDebugPanel extends AbstractPanel implements Tab {
 		initialize();
 	}
 
+	@SuppressWarnings("deprecation")
 	private void initialize() {
 
 		this.setIcon(TLSDEBUG_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D,
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK, false));
 		this.setLayout(new BorderLayout());
 

--- a/src/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/src/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -64,12 +64,14 @@ public class TechPanel extends AbstractPanel {
  		initialize();
     }
 
+	@SuppressWarnings("deprecation")
 	private  void initialize() {
         this.setLayout(new CardLayout());
         this.setSize(474, 251);
         this.setName(Constant.messages.getString("wappalyzer.panel.title"));
 		this.setIcon(ExtensionWappalyzer.WAPPALYZER_ICON);
 		this.setDefaultAccelerator(KeyStroke.getKeyStroke(
+				// TODO Remove warn suppression and use View.getMenuShortcutKeyStroke with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
 				KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.ALT_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK, false));
 		this.setMnemonic(Constant.messages.getChar("wappalyzer.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());


### PR DESCRIPTION
Address compilation warning with usage of ToolKit.getMenuShortcutKeyMask
by suppressing it, the new method is only available in Java 10.