### PR TITLE
webdriverwindows: remove IEDriverServer

### DIFF
--- a/src/org/zaproxy/zap/extension/webdriverwindows/WebdriverDownload.java
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/WebdriverDownload.java
@@ -74,12 +74,6 @@ public class WebdriverDownload {
                 "https://github.com/" + repo + "/raw/master/files/webdriver/windows/32/chromedriver.exe",
                 srcdir, "files/webdriver/windows/32/chromedriver.exe");
 
-        downloadDriver(
-                "https://github.com/" + repo + "/raw/master/files/webdriver/windows/32/IEDriverServer.exe",
-                srcdir, "files/webdriver/windows/32/IEDriverServer.exe");
-        downloadDriver(
-                "https://github.com/" + repo + "/raw/master/files/webdriver/windows/64/IEDriverServer.exe",
-                srcdir, "files/webdriver/windows/64/IEDriverServer.exe");
         return 0;
     }
     

--- a/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 	Fix link in help page.<br>
+	Remove IEDriverServer, IE is no longer provided by Selenium add-on.<br>
 	]]>
 	</changes>
 	<extensions/>
@@ -16,9 +17,7 @@
 	<files>
 		<file>webdriver/windows/32/chromedriver.exe</file>
 		<file>webdriver/windows/32/geckodriver.exe</file>
-		<file>webdriver/windows/32/IEDriverServer.exe</file>
 		<file>webdriver/windows/64/geckodriver.exe</file>
-		<file>webdriver/windows/64/IEDriverServer.exe</file>
 	</files>
 	<helpset localetoken="%LC%">org.zaproxy.zap.extension.webdriverwindows.resources.help%LC%.helpset</helpset>
 	<not-before-version>2.5.0</not-before-version>

--- a/src/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/src/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -11,7 +11,6 @@ The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
 <li>Chrome - ChromeDriver 2.43</li>
 <li>Firefox - geckodriver 0.23.0</li>
-<li>Internet Explorer - IEDriverServer 3.7.0</li>
 </ul>
 
 <H2>See also</H2>


### PR DESCRIPTION
The Selenium add-on no longer supports it (#1947).
Update help accordingly.
Update changes in ZapAddOn.xml file.