### PR TITLE
spiderAjax: correct WebDriver requester ID

### DIFF
--- a/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/SpiderThread.java
@@ -428,7 +428,7 @@ public class SpiderThread implements Runnable {
 
 			ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
 			EmbeddedBrowser embeddedBrowser = WebDriverBackedEmbeddedBrowser.withDriver(extSelenium.getWebDriver(
-					HttpSender.SPIDER_INITIATOR,
+					HttpSender.AJAX_SPIDER_INITIATOR,
 					providedBrowserId,
 					configuration.getProxyConfiguration().getHostname(),
 					configuration.getProxyConfiguration().getPort()), filterAttributes, crawlWaitEvent, crawlWaitReload);

--- a/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/spiderAjax/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsSpiderAjaxConcepts</url>
 	<changes>
 	<![CDATA[
+	Correct WebDriver requester ID.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change SpiderThread to get the WebDriver using AJAX_SPIDER_INITIATOR
instead of SPIDER_INITIATOR.
Update changes in ZapAddOn.xml file.