### PR TITLE
fuzzdb: prevent compilation in Eclipse

### DIFF
--- a/addOns/fuzzdb/fuzzdb.gradle.kts
+++ b/addOns/fuzzdb/fuzzdb.gradle.kts
@@ -1,5 +1,16 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
+plugins {
+    eclipse
+}
+
+eclipse {
+    classpath {
+        // Prevent compilation of zapHomeFiles.
+        sourceSets = listOf()
+    }
+}
+
 version = "5"
 description = "FuzzDB files which can be used with the ZAP fuzzer"
 


### PR DESCRIPTION
Prevent the home files from being compiled by Eclipse, the files are not
intended to be compiled (and just leads to errors).