### PR TITLE
CSP Missing and Feature Policy: ignore missing headers on redirects

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Add Java Serialized Object (JSO) Scanner.
 - Fixed false positive when redirect destination is the same domain (Issue 5289).
+- CSP Missing and Feature Policy scan rule: Ignore missing headers on redirects unless Low threshold used.
+
 
 ## [25] - 2019-07-11
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScanner.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -58,7 +59,8 @@ public class ContentSecurityPolicyMissingScanner extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 
-        if (!msg.getResponseHeader().isHtml()
+        if ((!msg.getResponseHeader().isHtml()
+                        || HttpStatusCode.isRedirection(msg.getResponseHeader().getStatusCode()))
                 && !AlertThreshold.LOW.equals(this.getAlertThreshold())) {
             // Only really applies to HTML responses, but also check on Low threshold
             return;

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanner.java
@@ -24,7 +24,9 @@ import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -50,6 +52,10 @@ public class FeaturePolicyScanner extends PluginPassiveScanner {
 
         if (!httpMessage.getResponseHeader().isHtml()
                 && !httpMessage.getResponseHeader().isJavaScript()) {
+            return;
+        }
+        if (HttpStatusCode.isRedirection(httpMessage.getResponseHeader().getStatusCode())
+                && !AlertThreshold.LOW.equals(this.getAlertThreshold())) {
             return;
         }
 

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -37,7 +37,8 @@ Alerts generated:
 <H2>Content Security Policy (CSP) Header Not Set</H2>
 This checks HTML response headers for the presence of a Content Security Policy header.<br>
 By default this rule checks for the presence of the "Content-Security-Policy" header, 
-and at the Low threshold also checks for the "X-Content-Security-Policy" and "X-WebKit-CSP" headers.
+and at the Low threshold also checks for the "X-Content-Security-Policy" and "X-WebKit-CSP" headers.<br>
+Redirects and non HTML responses are ignored except at the Low threshold.
 <p>
 If a "Content-Security-Policy-Report-Only" header is found on a response an INFO alert is raised. This may represent an enforcement effort 
 that is actively being refined or developed, or one which is only partially implemented.
@@ -54,7 +55,8 @@ For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passiv
 
 <H2>Feature Policy Header Not Set</H2>
 This scanner checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Feature-Policy" header, 
-and alerts if one is not found.
+and alerts if one is not found.<br>
+Redirects are ignored except at the Low threshold.
 
 <H2>Hash Disclosure</H2>
 Passively scan for password hashes disclosed by the web server. <br>

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/ContentSecurityPolicyMissingScannerUnitTest.java
@@ -57,6 +57,34 @@ public class ContentSecurityPolicyMissingScannerUnitTest
     }
 
     @Test
+    public void givenMissingCspHeaderInRedirectAtMediumAlertThresholdThenNoAlertRaised()
+            throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
+        HttpMessage msg = createHttpMessageWithHeaders(301, HEADER_HTML);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void givenMissingCspHeaderInRedirectAtLowAlertThresholdThenAlertRaised()
+            throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        HttpMessage msg = createHttpMessageWithHeaders(301, HEADER_HTML);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertContentSecurityPolicyAlertRaised();
+    }
+
+    @Test
     public void givenCspHeaderAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
@@ -215,8 +243,14 @@ public class ContentSecurityPolicyMissingScannerUnitTest
     }
 
     private static HttpMessage createHttpMessageWithHeaders(String... headers) throws Exception {
+        return createHttpMessageWithHeaders(200, headers);
+    }
+
+    private static HttpMessage createHttpMessageWithHeaders(int responseCode, String... headers)
+            throws Exception {
         HttpMessage msg = new HttpMessage(new URI(URI, false));
-        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + String.join("\r\n", headers));
+        msg.setResponseHeader(
+                "HTTP/1.1 " + responseCode + " OK\r\n" + String.join("\r\n", headers));
         return msg;
     }
 }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScannerUnitTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThat;
 import org.apache.commons.httpclient.URI;
 import org.junit.Before;
 import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -89,5 +90,31 @@ public class FeaturePolicyScannerUnitTest extends PassiveScannerTest<FeaturePoli
         rule.scanHttpResponseReceive(msg, -1, createSource(msg));
         // Then
         assertEquals(alertsRaised.size(), 0);
+    }
+
+    @Test
+    public void shouldNotRaiseAlertOnMissingFeaturePolicyRedirectMediumThreshold()
+            throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
+        msg.setResponseHeader("HTTP/1.1 301 Moved Permanently\r\n");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertEquals(alertsRaised.size(), 0);
+    }
+
+    @Test
+    public void shouldRaiseAlertOnMissingFeaturePolicyRedirectLowThreshold() throws Exception {
+        // Given
+        rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
+        msg.setResponseHeader("HTTP/1.1 301 Moved Permanently\r\n");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertEquals(alertsRaised.size(), 1);
+        assertThat(alertsRaised.get(0), hasNameLoadedWithKey(MESSAGE_PREFIX + "name"));
     }
 }


### PR DESCRIPTION
Unless low threshold used

Signed-off-by: Simon Bennetts <psiinon@gmail.com>