### PR TITLE
quickstart: use default user agent for spider seed

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/AttackThread.java
+++ b/src/org/zaproxy/zap/extension/quickstart/AttackThread.java
@@ -179,7 +179,7 @@ public class AttackThread extends Thread {
 		SiteNode startNode = null;
     	// Request the URL
 		try {
-			final HttpMessage msg = new HttpMessage(new URI(url.toString(), true));
+			final HttpMessage msg = new HttpMessage(new URI(url.toString(), true), extension.getModel().getOptionsParam().getConnectionParam());
 			getHttpSender().sendAndReceive(msg,true);
 		
 	        if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Enable the extensions for all DB types.<br>
+	Use default user agent when creating seeds for the spider.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change AttackThread to create the HTTP message, for the spider, with the
connection configurations to use the default user agent.
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#4846 - User-Agent changes from configured value