### PR TITLE
Add default constructor to APIs (beta)

### DIFF
--- a/src/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
+++ b/src/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
@@ -47,6 +47,13 @@ public class ImportUrlsAPI extends ApiImplementor {
 
 	private ExtensionImportUrls extension;
 
+	/**
+	 * Provided only for API client generator usage.
+	 */
+	public ImportUrlsAPI() {
+		this(null);
+	}
+
 	public ImportUrlsAPI(ExtensionImportUrls extension) {
 		super();
 		this.extension = extension;

--- a/src/org/zaproxy/zap/extension/plugnhack/PlugNHackAPI.java
+++ b/src/org/zaproxy/zap/extension/plugnhack/PlugNHackAPI.java
@@ -58,6 +58,13 @@ public class PlugNHackAPI extends ApiImplementor {
     private ExtensionPlugNHack extension = null;
 
     /**
+     * Provided only for API client generator usage.
+     */
+    public PlugNHackAPI() {
+        this(null);
+    }
+
+    /**
      * 
      * @param ext 
      */

--- a/src/org/zaproxy/zap/extension/replacer/ReplacerAPI.java
+++ b/src/org/zaproxy/zap/extension/replacer/ReplacerAPI.java
@@ -60,6 +60,13 @@ public class ReplacerAPI extends ApiImplementor {
 
     private ExtensionReplacer extension = null;
 
+    /**
+     * Provided only for API client generator usage.
+     */
+    public ReplacerAPI() {
+        this(null);
+    }
+
     public ReplacerAPI(ExtensionReplacer ext) {
         extension = ext;
 


### PR DESCRIPTION
Make it easier to generate the API client files, by programmatically
instantiate all the APIs with the default constructor.