### PR TITLE
wappalyzer: update help

### DIFF
--- a/src/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/src/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -11,7 +11,6 @@ The Technology Detection add-on uses the Wappalyzer (http://wappalyzer.com/) rul
 It works in a very similar way to the Wappalyzer browser add-ons with the following exceptions:
 <ul>
 <li>It does not use the 'Global JavaScript variables' as these are difficult to test without a 'full' browser</li>
-<li>It does not not show the versions - this is still todo</li>
 <li>It does not not show the confidence - this is still todo</li>
 <li>It allows you to see the 'evidence' used to detect the technologies</li>
 </ul>


### PR DESCRIPTION
Remove the entry that has the version as a to do, the version is now
reported per changes done #1541.

---
Spotted while reviewing the add-on for a new release.