### PR TITLE
Use add-on classloader when creating JAXBContext

### DIFF
--- a/src/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
+++ b/src/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
@@ -59,6 +59,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.ls.DOMImplementationLS;
 import org.w3c.dom.ls.LSSerializer;
 import org.xml.sax.SAXException;
+import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.exportreport.filechooser.Utils;
 import org.zaproxy.zap.extension.exportreport.model.AlertItem;
@@ -229,7 +230,9 @@ final class ReportExport {
             report.add(s);
         }
 
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
+            Thread.currentThread().setContextClassLoader(ExtensionFactory.getAddOnLoader());
             javax.xml.bind.JAXBContext jc = javax.xml.bind.JAXBContext.newInstance(Report.class);
             Marshaller jaxbMarshaller = jc.createMarshaller();
             jaxbMarshaller.setProperty(javax.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT, true);
@@ -240,6 +243,8 @@ final class ReportExport {
             return path + fileName + Utils.DUMP;
         } catch (JAXBException e) {
             logger.error(e.getMessage(), e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(cl);
         }
         return "";
     }

--- a/src/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
+++ b/src/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
@@ -2,6 +2,7 @@ package org.zaproxy.zap.extension.saml;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.control.ExtensionFactory;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -181,7 +182,9 @@ public class SAMLConfiguration implements AttributeListener {
      * @return <code>true</code> if save is success, <code>false</code> otherwise
      */
     public boolean saveConfiguration() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
+            Thread.currentThread().setContextClassLoader(ExtensionFactory.getAddOnLoader());
             JAXBContext context = JAXBContext.newInstance(SAMLConfigData.class);
             Marshaller marshaller = context.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
@@ -189,6 +192,8 @@ public class SAMLConfiguration implements AttributeListener {
             return true;
         } catch (JAXBException e) {
             log.error("Saving configuration failed");
+        } finally {
+            Thread.currentThread().setContextClassLoader(cl);
         }
         return false;
     }
@@ -202,12 +207,16 @@ public class SAMLConfiguration implements AttributeListener {
      * @throws SAMLException
      */
     private Object loadXMLObject(Class<?> clazz, File file) throws SAMLException {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
+            Thread.currentThread().setContextClassLoader(ExtensionFactory.getAddOnLoader());
             JAXBContext context = JAXBContext.newInstance(clazz);
             Unmarshaller unmarshaller = context.createUnmarshaller();
             return unmarshaller.unmarshal(file);
         } catch (JAXBException e) {
             throw new SAMLException("XML loading failed", e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(cl);
         }
     }
 


### PR DESCRIPTION
Change ReportExport and SAMLConfiguration to use the add-on classloader
when creating the JAXBContext to ensure the add-ons are searched when
loading JAXB-API implementation, for when the add-ons bundle it.

Part of:
 - zaproxy/zaproxy#4214 - Unable to create reports with Export Report
 add-on and Java 9
 - zaproxy/zaproxy#5032 - SAML add-on leads to errors with Java 9+