### PR TITLE
wappalyzer: Add apps.json Parsing UnitTest

### DIFF
--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -20,7 +20,6 @@ package org.zaproxy.zap.extension.wappalyzer;
 
 import java.awt.EventQueue;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -34,9 +33,7 @@ import java.util.regex.Pattern;
 import javax.swing.ImageIcon;
 import javax.swing.tree.TreeNode;
 
-import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Logger;
-import org.apache.log4j.PatternLayout;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
@@ -318,18 +315,6 @@ public class ExtensionWappalyzer extends ExtensionAdaptor implements SessionChan
 	@Override
 	public void sessionScopeChanged(Session arg0) {
 		// Ignore
-	}
-
-	public static void main(String[] args) throws Exception {
-		// Quick way to test the apps.json file parsing
-		
-		ConsoleAppender ca = new ConsoleAppender();
-		ca.setWriter(new OutputStreamWriter(System.out));
-		ca.setLayout(new PatternLayout("%-5p [%t]: %m%n"));
-        Logger.getRootLogger().addAppender(ca);
-		
-		new ExtensionWappalyzer();
-		
 	}
 
 }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PatternErrorHandler.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PatternErrorHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.wappalyzer;
+
+import java.util.regex.PatternSyntaxException;
+
+public interface PatternErrorHandler {
+	void handleError(String pattern, PatternSyntaxException e);
+}

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -41,6 +41,15 @@ public class WappalyzerJsonParser {
 
 
     private static final Logger logger = Logger.getLogger(WappalyzerJsonParser.class);
+    private PatternErrorHandler patternErrorHandler;
+
+    public WappalyzerJsonParser() {
+        patternErrorHandler = (pattern, e) -> logger.error("Invalid pattern syntax " + pattern, e);
+    }
+
+    public WappalyzerJsonParser(PatternErrorHandler peh) {
+        this.patternErrorHandler = peh;
+    }
 
     public WappalyzerData parseDefaultAppsJson() throws IOException {
         return parseJson(getStringResource(ExtensionWappalyzer.RESOURCE + "/apps.json"));
@@ -158,7 +167,7 @@ public class WappalyzerJsonParser {
                 } catch (NumberFormatException e) {
                     logger.error("Invalid field syntax " + entry.getKey() + " : " + entry.getValue(), e);
                 } catch (PatternSyntaxException e) {
-                    logger.error("Invalid pattern syntax " + entry.getValue(), e);
+                    patternErrorHandler.handleError(entry.getValue(), e);
                 }
             }
         } else if (json != null) {
@@ -179,14 +188,14 @@ public class WappalyzerJsonParser {
                 try {
                     list.add(this.strToAppPattern(type, objStr));
                 } catch (PatternSyntaxException e) {
-                    logger.error("Invalid pattern syntax " + objStr, e);
+                    patternErrorHandler.handleError(objStr, e);
                 }
             }
         } else if (json != null) {
             try {
                 list.add(this.strToAppPattern(type, json.toString()));
             } catch (PatternSyntaxException e) {
-                logger.error("Invalid pattern syntax " + json.toString(), e);
+                patternErrorHandler.handleError(json.toString(), e);
             }
         }
         return list;

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.wappalyzer;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import org.junit.Test;
+
+public class WappalyzerAppsJsonParseUnitTest {
+
+	@Test
+	public void test() throws IOException {
+		// When - there's a parse exception, fail
+		WappalyzerJsonParser parser = new WappalyzerJsonParser(
+				(pattern, e) -> fail("Regular expression with errors: " + e));
+		parser.parseDefaultAppsJson();
+	}
+
+}


### PR DESCRIPTION
Add unittest and remove main method from ExtensionWappalyzer. If (when) someone does an apps.json upgrade (from AliasIO/wappalyzer) any failing patterns should be removed. (Per discussion in IRC and other PRs.)

Thanks to @thc202 for all the advice, collaboration, and extreme patience on this!

See https://travis-ci.com/zaproxy/zap-extensions/jobs/192365059 for PoC.