### PR TITLE
Updated an alert reference link

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migrate CSP Scanner into the main passive scan release package (promoting it to Release). Upgrade Salvation (dependency) to 2.6.0.
 - Application Error scanner change for HTTP 500. Alert changed to low risk for HTTP 500, and not raised at all when Threshold is High.  
 
+## 24 - 2019-04-16
+
+- Updated the reference link for the alert: Web Browser XSS Protection Not Enabled.
+
 ## 23 - 2018-08-15
 
 - Fix a typo in the description of Referer Exposes Session ID.

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,9 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Migrate CSP Scanner into the main passive scan release package (promoting it to Release). Upgrade Salvation (dependency) to 2.6.0.
 - Application Error scanner change for HTTP 500. Alert changed to low risk for HTTP 500, and not raised at all when Threshold is High.  
-
-## 24 - 2019-04-16
-
 - Updated the reference link for the alert: Web Browser XSS Protection Not Enabled.
 
 ## 23 - 2018-08-15

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -4,7 +4,7 @@ pscanrules.desc = Passive Scan Rules
 
 pscanrules.headerxssprotectionscanner.name = Web Browser XSS Protection Not Enabled
 pscanrules.headerxssprotectionscanner.desc = Web Browser XSS Protection is not enabled, or is disabled by the configuration of the 'X-XSS-Protection' HTTP response header on the web server
-pscanrules.headerxssprotectionscanner.refs = https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet\nhttps://blog.veracode.com/2014/03/guidelines-for-setting-security-headers/
+pscanrules.headerxssprotectionscanner.refs = https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet\nhttps://www.veracode.com/blog/2014/03/guidelines-for-setting-security-headers/
 pscanrules.headerxssprotectionscanner.extrainfo = The X-XSS-Protection HTTP response header allows the web server to enable or disable the web browser's XSS protection mechanism. The following values would attempt to enable it: \nX-XSS-Protection: 1; mode=block\nX-XSS-Protection: 1; report=http://www.example.com/xss\nThe following values would disable it:\nX-XSS-Protection: 0\nThe X-XSS-Protection HTTP response header is currently supported on Internet Explorer, Chrome and Safari (WebKit).\nNote that this alert is only raised if the response body could potentially contain an XSS payload (with a text-based content type, with a non-zero length).
 pscanrules.headerxssprotectionscanner.soln = Ensure that the web browser's XSS filter is enabled, by setting the X-XSS-Protection HTTP response header to '1'.
 


### PR DESCRIPTION
The old reference link for the alert "Web Browser XSS Protection Not Enabled" no longer works. Updated with a new link.