### PR TITLE
Add Uninitialized Env Var WAF Bypass

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -389,6 +389,11 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
                 break;
 
             case HIGH:
+		// Up to around 24 requests / param / page 
+                targetCount = 12;
+                blindTargetCount = 12;
+                break;
+			
             case INSANE:
                 targetCount = Math.max(PS_PAYLOADS.size(), (Math.max(NIX_OS_PAYLOADS.size(), WIN_OS_PAYLOADS.size())));
                 blindTargetCount = Math.max(PS_BLIND_PAYLOADS.size(), (Math.max(NIX_BLIND_OS_PAYLOADS.size(), WIN_BLIND_OS_PAYLOADS.size())));

--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -661,25 +661,24 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
         return result / responseTimes.size();
     }
 	
-    /*Generate payload variants for uninitialized variable waf bypass
+    /**
+     *Generate payload variants for uninitialized variable waf bypass
      *https://www.secjuice.com/web-application-firewall-waf-evasion/
      *
      * @param cmd the cmd to insert uninitialized variable
      */
     private static String insertUninitVar(String cmd){
-        //get a random 1-10 lowercase letters long variable name
-        int randLength = ThreadLocalRandom.current().nextInt(1,3);
-        byte[] array = new byte[randLength+1];
-        //$xxxxxx
+        int varLength = ThreadLocalRandom.current().nextInt(1,3)+1;
+        char[] array = new char[varLength];
+        //$xx
         array[0]='$';
-        for(int i=1;i<randLength+1;++i){
-            array[i]=(byte)ThreadLocalRandom.current().nextInt(97,123);
+        for(int i=1;i<varLength;++i){
+            array[i]=(char)ThreadLocalRandom.current().nextInt(97,123);
         }
-        String generatedName = new String(array);
+        String var = new String(array);
 	    
         //insert variable before each space and '/' in the path
-	//$ need to be \\$ in replaceall
-        return cmd.replaceAll("\\s","\\"+generatedName+" ").replaceAll("\\/","\\"+generatedName+"\\/");
+        return cmd.replaceAll("\\s",Matcher.quoteReplacement(var+" ")).replaceAll("\\/",Matcher.quoteReplacement(var+"/"));
     }
 
 

--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -678,6 +678,7 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
         String generatedName = new String(array);
 	    
         //insert variable before each space and '/' in the path
+	//$ need to be \\$ in replaceall
         return cmd.replaceAll("\\s","\\"+generatedName+" ").replaceAll("\\/","\\"+generatedName+"\\/");
     }
 

--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -668,7 +668,7 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
      */
     private static String insertUninitVar(String cmd){
         //get a random 1-10 lowercase letters long variable name
-        int randLength = ThreadLocalRandom.current().nextInt(1,11);
+        int randLength = ThreadLocalRandom.current().nextInt(1,3);
         byte[] array = new byte[randLength+1];
         //$xxxxxx
         array[0]='$';
@@ -676,17 +676,9 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
             array[i]=(byte)ThreadLocalRandom.current().nextInt(97,123);
         }
         String generatedName = new String(array);
-        StringBuffer res = new StringBuffer(cmd);
-
+	    
         //insert variable before each space and '/' in the path
-        for(int i=0;i<res.length();++i){
-            if(res.charAt(i)==' '||res.charAt(i)=='/'){
-                res.insert(i,generatedName);
-                i+=randLength+1;
-            }
-        }
-
-        return res.toString();
+        return cmd.replaceAll("\\s","\\"+generatedName+" ").replaceAll("\\/","\\"+generatedName+"\\/");
     }
 
 

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Maintenance changes.<br>
 	Persistent XSS scanner upated to address various false negatives (Issue 4692).<br>
+	Command Injection plugin updated to include payloads for Uninitialized environment variable WAF bypass (Issue 4968).<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
For issue #4968 Enhancement: Command Injection Uninitialized Env Var WAF Bypass.
I think is hard to know what Env is uninitialized on the target machine and as most env is in upper case, code just guesses a random lower case variable.

cat /etc/passwd will become:
cat$xxx $xxx/etc$xxx/passwd