### PR TITLE
jxbrowsers: bundle compatible ChromeDriver

### DIFF
--- a/src/org/zaproxy/zap/extension/jxbrowser/JxBrowserDownload.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/JxBrowserDownload.java
@@ -21,10 +21,14 @@ package org.zaproxy.zap.extension.jxbrowser;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 public class JxBrowserDownload {
 
@@ -34,7 +38,7 @@ public class JxBrowserDownload {
      * 
      * @param args
      */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
 
         final String VERSION = "6.22";
         final String repo = "zaproxy/zap-libs"; // Makes it easier for testing
@@ -78,22 +82,41 @@ public class JxBrowserDownload {
                 srcdir, "../jxbrowserlinux64/lib/jxbrowser-linux64-" + VERSION + ".jar");
 
         downloadLibrary(
+                "https://github.com/" + repo + "/raw/master/files/jxbrowser/webdriver/linux/chromedriver",
+                srcdir, "../jxbrowserlinux64/files/jxbrowser/webdriver/linux/chromedriver");
+
+        downloadLibrary(
                 "https://github.com/" + repo + "/raw/master/files/jxbrowser/jxbrowser-mac-" + VERSION + ".jar",
                 srcdir, "../jxbrowsermacos/lib/jxbrowser-mac-" + VERSION + ".jar");
+
+        downloadLibrary(
+                "https://github.com/" + repo + "/raw/master/files/jxbrowser/webdriver/macos/chromedriver",
+                srcdir, "../jxbrowsermacos/files/jxbrowser/webdriver/macos/chromedriver");
 
         downloadLibrary(
                 "https://github.com/" + repo + "/raw/master/files/jxbrowser/jxbrowser-win32-" + VERSION + ".jar",
                 srcdir, "../jxbrowserwindows/lib/jxbrowser-win32-" + VERSION + ".jar");
 
         downloadLibrary(
+                "https://github.com/" + repo + "/raw/master/files/jxbrowser/webdriver/windows/chromedriver.exe",
+                srcdir, "../jxbrowserwindows/files/jxbrowser/webdriver/windows/chromedriver.exe");
+
+        downloadLibrary(
                 "https://github.com/" + repo + "/raw/master/files/jxbrowser/jxbrowser-win64-" + VERSION + ".jar",
                 srcdir, "../jxbrowserwindows64/lib/jxbrowser-win64-" + VERSION + ".jar");
+
+        Path win64Dir = createFile(srcdir, "../jxbrowserwindows64/files/jxbrowser/webdriver/windows/").toPath();
+        Files.createDirectories(win64Dir);
+        Files.copy(
+                createFile(srcdir, "../jxbrowserwindows/files/jxbrowser/webdriver/windows/chromedriver.exe").toPath(),
+                win64Dir.resolve("chromedriver.exe"),
+                StandardCopyOption.REPLACE_EXISTING);
+
         return;
     }
 
     private static void downloadLibrary(String urlStr, File baseDir, String destFile) {
-        File dest = new File(
-                baseDir, JxBrowserDownload.class.getPackage().getName().replace(".", "/") + "/" + destFile);
+        File dest = createFile(baseDir, destFile);
         if (dest.exists()) {
             System.out.println("Already exists: " + dest.getAbsolutePath());
             return;
@@ -112,5 +135,9 @@ public class JxBrowserDownload {
             e.printStackTrace();
             System.exit(1);
         }
+    }
+
+    private static File createFile(File baseDir, String path) {
+        return new File(baseDir, JxBrowserDownload.class.getPackage().getName().replace(".", "/") + "/" + path);
     }
 }

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/ZapAddOn.xml
@@ -15,9 +15,13 @@
 			<addon>
 				<id>jxbrowser</id>
 			</addon>
+			<!--
+			Don't depend for the time being, the ChromeDriver provided no longer supports the Chromium version used by
+			JxBrowser. The JxBrowser add-on will bundle its own ChromeDriver.
 			<addon>
 				<id>webdriverlinux</id>
 			</addon>
+			-->
 		</addons>
 	</dependencies>
 	<extensions>
@@ -30,16 +34,15 @@
 						<id>selenium</id>
 						<semver><![CDATA[ >=2.0.0 & <3.0.0 ]]></semver>
 					</addon>
-					<addon>
-						<id>webdriverlinux</id>
-					</addon>
 				</addons>
 			</dependencies>
 		</extension>
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<files/>
+	<files>
+		<file>jxbrowser/webdriver/linux/chromedriver</file>
+	</files>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/ExtSelJxBrowserLinux64.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/ExtSelJxBrowserLinux64.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.jxbrowserlinux64.selenium;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +58,8 @@ public class ExtSelJxBrowserLinux64 extends ExtensionAdaptor {
         super.hook(extensionHook);
 
         if (Constant.isLinux() && Utils.isOs64Bits()) {
-            webDriverProvider = new JxBrowserProvider();
+            webDriverProvider = new JxBrowserProvider(
+                    Paths.get(Constant.getZapHome(), "jxbrowser/webdriver/linux/chromedriver"));
 
             ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
             extSelenium.addWebDriverProvider(webDriverProvider);

--- a/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserlinux64/selenium/JxBrowserProvider.java
@@ -21,13 +21,20 @@ package org.zaproxy.zap.extension.jxbrowserlinux64.selenium;
 
 import java.awt.EventQueue;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.log4j.Logger;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chrome.ChromeDriverService;
@@ -67,15 +74,19 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
 
     private static final String PROVIDER_ID = "jxbrowser";
 
+    private static final Logger LOGGER = Logger.getLogger(JxBrowserProvider.class);
+
     private final ProvidedBrowser providedBrowser;
+    private final Path webdriver;
     /* One ZapBrowserFrame per requesterId, so that tools like the Ajax Spider
      * don't interfere with other tools.
      */
     private Map<Integer, ZapBrowserFrame> requesterToZbf = new HashMap<Integer, ZapBrowserFrame>();
     private int chromePort;
 
-    public JxBrowserProvider() {
+    public JxBrowserProvider(Path webdriver) {
         this.providedBrowser = new ProvidedBrowserImpl();
+        this.webdriver = webdriver;
     }
 
     @Override
@@ -158,7 +169,13 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
             Browser browser = new Browser(new BrowserContext(contextParams));
             final BrowserPanel browserPanel = zbf.addNewBrowserPanel(isNotAutomated(requesterId), browser);
 
-            final ChromeDriverService service = new ChromeDriverService.Builder().usingAnyFreePort().build();
+            if (!ensureExecutable(webdriver)) {
+                throw new IllegalStateException("Failed to ensure WebDriver is executable.");
+            }
+            final ChromeDriverService service = new ChromeDriverService.Builder()
+                    .usingDriverExecutable(webdriver.toFile())
+                    .usingAnyFreePort()
+                    .build();
             service.start();
 
             DesiredCapabilities capabilities = new DesiredCapabilities();
@@ -194,6 +211,30 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
         } catch (Exception e) {
             throw new WebDriverException(e);
         }
+    }
+
+    private static void setExecutable(Path file) throws IOException {
+        if (!SystemUtils.IS_OS_MAC && !SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+
+        Set<PosixFilePermission> perms = Files.readAttributes(file, PosixFileAttributes.class).permissions();
+        if (perms.contains(PosixFilePermission.OWNER_EXECUTE)) {
+            return;
+        }
+
+        perms.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(file, perms);
+    }
+
+    private static boolean ensureExecutable(Path driver) {
+        try {
+            setExecutable(driver);
+            return true;
+        } catch (IOException e) {
+            LOGGER.warn("Failed to set the bundled WebDriver executable:", e);
+        }
+        return false;
     }
 
     private void cleanUpBrowser(final int requesterId, final BrowserPanel browserPanel) {

--- a/src/org/zaproxy/zap/extension/jxbrowsermacos/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowsermacos/ZapAddOn.xml
@@ -15,9 +15,13 @@
 			<addon>
 				<id>jxbrowser</id>
 			</addon>
+			<!--
+			Don't depend for the time being, the ChromeDriver provided no longer supports the Chromium version used by
+			JxBrowser. The JxBrowser add-on will bundle its own ChromeDriver.
 			<addon>
 				<id>webdrivermacos</id>
 			</addon>
+			-->
 		</addons>
 	</dependencies>
 	<extensions>
@@ -36,7 +40,9 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<files/>
+	<files>
+		<file>jxbrowser/webdriver/macos/chromedriver</file>
+	</files>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/MacOsJxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowsermacos/selenium/MacOsJxBrowserProvider.java
@@ -21,14 +21,20 @@ package org.zaproxy.zap.extension.jxbrowsermacos.selenium;
 
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.nio.file.Paths;
 
 import org.openqa.selenium.WebDriverException;
+import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.selenium.SingleWebDriverProvider;
 
 /**
  * A {@link SingleWebDriverProvider} for JxBrowser on MacOS.
  */
 public class MacOsJxBrowserProvider extends JxBrowserProvider {
+
+    public MacOsJxBrowserProvider() {
+        super(Paths.get(Constant.getZapHome(), "jxbrowser/webdriver/macos/chromedriver"));
+    }
 
     private Integer chromePort;
 

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/ZapAddOn.xml
@@ -15,9 +15,13 @@
 			<addon>
 				<id>jxbrowser</id>
 			</addon>
+			<!--
+			Don't depend for the time being, the ChromeDriver provided no longer supports the Chromium version used by
+			JxBrowser. The JxBrowser add-on will bundle its own ChromeDriver.
 			<addon>
 				<id>webdriverwindows</id>
 			</addon>
+			-->
 		</addons>
 	</dependencies>
 	<extensions>
@@ -36,7 +40,9 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<files/>
+	<files>
+		<file>jxbrowser/webdriver/windows/chromedriver.exe</file>
+	</files>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/ExtSelJxBrowserWindows.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/ExtSelJxBrowserWindows.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.jxbrowserwindows.selenium;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +58,8 @@ public class ExtSelJxBrowserWindows extends ExtensionAdaptor {
         super.hook(extensionHook);
 
         if (Constant.isWindows() && !Utils.isOs64Bits()) {
-            webDriverProvider = new JxBrowserProvider();
+            webDriverProvider = new JxBrowserProvider(
+                    Paths.get(Constant.getZapHome(), "jxbrowser/webdriver/windows/chromedriver.exe"));
 
             ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
             extSelenium.addWebDriverProvider(webDriverProvider);

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows/selenium/JxBrowserProvider.java
@@ -21,13 +21,20 @@ package org.zaproxy.zap.extension.jxbrowserwindows.selenium;
 
 import java.awt.EventQueue;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.log4j.Logger;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chrome.ChromeDriverService;
@@ -67,15 +74,19 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
 
     private static final String PROVIDER_ID = "jxbrowser";
 
+    private static final Logger LOGGER = Logger.getLogger(JxBrowserProvider.class);
+
     private final ProvidedBrowser providedBrowser;
+    private final Path webdriver;
     /* One ZapBrowserFrame per requesterId, so that tools like the Ajax Spider
      * don't interfere with other tools.
      */
     private Map<Integer, ZapBrowserFrame> requesterToZbf = new HashMap<Integer, ZapBrowserFrame>();
     private int chromePort;
 
-    public JxBrowserProvider() {
+    public JxBrowserProvider(Path webdriver) {
         this.providedBrowser = new ProvidedBrowserImpl();
+        this.webdriver = webdriver;
     }
 
     @Override
@@ -158,7 +169,13 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
             Browser browser = new Browser(new BrowserContext(contextParams));
             final BrowserPanel browserPanel = zbf.addNewBrowserPanel(isNotAutomated(requesterId), browser);
 
-            final ChromeDriverService service = new ChromeDriverService.Builder().usingAnyFreePort().build();
+            if (!ensureExecutable(webdriver)) {
+                throw new IllegalStateException("Failed to ensure WebDriver is executable.");
+            }
+            final ChromeDriverService service = new ChromeDriverService.Builder()
+                    .usingDriverExecutable(webdriver.toFile())
+                    .usingAnyFreePort()
+                    .build();
             service.start();
 
             DesiredCapabilities capabilities = new DesiredCapabilities();
@@ -194,6 +211,30 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
         } catch (Exception e) {
             throw new WebDriverException(e);
         }
+    }
+
+    private static void setExecutable(Path file) throws IOException {
+        if (!SystemUtils.IS_OS_MAC && !SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+
+        Set<PosixFilePermission> perms = Files.readAttributes(file, PosixFileAttributes.class).permissions();
+        if (perms.contains(PosixFilePermission.OWNER_EXECUTE)) {
+            return;
+        }
+
+        perms.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(file, perms);
+    }
+
+    private static boolean ensureExecutable(Path driver) {
+        try {
+            setExecutable(driver);
+            return true;
+        } catch (IOException e) {
+            LOGGER.warn("Failed to set the bundled WebDriver executable:", e);
+        }
+        return false;
     }
 
     private void cleanUpBrowser(final int requesterId, final BrowserPanel browserPanel) {

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows64/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows64/ZapAddOn.xml
@@ -15,9 +15,13 @@
 			<addon>
 				<id>jxbrowser</id>
 			</addon>
+			<!--
+			Don't depend for the time being, the ChromeDriver provided no longer supports the Chromium version used by
+			JxBrowser. The JxBrowser add-on will bundle its own ChromeDriver.
 			<addon>
 				<id>webdriverwindows</id>
 			</addon>
+			-->
 		</addons>
 	</dependencies>
 	<extensions>
@@ -36,7 +40,9 @@
 	</extensions>
 	<ascanrules/>
 	<pscanrules/>
-	<files/>
+	<files>
+		<file>jxbrowser/webdriver/windows/chromedriver.exe</file>
+	</files>
 	<not-before-version>2.7.0</not-before-version>
 	<not-from-version></not-from-version>
 </zapaddon>

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows64/selenium/ExtSelJxBrowserWindows64.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows64/selenium/ExtSelJxBrowserWindows64.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.jxbrowserwindows64.selenium;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,7 +58,8 @@ public class ExtSelJxBrowserWindows64 extends ExtensionAdaptor {
         super.hook(extensionHook);
 
         if (Constant.isWindows() && Utils.isOs64Bits()) {
-            webDriverProvider = new JxBrowserProvider();
+            webDriverProvider = new JxBrowserProvider(
+                    Paths.get(Constant.getZapHome(), "jxbrowser/webdriver/windows/chromedriver.exe"));
 
             ExtensionSelenium extSelenium = Control.getSingleton().getExtensionLoader().getExtension(ExtensionSelenium.class);
             extSelenium.addWebDriverProvider(webDriverProvider);

--- a/src/org/zaproxy/zap/extension/jxbrowserwindows64/selenium/JxBrowserProvider.java
+++ b/src/org/zaproxy/zap/extension/jxbrowserwindows64/selenium/JxBrowserProvider.java
@@ -21,13 +21,20 @@ package org.zaproxy.zap.extension.jxbrowserwindows64.selenium;
 
 import java.awt.EventQueue;
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.log4j.Logger;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chrome.ChromeDriverService;
@@ -67,15 +74,19 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
 
     private static final String PROVIDER_ID = "jxbrowser";
 
+    private static final Logger LOGGER = Logger.getLogger(JxBrowserProvider.class);
+
     private final ProvidedBrowser providedBrowser;
+    private final Path webdriver;
     /* One ZapBrowserFrame per requesterId, so that tools like the Ajax Spider
      * don't interfere with other tools.
      */
     private Map<Integer, ZapBrowserFrame> requesterToZbf = new HashMap<Integer, ZapBrowserFrame>();
     private int chromePort;
 
-    public JxBrowserProvider() {
+    public JxBrowserProvider(Path webdriver) {
         this.providedBrowser = new ProvidedBrowserImpl();
+        this.webdriver = webdriver;
     }
 
     @Override
@@ -158,8 +169,11 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
             Browser browser = new Browser(new BrowserContext(contextParams));
             final BrowserPanel browserPanel = zbf.addNewBrowserPanel(isNotAutomated(requesterId), browser);
 
+            if (!ensureExecutable(webdriver)) {
+                throw new IllegalStateException("Failed to ensure WebDriver is executable.");
+            }
             final ChromeDriverService service = new ChromeDriverService.Builder()
-                    .usingDriverExecutable(new File(Constant.getZapHome(), ""))
+                    .usingDriverExecutable(webdriver.toFile())
                     .usingAnyFreePort()
                     .build();
             service.start();
@@ -197,6 +211,30 @@ public class JxBrowserProvider implements SingleWebDriverProvider {
         } catch (Exception e) {
             throw new WebDriverException(e);
         }
+    }
+
+    private static void setExecutable(Path file) throws IOException {
+        if (!SystemUtils.IS_OS_MAC && !SystemUtils.IS_OS_UNIX) {
+            return;
+        }
+
+        Set<PosixFilePermission> perms = Files.readAttributes(file, PosixFileAttributes.class).permissions();
+        if (perms.contains(PosixFilePermission.OWNER_EXECUTE)) {
+            return;
+        }
+
+        perms.add(PosixFilePermission.OWNER_EXECUTE);
+        Files.setPosixFilePermissions(file, perms);
+    }
+
+    private static boolean ensureExecutable(Path driver) {
+        try {
+            setExecutable(driver);
+            return true;
+        } catch (IOException e) {
+            LOGGER.warn("Failed to set the bundled WebDriver executable:", e);
+        }
+        return false;
     }
 
     private void cleanUpBrowser(final int requesterId, final BrowserPanel browserPanel) {


### PR DESCRIPTION
Bundle compatible ChromeDriver (v2.37) in OS specific JxBrowser add-ons.
Change JxBrowserProvider to use the bundled ChromeDrivers.
Change JxBrowserDownload to download the ChromeDrivers.
Change ZapAddOn.xml files to no longer depend on the WebDriver add-ons
and to declare the bundled files.

---
Depends on zaproxy/zap-libs#29.