### PR TITLE
Use newer ZAP version for API generation

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -1,6 +1,7 @@
 import java.nio.charset.StandardCharsets
 import org.zaproxy.gradle.addon.AddOnPlugin
 import org.zaproxy.gradle.addon.AddOnPluginExtension
+import org.zaproxy.gradle.addon.apigen.ApiClientGenExtension
 import org.zaproxy.gradle.addon.manifest.ManifestExtension
 import org.zaproxy.gradle.addon.misc.ConvertMarkdownToHtml
 import org.zaproxy.gradle.addon.misc.CreateGitHubRelease
@@ -68,6 +69,8 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
+    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.8.0"))
+
     zapAddOn {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })
 
@@ -78,6 +81,13 @@ subprojects {
         wikiGen {
             wikiFilesPrefix.set("HelpAddons${zapAddOn.addOnId.get().capitalize()}")
             wikiDir.set(project.provider { project.layout.projectDirectory.dir(if (addOnsInZapCoreHelp.contains(zapAddOn.addOnId.get())) zapCoreHelpWikiDir else zapExtensionsWikiDir) })
+        }
+
+        apiClientGen {
+            classpath.run {
+                setFrom(apiGenClasspath)
+                from(tasks.named(JavaPlugin.JAR_TASK_NAME))
+            }
         }
     }
 }
@@ -139,6 +149,9 @@ fun AddOnPluginExtension.manifest(configure: ManifestExtension.() -> Unit): Unit
 
 fun AddOnPluginExtension.wikiGen(configure: WikiGenExtension.() -> Unit): Unit =
     (this as ExtensionAware).extensions.configure("wikiGen", configure)
+
+fun AddOnPluginExtension.apiClientGen(configure: ApiClientGenExtension.() -> Unit): Unit =
+    (this as ExtensionAware).extensions.configure("apiClientGen", configure)
 
 open class ValidateDeclaredAddOns : DefaultTask() {
 

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -24,10 +24,19 @@ zapAddOn {
         }
     }
 
+    val apiGenClasspath = configurations.detachedConfiguration(
+        dependencies.create("org.zaproxy:zap:2.8.0"),
+        dependencies.create(parent!!.childProjects.get("selenium")!!)
+    )
+
     apiClientGen {
         api.set("org.zaproxy.zap.extension.spiderAjax.AjaxSpiderAPI")
         options.set("org.zaproxy.zap.extension.spiderAjax.AjaxSpiderParam")
         messages.set(file("src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties"))
+        classpath.run {
+            setFrom(apiGenClasspath)
+            from(tasks.named(JavaPlugin.JAR_TASK_NAME))
+        }
     }
 }
 


### PR DESCRIPTION
Configure the build to use 2.8.0 for API generation.
Fix AJAX Spider API generation (missing Selenium dependency).