### PR TITLE
Add unit tests for ContentSecurityPolicyMissingScanner

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScanner.java
@@ -74,14 +74,14 @@ public class ContentSecurityPolicyMissingScanner extends PluginPassiveScanner {
         // Internet Exploder
         Vector<String> cspOptions = msg.getResponseHeader().getHeaders("Content-Security-Policy");
         // If it's not null or empty then we found one
-        if (cspOptions != null && cspOptions.isEmpty() == false) {
+        if (cspOptions != null && !cspOptions.isEmpty()) {
             cspHeaderFound = true;
         }
 
         Vector<String> cspROOptions =
                 msg.getResponseHeader().getHeaders("Content-Security-Policy-Report-Only");
         // If it's not null or empty then we found one
-        if (cspROOptions != null && cspROOptions.isEmpty() == false) {
+        if (cspROOptions != null && !cspROOptions.isEmpty()) {
             cspROHeaderFound = true;
         }
 
@@ -90,14 +90,14 @@ public class ContentSecurityPolicyMissingScanner extends PluginPassiveScanner {
         Vector<String> xcspOptions =
                 msg.getResponseHeader().getHeaders("X-Content-Security-Policy");
         // If it's not null or empty then we found one
-        if (xcspOptions != null && xcspOptions.isEmpty() == false) {
+        if (xcspOptions != null && !xcspOptions.isEmpty()) {
             xCspHeaderFound = true;
         }
 
         // X-WebKit-CSP is supported by Chrome 14+, and Safari 6+
         Vector<String> xwkcspOptions = msg.getResponseHeader().getHeaders("X-WebKit-CSP");
         // If it's not null or empty then we found one
-        if (xwkcspOptions != null && xwkcspOptions.isEmpty() == false) {
+        if (xwkcspOptions != null && !xwkcspOptions.isEmpty()) {
             xWebKitHeaderFound = true;
         }
 
@@ -126,13 +126,13 @@ public class ContentSecurityPolicyMissingScanner extends PluginPassiveScanner {
                             Alert.CONFIDENCE_MEDIUM, // Reliability
                             getName());
             alert.setDetail(
-                    getAlertAtrribute("desc"), // Description
+                    getAlertAttribute("desc"), // Description
                     msg.getRequestHeader().getURI().toString(), // URI
                     "", // Param
                     "", // Attack
                     "", // Other info
-                    getAlertAtrribute("soln"), // Solution
-                    getAlertAtrribute("refs"), // References
+                    getAlertAttribute("soln"), // Solution
+                    getAlertAttribute("refs"), // References
                     "", // Evidence
                     16, // CWE-16: Configuration
                     15, // WASC-15: Application Misconfiguration
@@ -146,15 +146,15 @@ public class ContentSecurityPolicyMissingScanner extends PluginPassiveScanner {
                             getPluginId(),
                             Alert.RISK_INFO,
                             Alert.CONFIDENCE_MEDIUM, // PluginID, Risk, Reliability
-                            getAlertAtrribute("ro.name"));
+                            getAlertAttribute("ro.name"));
             alert.setDetail(
-                    getAlertAtrribute("ro.desc"), // Description
+                    getAlertAttribute("ro.desc"), // Description
                     msg.getRequestHeader().getURI().toString(), // URI
                     "", // Param
                     "", // Attack
                     "", // Other info
-                    getAlertAtrribute("soln"), // Solution
-                    getAlertAtrribute("ro.refs"), // References
+                    getAlertAttribute("soln"), // Solution
+                    getAlertAttribute("ro.refs"), // References
                     "", // Evidence
                     16, // CWE-16: Configuration
                     15, // WASC-15: Application Misconfiguration
@@ -179,10 +179,10 @@ public class ContentSecurityPolicyMissingScanner extends PluginPassiveScanner {
 
     @Override
     public String getName() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+        return getAlertAttribute("name");
     }
 
-    private String getAlertAtrribute(String key) {
+    private String getAlertAttribute(String key) {
         return Constant.messages.getString(MESSAGE_PREFIX + key);
     }
 }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScannerUnitTest.java
@@ -1,0 +1,222 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.URI;
+import org.junit.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class ContentSecurityPolicyMissingScannerUnitTest
+        extends PassiveScannerTest<ContentSecurityPolicyMissingScanner> {
+    private static final String URI = "https://www.example.com";
+    private static final String HEADER_HTML = "Content-Type: text/html";
+    private static final String HEADER_TEXT = "Content-Type: text/plain";
+    private static final String HEADER_CSP = "Content-Security-Policy: x";
+    private static final String HEADER_X_CSP = "X-Content-Security-Policy: x";
+    private static final String HEADER_WEBKIT_CSP = "X-WebKit-CSP: x";
+    private static final String HEADER_REPORT_ONLY = "Content-Security-Policy-Report-Only: x";
+
+    @Override
+    protected ContentSecurityPolicyMissingScanner createScanner() {
+        return new ContentSecurityPolicyMissingScanner();
+    }
+
+    @Test
+    public void givenMissingCspHeaderThenAlertRaised() throws Exception {
+        // Given
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertContentSecurityPolicyAlertRaised();
+    }
+
+    @Test
+    public void givenCspHeaderAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void givenCspHeaderAtLowAlertThresholdThenAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertContentSecurityPolicyAlertRaised();
+    }
+
+    @Test
+    public void givenAllCspHeadersButXCspAtLowAlertThresholdThenAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP, HEADER_WEBKIT_CSP);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertContentSecurityPolicyAlertRaised();
+    }
+
+    @Test
+    public void givenAllCspHeadersButWebkitCspAtLowAlertThresholdThenAlertRaised()
+            throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP, HEADER_X_CSP);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertContentSecurityPolicyAlertRaised();
+    }
+
+    @Test
+    public void givenAllCspHeadersAtLowAlertThresholdThenNoAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        String[] headers = {HEADER_HTML, HEADER_CSP, HEADER_X_CSP, HEADER_WEBKIT_CSP};
+        HttpMessage msg = createHttpMessageWithHeaders(headers);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void givenTextContentTypeAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_TEXT);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void givenTextContentTypeAtLowAlertThresholdThenAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_TEXT);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertContentSecurityPolicyAlertRaised();
+    }
+
+    @Test
+    public void givenTextContentTypeWithCspHeadersAtLowAlertThresholdThenNoAlertRaised()
+            throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        String[] headers = {HEADER_TEXT, HEADER_CSP, HEADER_X_CSP, HEADER_WEBKIT_CSP};
+        HttpMessage msg = createHttpMessageWithHeaders(headers);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void givenReportOnlyCspThenInfoAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_REPORT_ONLY);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(2));
+        assertCSPAlertAttributes(alertsRaised.get(0), "", Alert.RISK_LOW);
+        assertCSPAlertAttributes(alertsRaised.get(1), "ro.", Alert.RISK_INFO);
+    }
+
+    @Test
+    public void givenReportOnlyAndCspHeadersThenInfoAlertRaised() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_REPORT_ONLY, HEADER_CSP);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertCSPAlertAttributes(alertsRaised.get(0), "ro.", Alert.RISK_INFO);
+    }
+
+    private void assertContentSecurityPolicyAlertRaised() {
+        assertThat(alertsRaised.size(), is(1));
+        assertCSPAlertAttributes(alertsRaised.get(0), "", Alert.RISK_LOW);
+    }
+
+    private static void assertCSPAlertAttributes(Alert alert, String key, int expectedRisk) {
+        assertThat(alert.getRisk(), is(expectedRisk));
+        assertThat(alert.getName(), is(getLocalisedString(key + "name")));
+        assertThat(alert.getDescription(), is(getLocalisedString(key + "desc")));
+        assertThat(alert.getReference(), is(getLocalisedString(key + "refs")));
+        assertThat(alert.getSolution(), is(getLocalisedString("soln")));
+        assertThat(alert.getConfidence(), is(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alert.getCweId(), is(16));
+        assertThat(alert.getWascId(), is(15));
+        assertThat(alert.getUri(), is(URI));
+    }
+
+    private static String getLocalisedString(String key) {
+        return Constant.messages.getString("pscanalpha.contentsecuritypolicymissing." + key);
+    }
+
+    private static HttpMessage createHttpMessageWithHeaders(String... headers) throws Exception {
+        HttpMessage msg = new HttpMessage(new URI(URI, false));
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + String.join("\r\n", headers));
+        return msg;
+    }
+}


### PR DESCRIPTION
  * Fix a typo with getAlertAttribute
  * Replace `== false` with `!`
  * Closes zaproxy/zaproxy#5496