### PR TITLE
Wappalyzer Performance Tweak

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Performance improvements.
 
 ## [12] - 2019-04-24
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -120,6 +120,9 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
     private void checkAppMatches(HttpMessage msg, Source source) {
         checkUrlMatches(msg);
         checkHeadersMatches(msg);
+        if (!msg.getResponseHeader().isText()) {
+            return; // Don't check body if not text'ish
+        }
         checkBodyMatches(msg);
         checkMetaElementsMatches(source);
         checkScriptMatches(msg);


### PR DESCRIPTION
In order to further address performance, such as this item I encountered the other day:
`79049 [ZAP-PassiveScanner] WARN
org.zaproxy.zap.extension.pscan.PassiveScanThread  - Passive Scan rule
Wappalyzer Scanner (Tech Detection) took 7 seconds to scan
http://xxx/favicon.ico image/x-icon 15086`

* WappalyzerPassiveScanner > Changed to skip response body checks if the response isn't a text type.
* WappalyzerPassiveScannerUnitTest > Updated to actually set the content-type on test messages. Added test methods to assert the expected behavior.
* CHANGELOG > Added note to unreleased section.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>