### PR TITLE
Remove ZapVersions configuration

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -146,10 +146,6 @@ subprojects {
             wikiFilesPrefix.set("HelpAddons${zapAddOn.addOnId.get().capitalize()}")
             wikiDir.set(project.provider { project.layout.projectDirectory.dir(if (mainAddOns.contains(zapAddOn.addOnId.get())) zapCoreHelpWikiDir else zapExtensionsWikiDir) })
         }
-
-        zapVersions {
-            downloadUrl.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/download/${zapAddOn.addOnId.get()}-v$version" })
-        }
     }
 }
 


### PR DESCRIPTION
The generation of the ZapVersions.xml data will be done in the zap-admin
repository when needed.