### PR TITLE
Skip WebDriver downloads in LGTM builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply(from = "$rootDir/gradle/travis-ci.gradle.kts")
+apply(from = "$rootDir/gradle/lgtm.gradle.kts")
 
 allprojects {
     apply(plugin = "com.diffplug.gradle.spotless")

--- a/gradle/lgtm.gradle.kts
+++ b/gradle/lgtm.gradle.kts
@@ -1,0 +1,14 @@
+import org.zaproxy.gradle.tasks.DownloadWebDriver
+
+// Build tweaks when running by LGTM
+
+System.getenv("LGTM_SRC")?.let {
+
+    allprojects {
+        // Don't download WebDrivers, the downloads fail more often than not.
+        tasks.withType(DownloadWebDriver::class).configureEach {
+            enabled = false
+        }
+    }
+
+}

--- a/gradle/travis-ci.gradle.kts
+++ b/gradle/travis-ci.gradle.kts
@@ -4,9 +4,11 @@ fun isEnvVarTrue(envvar: String) = System.getenv(envvar) == "true"
 
 if (isEnvVarTrue("TRAVIS") && isEnvVarTrue("CI")) {
 
-    tasks.withType(Test::class).configureEach {
-        testLogging {
-            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    allprojects {
+        tasks.withType(Test::class).configureEach {
+            testLogging {
+                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            }
         }
     }
 


### PR DESCRIPTION
The downloads fail too often breaking the analysis, while not required.
Change Travis CI tweaks to configure all test tasks in all projects, not
just the root project (which does not have any).