### PR TITLE
Assert number of messages sent by scanners

### DIFF
--- a/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerAppParamTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerAppParamTest.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Plugin;
+
+public abstract class ActiveScannerAppParamTest<T extends AbstractAppParamPlugin> extends ActiveScannerTest<T> {
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInLowStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.LOW;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInMediumStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.MEDIUM;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInHighStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.HIGH;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInInsaneStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.INSANE;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerAppTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/ActiveScannerAppTest.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
+import org.parosproxy.paros.core.scanner.Plugin;
+
+public abstract class ActiveScannerAppTest<T extends AbstractAppPlugin> extends ActiveScannerTest<T> {
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInLowStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.LOW;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerPage(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInMediumStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.MEDIUM;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerPage(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInHighStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.HIGH;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerPage(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInInsaneStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.INSANE;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage(""), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerPage(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/BufferOverflowUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/BufferOverflowUnitTest.java
@@ -30,7 +30,7 @@ import org.zaproxy.zap.model.TechSet;
 /**
  * Unit test for {@link BufferOverflow}.
  */
-public class BufferOverflowUnitTest extends ActiveScannerTest<BufferOverflow> {
+public class BufferOverflowUnitTest extends ActiveScannerAppParamTest<BufferOverflow> {
 
     @Override
     protected BufferOverflow createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrules/CodeInjectionPluginUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/CodeInjectionPluginUnitTest.java
@@ -24,13 +24,30 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
 /**
  * Unit test for {@link CodeInjectionPlugin}.
  */
-public class CodeInjectionPluginUnitTest extends ActiveScannerTest<CodeInjectionPlugin> {
+public class CodeInjectionPluginUnitTest extends ActiveScannerAppParamTest<CodeInjectionPlugin> {
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+        case LOW:
+            return recommendMax + 2;
+        case MEDIUM:
+        default:
+            return recommendMax;
+        case HIGH:
+            return recommendMax;
+        case INSANE:
+            return recommendMax;
+        }
+    }
 
     @Override
     protected CodeInjectionPlugin createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrules/CommandInjectionPluginUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/CommandInjectionPluginUnitTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThat;
 
 import org.apache.commons.configuration.Configuration;
 import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -32,7 +33,23 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 /**
  * Unit test for {@link CommandInjectionPlugin}.
  */
-public class CommandInjectionPluginUnitTest extends ActiveScannerTest<CommandInjectionPlugin> {
+public class CommandInjectionPluginUnitTest extends ActiveScannerAppParamTest<CommandInjectionPlugin> {
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+        case LOW:
+            return recommendMax + 6;
+        case MEDIUM:
+        default:
+            return recommendMax + 20;
+        case HIGH:
+            return recommendMax + 22;
+        case INSANE:
+            return recommendMax;
+        }
+    }
 
     @Override
     protected CommandInjectionPlugin createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrules/FormatStringUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/FormatStringUnitTest.java
@@ -30,7 +30,7 @@ import org.zaproxy.zap.model.TechSet;
 /**
  * Unit test for {@link FormatString}.
  */
-public class FormatStringUnitTest extends ActiveScannerTest<FormatString> {
+public class FormatStringUnitTest extends ActiveScannerAppParamTest<FormatString> {
 
     @Override
     protected FormatString createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2UnitTest.java
@@ -45,7 +45,7 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 
-public class TestCrossSiteScriptV2UnitTest extends ActiveScannerTest<TestCrossSiteScriptV2> {
+public class TestCrossSiteScriptV2UnitTest extends ActiveScannerAppParamTest<TestCrossSiteScriptV2> {
 
     @Override
     protected TestCrossSiteScriptV2 createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrules/TestDirectoryBrowsingUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestDirectoryBrowsingUnitTest.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+/**
+ * Unit test for {@link TestDirectoryBrowsing}.
+ */
+public class TestDirectoryBrowsingUnitTest extends ActiveScannerAppTest<TestDirectoryBrowsing> {
+
+    @Override
+    protected TestDirectoryBrowsing createScanner() {
+        return new TestDirectoryBrowsing();
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestExternalRedirectUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestExternalRedirectUnitTest.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+/**
+ * Unit test for {@link TestExternalRedirect}.
+ */
+public class TestExternalRedirectUnitTest extends ActiveScannerAppParamTest<TestExternalRedirect> {
+
+    @Override
+    protected TestExternalRedirect createScanner() {
+        return new TestExternalRedirect();
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestInjectionCRLFUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestInjectionCRLFUnitTest.java
@@ -1,0 +1,50 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+
+/**
+ * Unit test for {@link TestInjectionCRLF}.
+ */
+public class TestInjectionCRLFUnitTest extends ActiveScannerAppParamTest<TestInjectionCRLF> {
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+        case LOW:
+            return recommendMax + 1;
+        case MEDIUM:
+        default:
+            return recommendMax;
+        case HIGH:
+            return recommendMax;
+        case INSANE:
+            return recommendMax;
+        }
+    }
+
+    @Override
+    protected TestInjectionCRLF createScanner() {
+        return new TestInjectionCRLF();
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestParameterTamperUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestParameterTamperUnitTest.java
@@ -37,7 +37,7 @@ import fi.iki.elonen.NanoHTTPD.Response;
 /**
  * Unit test for {@link TestParameterTamper}.
  */
-public class TestParameterTamperUnitTest extends ActiveScannerTest<TestParameterTamper> {
+public class TestParameterTamperUnitTest extends ActiveScannerAppParamTest<TestParameterTamper> {
 
     @Override
     protected TestParameterTamper createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPathTraversalUnitTest.java
@@ -24,13 +24,12 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -41,73 +40,29 @@ import fi.iki.elonen.NanoHTTPD.Response;
 /**
  * Unit test for {@link TestPathTraversal}.
  */
-public class TestPathTraversalUnitTest extends ActiveScannerTest<TestPathTraversal> {
+public class TestPathTraversalUnitTest extends ActiveScannerAppParamTest<TestPathTraversal> {
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+        case LOW:
+            return recommendMax + 4;
+        case MEDIUM:
+        default:
+            return recommendMax + 6;
+        case HIGH:
+            return recommendMax + 7;
+        case INSANE:
+            return recommendMax;
+        }
+    }
 
     @Override
     protected TestPathTraversal createScanner() {
         TestPathTraversal scanner = new TestPathTraversal();
         scanner.setConfig(new ZapXmlConfiguration());
         return scanner;
-    }
-
-    @Test
-    public void shouldSendReasonableNumberOfMessagesInLowStrength() throws Exception {
-        // Given
-        rule.setAttackStrength(Plugin.AttackStrength.LOW);
-        rule.init(getHttpMessage("?p=v"), parent);
-        // When
-        rule.scan();
-        // Then
-        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(NUMBER_MSGS_ATTACK_STRENGTH_LOW + 4)));
-        assertThat(alertsRaised, hasSize(0));
-    }
-
-    @Test
-    public void shouldSendReasonableNumberOfMessagesInMediumStrength() throws Exception {
-        // Given
-        rule.setAttackStrength(Plugin.AttackStrength.MEDIUM);
-        rule.init(getHttpMessage("?p=v"), parent);
-        // When
-        rule.scan();
-        // Then
-        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(NUMBER_MSGS_ATTACK_STRENGTH_MEDIUM + 6)));
-        assertThat(alertsRaised, hasSize(0));
-    }
-
-    @Test
-    public void shouldSendReasonableNumberOfMessagesInDefaultStrength() throws Exception {
-        // Given
-        rule.setAttackStrength(Plugin.AttackStrength.DEFAULT); // Same as MEDIUM.
-        rule.init(getHttpMessage("?p=v"), parent);
-        // When
-        rule.scan();
-        // Then
-        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(NUMBER_MSGS_ATTACK_STRENGTH_MEDIUM + 6)));
-        assertThat(alertsRaised, hasSize(0));
-    }
-
-    @Test
-    public void shouldSendReasonableNumberOfMessagesInHighStrength() throws Exception {
-        // Given
-        rule.setAttackStrength(Plugin.AttackStrength.HIGH);
-        rule.init(getHttpMessage("?p=v"), parent);
-        // When
-        rule.scan();
-        // Then
-        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(NUMBER_MSGS_ATTACK_STRENGTH_HIGH + 7)));
-        assertThat(alertsRaised, hasSize(0));
-    }
-
-    @Test
-    public void shouldSendReasonableNumberOfMessagesInInsaneStrength() throws Exception {
-        // Given
-        rule.setAttackStrength(Plugin.AttackStrength.INSANE);
-        rule.init(getHttpMessage("?p=v"), parent);
-        // When
-        rule.scan();
-        // Then
-        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(75))); // No recommendation, use an arbitrary value.
-        assertThat(alertsRaised, hasSize(0));
     }
 
     @Test

--- a/test/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSAttackUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSAttackUnitTest.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+/**
+ * Unit test for {@link TestPersistentXSSAttack}.
+ */
+public class TestPersistentXSSAttackUnitTest extends ActiveScannerAppParamTest<TestPersistentXSSAttack> {
+
+    @Override
+    protected TestPersistentXSSAttack createScanner() {
+        return new TestPersistentXSSAttack();
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSPrimeUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSPrimeUnitTest.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+/**
+ * Unit test for {@link TestPersistentXSSPrime}.
+ */
+public class TestPersistentXSSPrimeUnitTest extends ActiveScannerAppParamTest<TestPersistentXSSPrime> {
+
+    @Override
+    protected TestPersistentXSSPrime createScanner() {
+        return new TestPersistentXSSPrime();
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSSpiderUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSSpiderUnitTest.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+/**
+ * Unit test for {@link TestPersistentXSSSpider}.
+ */
+public class TestPersistentXSSSpiderUnitTest extends ActiveScannerAppTest<TestPersistentXSSSpider> {
+
+    @Override
+    protected TestPersistentXSSSpider createScanner() {
+        return new TestPersistentXSSSpider();
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestRemoteFileIncludeUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestRemoteFileIncludeUnitTest.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules;
+
+/**
+ * Unit test for {@link TestRemoteFileInclude}.
+ */
+public class TestRemoteFileIncludeUnitTest extends ActiveScannerAppParamTest<TestRemoteFileInclude> {
+
+    @Override
+    protected TestRemoteFileInclude createScanner() {
+        return new TestRemoteFileInclude();
+    }
+
+}

--- a/test/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
@@ -39,7 +40,23 @@ import fi.iki.elonen.NanoHTTPD.Response;
 /**
  * Unit test for {@link TestSQLInjection}.
  */
-public class TestSQLInjectionUnitTest extends ActiveScannerTest<TestSQLInjection> {
+public class TestSQLInjectionUnitTest extends ActiveScannerAppParamTest<TestSQLInjection> {
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+        case LOW:
+            return recommendMax + 1;
+        case MEDIUM:
+        default:
+            return recommendMax + 14;
+        case HIGH:
+            return recommendMax + 22;
+        case INSANE:
+            return recommendMax + 5;
+        }
+    }
 
     @Override
     protected TestSQLInjection createScanner() {

--- a/test/org/zaproxy/zap/extension/ascanrules/TestServerSideIncludeUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/TestServerSideIncludeUnitTest.java
@@ -30,7 +30,7 @@ import org.zaproxy.zap.model.TechSet;
 /**
  * Unit test for {@link TestServerSideInclude}.
  */
-public class TestServerSideIncludeUnitTest extends ActiveScannerTest<TestServerSideInclude> {
+public class TestServerSideIncludeUnitTest extends ActiveScannerAppParamTest<TestServerSideInclude> {
 
     @Override
     protected TestServerSideInclude createScanner() {

--- a/test/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
+++ b/test/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.HostProcess;
@@ -66,6 +68,14 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
      * {@link org.parosproxy.paros.core.scanner.Plugin.AttackStrength#HIGH AttackStrength.HIGH}, per parameter being scanned.
      */
     protected static final int NUMBER_MSGS_ATTACK_STRENGTH_HIGH = 24;
+
+    /**
+     * The maximum number of messages that a scanner can send in
+     * {@link org.parosproxy.paros.core.scanner.Plugin.AttackStrength#INSANE AttackStrength.INSANE}, per parameter being
+     * scanned.
+     */
+    // Arbitrary value, there's no recommended number.
+    protected static final int NUMBER_MSGS_ATTACK_STRENGTH_INSANE = 75;
 
     /**
      * The recommended maximum number of messages that a scanner can send per page being
@@ -155,6 +165,9 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
         };
         
         rule = createScanner();
+        if (rule.getConfig() == null) {
+            rule.setConfig(new ZapXmlConfiguration());
+        }
     }
 
     @After
@@ -167,6 +180,48 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
     @Override
     public String getHtml(String name, Map<String, String> params) {
         return super.getHtml(getClass().getSimpleName() + "/" + name, params);
+    }
+
+    /**
+     * Gets the recommended maximum number of messages that a scanner can send per parameter for the given strength.
+     *
+     * @param strength the attack strength.
+     * @return the recommended maximum number of messages.
+     * @see AbstractAppParamPlugin
+     */
+    protected int getRecommendMaxNumberMessagesPerParam(Plugin.AttackStrength strength) {
+        switch (strength) {
+        case LOW:
+            return NUMBER_MSGS_ATTACK_STRENGTH_LOW;
+        case MEDIUM:
+        default:
+            return NUMBER_MSGS_ATTACK_STRENGTH_MEDIUM;
+        case HIGH:
+            return NUMBER_MSGS_ATTACK_STRENGTH_HIGH;
+        case INSANE:
+            return NUMBER_MSGS_ATTACK_STRENGTH_INSANE;
+        }
+    }
+
+    /**
+     * Gets the recommended maximum number of messages that a scanner can send per page for the given strength.
+     *
+     * @param strength the attack strength.
+     * @return the recommended maximum number of messages.
+     * @see AbstractAppPlugin
+     */
+    protected int getRecommendMaxNumberMessagesPerPage(Plugin.AttackStrength strength) {
+        switch (strength) {
+        case LOW:
+            return NUMBER_MSGS_ATTACK_PER_PAGE_LOW;
+        case MEDIUM:
+        default:
+            return NUMBER_MSGS_ATTACK_PER_PAGE_MED;
+        case HIGH:
+            return NUMBER_MSGS_ATTACK_PER_PAGE_HIGH;
+        case INSANE:
+            return NUMBER_MSGS_ATTACK_PER_PAGE_INSANE;
+        }
     }
 
 }


### PR DESCRIPTION
Add tests (for each attack strength) to assert the number of messages
sent by the scanners (AbstractAppParamPlugin and AbstractAppPlugin).