### PR TITLE
Update confidence level for reliable hash patterns

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
@@ -56,36 +56,36 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 		//Example: sa3tHJ3/KuYvI
 		//hashPatterns.put(Pattern.compile("\\b[A-Za-z0-9/]{13}\\b", Pattern.CASE_INSENSITIVE), new HashAlert ("Traditional DES", Alert.RISK_HIGH, Alert.WARNING));
 		
-		hashPatterns.put(Pattern.compile("\\$LM\\$[a-f0-9]{16}", Pattern.CASE_INSENSITIVE), new HashAlert ("LanMan / DES", Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		hashPatterns.put(Pattern.compile("\\$K4\\$[a-f0-9]{16},", Pattern.CASE_INSENSITIVE), new HashAlert ("Kerberos AFS DES", Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		hashPatterns.put(Pattern.compile("\\$2a\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE), new HashAlert ("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		hashPatterns.put(Pattern.compile("\\$2y\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE), new HashAlert ("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+		hashPatterns.put(Pattern.compile("\\$LM\\$[a-f0-9]{16}", Pattern.CASE_INSENSITIVE), new HashAlert ("LanMan / DES", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
+		hashPatterns.put(Pattern.compile("\\$K4\\$[a-f0-9]{16},", Pattern.CASE_INSENSITIVE), new HashAlert ("Kerberos AFS DES", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
+		hashPatterns.put(Pattern.compile("\\$2a\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE), new HashAlert ("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
+		hashPatterns.put(Pattern.compile("\\$2y\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE), new HashAlert ("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 		
 		//MD5 Crypt 
 		//Example: $1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/
-		hashPatterns.put(Pattern.compile("\\$1\\$[./0-9A-Za-z]{0,8}\\$[./0-9A-Za-z]{22}"), new HashAlert ("MD5 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+		hashPatterns.put(Pattern.compile("\\$1\\$[./0-9A-Za-z]{0,8}\\$[./0-9A-Za-z]{22}"), new HashAlert ("MD5 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
 		//SHA-256 Crypt
 		//Example: $5$MnfsQ4iN$ZMTppKN16y/tIsUYs/obHlhdP.Os80yXhTurpBMUbA5
 		//Example: $5$rounds=5000$usesomesillystri$KqJWpanXZHKq2BOB43TSaYhEWsQ1Lr5QNyPCDH/Tp.6
-		hashPatterns.put(Pattern.compile("\\$5\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{43}"), new HashAlert ("SHA-256 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		hashPatterns.put(Pattern.compile("\\$5\\$rounds=[0-9]+\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{43}"), new HashAlert ("SHA-256 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+		hashPatterns.put(Pattern.compile("\\$5\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{43}"), new HashAlert ("SHA-256 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
+		hashPatterns.put(Pattern.compile("\\$5\\$rounds=[0-9]+\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{43}"), new HashAlert ("SHA-256 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
 		//SHA-512 Crypt
 		//Example: $6$zWwwXKNj$gLAOoZCjcr8p/.VgV/FkGC3NX7BsXys3KHYePfuIGMNjY83dVxugPYlxVg/evpcVEJLT/rSwZcDMlVVf/bhf.1
 		//Example: $6$rounds=5000$usesomesillystri$D4IrlXatmP7rx3P3InaxBeoomnAihCKRVQP22JZ6EY47Wc6BkroIuUUBOov1i.S5KPgErtP/EN5mcO.ChWQW21
-		hashPatterns.put(Pattern.compile("\\$6\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{86}"), new HashAlert ("SHA-512 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		hashPatterns.put(Pattern.compile("\\$6\\$rounds=[0-9]+\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{86}"), new HashAlert ("SHA-512 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+		hashPatterns.put(Pattern.compile("\\$6\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{86}"), new HashAlert ("SHA-512 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
+		hashPatterns.put(Pattern.compile("\\$6\\$rounds=[0-9]+\\$[./0-9A-Za-z]{0,16}\\$[./0-9A-Za-z]{86}"), new HashAlert ("SHA-512 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
 		//BCrypt
 		//Example: $2a$05$bvIG6Nmid91Mu9RcmmWZfO5HJIMCT8riNW0hEp8f6/FuA2/mHZFpe
-		hashPatterns.put(Pattern.compile("\\$2\\$[0-9]{2}\\$[./0-9A-Za-z]{53}"), new HashAlert ("BCrypt",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		hashPatterns.put(Pattern.compile("\\$2a\\$[0-9]{2}\\$[./0-9A-Za-z]{53}"), new HashAlert ("BCrypt",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+		hashPatterns.put(Pattern.compile("\\$2\\$[0-9]{2}\\$[./0-9A-Za-z]{53}"), new HashAlert ("BCrypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
+		hashPatterns.put(Pattern.compile("\\$2a\\$[0-9]{2}\\$[./0-9A-Za-z]{53}"), new HashAlert ("BCrypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
 		//NTLM
 		//Example: $NT$7f8fe03093cc84b267b109625f6bbf4b		
-		hashPatterns.put(Pattern.compile("\\$3\\$\\$[0-9a-f]{32}"), new HashAlert("NTLM",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		hashPatterns.put(Pattern.compile("\\$NT\\$[0-9a-f]{32}"), new HashAlert("NTLM",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
+		hashPatterns.put(Pattern.compile("\\$3\\$\\$[0-9a-f]{32}"), new HashAlert("NTLM",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
+		hashPatterns.put(Pattern.compile("\\$NT\\$[0-9a-f]{32}"), new HashAlert("NTLM",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
 		//Mac OS X salted SHA-1
 		//Example: 0E6A48F765D0FFFFF6247FA80D748E615F91DD0C7431E4D9
@@ -175,9 +175,18 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 		String hashType = null;
 		Iterator<Pattern> patternIterator = hashPatterns.keySet().iterator();		
 		
+		int minimumConfidence = Alert.CONFIDENCE_LOW;
+		switch (this.getAlertThreshold()) {
+			case HIGH:   minimumConfidence = Alert.CONFIDENCE_HIGH; break;
+			case MEDIUM: minimumConfidence = Alert.CONFIDENCE_MEDIUM; break;
+		}
+
 		while (patternIterator.hasNext()) {
 			Pattern hashPattern = patternIterator.next();
 			HashAlert hashalert= hashPatterns.get(hashPattern);
+			if (hashalert.getReliability() < minimumConfidence) {
+				continue;
+			}
 			hashType = hashalert.getDescription();
 			if (log.isDebugEnabled()) log.debug("Trying Hash Pattern: "+ hashPattern + " for hash type "+ hashType);
 			for (String haystack: haystacks) {

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
@@ -35,33 +35,31 @@ import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 
-
 /**
  * A class to passively scan responses known Hash signatures
  * @author 70pointer@gmail.com
- *
  */
 
 public class HashDisclosureScanner extends PluginPassiveScanner {
-	
+
 	private PassiveScanThread parent = null;
-	
+
 	/**
-	 * a map of a regular expression pattern to details of the Hash type found 
+	 * a map of a regular expression pattern to details of the Hash type found
 	 */
 	static Map <Pattern, HashAlert> hashPatterns = new LinkedHashMap <Pattern, HashAlert> ();
-	
+
 	static {
 		//Traditional DES: causes *way* too many false positives to enable this..
 		//Example: sa3tHJ3/KuYvI
 		//hashPatterns.put(Pattern.compile("\\b[A-Za-z0-9/]{13}\\b", Pattern.CASE_INSENSITIVE), new HashAlert ("Traditional DES", Alert.RISK_HIGH, Alert.WARNING));
-		
+
 		hashPatterns.put(Pattern.compile("\\$LM\\$[a-f0-9]{16}", Pattern.CASE_INSENSITIVE), new HashAlert ("LanMan / DES", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 		hashPatterns.put(Pattern.compile("\\$K4\\$[a-f0-9]{16},", Pattern.CASE_INSENSITIVE), new HashAlert ("Kerberos AFS DES", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 		hashPatterns.put(Pattern.compile("\\$2a\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE), new HashAlert ("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 		hashPatterns.put(Pattern.compile("\\$2y\\$05\\$[a-zA-z0-9\\+\\-_./=]{53}", Pattern.CASE_INSENSITIVE), new HashAlert ("OpenBSD Blowfish", Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
-		
-		//MD5 Crypt 
+
+		//MD5 Crypt
 		//Example: $1$O3JMY.Tw$AdLnLjQ/5jXF9.MTp3gHv/
 		hashPatterns.put(Pattern.compile("\\$1\\$[./0-9A-Za-z]{0,8}\\$[./0-9A-Za-z]{22}"), new HashAlert ("MD5 Crypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
@@ -83,34 +81,34 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 		hashPatterns.put(Pattern.compile("\\$2a\\$[0-9]{2}\\$[./0-9A-Za-z]{53}"), new HashAlert ("BCrypt",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
 		//NTLM
-		//Example: $NT$7f8fe03093cc84b267b109625f6bbf4b		
+		//Example: $NT$7f8fe03093cc84b267b109625f6bbf4b
 		hashPatterns.put(Pattern.compile("\\$3\\$\\$[0-9a-f]{32}"), new HashAlert("NTLM",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 		hashPatterns.put(Pattern.compile("\\$NT\\$[0-9a-f]{32}"), new HashAlert("NTLM",Alert.RISK_HIGH, Alert.CONFIDENCE_HIGH));
 
 		//Mac OS X salted SHA-1
 		//Example: 0E6A48F765D0FFFFF6247FA80D748E615F91DD0C7431E4D9
 		hashPatterns.put(Pattern.compile("\\b[0-9A-F]{48}\\b"), new HashAlert("Mac OSX salted SHA-1",Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM));
-		
+
 		//SHA hashes occur fairly frequently in various legitimate uses, and are not necessarily indicative of an issue.
 		hashPatterns.put(Pattern.compile("\\b[0-9a-f]{128}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("SHA-512",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
 		hashPatterns.put(Pattern.compile("\\b[0-9a-f]{96}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("SHA-384",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
 		hashPatterns.put(Pattern.compile("\\b[0-9a-f]{64}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("SHA-256",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
 		hashPatterns.put(Pattern.compile("\\b[0-9a-f]{56}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("SHA-224",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
 		hashPatterns.put(Pattern.compile("\\b[0-9a-f]{40}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("SHA-1",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
-				
+
 		//LanMan (clashes with MD4/MD5) - note the case sensitivity here, however
-		//Example: 855c3697d9979e78ac404c4ba2c66533) 
+		//Example: 855c3697d9979e78ac404c4ba2c66533)
 		hashPatterns.put(Pattern.compile("\\b\\[0-9a-f]{32}\\b"), new HashAlert("LanMan",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
-		
+
 		//MD4/5 (clashes with LanMan)
 		//MD4/5 hashes occur fairly frequently in various legitimate uses, and are not necessarily indicative of an issue.
 		hashPatterns.put(Pattern.compile("\\b[0-9a-f]{32}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("MD4 / MD5",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
 
 		//TODO: for the main hash types, verify the value by hashing the parameters
-		//	if the hash value can be re-generated, then it is a "reflection" attack
-		//  if the hash value cannot be re-generated using the available data, then perhaps it is being retrieved from a database???  => Dangerous.  
+		//  - if the hash value can be re-generated, then it is a "reflection" attack
+		//  - if the hash value cannot be re-generated using the available data, then perhaps it is being retrieved from a database??? => Dangerous.
 	}
-	
+
 	private static Logger log = Logger.getLogger(HashDisclosureScanner.class);
 
 	/**
@@ -134,15 +132,15 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 	 */
 	@Override
 	public void scanHttpRequestSend(HttpMessage msg, int id) {
-		
-		if (log.isDebugEnabled()) log.debug("Checking request of message "+ msg + " for Hashes");
-		
+
+		if (log.isDebugEnabled()) log.debug("Checking request of message " + msg + " for Hashes");
+
 		//get the request contents as an array of Strings, so we can match against them
 		String requestheader = msg.getRequestHeader().getHeadersAsString();
 		String requestbody = msg.getRequestBody().toString();
 		String [] requestparts = {requestheader, requestbody};
-		
-		checkForHashes (msg, id, requestparts);
+
+		checkForHashes(msg, id, requestparts);
 	}
 
 	/**
@@ -153,28 +151,28 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 	 */
 	@Override
 	public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-		
-		if (log.isDebugEnabled()) log.debug("Checking response of message "+ msg + " for Hashes");
-		
+
+		if (log.isDebugEnabled()) log.debug("Checking response of message " + msg + " for Hashes");
+
 		//get the response contents as an array of Strings, so we can match against them
 		String responseheader = msg.getResponseHeader().getHeadersAsString();
 		String responsebody = msg.getResponseBody().toString();
 		String [] responseparts = {responseheader, responsebody};
-		
-		checkForHashes (msg, id, responseparts);
+
+		checkForHashes(msg, id, responseparts);
 	}
-	
+
 	/**
 	 * checks for hashes in the given array of strings, which relate to the parameter message
 	 * @param msg
 	 * @param id
 	 * @param haystacks
 	 */
-	public void checkForHashes (HttpMessage msg, int id, String [] haystacks) {
-		//try each of the patterns in turn against the response.				
+	public void checkForHashes(HttpMessage msg, int id, String [] haystacks) {
+		//try each of the patterns in turn against the response.
 		String hashType = null;
-		Iterator<Pattern> patternIterator = hashPatterns.keySet().iterator();		
-		
+		Iterator<Pattern> patternIterator = hashPatterns.keySet().iterator();
+
 		int minimumConfidence = Alert.CONFIDENCE_LOW;
 		switch (this.getAlertThreshold()) {
 			case HIGH:   minimumConfidence = Alert.CONFIDENCE_HIGH; break;
@@ -183,38 +181,37 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 
 		while (patternIterator.hasNext()) {
 			Pattern hashPattern = patternIterator.next();
-			HashAlert hashalert= hashPatterns.get(hashPattern);
+			HashAlert hashalert = hashPatterns.get(hashPattern);
 			if (hashalert.getReliability() < minimumConfidence) {
 				continue;
 			}
 			hashType = hashalert.getDescription();
-			if (log.isDebugEnabled()) log.debug("Trying Hash Pattern: "+ hashPattern + " for hash type "+ hashType);
+			if (log.isDebugEnabled()) log.debug("Trying Hash Pattern: " + hashPattern + " for hash type " + hashType);
 			for (String haystack: haystacks) {
 				Matcher matcher = hashPattern.matcher(haystack);
-		        while (matcher.find()) {
-		            String evidence = matcher.group();
-		            if (log.isDebugEnabled()) log.debug("Found a match for hash type "+ hashType +":" + evidence);
-		            
-			        if ( evidence!=null && evidence.length() > 0) {
+				while (matcher.find()) {
+					String evidence = matcher.group();
+					if (log.isDebugEnabled()) log.debug("Found a match for hash type " + hashType + ":" + evidence);
+					if (evidence != null && evidence.length() > 0) {
 						//we found something
-						Alert alert = new Alert(getPluginId(), hashalert.getRisk(), hashalert.getReliability(), getName() + " - "+ hashType );
+						Alert alert = new Alert(getPluginId(), hashalert.getRisk(), hashalert.getReliability(), getName() + " - " + hashType);
 						alert.setDetail(
-								getDescription() + " - "+ hashType, 
-								msg.getRequestHeader().getURI().toString(), 
+								getDescription() + " - " + hashType,
+								msg.getRequestHeader().getURI().toString(),
 								"", //param
-								"",  // attack 
-								getExtraInfo(msg, evidence),  //other info
-								getSolution(), 
-								getReference(), 
+								"", // attack
+								getExtraInfo(msg, evidence), //other info
+								getSolution(),
+								getReference(),
 								evidence,
-								200, //Information Exposure, 
+								200, //Information Exposure,
 								13, //Information Leakage
-								msg);  
+								msg);
 						parent.raiseAlert(id, alert);
 						//do NOT break at this point.. we need to find *all* the potential hashes in the response..
-			        }
-		        }
-			}	
+					}
+				}
+			}
 		}
 	}
 
@@ -266,8 +263,8 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 	 * @param arg0
 	 * @return
 	 */
-	private String getExtraInfo(HttpMessage msg, String arg0) {		
-		return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);        
+	private String getExtraInfo(HttpMessage msg, String arg0) {
+		return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);
 	}
 
 	static class HashAlert {
@@ -286,12 +283,11 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 		public int getReliability() {
 			return reliability;
 		}
-		
+
 		public HashAlert (String description, int risk, int reliability) {
 			this.description = description;
 			this.risk = risk;
-			this.reliability = reliability;			
+			this.reliability = reliability;
 		}
-		
 	}
 }

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Fix false positive due to RxJS Observable method being mistaken for ASP source disclosure.<br>
 	Tweak User Controllable Charset and Cookie Poisoning to use Description/Other Info field instead of Attack (Issue 5149).<br>
 	Only report missing STS header on redirects to HTTPS URLs on the same domain at Low threshold.<br>
+	Hash Disclosure (10097): Add threshold filtering and fix hash confidence levels.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Unlike `Mac OS X salted SHA-1`, which really has a MEDIUM
confidence level (because it will match any long hex string),
hashes with very specific patterns, such as
`$NT$7f8fe03093cc84b267b109625f6bbf4b` have now an HIGH
confidence, as they are very unlikely to be false positives