### PR TITLE
Fix Issue 5459 - Salvation 2.7.0 Upgrade

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Content Security Policy scan rule: Update to Salvation 2.7.0, add handling for script-src-elem, script-src-attr, style-src-elem, and style-src-attr (Issue 5459).
 
 ## [24] - 2019-06-07
 

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.shapesecurity:salvation:2.6.0")
+    implementation("com.shapesecurity:salvation:2.7.0")
 
     testImplementation(project(":testutils"))
     testImplementation("org.apache.commons:commons-lang3:3.7")

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanner.java
@@ -268,9 +268,13 @@ public class ContentSecurityPolicyScanner extends PluginPassiveScanner {
 
         if (pol.allowsScriptFromSource(PARSED_WILDCARD_URI)) {
             allowedSources.add("script-src");
+            allowedSources.add("script-src-elem");
+            allowedSources.add("script-src-attr");
         }
         if (pol.allowsStyleFromSource(PARSED_WILDCARD_URI)) {
             allowedSources.add("style-src");
+            allowedSources.add("style-src-elem");
+            allowedSources.add("style-src-attr");
         }
         if (pol.allowsImgFromSource(PARSED_WILDCARD_URI)) {
             allowedSources.add("img-src");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScannerUnitTest.java
@@ -73,9 +73,10 @@ public class ContentSecurityPolicyScannerUnitTest
         assertThat(
                 alertsRaised.get(1).getDescription(),
                 equalTo(
-                        "The following directives either allow wildcard sources (or ancestors), are not defined, or are overly broadly defined: \n"
-                                + "script-src, style-src, img-src, connect-src, frame-src, frame-ancestor, font-src, media-src, object-src, manifest-src, "
-                                + "worker-src, prefetch-src"));
+                        "The following directives either allow wildcard sources (or ancestors), are not "
+                                + "defined, or are overly broadly defined: \nscript-src, script-src-elem, script-src-attr"
+                                + ", style-src, style-src-elem, style-src-attr, img-src, connect-src, frame-src, "
+                                + "frame-ancestor, font-src, media-src, object-src, manifest-src, worker-src, prefetch-src"));
         assertThat(
                 alertsRaised.get(1).getEvidence(),
                 equalTo("default-src: 'none'; report_uri /__cspreport__"));


### PR DESCRIPTION
* pscanrules.gradle.kts - Change dependency to salvation 2.7.0.
* CHANGELOG.md - Updated.
* ContentSecurityPolicyScanner.java - Updated to add handling for script-src-elem, script-src-attr, style-src-elem, and style-src-attr.
* ContentSecurityPolicyScannerUnitTest.java  - Updated.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>