### PR TITLE
[WS-Passive Scan] Add XML Suspicious comment disclosure

### DIFF
--- a/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
+++ b/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
@@ -112,6 +112,33 @@
             <tr><th>WASC ID</th><td>13: Information Leakage</td></tr>
         </table>
 
+        <h3>Information Disclosure: Suspicious XML Comments</h3>
+
+        This script checks incoming WebSocket messages payloads, which are XML formatted, for suspicious comments. The comments it is searching for are relevant to components with which an attacker can extract useful information. Comments like FIXME, BUG, etc might be helpful for further attacks targeting the weaknesses of the web application.<br>
+
+        <br>
+        <table border="1"  width = "500">
+            <tr><th>Use case</th><th>Outcome</th></tr>
+            <tr><td>
+                <pre>&lt;xml_test&gt;&lt;!-- This is a comments section --&gt;&lt;/xml_test&gt;</pre>
+            </td><td>True Negative</td>
+            </tr>
+            <tr><td>
+                <pre>&lt;user_form&gt;&lt;!-- FIXME: Encode --&gt;&lt;/user_form&gt;</pre>
+            </td><td>True Positive</td>
+            </tr>
+            <caption>Examples</caption>
+        </table>
+
+        <br>
+        <table border="1"  width = "500">
+            <caption>Default Values</caption>
+            <tr><th>Risk</th><td>Info</td></tr>
+            <tr><th>Confidence</th><td>Medium</td></tr>
+            <tr><th>CWE ID</th><td>200: Information Exposure</td></tr>
+            <tr><th>WASC ID</th><td>13: Info Leakage</td></tr>
+        </table>
+
         <h3 id="ip_add_disc">Private Address Disclosure</h3>
         Checks incoming WebSocket message payload for inclusion of RFC 1918 IPv4 addresses as well as Amazon EC2 private hostnames (for example, ip-10-0-56-78). This information can give an attacker useful information about the IP address scheme of the internal network, and might be helpful for further attacks targeting internal systems. <br>
 

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/XML Comments Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/XML Comments Disclosure.js
@@ -1,0 +1,93 @@
+// This Script checks incoming WebSocket XML formatted messages for suspicious comments.
+
+// * Is based on: org.zaproxy.zap.extension.pscanrulesBeta.InformationDisclosureSuspiciousComments
+// ** And the comment list is copied from
+// *** https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/zapHomeFiles/xml/suspicious-comments.txt
+
+// Author: Manos Kirtas (manolis.kirt@gmail.com)
+
+OPCODE_TEXT = 0x1;
+RISK_INFO 	= 0;
+CONFIDENCE_MEDIUM = 2;
+
+var XmlUtils = Java.type("org.zaproxy.zap.utils.XmlUtils");
+var StringReader = Java.type("java.io.StringReader");
+var InputSource = Java.type("org.xml.sax.InputSource");
+var Node = Java.type("org.w3c.dom.Node");
+var Comment = Java.type("org.w3c.dom.Comment");
+
+var commentPatterns = [/\bTODO\b/gmi,
+                  /\bFIXME\b/gmi,
+                  /\bBUG\b/gmi,
+                  /\bBUGS\b/gmi,
+                  /\bXXX\b/gmi,
+                  /\bQUERY\b/gmi,
+                  /\bDB\b/gmi,
+                  /\bADMIN\b/gmi,
+                  /\bADMINISTRATOR\b/gmi,
+                  /\bUSER\b/gmi,
+                  /\bUSERNAME\b/gmi,
+                  /\bSELECT\b/gmi,
+                  /\bWHERE\b/gmi,
+                  /\bFROM\b/gmi,
+                  /\bLATER\b/gmi
+                ];
+
+function scan(helper,msg) {
+
+    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+        return;
+    }
+
+    var message = String(msg.getReadablePayload());
+    var xmlDoc = getParsedDocument(message);
+
+    if(xmlDoc == null){
+        return;
+    }
+    var commentsList = [];
+    getComments(xmlDoc.getDocumentElement(), commentsList);
+
+    commentsList.forEach(function(comment){
+        commentPatterns.forEach(function(pattern){
+            if(pattern.test(comment)){
+                helper.newAlert()
+                    .setRiskConfidence(RISK_INFO, CONFIDENCE_MEDIUM)
+                    .setName("Information Disclosure - Suspicious Comments in XML via WebSocket (script)")
+                    .setDescription("The response appears to contain suspicious comments which may help an attacker.")
+                    .setSolution("Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.")
+                    .setEvidence(comment)
+                    .setCweId(200) //CWE Id 200 - Information Exposure
+                    .setWascId(13) //WASC Id 13 - Info Leakage
+                    .raise();
+            }
+        });
+    });
+}
+
+function getComments(node, commentsList){
+	  var nodeList = node.getChildNodes();
+    for(var i = 0; i < nodeList.getLength(); i++){
+        var currentNode = nodeList.item(i);
+        if(currentNode.getNodeType() == Node.COMMENT_NODE){
+            commentsList.push(String(currentNode.getNodeValue()));
+        }
+        if (currentNode.hasChildNodes()) {
+            getComments(currentNode, commentsList);
+        }
+    }
+}
+
+function getParsedDocument(message){
+    var result = null;
+    var factory = XmlUtils.newXxeDisabledDocumentBuilderFactory();
+    factory.setIgnoringComments(false);
+    var builder = factory.newDocumentBuilder();
+    var is = new InputSource(new StringReader(message));
+    try{
+        result = builder.parse(is);
+    }catch(error){
+        result = null;
+    }
+    return result;
+}


### PR DESCRIPTION
This script seek at incoming WebSocket messages payloads, which are XML formatted, for suspicious comments. The comments it is searching for are relevant to components with which an attacker can extract useful information. Comments like FIXME, BUG, etc might be helpful for further attacks targeting the weaknesses of the web application.