### PR TITLE
zest: rely on script context writer

### DIFF
--- a/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/zest/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url>https://github.com/zaproxy/zap-core-help/wiki/HelpAddonsZestZest</url>
 	<changes>
 	<![CDATA[
+	Rely on script context writer for script output.<br>
 	]]>
 	</changes>
 	<dependencies>


### PR DESCRIPTION
Change ZestZapRunner to not set the script console writer as output
writer if the script context writer is already set, while both end up in
the script console the latter allows the core to intercept the writes.
For the cases the context writer is not set the writes are not
intercepted.
Update changes in ZapAddOn.xml file.

Related to zaproxy/zaproxy#5113 - Allow to differentiate scripts' output