### PR TITLE
viewstate: fix memory leak

### DIFF
--- a/src/org/zaproxy/zap/extension/viewstate/ExtensionHttpPanelViewStateView.java
+++ b/src/org/zaproxy/zap/extension/viewstate/ExtensionHttpPanelViewStateView.java
@@ -49,10 +49,6 @@ public class ExtensionHttpPanelViewStateView extends ExtensionAdaptor {
 	}
     private static Logger logger = Logger.getLogger(ExtensionHttpPanelViewStateView.class);
 	public static final String NAME = "ExtensionHttpPanelViewStateView";
-    private static HttpPanelViewStateView reqView;
-    private static HttpPanelViewStateView respView;
-    private static ViewStateModel reqModel;
-    private static ViewStateModel respModel;
 	
 	public ExtensionHttpPanelViewStateView() {
 		super(NAME);
@@ -115,9 +111,7 @@ public class ExtensionHttpPanelViewStateView extends ExtensionAdaptor {
 		
 		@Override
 		public HttpPanelView getNewView() {
-			reqModel = new ViewStateModel(ViewStateModel.VS_ACTION_REQUEST, null);
-			reqView = new HttpPanelViewStateView(reqModel, false);
-			return reqView;
+			return new HttpPanelViewStateView(new ViewStateModel(ViewStateModel.VS_ACTION_REQUEST, null), false);
 		}
 
 		@Override
@@ -137,9 +131,7 @@ public class ExtensionHttpPanelViewStateView extends ExtensionAdaptor {
 		
 		@Override
 		public HttpPanelView getNewView() {
-			respModel = new ViewStateModel(ViewStateModel.VS_ACTION_RESPONSE, null);
-			respView = new HttpPanelViewStateView(respModel, false);
-			return respView;
+			return new HttpPanelViewStateView(new ViewStateModel(ViewStateModel.VS_ACTION_RESPONSE, null), false);
 		}
 
 		@Override

--- a/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/viewstate/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.5.0.<br>
+	Fix memory leak.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionHttpPanelViewStateView to not keep references to the
latest model/view created (not used to anything), to not prevent them
and, more important, parent components from being GC'ed.
Update changes in ZapAddOn.xml file.

Related to #1751, this issue was preventing the Requester add-on from being completely GC'ed.