### PR TITLE
Fix build issues

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,6 +25,8 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     implementation("io.github.bonigarcia:webdrivermanager:3.3.0")
+    // Force use of 1.11 needed by ZAP plugin.
+    implementation("commons-codec:commons-codec:1.11")
 }
 
 java {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ProcessSvnDiggerFiles.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/ProcessSvnDiggerFiles.java
@@ -67,6 +67,7 @@ public class ProcessSvnDiggerFiles extends DefaultTask {
         Path dirbusterDir = outputDir.get().getAsFile().toPath().resolve(DIRBUSTER_DIR);
         Path svndiggerDir = dirbusterDir.resolve(SVNDIGGER_DIR);
 
+        getProject().delete(dirbusterDir.toFile());
         Files.createDirectories(svndiggerDir);
         Files.copy(srcDir.resolve(LICENCE_FILE_NAME), svndiggerDir.resolve(LICENCE_FILE_NAME));
         Files.copy(srcDir.resolve(README_FILE_NAME), svndiggerDir.resolve(README_FILE_NAME));


### PR DESCRIPTION
Force use of Commons Codec 1.11 (instead of 1.10 from transitive
dependencies of WebDriverManager) as it's required by the ZAP plugin
when generating the ZapVersions data.
Ensure the SvnDigger output directory is clean (by removing it) before
processing the files to avoid stale files/directories.