### PR TITLE
zest: send sequence messages with ZAP

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Send sequence messages with ZAP so that they make use of ZAP features e.g. authentication, HTTP
+Sender scripts. (Issue 5590)
 
 ## [29] - 2019-06-07
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
@@ -26,17 +26,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.cookie.CookiePolicy;
 import org.apache.log4j.Logger;
-import org.mozilla.zest.core.v1.ZestActionFailException;
-import org.mozilla.zest.core.v1.ZestAssertFailException;
 import org.mozilla.zest.core.v1.ZestAssignFailException;
 import org.mozilla.zest.core.v1.ZestAssignment;
-import org.mozilla.zest.core.v1.ZestClientFailException;
-import org.mozilla.zest.core.v1.ZestInvalidCommonTestException;
 import org.mozilla.zest.core.v1.ZestRequest;
 import org.mozilla.zest.core.v1.ZestResponse;
 import org.mozilla.zest.core.v1.ZestScript;
@@ -44,6 +38,7 @@ import org.mozilla.zest.core.v1.ZestStatement;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
+import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
@@ -56,7 +51,6 @@ import org.zaproxy.zap.extension.script.SequenceScript;
 import org.zaproxy.zap.model.StructuralNode;
 import org.zaproxy.zap.model.StructuralSiteNode;
 import org.zaproxy.zap.model.Target;
-import org.zaproxy.zap.users.User;
 
 public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript {
 
@@ -116,9 +110,8 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
             // prior statements in the script.
             HttpMessage msgScript = getMatchingMessageFromScript(msg);
             ZestScript scr = getBeforeSubScript(msgScript);
-            HttpSender sender = this.currentPlugin.getParent().getHttpSender();
 
-            runSequenceAuthenticated(sender, msg, scr);
+            run(scr, EMPTYPARAMS);
 
             // Once the script has run, update the message with results from
             mergeRequestBodyFromScript(msgOriginal);
@@ -133,38 +126,6 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
                             + e.getMessage());
         }
         return msgOriginal;
-    }
-
-    /** Run the ZestScript sequence while being properly authenticated */
-    private void runSequenceAuthenticated(HttpSender sender, HttpMessage msg, ZestScript scr)
-            throws ZestAssertFailException, ZestActionFailException, IOException,
-                    ZestInvalidCommonTestException, ZestAssignFailException,
-                    ZestClientFailException {
-
-        // We must handle the authentication "by hand" as the HttpRunner is not used (direct call to
-        // HttpClient)
-        // when executing Zest scripts
-
-        // Not sure is we do really need to revert to the original value.
-        // Let's say yes for now
-        String originalCookiePolicy = sender.getClient().getParams().getCookiePolicy();
-        HttpState originalState = sender.getClient().getState();
-
-        sender.getClient().getParams().setCookiePolicy(CookiePolicy.BROWSER_COMPATIBILITY);
-        sender.getClient().getState().clearCookies();
-
-        User forceUser = sender.getUser(msg);
-        if (forceUser != null) {
-            forceUser.processMessageToMatchUser(msg);
-            sender.getClient().setState(forceUser.getCorrespondingHttpState());
-        }
-
-        this.setHttpClient(sender.getClient());
-        this.run(scr, EMPTYPARAMS);
-
-        // Restore original values
-        sender.getClient().getParams().setCookiePolicy(originalCookiePolicy);
-        sender.getClient().setState(originalState);
     }
 
     private void mergeRequestBodyFromScript(HttpMessage msg) {
@@ -216,16 +177,24 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
             HttpMessage msgScript = getMatchingMessageFromScript(msg);
             ZestScript scr = getAfterSubScript(msgScript);
 
-            HttpSender sender = this.currentPlugin.getParent().getHttpSender();
-            runSequenceAuthenticated(sender, msg, scr);
+            run(scr, EMPTYPARAMS);
 
-            // Clean up redundant cookies
-            sender.getClient().getState().clearCookies();
         } catch (Exception e) {
             logger.debug(
                     "Error running Sequence script in 'runSequenceAfter' method : "
                             + e.getMessage());
         }
+    }
+
+    @Override
+    public ZestResponse send(ZestRequest request) throws IOException {
+        HttpMessage msg = ZestZapUtils.toHttpMessage(request, null);
+        HostProcess parent = currentPlugin.getParent();
+        HttpSender httpSender = parent.getHttpSender();
+        msg.setRequestingUser(httpSender.getUser(msg));
+        httpSender.sendAndReceive(msg, request.isFollowRedirects());
+        parent.notifyNewMessage(currentPlugin, msg);
+        return ZestZapUtils.toZestResponse(msg);
     }
 
     @Override
@@ -236,34 +205,6 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
             }
         }
         return false;
-    }
-
-    @Override
-    public ZestResponse runStatement(
-            ZestScript script, ZestStatement stmt, ZestResponse lastResponse)
-            throws ZestAssertFailException, ZestActionFailException, ZestInvalidCommonTestException,
-                    IOException, ZestAssignFailException, ZestClientFailException {
-
-        // This method makes sure each request from a Sequence Script is displayed on the Active
-        // Scan results tab.
-        ZestResponse response = null;
-        try {
-            response = super.runStatement(script, stmt, lastResponse);
-        } catch (NullPointerException e) {
-            logger.debug(
-                    "NullPointerException occurred, while running Sequence Script: "
-                            + e.getMessage());
-        }
-
-        try {
-            if (stmt instanceof ZestRequest) {
-                HttpMessage msg = ZestZapUtils.toHttpMessage((ZestRequest) stmt, response);
-                this.currentPlugin.getParent().notifyNewMessage(msg);
-            }
-        } catch (Exception e) {
-            logger.debug("Exception while trying to notify of unscanned message in a sequence.");
-        }
-        return response;
     }
 
     @Override


### PR DESCRIPTION
Use ZAP instead of Zest's client to send the messages from the sequence
scripts so that they make use of ZAP features (e.g. authentication, HTTP
Sender scripts).

Fix zaproxy/zaproxy#5590 - Sequence script does not invoke HTTP Sender
script