### PR TITLE
selenium: just quit the WebDrivers

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -210,7 +210,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         for (WebDriver wd : this.proxiedWebDrivers) {
             // Just to make sure
             try {
-                wd.close();
                 wd.quit();
             } catch (Exception ex) {
                 // Ignore - the user might well have already closed the browser

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -13,6 +13,7 @@
 	Mention the configuration keys in the options help page.<br>
 	Tweak error message shown when failed to start/connect to the browser.<br>
 	Disable Firefox JSON viewer when used by AJAX Spider to prevent crawl.<br>
+	Prevent WebDriver process leak when closing ZAP.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionSelenium to just quit the WebDrivers, calling also close
leads to WebDriver process leaks (e.g. geckodriver) if the browser was
previously closed.
Update changes in ZapAddOn.xml file.