### PR TITLE
Add License to ViewState Scanner

### DIFF
--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanner.java
@@ -1,3 +1,22 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2012 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.zaproxy.zap.extension.pscanrules;
 
 import java.io.IOException;


### PR DESCRIPTION
2012 based on:
https://github.com/zaproxy/zap-extensions/commit/1ae748d5346ace3843648ba7374244fdc4aaa343#diff-e465b5d5344c14fb9a37701810248775

It took me quite a while to track that down. If anyone has advice on searching repo history I'm all ears (Eclipse or CLI).

Edit: I came up with this after going through a bunch of pain via the github web UI: `git log --before="2012-12-31" -Sviewstate` or `git log --before="2012-12-31" -Sviewstate --pretty="%h - %ad - %s"`