### PR TITLE
domxss: correct default when no browser specified

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [9] - 2019-06-12
+### Fixed
+- Use default browser when no browser is specified in the configuration rule.
 
 ## [8] - 2019-06-07
 ### Changed
@@ -40,5 +41,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 1 - 2015-08-24
 
 
-
+[9]: https://github.com/zaproxy/zap-extensions/releases/domxss-v9
 [8]: https://github.com/zaproxy/zap-extensions/releases/domxss-v8

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/TestDomXSS.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/TestDomXSS.java
@@ -165,7 +165,9 @@ public class TestDomXSS extends AbstractAppParamPlugin {
 
         try {
             String browserId = this.getConfig().getString(RULE_BROWSER_ID, DEFAULT_BROWSER.getId());
-            browser = Browser.getBrowserWithIdNoFailSafe(browserId);
+            if (browserId != null && !browserId.isEmpty()) {
+                browser = Browser.getBrowserWithIdNoFailSafe(browserId);
+            }
         } catch (ConversionException e) {
             log.debug(
                     "Invalid value for '"

--- a/addOns/domxss/src/main/javahelp/org/zaproxy/zap/extension/domxss/resources/help/contents/about.html
+++ b/addOns/domxss/src/main/javahelp/org/zaproxy/zap/extension/domxss/resources/help/contents/about.html
@@ -16,6 +16,11 @@ Aabha Biyani, and the ZAP Dev Team
 
 <H2>History</H2>
 
+<H3>Version 9 - 2019-06-12</H3>
+<ul>
+	<li>Use default browser when no browser is specified in the configuration rule.</li>
+</ul>
+
 <H3>Version 8 - 2019-06-07</H3>
 <ul>
 	<li>Run with Firefox headless by default (Issue 3866).</li>


### PR DESCRIPTION
Don't try to get a browser if there's no ID in the configuration rule
(it would lead to an exception), instead use the default.
Prepare add-on release.