### PR TITLE
sse: adjust log levels and remove stacktrace print

### DIFF
--- a/src/org/zaproxy/zap/extension/sse/EventStreamListener.java
+++ b/src/org/zaproxy/zap/extension/sse/EventStreamListener.java
@@ -42,10 +42,8 @@ public class EventStreamListener implements Runnable {
 		} catch (Exception e) {
 			// includes SocketException
 			// no more reading possible
-			e.printStackTrace();
-			logger.info("Server-Sent Events server produced exception: " + e.getMessage(), e);
+			logger.warn("An exception occurred while reading Server-Sent Events: " + e.getMessage(), e);
 		} finally {
-			logger.info("Server-Sent Events server closed its connection - shutdown");
 			this.proxy.stop();
 		}
 	}

--- a/src/org/zaproxy/zap/extension/sse/EventStreamProxy.java
+++ b/src/org/zaproxy/zap/extension/sse/EventStreamProxy.java
@@ -85,7 +85,9 @@ public class EventStreamProxy {
 	
 	public void stop() {
 		try {
-			logger.info("Close Server-Sent Events stream #" + dataStreamObject.getId() + "!");
+			if (logger.isDebugEnabled()) {
+				logger.debug("Close Server-Sent Events stream #" + dataStreamObject.getId());
+			}
 
 			listener.close(); // closes reader
 			writer.close();
@@ -93,8 +95,9 @@ public class EventStreamProxy {
 			notifyStateObservers(State.CLOSED);
 			dataStreamObject.setEndTimestamp(Calendar.getInstance().getTimeInMillis());
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			if (logger.isDebugEnabled()) {
+				logger.debug("An exception occurred while stopping the proxy:", e);
+			}
 		}
 		//TODO close thread also?
 	}
@@ -178,7 +181,9 @@ public class EventStreamProxy {
 		sse.setStreamId(dataStreamObject.getId());
 		sse.finishData();
 		
-		logger.info("Processed Server-Sent Event" + sse.toString());
+		if (logger.isDebugEnabled()) {
+			logger.debug("Processed Server-Sent Event" + sse.toString());
+		}
 		
 		boolean doForward = notifyObservers(sse);
 		if (doForward) {
@@ -194,7 +199,7 @@ public class EventStreamProxy {
 			writer.write(sse.getRawEvent()+"\n\n");
 			writer.flush();
 		} catch (IOException e) {
-			logger.error("forwarding event " + sse.toString() + " was not possible due to: " + e.getMessage(), e);
+			logger.warn("Forwarding event " + sse.toString() + " was not possible due to: " + e.getMessage(), e);
 			stop();
 		}
 	}

--- a/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/sse/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.5.0.<br>
+	Adjust log levels to be less verbose.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/sse/db/TableEventStream.java
+++ b/src/org/zaproxy/zap/extension/sse/db/TableEventStream.java
@@ -471,7 +471,9 @@ public class TableEventStream extends ParosAbstractTable {
 						// proceed with insert
 						stmt = psInsertStream;
 						addIdOnSuccess = true;
-						logger.info("insert stream: " + stream.toString());
+						if (logger.isDebugEnabled()) {
+							logger.debug("insert stream: " + stream.toString());
+						}
 					}
 
 					Long startTs = stream.getStartTimestamp();
@@ -533,7 +535,9 @@ public class TableEventStream extends ParosAbstractTable {
 						throw new DatabaseException("stream not inserted: " + event.getStreamId());
 					}
 					
-					logger.info("insert event: " + event.toString());
+					if (logger.isDebugEnabled()) {
+						logger.debug("insert event: " + event.toString());
+					}
 
 					psInsertEvent.setInt(1, event.getId());
 					psInsertEvent.setInt(2, event.getStreamId());


### PR DESCRIPTION
Adjust log levels to be less verbose (info to debug) and have some
events with more relevance (info to warn), also, remove redundant log
message already done by the proxy.
Remove prints of exceptions' stacktraces, either already included in
logging message or added to a new one.
Update changes in ZapAddOn.xml file.