### PR TITLE
xxeplugin: Fixing ArrayIndexOutOfBoundsException and remove original xml header

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixed ArrayIndexOutOfBoundsException issue in XML External Entity Attack scan rule.
+  - Now removes original XML header in "Local File Reflection Attack".
 
 ## [26] - 2019-07-11
 

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XXEPluginTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XXEPluginTest.java
@@ -1,0 +1,109 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesBeta;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class XXEPluginTest extends ActiveScannerTest<XXEPlugin> {
+
+    @Override
+    protected XXEPlugin createScanner() {
+        return new XXEPlugin();
+    }
+
+    @Test
+    public void replaceElementAndRemoveHeader() {
+        // Given
+        String requestBody = "<?xml version=\"1.0\"?><comment><text>\ntest\n</text></comment>";
+        // When
+        String payload = XXEPlugin.createLfrPayload(requestBody);
+        // Then
+        String expectedPayload =
+                XXEPlugin.ATTACK_HEADER + "<comment><text>&zapxxe;</text></comment>";
+        assertThat(payload, is(expectedPayload));
+    }
+
+    @Test
+    public void doNotReplaceAttributes() {
+        // Given
+        String requestBody =
+                "<?xml version=\"1.0\"?><comment><text abc=\"123\">test</text></comment>";
+        // When
+        String payload = XXEPlugin.createLfrPayload(requestBody);
+        // Then
+        String expectedPayload =
+                XXEPlugin.ATTACK_HEADER + "<comment><text abc=\"123\">&zapxxe;</text></comment>";
+        assertThat(payload, is(expectedPayload));
+    }
+
+    @Test
+    public void replaceMultipleElementsAndRemoveHeader() {
+        // Given
+        String requestBody =
+                "\n"
+                        + "<?xml version=\"1.0\"?>\n"
+                        + "<comments>\n"
+                        + "    <comment>\n"
+                        + "    <text>test\n"
+                        + "    </text>\n"
+                        + "    </comment>\n"
+                        + "\n"
+                        + "    <comment>\n"
+                        + "    <text>   test   </text>\n"
+                        + "    </comment>\n"
+                        + "    <comment>\n"
+                        + "\n"
+                        + "<otherValue>A</otherValue>\n"
+                        + "<otherValue>B</otherValue>\n"
+                        + "<otherValue>C</otherValue>\n"
+                        + "\n"
+                        + "<otherValue>D</otherValue>\n"
+                        + "    </comment>\n"
+                        + "</comments>";
+        // When
+        String payload = XXEPlugin.createLfrPayload(requestBody);
+        // Then
+        String expectedPayload =
+                XXEPlugin.ATTACK_HEADER
+                        + "\n"
+                        + "\n"
+                        + "<comments>\n"
+                        + "    <comment>\n"
+                        + "    <text>&zapxxe;</text>\n"
+                        + "    </comment>\n"
+                        + "\n"
+                        + "    <comment>\n"
+                        + "    <text>&zapxxe;</text>\n"
+                        + "    </comment>\n"
+                        + "    <comment>\n"
+                        + "\n"
+                        + "<otherValue>&zapxxe;</otherValue>\n"
+                        + "<otherValue>&zapxxe;</otherValue>\n"
+                        + "<otherValue>&zapxxe;</otherValue>\n"
+                        + "\n"
+                        + "<otherValue>&zapxxe;</otherValue>\n"
+                        + "    </comment>\n"
+                        + "</comments>";
+        assertThat(payload, is(expectedPayload));
+    }
+}


### PR DESCRIPTION
Fixing ArrayIndexOutOfBoundsException in xxeplugin. There must be a LOCAL_FILE_PATTERNS entry for each LOCAL_FILE_TARGETS entry

Remove XXEPlugin now removes original xml header in Local File Reflection Attack. Added some tests for replacing values with payloads in xml