### PR TITLE
Change the download URL of the add-ons

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -127,7 +127,7 @@ subprojects {
         }
 
         zapVersions {
-            downloadUrl.set("https://github.com/zaproxy/zap-extensions/releases/download/2.7")
+            downloadUrl.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/download/${zapAddOn.addOnId.get()}-v$version" })
         }
     }
 }


### PR DESCRIPTION
Change to link to the tag of the add-on (instead of being tied to the
current ZAP release, e.g. tag 2.7).