### PR TITLE
selenium: remove IE support

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/src/org/zaproxy/zap/extension/selenium/Browser.java
@@ -46,6 +46,11 @@ public enum Browser {
      * @see #getFailSafeBrowser()
      */
     HTML_UNIT("htmlunit", true),
+    /**
+     * @deprecated Does not support required capabilities
+     *             ({@link org.openqa.selenium.remote.CapabilityType#ACCEPT_INSECURE_CERTS ACCEPT_INSECURE_CERTS}).
+     */
+    @Deprecated
     INTERNET_EXPLORER("ie", false),
     OPERA("opera", false),
     PHANTOM_JS("phantomjs", true),
@@ -222,8 +227,6 @@ public enum Browser {
         switch (browser) {
         case CHROME:
             return "chromedriver";
-        case INTERNET_EXPLORER:
-            return "IEDriverServer";
         case FIREFOX:
             return "geckodriver";
         default:

--- a/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/src/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -39,13 +39,12 @@ import org.apache.commons.lang.Validate;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Proxy;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
-import org.openqa.selenium.ie.InternetExplorerDriver;
-import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
 import org.openqa.selenium.remote.CapabilityType;
@@ -164,7 +163,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         addBuiltInProvider(Browser.CHROME);
         addBuiltInProvider(Browser.FIREFOX);
         addBuiltInProvider(Browser.HTML_UNIT);
-        addBuiltInProvider(Browser.INTERNET_EXPLORER);
         addBuiltInProvider(Browser.PHANTOM_JS);
         addBuiltInProvider(Browser.SAFARI);
 
@@ -718,11 +716,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
             setCommonOptions(htmlunitCapabilities, proxyAddress, proxyPort);
             return new HtmlUnitDriver(DesiredCapabilities.htmlUnit().merge(htmlunitCapabilities));
         case INTERNET_EXPLORER:
-            InternetExplorerOptions ieOptions = new InternetExplorerOptions();
-            setCommonOptions(ieOptions, proxyAddress, proxyPort);
-            ieOptions.setCapability(InternetExplorerDriver.IE_USE_PER_PROCESS_PROXY, true);
-
-            return new InternetExplorerDriver(ieOptions);
+            throw new WebDriverException("No longer available, does not support the required capabilities.");
             /* No longer supported in the Selenium standalone jar
              * need to decide if we support older Opera versions 
         case OPERA:
@@ -809,8 +803,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         switch (browser) {
         case CHROME:
             return getMessages().getString("selenium.warn.message.failed.start.browser.chrome");
-        case INTERNET_EXPLORER:
-            return getMessages().getString("selenium.warn.message.failed.start.browser.ie");
         case PHANTOM_JS:
             return getMessages().getString("selenium.warn.message.failed.start.browser.phantomjs");
         default:
@@ -827,7 +819,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         browsers.add(Browser.SAFARI);
         // Requires drivers, but hopefully they are already provided.
         browsers.add(Browser.CHROME);
-        browsers.add(Browser.INTERNET_EXPLORER);
         browsers.add(Browser.FIREFOX);
 
         if (!getOptions().getPhantomJsBinaryPath().isEmpty()) {
@@ -866,13 +857,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                     getOptions().setFirefoxDriverPath(path);
                 }
             }
-
-            if (getOptions().getIeDriverPath().isEmpty()) {
-                String path = Browser.getBundledWebDriverPath(Browser.INTERNET_EXPLORER);
-                if (path != null) {
-                    getOptions().setIeDriverPath(path);
-                }
-            }
         }
 
         @Override
@@ -886,11 +870,6 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                     && Files.notExists(Paths.get(getOptions().getFirefoxDriverPath()))) {
                 getOptions().setFirefoxDriverPath("");
             }
-
-            if (Browser.isBundledWebDriverPath(getOptions().getIeDriverPath())
-                    && Files.notExists(Paths.get(getOptions().getIeDriverPath()))) {
-                getOptions().setIeDriverPath("");
-            }
         }
 
     }
@@ -903,7 +882,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
     public static boolean isConfigured(Browser browser) {
         switch (browser) {
         case INTERNET_EXPLORER:
-            return Constant.isWindows();
+            return false;
         case SAFARI:
             return Constant.isMacOsX();
         default:

--- a/src/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
+++ b/src/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
@@ -40,7 +40,6 @@ import org.zaproxy.zap.extension.api.ZapApiIgnore;
  * <li>The path to ChromeDriver;</li>
  * <li>The path to Firefox binary;</li>
  * <li>The path to Firefox driver (geckodriver);</li>
- * <li>The path to IEDriverServer;</li>
  * <li>The path to PhantomJS binary.</li>
  * </ul>
  * 
@@ -52,6 +51,10 @@ public class SeleniumOptions extends VersionedAbstractParam {
     public static final String CHROME_DRIVER_SYSTEM_PROPERTY = ChromeDriverService.CHROME_DRIVER_EXE_PROPERTY;
     public static final String FIREFOX_BINARY_SYSTEM_PROPERTY = "zap.selenium.webdriver.firefox.bin";
     public static final String FIREFOX_DRIVER_SYSTEM_PROPERTY = "webdriver.gecko.driver";
+    /**
+     * @deprecated IE is no longer supported.
+     */
+    @Deprecated
     public static final String IE_DRIVER_SYSTEM_PROPERTY = InternetExplorerDriverService.IE_DRIVER_EXE_PROPERTY;
     public static final String PHANTOM_JS_BINARY_SYSTEM_PROPERTY = PhantomJSDriverService.PHANTOMJS_EXECUTABLE_PATH_PROPERTY;
 
@@ -64,7 +67,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
      * @see #CONFIG_VERSION_KEY
      * @see #updateConfigsImpl(int)
      */
-    private static final int CURRENT_CONFIG_VERSION = 1;
+    private static final int CURRENT_CONFIG_VERSION = 2;
 
     /**
      * The base key for all selenium configurations.
@@ -94,11 +97,6 @@ public class SeleniumOptions extends VersionedAbstractParam {
     private static final String FIREFOX_DRIVER_KEY = SELENIUM_BASE_KEY + ".firefoxDriver";
 
     /**
-     * The configuration key to read/write the path to IEDriverServer.
-     */
-    private static final String IE_DRIVER_KEY = SELENIUM_BASE_KEY + ".ieDriver";
-
-    /**
      * The configuration key to read/write the path PhantomJS binary.
      */
     private static final String PHANTOM_JS_BINARY_KEY = SELENIUM_BASE_KEY + ".phantomJsBinary";
@@ -117,11 +115,6 @@ public class SeleniumOptions extends VersionedAbstractParam {
      * The path to Firefox driver (geckodriver).
      */
     private String firefoxDriverPath = "";
-
-    /**
-     * The path to IEDriverServer.
-     */
-    private String ieDriverPath = "";
 
     /**
      * The path to PhantomJS binary.
@@ -145,7 +138,6 @@ public class SeleniumOptions extends VersionedAbstractParam {
         chromeDriverPath = getWebDriverPath(Browser.CHROME, CHROME_DRIVER_SYSTEM_PROPERTY, CHROME_DRIVER_KEY);
         firefoxBinaryPath = readSystemPropertyWithOptionFallback(FIREFOX_BINARY_SYSTEM_PROPERTY, FIREFOX_BINARY_KEY);
         firefoxDriverPath = getWebDriverPath(Browser.FIREFOX, FIREFOX_DRIVER_SYSTEM_PROPERTY, FIREFOX_DRIVER_KEY);
-        ieDriverPath = getWebDriverPath(Browser.INTERNET_EXPLORER, IE_DRIVER_SYSTEM_PROPERTY, IE_DRIVER_KEY);
 
         phantomJsBinaryPath = readSystemPropertyWithOptionFallback(PHANTOM_JS_BINARY_SYSTEM_PROPERTY, PHANTOM_JS_BINARY_KEY);
     }
@@ -211,7 +203,11 @@ public class SeleniumOptions extends VersionedAbstractParam {
 
     @Override
     protected void updateConfigsImpl(int fileVersion) {
-        // Nothing to do.
+        switch (fileVersion) {
+        case 1:
+            getConfig().clearProperty("selenium.ieDriver");
+            break;
+        }
     }
 
     /**
@@ -306,9 +302,11 @@ public class SeleniumOptions extends VersionedAbstractParam {
      * Gets the path to IEDriverServer.
      *
      * @return the path to IEDriverServer, or empty if not set.
+     * @deprecated IE is no longer supported.
      */
+    @Deprecated
     public String getIeDriverPath() {
-        return ieDriverPath;
+        return "";
     }
 
     /**
@@ -316,15 +314,11 @@ public class SeleniumOptions extends VersionedAbstractParam {
      *
      * @param ieDriverPath the path to IEDriverServer, or empty if not known.
      * @throws IllegalArgumentException if {@code ieDriverPath} is {@code null}.
+     * @deprecated IE is no longer supported.
      */
+    @Deprecated
     public void setIeDriverPath(String ieDriverPath) {
-        Validate.notNull(ieDriverPath, "Parameter ieDriverPath must not be null.");
-
-        if (!this.ieDriverPath.equals(ieDriverPath)) {
-            this.ieDriverPath = ieDriverPath;
-
-            saveAndSetSystemProperty(IE_DRIVER_KEY, IE_DRIVER_SYSTEM_PROPERTY, ieDriverPath);
-        }
+        // Nothing to do.
     }
 
     /**

--- a/src/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
+++ b/src/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
@@ -50,7 +50,6 @@ import org.zaproxy.zap.utils.FontUtils;
  * <li>The path to ChromeDriver;</li>
  * <li>The path to Firefox binary.</li>
  * <li>The path to Firefox driver (geckodriver).</li>
- * <li>The path to IEDriverServer;</li>
  * <li>The path to PhantomJS binary.</li>
  * </ul>
  * 
@@ -66,9 +65,6 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
     private final JTextField firefoxDriverTextField;
     private final JLabel infoBundledFirefoxDriverLabel;
     private final JButton useBundledFirefoxDriverButton;
-    private final JTextField ieDriverTextField;
-    private final JLabel infoBundledIeDriverLabel;
-    private final JButton useBundledIeDriverButton;
 
     private final JTextField firefoxBinaryTextField;
     private final JTextField phantomJsBinaryTextField;
@@ -122,22 +118,6 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                 firefoxDriverTextField,
                 Browser.FIREFOX);
 
-        ieDriverTextField = createTextField();
-        JButton ieDriverButton = createButtonFileChooser(selectFileButtonLabel, ieDriverTextField);
-        JLabel ieDriverLabel = new JLabel(resourceBundle.getString("selenium.options.label.driver.ie"));
-        ieDriverLabel.setLabelFor(ieDriverButton);
-
-        infoBundledIeDriverLabel = createBundledWebDriverLabel(
-                infoBundledWebDriverlabel,
-                infoBundledWebDriverToolTip,
-                infoIcon);
-        useBundledIeDriverButton = createBundledWebDriverButton(
-                bundledWebDriverButtonLabel,
-                bundledWebDriverButtonToolTip,
-                infoBundledWebDriverToolTip,
-                ieDriverTextField,
-                Browser.INTERNET_EXPLORER);
-
         phantomJsBinaryTextField = createTextField();
         JButton phantomJsBinaryButton = createButtonFileChooser(selectFileButtonLabel, phantomJsBinaryTextField);
         JLabel phantomJsBinaryLabel = new JLabel(resourceBundle.getString("selenium.options.label.phantomjs.binary"));
@@ -164,8 +144,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                         .addGroup(
                                 driversLayout.createParallelGroup(GroupLayout.Alignment.TRAILING)
                                         .addComponent(chromeDriverLabel)
-                                        .addComponent(firefoxDriverLabel)
-                                        .addComponent(ieDriverLabel))
+                                        .addComponent(firefoxDriverLabel))
                         .addGroup(
                                 driversLayout.createParallelGroup(GroupLayout.Alignment.LEADING)
                                         .addGroup(
@@ -187,17 +166,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                                                         .addGroup(
                                                                 driversLayout.createParallelGroup()
                                                                         .addComponent(firefoxDriverButton)
-                                                                        .addComponent(useBundledFirefoxDriverButton)))
-                                        .addGroup(
-                                                driversLayout.createSequentialGroup()
-                                                        .addGroup(
-                                                                driversLayout.createParallelGroup()
-                                                                        .addComponent(ieDriverTextField)
-                                                                        .addComponent(infoBundledIeDriverLabel))
-                                                        .addGroup(
-                                                                driversLayout.createParallelGroup()
-                                                                        .addComponent(ieDriverButton)
-                                                                        .addComponent(useBundledIeDriverButton)))));
+                                                                        .addComponent(useBundledFirefoxDriverButton)))));
 
         driversLayout.setVerticalGroup(
                 driversLayout.createSequentialGroup()
@@ -218,16 +187,7 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
                         .addGroup(
                                 driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                         .addComponent(infoBundledFirefoxDriverLabel)
-                                        .addComponent(useBundledFirefoxDriverButton))
-                        .addGroup(
-                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                        .addComponent(ieDriverLabel)
-                                        .addComponent(ieDriverTextField)
-                                        .addComponent(ieDriverButton))
-                        .addGroup(
-                                driversLayout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                        .addComponent(infoBundledIeDriverLabel)
-                                        .addComponent(useBundledIeDriverButton)));
+                                        .addComponent(useBundledFirefoxDriverButton)));
 
         JPanel binariesPanel = new JPanel();
         binariesPanel.setBorder(
@@ -335,13 +295,6 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         firefoxDriverTextField
                 .setText(getEffectiveDriverPath(Browser.FIREFOX, seleniumOptions.getFirefoxDriverPath(), driverAvailable));
 
-        driverAvailable = Browser.hasBundledWebDriver(Browser.INTERNET_EXPLORER);
-        infoBundledIeDriverLabel.setVisible(!driverAvailable);
-        useBundledIeDriverButton.setEnabled(driverAvailable);
-
-        ieDriverTextField
-                .setText(getEffectiveDriverPath(Browser.INTERNET_EXPLORER, seleniumOptions.getIeDriverPath(), driverAvailable));
-
         firefoxBinaryTextField.setText(seleniumOptions.getFirefoxBinaryPath());
         phantomJsBinaryTextField.setText(seleniumOptions.getPhantomJsBinaryPath());
     }
@@ -381,7 +334,6 @@ class SeleniumOptionsPanel extends AbstractParamPanel {
         seleniumOptions.setChromeDriverPath(chromeDriverTextField.getText());
         seleniumOptions.setFirefoxBinaryPath(firefoxBinaryTextField.getText());
         seleniumOptions.setFirefoxDriverPath(firefoxDriverTextField.getText());
-        seleniumOptions.setIeDriverPath(ieDriverTextField.getText());
         seleniumOptions.setPhantomJsBinaryPath(phantomJsBinaryTextField.getText());
     }
 

--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -9,6 +9,7 @@
 	<dependencies/>
 	<changes>
 	<![CDATA[
+	Remove support for Internet Explorer, does not support required capabilities.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -21,24 +21,20 @@ selenium.options.label.button.select.file = Select...
 selenium.options.label.driver.chrome = ChromeDriver:
 selenium.options.label.firefox.binary = Firefox:
 selenium.options.label.firefox.driver = geckodriver:
-selenium.options.label.driver.ie = IEDriverServer:
 selenium.options.label.phantomjs.binary = PhantomJS:
 
 selenium.warn.message.failed.start.browser = Failed to start/connect to ''{0}'', is the browser available/supported?
 selenium.warn.message.failed.start.browser.chrome = Failed to start Chrome browser.\nMake sure that Chrome and ChromeDriver are available.\nFor more details refer to "Options Selenium screen" help page.
-selenium.warn.message.failed.start.browser.ie = Failed to start Internet Explorer.\nMake sure that both Internet Explorer and IEDriverServer are available.\nFor more details refer to "Options Selenium screen" help page.
 selenium.warn.message.failed.start.browser.phantomjs = Failed to start PhantomJS.\nMake sure that the PhantomJS binary is available.\nFor more details refer to "Options Selenium screen" help page.
 selenium.warn.message.failed.start.browser.notfound = The provided browser was not found.
 
 selenium.api.view.optionChromeDriverPath = Returns the current path to ChromeDriver
 selenium.api.view.optionFirefoxBinaryPath = Returns the current path to Firefox binary
 selenium.api.view.optionFirefoxDriverPath = Returns the current path to Firefox driver (geckodriver)
-selenium.api.view.optionIeDriverPath = Returns the current path to IEDriverServer
 selenium.api.view.optionPhantomJsBinaryPath = Returns the current path to PhantomJS binary
 selenium.api.action.setOptionChromeDriverPath = Sets the current path to ChromeDriver
 selenium.api.action.setOptionFirefoxBinaryPath = Sets the current path to Firefox binary
 selenium.api.action.setOptionFirefoxDriverPath = Sets the current path to Firefox driver (geckodriver)
-selenium.api.action.setOptionIeDriverPath = Sets the current path to IEDriverServer
 selenium.api.action.setOptionPhantomJsBinaryPath = Sets the current path to PhantomJS binary
 
 selenium.menu.openinbrowser = Open URL in Browser

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/api.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/api.html
@@ -37,12 +37,6 @@
 			<td>Returns the current path to Firefox driver (geckodriver)</td>
 		</tr>
 		<tr>
-			<td>optionIeDriverPath</td>
-			<td>view</td>
-			<td></td>
-			<td>Returns the current path to IEDriverServer</td>
-		</tr>
-		<tr>
 			<td>optionPhantomJsBinaryPath</td>
 			<td>view</td>
 			<td></td>
@@ -65,12 +59,6 @@
 			<td>action</td>
 			<td>String*</td>
 			<td>Sets the current path to Firefox driver (geckodriver)</td>
-		</tr>
-		<tr>
-			<td>setOptionIeDriverPath</td>
-			<td>action</td>
-			<td>String*</td>
-			<td>Sets the current path to IEDriverServer</td>
 		</tr>
 		<tr>
 			<td>setOptionPhantomJsBinaryPath</td>

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
@@ -49,16 +49,6 @@
 			<td>Bundled browser, does not have any requirement.</td>
 		</tr>
 		<tr>
-			<td>Internet Explorer</td>
-			<td>ie</td>
-			<td>The following version is known to work: 11 (older versions might work too).
-				Requires IEDriverServer, if not on the system's PATH, it can be set in the options.
-				For more information on IEDriverServer refer to the <a
-				href="https://code.google.com/p/selenium/wiki/InternetExplorerDriver">IEDriverServer
-					website</a> (see footer note for caveat when using Internet Explorer).
-			</td>
-		</tr>
-		<tr>
 			<td>Opera</td>
 			<td>opera</td>
 			<td>Temporarily not working.</td>
@@ -79,7 +69,7 @@
 			<td>&nbsp;</td>
 		</tr>
 	</table>
-	<p>To use Firefox, Chrome, Internet Explorer, Opera, PhantomJS and Safari, you must
+	<p>To use Firefox, Chrome, Opera, PhantomJS and Safari, you must
 		have them installed in your system. The ID of the browser can be used to choose the
 		browser when configuring ZAP through the command line or using the ZAP API (for example,
 		to set the AJAX Spider to use one or other browser).
@@ -110,11 +100,6 @@
 		available is advised to not use it in those cases. Some add-ons might choose to show
 		warning message when that happens. As workaround one could define, in the <code>hosts</code>
 		file, a domain name mapping to the local address and use that domain name instead.
-	<p>
-		<strong>Internet Explorer Note:</strong> Not all versions of Internet Explorer work out
-		of the box, refer to the <a
-			href="https://code.google.com/p/selenium/wiki/InternetExplorerDriver#Required_Configuration">IEDriverServer
-			website</a> for more details on how to configure them.
 
 	<H2>See also</H2>
 	<table>

--- a/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
+++ b/src/org/zaproxy/zap/extension/selenium/resources/help/contents/options.html
@@ -36,12 +36,6 @@
 			<td>Key: <code>selenium.firefoxDriver</code><br>Value: file system path to the geckodriver</td>
 		</tr>
 		<tr>
-			<td>IEDriverServer</td>
-			<td>This allows you to select the location of IEDriverServer.</td>
-			<td align="center">The path to the bundled WebDriver, if available.</td>
-			<td>Key: <code>selenium.ieDriver</code><br>Value: file system path to the IEDriverServer</td>
-		</tr>
-		<tr>
 			<th colspan="4">Binaries</th>
 		</tr>
 		<tr>

--- a/test/org/zaproxy/zap/extension/selenium/BrowserUnitTest.java
+++ b/test/org/zaproxy/zap/extension/selenium/BrowserUnitTest.java
@@ -82,17 +82,6 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnIEWhenGettingBrowserWithIEId() {
-        // Given
-        String ieId = "ie";
-        // When
-        Browser retrievedBrowser = Browser.getBrowserWithId(ieId);
-        // Then
-        assertThat(retrievedBrowser, is(equalTo(Browser.INTERNET_EXPLORER)));
-        assertThat(ieId, is(equalTo(Browser.INTERNET_EXPLORER.getId())));
-    }
-
-    @Test
     public void shouldReturnOperaWhenGettingBrowserWithOperaId() {
         // Given
         String operaId = "opera";

--- a/test/org/zaproxy/zap/extension/selenium/BrowsersComboBoxModelUnitTest.java
+++ b/test/org/zaproxy/zap/extension/selenium/BrowsersComboBoxModelUnitTest.java
@@ -144,7 +144,7 @@ public class BrowsersComboBoxModelUnitTest {
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedItem(FIREFOX);
         // When
-        browsersComboBoxModel.setSelectedItem(new BrowserUI("SomeName", Browser.INTERNET_EXPLORER));
+        browsersComboBoxModel.setSelectedItem(new BrowserUI("SomeName", Browser.CHROME));
         // Then
         assertThat(browsersComboBoxModel.getSelectedItem(), is(equalTo(FIREFOX)));
     }


### PR DESCRIPTION
No longer allow to choose Internet Explorer or configure the path to
IEDriverServer, the browser no longer starts as it does not support the
required capabilities (`acceptInsecureCerts`).
Update help accordingly.
Update changes in ZapAddOn.xml file.

Per reports in zaproxy/zaproxy#5213.