### PR TITLE
openapi: fix NPE when reporting errors

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added Accept header for importing an OpenAPI definition from an URL, in the proper format.
 - Correct import of v1.2 definitions (Issue 5262).
+- Fix exception when reporting errors.
 
 ## 12 - 2018-05-18
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -231,7 +231,11 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                 } catch (Exception e) {
                     if (initViaUi) {
                         String exMsg = e.getLocalizedMessage();
-                        exMsg = exMsg.length() >= 125 ? exMsg.substring(0, 122) + "..." : exMsg;
+                        if (exMsg != null) {
+                            exMsg = exMsg.length() >= 125 ? exMsg.substring(0, 122) + "..." : exMsg;
+                        } else {
+                            exMsg = "";
+                        }
                         View.getSingleton().showWarningDialog(Constant.messages.getString("openapi.parse.error", exMsg)
                                 + "\n\n" + Constant.messages.getString("openapi.parse.trailer"));
                     }


### PR DESCRIPTION
Change ExtensionOpenApi to check if the exception has a message before
processing it (thus preventing the NPE).

---
Reported in OWASP ZAP User Group:
https://groups.google.com/d/topic/zaproxy-users/c9HhSOB7ieU/discussion