### PR TITLE
imagelocationscanner: correct URL in help page

### DIFF
--- a/src/org/zaproxy/zap/extension/imagelocationscanner/ZapAddOn.xml
+++ b/src/org/zaproxy/zap/extension/imagelocationscanner/ZapAddOn.xml
@@ -8,6 +8,7 @@
 	<changes>
 	<![CDATA[
 		Maintenance changes.<br>
+		Correct repository URL in about help page.<br>
 	]]>
 	</changes>
 	<extensions>

--- a/src/org/zaproxy/zap/extension/imagelocationscanner/resources/help/contents/about.html
+++ b/src/org/zaproxy/zap/extension/imagelocationscanner/resources/help/contents/about.html
@@ -9,7 +9,7 @@ Image Location and Privacy Scanner - About
 <H1>Image Location and Privacy Scanner - About</H1>
 
 <H2>Source Code</H2>
-<a href="https://github.com/zaprhttps://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/imagelocationscanner">https://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/imagelocationscanner</a><br>
+<a href="https://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/imagelocationscanner">https://github.com/zaproxy/zap-extensions/tree/alpha/src/org/zaproxy/zap/extension/imagelocationscanner</a><br>
 <a href="https://github.com/veggiespam/ImageLocationScanner">https://github.com/veggiespam/ImageLocationScanner</a>
 
 <H2>Authors</H2>


### PR DESCRIPTION
Correct the repo URL in about help page.
Update changes in ZapAddOn.xml file.