### PR TITLE
Remove example comment from Messages files (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/jruby/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/jruby/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 jruby.desc	= Allows Ruby to be used for ZAP scripting

--- a/src/org/zaproxy/zap/extension/jython/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/jython/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 jython.desc	= Allows Python to be used for ZAP scripting

--- a/src/org/zaproxy/zap/extension/tokengen/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/tokengen/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 tokengen.activeAction = Token Generator


### PR DESCRIPTION
Remove example comment in Messages.properties files, remnant from
example add-on.