### PR TITLE
communityScripts: normalise license header/code

### DIFF
--- a/src/org/zaproxy/zap/extension/communityScripts/ExtensionCommunityScripts.java
+++ b/src/org/zaproxy/zap/extension/communityScripts/ExtensionCommunityScripts.java
@@ -3,11 +3,13 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
+ * Copyright 2016 The ZAP Development Team
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,14 +17,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.zaproxy.zap.extension.communityScripts;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
@@ -30,65 +30,71 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 
 /**
- * Community Scripts Extension - a packaged version of https://github.com/zaproxy/community-scripts 
- * @author psiinon
+ * Community Scripts Extension - a packaged version of https://github.com/zaproxy/community-scripts
  *
+ * @author psiinon
  */
 public class ExtensionCommunityScripts extends ExtensionAdaptor {
-	
-	private File scriptDir = new File(Constant.getZapHome(), "community-scripts");
 
-	private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private File scriptDir = new File(Constant.getZapHome(), "community-scripts");
 
-	static {
-		List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-		dependencies.add(ExtensionScript.class);
+    private static final List<Class<? extends Extension>> DEPENDENCIES;
 
-		DEPENDENCIES = Collections.unmodifiableList(dependencies);
-	}
+    static {
+        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
+        dependencies.add(ExtensionScript.class);
 
-	@Override
-	public String getAuthor() {
-		return "ZAP Community";
-	}
+        DEPENDENCIES = Collections.unmodifiableList(dependencies);
+    }
 
-	@Override
-	public String getName() {
-		return "ExtensionCommunityScripts";
-	}
+    @Override
+    public String getAuthor() {
+        return "ZAP Community";
+    }
 
-	@Override
-	public String getUIName() {
-		return Constant.messages.getString("communityScripts.name");
-	}
+    @Override
+    public String getName() {
+        return "ExtensionCommunityScripts";
+    }
 
-	@Override
-	public String getDescription() {
-		return Constant.messages.getString("communityScripts.desc");
-	}
-	
-	@Override
-	public List<Class<? extends Extension>> getDependencies() {
-		return DEPENDENCIES;
-	}
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("communityScripts.name");
+    }
 
-	@Override
-	public void postInit() {
-		addScripts();
-	}
-	
-	private void addScripts() {
-		Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class).addScriptsFromDir(scriptDir);
-	}
-	
-	@Override
-	public boolean canUnload() {
-		return true;
-	}
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("communityScripts.desc");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void postInit() {
+        addScripts();
+    }
+
+    private void addScripts() {
+        Control.getSingleton()
+                .getExtensionLoader()
+                .getExtension(ExtensionScript.class)
+                .addScriptsFromDir(scriptDir);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
 
     @Override
     public void unload() {
         super.unload();
-		Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class).removeScriptsFromDir(scriptDir);
+        Control.getSingleton()
+                .getExtensionLoader()
+                .getExtension(ExtensionScript.class)
+                .removeScriptsFromDir(scriptDir);
     }
 }


### PR DESCRIPTION
Normalise indentation and license header of ExtensionCommunityScripts
to eliminate changes when migrating to community-scripts repository (the
format/license is already being enforced there).
The class CommunityScriptFiles was not normalised, it will not be
migrated (superseded by the build).