### PR TITLE
webdrivers: update ChromeDriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [10] - 2019-06-07
+### Changed
+- Update ChromeDriver to v75.0.3770.8.
 
 ## [9] - 2019-05-28
 
@@ -54,5 +55,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[10]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v10
 [9]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v9
 [8]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v8

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,7 +9,7 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 74.0.3729.6</li>
+    <li>Chrome - ChromeDriver 75.0.3770.8</li>
     <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [10] - 2019-06-07
+### Changed
+- Update ChromeDriver to v75.0.3770.8.
 
 ## [9] - 2019-05-28
 
@@ -54,5 +55,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[10]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v10
 [9]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v9
 [8]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v8

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,7 +9,7 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 74.0.3729.6</li>
+    <li>Chrome - ChromeDriver 75.0.3770.8</li>
     <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.24.0"
-val chromeDriverVersion = "74.0.3729.6"
+val chromeDriverVersion = "75.0.3770.8"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [10] - 2019-06-07
+### Changed
+- Update ChromeDriver to v75.0.3770.8.
 
 ## [9] - 2019-05-28
 
@@ -57,5 +58,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[10]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v10
 [9]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v9
 [8]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v8

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,7 +9,7 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 74.0.3729.6</li>
+    <li>Chrome - ChromeDriver 75.0.3770.8</li>
     <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 


### PR DESCRIPTION
Update ChromeDriver to 75.0.3770.8.
Add release dates and link to tags.