### PR TITLE
zest: correct request conversion

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -18,6 +18,7 @@
 	Correct dialogue titles of client statements.<br>
 	Allow to invoke the context menu in text fields also with keyboard.<br>
 	Correct fields' state in Switch To Frame dialogue.<br>
+	Correct request conversion that dropped the topmost header (Issue 5100).<br>
 	]]>
 	</changes>
 	<dependencies>

--- a/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/src/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -814,20 +814,7 @@ public class ZestZapUtils {
 	}
 
 	private static void setAllHeaders(ZestRequest req, HttpMessage msg) {
-		String[] headers = msg.getRequestHeader().getHeadersAsString()
-				.split(HttpHeader.CRLF);
-		StringBuilder sb = new StringBuilder();
-		boolean first = true;
-		for (String header : headers) {
-			if (first) {
-				// Drop the first one as this one will get added anyway
-				first = false;
-			} else {
-				sb.append(header);
-				sb.append(HttpHeader.CRLF);
-			}
-		}
-		req.setHeaders(sb.toString());
+		req.setHeaders(msg.getRequestHeader().getHeadersAsString());
 	}
 
 	private static String correctTokens(String str) {

--- a/test/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
+++ b/test/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.zest;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.mozilla.zest.core.v1.ZestRequest;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ZestZapUtils}. */
+public class ZestZapUtilsUnitTest {
+
+    @Test
+    public void shouldKeepAllHeadersIfIncludingAllWhenConvertingHttpMessageToZestRequest() throws Exception {
+        // Given
+        boolean includeAllHeaders = true;
+        ZestParam zestParam = createZestParam();
+        zestParam.setIgnoredHeaders(Arrays.asList("B"));
+        String headers = "A: 1\r\nB: 2\r\nHost: example.com\r\n";
+        HttpMessage httpMessage = createRequest(headers);
+        // When
+        ZestRequest zestRequest = ZestZapUtils.toZestRequest(httpMessage, false, includeAllHeaders, zestParam);
+        // Then
+        assertThat(zestRequest.getHeaders(), is(equalTo(headers)));
+    }
+
+    @Test
+    public void shouldRemoveIgnoredHeadersIfNotIncludingAllWhenConvertingHttpMessageToZestRequest() throws Exception {
+        // Given
+        boolean includeAllHeaders = false;
+        ZestParam zestParam = createZestParam();
+        zestParam.setIgnoredHeaders(Arrays.asList("B"));
+        HttpMessage httpMessage = createRequest("A: 1\r\nB: 2\r\nHost: example.com\r\n");
+        // When
+        ZestRequest zestRequest = ZestZapUtils.toZestRequest(httpMessage, false, includeAllHeaders, zestParam);
+        // Then
+        assertThat(zestRequest.getHeaders(), is(equalTo("A: 1\r\nHost: example.com\r\n")));
+    }
+
+    private static ZestParam createZestParam() {
+        ZestParam zestParam = new ZestParam();
+        zestParam.load(new ZapXmlConfiguration());
+        return zestParam;
+    }
+
+    private static HttpMessage createRequest(String headers) throws HttpMalformedHeaderException {
+        return new HttpMessage(new HttpRequestHeader("GET / HTTP/1.1\r\n" + headers));
+    }
+}


### PR DESCRIPTION
Change ZestZapUtils to not drop the first header when converting the ZAP
request to Zest request, the method HttpHeader#getHeadersAsString()
returns just the headers so no header should be dropped.
Add tests to assert the expected behaviour.
Update changes in ZapAddOn.xml file.

Fix zaproxy/zaproxy#5100 - Some Zest Scripts Drop Every Topmost Request
Header