### PR TITLE
httpsinfo Prepare Release

### DIFF
--- a/addOns/httpsInfo/CHANGELOG.md
+++ b/addOns/httpsInfo/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [12] - 2019-04-26
 
 - New tabbed UI.
 - Update to DeepViolet 5.1.16.
@@ -53,3 +53,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 
+[12]: https://github.com/zaproxy/zap-extensions/releases/httpsInfo-v12

--- a/addOns/httpsInfo/httpsInfo.gradle.kts
+++ b/addOns/httpsInfo/httpsInfo.gradle.kts
@@ -8,6 +8,10 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
     }
+
+    wikiGen {
+        wikiFilesPrefix.set("HelpAddonsHttpsinfo")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
* Updated CHANGELOG.md based on `./gradlew :addOns:httpsinfo:pAOR`
* Minor change to httpsInfo.gradle.kts so that wiki generation will work (while httpsinfo uses a different prefix vs other add-ons)