### PR TITLE
Allow to use Chrome/Firefox headless and use Firefox headless by default

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
-
+### Changed
+- Run with Firefox headless by default (Issue 3866).
+- Depend on newer version of Selenium add-on.
 
 ## 7 - 2018-03-07
 

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -16,7 +16,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("selenium") {
-                    semVer.set("2.*")
+                    version.set("15.*")
                 }
             }
         }

--- a/addOns/domxss/src/main/javahelp/org/zaproxy/zap/extension/domxss/resources/help/contents/domxss.html
+++ b/addOns/domxss/src/main/javahelp/org/zaproxy/zap/extension/domxss/resources/help/contents/domxss.html
@@ -11,11 +11,12 @@ DOM XSS Active Scan Rule
 An Active Scan rule for detecting DOM XSS vulnerabilities.
 <p>
 It launches browser windows and sends attack payloads to all of the relevant DOM elements.<br>
-As it launches browser windows it is not suitable for headless environments,
-and will take significantly longer than other (non browser based) rules. 
+As it launches browser windows it will take significantly longer than other (non browser based) rules. 
 </p>
 <p>
-This version only supports Firefox.<br>
+This version only supports Firefox. It can be run with GUI or headless (default), it can be changed with
+the rule <code>rules.domxss.browserid</code>, via the Options 'Rule configuration' panel, with values
+<code>firefox</code> and <code>firefox-headless</code>, respectively.<br>
 Future versions may support other browsers.
 </p>
 <p>

--- a/addOns/jxbrowsers/jxbrowser/CHANGELOG.md
+++ b/addOns/jxbrowsers/jxbrowser/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on newer version of Selenium add-on.
 
 ## [13] - 2019-04-18
 

--- a/addOns/jxbrowsers/jxbrowserlinux64/CHANGELOG.md
+++ b/addOns/jxbrowsers/jxbrowserlinux64/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on newer version of Selenium add-on.
 
 ## [11] - 2019-04-18
 

--- a/addOns/jxbrowsers/jxbrowsermacos/CHANGELOG.md
+++ b/addOns/jxbrowsers/jxbrowsermacos/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on newer version of Selenium add-on.
 
 ## [11] - 2019-04-18
 

--- a/addOns/jxbrowsers/jxbrowsers.gradle.kts
+++ b/addOns/jxbrowsers/jxbrowsers.gradle.kts
@@ -103,7 +103,7 @@ subprojects {
                             dependencies {
                                 addOns {
                                     register("selenium") {
-                                        semVer.set(" >=2.0.0 & <3.0.0 ")
+                                        version.set("15.*")
                                     }
                                 }
                             }

--- a/addOns/jxbrowsers/jxbrowserwindows/CHANGELOG.md
+++ b/addOns/jxbrowsers/jxbrowserwindows/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on newer version of Selenium add-on.
 
 ## [11] - 2019-04-18
 

--- a/addOns/jxbrowsers/jxbrowserwindows64/CHANGELOG.md
+++ b/addOns/jxbrowsers/jxbrowserwindows64/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Depend on newer version of Selenium add-on.
 
 ## [4] - 2019-04-18
 

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improve outgoing proxy failure error message (Issue 5304).
 - Introduce News panel and use default quick start page 
 - Dont make news request if -silent option used
+- Allow to use headless browsers in automated scans, use Firefox headless by default (Issue 3866).
+- Depend on newer version of Selenium add-on.
 
 ## 25 - 2018-12-11
 

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -18,10 +18,10 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("selenium") {
-                            semVer.set("2.*")
+                            version.set("15.*")
                         }
                         register("spiderAjax") {
-                            semVer.set("23.*")
+                            version.set("23.*")
                         }
                     }
                 }
@@ -33,7 +33,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("hud") {
-                            semVer.set(">= 0.4.0")
+                            version.set(">= 0.4.0")
                         }
                     }
                 }
@@ -45,7 +45,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("selenium") {
-                            semVer.set("2.*")
+                            version.set("15.*")
                         }
                     }
                 }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
@@ -24,6 +24,7 @@ import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.URI;
+import java.util.Optional;
 import javax.swing.Box;
 import javax.swing.ComboBoxModel;
 import javax.swing.JCheckBox;
@@ -34,6 +35,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.zaproxy.zap.extension.quickstart.PlugableSpider;
 import org.zaproxy.zap.extension.quickstart.QuickStartParam;
+import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ProvidedBrowserUI;
 import org.zaproxy.zap.extension.selenium.ProvidedBrowsersComboBoxModel;
 import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderParam;
@@ -107,7 +109,6 @@ public class AjaxSpiderExplorer implements PlugableSpider {
             browserComboBox = new JComboBox<ProvidedBrowserUI>();
             ProvidedBrowsersComboBoxModel model =
                     extension.getExtSelenium().createProvidedBrowsersComboBoxModel();
-            model.setIncludeHeadless(false);
             model.setIncludeUnconfigured(false);
             browserComboBox.setModel(model);
             browserComboBox.addActionListener(
@@ -122,6 +123,15 @@ public class AjaxSpiderExplorer implements PlugableSpider {
                                             browserComboBox.getSelectedItem().toString());
                         }
                     });
+
+            String defaultBrowserId = Browser.FIREFOX_HEADLESS.getId();
+            Optional<ProvidedBrowserUI> defaultItem =
+                    extension.getExtSelenium().getProvidedBrowserUIList().stream()
+                            .filter(e -> defaultBrowserId.equals(e.getBrowser().getId()))
+                            .findFirst();
+            if (defaultItem.isPresent()) {
+                browserComboBox.setSelectedItem(defaultItem.get());
+            }
         }
         return browserComboBox;
     }

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 All notable changes to this add-on will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
@@ -9,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Quit corresponding WebDrivers when removing WebDriver provider.
 - Enable ServiceWorker on launched Firefox browsers.
 - Ensure "localhost" is proxied through ZAP on Firefox >= 67.
+- Allow to start Chrome and Firefox in headless mode (Issue 3866).
+- Start using Semantic Versioning.
 
 ## 14 - 2019-01-31
 

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -1,6 +1,6 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "15"
+version = "15.0.0"
 description = "WebDriver provider and includes HtmlUnit browser"
 
 zapAddOn {
@@ -9,7 +9,6 @@ zapAddOn {
     zapVersion.set("2.7.0")
 
     manifest {
-        semVer.set("2.0.0")
         author.set("ZAP Dev Team")
     }
 

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
@@ -35,7 +35,9 @@ import org.parosproxy.paros.Constant;
 /** Defines the browsers supported by the add-on. */
 public enum Browser {
     CHROME("chrome", false),
+    CHROME_HEADLESS("chrome-headless", true),
     FIREFOX("firefox", false),
+    FIREFOX_HEADLESS("firefox-headless", true),
     /**
      * Headless browser, guaranteed to be always available.
      *
@@ -108,8 +110,12 @@ public enum Browser {
 
         if (CHROME.id.equals(id)) {
             return CHROME;
+        } else if (CHROME_HEADLESS.id.equals(id)) {
+            return CHROME_HEADLESS;
         } else if (FIREFOX.id.equals(id)) {
             return FIREFOX;
+        } else if (FIREFOX_HEADLESS.id.equals(id)) {
+            return FIREFOX_HEADLESS;
         } else if (HTML_UNIT.id.equals(id)) {
             return HTML_UNIT;
         } else if (INTERNET_EXPLORER.id.equals(id)) {
@@ -224,8 +230,10 @@ public enum Browser {
     private static String getWebDriverName(Browser browser) {
         switch (browser) {
             case CHROME:
+            case CHROME_HEADLESS:
                 return "chromedriver";
             case FIREFOX:
+            case FIREFOX_HEADLESS:
                 return "geckodriver";
             default:
                 return null;

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ExtensionSelenium.java
@@ -150,7 +150,9 @@ public class ExtensionSelenium extends ExtensionAdaptor {
         providedBrowsers = Collections.synchronizedMap(new HashMap<String, ProvidedBrowser>());
 
         addBuiltInProvider(Browser.CHROME);
+        addBuiltInProvider(Browser.CHROME_HEADLESS);
         addBuiltInProvider(Browser.FIREFOX);
+        addBuiltInProvider(Browser.FIREFOX_HEADLESS);
         addBuiltInProvider(Browser.HTML_UNIT);
         addBuiltInProvider(Browser.PHANTOM_JS);
         addBuiltInProvider(Browser.SAFARI);
@@ -717,11 +719,14 @@ public class ExtensionSelenium extends ExtensionAdaptor {
             int requester, Browser browser, String proxyAddress, int proxyPort) {
         switch (browser) {
             case CHROME:
+            case CHROME_HEADLESS:
                 ChromeOptions chromeOptions = new ChromeOptions();
                 setCommonOptions(chromeOptions, proxyAddress, proxyPort);
                 chromeOptions.addArguments("--proxy-bypass-list=<-loopback>");
+                chromeOptions.setHeadless(browser == Browser.CHROME_HEADLESS);
                 return new ChromeDriver(chromeOptions);
             case FIREFOX:
+            case FIREFOX_HEADLESS:
                 FirefoxOptions firefoxOptions = new FirefoxOptions();
                 setCommonOptions(firefoxOptions, proxyAddress, proxyPort);
 
@@ -768,6 +773,7 @@ public class ExtensionSelenium extends ExtensionAdaptor {
                     firefoxOptions.setCapability(CapabilityType.PROXY, (Object) null);
                 }
 
+                firefoxOptions.setHeadless(browser == Browser.FIREFOX_HEADLESS);
                 return new FirefoxDriver(firefoxOptions);
             case HTML_UNIT:
                 DesiredCapabilities htmlunitCapabilities = new DesiredCapabilities();

--- a/addOns/selenium/src/main/javahelp/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
+++ b/addOns/selenium/src/main/javahelp/org/zaproxy/zap/extension/selenium/resources/help/contents/intro.html
@@ -33,6 +33,11 @@
 			</td>
 		</tr>
 		<tr>
+			<td>Chrome Headless</td>
+			<td>chrome-headless</td>
+			<td>Starts Chrome without GUI.</td>
+		</tr>
+		<tr>
 			<td>Firefox</td>
 			<td>firefox</td>
 			<td>The following versions are known to work: 45 (ESR), 46, 47.0.1, 54, and 55 (older
@@ -42,6 +47,11 @@
 				href="https://github.com/mozilla/geckodriver">geckodriver website</a> (see footer note
 				for caveat when using geckodriver).
 			</td>
+		</tr>
+		<tr>
+			<td>Firefox Headless</td>
+			<td>firefox-headless</td>
+			<td>Starts Firefox without GUI.</td>
 		</tr>
 		<tr>
 			<td>HtmlUnit</td>

--- a/addOns/selenium/src/main/resources/org/zaproxy/zap/extension/selenium/resources/Messages.properties
+++ b/addOns/selenium/src/main/resources/org/zaproxy/zap/extension/selenium/resources/Messages.properties
@@ -3,7 +3,9 @@ selenium.extension.ui.name = WebDriver Provider
 selenium.extension.desc = Provides WebDrivers to control several browsers using Selenium and includes HtmlUnit browser.
 
 selenium.browser.name.chrome = Chrome
+selenium.browser.name.chrome-headless = Chrome Headless
 selenium.browser.name.firefox = Firefox
+selenium.browser.name.firefox-headless = Firefox Headless
 selenium.browser.name.htmlunit = HtmlUnit
 selenium.browser.name.ie  = Internet Explorer
 selenium.browser.name.opera = Opera

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Correct WebDriver requester ID.
 - Remove unused resource messages.
 - Generate start and stop events.
+- Run with Firefox headless by default (Issue 3866).
+- Depend on newer version of Selenium add-on.
 
 ## 22 - 2018-08-08
 

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -18,7 +18,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("selenium") {
-                    semVer.set("2.*")
+                    version.set("15.*")
                 }
             }
         }

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -135,7 +135,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
 
     private static final int DEFAULT_RELOAD_WAIT_TIME = 1000;
 
-    private static final String DEFAULT_BROWSER_ID = Browser.FIREFOX.getId();
+    private static final String DEFAULT_BROWSER_ID = Browser.FIREFOX_HEADLESS.getId();
 
     private static final boolean DEFAULT_CLICK_DEFAULT_ELEMS = true;
 

--- a/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/options.html
+++ b/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/options.html
@@ -31,7 +31,7 @@
 			<td>AJAX Spider relies on an external browser to crawl the targeted site. You can
 				specify which one you want to use. For more details on supported browsers refer to
 				"Selenium" add-on help pages.</td>
-			<td align="center">Firefox</td>
+			<td align="center">Firefox Headless</td>
 		</tr>
 		<tr>
 			<td>Number of Browser Windows to Open</td>

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Rely on script context writer for script output.
 - Correct message handling in HTTP Sender scripts.
 - Remove Scripts tree selection listener when add-on is uninstalled.
+- Depend on newer version of Selenium add-on.
 
 ## 28 - 2018-11-07
 

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -25,7 +25,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("selenium") {
-                    semVer.set(" >=2.0.0 & <3.0.0 ")
+                    version.set("15.*")
                 }
             }
         }


### PR DESCRIPTION
Change Selenium add-on to provide Chrome and Firefox headless, also, use semantic versioning.
Change AJAX Spider, DOM XSS, and Quick Start (AJAX Spider) to run with Firefox headless by default.
Change Zest and JxBrowser add-ons to depend on newer Selenium version.

Fix zaproxy/zaproxy#3866.