### PR TITLE
Fix Issue 5444 - Sessions Fixation Scan Rule NPE

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Fix FP in "Source Code Disclosure SVN" where the contents exactly matches, and only report issues with less evidence at a LOW threshold.
+- Fix NPE in "Session Fixation" scan rule when the path of the request URI is null.
 
 ## [25] - 2019-06-07
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
@@ -142,7 +142,7 @@ public class SessionFixation extends AbstractAppPlugin {
             // now loop, and see if the url is a login url in each of the contexts in turn...
             for (Context context : contextList) {
                 URI loginUri = extAuth.getLoginRequestURIForContext(context);
-                if (loginUri != null) {
+                if (loginUri != null && requestUri.getPath() != null) {
                     if (requestUri.getScheme().equals(loginUri.getScheme())
                             && requestUri.getHost().equals(loginUri.getHost())
                             && requestUri.getPort() == loginUri.getPort()


### PR DESCRIPTION
- Fix NPE in "Session Fixation" scan rule when the path of the request URI is null.
- Update Changelog.

Fixes zaproxy/zaproxy#5444

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>