### PR TITLE
Add unit tests for SourceCodeDisclosureScanner

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java
@@ -700,7 +700,7 @@ public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
                     msg.getRequestHeader().getURI().toString(),
                     "", // param
                     "", // attack
-                    getExtraInfo(msg, evidence), // other info
+                    getExtraInfo(evidence), // other info
                     getSolution(),
                     getReference(),
                     evidence,
@@ -761,11 +761,10 @@ public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
     /**
      * gets extra information associated with the alert
      *
-     * @param msg
-     * @param arg0
+     * @param evidence
      * @return
      */
-    private String getExtraInfo(HttpMessage msg, String arg0) {
-        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);
+    private String getExtraInfo(String evidence) {
+        return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", evidence);
     }
 }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScannerUnitTest.java
@@ -19,27 +19,113 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
+import org.junit.Before;
 import org.junit.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
 
 public class SourceCodeDisclosureScannerUnitTest
         extends PassiveScannerTest<SourceCodeDisclosureScanner> {
+
+    private static final String CODE_SQL = "insert into vulnerabilities values(";
+    private static final String CODE_PHP = "<?php echo 'evils'; ?>";
+    private static final String CODE_HTML = "<p>Innocent HTML</p>";
+    private static final String URI = "https://www.example.com";
+
+    private HttpMessage msg;
 
     @Override
     protected SourceCodeDisclosureScanner createScanner() {
         return new SourceCodeDisclosureScanner();
     }
 
+    @Before
+    public void createHttpMessage() throws IOException {
+        msg = new HttpMessage();
+        msg.setRequestHeader("GET " + URI + " HTTP/1.1");
+    }
+
     @Test
     public void scannerNameShouldMatch() {
         // Quick test to verify scanner name which is used in the policy dialog but not
         // alone in alerts
+        assertThat(rule.getName(), is(getLocalisedString("name")));
+    }
 
+    @Test
+    public void givenJustHtmlBodyThenNoAlertRaised() {
         // Given
-        SourceCodeDisclosureScanner thisScanner = createScanner();
+        msg.setResponseBody(CODE_HTML);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
         // Then
-        assertThat(thisScanner.getName(), equalTo("Source Code Disclosure"));
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void givenPHPCodeThenAlertRaised() {
+        // Given
+        msg.setResponseBody(wrapWithHTML(CODE_PHP));
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertAlertAttributes(alertsRaised.get(0), CODE_PHP, "PHP");
+    }
+
+    @Test
+    public void givenSQLCodeThenAlertRaised() {
+        // Given
+        msg.setResponseBody(wrapWithHTML(CODE_SQL));
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+        assertAlertAttributes(alertsRaised.get(0), CODE_SQL, "SQL");
+    }
+
+    @Test
+    public void givenSQLAndPhpCodeThenOnlyOneAlertRaised() {
+        // Given
+        msg.setResponseBody(wrapWithHTML(CODE_SQL + CODE_PHP));
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+    }
+
+    private String wrapWithHTML(String code) {
+        return CODE_HTML + code + CODE_HTML;
+    }
+
+    private void assertAlertAttributes(Alert alert, String evidence, final String language) {
+        assertThat(alert.getRisk(), is(Alert.RISK_MEDIUM));
+        assertThat(alert.getConfidence(), is(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alert.getName(), is(getLocalisedString("name") + " - " + language));
+        assertThat(alert.getDescription(), is(getLocalisedString("desc") + " - " + language));
+        assertThat(alert.getUri(), is(URI));
+        assertThat(alert.getOtherInfo(), is(getLocalisedString("extrainfo", evidence)));
+        assertThat(alert.getSolution(), is(getLocalisedString("soln")));
+        assertThat(alert.getReference(), is(getLocalisedString("refs")));
+        assertThat(alert.getEvidence(), is(evidence));
+        assertThat(alert.getCweId(), is(540));
+        assertThat(alert.getWascId(), is(13));
+    }
+
+    private String getLocalisedString(String key, Object... params) {
+        return Constant.messages.getString("pscanalpha.sourcecodedisclosure." + key, params);
     }
 }


### PR DESCRIPTION
Each regular expression in the language patterns is a small program
in itself.  I haven't tested each and every one as there are 180.
Instead I took 2 and tested their implementation.  For more confidence
I'd want to write at least one unit test per expression.

Additionally
  * Removes unused parameter
  * Closes zaproxy/zaproxy#5499