### PR TITLE
Issue 4454 - ServletParameterPollutionScanner only at Low Threshold

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Only scan for Servlet Parameter Pollution at LOW threshold (part of Issue 4454).
 
 ## [19] - 2019-06-07
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanner.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanner.java
@@ -28,6 +28,7 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -63,6 +64,10 @@ public class ServletParameterPollutionScanner extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (!AlertThreshold.LOW.equals(this.getAlertThreshold())) {
+            return;
+        }
+
         List<Element> formElements = source.getAllElements(HTMLElementName.FORM);
 
         if (formElements != null && formElements.size() > 0) {

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -36,6 +36,7 @@ This checks response headers for the presence of X-Powered-By details.
 Searches response content for HTML forms which fail to specify an action element. Version 3 of the 
 Java Servlet spec calls for aggregation of query string and post data elements which may result in 
 unintended handling of user controlled data. This may impact other frameworks and technologies as well.
+<strong>Note:</strong> This scan rule will only analyze responses on LOW Threshold.
 
 <H2>Timestamp Disclosure</H2>
 A timestamp was disclosed by the application/web server.

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScannerUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScannerUnitTest.java
@@ -22,8 +22,10 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
@@ -37,18 +39,29 @@ public class ServletParameterPollutionScannerUnitTest
         return new ServletParameterPollutionScanner();
     }
 
+    @Before
+    public void before() {
+        rule.setAlertThreshold(AlertThreshold.LOW);
+    }
+
     @Test
     public void givenNoFormsWhenScanHttpResponseReceiveThenNoAlertsRaised() throws Exception {
+        // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("");
+        // When
         scanHttpResponseReceive(msg);
+        // Then
         assertNumberOfAlertsRaised(0);
     }
 
     @Test
     public void givenFormWithActionAttributeWhenScanHttpResponseReceiveThenNoAlertsRaised()
             throws Exception {
+        // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action='ActionMan'>");
+        // When
         scanHttpResponseReceive(msg);
+        // Then
         assertNumberOfAlertsRaised(0);
     }
 
@@ -56,9 +69,12 @@ public class ServletParameterPollutionScannerUnitTest
     public void
             givenFormWithNoActionAttributeWhenScanHttpResponseReceiveThenAlertRaisedAndAlertPopulated()
                     throws Exception {
+        // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form />");
+        // When
         scanHttpResponseReceive(msg);
         Alert alert = getFirstAlertRaised();
+        // Then
         assertEquals(alert.getRisk(), Alert.RISK_MEDIUM);
         assertEquals(alert.getConfidence(), Alert.CONFIDENCE_LOW);
         assertEquals(alert.getUri(), URI);
@@ -66,18 +82,50 @@ public class ServletParameterPollutionScannerUnitTest
     }
 
     @Test
+    public void
+            givenFormWithNoActionAttributeWhenScanHttpResponseReceiveThenAtMediumThresholdThenNoAlertRaised()
+                    throws Exception {
+        // Given
+        HttpMessage msg = createHttpMessageFromHtml("<form />");
+        rule.setAlertThreshold(AlertThreshold.MEDIUM);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertNumberOfAlertsRaised(0);
+    }
+
+    @Test
+    public void
+            givenFormWithNoActionAttributeWhenScanHttpResponseReceiveThenAtHighThresholdThenNoAlertRaised()
+                    throws Exception {
+        // Given
+        HttpMessage msg = createHttpMessageFromHtml("<form />");
+        rule.setAlertThreshold(AlertThreshold.HIGH);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertNumberOfAlertsRaised(0);
+    }
+
+    @Test
     public void givenFormWithValuelessActionAttributeWhenScanHttpResponseReceiveThenAlertRaised()
             throws Exception {
+        // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action />");
+        // When
         scanHttpResponseReceive(msg);
+        // Then
         assertNumberOfAlertsRaised(1);
     }
 
     @Test
     public void givenFormWithEmptyActionAttributeWhenScanHttpResponseReceiveThenAlertRaised()
             throws Exception {
+        // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action='' />");
+        // When
         scanHttpResponseReceive(msg);
+        // Then
         assertNumberOfAlertsRaised(1);
     }
 
@@ -85,8 +133,11 @@ public class ServletParameterPollutionScannerUnitTest
     public void
             givenFormWithEmptyAndPopulatedActionAttributesWhenScanHttpResponseReceiveThenAlertRaised()
                     throws Exception {
+        // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action action='ActionMan' />");
+        // When
         scanHttpResponseReceive(msg);
+        // Then
         assertNumberOfAlertsRaised(1);
     }
 
@@ -94,8 +145,11 @@ public class ServletParameterPollutionScannerUnitTest
     public void
             givenTwoFormsWithNoActionAttributeWhenScanHttpResponseReceiveThenOnlyOneAlertRaised()
                     throws Exception {
+        // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form /><form />");
+        // When
         scanHttpResponseReceive(msg);
+        // Then
         assertNumberOfAlertsRaised(1);
     }
 


### PR DESCRIPTION
- CHANGELOG.md - Added change entry.
- ServletParameterPollutionScanner.java - Add Threshold check and return if not LOW.
- ServletParameterPollutionScannerUnitTest.java - Add before() method setting Threshold LOW (as used by the majority of the UnitTest methods). Add unit tests for new behavior. Add Given, When, and Then comments.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>