### PR TITLE
Updated import addons to use new Import menu

### DIFF
--- a/addOns/importLogFiles/CHANGELOG.md
+++ b/addOns/importLogFiles/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Internationalise some strings.
 - Update minimum ZAP version to 2.8.0.
+- Add import menu to (new) top level Import menu instead of Analyse menu.
 
 ## 4 - 2017-05-05
 

--- a/addOns/importLogFiles/CHANGELOG.md
+++ b/addOns/importLogFiles/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Internationalise some strings.
+- Update minimum ZAP version to 2.8.0.
 
 ## 4 - 2017-05-05
 

--- a/addOns/importLogFiles/importLogFiles.gradle.kts
+++ b/addOns/importLogFiles/importLogFiles.gradle.kts
@@ -3,7 +3,7 @@ description = "Allows you to import log files from ModSecurity and files previou
 
 zapAddOn {
     addOnName.set("Log File Importer")
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.8.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
+++ b/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
@@ -36,7 +36,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
-import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -58,6 +57,7 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpResponseBody;
+import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionImportLogFiles extends ExtensionAdaptor {
 
@@ -78,7 +78,7 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
         }
     }
 
-    private JMenuItem menuExample = null;
+    private ZapMenuItem menuExample = null;
 
     private static Logger log = Logger.getLogger(ExtensionImportLogFiles.class);
 
@@ -95,7 +95,7 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
         importLogAPI = new ImportLogAPI(null);
         extensionHook.addApiImplementor(importLogAPI);
         if (getView() != null) {
-            extensionHook.getHookMenu().addAnalyseMenuItem(getImportOption());
+            extensionHook.getHookMenu().addImportMenuItem(getImportOption());
         }
     }
 
@@ -104,10 +104,9 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
         return true;
     }
 
-    private JMenuItem getImportOption() {
+    private ZapMenuItem getImportOption() {
         if (menuExample == null) {
-            menuExample = new JMenuItem();
-            menuExample.setText(getMessageString("importLogFiles.analyze.import"));
+            menuExample = new ZapMenuItem("importLogFiles.import.importLOG");
 
             menuExample.addActionListener(
                     new java.awt.event.ActionListener() {

--- a/addOns/importLogFiles/src/main/resources/org/zaproxy/zap/extension/importLogFiles/resources/Messages.properties
+++ b/addOns/importLogFiles/src/main/resources/org/zaproxy/zap/extension/importLogFiles/resources/Messages.properties
@@ -1,7 +1,7 @@
 # This file defines the default (English) variants of all of the internationalised messages
 
 importLogFiles.desc=Example extension which provides the import option in the analyse section
-importLogFiles.analyze.import=Import Logs into Zap Site Tree...
+importLogFiles.import.importLOG=Import Logs into Zap Site Tree...
 importLogFiles.msg.placeholder=Placeholder message for future functionality
 
 importLogFiles.choosefile.filter.description = TEXT File

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correct import of v1.2 definitions (Issue 5262).
 - Fix exception when reporting errors.
 - Update minimum ZAP version to 2.8.0.
+- Add import menu to (new) top level Import menu instead of Tools menu.
 
 ## 12 - 2018-05-18
 

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added Accept header for importing an OpenAPI definition from an URL, in the proper format.
 - Correct import of v1.2 definitions (Issue 5262).
 - Fix exception when reporting errors.
+- Update minimum ZAP version to 2.8.0.
 
 ## 12 - 2018-05-18
 

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -3,7 +3,7 @@ description = "Imports and spiders Open API definitions."
 
 zapAddOn {
     addOnName.set("OpenAPI Support")
-    zapVersion.set("2.6.0")
+    zapVersion.set("2.8.0")
 
     manifest {
         author.set("ZAP Core Team plus Joanna Bona, Artur Grzesica, Michal Materniak and Marcin Spiewak")

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -89,8 +89,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
         }
 
         if (getView() != null) {
-            extensionHook.getHookMenu().addToolsMenuItem(getMenuImportLocalOpenApi());
-            extensionHook.getHookMenu().addToolsMenuItem(getMenuImportUrlOpenApi());
+            extensionHook.getHookMenu().addImportMenuItem(getMenuImportLocalOpenApi());
+            extensionHook.getHookMenu().addImportMenuItem(getMenuImportUrlOpenApi());
         }
 
         extensionHook.addApiImplementor(new OpenApiAPI(this));
@@ -114,9 +114,9 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     /* Menu option to import a local OpenApi file. */
     private ZapMenuItem getMenuImportLocalOpenApi() {
         if (menuImportLocalOpenApi == null) {
-            menuImportLocalOpenApi = new ZapMenuItem("openapi.topmenu.tools.importopenapi");
+            menuImportLocalOpenApi = new ZapMenuItem("openapi.topmenu.import.importopenapi");
             menuImportLocalOpenApi.setToolTipText(
-                    Constant.messages.getString("openapi.topmenu.tools.importopenapi.tooltip"));
+                    Constant.messages.getString("openapi.topmenu.import.importopenapi.tooltip"));
 
             menuImportLocalOpenApi.addActionListener(
                     new java.awt.event.ActionListener() {
@@ -145,10 +145,10 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     /* Menu option to import a OpenApi file from a given URL. */
     private ZapMenuItem getMenuImportUrlOpenApi() {
         if (menuImportUrlOpenApi == null) {
-            menuImportUrlOpenApi = new ZapMenuItem("openapi.topmenu.tools.importremoteopenapi");
+            menuImportUrlOpenApi = new ZapMenuItem("openapi.topmenu.import.importremoteopenapi");
             menuImportUrlOpenApi.setToolTipText(
                     Constant.messages.getString(
-                            "openapi.topmenu.tools.importremoteopenapi.tooltip"));
+                            "openapi.topmenu.import.importremoteopenapi.tooltip"));
 
             final ExtensionOpenApi shadowCopy = this;
             menuImportUrlOpenApi.addActionListener(

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -13,7 +13,7 @@ This add-on allows you to spider and import OpenAPI (Swagger) definitions (versi
 The add-on will automatically detect any Open API definitions and spider them as long as they are in scope.
 
 <H2>UI</H2>
-2 menu items are added to the Tools menu:
+2 menu items are added to the Import menu:
 <ul>
 <li>Import an Open API definition from the local file system</li>
 <li>Import an Open API definition from a URL</li>

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -7,10 +7,10 @@ openapi.cmdline.file.help = Import an Open API definition from the specified fil
 openapi.cmdline.url.help = Import an Open API definition from the specified URL
 
 openapi.desc = Allows you to spider and import OpenAPI (Swagger) definitions 
-openapi.topmenu.tools.importopenapi = Import an Open API definition from the local file system
-openapi.topmenu.tools.importopenapi.tooltip = The file must be a formal described OpenApi file.
-openapi.topmenu.tools.importremoteopenapi = Import an Open API definition from a URL
-openapi.topmenu.tools.importremoteopenapi.tooltip = The file must be a formal described OpenApi file.
+openapi.topmenu.import.importopenapi = Import an Open API definition from the local file system
+openapi.topmenu.import.importopenapi.tooltip = The file must be a formal described OpenApi file.
+openapi.topmenu.import.importremoteopenapi = Import an Open API definition from a URL
+openapi.topmenu.import.importremoteopenapi.tooltip = The file must be a formal described OpenApi file.
 
 openapi.importfromurldialog.pasteaction = Paste
 openapi.importfromurldialog.labeloverride = Override Host:

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change default accelerator for "Import a WSDL file from local file system".
 - Fix exception with Java 9+ (Issue 4037).
 - Update minimum ZAP version to 2.8.0.
+- Add import menus to (new) top level Import menu instead of Tools menu.
 
 ## 3 - 2017-03-31
 

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Various fixes (related to Issue 4832 and other testing).
 - Change default accelerator for "Import a WSDL file from local file system".
 - Fix exception with Java 9+ (Issue 4037).
+- Update minimum ZAP version to 2.8.0.
 
 ## 3 - 2017-03-31
 

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -3,7 +3,7 @@ description = "Imports and scans WSDL files containing SOAP endpoints."
 
 zapAddOn {
     addOnName.set("SOAP Scanner")
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.8.0")
 
     manifest {
         author.set("Alberto (albertov91) + ZAP Core team")

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -60,8 +60,8 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
         extensionHook.addApiImplementor(new SoapAPI(this));
 
         if (getView() != null) {
-            extensionHook.getHookMenu().addToolsMenuItem(getMenuImportLocalWSDL());
-            extensionHook.getHookMenu().addToolsMenuItem(getMenuImportUrlWSDL());
+            extensionHook.getHookMenu().addImportMenuItem(getMenuImportLocalWSDL());
+            extensionHook.getHookMenu().addImportMenuItem(getMenuImportUrlWSDL());
 
             /*
              * Custom spider parser is added in order to explore not only WSDL files, but
@@ -95,12 +95,12 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
         if (menuImportLocalWSDL == null) {
             menuImportLocalWSDL =
                     new ZapMenuItem(
-                            "soap.topmenu.tools.importWSDL",
+                            "soap.topmenu.import.importWSDL",
                             getView()
                                     .getMenuShortcutKeyStroke(
                                             KeyEvent.VK_I, KeyEvent.SHIFT_DOWN_MASK, false));
             menuImportLocalWSDL.setToolTipText(
-                    Constant.messages.getString("soap.topmenu.tools.importWSDL.tooltip"));
+                    Constant.messages.getString("soap.topmenu.import.importWSDL.tooltip"));
 
             menuImportLocalWSDL.addActionListener(
                     new java.awt.event.ActionListener() {
@@ -115,7 +115,7 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
                             FileNameExtensionFilter filter =
                                     new FileNameExtensionFilter(
                                             Constant.messages.getString(
-                                                    "soap.topmenu.tools.importWSDL.filter.description"),
+                                                    "soap.topmenu.import.importWSDL.filter.description"),
                                             "wsdl");
                             chooser.setFileFilter(filter);
                             int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
@@ -133,10 +133,10 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
         if (menuImportUrlWSDL == null) {
             menuImportUrlWSDL =
                     new ZapMenuItem(
-                            "soap.topmenu.tools.importRemoteWSDL",
+                            "soap.topmenu.import.importRemoteWSDL",
                             getView().getMenuShortcutKeyStroke(KeyEvent.VK_J, 0, false));
             menuImportUrlWSDL.setToolTipText(
-                    Constant.messages.getString("soap.topmenu.tools.importRemoteWSDL.tooltip"));
+                    Constant.messages.getString("soap.topmenu.import.importRemoteWSDL.tooltip"));
 
             final ExtensionImportWSDL shadowCopy = this;
             menuImportUrlWSDL.addActionListener(

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -19,13 +19,11 @@
  */
 package org.zaproxy.zap.extension.soap;
 
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import javax.swing.JFileChooser;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import org.parosproxy.paros.Constant;
@@ -93,19 +91,14 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
     }
 
     /* Menu option to import a local WSDL file. */
-    @SuppressWarnings("deprecation")
     private ZapMenuItem getMenuImportLocalWSDL() {
         if (menuImportLocalWSDL == null) {
             menuImportLocalWSDL =
                     new ZapMenuItem(
                             "soap.topmenu.tools.importWSDL",
-                            // TODO Remove warn suppression and use View.getMenuShortcutKeyStroke
-                            // with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
-                            KeyStroke.getKeyStroke(
-                                    KeyEvent.VK_I,
-                                    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()
-                                            | KeyEvent.SHIFT_DOWN_MASK,
-                                    false));
+                            getView()
+                                    .getMenuShortcutKeyStroke(
+                                            KeyEvent.VK_I, KeyEvent.SHIFT_DOWN_MASK, false));
             menuImportLocalWSDL.setToolTipText(
                     Constant.messages.getString("soap.topmenu.tools.importWSDL.tooltip"));
 
@@ -136,18 +129,12 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
     }
 
     /* Menu option to import a WSDL file from a given URL. */
-    @SuppressWarnings("deprecation")
     private ZapMenuItem getMenuImportUrlWSDL() {
         if (menuImportUrlWSDL == null) {
             menuImportUrlWSDL =
                     new ZapMenuItem(
                             "soap.topmenu.tools.importRemoteWSDL",
-                            // TODO Remove warn suppression and use View.getMenuShortcutKeyStroke
-                            // with newer ZAP (or use getMenuShortcutKeyMaskEx() with Java 10+)
-                            KeyStroke.getKeyStroke(
-                                    KeyEvent.VK_J,
-                                    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask(),
-                                    false));
+                            getView().getMenuShortcutKeyStroke(KeyEvent.VK_J, 0, false));
             menuImportUrlWSDL.setToolTipText(
                     Constant.messages.getString("soap.topmenu.tools.importRemoteWSDL.tooltip"));
 

--- a/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
+++ b/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
@@ -12,7 +12,7 @@ This add-on imports and scans WSDL files containing SOAP endpoints.
 <h2>Importing</H2>
 The add-on will automatically detect any SOAP definitions and spider them as long as they are in scope.
 <br><br>
-2 menu items are also added to the Tools menu:
+2 menu items are also added to the Import menu:
 <ul>
 <li>Import a WSDL file from local file system</li>
 <li>Import a WSDL file from a URL</li>

--- a/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
+++ b/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
@@ -4,12 +4,12 @@ soap.api.action.importFile = Import a WSDL definition from local file.
 soap.api.action.importUrl = Import a WSDL definition from a URL.
 
 soap.desc=Allows you to import a WSDL file containing operations which ZAP will access, adding them to the Sites tree.
-soap.topmenu.tools.importWSDL=Import a WSDL file from local file system
-soap.topmenu.tools.importWSDL.tooltip=The file must be a formal described WSDL file.
-soap.topmenu.tools.importWSDL.filter.description = WSDL File
-soap.topmenu.tools.importWSDL.fail=Unable to access endpoint defined in {0}
-soap.topmenu.tools.importRemoteWSDL=Import a WSDL file from a URL
-soap.topmenu.tools.importRemoteWSDL.tooltip=The file must be a formal described WSDL file.
+soap.topmenu.import.importWSDL=Import a WSDL file from local file system
+soap.topmenu.import.importWSDL.tooltip=The file must be a formal described WSDL file.
+soap.topmenu.import.importWSDL.filter.description = WSDL File
+soap.topmenu.import.importWSDL.fail=Unable to access endpoint defined in {0}
+soap.topmenu.import.importRemoteWSDL=Import a WSDL file from a URL
+soap.topmenu.import.importRemoteWSDL.tooltip=The file must be a formal described WSDL file.
 
 soap.soapactionspoofing.name=SOAP Action Spoofing
 soap.soapactionspoofing.desc=An unintended SOAP operation was executed by the server.


### PR DESCRIPTION
Part of issue [zaproxy#3578](https://github.com/zaproxy/zaproxy/issues/3578). 

Updated the following alpha addons to use new Import Menu.

- [x] OpenAPI Support Add-ons
- [x] SOAP Scanner Add-ons
- [x] Log file Import Add-on