### PR TITLE
Remove unreachable strength/threshold cases

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
@@ -228,11 +228,6 @@ public class TestExternalRedirect extends AbstractAppParamPlugin {
                 targetCount = 9;
                 break;
                 
-            case DEFAULT:
-            	// This works out as a total of 9 reqs / param
-                targetCount = 9;
-    			break;
-
             case HIGH:
                 // This works out as a total of 15 reqs / param
                 targetCount = REDIRECT_TARGETS.length;

--- a/src/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanner.java
@@ -54,8 +54,8 @@ public class XContentTypeOptionsScanner extends PluginPassiveScanner {
 				includeErrorRedirectResponses = true; break;
 			case HIGH:  
 			case MEDIUM: 					
-			case DEFAULT: 
-			case OFF: } 
+			default:
+		}
 		if (msg.getResponseBody().length() > 0) {
 			int responseStatus = msg.getResponseHeader().getStatusCode();
 			// If it's an error and we're not including error responses then just return without alerting

--- a/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrules/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Remove switch cases using `DEFAULT` or `OFF` for `AttackStrength` and
`AlertThreshold`, those cases do not happen, the methods used to obtain
the strength/threshold return the value configured for the default
strength (for example, MEDIUM) and the `OFF` is used to disable the
scanners so the scanner would not even be called in that case.
Update changes in ZapAddOn.xml file (where required).