### PR TITLE
zest: show inverse state in more expressions

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Allow to access the options through Zest panel.<br>
 	Title caps adjustments (Issue 2000).<br>
 	Use selected text when adding assignments from the request/response.<br>
+	Show expression's inverse state in more tree nodes.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -184,8 +184,9 @@ public class ZestZapUtils {
 		} else if (za instanceof ZestExpressionLength) {
 			ZestExpressionLength sla = (ZestExpressionLength) za;
 			if (incParams) {
+				String key = sla.isInverse() ? "zest.element.expression.length.inverse" : "zest.element.expression.length";
 				return indexStr + Constant.messages
-						.getString("zest.element.expression.length", sla.getVariableName(), sla.getLength(), sla.getApprox());
+						.getString(key, sla.getVariableName(), sla.getLength(), sla.getApprox());
 			} else {
 				return indexStr + Constant.messages
 						.getString("zest.element.expression.length.title");
@@ -222,8 +223,9 @@ public class ZestZapUtils {
 			// TODO case exact
 			ZestExpressionEquals zer = (ZestExpressionEquals) za;
 			if (incParams) {
+				String key = zer.isInverse() ? "zest.element.expression.equals.inverse" : "zest.element.expression.equals";
 				return indexStr
-						+ Constant.messages.getString("zest.element.expression.equals", zer.getVariableName(), zer.getValue());
+						+ Constant.messages.getString(key, zer.getVariableName(), zer.getValue());
 			} else {
 				return indexStr + Constant.messages
 						.getString("zest.element.expression.equals.title");
@@ -261,7 +263,8 @@ public class ZestZapUtils {
 		} else if (za instanceof ZestExpressionIsInteger) {
 			ZestExpressionIsInteger zer = (ZestExpressionIsInteger) za;
 			if (incParams) {
-				return indexStr + Constant.messages.getString("zest.element.expression.isint", zer.getVariableName());
+				String key = zer.isInverse() ? "zest.element.expression.isint.inverse" : "zest.element.expression.isint";
+				return indexStr + Constant.messages.getString(key, zer.getVariableName());
 			} else {
 				return indexStr + Constant.messages
 						.getString("zest.element.expression.isint.title");

--- a/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/zest/resources/Messages.properties
@@ -347,7 +347,7 @@ zest.element.assert						= Assert - {0}
 zest.element.assert.length				= Assert - Length ({0}) = {1} +/- {2}%
 zest.element.assert.length.title		= Assert - Length
 zest.element.assert.regex.inc			= Assert - {0} Regex ({1})
-zest.element.assert.regex.exc			= Assert - {0} Regex ! ({1})
+zest.element.assert.regex.exc			= Assert - {0} Regex Not ({1})
 zest.element.assert.regex.title			= Assert - Regex
 zest.element.assert.statuscode			= Assert - Status Code ({0})
 zest.element.assert.statuscode.title	= Assert - Status Code
@@ -412,13 +412,16 @@ zest.element.expression.clientelement	= Client Element Exists : [{0}] {1}:{2}
 zest.element.expression.clientelement.title	= Client Element Exists
 zest.element.expression.structured		= Complex Condition
 zest.element.expression.length			= Length ({0} = {1} +/- {2}%)
+zest.element.expression.length.inverse = Length Not ({0} = {1} +/- {2}%)
 zest.element.expression.length.title	= Length
 zest.element.expression.equals			= {0} Equals ({1})
+zest.element.expression.equals.inverse = {0} Not Equals ({1})
 zest.element.expression.equals.title	= Equals
 zest.element.expression.isint			= Is Integer ({0})
+zest.element.expression.isint.inverse = Is Not Integer ({0})
 zest.element.expression.isint.title 	= Is Integer
 zest.element.expression.regex.inc		= {0} Regex ({1})
-zest.element.expression.regex.exc		= {0} Regex ! ({1})
+zest.element.expression.regex.exc		= {0} Regex Not ({1})
 zest.element.expression.regex.title		= Regex
 zest.element.expression.resptimegt		= Response Time ( > {0})
 zest.element.expression.resptimelt		= Response Time ( < {0})


### PR DESCRIPTION
Change ZestZapUtils to also show the inverse state (as "Not") in equals,
is integer, and length expressions' tree nodes.
Replace "!" with "Not" in other existing regex expression/assert to be
more noticeable.
Update changes in ZapAddOn.xml file.