### PR TITLE
selenium: ensure ServiceWorkers enabled in Firefox

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove support for Internet Explorer, does not support required capabilities.
 - Quit corresponding WebDrivers when removing WebDriver provider.
+- Enable ServiceWorker on launched Firefox browsers.
 
 ## 14 - 2019-01-31
 

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -685,6 +685,9 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                 firefoxOptions.setBinary(binaryPath);
             }
 
+            // Ensure ServiceWorkers are enabled for the HUD.
+            firefoxOptions.addPreference("dom.serviceWorkers.enabled", true);
+
             // Disable the captive checks/requests, mainly to avoid flooding
             // the AJAX Spider results (those requests are out of scope) but
             // also useful for other launched browsers.


### PR DESCRIPTION
Change `ExtensionSelenium` to enable the ServiceWorkers for Firefox to
allow to use the HUD more easily (in case it's disabled by default).