### PR TITLE
quickstart: inform when disabled by current mode

### DIFF
--- a/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/src/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -246,7 +246,9 @@ public class ExtensionQuickStart extends ExtensionAdaptor implements SessionChan
 
 	@Override
 	public void sessionModeChanged(Mode mode) {
-		this.getQuickStartPanel().setMode(mode);
+		if (getView() != null) {
+			this.getQuickStartPanel().setMode(mode);
+		}
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/src/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -58,10 +58,13 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 
 	private static final long serialVersionUID = 1L;
 
+	private static final String DEFAULT_VALUE_URL_FIELD = "http://";
+
 	private ExtensionQuickStart extension;
 	private JButton attackButton = null;
 	private JButton stopButton = null;
 	private ZapTextField urlField = null;
+	private JButton selectButton;
 	private JLabel progressLabel = null;
 	private JPanel panelContent = null;
 	private JLabel lowerPadding = new JLabel("");
@@ -122,7 +125,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 				LayoutHelper.getGBC(0, ++panelY, 1, 0.0D, new Insets(5,5,5,5)));
 
 		JPanel urlSelectPanel = new JPanel(new GridBagLayout());
-		JButton selectButton = new JButton(Constant.messages.getString("all.button.select"));
+		selectButton = new JButton(Constant.messages.getString("all.button.select"));
 		selectButton.setIcon(DisplayUtils.getScaledIcon(new ImageIcon(View.class.getResource("/resource/icon/16/094.png")))); // Globe icon
 		selectButton.addActionListener(new java.awt.event.ActionListener() { 
 			@Override
@@ -196,11 +199,15 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 		case safe:
 		case protect:
 			this.getUrlField().setEditable(false);
+			this.getUrlField().setText(Constant.messages.getString("quickstart.field.url.disabled.mode"));
+			this.selectButton.setEnabled(false);
 			this.getAttackButton().setEnabled(false);
 			break;
 		case standard:
 		case attack:
 			this.getUrlField().setEditable(true);
+			this.getUrlField().setText(DEFAULT_VALUE_URL_FIELD);
+			this.selectButton.setEnabled(true);
 			this.getAttackButton().setEnabled(true);
 			break;
 		}
@@ -209,7 +216,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 	private ZapTextField getUrlField () {
 		if (urlField == null) {
 			urlField = new ZapTextField();
-			urlField.setText("http://");
+			urlField.setText(DEFAULT_VALUE_URL_FIELD);
 		}
 		return urlField;
 	}

--- a/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/quickstart/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Inform when quick attack is disabled by the current mode (Issue 5069).<br>
 	Notify when quick attack starts.<br>
 	]]>
 	</changes>

--- a/src/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
@@ -32,6 +32,7 @@ quickstart.cmdline.quickout.error.save.report = An error occurred while saving t
 quickstart.cmdline.quickurl.error.invalidUrl = The provided URL to attack is not valid:
 quickstart.cmdline.quickout.save.report.successful = The report was successfully saved to:\n{0}
 quickstart.cmdline.url.help				= The URL to attack, eg http://www.example.com
+quickstart.field.url.disabled.mode = Attacking arbitrary URLs is not permitted in Protected or Safe mode.
 quickstart.label.show					= Show this tab on start up:
 quickstart.label.explore				= Explore your application:
 quickstart.label.mitm					= Configure your browser:


### PR DESCRIPTION
Change QuickStartPanel to show a message in the URL field when the mode
does not allow to start the attack, also, disable the button that allows
to select a target.
Change ExtensionQuickStart to not initialise the view components if
there's no view when the mode is changed.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#5069 - Add a message to explain why Quick Scan not
available in protected etc modes