### PR TITLE
requester: dynamically unload the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/requester/ExtensionRequester.java
+++ b/src/org/zaproxy/zap/extension/requester/ExtensionRequester.java
@@ -129,7 +129,14 @@ public class ExtensionRequester extends ExtensionAdaptor {
 	
 	@Override
 	public boolean canUnload() {
-		return false;
+		return true;
+	}
+
+	@Override
+	public void unload() {
+		if (getView() != null) {
+			getRequesterPanel().unload();
+		}
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/requester/NumberedTabbedPane.java
+++ b/src/org/zaproxy/zap/extension/requester/NumberedTabbedPane.java
@@ -74,5 +74,11 @@ public abstract class NumberedTabbedPane extends JTabbedPane {
 		this.setSelectedIndex(index);
     }    
 		
+    void unload() {
+        int editorPanels = getTabCount() - 1;
+        for (int i = 0; i < editorPanels; i++) {
+            ((ManualHttpRequestEditorPanel) getComponentAt(i)).beforeClose();
+        }
+    }
 };
 

--- a/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
+++ b/src/org/zaproxy/zap/extension/requester/RequesterPanel.java
@@ -64,4 +64,7 @@ public class RequesterPanel extends AbstractPanel {
       	getRequesterNumberedTabbedPane().addTab(requestPane);      	
       }
   	
+    void unload() {
+        getRequesterNumberedTabbedPane().unload();
+    }
   	};

--- a/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/requester/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Maintenance changes.<br>
 	Change default accelerator for Requester tab.<br>
+	Dynamically unload the add-on.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionRequester to unload the view components dynamically
added and declare that it can be unloaded.
Change NumberedTabbedPane and RequesterPanel to unload the components,
that is, remove the request/response panels from core class.
Update changes in ZapAddOn.xml file.