### PR TITLE
ascanAlpha add initial XSLT scan rule unit test

### DIFF
--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -13,4 +13,6 @@ zapAddOn {
 
 dependencies {
     implementation("org.jsoup:jsoup:1.7.2")
+
+    testImplementation(project(":testutils"))
 }

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerAppParamTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerAppParamTest.java
@@ -1,0 +1,92 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2018 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Plugin;
+
+public abstract class ActiveScannerAppParamTest<T extends AbstractAppParamPlugin>
+        extends ActiveScannerTest<T> {
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInLowStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.LOW;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(
+                httpMessagesSent,
+                hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInMediumStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.MEDIUM;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(
+                httpMessagesSent,
+                hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInHighStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.HIGH;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(
+                httpMessagesSent,
+                hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldSendReasonableNumberOfMessagesInInsaneStrength() throws Exception {
+        // Given
+        Plugin.AttackStrength strength = Plugin.AttackStrength.INSANE;
+        rule.setAttackStrength(strength);
+        rule.init(getHttpMessage("?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(
+                httpMessagesSent,
+                hasSize(lessThanOrEqualTo(getRecommendMaxNumberMessagesPerParam(strength))));
+        assertThat(alertsRaised, hasSize(0));
+    }
+}

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2016 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import org.parosproxy.paros.core.scanner.AbstractPlugin;
+import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
+
+public abstract class ActiveScannerTest<T extends AbstractPlugin>
+        extends ActiveScannerTestUtils<T> {
+
+    @Override
+    protected void setUpMessages() {
+        mockMessages(new ExtensionAscanRulesAlpha());
+    }
+}

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/XSLTInjectionUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/XSLTInjectionUnitTest.java
@@ -1,0 +1,99 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.StaticContentServerHandler;
+
+/** Unit test for {@link XSLTInjection}. */
+public class XSLTInjectionUnitTest extends ActiveScannerAppParamTest<XSLTInjection> {
+
+    @Override
+    protected XSLTInjection createScanner() {
+        return new XSLTInjection();
+    }
+
+    @Test
+    public void shouldNotAlertIfResponseDoesNotContainRelevantContent() throws Exception {
+        // Given
+        String path = "/shouldNotAlert";
+
+        this.nano.addHandler(
+                new StaticContentServerHandler(
+                        path, "<html><head></head><H>Awesome Title</H1> Some Text... <html>"));
+
+        HttpMessage msg = this.getHttpMessage(path + "?name=test");
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+        assertEquals(httpMessagesSent.size(), 8);
+    }
+
+    @Test
+    public void shouldAlertIfResponseContainsRelevantErrorString() throws Exception {
+        // Given
+        String path = "/shouldReportError";
+        String errorString = "XSLT compile error";
+
+        this.nano.addHandler(
+                new StaticContentServerHandler(path, "<html>Uh oh " + errorString + ".<html>"));
+
+        HttpMessage msg = this.getHttpMessage(path + "?name=test");
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getName(), "XSLT Injection");
+        assertThat(alertsRaised.get(0).getEvidence(), is("XSLT compile error"));
+        assertEquals(alertsRaised.get(0).getRisk(), Alert.RISK_MEDIUM);
+        assertThat(alertsRaised.get(0).getParam(), is("name"));
+    }
+
+    @Test
+    public void shouldAlertIfResponseContainsVendorString() throws Exception {
+        // Given
+        String path = "/shouldReportVendor";
+        String vendorString = "Saxon-CE 1.1 from Saxonica";
+
+        this.nano.addHandler(
+                new StaticContentServerHandler(path, "<html>" + vendorString + "<html>"));
+
+        HttpMessage msg = this.getHttpMessage(path + "?name=test");
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getName(), "XSLT Injection");
+        assertThat(alertsRaised.get(0).getEvidence(), is("Saxonica"));
+        assertEquals(alertsRaised.get(0).getRisk(), Alert.RISK_MEDIUM);
+        assertThat(alertsRaised.get(0).getParam(), is("name"));
+    }
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/StaticContentServerHandler.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/StaticContentServerHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.testutils;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+
+public class StaticContentServerHandler extends NanoServerHandler {
+
+    private final String content;
+
+    public StaticContentServerHandler(String path, String content) {
+        super(path);
+        this.content = content;
+    }
+
+    @Override
+    protected Response serve(IHTTPSession session) {
+        return newFixedLengthResponse(content);
+    }
+}


### PR DESCRIPTION
* ascanrulesAlpha.gradle.kts > add testutils testImplementation to dependencies
* ActiveScannerAppParamTest, ActiveScannerTest > UnitTest infra pulled from release or beta (I forget which, I believe they're the same).
* XSLTInjectionUnitTest > The new unit tests.
* StaticContentServerHandler > Convenience class added.

This is not meant to be a complete set of unit tests, but more to set the ground work for future use.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>