### PR TITLE
jxbrowser: tweak messages and log browser version

### DIFF
--- a/src/org/zaproxy/zap/extension/jxbrowser/ExtensionJxBrowser.java
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ExtensionJxBrowser.java
@@ -19,14 +19,19 @@
  */
 package org.zaproxy.zap.extension.jxbrowser;
 
+import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
+
+import com.teamdev.jxbrowser.chromium.ProductInfo;
 
 public class ExtensionJxBrowser extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionJxBrowser";
 
     public static final String RESOURCES = "/org/zaproxy/zap/extension/jxbrowser/resources";
+
+    private static final Logger LOGGER = Logger.getLogger(ExtensionJxBrowser.class);
 
     /**
      * A minimal extension, just needed to load the messages correctly;)
@@ -38,6 +43,7 @@ public class ExtensionJxBrowser extends ExtensionAdaptor {
     @Override
     public void init() {
         super.init();
+        LOGGER.info("Using version " + ProductInfo.getVersion() + " of JxBrowser.");
     }
 
     @Override

--- a/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/jxbrowser/ZapAddOn.xml
@@ -7,6 +7,8 @@
 	<url></url>
 	<changes>
 	<![CDATA[
+	Fix typo and tweak error message.<br>
+	Log JxBrowser version on start up.<br>
 	]]>
 	</changes>
 	<dependencies/>

--- a/src/org/zaproxy/zap/extension/jxbrowser/resources/Messages.properties
+++ b/src/org/zaproxy/zap/extension/jxbrowser/resources/Messages.properties
@@ -7,8 +7,7 @@ jxbrowser.browser.button.sites	= Select URL from Sites tree
 jxbrowser.browser.firstpage		= <html><head><title>Welcome</title></head><body>\
 <h3>Welcome to the ZAP Browser (based on JxBrowser)</h3>\
 <p>This browser is automatically configured to proxy via ZAP and also now accepts 'invalid' certificates by default, which includes the ZAP root certificate.</p>\
-<p>You can still use any other browser to proxy via ZAP but you will need to manually configure those browsers\
-to proxy via ZAP.</p>\
+<p>You can still use any other browser to proxy via ZAP but you will need to manually configure those browsers to proxy via ZAP.</p>\
 </body><html>
 jxbrowser.browser.newtab 		= New Tab
 jxbrowser.browser.title			= {0} - ZAP JxBrowser
@@ -16,4 +15,4 @@ jxbrowser.browser.popupmenu.opennewtab	= Open link in new tab
 jxbrowser.browser.popupmenu.reload		= Reload
 jxbrowser.button.launch			= Launch the ZAP JxBrowser proxying through ZAP
 jxbrowser.menu.launch			= Launch the ZAP JxBrowser
-jxbrowser.warn.message.failed.start.browser = Failed to start JxBrowser.\nMake sure that ChromeDriver is available.\nFor more details refer to "Options Selenium screen" help page.
+jxbrowser.warn.message.failed.start.browser = Failed to start JxBrowser.\nThe ZAP log file should contain more details.


### PR DESCRIPTION
Fix typo in the initial message shown in the browser window (missing
space between "browsers" and "to").
Remove references to the ChromeDriver and Selenium help page in the
message that indicates that the browser failed to start, the driver is
now bundled in the JxBrowser add-ons.
Log the JxBrowser version used by the add-on, to be easier to know which
version is in use.