### PR TITLE
selenium: disable JSON viewer for AJAX Spider

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Enable the extension for all DB types.<br>
 	Mention the configuration keys in the options help page.<br>
 	Tweak error message shown when failed to start/connect to the browser.<br>
+	Disable Firefox JSON viewer when used by AJAX Spider to prevent crawl.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/internal/BuiltInSingleWebDriverProvider.java
+++ b/src/org/zaproxy/zap/extension/selenium/internal/BuiltInSingleWebDriverProvider.java
@@ -54,12 +54,12 @@ public class BuiltInSingleWebDriverProvider implements SingleWebDriverProvider {
 
     @Override
     public WebDriver getWebDriver(int requester) {
-        return ExtensionSelenium.getWebDriver(browser);
+        return ExtensionSelenium.getWebDriver(requester, browser);
     }
 
     @Override
     public WebDriver getWebDriver(int requester, String proxyAddress, int proxyPort) {
-        return ExtensionSelenium.getWebDriver(browser, proxyAddress, proxyPort);
+        return ExtensionSelenium.getWebDriver(requester, browser, proxyAddress, proxyPort);
     }
 
     @Override


### PR DESCRIPTION
Disable Firefox JSON viewer when returning a WebDriver for AJAX Spider
to prevent the spider from crawling it.
Add static methods to ExtensionSelenium to allow to get a WebDriver with
a requester and Browser, to be used by BuiltInSingleWebDriverProvider.
Change BuiltInSingleWebDriverProvider to call the new methods.
Update changes in ZapAddOn.xml file.