### PR TITLE
Correct request/response body checks

### DIFF
--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## Changed
 - Update minimum ZAP version to 2.5.0.
+- Maintenance changes.
 
 ## 5 - 2017-07-21
 

--- a/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/ResponseBrowserView.java
+++ b/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/ResponseBrowserView.java
@@ -169,7 +169,7 @@ public class ResponseBrowserView implements HttpPanelView, HttpPanelViewModelLis
     static boolean isHtml(final Message aMessage) {
         if (aMessage instanceof HttpMessage) {
             HttpMessage httpMessage = (HttpMessage) aMessage;
-            if (httpMessage.getResponseBody() == null) {
+            if (httpMessage.getResponseBody().length() == 0) {
                 return false;
             }
             return httpMessage.getResponseHeader().isHtml();

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-
+## Changed
+- Maintenance changes.
 
 ## 9 - 2018-02-19
 

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/InvokeAppWorker.java
@@ -93,9 +93,8 @@ public class InvokeAppWorker extends SwingWorker<Void, Void> {
             }
             site = site + "/";
         }
-        if (msg.getRequestBody() != null) {
-            postdata = msg.getRequestBody().toString();
-            postdata = postdata.replaceAll("\n", "\\n");
+        if (msg.getRequestBody().length() != 0) {
+            postdata = msg.getRequestBody().toString().replaceAll("\n", "\\n");
         }
         Vector<String> cookies = msg.getRequestHeader().getHeaders(HttpHeader.COOKIE);
         if (cookies != null && cookies.size() > 0) {

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
@@ -158,7 +158,7 @@ public class SOAPActionSpoofingActiveScanner extends AbstractAppPlugin {
 
     // Relaxed accessibility for testing.
     int scanResponse(HttpMessage msg, HttpMessage originalMsg) {
-        if (msg.getResponseBody() == null) return EMPTY_RESPONSE;
+        if (msg.getResponseBody().length() == 0) return EMPTY_RESPONSE;
         String responseContent = new String(msg.getResponseBody().getBytes());
         responseContent = responseContent.trim();
 

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -198,16 +198,11 @@ public class WSDLCustomParser {
                 return;
             }
 
-            /* Checks response content. */
-            if (httpRequest.getResponseBody() != null) {
-                String content = httpRequest.getResponseBody().toString();
-                if (content == null || content.trim().length() <= 0) {
-                    // LOG.warn("URL response from WSDL file request has no body
-                    // content.");
-                } else {
-                    // WSDL parsing.
-                    parseWSDLContent(content);
-                }
+            String content = httpRequest.getResponseBody().toString();
+            if (content.trim().isEmpty()) {
+                LOG.debug("Response from WSDL file request has no body content, url: " + url);
+            } else {
+                parseWSDLContent(content);
             }
         } catch (Exception e) {
             LOG.error("There was an error while parsing WSDL from URL. ", e);


### PR DESCRIPTION
Check that the request/response body is empty instead of null, they are
never null.
In one case remove the check completely and just check the body as
string (used later), also, log (debug) when empty.