### PR TITLE
scripts: mention custom variables

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.8.0.
+- Update help to mention custom script/global variables (Issue 3402).
 
 ### Fixed
 - Fix links in script templates.

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
@@ -71,6 +71,20 @@ org.zaproxy.zap.extension.script.ScriptVars.setScriptVar("ScriptName", "var.name
 org.zaproxy.zap.extension.script.ScriptVars.getScriptVar("ScriptName", "var.name")<br/>
 </code>
 
+<H2>Custom Global/Script Variables</H2>
+Newer versions of ZAP (after 2.8.0) allow to set custom global/script variables, which can be of any type not
+just strings, for example, lists, maps.<br/>
+In JavaScript they are accessed/set as follows:<br/><br/>
+<code>
+var ScriptVars = Java.type("org.zaproxy.zap.extension.script.ScriptVars")
+
+ScriptVars.setScriptCustomVar(this.context, "var.name", {x: 1, y: 3})
+print(ScriptVars.getScriptCustomVar(this.context, "var.name").y) // Prints 3
+
+ScriptVars.setGlobalCustomVar("var.name", ["A", "B", "C", "D"])
+print(ScriptVars.getGlobalCustomVar("var.name")[2]) // Prints C
+</code>
+
 <H2>See also</H2>
 <table>
 <tr>


### PR DESCRIPTION
Mention in the help how to access/set custom variables.

Part of zaproxy/zaproxy#3402 - Share custom variables between scripts