### PR TITLE
replaced joda.time.datetime with java.time.localtime (JDK8).

### DIFF
--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added SAML Passive Scanner
 - Dynamically unload the add-on.
 - Fix exception with Java 9+ (Issue 5032).
+- Replaced joda.time.datetime with java.time.localtime (Java8).
 
 ## 7 - 2017-11-24
 

--- a/addOns/saml/saml.gradle.kts
+++ b/addOns/saml/saml.gradle.kts
@@ -11,6 +11,5 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("joda-time:joda-time:2.2")
     implementation("org.glassfish.jaxb:jaxb-runtime:2.3.2")
 }

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLMessage.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLMessage.java
@@ -2,7 +2,6 @@ package org.zaproxy.zap.extension.saml;
 
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
-import org.joda.time.DateTime;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.w3c.dom.*;
@@ -23,6 +22,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -156,7 +156,7 @@ public class SAMLMessage {
                 case Integer:
                     return Integer.parseInt(value);
                 case TimeStamp:
-                    return DateTime.parse(value);
+                    return LocalDateTime.parse(value);
                 default:
                     return value;
             }


### PR DESCRIPTION
replaced joda.time.datetime with java.time.localtime (JDK8). Fixes zaproxy/zaproxy#5301.