### PR TITLE
Adds Feature Policy scanner

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove X AspNet Version Scanner (promoted to beta Issue 4468).
 - Remove X Debug Token Scanner (promoted to beta Issue 4469).
 - Remove X PoweredBy Scanner (promoted to beta Issue 4470).
+- Add scanner for missing Feature Policy header.
 
 ## 23 - 2019-02-08
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanner.java
@@ -1,0 +1,111 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.util.Vector;
+import net.htmlparser.jericho.Source;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+/**
+ * Feature Policy Header Missing passive scan rule https://github.com/zaproxy/zaproxy/issues/4885
+ */
+public class FeaturePolicyScanner extends PluginPassiveScanner {
+
+    private static final String MESSAGE_PREFIX = "pscanalpha.featurepolicymissing.";
+    private static final Logger LOGGER = Logger.getLogger(FeaturePolicyScanner.class);
+    private static final int PLUGIN_ID = 10063;
+
+    private PassiveScanThread parent = null;
+
+    @Override
+    public void scanHttpRequestSend(HttpMessage httpMessage, int id) {
+        // Only checking the response for this plugin
+    }
+
+    @Override
+    public void scanHttpResponseReceive(HttpMessage httpMessage, int id, Source source) {
+        long start = System.currentTimeMillis();
+
+        if (!httpMessage.getResponseHeader().isHtml()
+                && !httpMessage.getResponseHeader().isJavaScript()) {
+            return;
+        }
+
+        // Feature-Policy is supported by Chrome 60+, Firefox 65+, Opera 47+, but not by Internet
+        // Exploder or Safari
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Browser_compatibility
+        Vector<String> featurePolicyOptions =
+                httpMessage.getResponseHeader().getHeaders("Feature-Policy");
+        if (featurePolicyOptions == null || featurePolicyOptions.isEmpty()) {
+            Alert alert =
+                    new Alert(
+                            getPluginId(), // PluginID
+                            Alert.RISK_LOW, // Risk
+                            Alert.CONFIDENCE_MEDIUM, // Reliability
+                            getName());
+            alert.setDetail(
+                    getAlertAttribute("desc"), // Description
+                    httpMessage.getRequestHeader().getURI().toString(), // URI
+                    "", // Param
+                    "", // Attack
+                    "", // Other info
+                    getAlertAttribute("soln"), // Solution
+                    getAlertAttribute("refs"), // References
+                    "", // Evidence
+                    0, // CWE-16: Configuration
+                    0, // WASC-15: Application Misconfiguration
+                    httpMessage); // HttpMessage
+            parent.raiseAlert(id, alert);
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "\tScan of record "
+                            + id
+                            + " took "
+                            + (System.currentTimeMillis() - start)
+                            + " ms");
+        }
+    }
+
+    @Override
+    public void setParent(PassiveScanThread passiveScanThread) {
+        this.parent = passiveScanThread;
+    }
+
+    @Override
+    public int getPluginId() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    private static String getAlertAttribute(String key) {
+        return Constant.messages.getString(MESSAGE_PREFIX + key);
+    }
+}

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -52,6 +52,10 @@ Passively scan responses for signatures that are indicative that Directory Brows
 This implements a very simple example passive scan rule.<br>
 For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
 
+<H2>Feature Policy Header Not Set</H2>
+This scanner checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Feature-Policy" header, 
+and alerts if one is not found.
+
 <H2>Hash Disclosure</H2>
 Passively scan for password hashes disclosed by the web server. <br>
 Various formats are including, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes. 

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -7,6 +7,11 @@ pscanalpha.examplefile.other=This is for information that doesnt fit in any of t
 pscanalpha.examplefile.soln=A general description of how to solve the problem
 pscanalpha.examplefile.refs=http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
 
+pscanalpha.featurepolicymissing.name=Feature Policy Header Not Set
+pscanalpha.featurepolicymissing.desc=Feature Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Feature Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.
+pscanalpha.featurepolicymissing.refs=https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy\nhttps://developers.google.com/web/updates/2018/06/feature-policy\nhttps://scotthelme.co.uk/a-new-security-header-feature-policy/\nhttps://w3c.github.io/webappsec-feature-policy/\nhttps://www.smashingmagazine.com/2018/12/feature-policy/
+pscanalpha.featurepolicymissing.soln=Ensure that your web server, application server, load balancer, etc. is configured to set the Feature-Policy header.
+
 pscanalpha.inpagebanner.name=In Page Banner Information Leak
 pscanalpha.inpagebanner.desc=The server returned a version banner string in the response content. Such information leaks may allow attackers to further target specific issues impacting the product and version in use.
 pscanalpha.inpagebanner.other=There is a chance that the highlight in the finding is on a value in the headers, versus the actual matched string in the response body.

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScannerUnitTest.java
@@ -1,0 +1,94 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.junit.Before;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+
+public class FeaturePolicyScannerUnitTest extends PassiveScannerTest<FeaturePolicyScanner> {
+
+    private static final String MESSAGE_PREFIX = "pscanalpha.featurepolicymissing.";
+    private HttpMessage msg;
+
+    @Before
+    public void before() throws Exception {
+        HttpRequestHeader requestHeader = new HttpRequestHeader();
+        requestHeader.setURI(new URI("http://example.com", false));
+
+        msg = new HttpMessage();
+        msg.setRequestHeader(requestHeader);
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n");
+    }
+
+    @Override
+    protected FeaturePolicyScanner createScanner() {
+        return new FeaturePolicyScanner();
+    }
+
+    @Test
+    public void shouldRaiseAlertOnMissingFeaturePolicyHTML() throws Exception {
+        // Given
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertEquals(alertsRaised.size(), 1);
+        assertThat(alertsRaised.get(0), hasNameLoadedWithKey(MESSAGE_PREFIX+"name"));
+    }
+
+    @Test
+    public void shouldRaiseAlertOnMissingFeaturePolicyJavaScript() throws Exception {
+        // Given
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/javascript");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertEquals(alertsRaised.size(), 1);
+    }
+
+    @Test
+    public void shouldNotRaiseAlertOnMissingFeaturePolicyOthers() throws Exception {
+        // Given
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertEquals(alertsRaised.size(), 0);
+    }
+
+    @Test
+    public void shouldNotRaiseAlertOnAvailableFeaturePolicy() throws Exception {
+        // Given
+        msg.getResponseHeader().addHeader("Feature-Policy", "vibrate 'none'");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/HTML");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertEquals(alertsRaised.size(), 0);
+    }
+
+}


### PR DESCRIPTION
Adds the feature policy scanner to `alphascanrules`
          Unit tests included.
          Fixes https://github.com/zaproxy/zaproxy/issues/4885