### PR TITLE
Add SonarCloud as a Scheduled GitHub Action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,34 @@
+name: Run Sonar
+
+on: 
+  schedule:
+    - cron: '0 15 * * SAT'
+
+jobs:
+  sonar:
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Setup JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Gradle Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+          ~/.m2/repository/webdriver/
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Gradle Test & Coverage Report
+      run: ./gradlew test jacocoTestReport -Dorg.gradle.jvmargs=-Xmx4096m
+    - name: Sonarcloud Scan
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: ./gradlew sonarqube --stacktrace

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -42,6 +42,12 @@ subprojects {
         toolVersion = jacocoToolVersion
     }
 
+    tasks.named<JacocoReport>("jacocoTestReport") {
+        reports {
+            xml.isEnabled = true
+        }
+    }
+
     val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.9.0"))
 
     zapAddOn {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.diffplug.gradle.spotless")
     id("com.github.ben-manes.versions") version "0.27.0"
+    id("org.sonarqube") version "3.0"
 }
 
 apply(from = "$rootDir/gradle/travis-ci.gradle.kts")
@@ -34,5 +35,13 @@ allprojects {
 
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()
+    }
+}
+
+sonarqube {
+    properties {
+        property("sonar.projectKey", "zaproxy_zap-extensions")
+        property("sonar.organization", "zaproxy")
+        property("sonar.host.url", "https://sonarcloud.io")
     }
 }


### PR DESCRIPTION
~Add support for Sonar scan for each branch according to [Using SonarCloud with Travis CI](https://docs.travis-ci.com/user/sonarcloud/)~

~To do to make it work:~
~1. Get a token from https://sonarcloud.io/account/security~
~2. Add an environment variable SONAR_TOKEN with the token in travis-ci.org~
~3. To activate analysis on pull requests, you need to install the SonarCloud application on your GitHub organization(s).  (cf. https://docs.travis-ci.com/user/sonarcloud/#analysis-of-internal-pull-requests)~

- addOns.gradle.kts > Modified so that jacoco reports include XML output.
- build.gradle.kts > Modified to include sonarqube.
- sonar.yml > Added to run a GitHub action workflow every Saturday in order to update the SonarCloud SAST results and coverage info.