### PR TITLE
HttpsInfo: Update DeepViolet

### DIFF
--- a/addOns/httpsInfo/CHANGELOG.md
+++ b/addOns/httpsInfo/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - New tabbed UI.
+- Update to DeepViolet 5.1.16.
 
 ## 11 - 2017-11-28
 

--- a/addOns/httpsInfo/httpsInfo.gradle.kts
+++ b/addOns/httpsInfo/httpsInfo.gradle.kts
@@ -11,9 +11,9 @@ zapAddOn {
 }
 
 dependencies {
-    implementation(files("lib/dvAPI_5.0.3.jar"))
+    implementation("com.github.spoofzu:DeepViolet:5.1.16")
     implementation("org.slf4j:slf4j-log4j12:1.7.6") {
-        // Bundled in Deep Violet JAR.
-        exclude(group = "org.slf4j", module = "slf4j-api")
+        // Provided by ZAP.
+        exclude(group = "log4j")
     }
 }

--- a/addOns/httpsInfo/src/main/java/org/zaproxy/zap/extension/httpsinfo/HttpsInfoOutputPanel.java
+++ b/addOns/httpsInfo/src/main/java/org/zaproxy/zap/extension/httpsinfo/HttpsInfoOutputPanel.java
@@ -45,7 +45,7 @@ public class HttpsInfoOutputPanel extends OutputPanel {
 
 	private static final String NEWLINE = System.lineSeparator();
 	
-	private static final Logger LOGGER = Logger.getLogger(ExtensionHttpsInfo.class);
+	private static final Logger LOGGER = Logger.getLogger(HttpsInfoOutputPanel.class);
 
 	private static final int BEAST_PLUGIN_ID = 10200;
 	private static final int CRIME_PLUGIN_ID = 10201;
@@ -104,7 +104,7 @@ public class HttpsInfoOutputPanel extends OutputPanel {
 		return session;
 	}
 	
-	private void setDvEng(IDVSession session) {
+	private void setDvEng(IDVSession session) throws DVException {
 		this.dvEng = DVFactory.getDVEng(session);
 	}
 	
@@ -125,7 +125,11 @@ public class HttpsInfoOutputPanel extends OutputPanel {
 					View.getSingleton().showWarningDialog(warnMsg);
 					return;
 				}
-				setDvEng(getSession());
+				try {
+					setDvEng(getSession());
+				} catch (DVException e) {
+					LOGGER.warn(e.getMessage(), e);
+				}
 				showGeneral();
 				showCipherSuites();
 			}


### PR DESCRIPTION
* Remove lib/dvAPI_5.0.3.jar
* httpsInfo.gradle.kts - Remove local lib reference and use 5.1.16 from maven.
* HttpsInfoOutputPanel - Minor changes for compatability with latest DV, and to correct incorrect logger setup.
* Updated changelog.

Fixes zaproxy/zaproxy#5254

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>