### PR TITLE
Issue 4924 - CacheableScanner Fix NumberFormatException

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanner.java
@@ -407,7 +407,17 @@ public class CacheableScanner extends PluginPassiveScanner{
 								lifetimeFound = true;
 								lifetimesFound++;
 								//get the portion of the string after "maxage="
-								lifetime = Long.parseLong(directiveToken.substring("max-age=".length()));
+								// Split on comma and use 0th item in case there weren't spaces: 
+								// Cache-Control: max-age=7776000,private
+								try {
+									lifetime = Long.parseLong(directiveToken.split(",")[0].substring("max-age=".length()));
+								} catch (NumberFormatException nfe) {
+									lifetimeFound = false;
+									lifetimesFound--;
+									if (logger.isDebugEnabled()) {
+										logger.debug("Could not parse max-age to establish lifetime. Perhaps the value exceeds Long.MAX_VALUE or contains non-number characters:" + directiveToken);
+									}
+								}
 								freshEvidence = directiveToken;
 							}
 						}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Prevent User Controlled HTML Attribute scanner from sometimes raising duplicate alerts.<br>
 	User Controlled HTML Attribute scanner now properly reports the parameter name in alerts.<br>
 	Add In Page Banner Info Leak scanner (Issue 178).<br>
+	CacheableScanner: Handle max-age with comma but no space in directive (Issue 4924).<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
- CacheableScanner - When parsing "lifetime" (max-age) value split on comma and use the 0th item in case there's a malformed value passed. (This works whether or not there's a comma to split on. The string was already split on space, and has been checked to start with max-age.) If a NFE still occurs (exceed Long.MAX_VALUE or still non-number characters) mark lifetime as not found and log a debug message. 
- ZapAddOn.xml - Updated change section.

Fixes zaproxy/zaproxy#4924