### PR TITLE
websocket: correct output stream used for server

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
@@ -598,6 +598,7 @@ public class WebSocketProxyV13 extends WebSocketProxy {
 		@Override
 		public boolean forward(OutputStream out) throws IOException {
 			if (out == null) {
+				logger.warn("No output stream to forward message #" + getMessageId());
 				return false;
 			}
 			

--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	Fix exceptions when handling/dispatching events.<br>
 	Add wrapper to websocket API responses.<br>
 	Fix exception when handling API request with no API implementor.<br>
+	Correct output stream used in server mode.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -21,6 +21,7 @@ ZAP Dev Team
 	<li>Fix exceptions when handling/dispatching events.</li>
 	<li>Add wrapper to websocket API responses.</li>
 	<li>Fix exception when handling API request with no API implementor.</li>
+	<li>Correct output stream used in server mode.</li>
 </ul>
 
 <H3>Version 18 - 2018/08/01</H3>


### PR DESCRIPTION
Change WebSocketProxy to always use the local output stream when in
server mode (there's no remote to read/write to).
Change WebSocketProxyV13 to warn when no output stream exists (shouldn't
happen under normal conditions).
Update changes in ZapAddOn.xml file and about help page.