### PR TITLE
selenium: quit WebDrivers when removing provider

### DIFF
--- a/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/selenium/ZapAddOn.xml
@@ -10,6 +10,7 @@
 	<changes>
 	<![CDATA[
 	Remove support for Internet Explorer, does not support required capabilities.<br>
+	Quit corresponding WebDrivers when removing WebDriver provider.<br>
 	]]>
 	</changes>
 	<extensions>


### PR DESCRIPTION
Change ExtensionSelenium to quit the WebDrivers of the provider being
removed, to prevent leaks and avoid other issues.
Update changes in ZapAddOn.xml file.