### PR TITLE
Fix source disclosure false positive 

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
@@ -85,7 +85,7 @@ public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
 		languagePatterns.put(Pattern.compile("public\\s+static\\s+void\\s+main\\s*\\(\\s*String\\s*\\[\\s*\\]\\s*[a-z0-9]+\\s*\\)\\s*\\{", Pattern.MULTILINE | Pattern.DOTALL | Pattern.CASE_INSENSITIVE), "Java");
 
 		//ASP
-		languagePatterns.put(Pattern.compile("On\\s*Error\\s*Resume\\s*Next", Pattern.CASE_INSENSITIVE), "ASP");
+		languagePatterns.put(Pattern.compile("On\\s+Error\\s+Resume\\s+Next", Pattern.CASE_INSENSITIVE), "ASP");
 		languagePatterns.put(Pattern.compile("Server.CreateObject\\s*\\(\\s*\"[a-z0-9.]+\"\\s*\\)", Pattern.CASE_INSENSITIVE), "ASP");
 		languagePatterns.put(Pattern.compile("Request.QueryString\\s*\\(\\s*\"[a-z0-9]+\"\\s*\\)", Pattern.CASE_INSENSITIVE), "ASP");
 		languagePatterns.put(Pattern.compile("If\\s*\\(\\s*Err.Number\\s*.+\\)\\s*Then", Pattern.CASE_INSENSITIVE), "ASP");

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Fix a stack overflow with PII Scanner.<br>
 	Fix a DateParseException in Cacheable Scanner (Issue 4969).<br>
 	Fix Open Redirect (10028) "Attack" should be Desc.<br>
+        Fix false positive due to RxJS Observable method being mistaken for ASP source disclosure.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
The current ASP 'On Error Resume Next' source disclosure detection pattern also matches Rx.Observable.onErrorResumeNext in RxJS because it specifies any amount of whitespace between the terms (including none). The latter executes in the browser, and so must be disclosed!
 