### PR TITLE
Issue 5080 - Replacer API "Replacement" shouldn't be mandatory

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -633,6 +633,11 @@
   	<target name="deploy-replacer" description="deploy the replacer extension">
   		<build-deploy-addon name="replacer"/>
 	</target>
+	
+	<target name="deploy-replacer-without-help-indexes" description="deploy the replacer extension, without building help indexes">
+		<!-- To facilitate quick Dev builds -->
+		<build-deploy-addon-without-help-indexes name="replacer" />
+	</target>
 
 	<target name="generate-wiki-replacer" description="Generates the wiki of replacer">
 		<generate-wiki-core addon="replacer" />

--- a/src/org/zaproxy/zap/extension/replacer/ReplacerAPI.java
+++ b/src/org/zaproxy/zap/extension/replacer/ReplacerAPI.java
@@ -73,9 +73,8 @@ public class ReplacerAPI extends ApiImplementor {
                                 PARAM_ENABLED,
                                 PARAM_MATCH_TYPE,
                                 PARAM_MATCH_REGEX,
-                                PARAM_MATCH_STRING,
-                                PARAM_REPLACEMENT },
-                        new String[] { PARAM_INITIATORS }));
+                                PARAM_MATCH_STRING},
+                        new String[] { PARAM_REPLACEMENT, PARAM_INITIATORS }));
 
         this.addApiAction(new ApiAction(ACTION_REMOVE_RULE, new String[] { PARAM_DESC }));
         this.addApiAction(new ApiAction(ACTION_SET_ENABLED, new String[] { PARAM_DESC, PARAM_BOOL }));
@@ -165,7 +164,7 @@ public class ReplacerAPI extends ApiImplementor {
                             type,
                             matchString,
                             matchRegex,
-                            params.getString(PARAM_REPLACEMENT),
+                            getParam(params, PARAM_REPLACEMENT, ""),
                             initiators,
                             enabled));
 

--- a/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/replacer/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Maintenance changes.<br>
+	API, Replacement String should not be mandatory (Issue 5080).
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
- build.xml > Added "deploy-replacer-without-help-indexes" target for quick dev builds.
- ReplacerAPI.java > Moved PARAM_REPLACEMENT to optional param list.
- ZapAddOn.xml > Updated changes section.

Fixes zaproxy/zaproxy#5080