### PR TITLE
Bundle Diff Utils in ascanrules/Beta and diff

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Maintenance changes.
 - Promote Source Code Disclosure WEB-INF (Issue 4448).
+- Bundle Diff Utils library instead of relying on core. 
 
 ## 32 - 2018-10-04
 

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -14,6 +14,7 @@ zapAddOn {
 }
 
 dependencies {
+    implementation("com.googlecode.java-diff-utils:diffutils:1.2.1")
     implementation("org.bitbucket.mstrobel:procyon-compilertools:0.5.25")
 
     testImplementation(project(":testutils"))

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix missing resource messages with Cross-Domain Misconfiguration scanner.
 - Remove Source Code Disclosure WEB-INF Scanner (promoted to release Issue 4448).
 - Report source code disclosure alerts at Medium instead of High 
+- Bundle Diff Utils library instead of relying on core.
 
 ## 24 - 2018-07-31
 

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -14,6 +14,8 @@ zapAddOn {
 }
 
 dependencies {
+    implementation("com.googlecode.java-diff-utils:diffutils:1.2.1")
+
     testImplementation(project(":testutils"))
     testImplementation("org.apache.commons:commons-lang3:3.5")
 }

--- a/addOns/diff/CHANGELOG.md
+++ b/addOns/diff/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Maintenance changes.
+- Bundle Diff Utils library instead of relying on core.
 
 ## 8 - 2017-11-27
 

--- a/addOns/diff/diff.gradle.kts
+++ b/addOns/diff/diff.gradle.kts
@@ -13,6 +13,10 @@ zapAddOn {
     }
 }
 
+dependencies {
+    implementation("com.googlecode.java-diff-utils:diffutils:1.2.1")
+}
+
 spotless {
     java {
         target(fileTree(projectDir) {


### PR DESCRIPTION
Change ascanrules, ascanrulesBeta, and diff to depend on Diff Utils to
bundle the dependency in the add-on instead of using the one from core,
which will be removed.

Related to zaproxy/zaproxy#5380 - Set Diff Utils as a runtime only
dependency