### PR TITLE
quickstart: link to newer getting started guide

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Maintenance changes.
+- Link to newer Getting Started Guide.
 
 ## [26] - 2019-06-07
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/LearnMorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/LearnMorePanel.java
@@ -46,7 +46,7 @@ public class LearnMorePanel extends QuickStartSubPanel {
 
     private static final String FAQ_LINK = "https://github.com/zaproxy/zaproxy/wiki/FAQtoplevel";
     private static final String GETTING_STARTED_LINK =
-            "https://github.com/zaproxy/zaproxy/releases/download/2.7.0/ZAPGettingStartedGuide-2.7.pdf";
+            "https://github.com/zaproxy/zaproxy/releases/download/v2.8.0/ZAPGettingStartedGuide-2.8.pdf";
     private static final String USER_GROUP_LINK = "https://groups.google.com/group/zaproxy-users";
     private static final String USER_GUIDE_LINK = "https://github.com/zaproxy/zap-core-help/wiki";
 


### PR DESCRIPTION
Link to 2.8.0 instead of 2.7.0.