### PR TITLE
zest: allow to invoke popup menu with keyboard

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -15,6 +15,7 @@
 	Title caps adjustments (Issue 2000).<br>
 	Use selected text when adding assignments from the request/response.<br>
 	Show expression's inverse state in more tree nodes.<br>
+	Allow to invoke the context menu in text fields also with keyboard.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.zest;
 
-import java.awt.event.MouseAdapter;
+import java.awt.Component;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -28,6 +28,9 @@ import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.swing.JComponent;
+import javax.swing.JPopupMenu;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -107,6 +110,8 @@ public class ZestZapUtils {
 	
 	// Only use for debugging for now, as the tree wont be fully updated if indexes change
 	private static boolean showIndexes = false;
+
+	private static JPopupMenu popupMenu;
 
 	public static String toUiString(ZestElement za) {
 		return toUiString(za, true, 0);
@@ -872,26 +877,26 @@ public class ZestZapUtils {
 		return 0;
 	}
 
-	public static MouseAdapter stdMenuAdapter() {
-		return new java.awt.event.MouseAdapter() {
-			@Override
-			public void mousePressed(java.awt.event.MouseEvent e) {
-				mouseAction(e);
-			}
+	// TODO remove once targeting core version that allows to set the pop up menu into the fields of StandardFieldsDialog.
+	public static void setMainPopupMenu(Component component) {
+		if (component instanceof JComponent) {
+			((JComponent) component).setComponentPopupMenu(getPopupMenu());
+		}
+	}
 
-			@Override
-			public void mouseReleased(java.awt.event.MouseEvent e) {
-				mouseAction(e);
-			}
+	private static JPopupMenu getPopupMenu() {
+		if (popupMenu == null) {
+			popupMenu = new JPopupMenu() {
 
-			public void mouseAction(java.awt.event.MouseEvent e) {
-				// right mouse button action
-				if (e.isPopupTrigger()) {
-					View.getSingleton().getPopupMenu()
-							.show(e.getComponent(), e.getX(), e.getY());
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public void show(Component invoker, int x, int y) {
+					View.getSingleton().getPopupMenu().show(invoker, x, y);
 				}
-			}
-		};
+			};
+		}
+		return popupMenu;
 	}
 	
 	public static boolean isValidVariableName(String name) {

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
@@ -132,14 +132,12 @@ public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog
 				this.addComboField(FIELD_PRIORITY, priorities, 
 						priorityToStr(ZestActionFail.Priority.valueOf(za.getPriority())));
 			}
-			// Enable right click menus
-			this.addFieldListener(FIELD_MESSAGE, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_MESSAGE)); 
 
 		} else if (action instanceof ZestActionPrint) {
 			ZestActionPrint za = (ZestActionPrint) action;
 			this.addMultilineField(FIELD_MESSAGE, za.getMessage());
-			// Enable right click menus
-			this.addFieldListener(FIELD_MESSAGE, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_MESSAGE)); 
 			
 		} else if (action instanceof ZestActionSleep) {
 			ZestActionSleep za = (ZestActionSleep) action;

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssertionsDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssertionsDialog.java
@@ -105,8 +105,7 @@ public class ZestAssertionsDialog extends StandardFieldsDialog implements ZestDi
 			this.addCheckBoxField(FIELD_EXACT, za.isCaseExact());
 			this.addCheckBoxField(FIELD_INVERSE, za.isInverse());
 			
-			// Enable right click menus
-			this.addFieldListener(FIELD_VALUE, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE)); 
 
 		} else if (assertion.getRootExpression() instanceof ZestExpressionRegex) {
 			ZestExpressionRegex za = (ZestExpressionRegex) assertion.getRootExpression();

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
@@ -144,8 +144,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
 					assign.getVariableName(), true);
 			this.addTextField(FIELD_STRING, za.getString());
 			
-			// Enable right click menus
-			this.addFieldListener(FIELD_STRING, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_STRING)); 
 
 		} else if (assign instanceof ZestAssignReplace) {
 			ZestAssignReplace za = (ZestAssignReplace) assign;
@@ -156,9 +155,8 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
 			this.addCheckBoxField(FIELD_REGEX, za.isRegex());
 			this.addCheckBoxField(FIELD_EXACT, za.isCaseExact());
 
-			// Enable right click menus
-			this.addFieldListener(FIELD_REPLACE, ZestZapUtils.stdMenuAdapter()); 
-			this.addFieldListener(FIELD_REPLACEMENT, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_REPLACE)); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_REPLACEMENT)); 
 			
 		} else if (assign instanceof ZestAssignCalc) {
 			ZestAssignCalc za = (ZestAssignCalc) assign;
@@ -174,8 +172,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
 					}, 
 					ZestZapUtils.calcOperationToLabel(za.getOperation()));
 			
-			// Enable right click menus
-			this.addFieldListener(FIELD_STRING, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_STRING)); 
 
 		}
 		

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementAssignDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementAssignDialog.java
@@ -53,8 +53,7 @@ public class ZestClientElementAssignDialog extends ZestClientElementDialog imple
 		} else {
 			this.setTitle(Constant.messages.getString("zest.dialog.clientElementAssign.edit.title"));
 		}
-		// Enable right click menus
-		this.addFieldListener(FIELD_ATTRIBUTE, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_ATTRIBUTE)); 
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementDialog.java
@@ -83,8 +83,7 @@ public abstract class ZestClientElementDialog extends StandardFieldsDialog imple
 		this.addComboField(FIELD_ELEMENT_TYPE, getElementTypeFields(), clientType);
 		this.addTextField(FIELD_ELEMENT, client.getElement());
 		
-		// Enable right click menus
-		this.addFieldListener(FIELD_ELEMENT, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_ELEMENT)); 
 	}
 
 	private List<String> getElementTypeFields() {

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementSendKeysDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementSendKeysDialog.java
@@ -54,8 +54,7 @@ public class ZestClientElementSendKeysDialog extends ZestClientElementDialog imp
 			this.setTitle(Constant.messages.getString("zest.dialog.clientElementSendKeys.edit.title"));
 		}
 		
-		// Enable right click menus
-		this.addFieldListener(FIELD_VALUE, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE)); 
 
 	}
 

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
@@ -116,8 +116,7 @@ public class ZestClientLaunchDialog extends StandardFieldsDialog implements Zest
         
         this.addTableField(1, this.getParamsTable(), buttons);
 		
-		// Enable right click menus
-		this.addFieldListener(FIELD_URL, ZestZapUtils.stdMenuAdapter());
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_URL));
 	}
 	
 	private List<String[]> getCapabilities(ZestClientLaunch client) {

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
@@ -84,8 +84,7 @@ public class ZestClientSwitchToFrameDialog extends StandardFieldsDialog implemen
 		this.addNumberField(FIELD_FRAME_INDEX, -1, 1024, client.getFrameIndex());
 		this.addCheckBoxField(FIELD_PARENT_FRAME, client.isParent());
 		
-		// Enable right click menus
-		this.addFieldListener(FIELD_FRAME_NAME, ZestZapUtils.stdMenuAdapter());
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_FRAME_NAME));
 		
 		// Only allow one choice to be selected
 		this.addFieldListener(FIELD_FRAME_NAME, new ActionListener() {

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowHandleDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowHandleDialog.java
@@ -73,8 +73,7 @@ public class ZestClientWindowHandleDialog extends StandardFieldsDialog implement
 		this.addTextField(FIELD_URL, client.getUrl());
 		this.addCheckBoxField(FIELD_REGEX, client.isRegex());
 		
-		// Enable right click menus
-		this.addFieldListener(FIELD_URL, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_URL)); 
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestControlDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestControlDialog.java
@@ -72,8 +72,7 @@ public class ZestControlDialog extends StandardFieldsDialog implements ZestDialo
 		if (control instanceof ZestControlReturn) {
 			ZestControlReturn za = (ZestControlReturn) control;
 			this.addTextField(FIELD_VALUE, za.getValue());
-			// Enable right click menus
-			this.addFieldListener(FIELD_VALUE, ZestZapUtils.stdMenuAdapter());
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE));
 		}
 		this.addPadding();
 	}

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
@@ -65,11 +65,10 @@ public class ZestCookieDialog extends StandardFieldsDialog implements ZestDialog
 		this.addTextField(FIELD_PARAM_PATH, path);
 		this.addPadding();
 		
-		// Enable right click menus
-		this.addFieldListener(FIELD_PARAM_DOMAIN, ZestZapUtils.stdMenuAdapter()); 
-		this.addFieldListener(FIELD_PARAM_NAME, ZestZapUtils.stdMenuAdapter()); 
-		this.addFieldListener(FIELD_PARAM_VALUE, ZestZapUtils.stdMenuAdapter()); 
-		this.addFieldListener(FIELD_PARAM_PATH, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_DOMAIN)); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_NAME)); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_VALUE)); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_PATH)); 
 
 	}
 	

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestExpressionDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestExpressionDialog.java
@@ -126,8 +126,7 @@ public class ZestExpressionDialog extends StandardFieldsDialog implements ZestDi
 			this.addTextField(FIELD_VALUE, za.getValue());
 			this.addCheckBoxField(FIELD_EXACT, za.isCaseExact());
 			
-			// Enable right click menus
-			this.addFieldListener(FIELD_VALUE, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE)); 
 
 		} else if (expression instanceof ZestExpressionStatusCode) {
 			ZestExpressionStatusCode za = (ZestExpressionStatusCode) expression;
@@ -171,8 +170,7 @@ public class ZestExpressionDialog extends StandardFieldsDialog implements ZestDi
 			this.addComboField(ZestClientElementDialog.FIELD_ELEMENT_TYPE, getElementTypeFields(), clientType);
 			this.addTextField(ZestClientElementDialog.FIELD_ELEMENT, zc.getElement());
 			
-			// Enable right click menus
-			this.addFieldListener(ZestClientElementDialog.FIELD_ELEMENT, ZestZapUtils.stdMenuAdapter()); 
+			ZestZapUtils.setMainPopupMenu(this.getField(ZestClientElementDialog.FIELD_ELEMENT)); 
 
 		}
 		this.addCheckBoxField(FIELD_INVERSE, expression.isInverse());

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
@@ -175,8 +175,7 @@ public class ZestLoopDialog extends StandardFieldsDialog implements ZestDialog {
 		this.addComboField(ZestClientElementDialog.FIELD_ELEMENT_TYPE, getElementTypeFields(), clientType);
 		this.addTextField(ZestClientElementDialog.FIELD_ELEMENT, loop.getElement());
 		
-		// Enable right click menus
-		this.addFieldListener(ZestClientElementDialog.FIELD_ELEMENT, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(ZestClientElementDialog.FIELD_ELEMENT));
 	}
 
 	private void drawLoopRegexDialog(ZestLoopRegex loop) {

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestParameterDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestParameterDialog.java
@@ -60,8 +60,8 @@ public class ZestParameterDialog extends StandardFieldsDialog implements ZestDia
 		this.addTextField(FIELD_PARAM_VALUE, value);
 		this.addPadding();
 		
-		this.addFieldListener(FIELD_PARAM_NAME, ZestZapUtils.stdMenuAdapter()); 
-		this.addFieldListener(FIELD_PARAM_VALUE, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_NAME));
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_VALUE));
 
 	}
 	

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
@@ -135,10 +135,9 @@ public class ZestRequestDialog extends StandardFieldsDialog implements ZestDialo
 		this.addMultilineField(0, FIELD_HEADERS, request.getHeaders());
 		this.addMultilineField(0, FIELD_BODY, request.getData());
 		
-		// Enable right click menus
-		this.addFieldListener(FIELD_URL, ZestZapUtils.stdMenuAdapter()); 
-		this.addFieldListener(FIELD_HEADERS, ZestZapUtils.stdMenuAdapter()); 
-		this.addFieldListener(FIELD_BODY, ZestZapUtils.stdMenuAdapter()); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_URL)); 
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_HEADERS));
+		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_BODY));
 
 		// Cookies tab
         List<JButton> buttons = new ArrayList<JButton>();


### PR DESCRIPTION
Set the popup menu into the text fields so that the popup menu can be
invoked with mouse (as before) and keyboard.
Update changes in ZapAddOn.xml file.