### PR TITLE
accessControl: do not use attack/evidence fields

### DIFF
--- a/src/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
+++ b/src/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
@@ -88,13 +88,15 @@ public class AccessControlAlertsProcessor {
 		}
 		// @formatter:off
 		alert.setDetail(Vulnerabilities.getDescription(vulnerabilityAuthorization), result.getUri(), "", // Param
-				Constant.messages.getString("accessControl.alert.authorization.attack", result.getUser()
-						.getName()), // Attack
-				"", // Other info
+				"", // Attack
+				Constant.messages.getString(
+						"accessControl.alert.authorization.otherinfo",
+						result.getUser().getName(),
+						result.isRequestAuthorized(),
+						result.getAccessRule()),
 				Vulnerabilities.getSolution(vulnerabilityAuthorization), // Solution
 				Vulnerabilities.getReference(vulnerabilityAuthorization), // Reference
-				Constant.messages.getString("accessControl.alert.authorization.evidence",
-						result.isRequestAuthorized(), result.getAccessRule()), // Evidence
+				"", // Evidence
 				285, // CWE Id
 				2, // WASC Id
 				msg);
@@ -115,12 +117,14 @@ public class AccessControlAlertsProcessor {
 		// @formatter:off
 		alert.setDetail(Vulnerabilities.getDescription(vulnerabilityAuthentication), result.getUri(),
 				"", // Param
-				Constant.messages.getString("accessControl.alert.authentication.attack"), // Attack
-				"", // Other info
+				"", // Attack
+				Constant.messages.getString(
+						"accessControl.alert.authentication.otherinfo",
+						result.isRequestAuthorized(),
+						result.getAccessRule()),
 				Vulnerabilities.getSolution(vulnerabilityAuthentication), // Solution
 				Vulnerabilities.getReference(vulnerabilityAuthentication), // Reference
-				Constant.messages.getString("accessControl.alert.authentication.evidence",
-						result.isRequestAuthorized(), result.getAccessRule()), // Evidence
+				"", // Evidence
 				287, // CWE Id
 				1, // WASC Id
 				msg);

--- a/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/accessControl/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Dynamically unload the add-on.<br>
 	Inform of running tests (e.g. on session change, add-on uninstall).<br>
 	Improve error handling during test.<br>
+	Tweak alerts to use Other Info field instead of Attack/Evidence.<br>
 	]]> 
 	</changes>
 	<dependson />

--- a/src/org/zaproxy/zap/extension/accessControl/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/accessControl/resources/Messages.properties
@@ -52,8 +52,6 @@ accessControl.contextTree.root					= Context access rules
 accessControl.contextTree.hanging				= Older rules
 
 accessControl.alert.authorization.name = Access Control Issue - Improper Authorization
-accessControl.alert.authorization.attack = Accessed as user: {0} 
-accessControl.alert.authorization.evidence = Request detected as authorized: {0}. The defined access rule for resource is that access should be: {1}.
+accessControl.alert.authorization.otherinfo = Accessed as user: {0}\n\nRequest detected as authorized: {1}. The defined access rule for resource is that access should be: {2}.
 accessControl.alert.authentication.name = Access Control Issue - Improper Authentication
-accessControl.alert.authentication.attack = Accessed as an unauthenticated user. 
-accessControl.alert.authentication.evidence = Request detected as authorized: {0}. The defined access rule for resource is that access should be: {1}.
+accessControl.alert.authentication.otherinfo = Accessed as an unauthenticated user.\n\nRequest detected as authorized: {0}. The defined access rule for resource is that access should be: {1}.


### PR DESCRIPTION
Change the alerts to use other info field instead of attack/evidence
fields, the info provided is not the attack nor the evidence (as
expected for those fields).
Update changes in ZapAddOn.xml file.