### PR TITLE
Update API generator for 2.7.0 and 2.8.0

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -679,14 +679,13 @@
 		</copy>
 	</target>
 
-    <target name="generate-apis" description="generates the client APIs">
+    <target name="generate-apis" depends="compile" description="generates the client APIs">
         <path id="classpath">
-            <pathelement location="../bin" />
-            <pathelement location="./build" />
-            <fileset dir="../lib" includes="**/*.jar" />
-            <fileset dir="../../zaproxy/lib" includes="**/*.jar" />
+            <pathelement location="${build}" />
+            <pathelement location="${src}" />
+            <fileset dir="${dist.lib.dir}" includes="**/*.jar" />
         </path>
-		<java classname="org.zaproxy.zap.extension.ApiGenerator" dir=".." fork="yes">
+		<java classname="org.zaproxy.zap.extension.api.ApiGenerator" dir=".." fork="yes">
 			<classpath refid="classpath" />
 		</java>
     </target>

--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1,0 +1,1 @@
+# Dummy file for org.zaproxy.zap.extension.api.ApiGenerator, required for ZAP <= 2.7.0.

--- a/src/org/zaproxy/zap/extension/api/ApiGenerator.java
+++ b/src/org/zaproxy/zap/extension/api/ApiGenerator.java
@@ -17,11 +17,15 @@
  * See the License for the specific language governing permissions and 
  * limitations under the License. 
  */
-package org.zaproxy.zap.extension;
+package org.zaproxy.zap.extension.api;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
 
 import org.zaproxy.zap.extension.api.ApiImplementor;
 import org.zaproxy.zap.extension.api.JavaAPIGenerator;
@@ -33,13 +37,16 @@ import org.zaproxy.zap.extension.selenium.SeleniumAPI;
 import org.zaproxy.zap.extension.selenium.SeleniumOptions;
 import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderAPI;
 import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderParam;
+import org.zaproxy.zap.extension.websocket.WebSocketAPI;
 
 public class ApiGenerator {
 
 	private static final String JAVA_OUTPUT_DIR = "../zap-api-java/subprojects/zap-clientapi/src/main/java/org/zaproxy/clientapi/gen";
 
+	private static final String PHP_OUTPUT_DIR = "../zaproxy/php/api/zapv2/src/Zap";
+
 	private static final String PYTHON_OUTPUT_DIR = "../zap-api-python/src/zapv2/";
-	
+
 	private static final String NODE_OUTPUT_DIR = "../zap-api-nodejs/src/";
 
 	public static List<ApiImplementor> getApiImplementors() {
@@ -62,6 +69,7 @@ public class ApiGenerator {
 
 		list.add(new RevealAPI(null));
 		list.add(new SeleniumAPI(new SeleniumOptions()));
+		list.add(new WebSocketAPI(null));
 
 		return list;
 	}
@@ -70,24 +78,61 @@ public class ApiGenerator {
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		try {
-			JavaAPIGenerator japi = new JavaAPIGenerator(JAVA_OUTPUT_DIR, true);
-			japi.generateAPIFiles(getApiImplementors());
+		List<ApiGeneratorWrapper> generators = Arrays.asList(
+				wrapper(JavaAPIGenerator.class, JAVA_OUTPUT_DIR),
+				wrapper(NodeJSAPIGenerator.class, NODE_OUTPUT_DIR),
+				wrapper(PhpAPIGenerator.class, PHP_OUTPUT_DIR),
+				wrapper(PythonAPIGenerator.class, PYTHON_OUTPUT_DIR)
+				// wrapper(WikiAPIGenerator.class, "../zaproxy-wiki")
+		);
+		getApiImplementors().forEach(api -> {
+			ResourceBundle bundle = ResourceBundle.getBundle(
+					api.getClass().getPackage().getName() + ".resources.Messages",
+					Locale.ENGLISH,
+					api.getClass().getClassLoader(),
+					ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_PROPERTIES));
 
-			NodeJSAPIGenerator napi = new NodeJSAPIGenerator(NODE_OUTPUT_DIR, true);
-			napi.generateAPIFiles(getApiImplementors());
-		
-			PhpAPIGenerator phapi = new PhpAPIGenerator("../zaproxy/php/api/zapv2/src/Zap", true);
-			phapi.generateAPIFiles(getApiImplementors());
+			generators.forEach(generator -> generator.generate(api, bundle));
+		});
+	}
 
-			PythonAPIGenerator pyapi = new PythonAPIGenerator(PYTHON_OUTPUT_DIR, true);
-			pyapi.generateAPIFiles(getApiImplementors());
+	private static ApiGeneratorWrapper wrapper(Class<? extends AbstractAPIGenerator> clazz, String outputDir) {
+		return new ApiGeneratorWrapper(clazz, outputDir);
+	}
 
-			//WikiAPIGenerator wapi = new WikiAPIGenerator("../zaproxy-wiki", true);
-			//wapi.generateWikiFiles(getApiImplementors());
-			
-		} catch (IOException e) {
-			e.printStackTrace();
+	private static class ApiGeneratorWrapper {
+
+		private final Class<? extends AbstractAPIGenerator> clazz;
+		private final String outputDir;
+
+		public ApiGeneratorWrapper(Class<? extends AbstractAPIGenerator> clazz, String outputDir) {
+			this.clazz = clazz;
+			this.outputDir = outputDir;
+		}
+
+		public void generate(ApiImplementor api, ResourceBundle bundle) {
+			AbstractAPIGenerator generator;
+			try {
+				generator = createInstance(bundle);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+
+			try {
+				generator.generateAPIFiles(Arrays.asList(api));
+			} catch (IOException e) {
+				throw new UncheckedIOException(e);
+			}
+		}
+
+		private AbstractAPIGenerator createInstance(ResourceBundle bundle) throws Exception {
+			try {
+				return clazz.getDeclaredConstructor(String.class, boolean.class, ResourceBundle.class)
+						.newInstance(outputDir, true, bundle);
+			} catch (NoSuchMethodException e) {
+				System.out.println("Defaulting to generator without ResourceBundle, no descriptions will be included.");
+				return clazz.getDeclaredConstructor(String.class, boolean.class).newInstance(outputDir, true);
+			}
 		}
 	}
 


### PR DESCRIPTION
Move ApiGenerator to api package to access core class.
Add Websocket API to ApiGenerator.
Change ApiGenerator to make use of the new core method (>=2.8.0) which
allows to pass a ResourceBundle, to include the descriptions of the API
endpoints being generated.
Add dummy Messages.properties to be able to work with ZAP 2.7.0.
Update generate-apis in build.xml file to include just the required
files on the classpath and to depend on compile to work by itself.

For zaproxy/zaproxy#5044 - NodeJS API Upgrade