### PR TITLE
Use core rule config constants

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/src/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -36,6 +36,7 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.model.Vulnerabilities;
@@ -53,7 +54,7 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
 	/**
 	 * The name of the rule to obtain the time, in seconds, for time-based attacks.
 	 */
-	private static final String RULE_SLEEP_TIME = "rules.common.sleep";
+	private static final String RULE_SLEEP_TIME = RuleConfigParam.RULE_COMMON_SLEEP_TIME;
 
 	/**
 	 * Prefix for internationalised messages used by this rule

--- a/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrules/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+	Maintenance changes.<br>
 	]]>
     </changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrules/CookieUtils.java
+++ b/src/org/zaproxy/zap/extension/pscanrules/CookieUtils.java
@@ -25,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 
 /**
  * Utility class to extract/parse/check Set-Cookie header values.
@@ -171,7 +172,7 @@ class CookieUtils {
     public static Set<String> getCookieIgnoreList(Model model) {
         Set<String> ignoreList = new HashSet<String>();
         String ignoreConf = model.getOptionsParam().getConfig().
-                getString("rules.cookie.ignorelist");
+                getString(RuleConfigParam.RULE_COOKIE_IGNORE_LIST);
         if (ignoreConf != null && ignoreConf.length() > 0) {
             for (String str : ignoreConf.split(",")) {
                 String strTrim = str.trim();

--- a/test/org/zaproxy/zap/extension/ascanrules/CommandInjectionPluginUnitTest.java
+++ b/test/org/zaproxy/zap/extension/ascanrules/CommandInjectionPluginUnitTest.java
@@ -34,6 +34,7 @@ import org.apache.commons.configuration.Configuration;
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
@@ -181,8 +182,7 @@ public class CommandInjectionPluginUnitTest extends ActiveScannerAppParamTest<Co
 
     private static Configuration configWithSleepRule(String value) {
         Configuration config = new ZapXmlConfiguration();
-        // TODO Replace with RuleConfigParam.RULE_COMMON_SLEEP_TIME once available.
-        config.setProperty("rules.common.sleep", value);
+        config.setProperty(RuleConfigParam.RULE_COMMON_SLEEP_TIME, value);
         return config;
     }
 

--- a/test/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScannerUnitTest.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public class CookieHttpOnlyScannerUnitTest extends PassiveScannerTest<CookieHttpOnlyScanner> {
@@ -127,7 +128,7 @@ public class CookieHttpOnlyScannerUnitTest extends PassiveScannerTest<CookieHttp
     @Test
     public void cookieOnIgnoreList() throws HttpMalformedHeaderException {
         
-        model.getOptionsParam().getConfig().setProperty("rules.cookie.ignorelist", "aaaa,test,bbb");
+        model.getOptionsParam().getConfig().setProperty(RuleConfigParam.RULE_COOKIE_IGNORE_LIST, "aaaa,test,bbb");
         
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -148,7 +149,7 @@ public class CookieHttpOnlyScannerUnitTest extends PassiveScannerTest<CookieHttp
     @Test
     public void cookieNotOnIgnoreList() throws HttpMalformedHeaderException {
         
-        model.getOptionsParam().getConfig().setProperty("rules.cookie.ignorelist", "aaaa,bbb,ccc");
+        model.getOptionsParam().getConfig().setProperty(RuleConfigParam.RULE_COOKIE_IGNORE_LIST, "aaaa,bbb,ccc");
         
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");

--- a/test/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScannerUnitTest.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 public class CookieSecureFlagScannerUnitTest extends PassiveScannerTest<CookieSecureFlagScanner> {
@@ -127,7 +128,7 @@ public class CookieSecureFlagScannerUnitTest extends PassiveScannerTest<CookieSe
     
     @Test
     public void cookieOnIgnoreList() throws HttpMalformedHeaderException {
-        model.getOptionsParam().getConfig().setProperty("rules.cookie.ignorelist", "aaaa,test,bbb");
+        model.getOptionsParam().getConfig().setProperty(RuleConfigParam.RULE_COOKIE_IGNORE_LIST, "aaaa,test,bbb");
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -146,7 +147,7 @@ public class CookieSecureFlagScannerUnitTest extends PassiveScannerTest<CookieSe
 
     @Test
     public void cookieNotOnIgnoreList() throws HttpMalformedHeaderException {
-        model.getOptionsParam().getConfig().setProperty("rules.cookie.ignorelist", "aaaa,bbb,ccc");
+        model.getOptionsParam().getConfig().setProperty(RuleConfigParam.RULE_COOKIE_IGNORE_LIST, "aaaa,bbb,ccc");
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");


### PR DESCRIPTION
Replace literal strings with the corresponding core rule configuration
constants. The add-ons are already targeting the minimum required ZAP
version.
Update changes in ZapAddOn.xml file (where needed).