### PR TITLE
Fixed wrong header name "Request-Range"

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-
+### Fixed
+- Fix typo in request header used by Apache Range Header DoS.
 
 ## 23 - 2019-02-06
 

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ApacheRangeHeaderDos.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ApacheRangeHeaderDos.java
@@ -173,7 +173,7 @@ public class ApacheRangeHeaderDos extends AbstractAppPlugin {
 	private void setRequestHeaders(HttpMessage aMessage, String rangeValue) {
 		rangeValue = "bytes=" + rangeValue;
 		aMessage.getRequestHeader().setHeader("Range", rangeValue);
-		aMessage.getRequestHeader().setHeader("Range-Request", rangeValue);
+		aMessage.getRequestHeader().setHeader("Request-Range", rangeValue);
 		aMessage.getRequestHeader().setHeader("Connection", "close");
 	}
 


### PR DESCRIPTION
As stated in https://httpd.apache.org/security/CVE-2011-3192.txt "Request-Range" is legacy so it is good to send both "Range" and "Request-Range". But "Range-Request" does not exist.