### PR TITLE
ascanrulesBeta: correct msg used in method scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
@@ -168,11 +168,10 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
             // send an OPTIONS message, and see what the server reports. Do
             // not try any methods not listed in those results.
             HttpMessage optionsmsg = getNewMsg();
-            HttpRequestHeader optionsRequestHeader = this.getBaseMsg().getRequestHeader();
+            HttpRequestHeader optionsRequestHeader = optionsmsg.getRequestHeader();
             optionsRequestHeader.setMethod(HttpRequestHeader.OPTIONS);
             // OPTIONS is not supported in 1.0
             optionsRequestHeader.setVersion(HttpRequestHeader.HTTP11);
-            optionsmsg.setRequestHeader(optionsRequestHeader);
 
             sendAndReceive(optionsmsg, false); // do not follow redirects
 

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+	Correct HTTP message usage in Insecure HTTP Method scanner.<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change InsecureHTTPMethod to not modify the base message when composing
the OPTIONS attack message, that might mislead the following tests since
the base message would no longer be the same/expected.
Update changes in ZapAddOn.xml file.