### PR TITLE
webdrivers: update WebDrivers, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [13] - 2019-10-23
+### Changed
+- Update ChromeDriver to v78.0.3904.70.
+- Update geckodriver to v0.26.0.
 
 ## [12] - 2019-09-13
 ### Changed
@@ -67,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[13]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v12
 [11]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v11
 [10]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v10

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,8 +9,8 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 77.0.3865.40</li>
-    <li>Firefox - geckodriver 0.25.0</li>
+    <li>Chrome - ChromeDriver 78.0.3904.70</li>
+    <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [13] - 2019-10-23
+### Changed
+- Update ChromeDriver to v78.0.3904.70.
+- Update geckodriver to v0.26.0.
 
 ## [12] - 2019-09-13
 ### Changed
@@ -67,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[13]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v12
 [11]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v11
 [10]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v10

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,8 +9,8 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 77.0.3865.40</li>
-    <li>Firefox - geckodriver 0.25.0</li>
+    <li>Chrome - ChromeDriver 78.0.3904.70</li>
+    <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -4,8 +4,8 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 
 description = "Common configuration of the WebDriver add-ons."
 
-val geckodriverVersion = "0.25.0"
-val chromeDriverVersion = "77.0.3865.40"
+val geckodriverVersion = "0.26.0"
+val chromeDriverVersion = "78.0.3904.70"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [13] - 2019-10-23
+### Changed
+- Update ChromeDriver to v78.0.3904.70.
+- Update geckodriver to v0.26.0.
 
 ## [12] - 2019-09-13
 ### Changed
@@ -70,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[13]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v12
 [11]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v11
 [10]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v10

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,8 +9,8 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 77.0.3865.40</li>
-    <li>Firefox - geckodriver 0.25.0</li>
+    <li>Chrome - ChromeDriver 78.0.3904.70</li>
+    <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 
 <H2>See also</H2>


### PR DESCRIPTION
Update ChromeDriver to 78.0.3904.70 and geckodriver to 0.26.0.
Add release dates and links to tags.