### PR TITLE
Add wrapper to websocket API responses.

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix exceptions when handling/dispatching events.<br>
+	Add wrapper to websocket API responses.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -19,6 +19,7 @@ ZAP Dev Team
 <H3>Version 19 - TBD</H3>
 <ul>
 	<li>Fix exceptions when handling/dispatching events.</li>
+	<li>Add wrapper to websocket API responses.</li>
 </ul>
 
 <H3>Version 18 - 2018/08/01</H3>


### PR DESCRIPTION
Adds a wrapper around all of the API responses, but only if the user supplies an 'id' - if they dont then no response is sent. If the user also supplies a 'caller' (eg for routing) then this is also returned.

Without this its not really possible for the caller to work out which response is for which request.
Required for the HUD :)