### PR TITLE
Add alert for Java Serialized Object (JSO)

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,10 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Content Security Policy scan rule: Update to Salvation 2.7.0, add handling for script-src-elem, script-src-attr, style-src-elem, and style-src-attr (Issue 5459).
 
-## [24] - 2019-07-20
-
-- Add Java Serialized Object (JSO) alarm.
-
 ## [24] - 2019-06-07
 
 - Maintenance changes.

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Content Security Policy scan rule: Update to Salvation 2.7.0, add handling for script-src-elem, script-src-attr, style-src-elem, and style-src-attr (Issue 5459).
 
+## [24] - 2019-07-20
+
+- Add Java Serialized Object (JSO) alarm.
+
 ## [24] - 2019-06-07
 
 - Maintenance changes.

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Add Java Serialized Object (JSO) alarm.
+- Add Java Serialized Object (JSO) Scanner.
 
 ## [25] - 2019-07-11
 

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add Java Serialized Object (JSO) alarm.
 
 ## [25] - 2019-07-11
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanner.java
@@ -25,12 +25,13 @@ import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpBody;
 import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-/** Java Serialized Objects (JSO) scanner. Detect the magic sequence and generate an alarm */
+/** Java Serialized Objects (JSO) scanner. Detect the magic sequence and generate an alert */
 public class JsoScanner extends PluginPassiveScanner {
 
     /** Prefix for internationalized messages used by this rule */
@@ -49,7 +50,7 @@ public class JsoScanner extends PluginPassiveScanner {
 
         checkJsoInCookies(msg, msg.getRequestHeader().getHttpCookies());
 
-        checkJsoInBody(msg, msg.getRequestBody().getBytes(), msg.getRequestBody().toString());
+        checkJsoInBody(msg, msg.getRequestBody());
     }
 
     @Override
@@ -58,7 +59,7 @@ public class JsoScanner extends PluginPassiveScanner {
 
         checkJsoInCookies(msg, msg.getResponseHeader().getHttpCookies(null));
 
-        checkJsoInBody(msg, msg.getResponseBody().getBytes(), msg.getResponseBody().toString());
+        checkJsoInBody(msg, msg.getResponseBody());
     }
 
     private void checkJsoInQueryParameters(HttpMessage msg) {
@@ -79,10 +80,10 @@ public class JsoScanner extends PluginPassiveScanner {
         }
     }
 
-    private void checkJsoInBody(HttpMessage msg, byte[] bytes, String body) {
-        byte[] startOfBody = Arrays.copyOfRange(bytes, 0, JSO_BYTE_MAGIC_SEQUENCE.length);
+    private void checkJsoInBody(HttpMessage msg, HttpBody body) {
+        byte[] startOfBody = Arrays.copyOfRange(body.getBytes(), 0, JSO_BYTE_MAGIC_SEQUENCE.length);
         if (Arrays.equals(JSO_BYTE_MAGIC_SEQUENCE, startOfBody)
-                || hasJsoBase64MagicSequence(body)) {
+                || hasJsoBase64MagicSequence(body.toString())) {
             raiseAlert(msg, "");
         }
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanner.java
@@ -1,0 +1,137 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.net.*;
+import java.nio.charset.*;
+import java.util.*;
+import net.htmlparser.jericho.*;
+import org.parosproxy.paros.*;
+import org.parosproxy.paros.core.scanner.*;
+import org.parosproxy.paros.network.*;
+import org.zaproxy.zap.extension.pscan.*;
+
+/** Java Serialized Objects (JSO) scanner. Detect the magic sequence and generate an alarm */
+public class JsoScanner extends PluginPassiveScanner {
+
+    /** Prefix for internationalized messages used by this rule */
+    private static final String MESSAGE_PREFIX = "pscanalpha.jso.";
+
+    private static final byte[] JSO_BYTE_MAGIC_SEQUENCE = {(byte) 0xac, (byte) 0xed, 0x00, 0x05};
+    private static final String JSO_BASE_64_MAGIC_SEQUENCE = "rO0AB";
+    private PassiveScanThread parent;
+
+    @Override
+    public void scanHttpRequestSend(HttpMessage msg, int id) {
+        // do nothing
+    }
+
+    @Override
+    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        checkJsoInHeaders(msg);
+
+        checkJsoInCookies(msg);
+
+        checkJsoInBody(msg);
+    }
+
+    private void checkJsoInBody(HttpMessage msg) {
+        byte[] startOfBody =
+                Arrays.copyOfRange(
+                        msg.getResponseBody().getBytes(), 0, JSO_BYTE_MAGIC_SEQUENCE.length);
+        String startOfBodyAsString =
+                new String(
+                        Arrays.copyOfRange(
+                                msg.getResponseBody().getBytes(),
+                                0,
+                                JSO_BASE_64_MAGIC_SEQUENCE.length()),
+                        StandardCharsets.UTF_8);
+        if (Arrays.equals(JSO_BYTE_MAGIC_SEQUENCE, startOfBody)
+                || hasJsoBase64MagicSequence(startOfBodyAsString)) {
+            Alert alert = buidAlert(msg, "");
+            parent.raiseAlert(getPluginId(), alert);
+        }
+    }
+
+    private void checkJsoInCookies(HttpMessage msg) {
+        for (HttpCookie cookie : msg.getResponseHeader().getHttpCookies(null)) {
+            String value = cookie.getValue();
+            if (!hasJsoBase64MagicSequence(value)) {
+                continue;
+            }
+
+            Alert alert = buidAlert(msg, cookie.toString());
+            parent.raiseAlert(getPluginId(), alert);
+        }
+    }
+
+    private boolean hasJsoBase64MagicSequence(String value) {
+        return value.startsWith(JSO_BASE_64_MAGIC_SEQUENCE);
+    }
+
+    private void checkJsoInHeaders(HttpMessage msg) {
+        for (HttpHeaderField header : msg.getResponseHeader().getHeaders()) {
+            String value = header.getValue();
+            if (!hasJsoBase64MagicSequence(value)) {
+                continue;
+            }
+
+            Alert alert = buidAlert(msg, header.toString());
+            parent.raiseAlert(getPluginId(), alert);
+        }
+    }
+
+    private Alert buidAlert(HttpMessage msg, String evidence) {
+        Alert alert =
+                new Alert(getPluginId(), Alert.RISK_MEDIUM, Alert.CONFIDENCE_MEDIUM, getName());
+        alert.setDetail(
+                Constant.messages.getString(MESSAGE_PREFIX + "desc"),
+                msg.getRequestHeader().getURI() + "",
+                null,
+                "",
+                "",
+                getString("soln"),
+                getString("refs"),
+                evidence,
+                502, // CWE-502: Deserialization of Untrusted Data
+                -1, // No WASC-ID
+                msg);
+        return alert;
+    }
+
+    private String getString(String param) {
+        return Constant.messages.getString(MESSAGE_PREFIX + param, "");
+    }
+
+    @Override
+    public void setParent(PassiveScanThread parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public int getPluginId() {
+        return 90303;
+    }
+}

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -113,6 +113,13 @@ Sun Java System Web Server<br>
 TornadoServer web server<br>
 WordPress<br>
 
+<H2>Java Serialization Object</H2>
+Java Serialization Object (JSO) is a way to save and exchange objects between Java applications.<br>
+Different problems are associated with JSO. Sensitive data can leak to the stream of bytes.<br>
+An attacker can also modify the data and exploit JSO to do a Remote Code Execution on the server.<br>
+JSO should not be used by Java programs. Strong controls must be done on serialized data<br>
+JSO are a type of vulnerabilities associated to A8:2017-Insecure Deserialization.
+
 <H2>Modern Web Application</H2>
 This raises an informational alert if a site appears to be a modern web application.<br>
 It does not indicate any potential vulnerabilities but it could indicate that the ajax spider might be more effective at exploring this site compared to the traditional spider.

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -117,7 +117,7 @@ WordPress<br>
 Java Serialization Object (JSO) is a way to save and exchange objects between Java applications.<br>
 Different problems are associated with JSO. Sensitive data can leak to the stream of bytes.<br>
 An attacker can also modify the data and exploit JSO to do a Remote Code Execution on the server.<br>
-JSO should not be used by Java programs. Strong controls must be done on serialized data<br>
+JSO should not be used by Java programs. Strong controls must be done on serialized data.<br>
 JSO are a type of vulnerabilities associated to A8:2017-Insecure Deserialization.
 
 <H2>Modern Web Application</H2>

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -227,3 +227,8 @@ pscanalpha.xchromeloggerdata.refs=https://craig.is/writing/chrome-logger
 pscanalpha.xchromeloggerdata.soln=Disable this functionality in Production when it might leak information that could be leveraged by an attacker. Alternatively ensure that use of the functionality is tied to a strong authorization check and only available to administrators or support personnel for troubleshooting purposes not general users.
 pscanalpha.xchromeloggerdata.otherinfo.msg=The following represents an attempt to base64 decode the value:
 pscanalpha.xchromeloggerdata.otherinfo.error=Header value could not be base64 decoded:
+
+pscanalpha.jso.name=Java Serialization Object
+pscanalpha.jso.desc=Java Serialization seems to be in use. If not correctly validated, an attacker can send a specially crafted object. This can lead to a dangerous "Remote Code Execution". A magic sequence identifying JSO has been detected (Base64: rO0AB, Raw: 0xac, 0xed, 0x00, 0x05).
+pscanalpha.jso.soln=Deserialization of untrusted data is inherently dangerous and should be avoided.
+pscanalpha.jso.refs=https://www.oracle.com/technetwork/java/seccodeguide-139067.html#8

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
@@ -1,0 +1,127 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.util.*;
+import org.junit.*;
+import org.parosproxy.paros.network.*;
+
+public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInHeader() throws Exception {
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "X-Custom-Info: " + jso + "\r\n");
+
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInCookie() throws Exception {
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Set-Cookie: CRUNCHY=" + jso + "\r\n");
+
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertGivenNoJsoHasBeenDetected() throws Exception {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "X-Custom-Info: NOPE\r\n");
+
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised, empty());
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInRawBody() throws Exception {
+        HttpMessage msg = new HttpMessage();
+        byte[] jso = createJso();
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Content-Type: application/octet-stream\r\n"
+                        + "Content-Disposition: attachment; filename=\"jso.bin\"\r\n"
+                        + "Content-Length: "
+                        + jso.length
+                        + "\r\n");
+        msg.setResponseBody(jso);
+
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInBase64Body() throws Exception {
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Content-Type: application/octet-stream\r\n"
+                        + "Content-Disposition: attachment; filename=\"jso.bin\"\r\n"
+                        + "Content-Length: "
+                        + jso.length()
+                        + "\r\n");
+        msg.setResponseBody(jso);
+
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    private static byte[] createJso() throws IOException {
+        AnObject anObject = new AnObject();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(out);
+        objectOutputStream.writeObject(anObject);
+        return out.toByteArray();
+    }
+
+    @Override
+    protected JsoScanner createScanner() {
+        return new JsoScanner();
+    }
+
+    private static class AnObject implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private static String value;
+
+        public static String getValue() {
+            return value;
+        }
+
+        public static void setValue(String value) {
+            AnObject.value = value;
+        }
+    }
+}

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
@@ -19,8 +19,9 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
-import org.junit.Test;
-import org.parosproxy.paros.network.HttpMessage;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,10 +30,8 @@ import java.io.Serializable;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
 
 public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
@@ -19,52 +19,74 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 
-import java.io.*;
-import java.util.*;
-import org.junit.*;
-import org.parosproxy.paros.network.*;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Base64;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
 
 public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
-    @Test
-    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInHeader() throws Exception {
-        HttpMessage msg = new HttpMessage();
-        String jso = Base64.getEncoder().encodeToString(createJso());
-        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "X-Custom-Info: " + jso + "\r\n");
 
-        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
-
-        assertThat(alertsRaised, hasSize(1));
-    }
-
-    @Test
-    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInCookie() throws Exception {
-        HttpMessage msg = new HttpMessage();
-        String jso = Base64.getEncoder().encodeToString(createJso());
-        msg.setRequestHeader("GET / HTTP/1.1");
-        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Set-Cookie: CRUNCHY=" + jso + "\r\n");
-
-        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
-
-        assertThat(alertsRaised, hasSize(1));
-    }
+    public static final String URI_ENCODED_JSO =
+            "%C2%AC%C3%AD%00%05sr%00Eorg.zaproxy.zap.extension.pscanrulesAlpha.JsoScannerUnitTest%24AnObject%00%00%00%00%00%00%00%01%02%00%00xp";
 
     @Test
     public void shouldNotRaiseAlertGivenNoJsoHasBeenDetected() throws Exception {
+        // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "X-Custom-Info: NOPE\r\n");
 
+        // When
         rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
+        // Then
         assertThat(alertsRaised, empty());
     }
 
     @Test
-    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInRawBody() throws Exception {
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInHeaderOfResponse() throws Exception {
+        // Given
         HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "X-Custom-Info: " + jso + "\r\n");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInCookieOfResponse() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Set-Cookie: CRUNCHY=" + jso + "\r\n");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInRawBodyOfResponse()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
         byte[] jso = createJso();
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"
@@ -75,16 +97,20 @@ public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
                         + "\r\n");
         msg.setResponseBody(jso);
 
+        // When
         rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
+        // Then
         assertThat(alertsRaised, hasSize(1));
     }
 
     @Test
-    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInBase64Body() throws Exception {
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInBase64BodyOfResponse()
+            throws Exception {
+        // Given
         HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
         String jso = Base64.getEncoder().encodeToString(createJso());
-
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"
                         + "Content-Type: application/octet-stream\r\n"
@@ -94,8 +120,156 @@ public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
                         + "\r\n");
         msg.setResponseBody(jso);
 
+        // When
         rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
 
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInRequestParameterOfRequest()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET /some_action?q=" + URI_ENCODED_JSO + "&p=&m HTTP/1.1");
+
+        // When
+        rule.scanHttpRequestSend(msg, -1);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInRequestParameterOfResponse()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setRequestHeader("GET /some_action?q=" + jso + "&p=&m HTTP/1.1");
+
+        // When
+        rule.scanHttpRequestSend(msg, -1);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInHeaderOfRequest() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "X-Custom-Info: " + jso + "\r\n");
+
+        // When
+        rule.scanHttpRequestSend(msg, -1);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInCookieOfRequest() throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "Cookie: CRUNCHY=" + jso + "\r\n");
+
+        // When
+        rule.scanHttpRequestSend(msg, -1);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInRawBodyOfPOSTRequest()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        byte[] jso = createJso();
+        msg.setRequestHeader(
+                "POST / HTTP/1.1\r\n"
+                        + "Content-Type: application/octet-stream\r\n"
+                        + "Content-Disposition: attachment; filename=\"jso.bin\"\r\n"
+                        + "Content-Length: "
+                        + jso.length
+                        + "\r\n");
+        msg.setRequestBody(jso);
+
+        // When
+        rule.scanHttpRequestSend(msg, -1);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Ignore
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInBase64BodyOfRequest()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setRequestHeader(
+                "GET / HTTP/1.1\r\n"
+                        + "Content-Type: application/octet-stream\r\n"
+                        + "Content-Disposition: attachment; filename=\"jso.bin\"\r\n"
+                        + "Content-Length: "
+                        + jso.length()
+                        + "\r\n");
+        msg.setResponseBody(jso);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Ignore
+    @Test
+    public void shouldRaiseAlertGivenJsoMagicBytesAreDetectedInRequestParameterOfRequest()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET /some_action?q=" + URI_ENCODED_JSO + "&p= HTTP/1.1");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInHeaderOfResponse()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "X-Custom-Info: " + URI_ENCODED_JSO);
+
+        // When
+        rule.scanHttpRequestSend(msg, -1);
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInCookieOfRequest()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        String jso = Base64.getEncoder().encodeToString(createJso());
+        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "Cookie: CRUNCHY=" + URI_ENCODED_JSO + "\r\n");
+
+        // When
+        rule.scanHttpRequestSend(msg, -1);
+
+        // Then
         assertThat(alertsRaised, hasSize(1));
     }
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScannerUnitTest.java
@@ -19,22 +19,22 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import org.junit.Test;
-import org.parosproxy.paros.network.HttpMessage;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
 
 public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
-
-    private static final String URI_ENCODED_JSO =
-            "%C2%AC%C3%AD%00%05sr%00Eorg.zaproxy.zap.extension.pscanrulesAlpha.JsoScannerUnitTest%24AnObject%00%00%00%00%00%00%00%01%02%00%00xp";
 
     /* Testing JSO in response */
     @Test
@@ -150,7 +150,7 @@ public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
-        msg.setRequestHeader("GET /some_action?q=" + URI_ENCODED_JSO + "&p=&m HTTP/1.1");
+        msg.setRequestHeader("GET /some_action?q=" + createUriEncodedJso() + "&p=&m HTTP/1.1");
 
         // When
         rule.scanHttpRequestSend(msg, -1);
@@ -179,7 +179,7 @@ public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
-        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "X-Custom-Info: " + URI_ENCODED_JSO);
+        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "X-Custom-Info: " + createUriEncodedJso());
 
         // When
         rule.scanHttpRequestSend(msg, -1);
@@ -208,7 +208,8 @@ public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
-        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "Cookie: CRUNCHY=" + URI_ENCODED_JSO + "\r\n");
+        msg.setRequestHeader(
+                "GET / HTTP/1.1\r\n" + "Cookie: CRUNCHY=" + createUriEncodedJso() + "\r\n");
 
         // When
         rule.scanHttpRequestSend(msg, -1);
@@ -281,6 +282,12 @@ public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
         ObjectOutputStream objectOutputStream = new ObjectOutputStream(out);
         objectOutputStream.writeObject(anObject);
         return out.toByteArray();
+    }
+
+    private static String createUriEncodedJso() throws IOException {
+        return URLEncoder.encode(
+                new String(createJso(), StandardCharsets.ISO_8859_1),
+                StandardCharsets.UTF_8.name());
     }
 
     @Override


### PR DESCRIPTION
Detect potential JSO based on signature
 - When cookie or header start with special base64 signature
 - When body or header start with special base64 or raw signatures

Next steps:
 - Add payload generator
 - Add in active scan 