### PR TITLE
[WS-Passive-Scan] Add Debug Error Disclosure

### DIFF
--- a/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
+++ b/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/pscanrules.html
@@ -78,6 +78,27 @@
             <tr><th>WASC ID</th><td>13: Information Leakage</td></tr>
         </table>
 
+        <h3>Information Disclosure: Debug Errors</h3>
+
+        This script checks the incoming WebSocket message payload for known Debug Error message fragments. Access to such details may provide a malicious individual with means by which to further abuse the web site. They may also leak data not specifically meant for end user consumption.<br>
+
+        <br>
+        <table border="1"  width = "500">
+            <tr><th>Use case</th><th>Outcome</th></tr>
+            <tr><td>Error Occurred While Processing Request</td><td>True Positive</td></tr>
+            <tr><td>PHP Warning: Error While Sending QUERY Packet</td><td>True Positive</td></tr>
+            <caption>Examples</caption>
+        </table>
+
+        <br>
+        <table border="1"  width = "500">
+            <caption>Default Values</caption>
+            <tr><th>Risk</th><td>Info</td></tr>
+            <tr><th>Confidence</th><td>Medium</td></tr>
+            <tr><th>CWE ID</th><td>200: Information Exposure</td></tr>
+            <tr><th>WASC ID</th><td>13: Info Leakage</td></tr>
+        </table>
+
         <h3>Information Disclosure: Email address</h3>
 
         This script scans incoming WebSocket messages for email addresses. Email addresses may be not specifically meant for end user consumption.<br>

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Debug Error Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Debug Error Disclosure.js
@@ -1,0 +1,70 @@
+// * This Script analyzes incoming websocket messages for error debug messages
+
+// * Based on org.zaproxy.zap.extension.pscanrules.InformationDisclosureDebugErrors
+// * Debug Error messages are equal to:
+// * * https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/zapHomeFiles/xml/debug-error-messages.txt
+
+// Author: Manos Kirtas (manolis.kirt@gmail.com)
+
+OPCODE_TEXT = 0x1;
+RISK_LOW = 1;
+CONFIDENCE_MEDIUM = 2;
+
+var debug_messages = [
+    /Error Occurred While Processing Request/igm,
+    /Internal Server Error/igm,
+    /test page for apache/igm,
+    /failed to open stream: HTTP request failed!/igm,
+    /Parse error: parse error, unexpected T_VARIABLE/igm,
+    /The script whose uid is/igm,
+    /PHP Parse error/igm,
+    /PHP Warning/igm,
+    /PHP Error/igm,
+    /Warning: Cannot modify header information - headers already sent/igm,
+    /mysqli error is/igm,
+    /mysql error is/igm,
+    /404 SC_NOT_FOUND/igm,
+    /ASP.NET_SessionId/igm,
+    /servlet error:/igm,
+    /Under construction/igm,
+    /Welcome to Windows 2000 Internet Services/igm,
+    /welcome to iis 4.0/igm,
+    /Warning: Supplied argument is not a valid File-Handle resource/igm,
+    /Warning: Division by zero in/igm,
+    /Warning: SAFE MODE Restriction in effect./igm,
+    /Error Message : Error loading required libraries./igm,
+    /Fatal error: Call to undefined function/igm,
+    /access denied for user/igm,
+    /incorrect syntax near/igm,
+    /Unclosed quotation mark before the character string/igm,
+    /There seems to have been a problem with the/igm,
+    /customErrors mode/igm,
+    /This error page might contain sensitive information because ASP.NET/igm
+];
+
+function scan(helper,msg) {
+
+    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+        return;
+    }
+    var message = String(msg.getReadablePayload());
+    var matches;
+
+    debug_messages.forEach(function(pattern){
+        if((matches = message.match(pattern)) != null){
+            matches.forEach(function(evidence){
+                helper.newAlert()
+                    .setName("Information Disclosure - Debug Error Messages via WebSocket (script)")
+                    .setRiskConfidence(RISK_LOW, CONFIDENCE_MEDIUM)
+                    .setDescription("The response appeared to contain common error messages returned"
+                                    + " by platforms such as ASP.NET, and Web-servers such as IIS and Apache. You can configure"
+                                    + " the list of common debug messages.")
+                    .setSolution("Disable debugging messages before pushing to production.")
+                    .setEvidence(evidence)
+                    .setCweId(200) // CWE-200: Information Exposure
+                    .setWascId(13) // WASC Id 13 - Info leakage
+                    .raise();
+            });
+        }
+    });
+}


### PR DESCRIPTION
This script checks the incoming WebSocket message payload for known Debug Error message fragments. Access to such details may provide a malicious individual with means by which to further abuse the web site. They may also leak data not specifically meant for end user consumption.
