### PR TITLE
openapi: do not consume resource if not parsed

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Do not consume spider resource if not parsed as OpenAPI definition.
 
 ## [13] - 2019-07-18
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
@@ -58,6 +58,7 @@ public class OpenApiSpider extends SpiderParser {
             requestor.run(converter.getRequestModels());
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
+            return false;
         }
 
         return true;


### PR DESCRIPTION
Change `OpenApiSpider` to not consume the resource if not actually
parsed, to still allow other spider parsers (e.g. text) to parse it.