### PR TITLE
zest: display HTTP message on node selection

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
+	Display HTTP message also when request statement is selected with keyboard.<br>
 	Update Content-Length of proxied responses (Issue 4613).<br>
 	Added input for Variable Name in Client Element Assign dialog.<br>
 	Allow to clear the Zest panel.<br>


### PR DESCRIPTION
Change ZestDialogManager to display the HTTP message when a ZestRequest
statement is selected (e.g. using keyboard), not just when clicked.
Update changes in ZapAddOn.xml file.