### PR TITLE
Improve PS control pattern to reduce FPs.

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Improved PowerShell injection control patterns to reduce false positives.
 
 ## [33] - 2019-06-07
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -70,7 +70,7 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
     // PowerShell Command constants
     private static final String PS_TEST_CMD = "get-help";
     private static final Pattern PS_CTRL_PATTERN =
-            Pattern.compile("(?:\\sget-help)|cmdlet|get-alias", Pattern.CASE_INSENSITIVE);
+            Pattern.compile("(?:\\sGet-Help)(?i)|cmdlet|get-alias");
 
     // Useful if space char isn't allowed by filters
     // http://www.blackhatlibrary.net/Command_Injection


### PR DESCRIPTION
Current PS injection control pattern trips and causes FPs on anything that reflects the 'get-help' string that is being used as a test.
Therefore, the control pattern for the string "Get-Help" was changed to being case sensitive with capitalized letters (injection and command would work if entered in any case, and then the output would reflect Get-Help in capitalized form), while the rest of the regex was forced case-insensitive with the (?i) modifier in the regex.
This tests now matches " Get-Help" specifically (including leading space) and "cmdlet","get-alias" in any case, but not " get-help".