### PR TITLE
zest: fix listeners in Switch To Frame dialogue

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -16,6 +16,7 @@
 	Use selected text when adding assignments from the request/response.<br>
 	Show expression's inverse state in more tree nodes.<br>
 	Allow to invoke the context menu in text fields also with keyboard.<br>
+	Correct fields' state in Switch To Frame dialogue.<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
+++ b/src/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
@@ -27,6 +27,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
 import org.mozilla.zest.core.v1.ZestClientSwitchToFrame;
 import org.mozilla.zest.core.v1.ZestStatement;
 import org.parosproxy.paros.Constant;
@@ -34,6 +37,8 @@ import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.extension.zest.ZestZapUtils;
+import org.zaproxy.zap.utils.ZapNumberSpinner;
+import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
 public class ZestClientSwitchToFrameDialog extends StandardFieldsDialog implements ZestDialog {
@@ -87,20 +92,33 @@ public class ZestClientSwitchToFrameDialog extends StandardFieldsDialog implemen
 		ZestZapUtils.setMainPopupMenu(this.getField(FIELD_FRAME_NAME));
 		
 		// Only allow one choice to be selected
-		this.addFieldListener(FIELD_FRAME_NAME, new ActionListener() {
+		((ZapTextField) getField(FIELD_FRAME_NAME)).getDocument().addDocumentListener(new DocumentListener() {
+
 			@Override
-			public void actionPerformed(ActionEvent e) {
-				if (! isEmptyField(FIELD_FRAME_NAME)) {
+			public void insertUpdate(DocumentEvent e) {
+				checkFieldContent(e);
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				checkFieldContent(e);
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				checkFieldContent(e);
+			}
+
+			private void checkFieldContent(DocumentEvent e) {
+				if (e.getDocument().getLength() > 0) {
 					setFieldValue(FIELD_FRAME_INDEX, -1);			
 				}
 			}});
-		this.addFieldListener(FIELD_FRAME_INDEX, new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
+		((ZapNumberSpinner) getField(FIELD_FRAME_INDEX)).addChangeListener(e -> {
 				if (getIntValue(FIELD_FRAME_INDEX) >= 0) {
 					setFieldValue(FIELD_FRAME_NAME, "");			
 				}
-			}});
+			});
 		this.addFieldListener(FIELD_PARENT_FRAME, new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
Change ZestClientSwitchToFrameDialog to use a DocumentListener for the
name and ChangeListener for the index, to properly react to changes in
those fields.
Update changes in ZapAddOn.xml file.