### PR TITLE
fuzzdb: update ZAP and prepare release

### DIFF
--- a/addOns/fuzzdb/CHANGELOG.md
+++ b/addOns/fuzzdb/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [5] - 2019-06-27
 ### Changed
-- Update minimum ZAP version to 2.5.0.
+- Update minimum ZAP version to 2.8.0.
 
 ### Removed
 - Move web-backdoors to a new add-on, FuzzDB Web Backdoors, to avoid causing issues with AVs. [#5294](https://github.com/zaproxy/zaproxy/issues/5294)
@@ -26,3 +26,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 First version.
 
+[5]: https://github.com/zaproxy/zap-extensions/releases/fuzzdb-v5

--- a/addOns/fuzzdb/fuzzdb.gradle.kts
+++ b/addOns/fuzzdb/fuzzdb.gradle.kts
@@ -17,7 +17,7 @@ description = "FuzzDB files which can be used with the ZAP fuzzer"
 zapAddOn {
     addOnName.set("FuzzDB files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.5.0")
+    zapVersion.set("2.8.0")
 
     manifest {
         author.set("ZAP Dev Team")


### PR DESCRIPTION
Update minimum ZAP version to 2.8.0.
Update changelog with release date and link to tag.