### PR TITLE
Refactor Trusted Domains into a consistent class

### DIFF
--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/RegexTrust.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/RegexTrust.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http.domains;
+
+import java.util.regex.Pattern;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class RegexTrust implements Trust {
+    private static final Logger LOG = LogManager.getLogger(RegexTrust.class);
+
+    static final Pattern SIMPLE_URL_REGEX = Pattern.compile("https?://");
+
+    private final Pattern regex;
+
+    public RegexTrust(String regex) {
+        if (SIMPLE_URL_REGEX.matcher(regex).find()) {
+            LOG.warn(
+                    "Trusted Domains regex seems to contain a URL pattern not just a domain pattern: {}",
+                    regex);
+        }
+
+        this.regex = Pattern.compile(regex);
+    }
+
+    @Override
+    public boolean isTrusted(String url) {
+        return regex.matcher(url).matches();
+    }
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/SameOriginPolicyTrust.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/SameOriginPolicyTrust.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http.domains;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+
+public class SameOriginPolicyTrust implements Trust {
+    private final URI origin;
+
+    public SameOriginPolicyTrust(URI origin) {
+        this.origin = origin;
+    }
+
+    @Override
+    public boolean isTrusted(String url) {
+        try {
+            URI resourceUri = new URI(url, false);
+            return origin.getScheme().equals(resourceUri.getScheme())
+                    && origin.getAuthority().equals(resourceUri.getAuthority())
+                    && origin.getPort() == resourceUri.getPort();
+        } catch (URIException e) {
+            // Badly formatted resource should be ignored
+            return true;
+        }
+    }
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/Trust.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/Trust.java
@@ -1,0 +1,24 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http.domains;
+
+public interface Trust {
+    boolean isTrusted(String url);
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/TrustedDomains.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/domains/TrustedDomains.java
@@ -1,0 +1,68 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http.domains;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
+
+public class TrustedDomains {
+    private static final Logger LOG = LogManager.getLogger(TrustedDomains.class);
+
+    private String trustedConfig = "";
+    private List<Trust> trustedDomainRegexesPatterns = new ArrayList<>();
+
+    public boolean isIncluded(String link) {
+        return trustedDomainRegexesPatterns.stream().anyMatch(regex -> regex.isTrusted(link));
+    }
+
+    public void update(String trustedConf) {
+        if (trustedConf.equals(this.trustedConfig)) {
+            return;
+        }
+
+        trustedDomainRegexesPatterns.clear();
+        this.trustedConfig = trustedConf;
+        for (String regex : trustedConf.split(",")) {
+            add(regex);
+        }
+    }
+
+    private void add(String regex) {
+        String regexTrim = regex.trim();
+        if (!regexTrim.isEmpty()) {
+            try {
+                add(new RegexTrust(regexTrim));
+            } catch (Exception e) {
+                LOG.warn(
+                        "Invalid regex in rule {} : {}",
+                        RuleConfigParam.RULE_DOMAINS_TRUSTED,
+                        regex,
+                        e);
+            }
+        }
+    }
+
+    public void add(Trust trust) {
+        trustedDomainRegexesPatterns.add(trust);
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/http/domains/RegexTrustUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/http/domains/RegexTrustUnitTest.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http.domains;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class RegexTrustUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http.cat", "www.httpexample.com"})
+    void shouldNotMatchDomainsEvenIfTheyIncludeSchemeLikeSubstrings(String candidate) {
+        // Given / When
+        boolean found = RegexTrust.SIMPLE_URL_REGEX.matcher(candidate).find();
+        // Then
+        assertFalse(found);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http://example.com", "https://www.httpexample.com"})
+    void shouldMatchStringsThatStartWithSchemes(String candidate) {
+        // Given / When
+        boolean found = RegexTrust.SIMPLE_URL_REGEX.matcher(candidate).find();
+        // Then
+        assertTrue(found);
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/http/domains/TrustedDomainsUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/http/domains/TrustedDomainsUnitTest.java
@@ -1,0 +1,65 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http.domains;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TrustedDomainsUnitTest {
+    private TrustedDomains trustedDomains;
+
+    @BeforeEach
+    void setup() {
+        trustedDomains = new TrustedDomains();
+    }
+
+    @Test
+    void shouldBeIncludedForPath() {
+        // Given
+        trustedDomains.update("https://www.example2.com/.*");
+        // When
+        boolean included = trustedDomains.isIncluded("https://www.example2.com/page1");
+        // Then
+        assertTrue(included);
+    }
+
+    @Test
+    void shouldNotBeIncludedForDifferentDomain() {
+        // Given
+        trustedDomains.update("https://www.example2.com/.*");
+        // When
+        boolean included = trustedDomains.isIncluded("https://www.example3.com/page1");
+        // Then
+        assertFalse(included);
+    }
+
+    @Test
+    void shouldNotBeIncludedForAnInvalidRegex() {
+        // Given
+        trustedDomains.update("[");
+        // When
+        boolean included = trustedDomains.isIncluded("https://www.example2.com/page1");
+        // Then
+        assertFalse(included);
+    }
+}

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
+- Sub Resource Integrity Attribute Missing scan rule now supports Trusted Domains.
 
 ### Fixed
 - False positive condition from Sub Resource Integrity Attribute Missing scan rule when rel=canonical is used (Issue 7040).

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -9,7 +9,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.7.0 & < 2.0.0")
+                    version.set(">= 1.10.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -7,6 +7,19 @@ Passive Scan Rules - Alpha
 </HEAD>
 <BODY>
 <H1>Passive Scan Rules - Alpha</H1>
+
+<H2>General Configuration</H2>
+
+<H3>Trusted Domains</H3>
+You can specify a comma separated list of URL regex patterns using the <code>rules.domains.trusted</code> parameter via the Options 'Rule configuration' panel.
+Any link URL that matches one of these patterns will be considered to be in a trusted domain and will therefore not be reported.
+Following rules supports <b>Trusted Domains</b> :
+<ul>
+ <li>Sub Resource Integrity Attribute Missing</li>
+</ul>
+
+<hr>
+
 The following alpha status passive scan rules are included in this add-on:
 
 <H2>An example passive scan rule which loads data from a file</H2>
@@ -117,6 +130,8 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 This rule checks whether the integrity attribute in the script or the link element served by an external resource (for example: CDN) is missing.<br>
 It helps mitigate an attack where the CDN has been compromised and content has been replaced by malicious content.<br>
 Note: A suggested integrity hash value will be present in the relevant Alert's Other Info details if it can be resolved to a script in the Sites Tree.
+<p>
+This rule supports <b>Trusted Domains</b>, check "General Configuration" for more information.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java">SubResourceIntegrityAttributeScanRule.java</a>
 

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Reverse Tabnabbing scan rule now leverages the Common Library Trusted Domains implementation.
 
 ## [29] - 2022-04-05
 ### Changed

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.7.0 & < 2.0.0")
+                    version.set(">= 1.10.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -8,6 +8,19 @@ Passive Scan Rules - Beta
 </HEAD>
 <BODY>
 <H1>Passive Scan Rules - Beta</H1>
+
+<H2>General Configuration</H2>
+
+<H3>Trusted Domains</H3>
+You can specify a comma separated list of URL regex patterns using the <code>rules.domains.trusted</code> parameter via the Options 'Rule configuration' panel.
+Any link URL that matches one of these patterns will be considered to be in a trusted domain and will therefore not be reported.
+Following rules supports <b>Trusted Domains</b> :
+<ul>
+ <li>Reverse Tabnabbing</li>
+</ul>
+
+<hr>
+
 The following beta status passive scan rules are included in this add-on:
 
 <H2>Big Redirect Detected (Potential Sensitive Information Leak)</H2>
@@ -89,8 +102,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 This checks to see if any links use a target attribute using "opener" keyword in the "rel" attribute, as this may allow target pages to take over the page that opens them.<br>
 By default this rule will ignore all links that are in the same context as the page. At the LOW threshold it will only ignore links that are on the same host.<br>
 At HIGH threshold it will only report links that use the "_blank" target.<br>
-You can specify a comma separated list of URL regex patterns using the <code>rules.domains.trusted</code> parameter via the Options 'Rule configuration' panel.
-Any link URL that matches one of these patterns will be considered to be in a trusted domain and will therefore not be reported.
+ This rule supports <b>Trusted Domains</b>, check "General Configuration" for more information.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java">LinkTargetScanRule.java</a>
 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -142,8 +143,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         rule.getConfig()
-                .setProperty(
-                        LinkTargetScanRule.TRUSTED_DOMAINS_PROPERTY, "https://www.example2.com/.*");
+                .setProperty(RuleConfigParam.RULE_DOMAINS_TRUSTED, "https://www.example2.com/.*");
         // When
         msg.setResponseBody(
                 "<html><a href=\"https://www.example2.com/page1\" rel=\"opener\" target=\"_blank\">link</a></html>");
@@ -159,8 +159,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         rule.getConfig()
-                .setProperty(
-                        LinkTargetScanRule.TRUSTED_DOMAINS_PROPERTY, "https://www.example2.com/.*");
+                .setProperty(RuleConfigParam.RULE_DOMAINS_TRUSTED, "https://www.example2.com/.*");
         // When
         msg.setResponseBody(
                 "<html><a href=\"https://www.example3.com/page1\" rel=\"opener\" target=\"_blank\">link</a></html>");
@@ -465,7 +464,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
-        rule.getConfig().setProperty(LinkTargetScanRule.TRUSTED_DOMAINS_PROPERTY, "[");
+        rule.getConfig().setProperty(RuleConfigParam.RULE_DOMAINS_TRUSTED, "[");
         msg.setResponseBody(
                 "<html><a href=\"https://www.example2.com/page1\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));


### PR DESCRIPTION
This PR is the refactoring described in #2164 ([More information here](https://github.com/zaproxy/zap-extensions/pull/2164#issuecomment-532258685))

This PR:
- Add a class to manage trusted domains (`rules.domains.trusted` parameter)
- Refactor `LinkTargetScanner` and `SubResourceIntegrityAttributeScanner` to use this class
- Update documentation (pscan*.html) to have only one paragraph about `rules.domains.trusted` parameter and add references from `LinkTargetScanner` and `SubResourceIntegrityAttributeScanner` paragraphs

Comments are welcome. :smirk_cat: 