### PR TITLE
accessControl: notify test finished, always

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/AccessControlScannerThread.java
+++ b/src/org/zaproxy/zap/extension/accessControl/AccessControlScannerThread.java
@@ -132,8 +132,20 @@ public class AccessControlScannerThread extends
 
 	@Override
 	protected void scan() {
+		try {
+			notifyScanStarted();
+			scanImpl();
+			log.debug("Access control scan succesfully completed.");
+		} catch (Exception e) {
+			log.error("An error occurred while scanning:", e);
+		} finally {
+			setScanProgress(getScanMaximumProgress());
+			setRunningState(false);
+			notifyScanFinished();
+		}
+	}
 
-		notifyScanStarted();
+	private void scanImpl() {
 
 		// Build the list of urls' which will be attacked
 		List<SiteNode> targetNodes = getTargetUrlsList();
@@ -184,12 +196,6 @@ public class AccessControlScannerThread extends
 			// Make sure we update the progress
 			setScanProgress(++progress);
 		}
-
-		// Setup the finished status properly
-		log.debug("Access control scan succesfully completed.");
-		setScanProgress(getScanMaximumProgress());
-		setRunningState(false);
-		notifyScanFinished();
 	}
 
 	/**

--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Respect the current mode and react to changes.<br>
 	Dynamically unload the add-on.<br>
 	Inform of running tests (e.g. on session change, add-on uninstall).<br>
+	Improve error handling during test.<br>
 	]]> 
 	</changes>
 	<dependson />


### PR DESCRIPTION
Change AccessControlScannerThread to notify that it has finished in a
finally block to ensure it's always done. Also, catch and log any
exceptions that might occur during the test.

Related to zaproxy/zaproxy#5097 - Catch credentials exception when
authenticating