### PR TITLE
selenium: proxy "localhost" in Chrome 72

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -671,6 +671,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         case CHROME:
             ChromeOptions chromeOptions = new ChromeOptions();
             setCommonOptions(chromeOptions, proxyAddress, proxyPort);
+            chromeOptions.addArguments("--proxy-bypass-list=<-loopback>");
             return new ChromeDriver(chromeOptions);
         case FIREFOX:
             FirefoxOptions firefoxOptions = new FirefoxOptions();

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -14,6 +14,7 @@
 	Tweak error message shown when failed to start/connect to the browser.<br>
 	Disable Firefox JSON viewer when used by AJAX Spider to prevent crawl.<br>
 	Prevent WebDriver process leak when closing ZAP.<br>
+	Ensure "localhost" is proxied through ZAP on Chrome >= 72.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionSelenium to add an argument to ChromeOptions to not
bypass localhost when proxying, thanks to:
https://github.com/cypress-io/cypress/issues/1872#issuecomment-450800890
for the syntax to use with `proxy-bypass-list`.
Update changes in ZapAddOn.xml file.