### PR TITLE
Add Help for Custom Payloads, Update ascanrulesAlpha Help, etc

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add dependency on Custom Payloads add-on. The payloads of the Test User Agent scanner are now customizable.
 - Added XSLT Injection Scanner (issue 3572).
 
+### Changed
+- Update minimum ZAP version to 2.8.0.
+
 ## [25] - 2019-07-11
 
 ### Fixed

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -16,7 +16,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("custompayloads") {
-                            version.set("1.*")
+                            version.set("0.9.*")
                         }
                     }
                 }

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -100,7 +100,8 @@ may be interested in.<br><br>
 The trace.axd scanner targets Microsoft based technologies: IIS, Windows, ASP, and MSSQL.
 
 <H2>User Agent Fuzzer</H2>
-This active scanner checks for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). The scanner compares the response statuscode and the hashcode of the response body with the original response.
+This active scanner checks for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). The scanner compares the response statuscode and the hashcode of the response body with the original response.<br>
+<strong>Note:</strong> If the Custom Payloads addon is installed you can add your own User Agent strings (payloads) in the Custom Payloads options panel.
 
 <H2>XSLT Injection Scanner</H2>
 This active scanner checks for certain responses induced by injecting XSL transformations. <br/>

--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -1,4 +1,4 @@
-version = "1.0.0"
+version = "0.9.0"
 description = "Ability to add, edit or remove payloads that are used i.e. by active scanners"
 
 zapAddOn {

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/contents/custompayloads.html
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/contents/custompayloads.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<TITLE>
+Custom Payloads - alpha
+</TITLE>
+</HEAD>
+<BODY BGCOLOR="#ffffff">
+<H1>Custom Payloads - alpha</H1>
+
+This addon adds an Options panel from which users are able to add, update, remove payloads of their creation/choosing for use by active or passive scan rules 
+which support custom payloads (accessible via the Tools menu Options menu item).
+
+</BODY>
+</HTML>

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/helpset.hs
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/helpset.hs
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE helpset
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
+<helpset version="2.0" xml:lang="en-GB">
+  <title>Custom Payloads - Alpha | ZAP Extension</title>
+
+  <maps>
+     <homeID>top</homeID>
+     <mapref location="map.jhm"/>
+  </maps>
+
+  <view>
+    <name>TOC</name>
+    <label>Contents</label>
+    <type>org.zaproxy.zap.extension.help.ZapTocView</type>
+    <data>toc.xml</data>
+  </view>
+
+  <view>
+    <name>Index</name>
+    <label>Index</label>
+    <type>javax.help.IndexView</type>
+    <data>index.xml</data>
+  </view>
+
+  <view>
+    <name>Search</name>
+    <label>Search</label>
+    <type>javax.help.SearchView</type>
+    <data engine="com.sun.java.help.search.DefaultSearchEngine">
+      JavaHelpSearch
+    </data>
+  </view>
+
+  <view>
+    <name>Favorites</name>
+    <label>Favorites</label>
+    <type>javax.help.FavoritesView</type>
+  </view>
+</helpset>

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/index.xml
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/index.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE index
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Index Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/index_2_0.dtd">
+
+<index version="2.0">
+    <!-- index entries are merged (sorted) into core index -->
+	<indexitem text="custompayloads" target="custompayloads" />
+</index>

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/map.jhm
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/map.jhm
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE map
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Map Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/map_1_0.dtd">
+
+<map version="1.0">
+    <mapID target="custompayloads" url="contents/custompayloads.html" />
+</map>

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/toc.xml
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/toc.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE toc
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp TOC Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/toc_2_0.dtd">
+
+<toc version="2.0">
+	<tocitem text="ZAP User Guide" tocid="toplevelitem">
+		<tocitem text="Add Ons" tocid="addons">
+			<tocitem text="Custom Payloads - alpha" target="custompayloads"/>
+		</tocitem>
+	</tocitem>
+</toc>


### PR DESCRIPTION
ascanrulesAlpha > Updated help for User Agent Fuzzer scan rulesmentioning Custom Payloads.
Custompayloads > Added basic help.
Both > Updated custompayloads version and dependency to 0.9.0.

Follow-up to: https://github.com/zaproxy/zap-extensions/pull/1114

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>