### PR TITLE
Unit-Tests for class CacheableScanner second step

### DIFF
--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScannerUnitTest.java
@@ -27,10 +27,15 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.httpclient.util.DateUtil;
 import org.junit.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
+/* All test-cases should raise storeable and cacheable alerts
+ * or should verfiy the absence of exceptions.
+ */
 public class CacheableScannerUnitTest extends PassiveScannerTest<CacheableScanner> {
 
     private HttpMessage createMessage() throws URIException {
@@ -41,6 +46,25 @@ public class CacheableScannerUnitTest extends PassiveScannerTest<CacheableScanne
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader(requestHeader);
         return msg;
+    }
+
+    private HttpMessage createMessageBasicAuthorization() throws URIException {
+        HttpRequestHeader requestHeader = new HttpRequestHeader();
+        requestHeader.setMethod("GET");
+        requestHeader.setURI(new URI("https://example.com/fred/", false));
+        requestHeader.addHeader(HttpHeader.AUTHORIZATION, "basic");
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(requestHeader);
+        return msg;
+    }
+
+    private void assertStoreAndCacheable(String expectedEvidence) {
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo(expectedEvidence));
+        assertThat(
+                alertsRaised.get(0).getName(),
+                equalTo(Constant.messages.getString("pscanalpha.storablecacheable.name")));
     }
 
     @Override
@@ -78,5 +102,206 @@ public class CacheableScannerUnitTest extends PassiveScannerTest<CacheableScanne
         rule.scanHttpResponseReceive(msg, -1, createSource(msg));
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndExpiryDateGiven()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader(
+                "HTTP/1.1 207 OK\r\n"
+                        + "Cache-Control: must-revalidate\r\n"
+                        + "Expires: Wed, 02 Oct 2019 07:00:00 GMT\r\n"
+                        + "Date: Wed, 02 Oct 2019 06:00:00 GMT");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("Wed, 02 Oct 2019 07:00:00 GMT");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndCacheIsPublic()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader("HTTP/1.1 207 OK\r\n" + "Cache-Control: public");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndMaxAgeGiven()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader("HTTP/1.1 207 OK\r\n" + "Cache-Control: max-age=100");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("max-age=100");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndS_MaxAgeGiven()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader("HTTP/1.1 207 OK\r\n" + "Cache-Control: s-maxage=100");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("s-maxage=100");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault()
+            throws URIException, HttpMalformedHeaderException {
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("200");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("203");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("204");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("206");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("300");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("301");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("404");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("405");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("410");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("414");
+        shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("501");
+    }
+
+    private void shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault(String statusCode)
+            throws URIException, HttpMalformedHeaderException {
+        // setup for private method needed
+        alertsRaised.clear();
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader(
+                "HTTP/1.1 " + statusCode + " OK\r\n" + "Cache-Control: must-revalidate");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndCacheMustRevalidated()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessageBasicAuthorization();
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Cache-Control: must-revalidate");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndCacheIsPublic()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessageBasicAuthorization();
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Cache-Control: public");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndS_MaxAgeCacheGiven()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessageBasicAuthorization();
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Cache-Control: s-maxage=100");
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        // Then
+        assertStoreAndCacheable("s-maxage=100");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndS_MaxAgeDirectiveIsSet()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Cache-Control: s-maxage=100, public");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertStoreAndCacheable("s-maxage=100");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndMaxAgeDirectiveIsSet()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Cache-Control: max-age=100,public");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertStoreAndCacheable("max-age=100,public");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndExpirySpecified()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Cache-Control: public\r\n"
+                        + "Expires: Wed, 02 Oct 2019 08:00:00 GMT\r\n"
+                        + "Date: Wed, 02 Oct 2019 07:00:00 GMT");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertStoreAndCacheable("Wed, 02 Oct 2019 08:00:00 GMT");
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableCacheIsFreshWhenNoLifetimeSpecified()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader("HTTP/1.1 200 OK\r\n" + "Cache-Control: public");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertStoreAndCacheable("");
+        assertThat(
+                alertsRaised.get(0).getOtherInfo(),
+                equalTo(
+                        Constant.messages.getString(
+                                "pscanalpha.storablecacheable.otherinfo.liberallifetimeheuristic")));
+    }
+
+    @Test
+    public void shouldRaiseAlertStoreAndCacheableWhenStaleRetrieveAllowed()
+            throws URIException, HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = createMessage();
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Cache-Control: public\r\n"
+                        + "Expires: Wed, 02 Oct 2019 06:00:00 GMT\r\n"
+                        + "Date: Wed, 02 Oct 2019 07:00:00 GMT");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertStoreAndCacheable("");
     }
 }


### PR DESCRIPTION
This Pull-Request adds all unit-tests, where we expect the response to be store- and cacheable.
In the first step the focus was on non-storeable or non-cacheable responses. Now in the second step the focus is on store- and cacheable responses.

Fix zaproxy/zaproxy#5500.