### PR TITLE
Fix release on tag

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -10,12 +10,13 @@ action "Add-On Tag Filter" {
 
 action "Actor Filter" {
   uses = "actions/bin/filter@3c0b4f0e63ea54ea5df2914b4fabf383368cd0da"
+  needs = ["Add-On Tag Filter"]
   args = ["actor", "kingthorin", "psiinon", "thc202"]
 }
 
 action "Build and Release Add-On" {
   uses = "docker://openjdk:8"
-  needs = ["Actor Filter", "Add-On Tag Filter"]
+  needs = ["Actor Filter"]
   runs = "./gradlew"
   args = "createReleaseFromGitHubRef"
   secrets = ["GITHUB_TOKEN"]

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/CreateGitHubRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/CreateGitHubRelease.java
@@ -121,7 +121,7 @@ public class CreateGitHubRelease extends DefaultTask {
             throw new InvalidUserDataException("Only one type of body property must be set.");
         }
 
-        GHRepository ghRepo = GitHub.connectUsingOAuth(authToken.get()).getRepository(repo.get());
+        GHRepository ghRepo = GitHub.connect("", authToken.get()).getRepository(repo.get());
 
         validateTagExists(ghRepo, tag.get());
         validateReleaseDoesNotExist(ghRepo, tag.get());


### PR DESCRIPTION
Use empty login name when creating the GitHub API instance to avoid
requesting the login name (which is not accessible).
Execute the filters sequentially and the tag filter first, to stop
earlier and with neutral result.