### PR TITLE
Websockets: scale fonts and icons correctly

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Validate the Origin for API connections.
 - Generate websocket events.
 - Add break API endpoints.
+- Scale fonts and icons correctly
 
 ## 18 - 2018-08-01
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/OptionsWebSocketPanel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/OptionsWebSocketPanel.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.websocket.ui;
 
 import java.awt.Component;
 import java.awt.FlowLayout;
-import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -30,6 +29,7 @@ import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.zap.utils.FontUtils;
 
 /**
  * The GUI WebSocket options panel.
@@ -87,7 +87,7 @@ public class OptionsWebSocketPanel extends AbstractParamPanel {
     private Component getPanel() {
         JPanel panel = new JPanel(new GridBagLayout());
         panel.setBorder(new EmptyBorder(2, 2, 2, 2));
-        panel.setFont(new Font("Dialog", java.awt.Font.PLAIN, 11));
+        panel.setFont(FontUtils.getFont(FontUtils.Size.standard));
 
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.anchor = GridBagConstraints.WEST;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesView.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesView.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.websocket.ui;
 
 import java.awt.EventQueue;
-import java.awt.Font;
 import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -38,6 +37,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.websocket.WebSocketException;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
+import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.TableColumnManager;
 
 /** Wraps a {@link JXTable} that is used to display WebSocket messages. */
@@ -89,7 +89,7 @@ public class WebSocketMessagesView implements Runnable {
 
             setColumnWidths();
 
-            view.setFont(new Font("Dialog", Font.PLAIN, 12));
+            view.setFont(FontUtils.getFont(FontUtils.Size.standard));
             view.setDoubleBuffered(true);
             view.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
             view.addMouseListener(getMouseListener());

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewFilterDialog.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewFilterDialog.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.websocket.ui;
 
-import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -38,6 +37,7 @@ import javax.swing.KeyStroke;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.DisplayUtils;
 
 /** Filter WebSocket messages in {@link WebSocketPanel}. Show only specific ones. */
 public class WebSocketMessagesViewFilterDialog extends AbstractDialog {
@@ -109,13 +109,16 @@ public class WebSocketMessagesViewFilterDialog extends AbstractDialog {
         if (dialogPanel == null) {
             dialogPanel = new JPanel();
             dialogPanel.setLayout(new GridBagLayout());
-            dialogPanel.setPreferredSize(new Dimension(wsUiHelper.getDialogWidth() + 20, 360));
+            dialogPanel.setPreferredSize(
+                    DisplayUtils.getScaledDimension(wsUiHelper.getDialogWidth() + 20, 360));
 
             int y = 0;
 
             JLabel description = new JLabel(MSG);
-            description.setPreferredSize(new Dimension(wsUiHelper.getDialogWidth() - 20, 60));
-            description.setMaximumSize(new Dimension(wsUiHelper.getDialogWidth() - 20, 100));
+            description.setPreferredSize(
+                    DisplayUtils.getScaledDimension(wsUiHelper.getDialogWidth() - 20, 60));
+            description.setMaximumSize(
+                    DisplayUtils.getScaledDimension(wsUiHelper.getDialogWidth() - 20, 100));
             dialogPanel.add(description, wsUiHelper.getDescriptionConstraints(0, y++));
 
             // add opcode selection
@@ -126,7 +129,7 @@ public class WebSocketMessagesViewFilterDialog extends AbstractDialog {
 
             JScrollPane opcodeListScrollPane = wsUiHelper.getOpcodeMultipleSelect();
             opcodeListScrollPane.setPreferredSize(
-                    new Dimension(wsUiHelper.getDialogWidth() - 200, 120));
+                    DisplayUtils.getScaledDimension(wsUiHelper.getDialogWidth() - 200, 120));
             dialogPanel.add(opcodeListScrollPane, constraints);
 
             // add title for upcoming WebSocket specific options

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.websocket.ui;
 
 import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -65,6 +64,7 @@ import org.zaproxy.zap.extension.websocket.WebSocketProxy.State;
 import org.zaproxy.zap.extension.websocket.brk.WebSocketBreakpointsUiManagerInterface;
 import org.zaproxy.zap.extension.websocket.db.TableWebSocket;
 import org.zaproxy.zap.extension.websocket.db.WebSocketStorage;
+import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.StickyScrollbarAdjustmentListener;
 import org.zaproxy.zap.view.ZapToggleButton;
 
@@ -95,21 +95,26 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
         connectedChannelIds = new HashSet<>();
 
         disconnectIcon =
-                new ImageIcon(
-                        WebSocketPanel.class.getResource(
-                                "/resource/icon/fugue/plug-disconnect.png"));
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(
+                                WebSocketPanel.class.getResource(
+                                        "/resource/icon/fugue/plug-disconnect.png")));
         connectIcon =
-                new ImageIcon(
-                        WebSocketPanel.class.getResource("/resource/icon/fugue/plug-connect.png"));
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(
+                                WebSocketPanel.class.getResource(
+                                        "/resource/icon/fugue/plug-connect.png")));
 
         disconnectTargetIcon =
-                new ImageIcon(
-                        WebSocketPanel.class.getResource(
-                                "/resource/icon/fugue/plug-disconnect-target.png"));
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(
+                                WebSocketPanel.class.getResource(
+                                        "/resource/icon/fugue/plug-disconnect-target.png")));
         connectTargetIcon =
-                new ImageIcon(
-                        WebSocketPanel.class.getResource(
-                                "/resource/icon/fugue/plug-connect-target.png"));
+                DisplayUtils.getScaledIcon(
+                        new ImageIcon(
+                                WebSocketPanel.class.getResource(
+                                        "/resource/icon/fugue/plug-connect-target.png")));
     };
 
     private JToolBar panelToolbar = null;
@@ -219,7 +224,7 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
             panelToolbar.setEnabled(true);
             panelToolbar.setFloatable(false);
             panelToolbar.setRollover(true);
-            panelToolbar.setPreferredSize(new java.awt.Dimension(800, 30));
+            panelToolbar.setPreferredSize(DisplayUtils.getScaledDimension(800, 30));
             panelToolbar.setFont(new java.awt.Font("Dialog", java.awt.Font.PLAIN, 12));
             panelToolbar.setName("websocket.toolbar");
 
@@ -316,7 +321,10 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
             optionsButton.setToolTipText(
                     Constant.messages.getString("websocket.toolbar.button.options"));
             optionsButton.setIcon(
-                    new ImageIcon(WebSocketPanel.class.getResource("/resource/icon/16/041.png")));
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    WebSocketPanel.class.getResource(
+                                            "/resource/icon/16/041.png"))));
             optionsButton.addActionListener(
                     new ActionListener() {
                         @Override
@@ -334,9 +342,10 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
         if (filterButton == null) {
             filterButton = new JButton();
             filterButton.setIcon(
-                    new ImageIcon(
-                            WebSocketPanel.class.getResource(
-                                    "/resource/icon/16/054.png"))); // 'filter' icon
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    WebSocketPanel.class.getResource(
+                                            "/resource/icon/16/054.png")))); // 'filter' icon
             filterButton.setToolTipText(
                     Constant.messages.getString("websocket.filter.button.filter"));
 
@@ -367,8 +376,10 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
             handshakeButton = new JButton();
             handshakeButton.setEnabled(false);
             handshakeButton.setIcon(
-                    new ImageIcon(
-                            WebSocketPanel.class.getResource("/resource/icon/16/handshake.png")));
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    WebSocketPanel.class.getResource(
+                                            "/resource/icon/16/handshake.png"))));
             handshakeButton.setToolTipText(
                     Constant.messages.getString("websocket.filter.button.handshake"));
 
@@ -417,8 +428,10 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
         if (brkButton == null) {
             brkButton = new JButton();
             brkButton.setIcon(
-                    new ImageIcon(
-                            WebSocketPanel.class.getResource("/resource/icon/16/break_add.png")));
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    WebSocketPanel.class.getResource(
+                                            "/resource/icon/16/break_add.png"))));
             brkButton.setToolTipText(
                     Constant.messages.getString("websocket.filter.button.break_add"));
 
@@ -447,7 +460,7 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
             // updates viewport only when scrollbar is released
 
             scrollPanel = new JScrollPane(messagesView.getViewComponent());
-            scrollPanel.setPreferredSize(new Dimension(800, 200));
+            scrollPanel.setPreferredSize(DisplayUtils.getScaledDimension(800, 200));
             scrollPanel.setName("WebSocketPanelActions");
 
             scrollPanel
@@ -783,10 +796,15 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
         if (scopeButton == null) {
             scopeButton = new ZapToggleButton();
             scopeButton.setIcon(
-                    new ImageIcon(
-                            LogPanel.class.getResource("/resource/icon/fugue/target-grey.png")));
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    LogPanel.class.getResource(
+                                            "/resource/icon/fugue/target-grey.png"))));
             scopeButton.setSelectedIcon(
-                    new ImageIcon(LogPanel.class.getResource("/resource/icon/fugue/target.png")));
+                    DisplayUtils.getScaledIcon(
+                            new ImageIcon(
+                                    LogPanel.class.getResource(
+                                            "/resource/icon/fugue/target.png"))));
             scopeButton.setToolTipText(
                     Constant.messages.getString("history.scope.button.unselected"));
             scopeButton.setSelectedToolTipText(

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketUiHelper.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketUiHelper.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.websocket.ui;
 
-import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.event.ItemEvent;
@@ -43,6 +42,7 @@ import org.zaproxy.zap.extension.websocket.WebSocketChannelDTO;
 import org.zaproxy.zap.extension.websocket.WebSocketMessage;
 import org.zaproxy.zap.extension.websocket.WebSocketMessage.Direction;
 import org.zaproxy.zap.extension.websocket.utility.WebSocketUtils;
+import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 
 public class WebSocketUiHelper {
@@ -640,7 +640,7 @@ public class WebSocketUiHelper {
 
     public JComponent createVerticalSeparator() {
         JSeparator x = new JSeparator(SwingConstants.VERTICAL);
-        x.setPreferredSize(new Dimension(20, 20));
+        x.setPreferredSize(DisplayUtils.getScaledDimension(20, 20));
         return x;
     }
 }


### PR DESCRIPTION
The websockets tab does not scale correctly when a user defined font size is specified, this is particularly obvious when using a high DPI display.
To test configure ZAP to use a much larger font size - without this change the text and icons in the Websockets tab are not correctly scaled.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>