### PR TITLE
Downgrade source code disclosure to Medium

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correct HTTP message usage in Insecure HTTP Method scanner.
 - Fix missing resource messages with Cross-Domain Misconfiguration scanner.
 - Remove Source Code Disclosure WEB-INF Scanner (promoted to release Issue 4448).
+- Report source code disclosure alerts at Medium instead of High 
 
 ## 24 - 2018-07-31
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
@@ -225,9 +225,9 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
 
     @Override
     public int getRisk() {
-        return Alert
-                .RISK_HIGH; // definitely a High. If we get the source, we don't need to hack the
-        // app any more, because we can just analyse it off-line! Sweet..
+        // If we get the source (and its not open source), we don't need to hack the app any more,
+        // because we can just analyse it off-line! Sweet..
+        return Alert.RISK_MEDIUM;
     }
 
     @Override
@@ -349,7 +349,7 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
                     // if we get to here, is is very likely that we have source file inclusion
                     // attack. alert it.
                     bingo(
-                            Alert.RISK_HIGH,
+                            Alert.RISK_MEDIUM,
                             getConfidence(attackmsgResponseStatusCode),
                             getName(),
                             getDescription(),
@@ -623,7 +623,7 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
                                                 // if we get to here, is is very likely that we have
                                                 // source file inclusion attack. alert it.
                                                 bingo(
-                                                        Alert.RISK_HIGH,
+                                                        Alert.RISK_MEDIUM,
                                                         getConfidence(
                                                                 svnSourceFileAttackMsgStatusCode),
                                                         getName(),

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove X Debug Token Scanner (promoted to beta Issue 4469).
 - Remove X PoweredBy Scanner (promoted to beta Issue 4470).
 - Add scanner for missing Feature Policy header.
+- Report source code disclosure alerts at Medium instead of High 
 
 ## 23 - 2019-02-08
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
@@ -691,7 +691,7 @@ public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
             Alert alert =
                     new Alert(
                             getPluginId(),
-                            Alert.RISK_HIGH,
+                            Alert.RISK_MEDIUM,
                             Alert.CONFIDENCE_MEDIUM,
                             getName() + " - " + programminglanguage);
 


### PR DESCRIPTION
In my view disclosing the source code is not as serious as things like XSS and SQLi. It may well be a serious problem for the company involved but it does not mean that the attacker will definitely be able to find other vulnerabilities, especially if the code is already open source.

Happy to discuss this further if anyone disagrees...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>