### PR TITLE
Add helper release tasks

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -7,6 +7,8 @@ import org.zaproxy.gradle.addon.wiki.WikiGenExtension
 import org.zaproxy.gradle.addon.zapversions.ZapVersionsExtension
 import org.zaproxy.gradle.tasks.CreateGitHubRelease
 import org.zaproxy.gradle.tasks.ExtractLatestChangesChangelog
+import org.zaproxy.gradle.tasks.PrepareAddOnNextDevIter
+import org.zaproxy.gradle.tasks.PrepareAddOnRelease
 
 plugins {
     id("org.zaproxy.add-on") version "0.1.0" apply false
@@ -111,6 +113,18 @@ subprojects {
     java {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    tasks.register<PrepareAddOnRelease>("prepareAddOnRelease") {
+        changelog.set(file("CHANGELOG.md"))
+        version.set(project.provider { zapAddOn.addOnVersion.get() })
+        releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v${zapAddOn.addOnVersion.get()}" })
+    }
+
+    tasks.register<PrepareAddOnNextDevIter>("prepareAddOnNextDevIter") {
+        changelog.set(file("CHANGELOG.md"))
+        buildFile.set(file("${project.name}.gradle.kts"))
+        currentVersion.set(project.provider { zapAddOn.addOnVersion.get() })
     }
 
     tasks.register<ExtractLatestChangesChangelog>("extractLatestChanges") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     // Include annotations used by the above library to avoid compiler warnings.
     compileOnly("com.google.code.findbugs:findbugs-annotations:3.0.1")
     compileOnly("com.infradna.tool:bridge-method-annotation:1.18")
+    implementation("com.github.zafarkhaja:java-semver:0.9.0")
 }
 
 java {

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/PrepareAddOnNextDevIter.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/PrepareAddOnNextDevIter.java
@@ -1,0 +1,181 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import com.github.zafarkhaja.semver.ParseException;
+import com.github.zafarkhaja.semver.Version;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * A task that prepares the next development iteration of an add-on.
+ *
+ * <p>Adds the Unreleased section to the changelog and bumps the version in the build file.
+ */
+public class PrepareAddOnNextDevIter extends DefaultTask {
+
+    private static final String UNRELEASED_SECTION = "## Unreleased";
+    private static final Pattern VERSION_PATTERN = Pattern.compile("## \\[?.+]?.*");
+
+    private final Property<String> currentVersion;
+    private final RegularFileProperty buildFile;
+    private final RegularFileProperty changelog;
+
+    public PrepareAddOnNextDevIter() {
+        ObjectFactory objects = getProject().getObjects();
+        this.currentVersion = objects.property(String.class);
+        this.buildFile = objects.fileProperty();
+        this.changelog = objects.fileProperty();
+    }
+
+    @Input
+    public Property<String> getCurrentVersion() {
+        return currentVersion;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getBuildFile() {
+        return buildFile;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getChangelog() {
+        return changelog;
+    }
+
+    @TaskAction
+    public void prepare() throws IOException {
+        Path updatedChangelog = updateChangelog();
+        Path updatedBuildFile = updateBuildFile();
+
+        Files.copy(
+                updatedChangelog,
+                changelog.getAsFile().get().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(
+                updatedBuildFile,
+                buildFile.getAsFile().get().toPath(),
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private Path updateChangelog() throws IOException {
+        Path changelogPath = changelog.getAsFile().get().toPath();
+        Path updatedChangelog =
+                getTemporaryDir().toPath().resolve("updated-" + changelogPath.getFileName());
+
+        boolean insertUnreleased = true;
+
+        try (BufferedReader reader = Files.newBufferedReader(changelogPath);
+                BufferedWriter writer = Files.newBufferedWriter(updatedChangelog)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (insertUnreleased) {
+                    if (line.startsWith(UNRELEASED_SECTION)) {
+                        throw new InvalidUserDataException(
+                                "The changelog already contains the unreleased section.");
+                    }
+
+                    if (VERSION_PATTERN.matcher(line).find()) {
+                        writer.write(UNRELEASED_SECTION);
+                        writer.write("\n\n\n");
+                        insertUnreleased = false;
+                    }
+                }
+                writer.write(line);
+                writer.write("\n");
+            }
+        }
+
+        if (insertUnreleased) {
+            throw new InvalidUserDataException(
+                    "Failed to insert the unreleased section, no version section found.");
+        }
+
+        return updatedChangelog;
+    }
+
+    private Path updateBuildFile() throws IOException {
+        Path buildFilePath = buildFile.getAsFile().get().toPath();
+        Path updatedBuildFile =
+                getTemporaryDir().toPath().resolve("updated-" + buildFilePath.getFileName());
+
+        String currentVersionLine = versionLine(currentVersion.get());
+        String newVersion = bumpVersion(currentVersion.get());
+
+        boolean updateVersion = true;
+        try (BufferedReader reader = Files.newBufferedReader(buildFilePath);
+                BufferedWriter writer = Files.newBufferedWriter(updatedBuildFile)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (updateVersion && currentVersionLine.equals(line)) {
+                    line = versionLine(newVersion);
+                    updateVersion = false;
+                }
+                writer.write(line);
+                writer.write("\n");
+            }
+        }
+
+        if (updateVersion) {
+            throw new InvalidUserDataException(
+                    "Failed to update the version, current version line not found: "
+                            + currentVersionLine);
+        }
+
+        return updatedBuildFile;
+    }
+
+    private static String versionLine(String version) {
+        return "version = \"" + version + "\"";
+    }
+
+    private static String bumpVersion(String version) {
+        try {
+            int currentVersion = Integer.parseInt(version);
+            return Integer.toString(++currentVersion);
+        } catch (NumberFormatException e) {
+            // Ignore, not an integer version.
+        }
+
+        try {
+            return Version.valueOf(version).incrementMinorVersion().toString();
+        } catch (IllegalArgumentException | ParseException e) {
+            throw new InvalidUserDataException(
+                    "Failed to parse the current version: " + version, e);
+        }
+    }
+}

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/PrepareAddOnRelease.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/PrepareAddOnRelease.java
@@ -1,0 +1,126 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.gradle.tasks;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.regex.Pattern;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * A task that prepares the release of an add-on.
+ *
+ * <p>Replaces the Unreleased section and adds the release link to the changelog.
+ */
+public class PrepareAddOnRelease extends DefaultTask {
+
+    private static final Pattern VERSION_LINK_PATTERN = Pattern.compile("\\[.+]:");
+
+    private final Property<String> version;
+    private final Property<String> releaseLink;
+    private final Property<String> releaseDate;
+    private final RegularFileProperty changelog;
+
+    public PrepareAddOnRelease() {
+        ObjectFactory objects = getProject().getObjects();
+        this.version = objects.property(String.class);
+        this.releaseLink = objects.property(String.class);
+        this.releaseDate = objects.property(String.class).value(LocalDate.now().toString());
+        this.changelog = objects.fileProperty();
+    }
+
+    @Input
+    public Property<String> getVersion() {
+        return version;
+    }
+
+    @Input
+    public Property<String> getReleaseLink() {
+        return releaseLink;
+    }
+
+    @Input
+    public Property<String> getReleaseDate() {
+        return releaseDate;
+    }
+
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public RegularFileProperty getChangelog() {
+        return changelog;
+    }
+
+    @TaskAction
+    public void prepare() throws IOException {
+        Path changelogPath = changelog.getAsFile().get().toPath();
+        Path updatedChangelog =
+                getTemporaryDir().toPath().resolve("updated-" + changelogPath.getFileName());
+
+        boolean insertLink = true;
+        boolean replaceUnreleased = true;
+
+        try (BufferedReader reader = Files.newBufferedReader(changelogPath);
+                BufferedWriter writer = Files.newBufferedWriter(updatedChangelog)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (insertLink && VERSION_LINK_PATTERN.matcher(line).find()) {
+                    writeReleaseLink(writer);
+                    writer.write("\n");
+                    insertLink = false;
+                } else if (replaceUnreleased && line.startsWith("## Unreleased")) {
+                    line = "## [" + version.get() + "] - " + releaseDate.get();
+                    replaceUnreleased = false;
+                }
+                writer.write(line);
+                writer.write("\n");
+            }
+
+            if (insertLink) {
+                writer.write("\n");
+                writeReleaseLink(writer);
+            }
+        }
+
+        if (replaceUnreleased) {
+            throw new InvalidUserDataException("Changelog does not have the unreleased section.");
+        }
+
+        Files.copy(updatedChangelog, changelogPath, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void writeReleaseLink(Writer writer) throws IOException {
+        writer.write("[" + version.get() + "]: " + releaseLink.get());
+    }
+}


### PR DESCRIPTION
Add the following tasks to help with the release process:
 - `prepareAddOnRelease` to update the changelog with the release date
 and link to the GitHub release;
 - `prepareAddOnNextDevIter` to add the unreleased section to changelog
 and bump the version in the build file.