### PR TITLE
gettingStarted: set minimum ZAP version to 2.8.0

### DIFF
--- a/addOns/gettingStarted/gettingStarted.gradle.kts
+++ b/addOns/gettingStarted/gettingStarted.gradle.kts
@@ -10,5 +10,6 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
+        notBeforeVersion.set("2.8.0")
     }
 }


### PR DESCRIPTION
The guide is already targeting the newer version.