### PR TITLE
Add default constructor to APIs (alpha)

### DIFF
--- a/src/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
+++ b/src/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
@@ -140,6 +140,13 @@ public class ImportLogAPI extends ApiImplementor {
     }
     */
 
+    /**
+     * Provided only for API client generator usage.
+     */
+    public ImportLogAPI() {
+        this(null);
+    }
+
     // Methods to show in the http API view
     public ImportLogAPI(ExtensionImportLogFiles extensionImportLogFiles) {
         this.addApiAction(new ApiAction(Import_Zap_Log_From_File, new String[] { PARAM_FILE }));

--- a/src/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
+++ b/src/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
@@ -42,6 +42,13 @@ public class OpenApiAPI extends ApiImplementor {
     private static final String PARAM_HOST_OVERRIDE = "hostOverride";
     private ExtensionOpenApi extension = null;
 
+    /**
+     * Provided only for API client generator usage.
+     */
+    public OpenApiAPI() {
+        this(null);
+    }
+
     public OpenApiAPI(ExtensionOpenApi ext) {
         extension = ext;
         this.addApiAction(new ApiAction(ACTION_IMPORT_FILE, new String[] { PARAM_FILE }));

--- a/src/org/zaproxy/zap/extension/soap/SoapAPI.java
+++ b/src/org/zaproxy/zap/extension/soap/SoapAPI.java
@@ -39,6 +39,13 @@ public class SoapAPI extends ApiImplementor {
 	private static final String PARAM_FILE = "file";
 	private ExtensionImportWSDL extension = null;
 
+	/**
+	 * Provided only for API client generator usage.
+	 */
+	public SoapAPI() {
+		this(null);
+	}
+
 	public SoapAPI(ExtensionImportWSDL ext) {
 		extension = ext;
 		this.addApiAction(new ApiAction(ACTION_IMPORT_FILE, new String[] { PARAM_FILE }));


### PR DESCRIPTION
Make it easier to generate the API client files, by programmatically
instantiate all the APIs with the default constructor.