### PR TITLE
Fix Issue 5215 - HashDisclosureScanner ignore obvious jsessionid Values

### DIFF
--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScanner.java
@@ -102,7 +102,7 @@ public class HashDisclosureScanner extends PluginPassiveScanner {
 
 		//MD4/5 (clashes with LanMan)
 		//MD4/5 hashes occur fairly frequently in various legitimate uses, and are not necessarily indicative of an issue.
-		hashPatterns.put(Pattern.compile("\\b[0-9a-f]{32}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("MD4 / MD5",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
+		hashPatterns.put(Pattern.compile("(?<!jsessionid=)\\b[0-9a-f]{32}\\b", Pattern.CASE_INSENSITIVE), new HashAlert("MD4 / MD5",Alert.RISK_LOW, Alert.CONFIDENCE_LOW));
 
 		//TODO: for the main hash types, verify the value by hashing the parameters
 		//  - if the hash value can be re-generated, then it is a "reflection" attack

--- a/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/pscanrulesAlpha/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 		PiiScanner add word boundary checks to reduce false positives.<br>
+		HashDisclosureScanner prevent false positives on obvious jsessionid values (Issue 5215).<br>
 	]]>
 	</changes>
 	<extensions>

--- a/test/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScannerUnitTest.java
+++ b/test/org/zaproxy/zap/extension/pscanrulesAlpha/HashDisclosureScannerUnitTest.java
@@ -1,0 +1,119 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Unit test for {@link HashDisclosureScanner}.
+ */
+public class HashDisclosureScannerUnitTest extends PassiveScannerTest<HashDisclosureScanner> {
+
+    @Override
+    protected HashDisclosureScanner createScanner() {
+        return new HashDisclosureScanner();
+    }
+
+    @Before
+    public void before() throws HttpMalformedHeaderException {
+        rule.setAlertThreshold(AlertThreshold.LOW); // Required by MD4/MD5 tests
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenResponseContainsUpperMd5Hash() throws Exception {
+        // Given - Upper MD5
+        String hashVal = "DD6433D07B73FC14A2A4D03C5A8FAA90";
+        HttpMessage msg = createMsg(hashVal);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertThat(alertsRaised.get(0).getName(), is("Hash Disclosure - MD4 / MD5"));
+        assertThat(alertsRaised.get(0).getEvidence(), is(hashVal));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenResponseContainsLowerMd5Hash() throws Exception {
+        // Given - Lower MD5
+        String hashVal = "cc03e747a6afbbcbf8be7668acfebee5";
+        HttpMessage msg = createMsg(hashVal);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertThat(alertsRaised.get(0).getName(), is("Hash Disclosure - MD4 / MD5"));
+        assertThat(alertsRaised.get(0).getEvidence(), is(hashVal));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenResponseContainsCookieWithMd5Hash() throws Exception {
+        // Given - Lower MD5
+        String hashVal = "cc03e747a6afbbcbf8be7668acfebee5";
+        HttpMessage msg = createMsg("");
+        msg.getResponseHeader().addHeader(HttpHeader.SET_COOKIE, "userid=" + hashVal);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertThat(alertsRaised.get(0).getName(), is("Hash Disclosure - MD4 / MD5"));
+        assertThat(alertsRaised.get(0).getEvidence(), is(hashVal));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertWhenResponseContainsNonMd5Hash() throws Exception {
+        // Given - Not MD5 (mm)
+        String hashVal = "mm6433d07b73fc14a2a4d03c5a8faa90";
+        HttpMessage msg = createMsg(hashVal);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertWhenResponseContainsObviousJsessionid() throws Exception {
+        // Given - jsessionid cookie
+        String hashVal = "dd6433d07b73fc14a2a4d03c5a8faa90";
+        HttpMessage msg = createMsg("");
+        msg.getResponseHeader().addHeader(HttpHeader.SET_COOKIE, "jsessionid=" + hashVal);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    private HttpMessage createMsg(String hashVal) throws HttpMalformedHeaderException {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" +
+                "Server: Apache-Coyote/1.1\r\n");
+        msg.setResponseBody("{\"hash\": \"" + hashVal + "\"}");
+        return msg;
+    }
+
+}


### PR DESCRIPTION
- HashDisclosureScanner - Update MD4/MD5 regex. https://www.regexplanet.com/share/index.html?share=yyyyu0ua0ar
- HashDisclosureScannerUnitTest - Created, adding unit tests.
- ZapAddOn.xml - Updated changes section with new entry.

Fixes zaproxy/zaproxy#5215