### PR TITLE
[WS-Passive-Scan] Credit Card Disclosure

### DIFF
--- a/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
+++ b/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
@@ -55,6 +55,29 @@
             <tr><th>WASC ID</th><td>13: Information Leakage</td></tr>
         </table>
 
+        <h3>Information Disclosure: Credit Card Number</h3>
+
+        This script scans for the presence of Personally Information Identifiable in incoming WebSocket message paylaod.
+        More specifically, it passively scans payload for credit card numbers. The available scans are for the following credit card types:
+        {American Express, Diners Club, Discover, Jcb, Mestro, Master Card, Visa}.<br>
+
+        <br>
+        <table border="1"  width = "500">
+            <tr><th>Use case</th><th>Outcome</th></tr>
+            <tr><td>5264 8109 66944441</td><td>True Positive</td></tr>
+            <tr><td>{"z":0.4333009597918351}</td><td>False Positive</td></tr>
+            <caption>Examples</caption>
+        </table>
+
+        <br>
+        <table border="1"  width = "500">
+            <caption>Default Values</caption>
+            <tr><th>Risk</th><td>High</td></tr>
+            <tr><th>Confidence</th><td>High</td></tr>
+            <tr><th>CWE ID</th><td>359: Exposure of Private Information ('Privacy Violation')</td></tr>
+            <tr><th>WASC ID</th><td>13: Information Leakage</td></tr>
+        </table>
+
         <h3>Information Disclosure: Email address</h3>
 
         This script scans incoming WebSocket messages for email addresses. Email addresses may be not specifically meant for end user consumption.<br>

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/PII Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/PII Disclosure.js
@@ -1,0 +1,89 @@
+// This script scans for the presence of Personally Information Identifiable in incoming WebSocket Messages.
+// More specifically, it passively scans messages for credit card numbers
+
+// * This script is based on org.zaproxy.zap.extension.pscanrulesAlpha.Piicanner
+
+// * Regex: https://regex101.com/r/RBY77J/3
+
+// Author: Manos Kirtas (manolis.kirt@gmail.com)
+
+OPCODE_TEXT = 0x1;
+RISK_HIGH 	= 3;
+CONFIDENCE_HIGH = 3;
+
+SEQUENCE_NUM = 3;
+
+creditCards = {
+    'American Express' : /\b(?:3[47][0-9]{13})\b/gm,
+    'Diners Club' :  /\b(?:3(?:0[0-5]|[68][0-9])[0-9]{11})\b/gm,
+    'Discover' : /\b(?:6(?:011|5[0-9]{2})(?:[0-9]{12}))\b/gm,
+    'Jcb' : /\b(?:(?:2131|1800|35\d{3})\d{11})\b/gm,
+    'Mestro' : /\b(?:(?:5[0678]\d\d|6304|6390|67\d\d)\d{8,15})\b/gm,
+    'Master Card' : /\b(?:(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12})\b/gm,
+    'Visa' : /\b(?:4[0-9]{12})(?:[0-9]{3})?\b/gm
+};
+
+function scan(helper,msg) {
+
+    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+        return;
+    }
+    var message = String(msg.getReadablePayload());
+    var numberSequences = getNumberOfSequence(message,SEQUENCE_NUM);
+    var matches;
+
+    numberSequences.forEach(function(sequence){
+        Object.keys(creditCards).forEach(function(creditCardType){
+
+            if((matches = sequence.match(creditCards[creditCardType])) != null){
+                matches.forEach(function(match){
+                    if(validateLuhnCheckSum(match)){
+
+                        helper.newAlert()
+                            .setRiskConfidence(RISK_HIGH, CONFIDENCE_HIGH)
+                            .setName("Personally Identifiable Information via WebSocket (script)")
+                            .setDescription("The response contains Personally Identifiable Information,"
+                                            + " such as CC number. Credit Card type detected: "
+                                            + creditCardType + ".")
+                            .setEvidence(match)
+                            .setCweId(359)  // CWE-359: Exposure of Private Information ('Privacy Violation')
+                            .setWascId(13)  // WASC-13: Information Leakage
+                            .raise();
+                    }
+                });
+            }
+        });
+    });
+}
+
+function getNumberOfSequence(inputString, seqNum){
+    var numSeqRegex = new RegExp("(?:\\d{" + seqNum + ",}[\\s]*)+",'g'); // Return any sequence of numbers equal or greater than seqNum
+    var whitespaces = /\s+/g;
+    var newNumSeq = [];
+    var matches;
+
+    if( (matches = inputString.match(numSeqRegex)) != null){
+        matches.forEach(function(seq){
+            newNumSeq.push(seq.replace(whitespaces, "")); // Replace any whitespace with empty string
+        });
+    }
+    return newNumSeq;
+}
+
+function validateLuhnCheckSum(match){
+    var sum = 0;
+    var parity = match.length % 2;
+
+    for(var i = 0; i < match.length; i++){
+        var digit = parseInt(match[i]);
+
+        if(i % 2 == parity){
+            digit *= 2;
+            if(digit > 9){
+                digit -= 9;
+            }
+        }
+        sum += digit;
+    }
+    return (sum % 2) == 0;
+}


### PR DESCRIPTION
This script scans for the presence of Personally Information Identifiable in incoming WebSocket Messages. More specifically, it passively scan messages for credit card numbers

TODOs:
- [x] Add help content 
- [x] Based on  #2089