### PR TITLE
fuzz: address core deprecation

### DIFF
--- a/src/org/zaproxy/zap/extension/fuzz/FuzzersStatusPanel.java
+++ b/src/org/zaproxy/zap/extension/fuzz/FuzzersStatusPanel.java
@@ -53,7 +53,7 @@ public class FuzzersStatusPanel extends ScanPanel2<Fuzzer<?>, FuzzersController>
     private FuzzerListenerImpl fuzzerListener;
 
     public FuzzersStatusPanel(FuzzOptions fuzzerOptions, FuzzersController mainFuzzerScanController, Action fuzzerUIStarter) {
-        super("fuzz", FuzzerUIUtils.FUZZER_ICON, mainFuzzerScanController, fuzzerOptions);
+        super("fuzz", FuzzerUIUtils.FUZZER_ICON, mainFuzzerScanController);
 
         getNewScanButton().setAction(fuzzerUIStarter);
         mainFuzzerScanController.setFuzzerScansPanel(this);


### PR DESCRIPTION
Change FuzzersStatusPanel to not call the deprecated constructor,
already targeting newer ZAP version.