### PR TITLE
Include test stack trace when running in Travis CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     id("com.diffplug.gradle.spotless") version "3.20.0"
 }
 
+apply(from = "$rootDir/gradle/travis-ci.gradle.kts")
+
 allprojects {
     apply(plugin = "com.diffplug.gradle.spotless")
 

--- a/gradle/travis-ci.gradle.kts
+++ b/gradle/travis-ci.gradle.kts
@@ -1,0 +1,13 @@
+// Build tweaks when running in Travis CI
+
+fun isEnvVarTrue(envvar: String) = System.getenv(envvar) == "true"
+
+if (isEnvVarTrue("TRAVIS") && isEnvVarTrue("CI")) {
+
+    tasks.withType(Test::class).configureEach {
+        testLogging {
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        }
+    }
+
+}


### PR DESCRIPTION
Use full format to output the stack trace when the tests fail, to make
it easier to know where it's failing.

---
(Same behaviour as in zap-hud repo.)