### PR TITLE
testutils: update Mockito to 3.1.0

### DIFF
--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScannerUnitTest.java
@@ -19,15 +19,16 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
+import org.mockito.Mock;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
@@ -35,8 +36,19 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.Context;
 
+/** Unit test for {@link CrossDomainScriptInclusionScanner}. */
 public class CrossDomainScriptInclusionScannerUnitTest
         extends PassiveScannerTest<CrossDomainScriptInclusionScanner> {
+
+    @Mock Model model;
+    @Mock Session session;
+
+    @Before
+    public void setup() {
+        when(session.getContextsForUrl(anyString())).thenReturn(Collections.emptyList());
+        when(model.getSession()).thenReturn(session);
+        rule.setModel(model);
+    }
 
     @Override
     protected CrossDomainScriptInclusionScanner createScanner() {
@@ -89,12 +101,6 @@ public class CrossDomainScriptInclusionScannerUnitTest
 
     @Test
     public void crossDomainScript() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -124,12 +130,6 @@ public class CrossDomainScriptInclusionScannerUnitTest
 
     @Test
     public void crossDomainScriptWithIntegrity() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -155,12 +155,6 @@ public class CrossDomainScriptInclusionScannerUnitTest
 
     @Test
     public void crossDomainScriptWithNullIntegrity() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -190,16 +184,10 @@ public class CrossDomainScriptInclusionScannerUnitTest
 
     @Test
     public void crossDomainScriptNotInContext() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
+        // Given
         Context context = new Context(session, -1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
-        List<Context> contexts = new ArrayList<Context>();
-        contexts.add(context);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
+        when(session.getContextsForUrl(anyString())).thenReturn(asList(context));
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -258,17 +246,11 @@ public class CrossDomainScriptInclusionScannerUnitTest
 
     @Test
     public void crossDomainScriptInContextHigh() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
+        // Given
         Context context = new Context(session, -1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
         context.addIncludeInContextRegex("https://www.otherDomain.com/.*");
-        List<Context> contexts = new ArrayList<Context>();
-        contexts.add(context);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
+        when(session.getContextsForUrl(anyString())).thenReturn(asList(context));
 
         rule.setAlertThreshold(AlertThreshold.HIGH);
 
@@ -296,17 +278,11 @@ public class CrossDomainScriptInclusionScannerUnitTest
 
     @Test
     public void crossDomainScriptInContextMed() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
+        // Given
         Context context = new Context(session, -1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
         context.addIncludeInContextRegex("https://www.otherDomain.com/.*");
-        List<Context> contexts = new ArrayList<Context>();
-        contexts.add(context);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
+        when(session.getContextsForUrl(anyString())).thenReturn(asList(context));
 
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
 
@@ -334,18 +310,7 @@ public class CrossDomainScriptInclusionScannerUnitTest
 
     @Test
     public void crossDomainScriptInContextLow() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        Context context = new Context(session, -1);
-        context.addIncludeInContextRegex("https://www.example.com/.*");
-        context.addIncludeInContextRegex("https://www.otherDomain.com/.*");
-        List<Context> contexts = new ArrayList<Context>();
-        contexts.add(context);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
-
+        // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
 
         HttpMessage msg = new HttpMessage();

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/LinkTargetScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/LinkTargetScannerUnitTest.java
@@ -21,13 +21,14 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
+import org.mockito.Mock;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
@@ -36,10 +37,21 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
+/** Unit test for {@link LinkTargetScanner}. */
 public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScanner> {
 
     private static final String HTML_CONTENT_TYPE = "text/html;charset=ISO-8859-1";
     private static final String TEXT_CONTENT_TYPE = "text/plain; charset=us-ascii";
+
+    @Mock Model model;
+    @Mock Session session;
+
+    @Before
+    public void setup() {
+        when(session.getContextsForUrl(anyString())).thenReturn(Collections.emptyList());
+        when(model.getSession()).thenReturn(session);
+        rule.setModel(model);
+    }
 
     @Override
     protected LinkTargetScanner createScanner() {
@@ -60,12 +72,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
 
     @Test
     public void dontRaiseIssueWhenNoLinks() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -79,12 +85,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
 
     @Test
     public void dontRaiseIssueWhenOneLinkNoTarget() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -99,18 +99,11 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenOneLinkWithBlankTargetSameDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
+        // Given
         Context context1 = new Context(session, 0);
         context1.addIncludeInContextRegex("https://www.example.com.*");
         context1.addIncludeInContextRegex("https://www.example2.com.*");
-        List<Context> contextList = new ArrayList<Context>();
-        contextList.add(context1);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contextList);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
-        // Given
+        when(session.getContextsForUrl(anyString())).thenReturn(Arrays.asList(context1));
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
@@ -125,11 +118,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenOneLinkWithBlankTargetTrustedDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -148,11 +136,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void raiseIssueWhenOneLinkWithBlankTargetUntrustedDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -174,12 +157,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void raiseIssueWhenOneLinkWithBlankTargetDifferentDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -197,12 +174,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
 
     @Test
     public void raiseIssueWhenOneLinkWithOtherTarget() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -221,12 +192,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenOneLinkWithOtherTargetHighThreshold()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -243,12 +208,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void raiseIssueWhenAreaWithBlankTargetDifferentDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -273,12 +232,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
 
     @Test
     public void dontRaiseIssueWhenAreaWithOtherTarget() throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -299,12 +252,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenManyLinksWithBlankTargetSameDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -327,12 +274,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void raiseIssueWhenManyLinksWithBlankTargetDifferentDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -358,12 +299,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenOneLinkWithBlankTargetNoopenerNoReferrer()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -379,12 +314,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenOneLinkWithBlankTargetNoreferrerNoopener()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -400,12 +329,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenManyLinksWithOneBlankTargetSameDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -428,12 +351,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void raiseIssueWhenManyLinksWithOneBlankTargetDifferentDomain()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -459,12 +376,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenOneLinkWithBlankTargetNonHtml()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(new ArrayList<Context>());
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -480,18 +391,11 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void dontRaiseIssueWhenOneLinkWithBlankTargetInContext()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
+        // Given
         Context context = new Context(session, 0);
         context.addIncludeInContextRegex("https://www.example.com/.*");
         context.addIncludeInContextRegex("https://www.example2.com/.*");
-        ArrayList<Context> contexts = new ArrayList<Context>();
-        contexts.add(context);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
-        // Given
+        when(session.getContextsForUrl(anyString())).thenReturn(Arrays.asList(context));
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
@@ -506,18 +410,11 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
     @Test
     public void raiseIssueWhenOneLinkWithBlankTargetNotInContext()
             throws HttpMalformedHeaderException {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
+        // Given
         Context context = new Context(session, 0);
         context.addIncludeInContextRegex("https://www.example.com/.*");
         context.addIncludeInContextRegex("https://www.example2.com/.*");
-        ArrayList<Context> contexts = new ArrayList<Context>();
-        contexts.add(context);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
-        // Given
+        when(session.getContextsForUrl(anyString())).thenReturn(Arrays.asList(context));
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
@@ -534,16 +431,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
 
     @Test
     public void shouldNotFailIfLinkOrAreaDoesNotHaveHref() throws Exception {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        Context context = Mockito.mock(Context.class);
-        when(context.isInContext(Matchers.anyString())).thenReturn(true);
-        ArrayList<Context> contexts = new ArrayList<>();
-        contexts.add(context);
-        when(session.getContextsForUrl(Matchers.anyString())).thenReturn(contexts);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -556,11 +443,6 @@ public class LinkTargetScannerUnitTest extends PassiveScannerTest<LinkTargetScan
 
     @Test
     public void shouldNotFailIfInvalidRegex() throws Exception {
-        // Mock the model and session
-        Model model = Mockito.mock(Model.class);
-        Session session = Mockito.mock(Session.class);
-        when(model.getSession()).thenReturn(session);
-        rule.setModel(model);
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
@@ -19,7 +19,11 @@
  */
 package org.zaproxy.zap.extension.sse;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -31,9 +35,10 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
+/** Unit test for {@link EventStreamListener}. */
 @RunWith(MockitoJUnitRunner.class)
 public class EventStreamListenerUnitTest {
 

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
@@ -21,7 +21,10 @@ package org.zaproxy.zap.extension.sse;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -29,7 +32,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.I18N;
 

--- a/addOns/tokengen/src/test/java/org/zaproxy/zap/extension/tokengen/TokenRandomStreamUnitTest.java
+++ b/addOns/tokengen/src/test/java/org/zaproxy/zap/extension/tokengen/TokenRandomStreamUnitTest.java
@@ -26,8 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
+/** Unit test for {@link TokenRandomStream}. */
 @RunWith(MockitoJUnitRunner.class)
 public class TokenRandomStreamUnitTest {
 

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -24,13 +24,12 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Vector;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -133,11 +132,9 @@ public class WappalyzerPassiveScannerUnitTest
 
     private HttpMessage makeHttpMessage() throws HttpMalformedHeaderException {
         HttpMessage httpMessage = new HttpMessage();
-        SiteNode siteNode = Mockito.mock(SiteNode.class);
-        given(siteNode.getPastHistoryReference()).willReturn(new Vector<>());
 
-        HistoryReference ref = Mockito.mock(HistoryReference.class);
-        given(ref.getSiteNode()).willReturn(siteNode);
+        HistoryReference ref = mock(HistoryReference.class);
+        given(ref.getSiteNode()).willReturn(mock(SiteNode.class));
 
         httpMessage.setHistoryRef(ref);
 

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/pscan/WebSocketPassiveScannerManagerUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/pscan/WebSocketPassiveScannerManagerUnitTest.java
@@ -130,8 +130,6 @@ public class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
     public void shouldDisableScanner() {
         // Given
         WebSocketPassiveScanner scanner1 = mock(WebSocketPassiveScanner.class);
-        when(scanner1.getName()).thenReturn("WsScanner-1");
-        when(scanner1.getId()).thenReturn(1);
 
         // When
         wsPscanManager.setAllEnable(true);

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -20,10 +20,12 @@
 package org.zaproxy.zap.testutils;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,9 +61,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -155,9 +156,8 @@ public abstract class TestUtils {
         File langDir = new File(Constant.getZapInstall(), "lang");
         ClassLoaderUtil.addFile(langDir.getAbsolutePath());
 
-        ExtensionLoader extLoader = Mockito.mock(ExtensionLoader.class);
-        Control control = Mockito.mock(Control.class);
-        Mockito.when(control.getExtensionLoader()).thenReturn(extLoader);
+        Control control = mock(Control.class, withSettings().lenient());
+        when(control.getExtensionLoader()).thenReturn(mock(ExtensionLoader.class));
 
         // Init all the things
         Constant.getInstance();
@@ -493,7 +493,7 @@ public abstract class TestUtils {
      * @param extension the target extension to mock the messages
      */
     protected static void mockMessages(final Extension extension) {
-        I18N i18n = Mockito.mock(I18N.class);
+        I18N i18n = mock(I18N.class, withSettings().lenient());
         Constant.messages = i18n;
 
         given(i18n.getLocal()).willReturn(Locale.getDefault());
@@ -515,7 +515,7 @@ public abstract class TestUtils {
                             }
                         });
 
-        when(i18n.getString(anyString(), anyVararg()))
+        when(i18n.getString(anyString(), any()))
                 .thenAnswer(
                         new Answer<String>() {
 

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     api("junit:junit:4.11")
 
     api("org.hamcrest:hamcrest-library:1.3")
-    api("org.mockito:mockito-core:1.9.0")
+    api("org.mockito:mockito-core:3.1.0")
 
     api("org.nanohttpd:nanohttpd-webserver:$nanohttpdVersion")
     api("org.nanohttpd:nanohttpd-websocket:$nanohttpdVersion")


### PR DESCRIPTION
Change tests to:
 - Address deprecations;
 - Remove unnecessary stubbings or make the mock lenient if the stubs
 are used in different/several tests;
 - Extract mocks/stubs in some classes to avoid repeating the same in
 several/every test.