### PR TITLE
ascanrules: correct time replacement

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -19,7 +19,6 @@ package org.zaproxy.zap.extension.ascanrules;
 
 import java.io.IOException;
 import java.net.SocketException;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -546,11 +545,12 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
 
         it = blindOsPayloads.iterator();
         
+        String timeSleepSecondsStr = String.valueOf(timeSleepSeconds);
         for(int i = 0; it.hasNext() && (i < blindTargetCount); i++) {
             HttpMessage msg = getNewMsg();
             payload = it.next();
             
-            paramValue = value + MessageFormat.format(payload, timeSleepSeconds);
+            paramValue = value + payload.replace("{0}", timeSleepSecondsStr);
             setParameter(msg, paramName, paramValue);
 
             if (log.isDebugEnabled()) {

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Maintenance changes.<br>
 	Persistent XSS scanner upated to address various false negatives (Issue 4692).<br>
 	Command Injection plugin updated to include payloads for Uninitialized environment variable WAF bypass (Issue 4968).<br>
+	Correct Remote OS Command Injection to use the expected time in all time based paylods.<br>
 	]]>
     </changes>
 	<extensions>


### PR DESCRIPTION
Change CommandInjectionPlugin to replace the time token directly without
using MessageFormat, some of the payloads are quoted which would prevent
the replacement (while one could escape the quotes and keep using the
MessageFormat it would make the payloads harder to read and maintain).
Add test to assert the expected behaviour.
Update changes in ZapAddOn.xml file.

---
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/JUQFaBTRYwo/discussion