### PR TITLE
websocket: fix NPE when handling API request

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -198,6 +198,9 @@ public class WebSocketAPI extends ApiImplementor {
                             }
                         } else {
                             ApiImplementor impl = API.getInstance().getImplementors().get(component);
+                            if (impl == null) {
+                                throw new ApiException(ApiException.Type.NO_IMPLEMENTOR);
+                            }
                             RequestType reqType = RequestType.valueOf(json.getString("type"));
                             ApiResponse apiResp;
 

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<![CDATA[
 	Fix exceptions when handling/dispatching events.<br>
 	Add wrapper to websocket API responses.<br>
+	Fix exception when handling API request with no API implementor.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -20,6 +20,7 @@ ZAP Dev Team
 <ul>
 	<li>Fix exceptions when handling/dispatching events.</li>
 	<li>Add wrapper to websocket API responses.</li>
+	<li>Fix exception when handling API request with no API implementor.</li>
 </ul>
 
 <H3>Version 18 - 2018/08/01</H3>


### PR DESCRIPTION
Change `WebSocketAPI` to check that the requested `ApiImplementor`
exists (not null) before using it, throwing an `ApiException` if it does
not.
Update changes in ZapAddOn.xml file and about help page.