### PR TITLE
regextester: close dialog when unloading extension

### DIFF
--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+ - Close dialogues when the add-on is uninstalled.
 
 ## [1] - 2019-06-19
 


### PR DESCRIPTION
Make sure that nothing is left open after the add-on is uninstalled.