### PR TITLE
websocket: fix NPE when dispatching events

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -484,15 +484,18 @@ public class WebSocketAPI extends ApiImplementor {
                 jsonTarget.put("target.maxDepth", target.getMaxDepth());
                 json.put("event.target", jsonTarget);
             }
-            // Can't use json.putAll as that performs auto json conversion, which we dont want
-            for ( Entry<String, String> entry : ev.getParameters().entrySet()) {
-                try {
-                    JSONSerializer.toJSON(entry.getValue());
-                    // Its valid JSON so escape
-                    json.put(entry.getKey(), "'" + entry.getValue() + "'");
-                } catch (JSONException e) {
-                    // Its not a valid JSON object so can add as is
-                    json.put(entry.getKey(), entry.getValue());
+            
+            if (ev.getParameters() != null) {
+                // Can't use json.putAll as that performs auto json conversion, which we dont want
+                for ( Entry<String, String> entry : ev.getParameters().entrySet()) {
+                    try {
+                        JSONSerializer.toJSON(entry.getValue());
+                        // Its valid JSON so escape
+                        json.put(entry.getKey(), "'" + entry.getValue() + "'");
+                    } catch (JSONException e) {
+                        // Its not a valid JSON object so can add as is
+                        json.put(entry.getKey(), entry.getValue());
+                    }
                 }
             }
             try {

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Fix an exception when dispatching events.
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -18,7 +18,7 @@ ZAP Dev Team
 
 <H3>Version 19 - TBD</H3>
 <ul>
-	<li></li>
+	<li>Fix an exception when dispatching events.</li>
 </ul>
 
 <H3>Version 18 - 2018/08/01</H3>


### PR DESCRIPTION
Change WebSocketAPI to check if the event has parameters before using
them.
Update changes in ZapAddOn.xml file and about help page.