### PR TITLE
testutils: add reason to default assertions

### DIFF
--- a/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
@@ -71,9 +71,15 @@ public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends 
     protected void defaultAssertions(Alert alert) {
         if (rule instanceof PluginPassiveScanner) {
             PluginPassiveScanner pps = (PluginPassiveScanner) rule;
-            assertThat(alert.getPluginId(), is(equalTo(pps.getPluginId())));
+            assertThat(
+                    "PluginPassiveScanner rules should set its ID to the alert.",
+                    alert.getPluginId(),
+                    is(equalTo(pps.getPluginId())));
         }
-        assertThat(alert.getAttack(), isEmptyOrNullString());
+        assertThat(
+                "Passive rules should not raise alerts with attack field.",
+                alert.getAttack(),
+                isEmptyOrNullString());
     }
 
     protected abstract T createScanner();


### PR DESCRIPTION
Make it clear what the problem is when doing the default assertions for
alerts raised by passive rules.