### PR TITLE
Remove obsolete Travis CI configuration (alpha)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 script: ant -buildfile build/build.xml test
-sudo: false
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Remove the `sudo: false` configuration, the builds run now always in the
same (new) infrastructure regardless of the configuration.

---
To keep in sync with master.