### PR TITLE
Add script to concatenate split downloads

### DIFF
--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Update the help to mention the bundled JRuby version.
+- Add script to concatenate split file downloads
 
 ## 6 - 2017-11-27
 

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/standalone/Split download extract.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/standalone/Split download extract.rb
@@ -5,7 +5,6 @@ require 'java'
 # to reduce the risk of a broken connection.
 
 extHist = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension("ExtensionHistory")
-raw_data = []
 if (extHist != nil)
   
   File.open 'YOUR FILE PATH', 'wb' do |f|

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/standalone/Split download extract.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/standalone/Split download extract.rb
@@ -1,0 +1,24 @@
+require 'java'
+
+# Adjust the script to get join a file download which is split over several requests.
+# This is useful if you have a JavaScript file download that downloads chunks of the file
+# to reduce the risk of a broken connection.
+
+extHist = org.parosproxy.paros.control.Control.getSingleton().getExtensionLoader().getExtension("ExtensionHistory")
+raw_data = []
+if (extHist != nil)
+  
+  File.open 'YOUR FILE PATH', 'wb' do |f|
+    extHist.getSelectedHistoryReferences.each do |hr|
+      content_type = hr.getHttpMessage.getResponseHeader.getHeader("Content-Type")
+      url = url = hr.getHttpMessage.getRequestHeader.getURI.toString
+      # additional filter to jump over files that are not desired - for example if you have a application
+      # that is polling data open in background so and you just do not want to manually select them in the history.
+      # if you do not want the filter, commment out the next line and the corresponding end
+      if (content_type.include? 'octet-stream') && (url.include? 'www.example.com')
+        payload = hr.getHttpMessage.getResponseBody.getBytes
+        f.write payload if payload
+      end
+    end
+  end
+end

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/standalone/Split download extract.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/standalone/Split download extract.rb
@@ -11,7 +11,7 @@ if (extHist != nil)
   File.open 'YOUR FILE PATH', 'wb' do |f|
     extHist.getSelectedHistoryReferences.each do |hr|
       content_type = hr.getHttpMessage.getResponseHeader.getHeader("Content-Type")
-      url = url = hr.getHttpMessage.getRequestHeader.getURI.toString
+      url = hr.getHttpMessage.getRequestHeader.getURI.toString
       # additional filter to jump over files that are not desired - for example if you have a application
       # that is polling data open in background so and you just do not want to manually select them in the history.
       # if you do not want the filter, commment out the next line and the corresponding end


### PR DESCRIPTION
sometimes resources are split into several chunks at a specific size. This has the advantage that you do not need to download the full resource in case a chunk fails. The disadvantage is, that in ZAP you have to store each chunk manually and join them with `cat` afterwards.

This script template simplifies this process as it can be adjusted for most sites.

Such splits may be done using range requests (not supported here in case of parallel usage as the chunks may be out of order) as well as URLs containing the numbers and are fetched in order.