### PR TITLE
Fix Issue 4969 - CacheableScanner DateParseException

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanner.java
@@ -25,6 +25,7 @@ import java.util.Vector;
 
 import net.htmlparser.jericho.Source;
 
+import org.apache.commons.httpclient.util.DateParseException;
 import org.apache.commons.httpclient.util.DateUtil;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -467,9 +468,10 @@ public class CacheableScanner extends PluginPassiveScanner{
 							} else {
 								//we have one expiry, and one date. Yippee.. Are they valid tough??
 								//both dates can be invalid, or have one of 3 formats, all of which MUST be supported!
-								Date expiresDate = DateUtil.parseDate( expiresHeader );
+								Date expiresDate = parseDate(expiresHeader);
+
 								if ( expiresDate != null) {
-									Date dateDate = DateUtil.parseDate( dateHeader );
+									Date dateDate = parseDate(dateHeader);
 									if ( dateDate != null) {
 										//calculate the lifetime = Expires - Date
 										lifetimeFound = true;
@@ -576,10 +578,20 @@ public class CacheableScanner extends PluginPassiveScanner{
 			}
 		}
 		catch (Exception e) {
-			logger.error("An error occurred while checking a URI for cacheability", e);
+			logger.error("An error occurred while checking a URI [ " + msg.getRequestHeader().getURI().toString() + " ] for cacheability", e);
 		}
 
 
+	}
+
+	private Date parseDate(String dateStr) {
+		Date newDate = null;
+		try {
+			newDate = DateUtil.parseDate(dateStr);
+		} catch(DateParseException dpe) {
+			// There was an error parsing the date, leave the var null
+		}
+		return newDate;
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix a stack overflow with PII Scanner.<br>
+	Fix a DateParseException in Cacheable Scanner (Issue 4969).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScannerUnitTest.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.util.Date;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.util.DateUtil;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpRequestHeader;
+
+public class CacheableScannerUnitTest extends PassiveScannerTest<CacheableScanner> {
+
+	private HttpMessage createMessage() throws URIException {
+		HttpRequestHeader requestHeader = new HttpRequestHeader();
+		requestHeader.setMethod("GET");
+		requestHeader.setURI(new URI("https://example.com/fred/", false));
+
+		HttpMessage msg = new HttpMessage();
+		msg.setRequestHeader(requestHeader);
+		return msg;
+	}
+
+	@Override
+	protected CacheableScanner createScanner() {
+		return new CacheableScanner();
+	}
+
+	@Test
+	public void scannerNameShouldMatch() {
+		// Quick test to verify scanner name which is used in the policy dialog but not
+		// alerts
+
+		// Given
+		CacheableScanner thisScanner = createScanner();
+		// Then
+		assertThat(thisScanner.getName(), equalTo("Content Cacheability"));
+	}
+
+	@Test
+	public void shouldNotCauseExceptionWhenExpiresHeaderHasZeroValue() throws URIException, HttpMalformedHeaderException {
+		// Given
+		HttpMessage msg = createMessage();
+		msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + 
+				"Cache-Control: must-revalidate,private\r\n" + 
+				"Pragma: must-revalidate,no-cache\r\n" + 
+				"Content-Type: text/xml;charset=UTF-8\r\n" + 
+				"Expires: 0\r\n" + // http-date expected, Ex: "Wed, 21 Oct 2015 07:28:00 GMT"
+				"Date: " + DateUtil.formatDate(new Date()) + "\r\n\r\n");
+		// When
+		rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+		// Then
+		assertThat(alertsRaised.size(), equalTo(1));
+	}
+
+}


### PR DESCRIPTION
Wrap calls to `DateUtil.parseDate` in try/catch blocks and allow the variable(s) to remain null if parsing fails. Enhance messaging in outter `catch (Exception e)` block.

Add very basic UnitTest that served as a PoC while putting this fix together.

Update changes section of ZapAddOn.xml.

Fixes zaproxy/zaproxy#4969