### PR TITLE
selenium: update Selenium library

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Update Selenium to version 3.141.59.
 
 ## [15.0.0] - 2019-06-07
 

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -20,7 +20,9 @@ zapAddOn {
 }
 
 dependencies {
-    api("org.seleniumhq.selenium:selenium-server:3.7.1")
+    api("org.seleniumhq.selenium:selenium-server:3.141.59")
+    api("org.seleniumhq.selenium:htmlunit-driver:2.36.0")
+    api("com.codeborne:phantomjsdriver:1.4.4")
 
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
Update Selenium library to version 3.141.59.
Add dependency on `htmlunit-driver` and `phantomjsdriver`, no longer
included in the other library.