### PR TITLE
Forced browse: Use logger instead of standard output 

### DIFF
--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Now targets ZAP 2.8.0.
 - Fix un-handled exception when base request doesn't end in a slash (Issue 5435).
 - Split up the functionality from the desktop UI and provide external access (Issue 2848)
+- Updated addon to use log4j instead of stdout (Issue 5530)
 
 ## Added
 - Table export button.

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Vector;
+import org.apache.log4j.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -37,6 +38,9 @@ import org.apache.commons.httpclient.methods.GetMethod;
  * @author James
  */
 public class GenBaseCase {
+	
+	/* Log object for this class */
+	private static final Logger LOG = Logger.getLogger(GenBaseCase.class.getName());
 
     /** Creates a new instance of GenBaseCase */
     private GenBaseCase() {}
@@ -70,14 +74,11 @@ public class GenBaseCase {
         BaseCase tempBaseCase = manager.getBaseCase(url, isDir, fileExtention);
 
         if (tempBaseCase != null) {
-            // System.out.println("Using prestored basecase");
             return tempBaseCase;
         }
 
-        // System.out.println("DEBUG GenBaseCase: URL to get baseCase for: " + url + " (" + type +
-        // ")");
-        if (Config.debug) {
-            System.out.println("DEBUG GenBaseCase: URL to get baseCase for:" + url);
+        if (LOG.isDebugEnabled()) {
+        	LOG.debug("GenBaseCase: URL to get baseCase for: " + url);
         }
 
         BaseCase baseCase = null;
@@ -99,9 +100,8 @@ public class GenBaseCase {
             }
         }
 
-        // System.out.println("DEBUG GenBaseCase: Getting :" + failurl + " (" + type + ")");
-        if (Config.debug) {
-            System.out.println("DEBUG GenBaseCase: Getting:" + failurl);
+        if (LOG.isDebugEnabled()) {
+        	LOG.debug("DEBUG GenBaseCase: Getting:" + failurl);
         }
 
         GetMethod httpget = new GetMethod(failurl.toString());
@@ -126,11 +126,8 @@ public class GenBaseCase {
 
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
-            if (Config.debug) {
-                System.out.println(
-                        "DEBUG GenBaseCase: base case for "
-                                + failurl.toString()
-                                + "came back as 200!");
+            if (LOG.isDebugEnabled()) {
+            	LOG.debug("DEBUG GenbaseCase: base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =
@@ -203,8 +200,8 @@ public class GenBaseCase {
                      */
                 }
 
-                if (Config.debug) {
-                    System.out.println("DEBUG GenBaseCase: base case was set to :" + baseResponce);
+                if (LOG.isDebugEnabled()) {
+                	LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
                 }
             }
         }
@@ -267,11 +264,8 @@ public class GenBaseCase {
         manager.workDone();
 
         if (failcode == 200) {
-            if (Config.debug) {
-                System.out.println(
-                        "DEBUG GenBaseCase: base case for "
-                                + failurl.toString()
-                                + "came back as 200!");
+            if (LOG.isDebugEnabled()) {
+            	LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =
@@ -287,8 +281,8 @@ public class GenBaseCase {
             // clean up the base case, based on the basecase URL
             baseResponce = FilterResponce.CleanResponce(baseResponce, failurl, failString);
 
-            if (Config.debug) {
-                System.out.println("DEBUG GenBaseCase: base case was set to :" + baseResponce);
+            if (LOG.isDebugEnabled()) {
+            	LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
             }
         }
 
@@ -334,11 +328,8 @@ public class GenBaseCase {
 
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
-            if (Config.debug) {
-                System.out.println(
-                        "DEBUG GenBaseCase: base case for "
-                                + failurl.toString()
-                                + "came back as 200!");
+            if (LOG.isDebugEnabled()) {
+            	LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
@@ -40,7 +40,7 @@ import org.apache.log4j.Logger;
 public class GenBaseCase {
 
     /* Log object for this class */
-    private static final Logger LOG = Logger.getLogger(GenBaseCase.class.getName());
+    private static final Logger LOG = Logger.getLogger(GenBaseCase.class);
 
     /** Creates a new instance of GenBaseCase */
     private GenBaseCase() {}
@@ -78,7 +78,7 @@ public class GenBaseCase {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("GenBaseCase: URL to get baseCase for: " + url);
+            LOG.debug("URL to get baseCase for: " + url);
         }
 
         BaseCase baseCase = null;
@@ -101,7 +101,7 @@ public class GenBaseCase {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("DEBUG GenBaseCase: Getting:" + failurl);
+            LOG.debug("Getting:" + failurl);
         }
 
         GetMethod httpget = new GetMethod(failurl.toString());
@@ -127,10 +127,7 @@ public class GenBaseCase {
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "DEBUG GenbaseCase: base case for "
-                                + failurl.toString()
-                                + " came back as 200!");
+                LOG.debug("Base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =
@@ -204,7 +201,7 @@ public class GenBaseCase {
                 }
 
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
+                    LOG.debug("Base case was set to: " + baseResponce);
                 }
             }
         }
@@ -268,10 +265,7 @@ public class GenBaseCase {
 
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "DEBUG GenBaseCase: base case for "
-                                + failurl.toString()
-                                + " came back as 200!");
+                LOG.debug("Base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =
@@ -288,7 +282,7 @@ public class GenBaseCase {
             baseResponce = FilterResponce.CleanResponce(baseResponce, failurl, failString);
 
             if (LOG.isDebugEnabled()) {
-                LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
+                LOG.debug("Base case was set to: " + baseResponce);
             }
         }
 
@@ -335,10 +329,7 @@ public class GenBaseCase {
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "DEBUG GenBaseCase: base case for "
-                                + failurl.toString()
-                                + " came back as 200!");
+                LOG.debug("Base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
@@ -38,9 +38,9 @@ import org.apache.commons.httpclient.methods.GetMethod;
  * @author James
  */
 public class GenBaseCase {
-	
-	/* Log object for this class */
-	private static final Logger LOG = Logger.getLogger(GenBaseCase.class.getName());
+    
+    /* Log object for this class */
+    private static final Logger LOG = Logger.getLogger(GenBaseCase.class.getName());
 
     /** Creates a new instance of GenBaseCase */
     private GenBaseCase() {}
@@ -78,7 +78,7 @@ public class GenBaseCase {
         }
 
         if (LOG.isDebugEnabled()) {
-        	LOG.debug("GenBaseCase: URL to get baseCase for: " + url);
+            LOG.debug("GenBaseCase: URL to get baseCase for: " + url);
         }
 
         BaseCase baseCase = null;
@@ -101,7 +101,7 @@ public class GenBaseCase {
         }
 
         if (LOG.isDebugEnabled()) {
-        	LOG.debug("DEBUG GenBaseCase: Getting:" + failurl);
+            LOG.debug("DEBUG GenBaseCase: Getting:" + failurl);
         }
 
         GetMethod httpget = new GetMethod(failurl.toString());
@@ -127,7 +127,7 @@ public class GenBaseCase {
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-            	LOG.debug("DEBUG GenbaseCase: base case for " + failurl.toString() + " came back as 200!");
+                LOG.debug("DEBUG GenbaseCase: base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =
@@ -201,7 +201,7 @@ public class GenBaseCase {
                 }
 
                 if (LOG.isDebugEnabled()) {
-                	LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
+                    LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
                 }
             }
         }
@@ -265,7 +265,7 @@ public class GenBaseCase {
 
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-            	LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
+                LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =
@@ -282,7 +282,7 @@ public class GenBaseCase {
             baseResponce = FilterResponce.CleanResponce(baseResponce, failurl, failString);
 
             if (LOG.isDebugEnabled()) {
-            	LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
+                LOG.debug("DEBUG GenBaseCase: base case was set to: " + baseResponce);
             }
         }
 
@@ -329,7 +329,7 @@ public class GenBaseCase {
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-            	LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
+                LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
             }
 
             BufferedReader input =

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
@@ -27,10 +27,10 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Vector;
-import org.apache.log4j.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.log4j.Logger;
 
 /**
  * Generates a base case for a dir or file rangle that is about to be scanned
@@ -38,7 +38,7 @@ import org.apache.commons.httpclient.methods.GetMethod;
  * @author James
  */
 public class GenBaseCase {
-    
+
     /* Log object for this class */
     private static final Logger LOG = Logger.getLogger(GenBaseCase.class.getName());
 
@@ -127,7 +127,10 @@ public class GenBaseCase {
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("DEBUG GenbaseCase: base case for " + failurl.toString() + " came back as 200!");
+                LOG.debug(
+                        "DEBUG GenbaseCase: base case for "
+                                + failurl.toString()
+                                + " came back as 200!");
             }
 
             BufferedReader input =
@@ -265,7 +268,10 @@ public class GenBaseCase {
 
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
+                LOG.debug(
+                        "DEBUG GenBaseCase: base case for "
+                                + failurl.toString()
+                                + " came back as 200!");
             }
 
             BufferedReader input =
@@ -329,7 +335,10 @@ public class GenBaseCase {
         // we now need to get the content as we need a base case!
         if (failcode == 200) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("DEBUG GenBaseCase: base case for " + failurl.toString() + " came back as 200!");
+                LOG.debug(
+                        "DEBUG GenBaseCase: base case for "
+                                + failurl.toString()
+                                + " came back as 200!");
             }
 
             BufferedReader input =

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
@@ -25,6 +25,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Vector;
+import org.apache.log4j.Logger;
 import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.Attributes;
 import net.htmlparser.jericho.Element;
@@ -42,6 +43,9 @@ public class HTMLparse extends Thread {
     private final Manager manager;
     boolean working;
     private boolean continueWorking = true;
+    
+    /* Logging object for the class */
+    private static final Logger LOG = Logger.getLogger(HTMLparse.class.getName());
 
     /** Creates a new instance of HTMLparse */
     public HTMLparse(Manager manager) {
@@ -73,11 +77,9 @@ public class HTMLparse extends Thread {
             if (sourceAsString != null || work != null) {
                 if (!sourceAsString.equals("")) {
 
-                    if (Config.debug) {
-
-                        System.out.println(
-                                "DEBUG HTMLParser: Parsing text from " + work.getWork().toString());
-                        System.out.println("DEBUG HTMLParser: text - " + sourceAsString);
+                    if (LOG.isDebugEnabled()) {
+                    	LOG.debug("DEBUG HTMLParser: Parsing text from " + work.getWork().toString());
+                    	LOG.debug("DEBUG HTMLParser: text - " + sourceAsString);
                     }
 
                     Vector links = new Vector(50, 10);

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
@@ -78,8 +78,8 @@ public class HTMLparse extends Thread {
                 if (!sourceAsString.equals("")) {
 
                     if (LOG.isDebugEnabled()) {
-                    	LOG.debug("DEBUG HTMLParser: Parsing text from " + work.getWork().toString());
-                    	LOG.debug("DEBUG HTMLParser: text - " + sourceAsString);
+                        LOG.debug("DEBUG HTMLParser: Parsing text from " + work.getWork().toString());
+                        LOG.debug("DEBUG HTMLParser: text - " + sourceAsString);
                     }
 
                     Vector links = new Vector(50, 10);

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
@@ -45,7 +45,7 @@ public class HTMLparse extends Thread {
     private boolean continueWorking = true;
 
     /* Logging object for the class */
-    private static final Logger LOG = Logger.getLogger(HTMLparse.class.getName());
+    private static final Logger LOG = Logger.getLogger(HTMLparse.class);
 
     /** Creates a new instance of HTMLparse */
     public HTMLparse(Manager manager) {
@@ -78,9 +78,8 @@ public class HTMLparse extends Thread {
                 if (!sourceAsString.equals("")) {
 
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "DEBUG HTMLParser: Parsing text from " + work.getWork().toString());
-                        LOG.debug("DEBUG HTMLParser: text - " + sourceAsString);
+                        LOG.debug("Parsing text from " + work.getWork().toString());
+                        LOG.debug("Parsed text - " + sourceAsString);
                     }
 
                     Vector links = new Vector(50, 10);

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
@@ -25,11 +25,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Vector;
-import org.apache.log4j.Logger;
 import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.Attributes;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.Source;
+import org.apache.log4j.Logger;
 
 /**
  * This class is to paser the returned html pages and extract other dirs and files from them
@@ -43,7 +43,7 @@ public class HTMLparse extends Thread {
     private final Manager manager;
     boolean working;
     private boolean continueWorking = true;
-    
+
     /* Logging object for the class */
     private static final Logger LOG = Logger.getLogger(HTMLparse.class.getName());
 
@@ -78,7 +78,8 @@ public class HTMLparse extends Thread {
                 if (!sourceAsString.equals("")) {
 
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("DEBUG HTMLParser: Parsing text from " + work.getWork().toString());
+                        LOG.debug(
+                                "DEBUG HTMLParser: Parsing text from " + work.getWork().toString());
                         LOG.debug("DEBUG HTMLParser: text - " + sourceAsString);
                     }
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -666,7 +666,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             }
 
             if(LOG.isDebugEnabled()) {
-            	LOG.info("Dir found: " + url.getFile() + " - " + statusCode);
+                LOG.info("Dir found: " + url.getFile() + " - " + statusCode);
             }
 
             // add to list of items that have already processed
@@ -697,9 +697,9 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             String rawResponce,
             BaseCase baseCaseObj) {
 
-    	if (LOG.isDebugEnabled()) {
-    		LOG.info("File found: " + url.getFile() + " - " + statusCode);
-    	}
+        if (LOG.isDebugEnabled()) {
+            LOG.info("File found: " + url.getFile() + " - " + statusCode);
+        }
 
         addParsedLink(url.getPath());
 
@@ -926,7 +926,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
 
                     totalDirsFound--;
                 } else {
-                	LOG.error("FAILED Removed " + processWork + " from dir queue");
+                    LOG.error("FAILED Removed " + processWork + " from dir queue");
                 }
             }
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -39,6 +39,7 @@ import org.apache.commons.httpclient.NTCredentials;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.httpclient.protocol.Protocol;
+import org.apache.log4j.Logger;
 
 public class Manager implements ProcessChecker.ProcessUpdate {
 
@@ -180,6 +181,9 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     // ZAP: Option to control whether only the dirs found under the startPoint should be
     // parsed/fetched.
     private boolean onlyUnderStartPoint = true;
+    
+    /* Logger object for the class */
+    private static final Logger LOG = Logger.getLogger(Manager.class.getName());
 
     // ZAP: Changed to public to allow it to be extended
     public Manager() {
@@ -243,7 +247,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             ex.printStackTrace();
         }
 
-        System.out.println("Starting dir/file list based brute forcing");
+        LOG.info("Starting dir/file list based brute forcing");
 
         setpUpHttpClient();
         createTheThreads();
@@ -300,7 +304,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             ex.printStackTrace();
         }
 
-        System.out.println("Starting dir/file pure brute forcing");
+        LOG.info("Starting dir/file pure brute forcing");
 
         setpUpHttpClient();
         createTheThreads();
@@ -330,7 +334,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
 
         urlFuzz = true;
 
-        System.out.println("Starting URL fuzz");
+        LOG.info("Starting URL fuzz");
 
         setpUpHttpClient();
         createTheThreads();
@@ -376,7 +380,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
 
         pureBrutefuzz = true;
 
-        System.out.println("Starting URL fuzz");
+        LOG.info("Starting URL fuzz");
 
         setpUpHttpClient();
         createTheThreads();
@@ -661,7 +665,10 @@ public class Manager implements ProcessChecker.ProcessUpdate {
                 }
             }
 
-            System.out.println("Dir found: " + url.getFile() + " - " + statusCode);
+            if(LOG.isDebugEnabled()) {
+            	LOG.info("Dir found: " + url.getFile() + " - " + statusCode);
+            }
+
             // add to list of items that have already processed
             addParsedLink(url.getPath());
 
@@ -690,7 +697,10 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             String rawResponce,
             BaseCase baseCaseObj) {
 
-        System.out.println("File found: " + url.getFile() + " - " + statusCode);
+    	if (LOG.isDebugEnabled()) {
+    		LOG.info("File found: " + url.getFile() + " - " + statusCode);
+    	}
+
         addParsedLink(url.getPath());
 
         headlessResult.addElement(
@@ -700,7 +710,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     public synchronized void foundError(URL url, String reason) {
         headlessResult.addElement(
                 new HeadlessResult(url.getFile() + ":" + reason, -1, HeadlessResult.ERROR));
-        System.err.println("ERROR: " + url.toString() + " - " + reason);
+        LOG.error("ERROR: " + url.toString() + " - " + reason);
     }
 
     public String getInputFile() {
@@ -823,7 +833,8 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             }
         }
 
-        System.out.println("DirBuster Stopped");
+        LOG.info("DirBuster Stopped");
+
         /*
          * reset the all the markers for what type of test we are doing
          */
@@ -915,7 +926,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
 
                     totalDirsFound--;
                 } else {
-                    System.err.println("FAILED Removed " + processWork + " from dir queue");
+                	LOG.error("FAILED Removed " + processWork + " from dir queue");
                 }
             }
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -181,7 +181,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     // ZAP: Option to control whether only the dirs found under the startPoint should be
     // parsed/fetched.
     private boolean onlyUnderStartPoint = true;
-    
+
     /* Logger object for the class */
     private static final Logger LOG = Logger.getLogger(Manager.class.getName());
 
@@ -665,7 +665,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
                 }
             }
 
-            if(LOG.isDebugEnabled()) {
+            if (LOG.isDebugEnabled()) {
                 LOG.info("Dir found: " + url.getFile() + " - " + statusCode);
             }
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -183,7 +183,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     private boolean onlyUnderStartPoint = true;
 
     /* Logger object for the class */
-    private static final Logger LOG = Logger.getLogger(Manager.class.getName());
+    private static final Logger LOG = Logger.getLogger(Manager.class);
 
     // ZAP: Changed to public to allow it to be extended
     public Manager() {
@@ -665,9 +665,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
                 }
             }
 
-            if (LOG.isDebugEnabled()) {
-                LOG.info("Dir found: " + url.getFile() + " - " + statusCode);
-            }
+            LOG.info("Dir found: " + url.getFile() + " - " + statusCode);
 
             // add to list of items that have already processed
             addParsedLink(url.getPath());
@@ -697,9 +695,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             String rawResponce,
             BaseCase baseCaseObj) {
 
-        if (LOG.isDebugEnabled()) {
-            LOG.info("File found: " + url.getFile() + " - " + statusCode);
-        }
+        LOG.info("File found: " + url.getFile() + " - " + statusCode);
 
         addParsedLink(url.getPath());
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -706,7 +706,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     public synchronized void foundError(URL url, String reason) {
         headlessResult.addElement(
                 new HeadlessResult(url.getFile() + ":" + reason, -1, HeadlessResult.ERROR));
-        LOG.error("ERROR: " + url.toString() + " - " + reason);
+        LOG.error(url.toString() + " - " + reason);
     }
 
     public String getInputFile() {
@@ -922,7 +922,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
 
                     totalDirsFound--;
                 } else {
-                    LOG.error("FAILED Removed " + processWork + " from dir queue");
+                    LOG.error("Removed " + processWork + " from dir queue");
                 }
             }
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -665,7 +665,9 @@ public class Manager implements ProcessChecker.ProcessUpdate {
                 }
             }
 
-            LOG.info("Dir found: " + url.getFile() + " - " + statusCode);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Dir found: " + url.getFile() + " - " + statusCode);
+            }
 
             // add to list of items that have already processed
             addParsedLink(url.getPath());
@@ -695,7 +697,9 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             String rawResponce,
             BaseCase baseCaseObj) {
 
-        LOG.info("File found: " + url.getFile() + " - " + statusCode);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("File found: " + url.getFile() + " - " + statusCode);
+        }
 
         addParsedLink(url.getPath());
 
@@ -706,7 +710,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     public synchronized void foundError(URL url, String reason) {
         headlessResult.addElement(
                 new HeadlessResult(url.getFile() + ":" + reason, -1, HeadlessResult.ERROR));
-        LOG.error(url.toString() + " - " + reason);
+        LOG.warn(url.toString() + " - " + reason);
     }
 
     public String getInputFile() {
@@ -922,7 +926,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
 
                     totalDirsFound--;
                 } else {
-                    LOG.error("Removed " + processWork + " from dir queue");
+                    LOG.warn("Failed to remove " + processWork + " from dir queue");
                 }
             }
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
@@ -21,6 +21,7 @@ package com.sittinglittleduck.DirBuster;
 
 import java.util.TimerTask;
 import java.util.Vector;
+import org.apache.log4j.Logger;
 
 public class ProcessChecker extends TimerTask {
 
@@ -29,6 +30,9 @@ public class ProcessChecker extends TimerTask {
     private long lastTotal = 0L;
     private Vector lastTen = new Vector(10, 1);
 
+    /* Logger object for the class */
+    private static final Logger LOG = Logger.getLogger(ProcessChecker.class.getName());
+    
     /** Creates a new instance of ProcessChecker */
     public interface ProcessUpdate {
 
@@ -114,48 +118,25 @@ public class ProcessChecker extends TimerTask {
 
             if (Config.debug) {
                 if (average == 0 || lastTenTotal == 0 || averageLastTen == 0) {
-                    System.out.println(
-                            "Current speed: "
-                                    + current
-                                    + " requests/sec\n"
-                                    + "Average speed: (T) "
-                                    + average
-                                    + ", (C) "
-                                    + averageLastTen
-                                    + " requests/sec\n"
-                                    + "Total Requests: "
-                                    + currentTotal
-                                    + "/"
-                                    + totalToDo
-                                    + "\n"
-                                    + "Time To Finish: ~\n"
-                                    + parseQueueLength);
+	        		LOG.info("Current Speed: " + current + " requests/sec\n"
+	        				+ "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
+	        				+ "Total Requests: " + currentTotal + "/" + totalToDo +"\n"
+	        				+ "Time To Finish: ~" + parseQueueLength);
+
                 } else {
                     long timeLeft = (totalToDo - currentTotal) / averageLastTen;
                     String timeToCompelete = convertSecsToTime(timeLeft);
                     lastTotal = currentTotal;
-                    System.out.println(
-                            "Current speed: "
-                                    + current
-                                    + " requests/sec\n"
-                                    + "Average speed: (T) "
-                                    + average
-                                    + ", (C) "
-                                    + averageLastTen
-                                    + " requests/sec\n"
-                                    + "Total Requests: "
-                                    + currentTotal
-                                    + "/"
-                                    + totalToDo
-                                    + "\n"
-                                    + "Time To Finish: "
-                                    + timeToCompelete
-                                    + "\n"
-                                    + parseQueueLength);
+                    LOG.info("Current speed: " + current + " request/sec\n"
+                    		+ "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
+                    		+ "Total Requests: " + currentTotal + "/" + totalToDo + "\n"
+                    		+ "Time To Finish: " + timeToCompelete + "\n" + parseQueueLength);
                 }
 
                 // System.out.println("workQ: " + manager.workQueue.size());
-                System.out.println("dirQ: " + manager.dirQueue.size());
+                if (LOG.isDebugEnabled()) {
+                	LOG.debug("dirQ: " + manager.dirQueue.size());
+                }
                 // System.out.println("parseQ: " + manager.parseQueue.size());
                 // manager.
             }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
@@ -118,24 +118,24 @@ public class ProcessChecker extends TimerTask {
 
             if (Config.debug) {
                 if (average == 0 || lastTenTotal == 0 || averageLastTen == 0) {
-	        		LOG.info("Current Speed: " + current + " requests/sec\n"
-	        				+ "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
-	        				+ "Total Requests: " + currentTotal + "/" + totalToDo +"\n"
-	        				+ "Time To Finish: ~" + parseQueueLength);
+                    LOG.info("Current Speed: " + current + " requests/sec\n"
+                            + "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
+                            + "Total Requests: " + currentTotal + "/" + totalToDo +"\n"
+                            + "Time To Finish: ~" + parseQueueLength);
 
                 } else {
                     long timeLeft = (totalToDo - currentTotal) / averageLastTen;
                     String timeToCompelete = convertSecsToTime(timeLeft);
                     lastTotal = currentTotal;
                     LOG.info("Current speed: " + current + " request/sec\n"
-                    		+ "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
-                    		+ "Total Requests: " + currentTotal + "/" + totalToDo + "\n"
-                    		+ "Time To Finish: " + timeToCompelete + "\n" + parseQueueLength);
+                            + "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
+                            + "Total Requests: " + currentTotal + "/" + totalToDo + "\n"
+                            + "Time To Finish: " + timeToCompelete + "\n" + parseQueueLength);
                 }
 
                 // System.out.println("workQ: " + manager.workQueue.size());
                 if (LOG.isDebugEnabled()) {
-                	LOG.debug("dirQ: " + manager.dirQueue.size());
+                    LOG.debug("dirQ: " + manager.dirQueue.size());
                 }
                 // System.out.println("parseQ: " + manager.parseQueue.size());
                 // manager.

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
@@ -31,7 +31,7 @@ public class ProcessChecker extends TimerTask {
     private Vector lastTen = new Vector(10, 1);
 
     /* Logger object for the class */
-    private static final Logger LOG = Logger.getLogger(ProcessChecker.class.getName());
+    private static final Logger LOG = Logger.getLogger(ProcessChecker.class);
 
     /** Creates a new instance of ProcessChecker */
     public interface ProcessUpdate {
@@ -116,9 +116,9 @@ public class ProcessChecker extends TimerTask {
                 parseQueueLength = String.valueOf(manager.parseQueue.size());
             }
 
-            if (Config.debug) {
+            if (LOG.isDebugEnabled()) {
                 if (average == 0 || lastTenTotal == 0 || averageLastTen == 0) {
-                    LOG.info(
+                    LOG.debug(
                             "Current Speed: "
                                     + current
                                     + " requests/sec\n"
@@ -139,7 +139,7 @@ public class ProcessChecker extends TimerTask {
                     long timeLeft = (totalToDo - currentTotal) / averageLastTen;
                     String timeToCompelete = convertSecsToTime(timeLeft);
                     lastTotal = currentTotal;
-                    LOG.info(
+                    LOG.debug(
                             "Current speed: "
                                     + current
                                     + " request/sec\n"

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
@@ -32,7 +32,7 @@ public class ProcessChecker extends TimerTask {
 
     /* Logger object for the class */
     private static final Logger LOG = Logger.getLogger(ProcessChecker.class.getName());
-    
+
     /** Creates a new instance of ProcessChecker */
     public interface ProcessUpdate {
 
@@ -118,19 +118,45 @@ public class ProcessChecker extends TimerTask {
 
             if (Config.debug) {
                 if (average == 0 || lastTenTotal == 0 || averageLastTen == 0) {
-                    LOG.info("Current Speed: " + current + " requests/sec\n"
-                            + "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
-                            + "Total Requests: " + currentTotal + "/" + totalToDo +"\n"
-                            + "Time To Finish: ~" + parseQueueLength);
+                    LOG.info(
+                            "Current Speed: "
+                                    + current
+                                    + " requests/sec\n"
+                                    + "Average Speed: (T) "
+                                    + average
+                                    + ", (C) "
+                                    + averageLastTen
+                                    + " requests/sec\n"
+                                    + "Total Requests: "
+                                    + currentTotal
+                                    + "/"
+                                    + totalToDo
+                                    + "\n"
+                                    + "Time To Finish: ~"
+                                    + parseQueueLength);
 
                 } else {
                     long timeLeft = (totalToDo - currentTotal) / averageLastTen;
                     String timeToCompelete = convertSecsToTime(timeLeft);
                     lastTotal = currentTotal;
-                    LOG.info("Current speed: " + current + " request/sec\n"
-                            + "Average Speed: (T) " + average + ", (C) " + averageLastTen + " requests/sec\n"
-                            + "Total Requests: " + currentTotal + "/" + totalToDo + "\n"
-                            + "Time To Finish: " + timeToCompelete + "\n" + parseQueueLength);
+                    LOG.info(
+                            "Current speed: "
+                                    + current
+                                    + " request/sec\n"
+                                    + "Average Speed: (T) "
+                                    + average
+                                    + ", (C) "
+                                    + averageLastTen
+                                    + " requests/sec\n"
+                                    + "Total Requests: "
+                                    + currentTotal
+                                    + "/"
+                                    + totalToDo
+                                    + "\n"
+                                    + "Time To Finish: "
+                                    + timeToCompelete
+                                    + "\n"
+                                    + parseQueueLength);
                 }
 
                 // System.out.println("workQ: " + manager.workQueue.size());

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
@@ -152,8 +152,8 @@ public class Worker implements Runnable {
                     } else if (code == HttpStatus.SC_NOT_FOUND
                             || code == HttpStatus.SC_BAD_REQUEST) {
                         if (LOG.isDebugEnabled()) {
-                        	LOG.debug("DEBUG Worker[" + threadId + "]: "
-                        			+ code + " for: " + url.toString());
+                            LOG.debug("DEBUG Worker[" + threadId + "]: "
+                                    + code + " for: " + url.toString());
                         }
                     } else {
                         notifyItemFound(
@@ -171,7 +171,7 @@ public class Worker implements Runnable {
                     if (m.find()) {
                         // do nothing as we have a 404
                         if (LOG.isDebugEnabled()) {
-                        	LOG.debug("DEBUG Worker[" + threadId + "]: Regex matched 404 code. (" + url.toString() + ")");
+                            LOG.debug("DEBUG Worker[" + threadId + "]: Regex matched 404 code. (" + url.toString() + ")");
                         }
 
                     } else {
@@ -274,7 +274,7 @@ public class Worker implements Runnable {
     private int makeRequest(HttpMethodBase httpMethod)
             throws HttpException, IOException, InterruptedException {
         if (LOG.isDebugEnabled()) {
-        	LOG.debug("DEBUG Worker[" + threadId + "]: " + httpMethod.getName() + " : " + url.toString());
+            LOG.debug("DEBUG Worker[" + threadId + "]: " + httpMethod.getName() + " : " + url.toString());
         }
 
         // set the custom HTTP headers
@@ -334,9 +334,9 @@ public class Worker implements Runnable {
                         work.getBaseCaseObj().getBaseCase(), work.getItemToCheck());
 
         if (m.find()) {
-        	if (LOG.isDebugEnabled()) {
-        		LOG.debug("DEBUG Worker[" + threadId + "]: 404 for: " + url.toString());
-        	}
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("DEBUG Worker[" + threadId + "]: 404 for: " + url.toString());
+            }
         } else if (!response.equalsIgnoreCase(basecase)) {
             notifyItemFound(code, response, rawResponse, basecase);
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
@@ -38,6 +38,8 @@ import org.apache.commons.httpclient.NoHttpResponseException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.HeadMethod;
+import org.apache.log4j.Logger;
+
 
 /** This class process workunit and determines if the link has been found or not */
 public class Worker implements Runnable {
@@ -52,6 +54,10 @@ public class Worker implements Runnable {
     private boolean working;
     private boolean stop = false;
 
+    /* Logger object for the class */
+    private static final Logger LOG = Logger.getLogger(Worker.class.getName());
+   
+    
     /**
      * Creates a new instance of Worker
      *
@@ -145,14 +151,9 @@ public class Worker implements Runnable {
                         verifyResponseForValidRequests(code, response, rawResponse);
                     } else if (code == HttpStatus.SC_NOT_FOUND
                             || code == HttpStatus.SC_BAD_REQUEST) {
-                        if (Config.debug) {
-                            System.out.println(
-                                    "DEBUG Worker["
-                                            + threadId
-                                            + "]: "
-                                            + code
-                                            + " for: "
-                                            + url.toString());
+                        if (LOG.isDebugEnabled()) {
+                        	LOG.debug("DEBUG Worker[" + threadId + "]: "
+                        			+ code + " for: " + url.toString());
                         }
                     } else {
                         notifyItemFound(
@@ -169,12 +170,8 @@ public class Worker implements Runnable {
 
                     if (m.find()) {
                         // do nothing as we have a 404
-                        if (Config.debug) {
-                            System.out.println(
-                                    "DEBUG Worker["
-                                            + threadId
-                                            + "]: Regex matched so it's a 404, "
-                                            + url.toString());
+                        if (LOG.isDebugEnabled()) {
+                        	LOG.debug("DEBUG Worker[" + threadId + "]: Regex matched 404 code. (" + url.toString() + ")");
                         }
 
                     } else {
@@ -276,14 +273,8 @@ public class Worker implements Runnable {
 
     private int makeRequest(HttpMethodBase httpMethod)
             throws HttpException, IOException, InterruptedException {
-        if (Config.debug) {
-            System.out.println(
-                    "DEBUG Worker["
-                            + threadId
-                            + "]: "
-                            + httpMethod.getName()
-                            + " : "
-                            + url.toString());
+        if (LOG.isDebugEnabled()) {
+        	LOG.debug("DEBUG Worker[" + threadId + "]: " + httpMethod.getName() + " : " + url.toString());
         }
 
         // set the custom HTTP headers
@@ -316,8 +307,8 @@ public class Worker implements Runnable {
          */
         int code = httpclient.executeMethod(httpMethod);
 
-        if (Config.debug) {
-            System.out.println("DEBUG Worker[" + threadId + "]: " + code + " " + url.toString());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("DEBUG Worker[" + threadId + "]: " + code + " " + url.toString());
         }
         return code;
     }
@@ -327,8 +318,8 @@ public class Worker implements Runnable {
     }
 
     private void verifyResponseForValidRequests(int code, String response, String rawResponse) {
-        if (Config.debug) {
-            System.out.println("DEBUG Worker[" + threadId + "]: Base Case Check " + url.toString());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("DEBUG Worker[" + threadId + "]: Base Case Check " + url.toString());
         }
 
         // TODO move this option to the Adv options
@@ -343,7 +334,9 @@ public class Worker implements Runnable {
                         work.getBaseCaseObj().getBaseCase(), work.getItemToCheck());
 
         if (m.find()) {
-            System.out.println("DEBUG Worker[" + threadId + "]: 404 for: " + url.toString());
+        	if (LOG.isDebugEnabled()) {
+        		LOG.debug("DEBUG Worker[" + threadId + "]: 404 for: " + url.toString());
+        	}
         } else if (!response.equalsIgnoreCase(basecase)) {
             notifyItemFound(code, response, rawResponse, basecase);
         }
@@ -352,8 +345,8 @@ public class Worker implements Runnable {
     private void notifyItemFound(
             int code, String response, String rawResponse, String basecase, String type) {
         if (work.isDir()) {
-            if (Config.debug) {
-                System.out.println(
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
                         "DEBUG Worker["
                                 + threadId
                                 + "]: Found Dir ("
@@ -365,8 +358,8 @@ public class Worker implements Runnable {
             manager.foundDir(url, code, response, basecase, rawResponse, work.getBaseCaseObj());
         } else {
             // found a file
-            if (Config.debug) {
-                System.out.println(
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
                         "DEBUG Worker["
                                 + threadId
                                 + "]: Found File ("

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
@@ -54,7 +54,7 @@ public class Worker implements Runnable {
     private boolean stop = false;
 
     /* Logger object for the class */
-    private static final Logger LOG = Logger.getLogger(Worker.class.getName());
+    private static final Logger LOG = Logger.getLogger(Worker.class);
 
     /**
      * Creates a new instance of Worker
@@ -151,7 +151,7 @@ public class Worker implements Runnable {
                             || code == HttpStatus.SC_BAD_REQUEST) {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug(
-                                    "DEBUG Worker["
+                                    "Worker["
                                             + threadId
                                             + "]: "
                                             + code
@@ -175,7 +175,7 @@ public class Worker implements Runnable {
                         // do nothing as we have a 404
                         if (LOG.isDebugEnabled()) {
                             LOG.debug(
-                                    "DEBUG Worker["
+                                    "Worker["
                                             + threadId
                                             + "]: Regex matched 404 code. ("
                                             + url.toString()
@@ -282,13 +282,7 @@ public class Worker implements Runnable {
     private int makeRequest(HttpMethodBase httpMethod)
             throws HttpException, IOException, InterruptedException {
         if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "DEBUG Worker["
-                            + threadId
-                            + "]: "
-                            + httpMethod.getName()
-                            + " : "
-                            + url.toString());
+            LOG.debug("Worker[" + threadId + "]: " + httpMethod.getName() + " : " + url.toString());
         }
 
         // set the custom HTTP headers
@@ -322,7 +316,7 @@ public class Worker implements Runnable {
         int code = httpclient.executeMethod(httpMethod);
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("DEBUG Worker[" + threadId + "]: " + code + " " + url.toString());
+            LOG.debug("Worker[" + threadId + "]: " + code + " " + url.toString());
         }
         return code;
     }
@@ -333,7 +327,7 @@ public class Worker implements Runnable {
 
     private void verifyResponseForValidRequests(int code, String response, String rawResponse) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("DEBUG Worker[" + threadId + "]: Base Case Check " + url.toString());
+            LOG.debug("Worker[" + threadId + "]: Base Case Check " + url.toString());
         }
 
         // TODO move this option to the Adv options
@@ -349,7 +343,7 @@ public class Worker implements Runnable {
 
         if (m.find()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("DEBUG Worker[" + threadId + "]: 404 for: " + url.toString());
+                LOG.debug("Worker[" + threadId + "]: 404 for: " + url.toString());
             }
         } else if (!response.equalsIgnoreCase(basecase)) {
             notifyItemFound(code, response, rawResponse, basecase);
@@ -360,26 +354,14 @@ public class Worker implements Runnable {
             int code, String response, String rawResponse, String basecase, String type) {
         if (work.isDir()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "DEBUG Worker["
-                                + threadId
-                                + "]: Found Dir ("
-                                + type
-                                + ")"
-                                + url.toString());
+                LOG.debug("Worker[" + threadId + "]: Found Dir (" + type + ")" + url.toString());
             }
             // we found a dir
             manager.foundDir(url, code, response, basecase, rawResponse, work.getBaseCaseObj());
         } else {
             // found a file
             if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "DEBUG Worker["
-                                + threadId
-                                + "]: Found File ("
-                                + type
-                                + ")"
-                                + url.toString());
+                LOG.debug("Worker[" + threadId + "]: Found File (" + type + ")" + url.toString());
             }
             manager.foundFile(url, code, response, basecase, rawResponse, work.getBaseCaseObj());
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
@@ -40,7 +40,6 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.HeadMethod;
 import org.apache.log4j.Logger;
 
-
 /** This class process workunit and determines if the link has been found or not */
 public class Worker implements Runnable {
 
@@ -56,8 +55,7 @@ public class Worker implements Runnable {
 
     /* Logger object for the class */
     private static final Logger LOG = Logger.getLogger(Worker.class.getName());
-   
-    
+
     /**
      * Creates a new instance of Worker
      *
@@ -152,8 +150,13 @@ public class Worker implements Runnable {
                     } else if (code == HttpStatus.SC_NOT_FOUND
                             || code == HttpStatus.SC_BAD_REQUEST) {
                         if (LOG.isDebugEnabled()) {
-                            LOG.debug("DEBUG Worker[" + threadId + "]: "
-                                    + code + " for: " + url.toString());
+                            LOG.debug(
+                                    "DEBUG Worker["
+                                            + threadId
+                                            + "]: "
+                                            + code
+                                            + " for: "
+                                            + url.toString());
                         }
                     } else {
                         notifyItemFound(
@@ -171,7 +174,12 @@ public class Worker implements Runnable {
                     if (m.find()) {
                         // do nothing as we have a 404
                         if (LOG.isDebugEnabled()) {
-                            LOG.debug("DEBUG Worker[" + threadId + "]: Regex matched 404 code. (" + url.toString() + ")");
+                            LOG.debug(
+                                    "DEBUG Worker["
+                                            + threadId
+                                            + "]: Regex matched 404 code. ("
+                                            + url.toString()
+                                            + ")");
                         }
 
                     } else {
@@ -274,7 +282,13 @@ public class Worker implements Runnable {
     private int makeRequest(HttpMethodBase httpMethod)
             throws HttpException, IOException, InterruptedException {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("DEBUG Worker[" + threadId + "]: " + httpMethod.getName() + " : " + url.toString());
+            LOG.debug(
+                    "DEBUG Worker["
+                            + threadId
+                            + "]: "
+                            + httpMethod.getName()
+                            + " : "
+                            + url.toString());
         }
 
         // set the custom HTTP headers

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -156,8 +156,8 @@ public class BruteForceURLFuzz implements Runnable {
                     incrementCounter(x);
                     Thread.sleep(20);
                 } catch (InterruptedException ex) {
-                    if(LOG.isDebugEnabled()) {
-                        LOG.error("makeList " + ex.toString());                        
+                    if (LOG.isDebugEnabled()) {
+                        LOG.error("makeList " + ex.toString());
                     }
                 }
             }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -57,7 +57,7 @@ public class BruteForceURLFuzz implements Runnable {
     private String urlFuzzEnd;
 
     /* Logger object for the class */
-    private static final Logger LOG = Logger.getLogger(BruteForceURLFuzz.class.getName());
+    private static final Logger LOG = Logger.getLogger(BruteForceURLFuzz.class);
 
     /** Creates a new instance of BruteForceWorkGenerator */
     public BruteForceURLFuzz(Manager manager) {
@@ -156,7 +156,7 @@ public class BruteForceURLFuzz implements Runnable {
                     incrementCounter(x);
                     Thread.sleep(20);
                 } catch (InterruptedException ex) {
-                    LOG.error("BruteForceURLFuzz: makeList " + ex.toString());
+                    LOG.error("makeList " + ex.toString());
                 }
             }
             /* re-initialize the index */
@@ -244,13 +244,7 @@ public class BruteForceURLFuzz implements Runnable {
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "BruteForceURLFuzz: listLen: "
-                            + listLength
-                            + " minLen: "
-                            + minLen
-                            + " maxLen: "
-                            + maxLen);
+            LOG.debug("listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
         }
 
         double total = 0;
@@ -259,7 +253,7 @@ public class BruteForceURLFuzz implements Runnable {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("BruteForceURLFuzz: Total for a pure brute force = " + total);
+            LOG.debug("Total for a pure brute force = " + total);
         }
 
         manager.setTotalPass(total);

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -156,7 +156,9 @@ public class BruteForceURLFuzz implements Runnable {
                     incrementCounter(x);
                     Thread.sleep(20);
                 } catch (InterruptedException ex) {
-                    LOG.error("makeList " + ex.toString());
+                    if(LOG.isDebugEnabled()) {
+                        LOG.error("makeList " + ex.toString());                        
+                    }
                 }
             }
             /* re-initialize the index */

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -31,10 +31,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.HeadMethod;
+import org.apache.log4j.Logger;
 
 /** @author James */
 public class BruteForceURLFuzz implements Runnable {
@@ -56,6 +55,9 @@ public class BruteForceURLFuzz implements Runnable {
     HttpClient httpclient;
     private String urlFuzzStart;
     private String urlFuzzEnd;
+    
+    /* Logger object for the class */
+    private static final Logger LOG = Logger.getLogger(BruteForceURLFuzz.class.getName());
 
     /** Creates a new instance of BruteForceWorkGenerator */
     public BruteForceURLFuzz(Manager manager) {
@@ -119,7 +121,7 @@ public class BruteForceURLFuzz implements Runnable {
             e.printStackTrace();
         }
 
-        System.out.println("Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
+        LOG.info("Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
         started = currentDir;
 
         String baseCase = null;
@@ -154,7 +156,7 @@ public class BruteForceURLFuzz implements Runnable {
                     incrementCounter(x);
                     Thread.sleep(20);
                 } catch (InterruptedException ex) {
-                    Logger.getLogger(BruteForceURLFuzz.class.getName()).log(Level.SEVERE, null, ex);
+                	continue;
                 }
             }
             /* re-initialize the index */
@@ -241,13 +243,19 @@ public class BruteForceURLFuzz implements Runnable {
 
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
-        System.out.println("listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+    	if (LOG.isDebugEnabled()) {
+    		LOG.debug("BruteForceURLFuzz: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+    	}
+    	
         double total = 0;
         for (int a = minLen; a <= maxLen; a++) {
             total = total + Math.pow(listLength, a);
         }
 
-        System.out.println("Total for a pure brute force = " + total);
+        if (LOG.isDebugEnabled()) {
+        	LOG.debug("BruteForceURLFuzz: Total for a pure brute force = " + total);	
+        }
+        
         manager.setTotalPass(total);
     }
 }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -156,7 +156,7 @@ public class BruteForceURLFuzz implements Runnable {
                     incrementCounter(x);
                     Thread.sleep(20);
                 } catch (InterruptedException ex) {
-                	LOG.error("BruteForceURLFuzz: makeList " + ex.toString());
+                    LOG.error("BruteForceURLFuzz: makeList " + ex.toString());
                 }
             }
             /* re-initialize the index */
@@ -243,17 +243,17 @@ public class BruteForceURLFuzz implements Runnable {
 
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
-    	if (LOG.isDebugEnabled()) {
-    		LOG.debug("BruteForceURLFuzz: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
-    	}
-    	
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("BruteForceURLFuzz: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+        }
+        
         double total = 0;
         for (int a = minLen; a <= maxLen; a++) {
             total = total + Math.pow(listLength, a);
         }
 
         if (LOG.isDebugEnabled()) {
-        	LOG.debug("BruteForceURLFuzz: Total for a pure brute force = " + total);	
+            LOG.debug("BruteForceURLFuzz: Total for a pure brute force = " + total);
         }
         
         manager.setTotalPass(total);

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -156,7 +156,7 @@ public class BruteForceURLFuzz implements Runnable {
                     incrementCounter(x);
                     Thread.sleep(20);
                 } catch (InterruptedException ex) {
-                	continue;
+                	LOG.error("BruteForceURLFuzz: makeList " + ex.toString());
                 }
             }
             /* re-initialize the index */

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -55,7 +55,7 @@ public class BruteForceURLFuzz implements Runnable {
     HttpClient httpclient;
     private String urlFuzzStart;
     private String urlFuzzEnd;
-    
+
     /* Logger object for the class */
     private static final Logger LOG = Logger.getLogger(BruteForceURLFuzz.class.getName());
 
@@ -244,9 +244,15 @@ public class BruteForceURLFuzz implements Runnable {
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("BruteForceURLFuzz: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+            LOG.debug(
+                    "BruteForceURLFuzz: listLen: "
+                            + listLength
+                            + " minLen: "
+                            + minLen
+                            + " maxLen: "
+                            + maxLen);
         }
-        
+
         double total = 0;
         for (int a = minLen; a <= maxLen; a++) {
             total = total + Math.pow(listLength, a);
@@ -255,7 +261,7 @@ public class BruteForceURLFuzz implements Runnable {
         if (LOG.isDebugEnabled()) {
             LOG.debug("BruteForceURLFuzz: Total for a pure brute force = " + total);
         }
-        
+
         manager.setTotalPass(total);
     }
 }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -35,6 +35,7 @@ import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.HeadMethod;
+import org.apache.log4j.Logger;
 
 /** @author James */
 public class BruteForceWorkGenerator implements Runnable {
@@ -60,6 +61,9 @@ public class BruteForceWorkGenerator implements Runnable {
     Vector extToCheck = new Vector(10, 5);
     private int failcode = 404;
     private boolean doingDirs = true;
+    
+    /* Logger object for the class */
+    private static final Logger LOG = Logger.getLogger(BruteForceWorkGenerator.class.getName());
 
     // find bug UuF
     // HttpState initialState;
@@ -299,13 +303,18 @@ public class BruteForceWorkGenerator implements Runnable {
 
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
-        System.out.println("listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+    	if (LOG.isDebugEnabled()) {
+    		LOG.debug("BruteForceWorkGenerator: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+    	}
+        
         double total = 0;
         for (int a = minLen; a <= maxLen; a++) {
             total = total + Math.pow(listLength, a);
         }
 
-        System.out.println("Total for a pure brute force = " + total);
+        if (LOG.isDebugEnabled()) {
+        	LOG.debug("BruteForceWorkGenerator: Total for a pure brute force = " + total);
+        }
         manager.setTotalPass(total);
     }
 }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -303,9 +303,9 @@ public class BruteForceWorkGenerator implements Runnable {
 
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
-    	if (LOG.isDebugEnabled()) {
-    		LOG.debug("BruteForceWorkGenerator: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
-    	}
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("BruteForceWorkGenerator: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+        }
         
         double total = 0;
         for (int a = minLen; a <= maxLen; a++) {
@@ -313,7 +313,7 @@ public class BruteForceWorkGenerator implements Runnable {
         }
 
         if (LOG.isDebugEnabled()) {
-        	LOG.debug("BruteForceWorkGenerator: Total for a pure brute force = " + total);
+            LOG.debug("BruteForceWorkGenerator: Total for a pure brute force = " + total);
         }
         manager.setTotalPass(total);
     }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -63,7 +63,7 @@ public class BruteForceWorkGenerator implements Runnable {
     private boolean doingDirs = true;
 
     /* Logger object for the class */
-    private static final Logger LOG = Logger.getLogger(BruteForceWorkGenerator.class.getName());
+    private static final Logger LOG = Logger.getLogger(BruteForceWorkGenerator.class);
 
     // find bug UuF
     // HttpState initialState;
@@ -304,13 +304,7 @@ public class BruteForceWorkGenerator implements Runnable {
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "BruteForceWorkGenerator: listLen: "
-                            + listLength
-                            + " minLen: "
-                            + minLen
-                            + " maxLen: "
-                            + maxLen);
+            LOG.debug("listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
         }
 
         double total = 0;
@@ -319,7 +313,7 @@ public class BruteForceWorkGenerator implements Runnable {
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("BruteForceWorkGenerator: Total for a pure brute force = " + total);
+            LOG.debug("Total for a pure brute force = " + total);
         }
         manager.setTotalPass(total);
     }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -61,7 +61,7 @@ public class BruteForceWorkGenerator implements Runnable {
     Vector extToCheck = new Vector(10, 5);
     private int failcode = 404;
     private boolean doingDirs = true;
-    
+
     /* Logger object for the class */
     private static final Logger LOG = Logger.getLogger(BruteForceWorkGenerator.class.getName());
 
@@ -304,9 +304,15 @@ public class BruteForceWorkGenerator implements Runnable {
     // calculates the total number of tries per pass
     private void calcTotalPerPass(int listLength, int minLen, int maxLen) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("BruteForceWorkGenerator: listLen: " + listLength + " minLen: " + minLen + " maxLen: " + maxLen);
+            LOG.debug(
+                    "BruteForceWorkGenerator: listLen: "
+                            + listLength
+                            + " minLen: "
+                            + minLen
+                            + " maxLen: "
+                            + maxLen);
         }
-        
+
         double total = 0;
         for (int a = minLen; a <= maxLen; a++) {
             total = total + Math.pow(listLength, a);

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
@@ -42,7 +42,6 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.HeadMethod;
 import org.apache.log4j.Logger;
 
-
 /** Produces the work to be done, when we are reading from a list */
 public class WorkerGenerator implements Runnable {
 
@@ -57,7 +56,7 @@ public class WorkerGenerator implements Runnable {
     private boolean stopMe = false;
     private boolean skipCurrent = false;
     HttpClient httpclient;
-    
+
     /* Logger Object for the class */
     private static final Logger LOG = Logger.getLogger(WorkerGenerator.class.getName());
 
@@ -147,7 +146,8 @@ public class WorkerGenerator implements Runnable {
                 // 400!
                 if (responceCode == 501 || responceCode == 400 || responceCode == 405) {
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("DEBUG WokerGen: Changing to GET only HEAD test returned 501(method no implmented) or a 400");
+                        LOG.debug(
+                                "DEBUG WokerGen: Changing to GET only HEAD test returned 501(method no implmented) or a 400");
                     }
                     // switch the mode to just GET requests
                     manager.setAuto(false);
@@ -239,10 +239,11 @@ public class WorkerGenerator implements Runnable {
                             // System.out.println("current dir = " + currentDir);
                             workQueue.put(new WorkUnit(currentURL, true, "GET", baseCaseObj, null));
                             if (LOG.isDebugEnabled()) {
-                                LOG.debug("DEBUG WokerGen: 1 adding dir to work list "
-                                        + method
-                                        + " "
-                                        + currentDir.toString());
+                                LOG.debug(
+                                        "DEBUG WokerGen: 1 adding dir to work list "
+                                                + method
+                                                + " "
+                                                + currentDir.toString());
                             }
                         } catch (MalformedURLException ex) {
                             ex.printStackTrace();
@@ -287,10 +288,11 @@ public class WorkerGenerator implements Runnable {
                                         new WorkUnit(currentURL, true, method, baseCaseObj, line));
                                 // System.out.println("Gen finshed adding to queue");
                                 if (LOG.isDebugEnabled()) {
-                                    LOG.debug("DEBUG WokerGen: 2 adding dir to work list "
-                                              + method
-                                              + " "
-                                              + currentURL.toString());
+                                    LOG.debug(
+                                            "DEBUG WokerGen: 2 adding dir to work list "
+                                                    + method
+                                                    + " "
+                                                    + currentURL.toString());
                                 }
                             } catch (MalformedURLException e) {
                                 // TODO deal with bad line

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
@@ -58,7 +58,7 @@ public class WorkerGenerator implements Runnable {
     HttpClient httpclient;
 
     /* Logger Object for the class */
-    private static final Logger LOG = Logger.getLogger(WorkerGenerator.class.getName());
+    private static final Logger LOG = Logger.getLogger(WorkerGenerator.class);
 
     /**
      * Creates a new instance of WorkerGenerator
@@ -139,7 +139,7 @@ public class WorkerGenerator implements Runnable {
                 int responceCode = httpclient.executeMethod(httphead);
 
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug("DEBUG WokerGen: responce code for head check = " + responceCode);
+                    LOG.debug("Response code for head check = " + responceCode);
                 }
 
                 // if the responce code is method not implemented or if the head requests return
@@ -147,7 +147,7 @@ public class WorkerGenerator implements Runnable {
                 if (responceCode == 501 || responceCode == 400 || responceCode == 405) {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug(
-                                "DEBUG WokerGen: Changing to GET only HEAD test returned 501(method no implmented) or a 400");
+                                "Changing to GET only HEAD test returned 501(method no implmented) or a 400");
                     }
                     // switch the mode to just GET requests
                     manager.setAuto(false);
@@ -218,7 +218,7 @@ public class WorkerGenerator implements Runnable {
                                     new InputStreamReader(new FileInputStream(inputFile)));
 
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("DEBUG WokerGen: Generating dir list for " + firstPart);
+                        LOG.debug("Generating dir list for " + firstPart);
                     }
 
                     URL currentURL;
@@ -240,7 +240,7 @@ public class WorkerGenerator implements Runnable {
                             workQueue.put(new WorkUnit(currentURL, true, "GET", baseCaseObj, null));
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug(
-                                        "DEBUG WokerGen: 1 adding dir to work list "
+                                        "1 adding dir to work list "
                                                 + method
                                                 + " "
                                                 + currentDir.toString());
@@ -289,7 +289,7 @@ public class WorkerGenerator implements Runnable {
                                 // System.out.println("Gen finshed adding to queue");
                                 if (LOG.isDebugEnabled()) {
                                     LOG.debug(
-                                            "DEBUG WokerGen: 2 adding dir to work list "
+                                            "2 adding dir to work list "
                                                     + method
                                                     + " "
                                                     + currentURL.toString());
@@ -397,7 +397,7 @@ public class WorkerGenerator implements Runnable {
                                                         line));
                                         if (LOG.isDebugEnabled()) {
                                             LOG.debug(
-                                                    "DEBUG WokerGen: adding file to work list "
+                                                    "adding file to work list "
                                                             + method
                                                             + " "
                                                             + currentURL.toString());

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
@@ -40,6 +40,8 @@ import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.HeadMethod;
+import org.apache.log4j.Logger;
+
 
 /** Produces the work to be done, when we are reading from a list */
 public class WorkerGenerator implements Runnable {
@@ -55,6 +57,9 @@ public class WorkerGenerator implements Runnable {
     private boolean stopMe = false;
     private boolean skipCurrent = false;
     HttpClient httpclient;
+    
+    /* Logger Object for the class */
+    private static final Logger LOG = Logger.getLogger(WorkerGenerator.class.getName());
 
     /**
      * Creates a new instance of WorkerGenerator
@@ -134,17 +139,15 @@ public class WorkerGenerator implements Runnable {
                 httphead.setFollowRedirects(Config.followRedirects);
                 int responceCode = httpclient.executeMethod(httphead);
 
-                if (Config.debug) {
-                    System.out.println(
-                            "DEBUG WokerGen: responce code for head check = " + responceCode);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("DEBUG WokerGen: responce code for head check = " + responceCode);
                 }
 
                 // if the responce code is method not implemented or if the head requests return
                 // 400!
                 if (responceCode == 501 || responceCode == 400 || responceCode == 405) {
-                    if (Config.debug) {
-                        System.out.println(
-                                "DEBUG WokerGen: Changing to GET only HEAD test returned 501(method no implmented) or a 400");
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("DEBUG WokerGen: Changing to GET only HEAD test returned 501(method no implmented) or a 400");
                     }
                     // switch the mode to just GET requests
                     manager.setAuto(false);
@@ -214,8 +217,8 @@ public class WorkerGenerator implements Runnable {
                             new BufferedReader(
                                     new InputStreamReader(new FileInputStream(inputFile)));
 
-                    if (Config.debug) {
-                        System.out.println("DEBUG WokerGen: Generating dir list for " + firstPart);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("DEBUG WokerGen: Generating dir list for " + firstPart);
                     }
 
                     URL currentURL;
@@ -235,12 +238,11 @@ public class WorkerGenerator implements Runnable {
                             // System.out.println("first part = " + firstPart);
                             // System.out.println("current dir = " + currentDir);
                             workQueue.put(new WorkUnit(currentURL, true, "GET", baseCaseObj, null));
-                            if (Config.debug) {
-                                System.out.println(
-                                        "DEBUG WokerGen: 1 adding dir to work list "
-                                                + method
-                                                + " "
-                                                + currentDir.toString());
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("DEBUG WokerGen: 1 adding dir to work list "
+                                		+ method
+                                        + " "
+                                        + currentDir.toString());
                             }
                         } catch (MalformedURLException ex) {
                             ex.printStackTrace();
@@ -284,12 +286,11 @@ public class WorkerGenerator implements Runnable {
                                 workQueue.put(
                                         new WorkUnit(currentURL, true, method, baseCaseObj, line));
                                 // System.out.println("Gen finshed adding to queue");
-                                if (Config.debug) {
-                                    System.out.println(
-                                            "DEBUG WokerGen: 2 adding dir to work list "
-                                                    + method
-                                                    + " "
-                                                    + currentURL.toString());
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.debug("DEBUG WokerGen: 2 adding dir to work list "
+                                              + method
+                                              + " "
+                                              + currentURL.toString());
                                 }
                             } catch (MalformedURLException e) {
                                 // TODO deal with bad line
@@ -392,8 +393,8 @@ public class WorkerGenerator implements Runnable {
                                                         method,
                                                         baseCaseObj,
                                                         line));
-                                        if (Config.debug) {
-                                            System.out.println(
+                                        if (LOG.isDebugEnabled()) {
+                                            LOG.debug(
                                                     "DEBUG WokerGen: adding file to work list "
                                                             + method
                                                             + " "

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
@@ -240,7 +240,7 @@ public class WorkerGenerator implements Runnable {
                             workQueue.put(new WorkUnit(currentURL, true, "GET", baseCaseObj, null));
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug("DEBUG WokerGen: 1 adding dir to work list "
-                                		+ method
+                                        + method
                                         + " "
                                         + currentDir.toString());
                             }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -154,11 +154,11 @@ public class WorkerGeneratorURLFuzz implements Runnable {
             }
 
             d = new BufferedReader(new InputStreamReader(new FileInputStream(inputFile)));
-            
+
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
             }
-            
+
             int filesProcessed = 0;
 
             BaseCase baseCaseObj =
@@ -193,7 +193,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
             }
         } catch (InterruptedException ex) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug(ex.toString());                
+                LOG.debug(ex.toString());
             }
         } catch (MalformedURLException ex) {
             LOG.warn("Failed to create the fuzzed URL:", ex);
@@ -205,7 +205,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                 manager.setURLFuzzGenFinished(true);
             } catch (IOException ex) {
                 if (LOG.isDebugEnabled()) {
-                    LOG.debug(ex.toString());                    
+                    LOG.debug(ex.toString());
                 }
             }
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -39,10 +39,9 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.methods.HeadMethod;
+import org.apache.log4j.Logger;
 
 /** Produces the work to be done, when we are reading from a list */
 public class WorkerGeneratorURLFuzz implements Runnable {
@@ -66,6 +65,9 @@ public class WorkerGeneratorURLFuzz implements Runnable {
 
     private String urlFuzzStart;
     private String urlFuzzEnd;
+    
+    /* Logger object for the class */
+    private static final Logger LOG = Logger.getLogger(WorkerGeneratorURLFuzz.class.getName());
 
     /**
      * Creates a new instance of WorkerGenerator
@@ -136,13 +138,13 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                     }
                     httphead.setFollowRedirects(Config.followRedirects);
                     int responceCode = httpclient.executeMethod(httphead);
-                    if (Config.debug) {
-                        System.out.println(
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(
                                 "DEBUG WokerGen: responce code for head check = " + responceCode);
                     }
                     if (responceCode == 501 || responceCode == 400 || responceCode == 405) {
-                        if (Config.debug) {
-                            System.out.println(
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug(
                                     "DEBUG WokerGen: Changing to GET only HEAD test returned 501(method no implmented) or a 400");
                         }
                         manager.setAuto(false);
@@ -153,7 +155,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
             }
 
             d = new BufferedReader(new InputStreamReader(new FileInputStream(inputFile)));
-            System.out.println(
+            LOG.info(
                     "Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
             int filesProcessed = 0;
 
@@ -188,18 +190,17 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                 Thread.sleep(3);
             }
         } catch (InterruptedException ex) {
-            Logger.getLogger(WorkerGeneratorURLFuzz.class.getName()).log(Level.SEVERE, null, ex);
+        	LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
         } catch (MalformedURLException ex) {
-            Logger.getLogger(WorkerGeneratorURLFuzz.class.getName()).log(Level.SEVERE, null, ex);
+        	LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
         } catch (IOException ex) {
-            Logger.getLogger(WorkerGeneratorURLFuzz.class.getName()).log(Level.SEVERE, null, ex);
+        	LOG.error("WorkerGeneratorURLFuzz IOException" + ex.toString());
         } finally {
             try {
                 d.close();
                 manager.setURLFuzzGenFinished(true);
             } catch (IOException ex) {
-                Logger.getLogger(WorkerGeneratorURLFuzz.class.getName())
-                        .log(Level.SEVERE, null, ex);
+            	LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
             }
         }
     }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -67,7 +67,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
     private String urlFuzzEnd;
 
     /* Logger object for the class */
-    private static final Logger LOG = Logger.getLogger(WorkerGeneratorURLFuzz.class.getName());
+    private static final Logger LOG = Logger.getLogger(WorkerGeneratorURLFuzz.class);
 
     /**
      * Creates a new instance of WorkerGenerator
@@ -139,12 +139,12 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                     httphead.setFollowRedirects(Config.followRedirects);
                     int responceCode = httpclient.executeMethod(httphead);
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("DEBUG WokerGen: responce code for head check = " + responceCode);
+                        LOG.debug("Response code for head check = " + responceCode);
                     }
                     if (responceCode == 501 || responceCode == 400 || responceCode == 405) {
                         if (LOG.isDebugEnabled()) {
                             LOG.debug(
-                                    "DEBUG WokerGen: Changing to GET only HEAD test returned 501(method no implmented) or a 400");
+                                    "Changing to GET only HEAD test returned 501(method no implmented) or a 400");
                         }
                         manager.setAuto(false);
                     }
@@ -188,17 +188,17 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                 Thread.sleep(3);
             }
         } catch (InterruptedException ex) {
-            LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
+            LOG.error(ex.toString());
         } catch (MalformedURLException ex) {
-            LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
+            LOG.error(ex.toString());
         } catch (IOException ex) {
-            LOG.error("WorkerGeneratorURLFuzz IOException" + ex.toString());
+            LOG.error(ex.toString());
         } finally {
             try {
                 d.close();
                 manager.setURLFuzzGenFinished(true);
             } catch (IOException ex) {
-                LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
+                LOG.error(ex.toString());
             }
         }
     }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -196,9 +196,9 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                 LOG.debug(ex.toString());                
             }
         } catch (MalformedURLException ex) {
-            LOG.error(ex.toString());
+            LOG.warn("Failed to create the fuzzed URL:", ex);
         } catch (IOException ex) {
-            LOG.error(ex.toString());
+            LOG.warn("Failed to create the fuzzed URL:", ex);
         } finally {
             try {
                 d.close();

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -65,7 +65,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
 
     private String urlFuzzStart;
     private String urlFuzzEnd;
-    
+
     /* Logger object for the class */
     private static final Logger LOG = Logger.getLogger(WorkerGeneratorURLFuzz.class.getName());
 
@@ -139,8 +139,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                     httphead.setFollowRedirects(Config.followRedirects);
                     int responceCode = httpclient.executeMethod(httphead);
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "DEBUG WokerGen: responce code for head check = " + responceCode);
+                        LOG.debug("DEBUG WokerGen: responce code for head check = " + responceCode);
                     }
                     if (responceCode == 501 || responceCode == 400 || responceCode == 405) {
                         if (LOG.isDebugEnabled()) {
@@ -155,8 +154,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
             }
 
             d = new BufferedReader(new InputStreamReader(new FileInputStream(inputFile)));
-            LOG.info(
-                    "Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
+            LOG.info("Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
             int filesProcessed = 0;
 
             BaseCase baseCaseObj =

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -190,17 +190,17 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                 Thread.sleep(3);
             }
         } catch (InterruptedException ex) {
-        	LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
+            LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
         } catch (MalformedURLException ex) {
-        	LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
+            LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
         } catch (IOException ex) {
-        	LOG.error("WorkerGeneratorURLFuzz IOException" + ex.toString());
+            LOG.error("WorkerGeneratorURLFuzz IOException" + ex.toString());
         } finally {
             try {
                 d.close();
                 manager.setURLFuzzGenFinished(true);
             } catch (IOException ex) {
-            	LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
+                LOG.error("WorkerGeneratorURLFuzz " + ex.toString());
             }
         }
     }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -154,7 +154,11 @@ public class WorkerGeneratorURLFuzz implements Runnable {
             }
 
             d = new BufferedReader(new InputStreamReader(new FileInputStream(inputFile)));
-            LOG.info("Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
+            
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Starting fuzz on " + firstPart + urlFuzzStart + "{dir}" + urlFuzzEnd);
+            }
+            
             int filesProcessed = 0;
 
             BaseCase baseCaseObj =
@@ -188,7 +192,9 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                 Thread.sleep(3);
             }
         } catch (InterruptedException ex) {
-            LOG.error(ex.toString());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(ex.toString());                
+            }
         } catch (MalformedURLException ex) {
             LOG.error(ex.toString());
         } catch (IOException ex) {
@@ -198,7 +204,9 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                 d.close();
                 manager.setURLFuzzGenFinished(true);
             } catch (IOException ex) {
-                LOG.error(ex.toString());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(ex.toString());                    
+                }
             }
         }
     }


### PR DESCRIPTION
Bruteforce extension was migrated from standard output to logging.

Standard outputs for debugging purposes that were already commented out were not removed as part of this pull request.

Fixes [#5530](https://github.com/zaproxy/zaproxy/issues/5530)
