### PR TITLE
selenium: proxy "localhost" in Firefox 67

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove support for Internet Explorer, does not support required capabilities.
 - Quit corresponding WebDrivers when removing WebDriver provider.
 - Enable ServiceWorker on launched Firefox browsers.
+- Ensure "localhost" is proxied through ZAP on Firefox >= 67.
 
 ## 14 - 2019-01-31
 

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -735,6 +735,9 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                     firefoxOptions.setBinary(binaryPath);
                 }
 
+                // Keep proxying localhost on Firefox >= 67
+                firefoxOptions.addPreference("network.proxy.allow_hijacking_localhost", true);
+
                 // Ensure ServiceWorkers are enabled for the HUD.
                 firefoxOptions.addPreference("dom.serviceWorkers.enabled", true);
 


### PR DESCRIPTION
Change ExtensionSelenium to add a preference to FirefoxOptions to keep
proxying localhost with newer Firefox versions.