### PR TITLE
Add default assertions to passive alerts (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormLoadScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormLoadScanner.java
@@ -105,7 +105,7 @@ public class InsecureFormLoadScanner extends PluginPassiveScanner {
 				getName());		
 		     
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), "", getExploitMessage(msg), 
+				.getURI().toString(), "", "", 
 				getExtraInfoMessage(msg, formElement),
 				getSolutionMessage(), getReferenceMessage(), 
 				"",	// No evidence
@@ -140,10 +140,6 @@ public class InsecureFormLoadScanner extends PluginPassiveScanner {
 
 	private String getReferenceMessage() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-	}
-
-	private String getExploitMessage(HttpMessage msg) {        
-        return Constant.messages.getString(MESSAGE_PREFIX + "exploit");
 	}
 
 	private String getExtraInfoMessage(HttpMessage msg, Element formElement) {		

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormPostScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/InsecureFormPostScanner.java
@@ -105,7 +105,7 @@ public class InsecureFormPostScanner extends PluginPassiveScanner {
 				getName());		
 		     
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), "", getExploitMessage(msg), 
+				.getURI().toString(), "", "", 
 				getExtraInfoMessage(msg, formElement),
 				getSolutionMessage(), getReferenceMessage(),  
 				"",	// No evidence
@@ -140,10 +140,6 @@ public class InsecureFormPostScanner extends PluginPassiveScanner {
 
 	private String getReferenceMessage() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-	}
-
-	private String getExploitMessage(HttpMessage msg) {        
-        return Constant.messages.getString(MESSAGE_PREFIX + "exploit");
 	}
 
 	private String getExtraInfoMessage(HttpMessage msg, Element formElement) {		

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCharsetScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCharsetScanner.java
@@ -203,8 +203,8 @@ public class UserControlledCharsetScanner extends PluginPassiveScanner {
 				getName());				    
 
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), param.getName(), getExploitMessage(msg), 
-				getExtraInfoMessage(msg, tag, attr, param, charset),
+				.getURI().toString(), param.getName(), "",
+				getExtraInfoMessage(tag, attr, param, charset),
 				getSolutionMessage(), getReferenceMessage(),  
 				"",	// No evidence
 				20,	// CWE-20: Improper Input Validation
@@ -240,13 +240,7 @@ public class UserControlledCharsetScanner extends PluginPassiveScanner {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
 	}
 
-	// XXX Consider removing the parameter msg, it's never used.
-	private String getExploitMessage(HttpMessage msg) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "exploit");
-	}
-
-	// XXX Consider removing the parameter msg, it's never used.
-	private String getExtraInfoMessage(HttpMessage msg, String tag, String attr,
+	private static String getExtraInfoMessage(String tag, String attr,
 			HtmlParameter param, String charset) {        
         return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", 
         		tag, attr, param.getName(), param.getValue(), charset);        

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCookieScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledCookieScanner.java
@@ -161,7 +161,7 @@ public class UserControlledCookieScanner extends PluginPassiveScanner {
 				getName());		
 		     
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), param.getName(), getExploitMessage(msg), 
+				.getURI().toString(), param.getName(), "",
 				getExtraInfoMessage(msg, param, cookie),
 				getSolutionMessage(), getReferenceMessage(),  
 				"",	// No evidence
@@ -198,18 +198,14 @@ public class UserControlledCookieScanner extends PluginPassiveScanner {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
 	}
 
-	private String getExploitMessage(HttpMessage msg) {
-        if ("GET".equalsIgnoreCase(msg.getRequestHeader().getMethod())) {      	        	
-        	return Constant.messages.getString(MESSAGE_PREFIX + "exploit.get");
-        } else if ("POST".equalsIgnoreCase(msg.getRequestHeader().getMethod())) {
-        	return Constant.messages.getString(MESSAGE_PREFIX + "exploit.post");
-        }
-        
-        return null;
-	}
-
 	private String getExtraInfoMessage(HttpMessage msg, HtmlParameter param, String cookie) {        
-        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", 
+        String introMessage = "";
+	    if ("GET".equalsIgnoreCase(msg.getRequestHeader().getMethod())) {                   
+	        introMessage = Constant.messages.getString(MESSAGE_PREFIX + "extrainfo.get");
+        } else if ("POST".equalsIgnoreCase(msg.getRequestHeader().getMethod())) {
+            introMessage = Constant.messages.getString(MESSAGE_PREFIX + "extrainfo.post");
+        }
+        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", introMessage,
         		msg.getRequestHeader().getURI().toString(), cookie, 
         		param.getName(), param.getValue());        
 	}

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledHTMLAttributesScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledHTMLAttributesScanner.java
@@ -236,7 +236,7 @@ public class UserControlledHTMLAttributesScanner extends PluginPassiveScanner {
 				getName());				    
 
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), param.getName(), getExploitMessage(msg), 
+				.getURI().toString(), param.getName(), "", 
 				getExtraInfoMessage(msg, htmlElement.getName(), 
 						htmlAttribute.getName(), param, userControlledValue),
 				getSolutionMessage(), getReferenceMessage(),  
@@ -272,10 +272,6 @@ public class UserControlledHTMLAttributesScanner extends PluginPassiveScanner {
 
 	private String getReferenceMessage() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-	}
-
-	private String getExploitMessage(HttpMessage msg) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "exploit");
 	}
 
 	private String getExtraInfoMessage(HttpMessage msg, String tag, String attr,

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledJavascriptEventScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/UserControlledJavascriptEventScanner.java
@@ -144,7 +144,7 @@ public class UserControlledJavascriptEventScanner extends PluginPassiveScanner {
 				getName());				    
 
 		alert.setDetail(getDescriptionMessage(), msg.getRequestHeader()
-				.getURI().toString(), param.getName(), getExploitMessage(msg), 
+				.getURI().toString(), param.getName(), "", 
 				getExtraInfoMessage(msg, htmlAttribute, param),
 				getSolutionMessage(), getReferenceMessage(),  
 				"",	// No evidence
@@ -179,10 +179,6 @@ public class UserControlledJavascriptEventScanner extends PluginPassiveScanner {
 
 	private String getReferenceMessage() {
 		return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-	}
-
-	private String getExploitMessage(HttpMessage msg) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "exploit");
 	}
 
 	private String getExtraInfoMessage(HttpMessage msg, Attribute htmlAttribute,

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -11,6 +11,7 @@
 	Fix a DateParseException in Cacheable Scanner (Issue 4969).<br>
 	Fix Open Redirect (10028) "Attack" should be Desc.<br>
         Fix false positive due to RxJS Observable method being mistaken for ASP source disclosure.<br>
+	Tweak User Controllable Charset and Cookie Poisoning to use Description/Other Info field instead of Attack (Issue 5149).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -25,14 +25,12 @@ pscanalpha.insecureformload.name=HTTP to HTTPS Insecure Transition in Form Post
 pscanalpha.insecureformload.desc=This check looks for insecure HTTP pages that host HTTPS forms. The issue is that an insecure HTTP page can easily be hijacked through MITM and the secure HTTPS form can be replaced or spoofed.
 pscanalpha.insecureformload.refs=
 pscanalpha.insecureformload.soln=Use HTTPS for landing pages that host secure forms.
-pscanalpha.insecureformload.exploit=
 pscanalpha.insecureformload.extrainfo=The response to the following request over HTTP included an HTTPS form tag action attribute value:\r\n\r\n{0}The context was:\r\n\r\n{1}
 
 pscanalpha.insecureformpost.name=HTTPS to HTTP Insecure Transition in Form Post
 pscanalpha.insecureformpost.desc=This check identifies secure HTTPS pages that host insecure HTTP forms. The issue is that a secure page is transitioning to an insecure page when data is uploaded through a form. The user may think they're submitting data to a secure page when in fact they are not.
 pscanalpha.insecureformpost.refs=
 pscanalpha.insecureformpost.soln=Ensure sensitive data is only sent over secured HTTPS channels.
-pscanalpha.insecureformpost.exploit=
 pscanalpha.insecureformpost.extrainfo=The response to the following request over HTTPS included an HTTP form tag action attribute value:\r\n\r\n{0}The context was:\r\n\r\n{1}
 
 pscanalpha.linktarget.name=Reverse Tabnabbing
@@ -41,32 +39,29 @@ pscanalpha.linktarget.refs=https://www.owasp.org/index.php/Reverse_Tabnabbing\nh
 pscanalpha.linktarget.soln=Do not use a target attribute, or if you have to then also add the attribute: rel="noopener noreferrer".
 
 pscanalpha.usercontrolledcharset.name=User Controllable Charset
-pscanalpha.usercontrolledcharset.desc=This check looks at user-supplied input in query string parameters and POST data to identify where Content-Type or meta tag charset declarations might be user-controlled. Such charset declarations should always be declared by the application. If an attacker can control the response charset, they could manipulate the HTML to perform XSS or other attacks.
+pscanalpha.usercontrolledcharset.desc=This check looks at user-supplied input in query string parameters and POST data to identify where Content-Type or meta tag charset declarations might be user-controlled. Such charset declarations should always be declared by the application. If an attacker can control the response charset, they could manipulate the HTML to perform XSS or other attacks. For example, an attacker controlling the <meta> element charset value is able to declare UTF-7 and is also able to include enough user-controlled payload early in the HTML document to have it interpreted as UTF-7. By encoding their payload with UTF-7 the attacker is able to bypass any server-side XSS protections and embed script in the page.
 pscanalpha.usercontrolledcharset.refs=
 pscanalpha.usercontrolledcharset.soln=Force UTF-8 in all charset declarations. If user-input is required to decide a charset declaration, ensure that only an allowed list is used.
-pscanalpha.usercontrolledcharset.exploit=An attacker controlling the <meta> element charset value is able to declare UTF-7 and is also able to include enough user-controlled payload early in the HTML document to have it interpreted as UTF-7. By encoding their payload with UTF-7 the attacker is able to bypass any server-side XSS protections and embed script in the page.
 pscanalpha.usercontrolledcharset.extrainfo=A(n) [{0}] tag [{1}] attribute\r\n\r\nThe user input found was:\r\n{2}={3}\r\n\r\nThe charset value it controlled was:\r\n{4}
 
 pscanalpha.usercontrolledcookie.name=Cookie Poisoning
 pscanalpha.usercontrolledcookie.desc=This check looks at user-supplied input in query string parameters and POST data to identify where cookie parameters might be controlled. This is called a cookie poisoning attack, and becomes exploitable when an attacker can manipulate the cookie in various ways. In some cases this will not be exploitable, however, allowing URL parameters to set cookie values is generally considered a bug.
 pscanalpha.usercontrolledcookie.refs=http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-cookie
 pscanalpha.usercontrolledcookie.soln=Do not allow user input to control cookie names and values. If some query string parameters must be set in cookie values, be sure to filter out semicolon's that can serve as name/value pair delimiters.
-pscanalpha.usercontrolledcookie.exploit.get=An attacker may be able to poison cookie values through URL parameters.  Try injecting a semicolon to see if you can add cookie values (e.g. name=controlledValue;name=anotherValue;).
-pscanalpha.usercontrolledcookie.exploit.post=An attacker may be able to poison cookie values through POST parameters. To test if this is a more serious issue, you should try resending that request as a GET, with the POST parameter included as a query string parmeter. For example:  http://nottrusted.com/page?value=maliciousInput.\r\n\r\n
-pscanalpha.usercontrolledcookie.extrainfo=This was identified at:\r\n\r\n{0}\r\n\r\nUser-input was found in the following cookie:\r\n{1}\r\n\r\nThe user input was:\r\n{2}={3}
+pscanalpha.usercontrolledcookie.extrainfo.get=An attacker may be able to poison cookie values through URL parameters.  Try injecting a semicolon to see if you can add cookie values (e.g. name=controlledValue;name=anotherValue;).\n\n
+pscanalpha.usercontrolledcookie.extrainfo.post=An attacker may be able to poison cookie values through POST parameters. To test if this is a more serious issue, you should try resending that request as a GET, with the POST parameter included as a query string parameter. For example:  http://nottrusted.com/page?value=maliciousInput.\r\n\r\n
+pscanalpha.usercontrolledcookie.extrainfo={0}This was identified at:\r\n\r\n{1}\r\n\r\nUser-input was found in the following cookie:\r\n{2}\r\n\r\nThe user input was:\r\n{3}={4}
 
 pscanalpha.usercontrolledjavascriptevent.name=User Controllable JavaScript Event (XSS)
 pscanalpha.usercontrolledjavascriptevent.desc=This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.            
 pscanalpha.usercontrolledjavascriptevent.refs=http://websecuritytool.codeplex.com/wikipage?title=Checks#user-javascript-event
 pscanalpha.usercontrolledjavascriptevent.soln=Validate all input and sanitize output it before writing to any Javascript on* events.
-pscanalpha.usercontrolledjavascriptevent.exploit=
 pscanalpha.usercontrolledjavascriptevent.extrainfo=User-controlled javascript event(s) was found. Exploitability will need to be manually determined. The page at the following URL:\r\n\r\n{0}\"\r\n\r\nincludes the following Javascript event which may be attacker-controllable: \r\n\r\nUser-input was found in the following data of an [{1}] event:\r\n{2}\r\n\r\nThe user input was:\r\n{3}
 
 pscanalpha.usercontrolledhtmlattributes.name=User Controllable HTML Element Attribute (Potential XSS)
 pscanalpha.usercontrolledhtmlattributes.desc=This check looks at user-supplied input in query string parameters and POST data to identify where certain HTML attribute values might be controlled. This provides hot-spot detection for XSS (cross-site scripting) that will require further review by a security analyst to determine exploitability.
 pscanalpha.usercontrolledhtmlattributes.refs=http://websecuritytool.codeplex.com/wikipage?title=Checks#user-controlled-html-attribute
 pscanalpha.usercontrolledhtmlattributes.soln=Validate all input and sanitize output it before writing to any HTML attributes.
-pscanalpha.usercontrolledhtmlattributes.exploit=
 pscanalpha.usercontrolledhtmlattributes.extrainfo=User-controlled HTML attribute values were found. Try injecting special characters to see if XSS might be possible. The page at the following URL:\r\n\r\n{0}\r\n\r\nappears to include user input in: \r\n\r\na(n) [{1}] tag [{2}] attribute \r\n\r\nThe user input found was:\r\n{3}={4}\r\n\r\nThe user-controlled value was:\r\n{5}
 
 pscanalpha.usercontrolledopenredirect.name=Open Redirect
@@ -177,7 +172,6 @@ pscanalpha.xpoweredbyheaderinfoleak.name=Server Leaks Information via "X-Powered
 pscanalpha.xpoweredbyheaderinfoleak.desc=The web/application server is leaking information via one or more "X-Powered-By" HTTP response headers. Access to such information may facilitate attackers identifying other frameworks/components your web application is reliant upon and the vulnerabilities such components may be subject to.
 pscanalpha.xpoweredbyheaderinfoleak.refs=http://blogs.msdn.com/b/varunm/archive/2013/04/23/remove-unwanted-http-response-headers.aspx\nhttp://www.troyhunt.com/2012/02/shhh-dont-let-your-response-headers.html
 pscanalpha.xpoweredbyheaderinfoleak.soln=Ensure that your web server, application server, load balancer, etc. is configured to suppress "X-Powered-By" headers.
-pscanalpha.xpoweredbyheaderinfoleak.exploit=
 pscanalpha.xpoweredbyheaderinfoleak.extrainfo=
 pscanalpha.xpoweredbyheaderinfoleak.otherinfo.msg=The following X-Powered-By headers were also found:\r\n
 
@@ -185,7 +179,6 @@ pscanalpha.contentsecuritypolicymissing.name=Content Security Policy (CSP) Heade
 pscanalpha.contentsecuritypolicymissing.desc=Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page \u2014 covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
 pscanalpha.contentsecuritypolicymissing.refs=https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy\nhttps://www.owasp.org/index.php/Content_Security_Policy\nhttp://www.w3.org/TR/CSP/\nhttp://w3c.github.io/webappsec/specs/content-security-policy/csp-specification.dev.html\nhttp://www.html5rocks.com/en/tutorials/security/content-security-policy/\nhttp://caniuse.com/#feat=contentsecuritypolicy\nhttp://content-security-policy.com/
 pscanalpha.contentsecuritypolicymissing.soln=Ensure that your web server, application server, load balancer, etc. is configured to set the Content-Security-Policy header, to achieve optimal browser support: "Content-Security-Policy" for Chrome 25+, Firefox 23+ and Safari 7+, "X-Content-Security-Policy" for Firefox 4.0+ and Internet Explorer 10+, and "X-WebKit-CSP" for Chrome 14+ and Safari 6+.
-pscanalpha.contentsecuritypolicymissing.exploit=
 pscanalpha.contentsecuritypolicymissing.extrainfo=
 pscanalpha.contentsecuritypolicymissing.ro.name=Content Security Policy (CSP) Report-Only Header Found
 pscanalpha.contentsecuritypolicymissing.ro.desc=The response contained a Content-Security-Policy-Report-Only header, this may indicate a work-in-progress implementation, or an oversight in promoting pre-Prod to Prod, etc.\n\nContent Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page \u2014 covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
@@ -195,7 +188,6 @@ pscanalpha.xbackendserver.name=X-Backend-Server Header Information Leak
 pscanalpha.xbackendserver.desc=The server is leaking information pertaining to backend systems (such as hostnames or IP addresses). Armed with this information an attacker may be able to attack other systems or more directly/efficiently attack those systems.
 pscanalpha.xbackendserver.refs=
 pscanalpha.xbackendserver.soln=Ensure that your web server, application server, load balancer, etc. is configured to suppress X-Backend-Server headers.
-pscanalpha.xbackendserver.exploit=
 pscanalpha.xbackendserver.extrainfo=
 
 pscanalpha.insecurecomponent.name = Insecure Component

--- a/test/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
+++ b/test/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
@@ -19,6 +19,11 @@
  */
 package org.zaproxy.zap.testutils;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.junit.Assert.assertThat;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,6 +36,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /**
  * Class with utility/helper methods for passive scanner tests ({@link org.zaproxy.zap.extension.pscan.PluginPassiveScanner
@@ -55,12 +61,21 @@ public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends 
         alertsRaised = new ArrayList<>();
         parent = new PassiveScanThread(null, null, new ExtensionAlert(), null) {
             @Override
-            public void raiseAlert(int arg0, Alert arg1) {
-                alertsRaised.add(arg1);
+            public void raiseAlert(int id, Alert alert) {
+                defaultAssertions(alert);
+                alertsRaised.add(alert);
             }
         };
         rule = createScanner();
         rule.setParent(parent);
+    }
+
+    protected void defaultAssertions(Alert alert) {
+        if (rule instanceof PluginPassiveScanner) {
+            PluginPassiveScanner pps = (PluginPassiveScanner) rule;
+            assertThat(alert.getPluginId(), is(equalTo(pps.getPluginId())));
+        }
+        assertThat(alert.getAttack(), isEmptyOrNullString());
     }
 
     protected abstract T createScanner();


### PR DESCRIPTION
Change UserControlledCharsetScanner to not set the attack field in the
alert, instead mention that in the description. Also, remove unused
parameter.
Change UserControlledCookieScanner to not set the attack field in the
alert, instead mention that in the extra info. Fix zaproxy/zaproxy#5149.
Change InsecureFormLoadScanner, UserControlledHTMLAttributesScanner,
InsecureFormPostScanner, and UserControlledJavascriptEventScanner to not
read the (empty) resource message for the attack field.
Remove other empty and unused attack resource messages, should not be
needed.
Change PassiveScannerTestUtils to assert that the alerts raised have the
attack field empty and the expected scanner ID.

Related to zaproxy/zaproxy#5061 and referenced issues.