### PR TITLE
testutils: correct count of messages sent

### DIFF
--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
@@ -145,20 +145,17 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
 
                     @Override
                     public void notifyNewMessage(HttpMessage msg) {
-                        super.notifyNewMessage(msg);
                         httpMessagesSent.add(msg);
                         countMessagesSent++;
                     }
 
                     @Override
                     public void notifyNewMessage(Plugin plugin) {
-                        super.notifyNewMessage(plugin);
                         countMessagesSent++;
                     }
 
                     @Override
                     public void notifyNewMessage(Plugin plugin, HttpMessage msg) {
-                        super.notifyNewMessage(plugin, msg);
                         httpMessagesSent.add(msg);
                         countMessagesSent++;
                     }


### PR DESCRIPTION
Do not call base methods when being notified of a new message otherwise
it would count same message twice (base implementation calls one of the
other methods).