### PR TITLE
ascanrulesBeta: remove unreachable strength cases

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
@@ -213,12 +213,6 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 	@Override
 	public void init() {
 		switch (this.getAttackStrength()) {
-		case DEFAULT:
-			numExtensionsToTry=10;
-			numSuffixesToTry=3;
-			numPrefixesToTry=2;
-			doSwitchFileExtension=false;
-			break;
 		case LOW:
 			numExtensionsToTry=3;
 			numSuffixesToTry=2;
@@ -243,6 +237,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 			numPrefixesToTry=filePrefixes.size();
 			doSwitchFileExtension=true;
 			break;
+		default:
 		}
 	}
 

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
@@ -508,8 +508,7 @@ public class HeartBleedActiveScanner extends AbstractHostPlugin {
 		case INSANE:
 			this.timeoutMs=12000;  //12 seconds
 			break;
-		case DEFAULT:
-			this.timeoutMs=5000;  //5 seconds
+		default:
 		}
 	}
 

--- a/test/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureUnitTest.java
@@ -82,18 +82,6 @@ public class BackupFileDisclosureUnitTest extends ActiveScannerTest<BackupFileDi
     }
 
     @Test
-    public void shouldSendReasonableNumberOfMessagesInDefaultStrength() throws Exception {
-        // Given
-        rule.setAttackStrength(Plugin.AttackStrength.DEFAULT); // Same as MEDIUM.
-        rule.init(getHttpMessage(URL), parent);
-        // When
-        rule.scan();
-        // Then
-        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(NUMBER_MSGS_ATTACK_PER_PAGE_MED)));
-        assertThat(alertsRaised, hasSize(0));
-    }
-
-    @Test
     public void shouldSendReasonableNumberOfMessagesInHighStrength() throws Exception {
         // Given
         rule.setAttackStrength(Plugin.AttackStrength.HIGH);


### PR DESCRIPTION
Remove the switch cases using `AttackStrength.DEFAULT`, those cases do
not happen, the method used to obtain the strength returns the value
configured for the default strength (for example, `MEDIUM`).
Remove test using `DEFAULT` strength, redundant with the other strength
tests.