### PR TITLE
saml: dynamically unload the add-on

### DIFF
--- a/src/org/zaproxy/zap/extension/saml/SAMLExtension.java
+++ b/src/org/zaproxy/zap/extension/saml/SAMLExtension.java
@@ -71,4 +71,9 @@ public class SAMLExtension extends ExtensionAdaptor {
             log.error("SAML Extension can't be loaded. Configuration not found or invalid",e);
         }
     }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
 }

--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Compressed SAMLMessage is not required<br>
 	Possibility to disable compression when sending<br>
 	Added SAML Passive Scanner<br>
+	Dynamically unload the add-on.<br>
 	]]>
 	</changes>
     <dependson/>

--- a/src/org/zaproxy/zap/extension/saml/ui/SamlExtentionSettingsUI.java
+++ b/src/org/zaproxy/zap/extension/saml/ui/SamlExtentionSettingsUI.java
@@ -112,12 +112,18 @@ public class SamlExtentionSettingsUI extends JFrame implements PassiveAttributeC
                         "Do You want to save changes before exit?", SamlI18n.getMessage("saml.settings.messages" +
                         ".confirm"),
                         JOptionPane.YES_NO_CANCEL_OPTION);
+                boolean exit = false;
                 if (response == JOptionPane.YES_OPTION) {
                     saveChanges();
-                    SamlExtentionSettingsUI.this.setVisible(false);
+                    exit = true;
                 } else if(response==JOptionPane.NO_OPTION){
                     resetChanges();
-                    SamlExtentionSettingsUI.this.setVisible(false);
+                    exit = true;
+                }
+
+                if (exit) {
+                    setVisible(false);
+                    dispose();
                 }
             }
         });


### PR DESCRIPTION
Change SAMLExtension to declare that it can be unloaded.
Change SamlExtentionSettingsUI to dispose when exited, to be GC'ed
sooner.
Update changes in ZapAddOn.xml file.