### PR TITLE
updated geckodriver and chromedriver webdriver versions.

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix link in help page.
 
+## 8 - 2019-04-5
+
+- Update Help
+- Update geckodriver to v0.24.0.
+- Update ChromeDriver to v73.0.3683.68.
+
 ## 7 - 2018-10-29
 
 - Add help.

--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Fix link in help page.
-
-## 8 - 2019-04-5
-
-- Update Help
 - Update geckodriver to v0.24.0.
 - Update ChromeDriver to v73.0.3683.68.
 

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,8 +9,8 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-<li>Chrome - ChromeDriver 2.43</li>
-<li>Firefox - geckodriver 0.23.0</li>
+    <li>Chrome - ChromeDriver 73.0.3683.68</li>
+    <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix link in help page.
 
+## 8 - 2019-04-5
+
+- Update Help
+- Update geckodriver to v0.24.0.
+- Update ChromeDriver to v73.0.3683.68.
+
 ## 7 - 2018-10-29
 
 - Add help.

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Fix link in help page.
-
-## 8 - 2019-04-5
-
-- Update Help
 - Update geckodriver to v0.24.0.
 - Update ChromeDriver to v73.0.3683.68.
 

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,8 +9,8 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-<li>Chrome - ChromeDriver 2.43</li>
-<li>Firefox - geckodriver 0.23.0</li>
+    <li>Chrome - ChromeDriver 73.0.3683.68</li>
+    <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -4,8 +4,8 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 
 description = "Common configuration of the WebDriver add-ons."
 
-val geckodriverVersion = "0.23.0"
-val chromeDriverVersion = "2.43"
+val geckodriverVersion = "0.24.0"
+val chromeDriverVersion = "74.0.3729.6"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.24.0"
-val chromeDriverVersion = "74.0.3729.6"
+val chromeDriverVersion = "73.0.3683.68"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix link in help page.
 - Remove IEDriverServer, IE is no longer provided by Selenium add-on.
 
+## 8 - 2019-04-5
+
+- Update Help
+- Update geckodriver to v0.24.0.
+- Update ChromeDriver to v73.0.3683.68.
+
 ## 7 - 2018-10-29
 
 - Add help.

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -7,10 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix link in help page.
 - Remove IEDriverServer, IE is no longer provided by Selenium add-on.
-
-## 8 - 2019-04-5
-
-- Update Help
 - Update geckodriver to v0.24.0.
 - Update ChromeDriver to v73.0.3683.68.
 

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,8 +9,8 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-<li>Chrome - ChromeDriver 2.43</li>
-<li>Firefox - geckodriver 0.23.0</li>
+    <li>Chrome - ChromeDriver 73.0.3683.68</li>
+    <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 
 <H2>See also</H2>


### PR DESCRIPTION
upgrading geckodriver version to `0.24.0` for issue Fixes zaproxy/zaproxy#5273
upgrading chromedriver version to `74.0.3729.6 ` for issue Fixes zaproxy/zaproxy#5274
