### PR TITLE
[WS-Passive-Scan] Add Private IP Disclosure

### DIFF
--- a/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
+++ b/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
@@ -11,5 +11,22 @@
         <h2 id="scripts">Scripts</h2>
         Scripts which are included by default in the add-on and they implement the following WebSocket passive scan rules:
 
+        <h2 id="ip_add_disc">Private Address Disclosure</h2>
+        Checks incoming WebSocket message payload for inclusion of RFC 1918 IPv4 addresses as well as Amazon EC2 private hostnames (for example, ip-10-0-56-78). This information can give an attacker useful information about the IP address scheme of the internal network, and might be helpful for further attacks targeting internal systems. <br>
+
+        This passive scanner may generate false positives in the case of larger dotted numeric strings, such as vp09.02.51.10.01.09.16, where the latter 4 octets appear to be a RFC 1918 IPv4 address. After review an analyst can mark such alerts as False Positives in ZAP.<br>
+        <br>
+        <table border="1"  width = "200">
+            <tr><th>Use case</th><th>Outcome</th></tr>
+            <tr><td>10.255.255.255</td><td>True Positive</td></tr>
+            <tr><td>ip-10.0.0.0</td><td>True Positive</td></tr>
+            <caption>Examples</caption>
+        </table>
+        <br>
+        <table border="1"  width = "200">
+            <caption>Default Values</caption>
+            <tr><th>Risk</th><td>Low</td></tr>
+            <tr><th>Confidence</th><td>Medium</td></tr>
+        </table>
     </BODY>
 </HTML>

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Private IP Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Private IP Disclosure.js
@@ -1,0 +1,85 @@
+// This script scans websocket messages for private IP V4 addresses as well as Amazon EC2 private hostnames
+// Private IP V4 such as: 10.x.x.x, 172.x.x.x, 192.168.x.x
+// Amazon EC2 private hostname: such as ip-10-0-56-78
+
+// * This Passive Scan base on http passive scan plugin:
+// ** org.zaproxy.zap.extension.pscanrules.TestInfoPrivateAddressDisclosure
+
+// * Regex test: https://regex101.com/r/SztaPj/2/
+
+// Author: Manos Kirtas (manolis.kirt@gmail.com)
+
+OPCODE_TEXT = 0x1;
+RISK_LOW 	= 1;
+CONFIDENCE_MEDIUM = 2;
+
+REGULAR_IP_OCTET = "(25[0-5]|2[0-4][0-9]|1?[0-9]{1,2})";
+REGULAR_PORTS = "(:(0|[1-9]\\d{0,3}|[1-5]\\d{4}|6[0-4]\\d{3}|65([0-4]\\d{2}|5[0-2]\\d|53[0-5]))\\b)?";
+
+var patternPre = [];
+
+/** Pattern for private IP V4 addresses as well as Amazon EC2 private hostnames */
+patternPre.push(
+    "(",
+    "\\b10\\.(",
+    REGULAR_IP_OCTET,
+    "\\.){2}",
+    REGULAR_IP_OCTET,
+    "\\b|",
+    "\\b172\\.",
+    "(3[01]|2[0-9]|1[6-9])\\.",
+    REGULAR_IP_OCTET,
+    "\\.",
+    REGULAR_IP_OCTET,
+    "\\b|",
+    "\\b192\\.168\\.",
+    REGULAR_IP_OCTET,
+    "\\.",
+    REGULAR_IP_OCTET,
+    "\\b|",
+    // find IPs from AWS hostnames such as "ip-10-2-3-200"
+    "\\bip-10-(",
+    REGULAR_IP_OCTET,
+    "-){2}",
+    REGULAR_IP_OCTET,
+    "\\b|",
+    "\\bip-172-",
+    "(3[01]|2[0-9]|1[6-9])-",
+    REGULAR_IP_OCTET,
+    "-",
+    REGULAR_IP_OCTET,
+    "\\b|",
+    "\\bip-192-168-",
+    REGULAR_IP_OCTET,
+    "-",
+    REGULAR_IP_OCTET,
+    "\\b)",
+    REGULAR_PORTS
+);
+
+function scan(helper,msg) {
+
+    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+        return;
+    }
+    var ipRegex = new RegExp(patternPre.join(""),"gim");
+    var message = String(msg.getReadablePayload());
+    var matches;
+
+    if((matches = message.match(ipRegex)) != null){
+
+        matches.forEach(function(evidence){
+            helper.newAlert()
+                .setRiskConfidence(RISK_LOW, CONFIDENCE_MEDIUM)
+                .setName("Private IP Disclosure via WebSocket (script)")
+                .setDescription("A private IP (such as 10.x.x.x, 172.x.x.x, 192.168.x.x)\
+ or an Amazon EC2 private hostname (for example, ip-10-0-56-78) has been found in the incoming\
+ WebSocket message. This information might be helpful for further attacks targeting\
+ internal systems.")
+                .setSolution("Remove the private IP address from the WebSocket messages.")
+                .setReference("https://tools.ietf.org/html/rfc1918")
+                .setEvidence(evidence)
+                .raise();
+        });
+    }
+}


### PR DESCRIPTION
This script scans websocket messages for private IP V4 addresses as well as Amazon EC2 private hostnames Private IP V4 such as: 10.x.x.x, 172.x.x.x, 192.168.x.x Amazon EC2 private hostname: such as ip-10-0-56-78

__________________________________________________________
TODOs:

- [x] Add help content
- [x] Based on  #2089
