### PR TITLE
Ability to replace byte values using hexadecimal escapes with the Replacer tool

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
- - Intercept and change non-ASCII payload (Issue 5328)
+ - Allow byte replacement using hexadecimal escapes (Issue 5328).
 
 ### Fixed
  - Fix link in API endpoint description.

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+ - Intercept and change non-ASCII payload (Issue 5328)
 
 ### Fixed
  - Fix link in API endpoint description.

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
  - Allow byte replacement using hexadecimal escapes (Issue 5328).
 
+### Added
+
+ - Allow byte replacement using hexadecimal escapes (Issue 5328).
+
 ### Fixed
  - Fix link in API endpoint description.
 

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
- - Allow byte replacement using hexadecimal escapes (Issue 5328).
 
 ### Added
 

--- a/addOns/replacer/replacer.gradle.kts
+++ b/addOns/replacer/replacer.gradle.kts
@@ -17,3 +17,7 @@ zapAddOn {
         messages.set(file("src/main/resources/org/zaproxy/zap/extension/replacer/resources/Messages.properties"))
     }
 }
+
+dependencies {
+    testImplementation(project(":testutils"))
+}

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -264,7 +264,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                             msg.getResponseHeader().setHeader(rule.getMatchString(), null);
                         } else {
                             msg.getResponseHeader()
-                                    .setHeader(rule.getMatchString(), rule.getReplacement());
+                                    .setHeader(rule.getMatchString(), rule.getEscapedReplacement());
                         }
                         break;
                     case RESP_HEADER_STR:

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -19,6 +19,12 @@
  */
 package org.zaproxy.zap.extension.replacer;
 
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Pattern;
+import javax.swing.*;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -31,13 +37,6 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.network.HttpSenderListener;
 import org.zaproxy.zap.view.ZapMenuItem;
-
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.regex.Pattern;
 
 /**
  * An add-on which provides an easy way to replace strings in requests and responses. TODO Implement

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -279,7 +279,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                                             header,
                                             rule.getMatchString(),
                                             p,
-                                            rule.getReplacement());
+                                            rule.getEscapedReplacement());
                             try {
                                 msg.setResponseHeader(new HttpResponseHeader(header));
                             } catch (HttpMalformedHeaderException e) {

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -296,7 +296,12 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                                         + rule.getReplacement());
                         String body = msg.getResponseBody().toString();
                         if (contains(body, rule.getMatchString(), p)) {
-                            body = replace(body, rule.getMatchString(), p, rule.getEscapedReplacement());
+                            body =
+                                    replace(
+                                            body,
+                                            rule.getMatchString(),
+                                            p,
+                                            rule.getEscapedReplacement());
                             msg.getResponseBody().setBody(body);
                             msg.getResponseHeader()
                                     .setContentLength(msg.getResponseBody().length());

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -184,7 +184,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                             msg.getRequestHeader().setHeader(rule.getMatchString(), null);
                         } else {
                             msg.getRequestHeader()
-                                    .setHeader(rule.getMatchString(), rule.getReplacement());
+                                    .setHeader(rule.getMatchString(), rule.getEscapedReplacement());
                         }
                         break;
                     case REQ_HEADER_STR:
@@ -200,7 +200,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                                             header,
                                             rule.getMatchString(),
                                             p,
-                                            rule.getReplacement());
+                                            rule.getEscapedReplacement());
                             try {
                                 msg.setRequestHeader(new HttpRequestHeader(header));
                             } catch (HttpMalformedHeaderException e) {
@@ -216,7 +216,12 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                                         + rule.getReplacement());
                         String body = msg.getRequestBody().toString();
                         if (contains(body, rule.getMatchString(), p)) {
-                            body = replace(body, rule.getMatchString(), p, rule.getReplacement());
+                            body =
+                                    replace(
+                                            body,
+                                            rule.getMatchString(),
+                                            p,
+                                            rule.getEscapedReplacement());
                             msg.getRequestBody().setBody(body);
                             msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
                         }

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -19,12 +19,6 @@
  */
 package org.zaproxy.zap.extension.replacer;
 
-import java.awt.Toolkit;
-import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.regex.Pattern;
-import javax.swing.KeyStroke;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -37,6 +31,13 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.network.HttpSenderListener;
 import org.zaproxy.zap.view.ZapMenuItem;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Pattern;
 
 /**
  * An add-on which provides an easy way to replace strings in requests and responses. TODO Implement
@@ -295,7 +296,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                                         + rule.getReplacement());
                         String body = msg.getResponseBody().toString();
                         if (contains(body, rule.getMatchString(), p)) {
-                            body = replace(body, rule.getMatchString(), p, rule.getReplacement());
+                            body = replace(body, rule.getMatchString(), p, rule.getEscapedReplacement());
                             msg.getResponseBody().setBody(body);
                             msg.getResponseHeader()
                                     .setContentLength(msg.getResponseBody().length());

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/HexString.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/HexString.java
@@ -1,0 +1,81 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.replacer;
+
+import java.util.regex.Pattern;
+
+class HexString {
+    static String compile(String binaryRegex) {
+        TransformString current = new TransformString(binaryRegex);
+        StringBuilder sb = new StringBuilder();
+        while (current.hasNext()) {
+            if (current.isEscapedCharEscaped()) {
+                sb.append(TransformString.ESCAPE_CHAR);
+                current.moveBy(2);
+            } else if (current.isValidHex()) {
+                sb.append(new String(new byte[] {current.readHex()}));
+                current.moveBy(4);
+            } else {
+                sb.append(current.currentChar());
+                current.moveBy(1);
+            }
+        }
+        return sb.toString();
+    }
+
+    private static class TransformString {
+        static final Pattern HEX_VALUE = Pattern.compile("^\\\\x\\p{XDigit}{2}.*");
+        static final char ESCAPE_CHAR = '\\';
+        static final String ESCAPED_ESCAPE_CHAR = "\\\\";
+
+        private final String content;
+        private int position;
+
+        private TransformString(String content) {
+            this.content = content;
+            this.position = 0;
+        }
+
+        boolean isEscapedCharEscaped() {
+            return content.substring(position).startsWith(ESCAPED_ESCAPE_CHAR);
+        }
+
+        boolean isValidHex() {
+            return HEX_VALUE.matcher(content.substring(position)).matches();
+        }
+
+        byte readHex() {
+            String value = "" + content.charAt(position + 2) + content.charAt(position + 3);
+            return (byte) Integer.parseInt(value, 16);
+        }
+
+        char currentChar() {
+            return content.charAt(position);
+        }
+
+        void moveBy(int numberOfCharsRead) {
+            position += numberOfCharsRead;
+        }
+
+        boolean hasNext() {
+            return position < content.length();
+        }
+    }
+}

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
@@ -42,6 +42,7 @@ class ReplacerParamRule extends Enableable {
     private String description;
     private String matchString;
     private String replacement;
+    private String escapedReplacement;
     private MatchType matchType;
     private boolean matchRegex;
     private List<Integer> initiators;
@@ -84,7 +85,8 @@ class ReplacerParamRule extends Enableable {
         this.matchType = matchType;
         this.matchString = matchString;
         this.matchRegex = matchRegex;
-        this.replacement = hex(replacement);
+        this.escapedReplacement = hex(replacement);
+        this.replacement = replacement;
         this.initiators = initiators;
     }
 
@@ -151,6 +153,10 @@ class ReplacerParamRule extends Enableable {
 
     public void setReplacement(String replacement) {
         this.replacement = replacement;
+    }
+
+    public String getEscapedReplacement() {
+        return escapedReplacement;
     }
 
     public List<Integer> getInitiators() {

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
@@ -136,7 +136,7 @@ class ReplacerParamRule extends Enableable {
         this.replacement = replacement;
     }
 
-    public String getEscapedReplacement() {
+    String getEscapedReplacement() {
         return escapedReplacement;
     }
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
@@ -19,16 +19,11 @@
  */
 package org.zaproxy.zap.extension.replacer;
 
-import static java.util.stream.Collectors.joining;
-
 import java.util.List;
-import java.util.stream.Stream;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.utils.Enableable;
 
 class ReplacerParamRule extends Enableable {
-
-    public static final String NON_ASCII = "\\\\x\\p{XDigit}{2}";
 
     public enum MatchType {
         REQ_HEADER,
@@ -85,23 +80,9 @@ class ReplacerParamRule extends Enableable {
         this.matchType = matchType;
         this.matchString = matchString;
         this.matchRegex = matchRegex;
-        this.escapedReplacement = hex(replacement);
+        this.escapedReplacement = HexString.compile(replacement);
         this.replacement = replacement;
         this.initiators = initiators;
-    }
-
-    private static String hex(String binaryRegex) {
-        Stream<String> content =
-                Stream.of(binaryRegex.split("((?<=" + NON_ASCII + ")|(?=" + NON_ASCII + "))"));
-        return content.map(
-                        x ->
-                                x.matches(NON_ASCII)
-                                        ? new String(
-                                                new byte[] {
-                                                    (byte) Integer.parseInt(x.substring(2), 16)
-                                                })
-                                        : x)
-                .collect(joining(""));
     }
 
     public ReplacerParamRule(ReplacerParamRule token) {

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -59,7 +59,7 @@ Hexadecimal bytes are represented with "\x00 - \xFF" (for example "abc\x01\x02\x
 <h3>Replacement String</h3>
 The new string that will replace the specified selection.
 Hexadecimal bytes are represented with "\x00 - \xFF".
-"\x00" byte can be keept with "\\x00".
+"\x00" byte can be kept with "\\x00".
 
 <h3>Enable</h3>
 If not set then the rule will not apply.

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -54,11 +54,12 @@ The string that will be used to identify what should be replaced - see Match Typ
 <h3>Match Regex</h3>
 If set then the Match String will be treated as a regex expression.
 This option is disabled when matching actual headers.
-Non-ASCII content are represented with "\x00 - \xFF" (for example "abc\x01\x02\x03def").
+Hexadecimal bytes are represented with "\x00 - \xFF" (for example "abc\x01\x02\x03def").
 
 <h3>Replacement String</h3>
 The new string that will replace the specified selection.
-Non-ASCII content are represented with "\x00 - \xFF".
+Hexadecimal bytes are represented with "\x00 - \xFF".
+"\x00" byte can be keept with "\\x00".
 
 <h3>Enable</h3>
 If not set then the rule will not apply.

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -59,7 +59,7 @@ Hexadecimal bytes are represented with "\x00 - \xFF" (for example "abc\x01\x02\x
 <h3>Replacement String</h3>
 The new string that will replace the specified selection.
 Hexadecimal bytes are represented with "\x00 - \xFF".
-"\x00" byte can be kept with "\\x00".
+The literal string "\x00" can be kept with "\\x00".
 
 <h3>Enable</h3>
 If not set then the rule will not apply.

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -54,9 +54,11 @@ The string that will be used to identify what should be replaced - see Match Typ
 <h3>Match Regex</h3>
 If set then the Match String will be treated as a regex expression.
 This option is disabled when matching actual headers.
+Non-ASCII content are represented with "\x00 - \xFF" (for example "abc\x01\x02\x03def").
 
 <h3>Replacement String</h3>
 The new string that will replace the specified selection.
+Non-ASCII content are represented with "\x00 - \xFF".
 
 <h3>Enable</h3>
 If not set then the rule will not apply.

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.replacer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_HEADER_STR;
+
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class ExtensionReplacerTest {
+
+    @Test
+    public void shouldReplaceHexValue() throws HttpMalformedHeaderException {
+        // Given
+        ExtensionReplacer extensionReplacer = new ExtensionReplacer();
+        ReplacerParamRule nonAsciiRegexRule =
+                new ReplacerParamRule(
+                        "",
+                        REQ_HEADER_STR,
+                        "abc\\x01\\x03\\x02def",
+                        true,
+                        "abc\\x01\\x02\\x03def",
+                        null,
+                        true);
+        extensionReplacer.getParams().getRules().add(nonAsciiRegexRule);
+
+        HttpMessage msg = new HttpMessage();
+        String binary = new String(new byte[] {'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'});
+        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "X-CUSTOM: " + binary);
+
+        // When
+        extensionReplacer.onHttpRequestSend(msg, 0, null);
+
+        // Then
+        assertThat(
+                msg.getRequestHeader().getHeader("X-CUSTOM"),
+                equalTo(new String(new byte[] {'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'})));
+    }
+}

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
@@ -35,14 +35,16 @@ import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RES
 
 public class ExtensionReplacerTest {
 
-    private static final String MATCHING_STRING_WITH_HEX_BYTE = new String(new byte[]{'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'});
-    private static final String REPLACED_STRING_WITH_BINARY_VALUE = new String(new byte[]{'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'});
+    private static final String MATCHING_STRING_WITH_HEX_BYTE =
+            new String(new byte[] {'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'});
+    private static final String REPLACED_STRING_WITH_BINARY_VALUE =
+            new String(new byte[] {'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'});
     private HttpMessage msg;
 
-  @Before
-  public void setUp() {
-      msg = new HttpMessage();
-  }
+    @Before
+    public void setUp() {
+        msg = new HttpMessage();
+    }
 
     @Test
     public void shouldReplaceHeaderByHexValueInRequest() throws HttpMalformedHeaderException {
@@ -88,9 +90,7 @@ public class ExtensionReplacerTest {
         extensionReplacer.onHttpRequestSend(msg, 0, null);
 
         // Then
-        assertThat(
-                msg.getRequestBody().toString(),
-                equalTo(REPLACED_STRING_WITH_BINARY_VALUE));
+        assertThat(msg.getRequestBody().toString(), equalTo(REPLACED_STRING_WITH_BINARY_VALUE));
     }
 
     @Test
@@ -112,7 +112,8 @@ public class ExtensionReplacerTest {
     @Test
     public void shouldReplaceHexValueInResponseHeader() throws HttpMalformedHeaderException {
         // Given
-        ExtensionReplacer extensionReplacer = given_a_hex_byte_replacement_rule_for(RESP_HEADER_STR);
+        ExtensionReplacer extensionReplacer =
+                given_a_hex_byte_replacement_rule_for(RESP_HEADER_STR);
 
         msg.setResponseHeader("HTTP/1.1 200 OK\r\nX-CUSTOM: " + MATCHING_STRING_WITH_HEX_BYTE);
 
@@ -137,12 +138,11 @@ public class ExtensionReplacerTest {
         extensionReplacer.onHttpResponseReceive(msg, 0, null);
 
         // Then
-        assertThat(
-                msg.getResponseBody().toString(),
-                equalTo(REPLACED_STRING_WITH_BINARY_VALUE));
+        assertThat(msg.getResponseBody().toString(), equalTo(REPLACED_STRING_WITH_BINARY_VALUE));
     }
 
-    private ExtensionReplacer given_a_hex_byte_replacement_rule_for(ReplacerParamRule.MatchType respHeaderStr) {
+    private ExtensionReplacer given_a_hex_byte_replacement_rule_for(
+            ReplacerParamRule.MatchType respHeaderStr) {
         ExtensionReplacer extensionReplacer = new ExtensionReplacer();
         ReplacerParamRule hexByteRegexRule =
                 new ReplacerParamRule(
@@ -156,6 +156,4 @@ public class ExtensionReplacerTest {
         extensionReplacer.getParams().getRules().add(hexByteRegexRule);
         return extensionReplacer;
     }
-
-
 }

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
@@ -19,11 +19,6 @@
  */
 package org.zaproxy.zap.extension.replacer;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.parosproxy.paros.network.HttpMalformedHeaderException;
-import org.parosproxy.paros.network.HttpMessage;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_BODY_STR;
@@ -32,6 +27,11 @@ import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_BODY_STR;
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_HEADER;
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_HEADER_STR;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
 
 public class ExtensionReplacerTest {
 

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
@@ -30,12 +30,13 @@ import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_HEADER;
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_HEADER_STR;
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_BODY_STR;
+import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_HEADER;
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_HEADER_STR;
 
 public class ExtensionReplacerTest {
 
     private static final String MATCHING_STRING_WITH_HEX_BYTE = new String(new byte[]{'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'});
-    public static final String REPLACED_STRING_WITH_BINARY_VALUE = new String(new byte[]{'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'});
+    private static final String REPLACED_STRING_WITH_BINARY_VALUE = new String(new byte[]{'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'});
     private HttpMessage msg;
 
   @Before
@@ -56,7 +57,7 @@ public class ExtensionReplacerTest {
         // Then
         assertThat(
                 msg.getRequestHeader().getHeader("abc\\x01\\x03\\x02def"),
-                equalTo(new String(new byte[] {'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'})));
+                equalTo(REPLACED_STRING_WITH_BINARY_VALUE));
     }
 
     @Test
@@ -93,6 +94,22 @@ public class ExtensionReplacerTest {
     }
 
     @Test
+    public void shouldReplaceHeaderByHexValueInResponse() throws HttpMalformedHeaderException {
+        // Given
+        ExtensionReplacer extensionReplacer = given_a_hex_byte_replacement_rule_for(RESP_HEADER);
+
+        msg.setRequestHeader("GET / HTTP/1.1\r\n" + "X-CUSTOM: " + MATCHING_STRING_WITH_HEX_BYTE);
+
+        // When
+        extensionReplacer.onHttpResponseReceive(msg, 0, null);
+
+        // Then
+        assertThat(
+                msg.getResponseHeader().getHeader("abc\\x01\\x03\\x02def"),
+                equalTo(REPLACED_STRING_WITH_BINARY_VALUE));
+    }
+
+    @Test
     public void shouldReplaceHexValueInResponseHeader() throws HttpMalformedHeaderException {
         // Given
         ExtensionReplacer extensionReplacer = given_a_hex_byte_replacement_rule_for(RESP_HEADER_STR);
@@ -105,7 +122,7 @@ public class ExtensionReplacerTest {
         // Then
         assertThat(
                 msg.getResponseHeader().getHeader("X-CUSTOM"),
-                equalTo(new String(new byte[] {'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'})));
+                equalTo(REPLACED_STRING_WITH_BINARY_VALUE));
     }
 
     @Test

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
@@ -19,33 +19,23 @@
  */
 package org.zaproxy.zap.extension.replacer;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
-import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_BODY_STR;
-import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_HEADER_STR;
-import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_HEADER;
-import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_HEADER_STR;
-
 import org.junit.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_BODY_STR;
+import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_HEADER_STR;
+import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_BODY_STR;
+import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.RESP_HEADER_STR;
 
 public class ExtensionReplacerTest {
 
     @Test
     public void shouldReplaceHexValueInRequestHeader() throws HttpMalformedHeaderException {
         // Given
-        ExtensionReplacer extensionReplacer = new ExtensionReplacer();
-        ReplacerParamRule hexByteRegexRule =
-                new ReplacerParamRule(
-                        "",
-                        REQ_HEADER_STR,
-                        "abc\\x01\\x03\\x02def",
-                        true,
-                        "abc\\x01\\x02\\x03def",
-                        null,
-                        true);
-        extensionReplacer.getParams().getRules().add(hexByteRegexRule);
+        ExtensionReplacer extensionReplacer = given_a_hex_byte_replacement_rule_for(REQ_HEADER_STR);
 
         HttpMessage msg = new HttpMessage();
         String binary = new String(new byte[] {'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'});
@@ -63,17 +53,7 @@ public class ExtensionReplacerTest {
     @Test
     public void shouldReplaceHexValueInRequestBody() throws HttpMalformedHeaderException {
         // Given
-        ExtensionReplacer extensionReplacer = new ExtensionReplacer();
-        ReplacerParamRule hexByteRegexRule =
-                new ReplacerParamRule(
-                        "",
-                        REQ_BODY_STR,
-                        "abc\\x01\\x03\\x02def",
-                        true,
-                        "abc\\x01\\x02\\x03def",
-                        null,
-                        true);
-        extensionReplacer.getParams().getRules().add(hexByteRegexRule);
+        ExtensionReplacer extensionReplacer = given_a_hex_byte_replacement_rule_for(REQ_BODY_STR);
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("POST / HTTP/1.1");
@@ -91,17 +71,7 @@ public class ExtensionReplacerTest {
     @Test
     public void shouldReplaceHexValueInResponseHeader() throws HttpMalformedHeaderException {
         // Given
-        ExtensionReplacer extensionReplacer = new ExtensionReplacer();
-        ReplacerParamRule hexByteRegexRule =
-                new ReplacerParamRule(
-                        "",
-                        RESP_HEADER_STR,
-                        "abc\\x01\\x03\\x02def",
-                        true,
-                        "abc\\x01\\x02\\x03def",
-                        null,
-                        true);
-        extensionReplacer.getParams().getRules().add(hexByteRegexRule);
+        ExtensionReplacer extensionReplacer = given_a_hex_byte_replacement_rule_for(RESP_HEADER_STR);
 
         HttpMessage msg = new HttpMessage();
         String binary = new String(new byte[] {'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'});
@@ -115,4 +85,39 @@ public class ExtensionReplacerTest {
                 msg.getResponseHeader().getHeader("X-CUSTOM"),
                 equalTo(new String(new byte[] {'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'})));
     }
+
+    @Test
+    public void shouldReplaceHexValueInResponseBody() throws HttpMalformedHeaderException {
+        // Given
+        ExtensionReplacer extensionReplacer = given_a_hex_byte_replacement_rule_for(RESP_BODY_STR);
+
+        HttpMessage msg = new HttpMessage();
+        msg.setResponseHeader("HTTP/1.1 200 OK");
+        msg.setResponseBody(new byte[] {'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'});
+
+        // When
+        extensionReplacer.onHttpResponseReceive(msg, 0, null);
+
+        // Then
+        assertThat(
+                msg.getResponseBody().toString(),
+                equalTo(new String(new byte[] {'a', 'b', 'c', 1, 2, 3, 'd', 'e', 'f'})));
+    }
+
+    private ExtensionReplacer given_a_hex_byte_replacement_rule_for(ReplacerParamRule.MatchType respHeaderStr) {
+        ExtensionReplacer extensionReplacer = new ExtensionReplacer();
+        ReplacerParamRule hexByteRegexRule =
+                new ReplacerParamRule(
+                        "",
+                        respHeaderStr,
+                        "abc\\x01\\x03\\x02def",
+                        true,
+                        "abc\\x01\\x02\\x03def",
+                        null,
+                        true);
+        extensionReplacer.getParams().getRules().add(hexByteRegexRule);
+        return extensionReplacer;
+    }
+
+
 }

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
@@ -33,28 +33,44 @@ public class ReplacerParamRuleTest {
         String replacement = "abc\\x01\\xaadef";
 
         // When
-        ReplacerParamRule nonAsciiRegexRule =
+        ReplacerParamRule hexValueRegexRule =
                 new ReplacerParamRule(
                         "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
 
         // Then
         assertThat(
-                nonAsciiRegexRule.getEscapedReplacement(),
+                hexValueRegexRule.getEscapedReplacement(),
                 equalTo(new String(new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'})));
     }
 
     @Test
-    public void shouldNotSubstituteHexValuesInReplacementStringGivenAntislashIsEscaped() {
+    public void shouldSubstituteHexValuesInReplacementStringForNonRegexMatch() {
+        // Given
+        String replacement = "abc\\x01\\xaadef";
+
+        // When
+        ReplacerParamRule hexValueRegexRule =
+                new ReplacerParamRule(
+                        "", REQ_HEADER_STR, "anyMatchString", false, replacement, null, true);
+
+        // Then
+        assertThat(
+                hexValueRegexRule.getEscapedReplacement(),
+                equalTo(new String(new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'})));
+    }
+
+    @Test
+    public void shouldNotSubstituteHexValuesInReplacementStringGivenBackslashIsEscaped() {
         // Given
         String replacement = "abc\\\\x01\\\\xaadef";
 
         // When
-        ReplacerParamRule nonAsciiRegexRule =
+        ReplacerParamRule hexValueRegexRule =
                 new ReplacerParamRule(
                         "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
 
         // Then
-        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("abc\\x01\\xaadef"));
+        assertThat(hexValueRegexRule.getEscapedReplacement(), equalTo("abc\\x01\\xaadef"));
     }
 
     @Test
@@ -63,26 +79,26 @@ public class ReplacerParamRuleTest {
         String replacement = "\\xZZ";
 
         // When
-        ReplacerParamRule nonAsciiRegexRule =
+        ReplacerParamRule hexValueRegexRule =
                 new ReplacerParamRule(
                         "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
 
         // Then
-        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("\\xZZ"));
+        assertThat(hexValueRegexRule.getEscapedReplacement(), equalTo("\\xZZ"));
     }
 
     @Test
-    public void shouldNotSubstituteGivenThereIsOnlyOneAntiSlash() {
+    public void shouldNotSubstituteGivenThereIsOnlyOneBackSlash() {
         // Given
         String replacement = "\\";
 
         // When
-        ReplacerParamRule nonAsciiRegexRule =
+        ReplacerParamRule hexValueRegexRule =
                 new ReplacerParamRule(
                         "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
 
         // Then
-        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("\\"));
+        assertThat(hexValueRegexRule.getEscapedReplacement(), equalTo("\\"));
     }
 
     @Test
@@ -91,11 +107,11 @@ public class ReplacerParamRuleTest {
         String replacement = "\\x";
 
         // When
-        ReplacerParamRule nonAsciiRegexRule =
+        ReplacerParamRule hexValueRegexRule =
                 new ReplacerParamRule(
                         "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
 
         // Then
-        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("\\x"));
+        assertThat(hexValueRegexRule.getEscapedReplacement(), equalTo("\\x"));
     }
 }

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
@@ -42,4 +42,60 @@ public class ReplacerParamRuleTest {
                 nonAsciiRegexRule.getEscapedReplacement(),
                 equalTo(new String(new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'})));
     }
+
+    @Test
+    public void shouldNotSubstituteHexValuesInReplacementStringGivenAntislashIsEscaped() {
+        // Given
+        String replacement = "abc\\\\x01\\\\xaadef";
+
+        // When
+        ReplacerParamRule nonAsciiRegexRule =
+                new ReplacerParamRule(
+                        "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
+
+        // Then
+        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("abc\\x01\\xaadef"));
+    }
+
+    @Test
+    public void shouldNotSubstituteGivenHexValueIsNotHexadecimal() {
+        // Given
+        String replacement = "\\xZZ";
+
+        // When
+        ReplacerParamRule nonAsciiRegexRule =
+                new ReplacerParamRule(
+                        "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
+
+        // Then
+        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("\\xZZ"));
+    }
+
+    @Test
+    public void shouldNotSubstituteGivenThereIsOnlyOneAntiSlash() {
+        // Given
+        String replacement = "\\";
+
+        // When
+        ReplacerParamRule nonAsciiRegexRule =
+                new ReplacerParamRule(
+                        "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
+
+        // Then
+        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("\\"));
+    }
+
+    @Test
+    public void shouldNotSubstituteGivenThereIsOnlyBeginningOfHexValue() {
+        // Given
+        String replacement = "\\x";
+
+        // When
+        ReplacerParamRule nonAsciiRegexRule =
+                new ReplacerParamRule(
+                        "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
+
+        // Then
+        assertThat(nonAsciiRegexRule.getEscapedReplacement(), equalTo("\\x"));
+    }
 }

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
@@ -39,7 +39,7 @@ public class ReplacerParamRuleTest {
 
         // Then
         assertThat(
-                nonAsciiRegexRule.getReplacement(),
+                nonAsciiRegexRule.getEscapedReplacement(),
                 equalTo(new String(new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'})));
     }
 }

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_HEADER_STR;
 
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 
 public class ReplacerParamRuleTest {
@@ -40,7 +41,10 @@ public class ReplacerParamRuleTest {
         // Then
         assertThat(
                 hexValueRegexRule.getEscapedReplacement(),
-                equalTo(new String(new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'})));
+                equalTo(
+                        new String(
+                                new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'},
+                                StandardCharsets.US_ASCII)));
     }
 
     @Test
@@ -56,7 +60,10 @@ public class ReplacerParamRuleTest {
         // Then
         assertThat(
                 hexValueRegexRule.getEscapedReplacement(),
-                equalTo(new String(new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'})));
+                equalTo(
+                        new String(
+                                new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'},
+                                StandardCharsets.US_ASCII)));
     }
 
     @Test

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.replacer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.*;
+import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ_HEADER_STR;
+
+import org.junit.Test;
+
+public class ReplacerParamRuleTest {
+
+    @Test
+    public void shouldSubstituteHexValuesInReplacementString() {
+        // Given
+        String replacement = "abc\\x01\\xaadef";
+
+        // When
+        ReplacerParamRule nonAsciiRegexRule =
+                new ReplacerParamRule(
+                        "", REQ_HEADER_STR, "anyMatchString", true, replacement, null, true);
+
+        // Then
+        assertThat(
+                nonAsciiRegexRule.getReplacement(),
+                equalTo(new String(new byte[] {'a', 'b', 'c', 1, (byte) 170, 'd', 'e', 'f'})));
+    }
+}


### PR DESCRIPTION
Resolve zaproxy/zaproxy#5328

When 
 * the Match string is "abc\x01\x03\x02def"  and is a regex
 * the content is "61 62 63 01 03 02 64 65 66" in hexa 
 * the replacement string is "abc\x01\x02\x03def"

Then
 *  the content is "61 62 63 01 02 03 64 65 66" in hexa 