### PR TITLE
Use core rule config constants (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
@@ -41,6 +41,7 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httpsessions.HttpSessionsParam;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
 
@@ -145,7 +146,7 @@ public class Csrftokenscan extends AbstractAppPlugin {
 	 */
 	@Override
 	public void init() {
-		String ignoreConf = getConfig().getString("rules.csrf.ignorelist");
+		String ignoreConf = getConfig().getString(RuleConfigParam.RULE_CSRF_IGNORE_LIST);
 		if (ignoreConf != null && ignoreConf.length() > 0) {
 			log.debug("Using ignore list: " + ignoreConf);
 			for (String str : ignoreConf.split(",")) {
@@ -155,8 +156,8 @@ public class Csrftokenscan extends AbstractAppPlugin {
 				}
 			}
 		}
-		ignoreAttName = getConfig().getString("rules.csrf.ignore.attname");
-		ignoreAttValue = getConfig().getString("rules.csrf.ignore.attvalue");
+		ignoreAttName = getConfig().getString(RuleConfigParam.RULE_CSRF_IGNORE_ATT_NAME);
+		ignoreAttValue = getConfig().getString(RuleConfigParam.RULE_CSRF_IGNORE_ATT_VALUE);
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -222,9 +223,9 @@ public class SQLInjectionHypersonic extends AbstractAppParamPlugin {
 		}
 		// Read the sleep value from the configs - note this is in milliseconds
 		try {
-			this.sleep = this.getConfig().getInt("rules.common.sleep", 5) * 1000;
+			this.sleep = this.getConfig().getInt(RuleConfigParam.RULE_COMMON_SLEEP_TIME, 5) * 1000;
 		} catch (ConversionException e) {
-			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString("rules.common.sleep"));
+			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString(RuleConfigParam.RULE_COMMON_SLEEP_TIME));
 		}
 		if ( this.debugEnabled ) {
 			log.debug("Sleep set to " + sleep + " milliseconds");

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -186,9 +187,9 @@ public class SQLInjectionMySQL extends AbstractAppParamPlugin {
 
 		// Read the sleep value from the configs
 		try {
-			this.sleep = this.getConfig().getInt("rules.common.sleep", 5);
+			this.sleep = this.getConfig().getInt(RuleConfigParam.RULE_COMMON_SLEEP_TIME, 5);
 		} catch (ConversionException e) {
-			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString("rules.common.sleep"));
+			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString(RuleConfigParam.RULE_COMMON_SLEEP_TIME));
 		}
 		if ( this.debugEnabled ) {
 			log.debug("Sleep set to " + sleep + " seconds");

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -207,9 +208,9 @@ public class SQLInjectionPostgresql extends AbstractAppParamPlugin {
 		}
 		// Read the sleep value from the configs
 		try {
-			this.sleep = this.getConfig().getInt("rules.common.sleep", 5);
+			this.sleep = this.getConfig().getInt(RuleConfigParam.RULE_COMMON_SLEEP_TIME, 5);
 		} catch (ConversionException e) {
-			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString("rules.common.sleep"));
+			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString(RuleConfigParam.RULE_COMMON_SLEEP_TIME));
 		}
 		if ( this.debugEnabled ) {
 			log.debug("Sleep set to " + sleep + " seconds");

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanner.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 
 /**
 * a scanner that looks for servers vulnerable to ShellShock  
@@ -93,9 +94,9 @@ public class ShellShockScanner extends AbstractAppParamPlugin {
 	public void init() {		
 		// Read the sleep value from the configs
 		try {
-			this.sleep = this.getConfig().getInt("rules.common.sleep", 5);
+			this.sleep = this.getConfig().getInt(RuleConfigParam.RULE_COMMON_SLEEP_TIME, 5);
 		} catch (ConversionException e) {
-			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString("rules.common.sleep"));
+			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString(RuleConfigParam.RULE_COMMON_SLEEP_TIME));
 		}
 		if ( log.isDebugEnabled() ) {
 			log.debug("Sleep set to " + sleep + " seconds");

--- a/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesBeta/CSRFCountermeasures.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
 
@@ -317,7 +318,7 @@ public class CSRFCountermeasures extends PluginPassiveScanner {
 
     protected String getCSRFIgnoreList() {
     	if (csrfIgnoreList == null) {
-    		return Model.getSingleton().getOptionsParam().getConfig().getString("rules.csrf.ignorelist");
+    		return Model.getSingleton().getOptionsParam().getConfig().getString(RuleConfigParam.RULE_CSRF_IGNORE_LIST);
     	}
     	return csrfIgnoreList;
     }
@@ -328,7 +329,7 @@ public class CSRFCountermeasures extends PluginPassiveScanner {
 
     protected String getCSRFIgnoreAttName() {
     	if (csrfAttIgnoreList == null) {
-    		return Model.getSingleton().getOptionsParam().getConfig().getString("rules.csrf.ignore.attname", null);	
+    		return Model.getSingleton().getOptionsParam().getConfig().getString(RuleConfigParam.RULE_CSRF_IGNORE_ATT_NAME, null);	
     	}
         return csrfAttIgnoreList;
     }
@@ -339,7 +340,7 @@ public class CSRFCountermeasures extends PluginPassiveScanner {
     
     protected String getCSRFIgnoreAttValue() {
     	if (csrfValIgnoreList == null) {
-    		return Model.getSingleton().getOptionsParam().getConfig().getString("rules.csrf.ignore.attvalue", null);
+    		return Model.getSingleton().getOptionsParam().getConfig().getString(RuleConfigParam.RULE_CSRF_IGNORE_ATT_VALUE, null);
     	}
     	return csrfValIgnoreList;
     }


### PR DESCRIPTION
Replace literal strings with the corresponding core rule configuration
constants. The add-ons are already targeting the minimum required ZAP
version.