### PR TITLE
jruby: fix NPE while unloading

### DIFF
--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update the help to mention the bundled JRuby version.
 - Fix link in a script template.
+- Fix exception while uninstalling the add-on with newer Java versions.
 
 ## 6 - 2017-11-27
 

--- a/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
+++ b/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
@@ -118,14 +118,16 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
     public void unload() {
         super.unload();
 
-        String engineName = getRubyScriptEngine().getFactory().getEngineName();
-        for (ScriptType type : this.getExtScript().getScriptTypes()) {
-            for (ScriptWrapper script : this.getExtScript().getScripts(type)) {
-                if (script.getEngineName().equals(engineName)) {
-                    if (script instanceof JrubyScriptWrapper) {
-                        ScriptNode node =
-                                this.getExtScript().getTreeModel().getNodeForScript(script);
-                        node.setUserObject(((JrubyScriptWrapper) script).getOriginal());
+        if (rubyScriptEngine != null) {
+            String engineName = rubyScriptEngine.getFactory().getEngineName();
+            for (ScriptType type : this.getExtScript().getScriptTypes()) {
+                for (ScriptWrapper script : this.getExtScript().getScripts(type)) {
+                    if (script.getEngineName().equals(engineName)) {
+                        if (script instanceof JrubyScriptWrapper) {
+                            ScriptNode node =
+                                    this.getExtScript().getTreeModel().getNodeForScript(script);
+                            node.setUserObject(((JrubyScriptWrapper) script).getOriginal());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Check that the script engine exists before attempting to use it when
unloading the extension, it does not exist with newer Java versions as
it fails to load.