### PR TITLE
websocket: validate the Origin for API connections

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/websocket/ZapAddOn.xml
@@ -12,6 +12,7 @@
 	Fix exception when handling API request with no API implementor.<br>
 	Correct output stream used in server mode.<br>
 	Add support for 'other' API operations.<br>
+	Validate the Origin for API connections.<br>
 	]]>
 	</changes>
 	<classnames>

--- a/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/websocket/resources/help/contents/about.html
@@ -23,6 +23,7 @@ ZAP Dev Team
 	<li>Fix exception when handling API request with no API implementor.</li>
 	<li>Correct output stream used in server mode.</li>
 	<li>Add support for 'other' API operations.</li>
+	<li>Validate the Origin for API connections.</li>
 </ul>
 
 <H3>Version 18 - 2018/08/01</H3>


### PR DESCRIPTION
Change WebSocketAPI to validate that the origin of the WebSocket
handshake is the expected one (that is, zap domain).
Update changes in ZapAddOn.xml file and about help page.