### PR TITLE
PiiScanner Add Word Boundary Check

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/PiiScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/PiiScanner.java
@@ -49,13 +49,13 @@ public class PiiScanner extends PluginPassiveScanner {
     private PassiveScanThread parent = null;
 
     private enum CreditCard {
-        AMERICAN_EXPRESS("American Express", "(?:3[47][0-9]{13})"),
-        DINERSCLUB("DinersClub", "(?:3(?:0[0-5]|[68][0-9])[0-9]{11})"),
-        DISCOVER("Discover", "(?:6(?:011|5[0-9]{2})(?:[0-9]{12}))"),
-        JCB("Jcb", "(?:(?:2131|1800|35\\d{3})\\d{11})"),
-        MASESTRO("Maestro", "(?:(?:5[0678]\\d\\d|6304|6390|67\\d\\d)\\d{8,15})"),
-        MASTERCARD("Mastercard", "(?:(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12})"),
-        VISA("Visa", "(?:4[0-9]{12})(?:[0-9]{3})?");
+        AMERICAN_EXPRESS("American Express", "\\b(?:3[47][0-9]{13})\\b"),
+        DINERSCLUB("DinersClub", "\\b(?:3(?:0[0-5]|[68][0-9])[0-9]{11})\\b"),
+        DISCOVER("Discover", "\\b(?:6(?:011|5[0-9]{2})(?:[0-9]{12}))\\b"),
+        JCB("Jcb", "\\b(?:(?:2131|1800|35\\d{3})\\d{11})\\b"),
+        MAESTRO("Maestro", "\\b(?:(?:5[0678]\\d\\d|6304|6390|67\\d\\d)\\d{8,15})\\b"),
+        MASTERCARD("Mastercard", "\\b(?:(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12})\\b"),
+        VISA("Visa", "\\b(?:4[0-9]{12})(?:[0-9]{3})?\\b");
 
         private final String name;
         private final Pattern pattern;

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -7,6 +7,7 @@
 	<url/>
 	<changes>
 	<![CDATA[
+		PiiScanner add word boundry checks to reduce false positives.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/PiiScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/PiiScannerUnitTest.java
@@ -19,7 +19,11 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.junit.Test;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
 /**
@@ -43,6 +47,26 @@ public class PiiScannerUnitTest extends PassiveScannerTest<PiiScanner> {
         // When
         rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
         // Then = No StackOverflowError
+    }
+
+    @Test
+    public void shouldNotRaiseAlertWhenNumberDoesntHaveWordBoundaries() throws Exception {
+        // Given
+        String cardNumber = "8.46786664623715e-47";
+        HttpMessage msg = createMsg(cardNumber);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    private HttpMessage createMsg(String cardNumber) throws HttpMalformedHeaderException {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n");
+        msg.setResponseBody("{\"cc\": \"" + cardNumber + "\"}");
+        return msg;
     }
 
     private static String numbers(int count) {


### PR DESCRIPTION
- PiiScanner add word boundary checks to reduce false positives.
- Added unittest and a utility method for message creation.
- Updated manifest.
- Fixed typo in `MAESTRO` enum name.

https://www.regexplanet.com/share/index.html?share=yyyyyq6d1nr (Click java, then test)

Fixes zaproxy/zaproxy#5124