### PR TITLE
ascanrulesBeta: fix missing resource messages

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanner.java
@@ -102,7 +102,7 @@ public class CrossDomainScanner extends AbstractHostPlugin {
 
 	@Override
 	public String getDescription() {
-		return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+		return "";
 	}
 
 	@Override
@@ -112,7 +112,7 @@ public class CrossDomainScanner extends AbstractHostPlugin {
 
 	@Override
 	public String getSolution() {
-		return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+		return "";
 	}
 
 	@Override

--- a/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesBeta/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Correct HTTP message usage in Insecure HTTP Method scanner.<br>
+	Fix missing resource messages with Cross-Domain Misconfiguration scanner.<br>
     ]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change CrossDomainScanner to return empty strings for the description
and solution instead of trying to get the resource messages (which do
not exist), the alerts being raised do not use those methods but
external code might still call them which would lead to exception or
errors.
Update changes in ZapAddOn.xml file.