### PR TITLE
frontendscanner: set URI and message to alerts

### DIFF
--- a/src/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerAPI.java
+++ b/src/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerAPI.java
@@ -116,7 +116,8 @@ public class FrontEndScannerAPI extends ApiImplementor {
             ).getJSONObject("alert");
 
             HistoryReference historyReference = new HistoryReference(
-                alertParams.getInt("historyReferenceId")
+                alertParams.getInt("historyReferenceId"),
+                true
             );
 
             Alert alert = new Alert(
@@ -128,6 +129,10 @@ public class FrontEndScannerAPI extends ApiImplementor {
             alert.setSource(Alert.Source.PASSIVE);
             alert.setDescription(alertParams.getString("description"));
             alert.setEvidence(alertParams.getString("evidence"));
+            alert.setUri(historyReference.getURI().toString());
+            alert.setHistoryRef(historyReference);
+            alert.setMessage(historyReference.getHttpMessage());
+            historyReference.clearHttpMessage();
 
             ExtensionAlert extAlert = Control
                 .getSingleton()


### PR DESCRIPTION
Change FrontEndScannerAPI to set the URI and the HTTP message to the
Alert being raised, otherwise it's not properly processed by core. Also,
for consistency set the HistoryReference.