### PR TITLE
Remove redundant add-ons' info URLs

### DIFF
--- a/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/cmss/ZapAddOn.xml
@@ -4,7 +4,6 @@
 	<status>alpha</status>
 	<description>Fingerprint web applications</description>
 	<author>ZAP Dev Team</author>
-	<url>https://github.com/zaproxy/zaproxy</url>
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.5.0.<br>

--- a/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/saml/ZapAddOn.xml
@@ -4,7 +4,6 @@
     <status>alpha</status>
     <description>Detect, Show, Edit, Fuzz SAML requests</description>
     <author>ZAP Dev Team</author>
-    <url>https://github.com/zaproxy/zaproxy</url>
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.5.0.<br>

--- a/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/vulncheck/ZapAddOn.xml
@@ -4,7 +4,6 @@
 	<status>alpha</status>
 	<description>list vulnerabilities from known databases </description>
 	<author>ZAP Dev Team</author>
-	<url>https://github.com/zaproxy/zaproxy</url>
 	<changes>
 	<![CDATA[
 	Update minimum ZAP version to 2.5.0.<br>


### PR DESCRIPTION
The info URLs linked to the main repo, which does not provide any info
about the add-ons.