### PR TITLE
CrossDomainScriptInclusionScanner - Only Analyze HTML Responses

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanner.java
@@ -55,7 +55,7 @@ public class CrossDomainScriptInclusionScanner extends PluginPassiveScanner {
 
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-		if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isText()){
+		if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isHtml()){
 			List<Element> sourceElements = source.getAllElements(HTMLElementName.SCRIPT);
 			if (sourceElements != null) {
 				for (Element sourceElement : sourceElements) {

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Fix a typo in the description of Referer Exposes Session ID.<br>
 	Address false negative on jsessionid in URL Rewrite when preceded by a semi-colon and potentially followed by parameters (Issue 3008).<br>
+	Address potential false positive in Cross Domain Script Inclusion Scanner by ensuring that only HTML responses are analyzed.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/src/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -31,7 +31,7 @@ A cookie set with the secure flag will not be sent during a plain HTTP session.
 
 <H2>Cross Domain Script Inclusion</H2>
 Validates whether or not scripts are included from domains other than the domain hosting the content. 
-By looking at the "src" attributes of "script" tags in the response.<br>
+By looking at the "src" attributes of "script" tags in HTML responses.<br>
 Allowed Cross-Domain scripts:  
 <ul>
 <li>Any script with a non-empty "integrity" attribute is ignored - the integrity value is not checked as this will be checked by the browser</li>

--- a/test/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScannerUnitTest.java
@@ -210,6 +210,33 @@ public class CrossDomainScriptInclusionScannerUnitTest extends PassiveScannerTes
     }
 
     @Test
+    public void shouldIgnoreNonHtmlResponses() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/thing.js HTTP/1.1");
+        
+        msg.setResponseBody(
+                "/* ------------------------------------------------------------\n" + 
+                "Sample usage:\n" + 
+                "<script type=\"text/javascript\" src=\"http://code.jquery.com/jquery-1.8.2.min.js\"></script>\n" + 
+                "<script type=\"text/javascript\" src=\"http://code.jquery.com/ui/1.9.0/jquery-ui.js\"></script>\n" + 
+                "...\n" + 
+                "----------------------------------------------------------- */\n" + 
+                "function myFunction(p1, p2) {\n" + 
+                "    return p1 * p2;\n" +
+                "}\n");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n" +
+                "Content-Type: application/javascript\r\n" +
+                "Content-Length: " + msg.getResponseBody().length() + "\r\n");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
     public void crossDomainScriptInContextHigh() throws HttpMalformedHeaderException {
         // Mock the model and session
         Model model = Mockito.mock(Model.class);


### PR DESCRIPTION
* CrossDomainScriptInclusionScanner - Added check for HTML responses (others skipped).
* CrossDomainScriptInclusionScannerUnitTest - Added a test to assert the new behavior and ensure FP doesn't happen.
* ZapAddOn.xml - Updated changes section.
pscanrules.html - Made the details more specific to account for this change.