### PR TITLE
Added Cloud Metadata Scanner

### DIFF
--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanner.java
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanner.java
@@ -1,0 +1,213 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ * 
+ * Copyright 2019 The ZAP Development Team
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.HttpVersion;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
+import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
+import org.apache.commons.httpclient.params.HttpMethodParams;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpMethodHelper;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.zap.ZapGetMethod;
+import org.zaproxy.zap.users.User;
+
+/**
+ * Attempts to retrieve cloud metadata by forging the host header and requesting a specific URL.
+ * See https://www.nginx.com/blog/trust-no-one-perils-of-trusting-user-input/ for more details
+ */
+public class CloudMetadataScanner extends AbstractHostPlugin {
+
+    /**
+     * Prefix for internationalised messages used by this rule
+     */
+    private static final String MESSAGE_PREFIX = "ascanalpha.cloudmetadata.";
+    
+    private static final int PLUGIN_ID = 90034;
+    private static final String METADATA_PATH = "/latest/meta-data/";
+    private static final String METADATA_HOST = "169.154.169.254";
+
+    private static final Logger LOG = Logger.getLogger(CloudMetadataScanner.class);
+    
+    @Override
+    public int getId() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+    
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    @Override
+    public String[] getDependency() {
+        return null;
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INJECTION;
+    }
+    
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    @Override
+    public int getCweId() {
+        return 0;
+    }
+
+    @Override
+    public int getWascId() {
+        return 0;
+    }
+
+    @Override
+    public void init() {
+
+    }
+
+    public void raiseAlert(HttpMessage newRequest) {
+        bingo(getRisk(), //Risk
+                Alert.CONFIDENCE_LOW, //Confidence/Reliability
+                getName(), //Name
+                getDescription(), //Description
+                newRequest.getRequestHeader().getURI().toString(), //Original URI
+                null, //Param
+                METADATA_HOST, //Attack
+                Constant.messages.getString(MESSAGE_PREFIX + "otherinfo"), //OtherInfo 
+                getSolution(), //Solution
+                "", //Evidence
+                getCweId(), //CWE ID
+                getWascId(), //WASC ID
+                newRequest); //HTTPMessage
+    }
+
+    @Override
+    public void scan() {
+        HttpMessage newRequest = getNewMsg();
+        try{
+            newRequest.getRequestHeader().getURI().setPath(METADATA_PATH);
+            this.sendMessageWithCustomHostHeader(newRequest, METADATA_HOST);
+            if (HttpStatusCode.isSuccess(newRequest.getResponseHeader().getStatusCode())) {
+                this.raiseAlert(newRequest);
+            }
+        } catch (Exception e) {
+            LOG.error("Error sending URL " + newRequest.getRequestHeader().getURI(), e);
+            return;
+        }
+    }
+    
+     void sendMessageWithCustomHostHeader(HttpMessage message, String host) throws IOException {
+         HttpMethodParams params = new HttpMethodParams();
+         params.setVirtualHost(host);
+         HttpMethod method = createRequestMethod(message.getRequestHeader(), message.getRequestBody(), params);
+         if (!(method instanceof EntityEnclosingMethod) || method instanceof ZapGetMethod) {
+             method.setFollowRedirects(false);
+         }
+         User forceUser = getParent().getHttpSender().getUser(message);
+         message.setTimeSentMillis(System.currentTimeMillis());
+         if (forceUser != null) {
+             getParent().getHttpSender().executeMethod(method, forceUser.getCorrespondingHttpState());
+         } else {
+             getParent().getHttpSender().executeMethod(method, null);
+         }
+         message.setTimeElapsedMillis((int) (System.currentTimeMillis() - message.getTimeSentMillis()));
+
+         HttpMethodHelper.updateHttpRequestHeaderSent(message.getRequestHeader(), method);
+
+         HttpResponseHeader resHeader = HttpMethodHelper.getHttpResponseHeader(method);
+         resHeader.setHeader(HttpHeader.TRANSFER_ENCODING, null);
+         message.setResponseHeader(resHeader);
+         message.getResponseBody().setCharset(resHeader.getCharset());
+         message.getResponseBody().setLength(0);
+         message.getResponseBody().append(method.getResponseBody());
+         message.setResponseFromTargetHost(true);
+         getParent().notifyNewMessage(this, message);
+     }
+
+    private static HttpMethod createRequestMethod(HttpRequestHeader header, HttpBody body, HttpMethodParams params)
+            throws URIException {
+        HttpMethod httpMethod = new ZapGetMethod();
+        httpMethod.setURI(header.getURI());
+        httpMethod.setParams(params);
+        params.setVersion(HttpVersion.HTTP_1_1);
+
+        String msg = header.getHeadersAsString();
+
+        String[] split = Pattern.compile("\\r\\n", Pattern.MULTILINE).split(msg);
+        String token = null;
+        String name = null;
+        String value = null;
+
+        int pos = 0;
+        for (int i = 0; i < split.length; i++) {
+            token = split[i];
+            if (token.equals("")) {
+                continue;
+            }
+
+            if ((pos = token.indexOf(":")) < 0) {
+                return null;
+            }
+            name = token.substring(0, pos).trim();
+            value = token.substring(pos + 1).trim();
+            httpMethod.addRequestHeader(name, value);
+
+        }
+        if (body != null && body.length() > 0 && (httpMethod instanceof EntityEnclosingMethod)) {
+            EntityEnclosingMethod post = (EntityEnclosingMethod) httpMethod;
+            post.setRequestEntity(new ByteArrayRequestEntity(body.getBytes()));
+        }
+        httpMethod.setFollowRedirects(false);
+        return httpMethod;
+    }
+}

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.6.0.<br>
+	Added Cloud Metadata Scanner<br>
 	]]>
 	</changes>
 	<extensions>
@@ -15,6 +16,7 @@
 	</extensions>
 	<ascanrules>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ApacheRangeHeaderDos</ascanrule>
+		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.CloudMetadataScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleSimpleActiveScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ExampleFileActiveScanner</ascanrule>
 		<ascanrule>org.zaproxy.zap.extension.ascanrulesAlpha.ElmahScanner</ascanrule>

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -8,6 +8,14 @@ ascanalpha.apacherangeheaderdosscanner.desc = The byterange filter in earlier ve
 ascanalpha.apacherangeheaderdosscanner.soln = Upgrade your Apache server to a currently stable version. Alternative solutions or workarounds are outlined in the references. 
 ascanalpha.apacherangeheaderdosscanner.refs = https://httpd.apache.org/security/CVE-2011-3192.txt\nhttp://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2011-3192
 
+ascanalpha.cloudmetadata.name = Cloud Metadata Potentially Exposed
+ascanalpha.cloudmetadata.desc = The Cloud Metadata Attack attempts to abuse a misconfigured NGINX server in order to access the instance metadata maintained by cloud service providers such as AWS, GCP and Azure.\n\
+All of these providers provide metadata via an internal unroutable IP address '169.254.169.254' - this can be exposed by incorrectly configured NGINX servers and accessed by using this IP address in the Host header field.
+ascanalpha.cloudmetadata.otherinfo = Based on the successful response status code cloud metadata may have been returned in the response. Check the response data to see if any cloud metadata has been returned.\n\
+ The meta data returned can include information that would allow an attacker to completely compromise the system.
+ascanalpha.cloudmetadata.refs = https://www.nginx.com/blog/trust-no-one-perils-of-trusting-user-input/
+ascanalpha.cloudmetadata.soln = Do not trust any user data in NGINX configs. In this case it is probably the use of the $host variable which is set from the 'Host' header and can be controlled by an attacker.
+
 ascanalpha.cookieslack.name = Cookie Slack Detector
 ascanalpha.cookieslack.desc = Repeated GET requests: drop a different cookie each time, followed by normal request with all cookies to stabilize session, compare responses against original baseline GET. This can reveal areas where cookie based authentication/attributes are not actually enforced.
 ascanalpha.cookieslack.otherinfo.intro = Cookies that don't have expected effects can reveal flaws in application logic. In the worst case, this can reveal where authentication via cookie token(s) is not actually enforced.\n

--- a/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/src/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -22,6 +22,10 @@ For more details see:
 Tests to see if the server is vulnerable to the Apache Range Header Denial of Service issue, by requesting eleven (11) 
 different byte ranges. Eleven ranges is one more than is accepted by patched/fixed servers.
 
+<H2>Cloud Metadata Attack</H2>
+Attempts to abuse a misconfigured NGINX server in order to access the instance metadata maintained by cloud service providers such as AWS, GCP and Azure.<br>
+All of these providers provide metadata via an internal unroutable IP address '169.254.169.254' - this can be exposed by incorrectly configured NGINX servers and accessed by using this IP address in the Host header field.
+
 <H2>Cookie Slack Detector</H2>
 Tests cookies to detect if some have no effect on response size when omitted, especially cookies containing the name "session" or "userid"
 


### PR DESCRIPTION
Thanks to @thc202 for the magic which preserves the Host header.
I've tested this and the host header is correctly sent.
However I havnt actually got a failing server to test this on :/
Confidence is currently LOW as it just checks for a non failing response code. Hopefully we can improve that if and when we get some failing servers to test with.