### PR TITLE
Forced Browse - Correct request count reported

### DIFF
--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Ensure requests are counted and progress updated (Issue 5437).
 
 ## [9] - 2020-01-17
 ### Changed

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -789,7 +789,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     }
 
     // TODO: check how  youAreFinished() is called and when it is called
-    public void youAreFinished() {
+    public synchronized void youAreFinished() {
 
         // clear all the queue
         workQueue.clear();
@@ -843,15 +843,15 @@ public class Manager implements ProcessChecker.ProcessUpdate {
         pureBrutefuzz = false;
     }
 
-    public double getTotalPass() {
+    public synchronized double getTotalPass() {
         return totalPass;
     }
 
-    public void setTotalPass(double totalPass) {
+    public synchronized void setTotalPass(double totalPass) {
         this.totalPass = totalPass;
     }
 
-    public int getTotalDirsFound() {
+    public synchronized int getTotalDirsFound() {
         return totalDirsFound;
     }
 
@@ -1078,7 +1078,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
         return baseCaseCounterCorrection;
     }
 
-    public int getParsedLinksProcessed() {
+    public synchronized int getParsedLinksProcessed() {
         return parsedLinksProcessed;
     }
 
@@ -1124,7 +1124,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
         parsedLinksProcessed++;
     }
 
-    public int getNumberOfBaseCasesProduced() {
+    public synchronized int getNumberOfBaseCasesProduced() {
         return numberOfBaseCasesProduced;
     }
 
@@ -1171,7 +1171,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
         this.currentlyProcessing = currentlyProcessing;
     }
 
-    public void addToWorkCorrection(int amount) {
+    public synchronized void addToWorkCorrection(int amount) {
         workAmountCorrection = workAmountCorrection + amount;
     }
 
@@ -1195,7 +1195,7 @@ public class Manager implements ProcessChecker.ProcessUpdate {
         return userName;
     }
 
-    public int getWorkAmountCorrection() {
+    public synchronized int getWorkAmountCorrection() {
         return workAmountCorrection;
     }
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -503,10 +503,10 @@ public class Manager implements ProcessChecker.ProcessUpdate {
             processedLinks.clear();
 
             task = new ProcessChecker(this);
-            timer.scheduleAtFixedRate(task, 1000L, 1000L);
+            timer.scheduleAtFixedRate(task, 0L, 1000L);
 
             task2 = new ProcessEnd(this);
-            timer.scheduleAtFixedRate(task2, 30000L, 30000L);
+            timer.scheduleAtFixedRate(task2, 0L, 10000L);
 
             // start the pure brute force thread
             if (pureBrute) {

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
@@ -45,9 +45,6 @@ public class ProcessChecker extends TimerTask {
     }
 
     public void run() {
-        if (System.currentTimeMillis() - scheduledExecutionTime() > 5000) {
-            return;
-        }
         long timePassed = (scheduledExecutionTime() - timeStarted) / 1000;
         if (timePassed > 0) {
             int totalDirs = 1;

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
@@ -414,12 +414,12 @@ public class Worker implements Runnable {
     }
 
     /** Method to call to pause the thread */
-    public void pause() {
+    public synchronized void pause() {
         pleaseWait = true;
     }
 
     /** Method to call to unpause the thread */
-    public void unPause() {
+    public synchronized void unPause() {
         pleaseWait = false;
     }
 
@@ -428,12 +428,12 @@ public class Worker implements Runnable {
      *
      * @return boolean value about if the thread is working
      */
-    public boolean isWorking() {
+    public synchronized boolean isWorking() {
         return working;
     }
 
     /** Method to call to stop the thread */
-    public void stopThread() {
+    public synchronized void stopThread() {
         this.stop = true;
     }
 }

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
@@ -83,18 +83,12 @@ public class DirBusterManager extends Manager {
     }
 
     public int getTotal() {
-        if (this.areWorkersAlive()) {
-            long bigTotal = this.getTotalToDo();
-            if (bigTotal > Integer.MAX_VALUE) {
-                total = Integer.MAX_VALUE;
-            } else if (bigTotal > total) {
-                // More work - ignore if less than before - this happens if its stopped early
-                total = (int) bigTotal;
-            }
-            if (total == 0) {
-                // Havt started yet
-                total = 100;
-            }
+        long bigTotal = this.getTotalToDo();
+        if (bigTotal > Integer.MAX_VALUE) {
+            total = Integer.MAX_VALUE;
+        } else if (bigTotal > total) {
+            // More work - ignore if less than before - this happens if its stopped early
+            total = (int) bigTotal;
         }
         return total;
     }

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
@@ -27,7 +27,7 @@ import org.apache.log4j.Logger;
 public class DirBusterManager extends Manager {
 
     private BruteForceListenner listenner;
-    private int total = 100;
+    private int total = 0;
     private boolean finished = false;
     private static Logger log = Logger.getLogger(DirBusterManager.class);
 
@@ -73,7 +73,7 @@ public class DirBusterManager extends Manager {
     }
 
     @Override
-    public void youAreFinished() {
+    public synchronized void youAreFinished() {
         super.youAreFinished();
         finished = true;
     }
@@ -99,7 +99,7 @@ public class DirBusterManager extends Manager {
         return total;
     }
 
-    private long getTotalToDo() {
+    private synchronized long getTotalToDo() {
         int totalDirs = 1;
 
         if (this.isRecursive() && this.getDoDirs()) {

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/DirBusterManager.java
@@ -27,7 +27,6 @@ import org.apache.log4j.Logger;
 public class DirBusterManager extends Manager {
 
     private BruteForceListenner listenner;
-    private int done = 0;
     private int total = 100;
     private boolean finished = false;
     private static Logger log = Logger.getLogger(DirBusterManager.class);
@@ -81,14 +80,6 @@ public class DirBusterManager extends Manager {
 
     public boolean hasFinished() {
         return finished;
-    }
-
-    @Override
-    public int getTotalDone() {
-        if (this.areWorkersAlive()) {
-            done = super.getTotalDone();
-        }
-        return done;
     }
 
     public int getTotal() {


### PR DESCRIPTION
The problem was in the getTotalDone() method: when the number of requests was too small the areWorkersAlive() check would return false without assigning any value to the done variable. Now we call the parent's method that returns its totalDone variable.

Also, I noticed some problems with the progress bar that shows the same percentage as the totalDone after finishing.

Adding a new target site was also unobvious to me, but it could be caused by a lack of experience. :)

Closes zaproxy/zaproxy#5437