### PR TITLE
websocket: sync event consumer management

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -7,7 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
-	Fix an exception when dispatching events.
+	Fix exceptions when handling/dispatching events.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -18,7 +18,7 @@ ZAP Dev Team
 
 <H3>Version 19 - TBD</H3>
 <ul>
-	<li>Fix an exception when dispatching events.</li>
+	<li>Fix exceptions when handling/dispatching events.</li>
 </ul>
 
 <H3>Version 18 - 2018/08/01</H3>


### PR DESCRIPTION
Change WebSocketAPI to sync the management of event consumers and to the
registered publishers to prevent concurrency issues.
Tweak existing change in ZapAddOn.xml and about help page.

---
For example:
```
35300 [ZAP-WS-Listener (remote) 'zap:443 (#1)'] ERROR org.zaproxy.zap.extension.websocket.WebSocketAPI  - 
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1134)
	at org.zaproxy.zap.extension.websocket.WebSocketAPI.getEventConsumer(WebSocketAPI.java:299)
	at org.zaproxy.zap.extension.websocket.WebSocketAPI.access$100(WebSocketAPI.java:65)
	at org.zaproxy.zap.extension.websocket.WebSocketAPI$1.onMessageFrame(WebSocketAPI.java:186)
	at org.zaproxy.zap.extension.websocket.WebSocketProxy.notifyMessageObservers(WebSocketProxy.java:718)
	at org.zaproxy.zap.extension.websocket.WebSocketProxy.processRead(WebSocketProxy.java:590)
	at org.zaproxy.zap.extension.websocket.WebSocketListener.run(WebSocketListener.java:89)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```