### PR TITLE
webdrivers: update ChromeDriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [11] - 2019-08-01
+### Changed
+- Update ChromeDriver to v76.0.3809.68.
 
 ## [10] - 2019-06-07
 ### Changed
@@ -58,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[11]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v11
 [10]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v10
 [9]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v9
 [8]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v8

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,7 +9,7 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 75.0.3770.8</li>
+    <li>Chrome - ChromeDriver 76.0.3809.68</li>
     <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [11] - 2019-08-01
+### Changed
+- Update ChromeDriver to v76.0.3809.68.
 
 ## [10] - 2019-06-07
 ### Changed
@@ -58,6 +59,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[11]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v11
 [10]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v10
 [9]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v9
 [8]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v8

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,7 +9,7 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 75.0.3770.8</li>
+    <li>Chrome - ChromeDriver 76.0.3809.68</li>
     <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.24.0"
-val chromeDriverVersion = "75.0.3770.8"
+val chromeDriverVersion = "76.0.3809.68"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [11] - 2019-08-01
+### Changed
+- Update ChromeDriver to v76.0.3809.68.
 
 ## [10] - 2019-06-07
 ### Changed
@@ -61,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[11]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v11
 [10]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v10
 [9]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v9
 [8]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v8

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,7 +9,7 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 75.0.3770.8</li>
+    <li>Chrome - ChromeDriver 76.0.3809.68</li>
     <li>Firefox - geckodriver 0.24.0</li>
 </ul>
 


### PR DESCRIPTION
Update ChromeDriver to 76.0.3809.68.
Add release dates and link to tags.