### PR TITLE
communityScripts: remove empty method

### DIFF
--- a/src/org/zaproxy/zap/extension/communityScripts/ExtensionCommunityScripts.java
+++ b/src/org/zaproxy/zap/extension/communityScripts/ExtensionCommunityScripts.java
@@ -73,10 +73,6 @@ public class ExtensionCommunityScripts extends ExtensionAdaptor {
 	}
 
 	@Override
-	public void postInstall() {
-	}
-	
-	@Override
 	public void postInit() {
 		addScripts();
 	}

--- a/src/org/zaproxy/zap/extension/communityScripts/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/communityScripts/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/community-scripts</url>
 	<changes>
 	<![CDATA[
+	Maintenance changes.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Remove empty method in ExtensionCommunityScripts.
Update changes in ZapAddOn.xml file.