### PR TITLE
Dont break on websocket API calls

### DIFF
--- a/src/org/zaproxy/zap/extension/websocket/WebSocketMessage.java
+++ b/src/org/zaproxy/zap/extension/websocket/WebSocketMessage.java
@@ -23,6 +23,8 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 
+import org.zaproxy.zap.extension.websocket.WebSocketProxy.Mode;
+
 /**
  * Represents a single WebSocket message, consisting of at least one frame.
  * <p>
@@ -459,6 +461,10 @@ public abstract class WebSocketMessage {
 		dto.payloadLength = getPayloadLength();
 		
 		return dto;
+	}
+	
+	public Mode getProxyMode() {
+		return this.proxy.getMode();
 	}
 	
 	@Override

--- a/src/org/zaproxy/zap/extension/websocket/brk/WebSocketProxyListenerBreak.java
+++ b/src/org/zaproxy/zap/extension/websocket/brk/WebSocketProxyListenerBreak.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.websocket.WebSocketMessage.Direction;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
 import org.zaproxy.zap.extension.websocket.WebSocketObserver;
 import org.zaproxy.zap.extension.websocket.WebSocketProxy;
+import org.zaproxy.zap.extension.websocket.WebSocketProxy.Mode;
 import org.zaproxy.zap.extension.websocket.WebSocketProxy.State;
 import org.zaproxy.zap.extension.websocket.db.WebSocketStorage;
 
@@ -66,6 +67,11 @@ public class WebSocketProxyListenerBreak implements WebSocketObserver {
 		}
 		
 		// message is safe => no need to set onlyIfInScope parameter to true
+        
+        if (Mode.SERVER.equals(wsMessage.getProxyMode())) {
+            // These are typically API calls, breaking on these would make the API unusable
+            return true;
+        }
         
         if (message instanceof WebSocketFuzzMessageDTO) {
         	// as this message was sent by some fuzzer, do not catch it


### PR DESCRIPTION
Not surprisingly this was found with the HUD.
Set websockets to break on the 'all request/response' break buttons and the HUD becomes unusable ;)