### PR TITLE
Add default constructor to APIs

### DIFF
--- a/src/org/zaproxy/zap/extension/reveal/RevealAPI.java
+++ b/src/org/zaproxy/zap/extension/reveal/RevealAPI.java
@@ -40,6 +40,13 @@ public class RevealAPI extends ApiImplementor {
 
     private final ExtensionReveal extension;
 
+    /**
+     * Provided only for API client generator usage.
+     */
+    public RevealAPI() {
+        this(null);
+    }
+
     public RevealAPI(ExtensionReveal extension) {
         this.addApiAction(new ApiAction(ACTION_SET_REVEAL, new String[] { PARAM_REVEAL }));
 

--- a/src/org/zaproxy/zap/extension/selenium/SeleniumAPI.java
+++ b/src/org/zaproxy/zap/extension/selenium/SeleniumAPI.java
@@ -29,6 +29,13 @@ public class SeleniumAPI extends ApiImplementor {
     private static final String API_PREFIX = "selenium";
 
     /**
+     * Provided only for API client generator usage.
+     */
+    public SeleniumAPI() {
+        // Nothing to do.
+    }
+
+    /**
      * Constructs a {@code SeleniumAPI} with the given {@code options} exposed through the API.
      * 
      * @param options the options that will be exposed through the API

--- a/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/src/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -95,6 +95,13 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 	private List<SpiderResource> resourcesError;
 	private SpiderThread spiderThread;
 
+	/**
+	 * Provided only for API client generator usage.
+	 */
+	public AjaxSpiderAPI() {
+		this(null);
+	}
+
 	public AjaxSpiderAPI(ExtensionAjax extension) {
 		this.extension = extension;
 		this.historyReferences = Collections.emptyList();

--- a/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -92,6 +92,13 @@ public class WebSocketAPI extends ApiImplementor {
 
     private String callbackUrl;
 
+    /**
+     * Provided only for API client generator usage.
+     */
+    public WebSocketAPI() {
+        this(null);
+    }
+
     public WebSocketAPI(ExtensionWebSocket extension) {
         this.extension = extension;
 


### PR DESCRIPTION
Make it easier to generate the API client files, by programmatically
instantiate all the APIs with the default constructor.