### PR TITLE
Generate and save CodeDx report with ReportLastScan.generate

### DIFF
--- a/addOns/codedx/CHANGELOG.md
+++ b/addOns/codedx/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-
+- Make fixes to the report generation process to handle encoding the same as other ZAP reports
 
 ## 7 - 2018-07-02
 

--- a/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/CodeDxAPI.java
+++ b/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/CodeDxAPI.java
@@ -89,16 +89,16 @@ public class CodeDxAPI extends ApiImplementor {
 			String fingerprint = this.getParam(params, ACTION_PARAM_FINGERPRINT, "");
 			boolean acceptPermanently = this.getParam(params, ACTION_PARAM_ACCEPT_PERM, false);
 
-			StringBuilder report = new StringBuilder();
+			boolean isEmpty = false;
 			try {
-				reportFile = UploadActionListener.generateReportFile(extension, report);
+				reportFile = UploadActionListener.generateReportFile(extension);
+				isEmpty = UploadActionListener.reportIsEmpty(reportFile);
 			} catch (Exception e) {
 				LOGGER.error(e.getMessage(), e);
 				throw new ApiException(Type.INTERNAL_ERROR, e.getMessage());
 			}
 			try {
-				// Check report length before splitting to avoid splitting large reports for no reason
-				if(report.length() > 200 || report.toString().trim().split("\n").length > 2) 
+				if(!isEmpty)
 					uploadFile(reportFile, serverUrl, apiKey, projectId, fingerprint, acceptPermanently);
 				else
 					return new ApiResponseElement("Result", "empty");


### PR DESCRIPTION
Files.write in generateReportFile appears to sometimes cause exceptions from encoding conflicts. This uses the ReportLastScan.generate method that saves to a file internally instead. It also now parses the report file with an XMLEventReader to check if it's empty.