### PR TITLE
Use core rule config constants (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionMsSQL.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionMsSQL.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -158,9 +159,9 @@ public class SQLInjectionMsSQL extends AbstractAppParamPlugin {
 
 		// Read the sleep value from the configs
 		try {
-			this.sleep = this.getConfig().getInt("rules.common.sleep", DEFAULT_SLEEP_TIME);
+			this.sleep = this.getConfig().getInt(RuleConfigParam.RULE_COMMON_SLEEP_TIME, DEFAULT_SLEEP_TIME);
 		} catch (ConversionException e) {
-			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString("rules.common.sleep"));
+			log.debug("Invalid value for 'rules.common.sleep': " + this.getConfig().getString(RuleConfigParam.RULE_COMMON_SLEEP_TIME));
 		}
 		if ( log.isDebugEnabled() ) {
 			log.debug("Sleep set to " + sleep + " seconds");

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-extensions/wiki/HelpAddonsAscanrulesAlphaAscanalpha</url>
 	<changes>
 	<![CDATA[
+	Update minimum ZAP version to 2.6.0.<br>
 	]]>
 	</changes>
 	<extensions>
@@ -38,6 +39,6 @@
 	<files>
 		<file>xml/example-ascan-file.txt</file>
 	</files>
-	<not-before-version>2.5.0</not-before-version>
+	<not-before-version>2.6.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/LinkTargetScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/LinkTargetScanner.java
@@ -42,6 +42,7 @@ import net.htmlparser.jericho.Source;
 
 public class LinkTargetScanner extends PluginPassiveScanner {
 
+    // TODO Replace "rules.domains.trusted" with RuleConfigParam.RULE_DOMAINS_TRUSTED once available.
     public static final String TRUSTED_DOMAINS_PROPERTY = "rules.domains.trusted";
     private static final String MESSAGE_PREFIX = "pscanalpha.linktarget.";
 


### PR DESCRIPTION
Replace literal string with corresponding core rule config constant.
Update changes in ZapAddOn.xml file and update minimum ZAP version,
required to use the constant.
Add TODO task to LinkTargetScanner to replace one rule config when
available.