### PR TITLE
BackupFileDisclosure Handle Empty "Backup" Responses

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
@@ -295,6 +295,10 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 		return 34;  //Predictable Resource Location
 	}
 
+	private boolean isEmptyResponse(byte[] response) {
+		return response.length == 0;
+	}
+
 	/**
 	 * attempts to find a backup file for the given file
 	 * @param uri the URI of a file
@@ -499,12 +503,9 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 
 				//just to complicate things.. I have a test case which for the random file, does NOT give a 404 (so gives404s == false) 
 				//but for a "Copy of" file, actually gives a 404 (for some unknown reason). We need to handle this case.
-				if ( 	( gives404s && requestStatusCode != HttpStatus.SC_NOT_FOUND) || 
-						(	(!gives404s) &&
-								nonexistfilemsg .getResponseHeader().getStatusCode() != requestStatusCode &&
-							(! Arrays.equals(disclosedData, nonexistfilemsgdata)) 
-						)
-					) {
+				if (!isEmptyResponse(disclosedData) && ((gives404s && requestStatusCode != HttpStatus.SC_NOT_FOUND)
+						|| ((!gives404s) && nonexistfilemsg.getResponseHeader().getStatusCode() != requestStatusCode
+								&& (!Arrays.equals(disclosedData, nonexistfilemsgdata))))) {
 					bingo(	Alert.RISK_MEDIUM, 
 							Alert.CONFIDENCE_MEDIUM,
 							Constant.messages.getString("ascanbeta.backupfiledisclosure.name"),
@@ -541,12 +542,12 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 				sendAndReceive(requestmsg, false);
 				disclosedData = requestmsg.getResponseBody().getBytes();
 				int requestStatusCode = requestmsg.getResponseHeader().getStatusCode();
+				// If the response is empty it's probably not really a backup
 
-				if ( 	( parentgives404s && requestStatusCode != HttpStatus.SC_NOT_FOUND) || 
-						(	(!parentgives404s) && 
-								nonexistparentmsg.getResponseHeader().getStatusCode() != requestStatusCode && 
-							(! Arrays.equals(disclosedData, nonexistparentmsgdata)))
-					) {
+				if (!isEmptyResponse(disclosedData)
+						&& ((parentgives404s && requestStatusCode != HttpStatus.SC_NOT_FOUND) || ((!parentgives404s)
+								&& nonexistparentmsg.getResponseHeader().getStatusCode() != requestStatusCode
+								&& (!Arrays.equals(disclosedData, nonexistparentmsgdata))))) {
 					bingo(	Alert.RISK_MEDIUM, 
 							Alert.CONFIDENCE_MEDIUM,
 							Constant.messages.getString("ascanbeta.backupfiledisclosure.name"),

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Correct timeout per attack strength in Heartbleed OpenSSL Vulnerability scanner.<br>
 	Issue 174: Added further method checks to the Insecure HTTP Methods Scanner.<br>
 	Skip "Source Code Disclosure - /WEB-INF folder" on Java 9+ (Issue 4038).<br>
+	BackupFileDisclosure - Handle empty "backup" responses.<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
BackupFileDisclosure > Ignore empty "backup" responses.
ZapAddOn.xml > Add to changes section.
BackupFileDisclosureUnitTest > Added a test to cover the new behavior.

Related to zaproxy/zaproxy#4850