### PR TITLE
wappalyzer: prepare release

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [12] - 2019-04-24
 
 - Switch to using re2j where possible - results in significant performance improvements.
 - Added version information column to Wappalyzer Results.
@@ -60,3 +60,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First version
 
+
+[12]: https://github.com/zaproxy/zap-extensions/releases/wappalyzer-v12

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -7,7 +7,7 @@
 <BODY BGCOLOR="#ffffff">
 <H1>Technology Detection Using Wappalyzer</H1>
 <p>
-The Technology Detection add-on uses the Wappalyzer (http://wappalyzer.com/) rules to detect the technologies used by applications.<p>
+The Technology Detection add-on uses the Wappalyzer rules to detect the technologies used by applications.<p>
 It works in a very similar way to the Wappalyzer browser add-ons with the following exceptions:
 <ul>
 <li>It does not use the 'Global JavaScript variables' as these are difficult to test without a 'full' browser</li>
@@ -23,7 +23,7 @@ Selecting a regex will switch to the 'Search' tab and search through the history
 <table>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-	<td><a href="http://wappalyzer.com/">http://wappalyzer.com/</a></td>
+	<td><a href="https://www.wappalyzer.com/">https://www.wappalyzer.com/</a></td>
 	<td>The Wappalyzer Homepage</td></tr>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>


### PR DESCRIPTION
Add release date and link to tag.
Change help page to use HTTPS for Wappalyzer home page (and link once).