### PR TITLE
webdrivers: add links to geckodriver/ChromeDriver

### DIFF
--- a/src/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/src/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -13,5 +13,19 @@ The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <li>Firefox - geckodriver 0.21.0</li>
 </ul>
 
+<H2>See also</H2>
+<table>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <td><a href="https://firefox-source-docs.mozilla.org/testing/geckodriver/geckodriver/Support.html">geckodriver » Supported platforms</a></td>
+        <td>to known which Firefox versions are supported.</td>
+    </tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <td><a href="api.html">ChromeDriver » Downloads</a></td>
+        <td>to known which Chrome versions are supported.</td>
+    </tr>
+</table>
+
 </BODY>
 </HTML>

--- a/src/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/src/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -13,5 +13,19 @@ The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <li>Firefox - geckodriver 0.21.0</li>
 </ul>
 
+<H2>See also</H2>
+<table>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <td><a href="https://firefox-source-docs.mozilla.org/testing/geckodriver/geckodriver/Support.html">geckodriver » Supported platforms</a></td>
+        <td>to known which Firefox versions are supported.</td>
+    </tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <td><a href="api.html">ChromeDriver » Downloads</a></td>
+        <td>to known which Chrome versions are supported.</td>
+    </tr>
+</table>
+
 </BODY>
 </HTML>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -14,5 +14,19 @@ The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <li>Internet Explorer - IEDriverServer 3.7.0</li>
 </ul>
 
+<H2>See also</H2>
+<table>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <td><a href="https://firefox-source-docs.mozilla.org/testing/geckodriver/geckodriver/Support.html">geckodriver » Supported platforms</a></td>
+        <td>to known which Firefox versions are supported.</td>
+    </tr>
+    <tr>
+        <td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+        <td><a href="api.html">ChromeDriver » Downloads</a></td>
+        <td>to known which Chrome versions are supported.</td>
+    </tr>
+</table>
+
 </BODY>
 </HTML>


### PR DESCRIPTION
Link to pages that show which versions of the browsers are supported by
the corresponding WebDriver implementations.