### PR TITLE
Remove example comment from Messages files (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/birtreports/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/birtreports/resources/Messages.properties
@@ -1,10 +1,5 @@
-# An example ZAP extension which adds a top level menu item.
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
-#ext.topmenu.desc=Example extension which provides a top level menu
-#ext.topmenu.tools.example= topmenu: an example menu
-#ext.topmenu.msg.example= topmenu: An example message 
 menu.birtreport.pdf.generate = Generate BIRT report PDF
 menu.birtreport.pdf.generate.success = BIRT report PDF successfully generated
 menu.birtreport.logo.upload = Upload BIRT Report logo

--- a/src/org/zaproxy/zap/extension/cmss/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/cmss/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 ext.topmenu.desc=Example extension which provides a top level menu

--- a/src/org/zaproxy/zap/extension/sequence/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/sequence/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 sequence.custom.tab.description = Sequences are defined as scripts.

--- a/src/org/zaproxy/zap/extension/vulncheck/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/vulncheck/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 ext.topmenu.desc=Example extension which provides a top level menu

--- a/src/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 wappalyzer.desc	= Technology detection using Wappalyzer - http://wappalyzer.com/

--- a/src/org/zaproxy/zap/extension/wavsepRpt/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/wavsepRpt/resources/Messages.properties
@@ -1,5 +1,3 @@
-# An example ZAP extension which adds a top level menu item. 
-#
 # This file defines the default (English) variants of all of the internationalised messages
 
 wavsepRpt.desc					= Wavsep report generator


### PR DESCRIPTION
Remove example comment in Messages.properties files, remnant from
example add-on.