### PR TITLE
Maintenance - Remove superfluous methods in active scan rules

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Improved PowerShell injection control patterns to reduce false positives.
+- Maintenance changes.
 
 ## [33] - 2019-06-07
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
@@ -55,11 +55,6 @@ public class BufferOverflow extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         return technologies.includes(Tech.C);
     }
@@ -87,9 +82,6 @@ public class BufferOverflow extends AbstractAppParamPlugin {
     public String getOther() {
         return Constant.messages.getString(MESSAGE_PREFIX + "other");
     }
-
-    @Override
-    public void init() {}
 
     /*
      * This method is called by the active scanner for each GET and POST parameter for every page

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
@@ -92,16 +92,6 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    /**
-     * Give back specific plugin dependencies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return new String[] {};
-    }
-
     @Override
     public boolean targets(TechSet technologies) {
         if (technologies.includes(Tech.ASP) || technologies.includes(Tech.PHP)) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -235,16 +235,6 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    /**
-     * Give back specific plugin dependencies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return new String[] {};
-    }
-
     @Override
     public boolean targets(TechSet technologies) {
         if (technologies.includes(Tech.Linux)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatString.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatString.java
@@ -73,11 +73,6 @@ public class FormatString extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         return technologies.includes(Tech.C);
     }
@@ -105,9 +100,6 @@ public class FormatString extends AbstractAppParamPlugin {
     private String getError(char c) {
         return Constant.messages.getString(MESSAGE_PREFIX + "error" + c);
     }
-
-    @Override
-    public void init() {}
 
     /*
      * This method is called by the active scanner for each GET and POST parameter for every page

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWEBINF.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWEBINF.java
@@ -100,11 +100,6 @@ public class SourceCodeDisclosureWEBINF extends AbstractHostPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
@@ -63,11 +63,6 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();
@@ -102,9 +97,6 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
         }
         return "Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan(HttpMessage msg, NameValuePair originalParam) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestDirectoryBrowsing.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestDirectoryBrowsing.java
@@ -67,11 +67,6 @@ public class TestDirectoryBrowsing extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
@@ -90,9 +85,6 @@ public class TestDirectoryBrowsing extends AbstractAppPlugin {
     public String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
-
-    @Override
-    public void init() {}
 
     private void checkIfDirectory(HttpMessage msg) throws URIException {
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
@@ -124,16 +124,6 @@ public class TestExternalRedirect extends AbstractAppParamPlugin {
     }
 
     /**
-     * Give back specific plugin dependencies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    /**
      * Get the description of the vulnerability when found
      *
      * @return the vulnerability description
@@ -192,10 +182,6 @@ public class TestExternalRedirect extends AbstractAppParamPlugin {
 
         return "Failed to load vulnerability reference from file";
     }
-
-    /** Initialize the plugin according to the overall environment configuration */
-    @Override
-    public void init() {}
 
     /**
      * Scan for External Redirect vulnerabilities

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestInjectionCRLF.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestInjectionCRLF.java
@@ -77,11 +77,6 @@ public class TestInjectionCRLF extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
@@ -100,9 +95,6 @@ public class TestInjectionCRLF extends AbstractAppParamPlugin {
     public String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan(HttpMessage msg, String param, String value) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
@@ -87,11 +87,6 @@ public class TestParameterTamper extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
@@ -110,9 +105,6 @@ public class TestParameterTamper extends AbstractAppParamPlugin {
     public String getReference() {
         return "";
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan(HttpMessage msg, String param, String value) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
@@ -196,11 +196,6 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();
@@ -236,9 +231,6 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
 
         return "Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     /**
      * scans all GET and POST parameters for Path Traversal vulnerabilities

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSAttack.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSAttack.java
@@ -103,9 +103,6 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
     }
 
     @Override
-    public void init() {}
-
-    @Override
     public void scan(HttpMessage msg, NameValuePair originalParam) {
         currentParamType = originalParam.getType();
         super.scan(msg, originalParam);

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSPrime.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSPrime.java
@@ -44,11 +44,6 @@ public class TestPersistentXSSPrime extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "misc");
     }
@@ -67,9 +62,6 @@ public class TestPersistentXSSPrime extends AbstractAppParamPlugin {
     public String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "misc");
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan(HttpMessage msg, String param, String value) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSSpider.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSSpider.java
@@ -69,9 +69,6 @@ public class TestPersistentXSSSpider extends AbstractAppPlugin {
     }
 
     @Override
-    public void init() {}
-
-    @Override
     public void scan() {
 
         HttpMessage msg = getBaseMsg();

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
@@ -83,11 +83,6 @@ public class TestRemoteFileInclude extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();
@@ -122,9 +117,6 @@ public class TestRemoteFileInclude extends AbstractAppParamPlugin {
         }
         return "Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan(HttpMessage msg, String param, String value) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -441,8 +441,6 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
         "\") UNION ALL select NULL" + SQL_ONE_LINE_COMMENT,
     };
 
-    /** plugin dependencies */
-    private static final String[] dependency = {};
     /** for logging. */
     private static Logger log = Logger.getLogger(TestSQLInjection.class);
     /** determines if we should output Debug level logging */
@@ -456,11 +454,6 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestServerSideInclude.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestServerSideInclude.java
@@ -68,11 +68,6 @@ public class TestServerSideInclude extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         if (technologies.includes(Tech.Linux)
                 || technologies.includes(Tech.MacOS)
@@ -101,9 +96,6 @@ public class TestServerSideInclude extends AbstractAppParamPlugin {
     public String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
-
-    @Override
-    public void init() {}
 
     // Pre-check the original response for the detection pattern (to avoid false positives)
     private boolean isEvidencePresent(Pattern pattern) {

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Maintenance changes.
 
 ## [25] - 2019-07-11
 

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/AbstractAppFilePlugin.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/AbstractAppFilePlugin.java
@@ -63,11 +63,6 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public int getCategory() {
         return Category.INFO_GATHER;
     }
@@ -86,9 +81,6 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
     public int getWascId() {
         return 13; // WASC-13: Information Leakage
     }
-
-    @Override
-    public void init() {}
 
     private String getOtherInfo() {
         return Constant.messages.getString(messagePrefix + "otherinfo");

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ApacheRangeHeaderDos.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ApacheRangeHeaderDos.java
@@ -73,11 +73,6 @@ public class ApacheRangeHeaderDos extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         return technologies.includes(Tech.Apache);
     }
@@ -101,9 +96,6 @@ public class ApacheRangeHeaderDos extends AbstractAppPlugin {
     public int getWascId() {
         return 10; // WASC-10: Denial of Service
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanner.java
@@ -83,11 +83,6 @@ public class CloudMetadataScanner extends AbstractHostPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public int getCategory() {
         return Category.INJECTION;
     }
@@ -106,9 +101,6 @@ public class CloudMetadataScanner extends AbstractHostPlugin {
     public int getWascId() {
         return 0;
     }
-
-    @Override
-    public void init() {}
 
     public void raiseAlert(HttpMessage newRequest) {
         bingo(

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ElmahScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ElmahScanner.java
@@ -76,11 +76,6 @@ public class ElmahScanner extends AbstractHostPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         return technologies.includes(Tech.IIS)
                 || technologies.includes(Tech.Windows)
@@ -107,9 +102,6 @@ public class ElmahScanner extends AbstractHostPlugin {
     public int getWascId() {
         return 13; // WASC-13: Informatin Leakage
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
@@ -94,17 +94,9 @@ public class ExampleFileActiveScanner extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public int getCategory() {
         return Category.MISC;
     }
-
-    @Override
-    public void init() {}
 
     /*
      * This method is called by the active scanner for each GET and POST parameter for every page

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
@@ -66,11 +66,6 @@ public class ExampleSimpleActiveScanner extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(
             TechSet technologies) { // This method allows the programmer or user to restrict when a
         // scanner is run based on the technologies selected.  For example, to restrict the scanner
@@ -114,9 +109,6 @@ public class ExampleSimpleActiveScanner extends AbstractAppParamPlugin {
         }
         return "Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     /*
      * This method is called by the active scanner for each GET and POST parameter for every page

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/GetForPostScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/GetForPostScanner.java
@@ -73,9 +73,6 @@ public class GetForPostScanner extends AbstractAppPlugin {
     }
 
     @Override
-    public void init() {}
-
-    @Override
     public void scan() {
         // Check if the user stopped things. One request per URL so check before
         // sending the request

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HttpOnlySite.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HttpOnlySite.java
@@ -76,11 +76,6 @@ public class HttpOnlySite extends AbstractHostPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public int getCategory() {
         return Category.MISC;
     }
@@ -99,9 +94,6 @@ public class HttpOnlySite extends AbstractHostPlugin {
     public int getWascId() {
         return 4; // WASC-04: Insufficient Transport Layer Protection
     }
-
-    @Override
-    public void init() {}
 
     public void raiseAlert(HttpMessage newRequest, String message) {
         String newUri = newRequest.getRequestHeader().getURI().toString();

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HttpoxyScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HttpoxyScanner.java
@@ -46,11 +46,6 @@ public class HttpoxyScanner extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
@@ -89,9 +84,6 @@ public class HttpoxyScanner extends AbstractAppPlugin {
     public String getSolution() {
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HttpsAsHttpScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HttpsAsHttpScanner.java
@@ -70,11 +70,6 @@ public class HttpsAsHttpScanner extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public int getCategory() {
         return Category.MISC;
     }
@@ -93,9 +88,6 @@ public class HttpsAsHttpScanner extends AbstractAppPlugin {
     public int getWascId() {
         return 4; // WASC-04: Insufficient Transport Layer Protection
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
@@ -46,8 +46,6 @@ import org.zaproxy.zap.utils.HirshbergMatcher;
  */
 public class LDAPInjection extends AbstractAppParamPlugin {
 
-    /** plugin dependencies */
-    private static final String[] dependency = {};
     /** for logging. */
     private static Logger log = Logger.getLogger(LDAPInjection.class);
 
@@ -114,11 +112,6 @@ public class LDAPInjection extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString(I18N_PREFIX + "ldapinjection.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ProxyDisclosureScanner.java
@@ -164,9 +164,6 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
     /** the number of Max-Forwards to apply. Set depending on the Attack strength. */
     private int MAX_FORWARDS_MAXIMUM = 0;
 
-    /** plugin dependencies (none) */
-    private static final String[] dependency = {};
-
     /** for logging. */
     private static Logger log = Logger.getLogger(ProxyDisclosureScanner.class);
 
@@ -178,11 +175,6 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/RelativePathConfusionScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/RelativePathConfusionScanner.java
@@ -179,11 +179,6 @@ public class RelativePathConfusionScanner extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
@@ -202,9 +197,6 @@ public class RelativePathConfusionScanner extends AbstractAppPlugin {
     public String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionMsSQL.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionMsSQL.java
@@ -76,8 +76,6 @@ public class SQLInjectionMsSQL extends AbstractAppParamPlugin {
         ORIG_VALUE_TOKEN + ")) \" WAITFOR DELAY '" + SLEEP_TOKEN + "' ((",
     };
 
-    /** plugin dependencies (none! not even "SQL Injection") */
-    private static final String[] dependency = {};
     /** for logging. */
     private static final Logger log = Logger.getLogger(SQLInjectionMsSQL.class);
 
@@ -97,11 +95,6 @@ public class SQLInjectionMsSQL extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanalpha.sqlinjection.mssql.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SQLInjectionSQLite.java
@@ -206,9 +206,6 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
 
     private char[] RANDOM_PARAMETER_CHARS = "abcdefghijklmnopqrstuvwyxz0123456789".toCharArray();
 
-    /** plugin dependencies (none! not even "SQL Injection") */
-    private static final String[] dependency = {};
-
     /** for logging. */
     private static Logger log = Logger.getLogger(SQLInjectionSQLite.class);
 
@@ -223,11 +220,6 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanalpha.sqlinjection.sqlite.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SlackerCookieDetector.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SlackerCookieDetector.java
@@ -307,11 +307,6 @@ public class SlackerCookieDetector extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString("ascanalpha.cookieslack.desc");
     }
@@ -340,9 +335,6 @@ public class SlackerCookieDetector extends AbstractAppPlugin {
         }
         return "Cookie Slack Detector: Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public int getRisk() {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureFileInclusion.java
@@ -148,11 +148,6 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureGit.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SourceCodeDisclosureGit.java
@@ -82,11 +82,6 @@ public class SourceCodeDisclosureGit extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString("ascanalpha.sourcecodedisclosure.desc");
     }
@@ -120,9 +115,6 @@ public class SourceCodeDisclosureGit extends AbstractAppPlugin {
         return Constant.messages.getString(
                 "ascanalpha.sourcecodedisclosure.gitbased.evidence", filename, gitURIs);
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/TestUserAgent.java
@@ -78,11 +78,6 @@ public class TestUserAgent extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
@@ -101,9 +96,6 @@ public class TestUserAgent extends AbstractAppPlugin {
     public String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed ArrayIndexOutOfBoundsException issue in XML External Entity Attack scan rule.
   - Now removes original XML header in "Local File Reflection Attack".
+- Maintenance changes.
 
 ## [26] - 2019-07-11
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
@@ -299,11 +299,6 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanner.java
@@ -83,11 +83,6 @@ public class CrossDomainScanner extends AbstractHostPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return "";
     }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
@@ -78,12 +78,6 @@ public class Csrftokenscan extends AbstractAppPlugin {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    /** @return dependencies of the plugin (none) */
-    @Override
-    public String[] getDependency() {
-        return null;
-    }
-
     /** @return the description of the vulnerability */
     @Override
     public String getDescription() {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionPlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionPlugin.java
@@ -69,16 +69,6 @@ public class ExpressionLanguageInjectionPlugin extends AbstractAppParamPlugin {
     }
 
     /**
-     * Give back specific pugin dependancies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return new String[] {};
-    }
-
-    /**
      * Get the description of the vulnerbaility when found
      *
      * @return the vulnerability description

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
@@ -66,12 +66,6 @@ public class HPP extends AbstractAppPlugin {
         return Constant.messages.getString("ascanbeta.HTTPParamPoll.name");
     }
 
-    /** @return dependencies of the plugin (none) */
-    @Override
-    public String[] getDependency() {
-        return null;
-    }
-
     /** @return the description of the vulnerability */
     @Override
     public String getDescription() {
@@ -95,10 +89,6 @@ public class HPP extends AbstractAppPlugin {
     public String getReference() {
         return Constant.messages.getString("ascanbeta.HTTPParamPoll.extrainfo");
     }
-
-    /** */
-    @Override
-    public void init() {}
 
     /**
      * Main method of the class. It is executed for each page. Determined whether the page in

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
@@ -866,11 +866,6 @@ public class HeartBleedActiveScanner extends AbstractHostPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
@@ -105,11 +105,6 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();
@@ -144,9 +139,6 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
         }
         return "Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflow.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflow.java
@@ -52,11 +52,6 @@ public class IntegerOverflow extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         return technologies.includes(Tech.C);
     }
@@ -84,9 +79,6 @@ public class IntegerOverflow extends AbstractAppParamPlugin {
     private String getError(char c) {
         return Constant.messages.getString(MESSAGE_PREFIX + "error" + c);
     }
-
-    @Override
-    public void init() {}
 
     /*
      * This method is called by the active scanner for each GET and POST parameter for every page

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOraclePlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOraclePlugin.java
@@ -70,16 +70,6 @@ public class PaddingOraclePlugin extends AbstractAppParamPlugin {
     }
 
     /**
-     * Give back specific pugin dependancies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return new String[] {};
-    }
-
-    /**
      * Get the description of the vulnerbaility when found
      *
      * @return the vulnerability description

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823.java
@@ -79,11 +79,6 @@ public class RemoteCodeExecutionCVE20121823 extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         if (technologies.includes(Tech.PHP)) {
             return true;
@@ -126,9 +121,6 @@ public class RemoteCodeExecutionCVE20121823 extends AbstractAppPlugin {
         }
         return "Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
@@ -179,9 +179,6 @@ public class SQLInjectionHypersonic extends AbstractAppParamPlugin {
                 + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
     };
 
-    /** plugin dependencies (none! not even "SQL Injection") */
-    private static final String[] dependency = {};
-
     /** for logging. */
     private static Logger log = Logger.getLogger(SQLInjectionHypersonic.class);
 
@@ -196,11 +193,6 @@ public class SQLInjectionHypersonic extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanbeta.sqlinjection.hypersonic.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
@@ -187,9 +187,6 @@ public class SQLInjectionMySQL extends AbstractAppParamPlugin {
                 + ") ) and \"\"=\"", // MySQL >= 5.0.12. Param in WHERE clause.
     };
 
-    /** plugin dependencies (none! not even "SQL Injection") */
-    private static final String[] dependency = {};
-
     /** for logging. */
     private static Logger log = Logger.getLogger(SQLInjectionMySQL.class);
 
@@ -204,11 +201,6 @@ public class SQLInjectionMySQL extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanbeta.sqlinjection.mysql.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
@@ -139,9 +139,6 @@ public class SQLInjectionOracle extends AbstractAppParamPlugin {
                 + SQL_ONE_LINE_COMMENT, // Param in WHERE clause somewhere
     };
 
-    /** plugin dependencies (none! not even "SQL Injection") */
-    private static final String[] dependency = {};
-
     /** for logging. */
     private static Logger log = Logger.getLogger(SQLInjectionOracle.class);
 
@@ -156,11 +153,6 @@ public class SQLInjectionOracle extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanbeta.sqlinjection.oracle.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
@@ -175,9 +175,6 @@ public class SQLInjectionPostgresql extends AbstractAppParamPlugin {
                 + SQL_ONE_LINE_COMMENT, // Param in WHERE clause.
     };
 
-    /** plugin dependencies (none! not even "SQL Injection") */
-    private static final String[] dependency = {};
-
     /** for logging. */
     private static Logger log = Logger.getLogger(SQLInjectionPostgresql.class);
 
@@ -192,11 +189,6 @@ public class SQLInjectionPostgresql extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanbeta.sqlinjection.postgres.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
@@ -62,8 +62,6 @@ import org.zaproxy.zap.model.Context;
  * @author 70pointer
  */
 public class SessionFixation extends AbstractAppPlugin {
-    /** plugin dependencies */
-    private static final String[] dependency = {};
 
     /** for logging. */
     private static Logger log = Logger.getLogger(SessionFixation.class);
@@ -79,11 +77,6 @@ public class SessionFixation extends AbstractAppPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanbeta.sessionfixation.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanner.java
@@ -61,11 +61,6 @@ public class ShellShockScanner extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString("ascanbeta.shellshock.desc");
     }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823.java
@@ -76,11 +76,6 @@ public class SourceCodeDisclosureCVE20121823 extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public boolean targets(TechSet technologies) {
         if (technologies.includes(Tech.PHP)) {
             return true;
@@ -123,9 +118,6 @@ public class SourceCodeDisclosureCVE20121823 extends AbstractAppPlugin {
         }
         return "Failed to load vulnerability reference from file";
     }
-
-    @Override
-    public void init() {}
 
     @Override
     public void scan() {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
@@ -89,9 +89,6 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
                     "<html"); // helps eliminate some common false positives in the case of 403s,
     // 302s, etc
 
-    @Override
-    public void init() {}
-
     /** returns the plugin id */
     @Override
     public int getId() {
@@ -102,11 +99,6 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return null;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
@@ -55,8 +55,6 @@ import org.zaproxy.zap.utils.HirshbergMatcher;
  * @author 70pointer
  */
 public class UsernameEnumeration extends AbstractAppPlugin {
-    /** plugin dependencies */
-    private static final String[] dependency = {};
 
     /** for logging. */
     private static Logger log = Logger.getLogger(UsernameEnumeration.class);
@@ -81,11 +79,6 @@ public class UsernameEnumeration extends AbstractAppPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString("ascanbeta.usernameenumeration.name");
-    }
-
-    @Override
-    public String[] getDependency() {
-        return dependency;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XXEPlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XXEPlugin.java
@@ -125,16 +125,6 @@ public class XXEPlugin extends AbstractAppPlugin implements ChallengeCallbackPlu
     }
 
     /**
-     * Give back specific pugin dependancies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return new String[] {};
-    }
-
-    /**
      * Get the description of the vulnerbaility when found
      *
      * @return the vulnerability description

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionPlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionPlugin.java
@@ -107,16 +107,6 @@ public class XpathInjectionPlugin extends AbstractAppParamPlugin {
     }
 
     /**
-     * Give back specific pugin dependancies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return new String[] {};
-    }
-
-    /**
      * Get the description of the vulnerbaility when found
      *
      * @return the vulnerability description

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Maintenance changes.
 
 ## [9] - 2019-06-12
 ### Fixed

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/TestDomXSS.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/TestDomXSS.java
@@ -119,11 +119,6 @@ public class TestDomXSS extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public String getDescription() {
         if (vuln != null) {
             return vuln.getDescription();

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix exception with Java 9+ (Issue 4037).
 - Update minimum ZAP version to 2.8.0.
 - Add import menus to (new) top level Import menu instead of Tools menu.
+- Maintenance changes.
 
 ## 3 - 2017-03-31
 

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
@@ -78,17 +78,9 @@ public class SOAPActionSpoofingActiveScanner extends AbstractAppPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public int getCategory() {
         return Category.MISC;
     }
-
-    @Override
-    public void init() {}
 
     /*
      * This method is called by the active scanner for each GET and POST parameter

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanner.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanner.java
@@ -66,17 +66,9 @@ public class SOAPXMLInjectionActiveScanner extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String[] getDependency() {
-        return null;
-    }
-
-    @Override
     public int getCategory() {
         return Category.MISC;
     }
-
-    @Override
-    public void init() {}
 
     /*
      * This method is called by the active scanner for each GET and POST parameter

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Maintenance changes.
 
 ## [13] - 2019-06-07
 

--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionPlugin.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionPlugin.java
@@ -182,16 +182,6 @@ public class SQLInjectionPlugin extends AbstractAppParamPlugin {
         return Constant.messages.getString(ALERT_MESSAGE_PREFIX + "refs");
     }
 
-    /**
-     * Give back specific pugin dependancies (none for this)
-     *
-     * @return the list of plugins that need to be executed before
-     */
-    @Override
-    public String[] getDependency() {
-        return new String[] {};
-    }
-
     @Override
     public boolean targets(TechSet technologies) {
         if (technologies.includes(Tech.Db)) {


### PR DESCRIPTION
- remove empty or unnecessary overridden `init()` and `getDependency()` methods, no longer required (since 2.5.0). Ref: https://github.com/zaproxy/zaproxy/pull/2346
- CHANGELOGs: added maintenance note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>