### PR TITLE
Use own add-on classloader for JAXBContext

### DIFF
--- a/src/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
+++ b/src/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
@@ -59,7 +59,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.ls.DOMImplementationLS;
 import org.w3c.dom.ls.LSSerializer;
 import org.xml.sax.SAXException;
-import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.exportreport.filechooser.Utils;
 import org.zaproxy.zap.extension.exportreport.model.AlertItem;
@@ -232,7 +231,7 @@ final class ReportExport {
 
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(ExtensionFactory.getAddOnLoader());
+            Thread.currentThread().setContextClassLoader(ReportExport.class.getClassLoader());
             javax.xml.bind.JAXBContext jc = javax.xml.bind.JAXBContext.newInstance(Report.class);
             Marshaller jaxbMarshaller = jc.createMarshaller();
             jaxbMarshaller.setProperty(javax.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT, true);

--- a/src/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
+++ b/src/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
@@ -2,7 +2,6 @@ package org.zaproxy.zap.extension.saml;
 
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.zaproxy.zap.control.ExtensionFactory;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -184,7 +183,7 @@ public class SAMLConfiguration implements AttributeListener {
     public boolean saveConfiguration() {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(ExtensionFactory.getAddOnLoader());
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
             JAXBContext context = JAXBContext.newInstance(SAMLConfigData.class);
             Marshaller marshaller = context.createMarshaller();
             marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
@@ -209,7 +208,7 @@ public class SAMLConfiguration implements AttributeListener {
     private Object loadXMLObject(Class<?> clazz, File file) throws SAMLException {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         try {
-            Thread.currentThread().setContextClassLoader(ExtensionFactory.getAddOnLoader());
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
             JAXBContext context = JAXBContext.newInstance(clazz);
             Unmarshaller unmarshaller = context.createUnmarshaller();
             return unmarshaller.unmarshal(file);


### PR DESCRIPTION
Use own add-on classloader instead of the main add-on classloader to
prevent one add-on from using the bundled JAXB-API implementation of
the other.

Follow up on #1833.