### PR TITLE
Extensions Leverage WritableFileChooser

### DIFF
--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Update minimum ZAP version to 2.5.0.
+- Improve permissions and space handling when saving.
 
 ## 6 - 2017-11-27
 

--- a/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
+++ b/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
@@ -46,6 +46,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.AbstractFrame;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class BeanShellConsoleFrame extends AbstractFrame {
 
@@ -247,7 +248,7 @@ public class BeanShellConsoleFrame extends AbstractFrame {
                                 }
 
                             } else {
-                                JFileChooser fc = new JFileChooser(scriptsDir);
+                                JFileChooser fc = new WritableFileChooser(new File(scriptsDir));
                                 fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
                                 int result = fc.showSaveDialog(getBeanShellPanel());
 
@@ -282,7 +283,7 @@ public class BeanShellConsoleFrame extends AbstractFrame {
                     new ActionListener() {
                         @Override
                         public void actionPerformed(ActionEvent e) {
-                            JFileChooser fc = new JFileChooser(scriptsDir);
+                            JFileChooser fc = new WritableFileChooser(new File(scriptsDir));
                             fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
                             int result = fc.showSaveDialog(getBeanShellPanel());
                             if (result == JFileChooser.APPROVE_OPTION) {

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Maintenance changes.
 - Link to newer Getting Started Guide.
+- Improve permissions and space handling when saving.
 
 ## [26] - 2019-06-07
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
@@ -52,6 +52,7 @@ import org.zaproxy.zap.extension.dynssl.DynSSLParam;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class DefaultExplorePanel extends QuickStartSubPanel {
     private static final long serialVersionUID = 1L;
@@ -144,7 +145,8 @@ public class DefaultExplorePanel extends QuickStartSubPanel {
                         @Override
                         public void actionPerformed(ActionEvent arg0) {
                             final JFileChooser fc =
-                                    new JFileChooser(System.getProperty("user.home"));
+                                    new WritableFileChooser(
+                                            new File(System.getProperty("user.home")));
                             fc.setFileSelectionMode(JFileChooser.FILES_ONLY);
                             fc.setMultiSelectionEnabled(false);
                             fc.setSelectedFile(new File(OWASP_ZAP_ROOT_CA_FILENAME));

--- a/addOns/tokengen/CHANGELOG.md
+++ b/addOns/tokengen/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Improve permissions and space handling when saving.
 
 ## [13] - 2019-07-15
 

--- a/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/AnalyseTokensDialog.java
+++ b/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/AnalyseTokensDialog.java
@@ -43,6 +43,7 @@ import org.parosproxy.paros.extension.AbstractDialog;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.FontUtils;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class AnalyseTokensDialog extends AbstractDialog implements TokenAnalyserListenner {
 
@@ -221,7 +222,7 @@ public class AnalyseTokensDialog extends AbstractDialog implements TokenAnalyser
 
     private void saveAnalysis() {
         JFileChooser chooser =
-                new JFileChooser(Model.getSingleton().getOptionsParam().getUserDirectory());
+                new WritableFileChooser(Model.getSingleton().getOptionsParam().getUserDirectory());
         File file = null;
         int rc = chooser.showSaveDialog(View.getSingleton().getMainFrame());
         if (rc == JFileChooser.APPROVE_OPTION) {
@@ -230,9 +231,6 @@ public class AnalyseTokensDialog extends AbstractDialog implements TokenAnalyser
                 if (file == null) {
                     return;
                 }
-                Model.getSingleton()
-                        .getOptionsParam()
-                        .setUserDirectory(chooser.getCurrentDirectory());
 
                 try (BufferedWriter out = new BufferedWriter(new FileWriter(file))) {
                     out.write(getErrorsArea().getText());

--- a/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/TokenPanel.java
+++ b/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/TokenPanel.java
@@ -49,6 +49,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.ScanStatus;
 import org.zaproxy.zap.view.ZapToggleButton;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class TokenPanel extends AbstractPanel {
 
@@ -441,7 +442,7 @@ public class TokenPanel extends AbstractPanel {
 
     private void saveTokens() {
         JFileChooser chooser =
-                new JFileChooser(Model.getSingleton().getOptionsParam().getUserDirectory());
+                new WritableFileChooser(Model.getSingleton().getOptionsParam().getUserDirectory());
         File file = null;
         int rc = chooser.showSaveDialog(View.getSingleton().getMainFrame());
         if (rc == JFileChooser.APPROVE_OPTION) {
@@ -450,9 +451,6 @@ public class TokenPanel extends AbstractPanel {
                 if (file == null) {
                     return;
                 }
-                Model.getSingleton()
-                        .getOptionsParam()
-                        .setUserDirectory(chooser.getCurrentDirectory());
 
                 CharacterFrequencyMap cfm = new CharacterFrequencyMap();
 


### PR DESCRIPTION
Update various extensions to leverage WritableFileChooser for saving and exporting.

Related to: zaproxy/zaproxy#5667 and zaproxy/zaproxy#5516

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>