### PR TITLE
Adds options to specify inclusion of scans/alerts in exportreport

### DIFF
--- a/addOns/exportreport/CHANGELOG.md
+++ b/addOns/exportreport/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Completed PDF Output support (Issue 5535)
+- Added option to specify active scan id in API.
+- Added option to specify inclusion of passive alerts in API and command line.
 
 ## [6] - 2019-06-24
 

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
@@ -54,6 +54,8 @@ public class ExportReportAPI extends ApiImplementor {
     private static final String ACTION_PARAM_SOURCE_DETAILS = "sourceDetails";
     private static final String ACTION_PARAM_ALERT_SEVERITY = "alertSeverity";
     private static final String ACTION_PARAM_ALERT_DETAILS = "alertDetails";
+    private static final String ACTION_PARAM_SCAN_ID = "scanId";
+    private static final String ACTION_PARAM_INCLUDE_PASSIVE_ALERTS = "includePassiveAlerts";
 
     private ExtensionExportReport extension;
 
@@ -70,7 +72,8 @@ public class ExportReportAPI extends ApiImplementor {
                             ACTION_PARAM_SOURCE_DETAILS,
                             ACTION_PARAM_ALERT_SEVERITY,
                             ACTION_PARAM_ALERT_DETAILS
-                        }));
+                        },
+                        new String[] {ACTION_PARAM_SCAN_ID, ACTION_PARAM_INCLUDE_PASSIVE_ALERTS}));
         this.addApiView(new ApiView(VIEW_FORMATS));
     }
 
@@ -276,6 +279,11 @@ public class ExportReportAPI extends ApiImplementor {
                                     "exportreport.message.console.info.pass.generate"));
                 }
 
+                int scanId = this.getParam(params, ACTION_PARAM_SCAN_ID, -1);
+
+                boolean includePassiveAlerts =
+                        getParam(params, ACTION_PARAM_INCLUDE_PASSIVE_ALERTS, true);
+
                 ArrayList<String> alertSeverityTemp =
                         extension.generateList(alertSeverityFlags, extension.getAlertSeverity());
 
@@ -292,7 +300,9 @@ public class ExportReportAPI extends ApiImplementor {
                             fileExtension,
                             sourceDetails,
                             alertSeverityTemp,
-                            alertDetailsTemp)) {
+                            alertDetailsTemp,
+                            scanId,
+                            includePassiveAlerts)) {
                         if (logger.isDebugEnabled()) {
                             logger.debug(
                                     Constant.messages.getString(

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
@@ -294,7 +294,8 @@ public class ExportReportAPI extends ApiImplementor {
                                     .getExtension(ExtensionActiveScan.class);
 
                     if (extension == null) {
-                        throw new IllegalArgumentException(
+                        throw new ApiException(
+                        		ApiException.Type.BAD_STATE,
                                 Constant.messages.getString(
                                         "exportreport.message.error.exception.extension"));
                     }
@@ -302,9 +303,10 @@ public class ExportReportAPI extends ApiImplementor {
                     scan = extension.getScan(scanId);
 
                     if (scan == null) {
-                        throw new IllegalStateException(
+                        throw new ApiException(
+                        		ApiException.Type.ILLEGAL_PARAMETER,
                                 Constant.messages.getString(
-                                        "exportreport.message.error.exception.invalidscanid"));
+                                        "exportreport.message.error.exception.invalidscanid", scanId));
                     }
                 }
 

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
@@ -295,7 +295,7 @@ public class ExportReportAPI extends ApiImplementor {
 
                     if (extension == null) {
                         throw new ApiException(
-                                ApiException.Type.BAD_STATE, "Active scan extenstion not enabled");
+                                ApiException.Type.BAD_STATE, "Active scan extension not enabled");
                     }
 
                     scan = extension.getScan(scanId);

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
@@ -295,18 +295,14 @@ public class ExportReportAPI extends ApiImplementor {
 
                     if (extension == null) {
                         throw new ApiException(
-                        		ApiException.Type.BAD_STATE,
-                                Constant.messages.getString(
-                                        "exportreport.message.error.exception.extension"));
+                                ApiException.Type.BAD_STATE, "Active scan extenstion not enabled");
                     }
 
                     scan = extension.getScan(scanId);
 
                     if (scan == null) {
                         throw new ApiException(
-                        		ApiException.Type.ILLEGAL_PARAMETER,
-                                Constant.messages.getString(
-                                        "exportreport.message.error.exception.invalidscanid", scanId));
+                                ApiException.Type.ILLEGAL_PARAMETER, ACTION_PARAM_SCAN_ID);
                     }
                 }
 

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
@@ -41,6 +41,7 @@ import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.exportreport.export.ExportReport;
 import org.zaproxy.zap.extension.exportreport.filechooser.FileList;
 import org.zaproxy.zap.extension.exportreport.filechooser.Utils;
@@ -85,10 +86,10 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
     private static final int ARG_SOURCE_INFO_IDX = 1;
     private static final int ARG_ALERT_SEVERITY_IDX = 2;
     private static final int ARG_ALERT_DETAILS_IDX = 3;
-    private static final int ARG_SCAN_ID_IDX = 4;
-    private static final int ARG_INCLUDE_PASSIVE_ALERTS_IDX = 5;
+    private static final int ARG_INCLUDE_PASSIVE_ALERTS_IDX = 4;
+    // private static final int ARG_SCAN_ID_IDX = 5;
 
-    private CommandLineArgument[] arguments = new CommandLineArgument[6];
+    private CommandLineArgument[] arguments = new CommandLineArgument[5];
 
     // Used for PDF export
     private List<Alert> alertsDB = null;
@@ -342,7 +343,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
             ArrayList<String> sourceDetails,
             ArrayList<String> alertSeverity,
             ArrayList<String> alertDetails,
-            int scanId,
+            ActiveScan scan,
             boolean includePassiveAlerts) {
         ExportReport report = new ExportReport();
         return report.generateReport(
@@ -352,7 +353,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
                 sourceDetails,
                 alertSeverity,
                 alertDetails,
-                scanId,
+                scan,
                 includePassiveAlerts);
     }
 
@@ -541,8 +542,8 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
             alertDetailsFull.addAll(alertDetails.size(), alertAdditional);
             ArrayList<String> alertDetailsTemp = generateList(alertDetailsFlags, alertDetailsFull);
 
+            /*
             int scanId = -1;
-            boolean includePassiveAlerts = true;
             if (arguments[ARG_SCAN_ID_IDX].isEnabled()) {
                 String scanIdStr = arguments[ARG_SCAN_ID_IDX].getArguments().get(0);
                 try {
@@ -551,7 +552,9 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
                     scanId = -1;
                 }
             }
+            */
 
+            boolean includePassiveAlerts = true;
             if (arguments[ARG_INCLUDE_PASSIVE_ALERTS_IDX].isEnabled()) {
                 String includePassiveAlertsStr =
                         arguments[ARG_INCLUDE_PASSIVE_ALERTS_IDX].getArguments().get(0);
@@ -567,7 +570,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
                         sourceDetails,
                         alertSeverityTemp,
                         alertDetailsTemp,
-                        scanId,
+                        null,
                         includePassiveAlerts)) {
                     CommandLine.info(
                             Constant.messages.getString(
@@ -640,6 +643,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
                         null,
                         "",
                         Constant.messages.getString("exportreport.cmdline.details.help"));
+        /*
         arguments[ARG_SCAN_ID_IDX] =
                 new CommandLineArgument(
                         "-scan_id",
@@ -647,6 +651,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
                         null,
                         "",
                         Constant.messages.getString("exportreport.cmdline.scanid.help"));
+        */
         arguments[ARG_INCLUDE_PASSIVE_ALERTS_IDX] =
                 new CommandLineArgument(
                         "-include_passive_alerts",

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
@@ -543,6 +543,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
             ArrayList<String> alertDetailsTemp = generateList(alertDetailsFlags, alertDetailsFull);
 
             /*
+             * TODO: Issue 2920 : Add scanId option to cmdline tool
             int scanId = -1;
             if (arguments[ARG_SCAN_ID_IDX].isEnabled()) {
                 String scanIdStr = arguments[ARG_SCAN_ID_IDX].getArguments().get(0);
@@ -644,6 +645,7 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
                         "",
                         Constant.messages.getString("exportreport.cmdline.details.help"));
         /*
+         * TODO: Issue 2920 : Add scanId option to cmdline tool
         arguments[ARG_SCAN_ID_IDX] =
                 new CommandLineArgument(
                         "-scan_id",

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExtensionExportReport.java
@@ -77,8 +77,6 @@ public class ExtensionExportReport extends ExtensionAdaptor implements CommandLi
     private ArrayList<String> alertSeverity = new ArrayList<String>();
     private ArrayList<String> alertDetails = new ArrayList<String>();
     private ArrayList<String> alertAdditional = new ArrayList<String>();
-    private int scanId = -1;
-    private boolean includePassiveAlerts = true;
     private FileList fileList = new FileList();
     private int maxList = 0;
     public static final int SOURCE_COUNT = 8;

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ExportReport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ExportReport.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.exportreport.ExtensionExportReport;
 import org.zaproxy.zap.extension.exportreport.filechooser.FileList;
 import org.zaproxy.zap.extension.exportreport.filechooser.ReportFileView;
@@ -103,7 +104,7 @@ public class ExportReport {
                                 extension.extensionGetDescription(),
                                 extension.getIncludedAlertSeverity(),
                                 extension.getIncludedAlertDetails(),
-                                -1,
+                                null,
                                 true);
             } catch (UnsupportedEncodingException e) {
                 logger.error(e.getMessage(), e);
@@ -241,7 +242,7 @@ public class ExportReport {
             ArrayList<String> sourceDetailsList,
             ArrayList<String> alertSeverityList,
             ArrayList<String> alertDetailsList,
-            int scanId,
+            ActiveScan scan,
             boolean includePassiveAlerts) {
 
         File f = new File(absolutePath);
@@ -275,7 +276,7 @@ public class ExportReport {
                             getDescription,
                             alertSeverityList,
                             alertDetailsList,
-                            scanId,
+                            scan,
                             includePassiveAlerts);
         } catch (UnsupportedEncodingException e) {
             logger.error(e.getMessage(), e);

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ExportReport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ExportReport.java
@@ -102,7 +102,9 @@ public class ExportReport {
                                 extension.extensionGetReportVer(),
                                 extension.extensionGetDescription(),
                                 extension.getIncludedAlertSeverity(),
-                                extension.getIncludedAlertDetails());
+                                extension.getIncludedAlertDetails(),
+                                -1,
+                                true);
             } catch (UnsupportedEncodingException e) {
                 logger.error(e.getMessage(), e);
                 view.showWarningDialog(
@@ -238,7 +240,9 @@ public class ExportReport {
             String ext,
             ArrayList<String> sourceDetailsList,
             ArrayList<String> alertSeverityList,
-            ArrayList<String> alertDetailsList) {
+            ArrayList<String> alertDetailsList,
+            int scanId,
+            boolean includePassiveAlerts) {
 
         File f = new File(absolutePath);
         String file = f.getName();
@@ -270,7 +274,9 @@ public class ExportReport {
                             extensionGetReportVer,
                             getDescription,
                             alertSeverityList,
-                            alertDetailsList);
+                            alertDetailsList,
+                            scanId,
+                            includePassiveAlerts);
         } catch (UnsupportedEncodingException e) {
             logger.error(e.getMessage(), e);
             CommandLine.error(Constant.messages.getString("exportreport.message.error.dump"));

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
@@ -160,8 +160,9 @@ final class ReportExport {
                             .getScan(scanId);
 
             if (scan == null) {
-            	logger.warn(Constant.messages.getString("exportreport.message.warning.invalidscanid"));
-            	scanId = -1;
+                logger.warn(
+                        Constant.messages.getString("exportreport.message.warning.invalidscanid"));
+                scanId = -1;
             }
         }
 

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
@@ -158,7 +158,11 @@ final class ReportExport {
                             .getExtensionLoader()
                             .getExtension(ExtensionActiveScan.class)
                             .getScan(scanId);
-            scanId = scan == null ? -1 : scanId;
+
+            if (scan == null) {
+            	logger.warn(Constant.messages.getString("exportreport.message.warning.invalidscanid"));
+            	scanId = -1;
+            }
         }
 
         if (scanId == -1) {
@@ -181,12 +185,11 @@ final class ReportExport {
                     alerts.add(new Alert(tableAlert.read(alertId)));
 
                 } catch (DatabaseException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    logger.error(e.getMessage(), e);
+                    logger.error("exportreport.message.error.exception");
                 }
             }
             if (includePassiveAlerts) {
-                // TODO fix
                 // there doesn't seem to be a way
                 // to access only the passive alerts
                 // so we check for all alerts

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/export/ReportExport.java
@@ -63,7 +63,6 @@ import org.w3c.dom.ls.LSSerializer;
 import org.xml.sax.SAXException;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
-import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.exportreport.filechooser.Utils;
 import org.zaproxy.zap.extension.exportreport.model.AlertItem;
 import org.zaproxy.zap.extension.exportreport.model.Alerts;
@@ -106,7 +105,7 @@ final class ReportExport {
             String reportDesc,
             ArrayList<String> alertSeverity,
             ArrayList<String> alertDetails,
-            int scanId,
+            ActiveScan scan,
             boolean includePassiveAlerts)
             throws UnsupportedEncodingException, URIException {
 
@@ -150,23 +149,7 @@ final class ReportExport {
 
         List<Alert> alerts = new ArrayList<>();
 
-        // check if scanid is valid when specified
-        ActiveScan scan = null;
-        if (scanId != -1) {
-            scan =
-                    Control.getSingleton()
-                            .getExtensionLoader()
-                            .getExtension(ExtensionActiveScan.class)
-                            .getScan(scanId);
-
-            if (scan == null) {
-                logger.warn(
-                        Constant.messages.getString("exportreport.message.warning.invalidscanid"));
-                scanId = -1;
-            }
-        }
-
-        if (scanId == -1) {
+        if (scan == null) {
             alerts =
                     Control.getSingleton()
                             .getExtensionLoader()

--- a/addOns/exportreport/src/main/javahelp/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
+++ b/addOns/exportreport/src/main/javahelp/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
@@ -327,6 +327,82 @@
                 </UL>
             </LI>
             <LI><HR></LI>
+
+            <LI><B>-scan_id (optional)</B>:
+                <UL style="list-style: none;">
+
+                    <LI>
+                        <H4>Description:</H4>
+                        <UL>
+                            <LI>Specifies the id of the scan that will be used to generate the report</LI>
+                        </UL>
+                    <LI>
+                    <LI>
+                        <H4>Input format:</H4>
+                        <UL>
+                            <LI>Only accepts integers, defaults to all scans if not respected</LI>
+                        </UL>
+                    </LI>
+                    <LI>
+                        <H4>Input restriction:</H4>
+                        <UL>
+                            <LI>Only accepts a valid existing scan id</LI>
+                        </UL>
+                    </LI>
+                    <LI>
+                        <H4>Example:</H4>
+                        <UL>
+                            <LI>-scan_id "4"</LI>
+                        </UL>
+                    </LI>
+                    <LI>
+                        <H4>Explanation:</H4>
+                        <UL>
+                            <LI>In the above example, only alerts raised during the scan with id '4' will be included in the report.</LI>
+                        </UL>
+                    </LI>
+                    <LI>
+                        <H4>Validation:</H4>
+                        <UL>
+                            <LI>Content is validated to be a valid scan id.</LI>
+                        </UL>
+                    </LI>
+                    <LI><BR></LI>
+                </UL>
+            </LI>
+            <LI><HR></LI>
+
+            <LI><B>-include_passive_alerts (optional)</B>:
+                <UL style="list-style: none;">
+
+                    <LI>
+                        <H4>Description:</H4>
+                        <UL>
+                            <LI>Specifies whether or not to include passive alerts in the report</LI>
+                        </UL>
+                    <LI>
+                    <LI>
+                        <H4>Input format:</H4>
+                        <UL>
+                            <LI>Only accepts boolean values, defaults to true if not respected</LI>
+                        </UL>
+                    </LI>
+                    <LI>
+                        <H4>Example:</H4>
+                        <UL>
+                            <LI>-include_passive_alerts "false"</LI>
+                        </UL>
+                    </LI>
+                    <LI>
+                        <H4>Explanation:</H4>
+                        <UL>
+                            <LI>In the above example, no passive alerts will be included in the report.</LI>
+                        </UL>
+                    </LI>
+                    <LI><BR></LI>
+                </UL>
+            </LI>
+            <LI><HR></LI>
         </UL>
 
         <UL style="list-style: none;">

--- a/addOns/exportreport/src/main/javahelp/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
+++ b/addOns/exportreport/src/main/javahelp/org/zaproxy/zap/extension/exportreport/resources/help/contents/exportreport.html
@@ -327,7 +327,7 @@
                 </UL>
             </LI>
             <LI><HR></LI>
-
+<!-- TODO: Issue 2920 : Add scanId option to cmdline tool
             <LI><B>-scan_id (optional)</B>:
                 <UL style="list-style: none;">
 
@@ -370,7 +370,9 @@
                     <LI><BR></LI>
                 </UL>
             </LI>
+            
             <LI><HR></LI>
+-->
 
             <LI><B>-include_passive_alerts (optional)</B>:
                 <UL style="list-style: none;">

--- a/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
+++ b/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
@@ -69,8 +69,8 @@ exportreport.message.error.sax = Error: SAX Exception, see log for more details.
 exportreport.message.error.io = Error: IO Exception, see log for more details.
 exportreport.message.error.json = Error: JSON Exception, see log for more details.
 exportreport.message.error.exception = Error: Exception, see log for more details.
-
-exportreport.message.warning.invalidscanid = Warning: The specified scan id could not be found, reporting all scans.
+exportreport.message.error.exception.invalidscanid = Error: The specified scan id could not be found.
+exportreport.message.error.exception.extension = Error: The active scan extension could not be found.
 
 exportreport.cmdline.export.help = -export_report <path> 	 Generate the 'Export Report' into the specified path in a desired format
 exportreport.cmdline.source.help = -source_info <info> 	 A semicolon delimited string "Title;By;For;Scan Date;Report Date;Scan Ver;Report Ver;Description"

--- a/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
+++ b/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
@@ -74,6 +74,8 @@ exportreport.cmdline.export.help = -export_report <path> Generate the 'Export Re
 exportreport.cmdline.source.help = -source_info A semicolon delimited string "Title;By;For;Scan Date;Report Date;Scan Ver;Report Ver;Description"
 exportreport.cmdline.risk.help = -alert_severity A semicolon delimited string accepting 't' or 'f' values for high, medium, low and informational Alert Risk
 exportreport.cmdline.details.help = -alert_details A semicolon delimited string accepting 't' or 'f' values for CWE ID, WASC ID, Description, Other Info, Solution, Reference, Request Header, Response Header, Request Body, Response Body
+exportreport.cmdline.scanid.help = -scan_id An integer value representing the scan to target
+exportreport.cmdline.passivealerts.help = -include_passive_alerts A boolean value indicating whether or not to include passive alerts
 
 exportreport.message.console.error.file.writable = [ERROR] {0} is not writable. See log for details.
 exportreport.message.console.error.file.extension = [ERROR] Invalid extension used, only .xhtml, .bootstrap.html, .xml, .json, .pdf and .doc are accepted. Some may not be supported until v2.0.

--- a/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
+++ b/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
@@ -70,12 +70,14 @@ exportreport.message.error.io = Error: IO Exception, see log for more details.
 exportreport.message.error.json = Error: JSON Exception, see log for more details.
 exportreport.message.error.exception = Error: Exception, see log for more details.
 
+exportreport.message.warning.invalidscanid = Warning: The specified scan id could not be found, reporting all scans.
+
 exportreport.cmdline.export.help = -export_report <path> Generate the 'Export Report' into the specified path in a desired format
 exportreport.cmdline.source.help = -source_info A semicolon delimited string "Title;By;For;Scan Date;Report Date;Scan Ver;Report Ver;Description"
 exportreport.cmdline.risk.help = -alert_severity A semicolon delimited string accepting 't' or 'f' values for high, medium, low and informational Alert Risk
 exportreport.cmdline.details.help = -alert_details A semicolon delimited string accepting 't' or 'f' values for CWE ID, WASC ID, Description, Other Info, Solution, Reference, Request Header, Response Header, Request Body, Response Body
-exportreport.cmdline.scanid.help = -scan_id An integer value representing the scan to target
-exportreport.cmdline.passivealerts.help = -include_passive_alerts A boolean value indicating whether or not to include passive alerts
+exportreport.cmdline.scanid.help = -scan_id An integer value representing the scan to target, by default every scan is included
+exportreport.cmdline.passivealerts.help = -include_passive_alerts A boolean value indicating whether or not to include passive alerts, default true
 
 exportreport.message.console.error.file.writable = [ERROR] {0} is not writable. See log for details.
 exportreport.message.console.error.file.extension = [ERROR] Invalid extension used, only .xhtml, .bootstrap.html, .xml, .json, .pdf and .doc are accepted. Some may not be supported until v2.0.

--- a/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
+++ b/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
@@ -69,8 +69,6 @@ exportreport.message.error.sax = Error: SAX Exception, see log for more details.
 exportreport.message.error.io = Error: IO Exception, see log for more details.
 exportreport.message.error.json = Error: JSON Exception, see log for more details.
 exportreport.message.error.exception = Error: Exception, see log for more details.
-exportreport.message.error.exception.invalidscanid = Error: The specified scan id {0} could not be found.
-exportreport.message.error.exception.extension = Error: The active scan extension could not be found.
 
 exportreport.cmdline.export.help = -export_report <path> 	 Generate the 'Export Report' into the specified path in a desired format
 exportreport.cmdline.source.help = -source_info <info> 	 A semicolon delimited string "Title;By;For;Scan Date;Report Date;Scan Ver;Report Ver;Description"

--- a/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
+++ b/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
@@ -72,12 +72,12 @@ exportreport.message.error.exception = Error: Exception, see log for more detail
 
 exportreport.message.warning.invalidscanid = Warning: The specified scan id could not be found, reporting all scans.
 
-exportreport.cmdline.export.help = -export_report <path> Generate the 'Export Report' into the specified path in a desired format
-exportreport.cmdline.source.help = -source_info A semicolon delimited string "Title;By;For;Scan Date;Report Date;Scan Ver;Report Ver;Description"
-exportreport.cmdline.risk.help = -alert_severity A semicolon delimited string accepting 't' or 'f' values for high, medium, low and informational Alert Risk
-exportreport.cmdline.details.help = -alert_details A semicolon delimited string accepting 't' or 'f' values for CWE ID, WASC ID, Description, Other Info, Solution, Reference, Request Header, Response Header, Request Body, Response Body
-exportreport.cmdline.scanid.help = -scan_id An integer value representing the scan to target, by default every scan is included
-exportreport.cmdline.passivealerts.help = -include_passive_alerts A boolean value indicating whether or not to include passive alerts, default true
+exportreport.cmdline.export.help = -export_report <path> 	 Generate the 'Export Report' into the specified path in a desired format
+exportreport.cmdline.source.help = -source_info <info> 	 A semicolon delimited string "Title;By;For;Scan Date;Report Date;Scan Ver;Report Ver;Description"
+exportreport.cmdline.risk.help = -alert_severity <list> 	 A semicolon delimited string accepting 't' or 'f' values for high, medium, low and informational Alert Severity
+exportreport.cmdline.details.help = -alert_details <list> 	 A semicolon delimited string accepting 't' or 'f' values for CWE ID, WASC ID, Description, Other Info, Solution, Reference, Request Header, Response Header, Request Body, Response Body
+exportreport.cmdline.scanid.help = -scan_id <id> 		 An integer value representing the scan to target, by default every scan is included
+exportreport.cmdline.passivealerts.help = -include_passive_alerts <value> A boolean value indicating whether or not to include passive alerts, default true
 
 exportreport.message.console.error.file.writable = [ERROR] {0} is not writable. See log for details.
 exportreport.message.console.error.file.extension = [ERROR] Invalid extension used, only .xhtml, .bootstrap.html, .xml, .json, .pdf and .doc are accepted. Some may not be supported until v2.0.

--- a/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
+++ b/addOns/exportreport/src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties
@@ -69,7 +69,7 @@ exportreport.message.error.sax = Error: SAX Exception, see log for more details.
 exportreport.message.error.io = Error: IO Exception, see log for more details.
 exportreport.message.error.json = Error: JSON Exception, see log for more details.
 exportreport.message.error.exception = Error: Exception, see log for more details.
-exportreport.message.error.exception.invalidscanid = Error: The specified scan id could not be found.
+exportreport.message.error.exception.invalidscanid = Error: The specified scan id {0} could not be found.
 exportreport.message.error.exception.extension = Error: The active scan extension could not be found.
 
 exportreport.cmdline.export.help = -export_report <path> 	 Generate the 'Export Report' into the specified path in a desired format


### PR DESCRIPTION
Fixes [#2920](https://github.com/zaproxy/zaproxy/issues/2920)

Modifies `exportreport`'s `generate` API action to include two new optional parameters : `scanId` and `includePassiveAlerts`. Updates the command line interface to support those options.