### PR TITLE
scripts: implement new ScriptUI methods

### DIFF
--- a/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/src/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import javax.swing.ImageIcon;
 import javax.swing.TransferHandler;
+import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.TreeCellRenderer;
 
 import org.apache.log4j.Logger;
@@ -680,6 +681,24 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
 		if (View.isInitialised()) {
 			this.getScriptsPanel().getTree().removeMouseListener(l);
 		}
+	}
+
+	// TODO uncomment once available in targeted ZAP version.
+	// @Override
+	public void addSelectionListener(TreeSelectionListener tsl) {
+		if (getView() == null) {
+			return;
+		}
+		this.getScriptsPanel().getTree().addTreeSelectionListener(tsl);
+	}
+
+	// TODO uncomment once available in targeted ZAP version.
+	//@Override
+	public void removeSelectionListener(TreeSelectionListener tsl) {
+		if (getView() == null) {
+			return;
+		}
+		this.getScriptsPanel().getTree().removeTreeSelectionListener(tsl);
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/scripts/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Warn of script changed by another program (post 2.7.0).<br>
 	Script console is disabled if script size > 1MB and highlight behavior is disabled if script size > 0.5MB.<br>
 	Allow to select the file path in the Edit Script dialogue.<br>
+	Allow to add selection listener to Scripts tree.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionScriptsUI to implement the methods that allow to add and
remove a tree selection listener.
Update changes in ZapAddOn.xml file.

Part of zaproxy/zaproxy#4964 - Allow to react to selection change in
Scripts tree