### PR TITLE
Remove unreachable strength/threshold stmt (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
@@ -157,11 +157,6 @@ public class LDAPInjection extends AbstractAppParamPlugin {
         	case LOW:
         		this.matchThreshold = 40;
         		break;
-        	//this case cannot currently be selected in the GUI, so it doesn't make much sense. 
-        	//But hey. For now, make it the same as "LOW"
-        	case OFF:
-        		this.matchThreshold = 40;
-        		break;
         	default:
         		break;
         }
@@ -178,12 +173,10 @@ public class LDAPInjection extends AbstractAppParamPlugin {
 	        case MEDIUM:
 	        	this.andRequests=4;
 	        	break;
-	        case DEFAULT:
-	        	this.andRequests=4;
-	        	break;
 	        case LOW:
 	        	this.andRequests=2;
 	        	break;
+	        default:
 	        }
     }
 

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
@@ -167,24 +167,12 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
 			MAX_FORWARDS_MAXIMUM=2;
 		} else if ( this.getAttackStrength() == AttackStrength.MEDIUM) {
 			MAX_FORWARDS_MAXIMUM=3;
-		} else if ( this.getAttackStrength() == AttackStrength.DEFAULT) {
-			MAX_FORWARDS_MAXIMUM=3;
 		} else if ( this.getAttackStrength() == AttackStrength.HIGH) {
 			MAX_FORWARDS_MAXIMUM=4;
 		} else if ( this.getAttackStrength() == AttackStrength.INSANE) {
 			MAX_FORWARDS_MAXIMUM=5;
 		}
 
-		//how thick a skin should we have as regards what we should consider an issue?
-		if ( this.getAlertThreshold() == AlertThreshold.LOW ) {
-
-		} else if ( this.getAlertThreshold() == AlertThreshold.MEDIUM ) {
-
-		} else if ( this.getAlertThreshold() == AlertThreshold.DEFAULT ) {
-
-		} else if ( this.getAlertThreshold() == AlertThreshold.HIGH ) {
-
-		}
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
@@ -277,9 +277,6 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
 		} else if ( this.getAlertThreshold() == AlertThreshold.MEDIUM ) {
 			parseDelayDifference = 200;
 			incrementalDelayIncreasesForAlert=2;
-		} else if ( this.getAlertThreshold() == AlertThreshold.DEFAULT ) {
-			parseDelayDifference = 200;
-			incrementalDelayIncreasesForAlert=2;
 		} else if ( this.getAlertThreshold() == AlertThreshold.HIGH ) {
 			parseDelayDifference = 400;
 			incrementalDelayIncreasesForAlert=3;

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
@@ -178,12 +178,7 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 		case LOW:
 			this.thresholdPercentage = 50;
 			break;
-		case OFF:
-			this.thresholdPercentage = 50;	// == LOW
-			break;
-		case DEFAULT:
-			this.thresholdPercentage = 75; // == medium
-			break;
+		default:
 		}
 	}
 	

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -167,12 +167,11 @@ public class Base64Disclosure extends PluginPassiveScanner {
 					//50% probability threshold (ie, "on balance of probability")
 					case HIGH:	probabilityThreshold = 0.50F; break;  
 					//25% probability threshold
-					case MEDIUM: 					
-					case DEFAULT: probabilityThreshold = 0.25F; break;	
+					case MEDIUM: probabilityThreshold = 0.25F; break;	
 					//10% probability threshold
 					case LOW: probabilityThreshold = 0.10F; break;		
 					//0% probability threshold (all structurally valid Base64 data is considered, regardless of how improbable  it is given character frequencies, etc)
-					case OFF: probabilityThreshold = 0.00F; break;		 
+					default:
 					}
 
 					//if the String is unlikely to be Base64, given the distribution of the characters


### PR DESCRIPTION
Remove switch cases and if statements using `DEFAULT` or `OFF` for
`AttackStrength` and `AlertThreshold`, those do not happen/match.
For ProxyDisclosureScanner remove all alert threshold checks, not doing
anything.