### PR TITLE
Add build target to generate the APIs (beta)

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -799,4 +799,15 @@
 		</copy>
 	</target>
 
+	<target name="generate-apis" depends="compile" description="Generates the API clients.">
+		<path id="classpath">
+			<pathelement location="${build}" />
+			<pathelement location="${src}" />
+			<fileset dir="${dist.lib.dir}" includes="**/*.jar" />
+		</path>
+		<java classname="org.zaproxy.zap.extension.api.ApiGenerator" dir=".." fork="yes">
+			<classpath refid="classpath" />
+		</java>
+	</target>
+
 </project>

--- a/src/lang/Messages.properties
+++ b/src/lang/Messages.properties
@@ -1,0 +1,1 @@
+# Dummy file for org.zaproxy.zap.extension.api.ApiGenerator, required for ZAP <= 2.7.0.


### PR DESCRIPTION
Add target generate-apis to build.xml file.
Move ApiGenerator to api package to access core class.
Change ApiGenerator to make use of the new core method (>=2.8.0) which
allows to pass a ResourceBundle, to include the descriptions of the API
endpoints being generated.
Add dummy Messages.properties to be able to work with ZAP 2.7.0.

For zaproxy/zaproxy#5044 - NodeJS API Upgrade