### PR TITLE
Bundle JDOM in sqliplugin and cmss

### DIFF
--- a/addOns/cmss/CHANGELOG.md
+++ b/addOns/cmss/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Update minimum ZAP version to 2.5.0.
+- Bundle JDOM library instead of relying on core.
 
 ## 2 - 2017-11-28
 

--- a/addOns/cmss/cmss.gradle.kts
+++ b/addOns/cmss/cmss.gradle.kts
@@ -12,6 +12,7 @@ zapAddOn {
 
 dependencies {
     implementation("com.googlecode.json-simple:json-simple:1.1.1")
+    implementation("org.jdom:jdom:1.1.3")
     implementation("org.jsoup:jsoup:1.7.2")
 
     testImplementation(project(":testutils"))

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Update minimum ZAP version to 2.5.0.
+- Bundle JDOM library instead of relying on core.
 
 ## 12 - 2017-11-27
 

--- a/addOns/sqliplugin/sqliplugin.gradle.kts
+++ b/addOns/sqliplugin/sqliplugin.gradle.kts
@@ -13,6 +13,10 @@ zapAddOn {
     }
 }
 
+dependencies {
+    implementation("org.jdom:jdom:1.1.3")
+}
+
 spotless {
     javaWith3rdPartyFormatted(project, listOf(
         "**/DBMSHelper.java",


### PR DESCRIPTION
Change sqliplugin and cmss to depend on JDOM to bundle the dependency
in the add-on instead of using the one from core, which will be removed.

Related to zaproxy/zaproxy#5374 - Remove usage of JDOM library