### PR TITLE
pscanrulesBeta: Username IDOR Scanner Custom Payloads support

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -5,8 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
 - Tweak Information Disclosure - Suspicious Comments scanner to ignore whitespace before/after suspicious comments terms in the suspicious-comments.txt config file.
 - Only scan for Servlet Parameter Pollution at LOW threshold (part of Issue 4454).
+- Username IDOR scan rule now supports use of the Custom Payload addon.
 
 ## [19] - 2019-06-07
 

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -10,9 +10,26 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
+        extensions {
+            register("org.zaproxy.zap.extension.pscanrulesBeta.payloader.ExtensionPayloader") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.zap.extension.pscanrulesBeta.payloader"))
+                }
+                dependencies {
+                    addOns {
+                        register("custompayloads") {
+                            version.set("0.9.*")
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("custompayloads")!!)
+
+    testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/payloader/ExtensionPayloader.java
@@ -1,0 +1,108 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesBeta.payloader;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.custompayloads.ExtensionCustomPayloads;
+import org.zaproxy.zap.extension.custompayloads.PayloadCategory;
+import org.zaproxy.zap.extension.pscanrulesBeta.UsernameIdorScanner;
+
+public class ExtensionPayloader extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtensionPayloader";
+    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static ExtensionCustomPayloads ecp;
+    private PayloadCategory idorCategory;
+
+    static {
+        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
+        dependencies.add(ExtensionCustomPayloads.class);
+        DEPENDENCIES = Collections.unmodifiableList(dependencies);
+    }
+
+    public ExtensionPayloader() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        ecp =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionCustomPayloads.class);
+        idorCategory =
+                new PayloadCategory(
+                        UsernameIdorScanner.USERNAME_IDOR_PAYLOAD_CATEGORY,
+                        UsernameIdorScanner.DEFAULT_USERNAMES);
+        ecp.addPayloadCategory(idorCategory);
+        UsernameIdorScanner.setPayloadProvider(() -> idorCategory.getPayloadsIterator());
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        UsernameIdorScanner.setPayloadProvider(null);
+        ecp.removePayloadCategory(idorCategory);
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+
+    @Override
+    public URL getURL() {
+        try {
+            return new URL(Constant.ZAP_HOMEPAGE);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("pscanbeta.payloader.desc");
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("pscanbeta.payloader.name");
+    }
+}

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -43,7 +43,10 @@ A timestamp was disclosed by the application/web server.
 
 <H2>Username Hash Found</H2>
 If any context contains defined users this scanner checks all responses for the presence of hashed values representing those usernames.
-Discovery of any such value may represent an Insecure Direct Object Reference (IDOR) vulnerability. Alerts are only raised as informational items as further manual testing is required in order to confirm and assess impact.
+<p><strong>Note:</strong> If the Custom Payloads addon is installed you can add your own Username strings (payloads) in the Custom Payloads options panel. 
+They will also be hashed and searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the 
+amount of time needed to passively scan. (The default payloads are "Admin" and "admin".)<br>
+<p>Discovery of any such value may represent an Insecure Direct Object Reference (IDOR) vulnerability. Alerts are only raised as informational items as further manual testing is required in order to confirm and assess impact.
 
 <H2>X-AspNet-Version Response Header Scanner</H2>
 This checks response headers for the presence of X-AspNet-Version/X-AspNetMvc-Version details.

--- a/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -36,6 +36,9 @@ pscanbeta.informationdisclosuresuspiciouscomments.name=Information Disclosure - 
 pscanbeta.informationdisclosuresuspiciouscomments.desc=The response appears to contain suspicious comments which may help an attacker.
 pscanbeta.informationdisclosuresuspiciouscomments.soln=Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.
 
+pscanbeta.payloader.desc=Provides support for custom payloads in scan rules.
+pscanbeta.payloader.name=Passive Scan Rules Beta Custom Payloads
+
 pscanbeta.servletparameterpollutionscanner.name=HTTP Parameter Override
 pscanbeta.servletparameterpollutionscanner.desc=Unspecified form action: HTTP parameter override attack potentially possible. This is a known problem with Java Servlets but other platforms may also be vulnerable.
 pscanbeta.servletparameterpollutionscanner.soln=All forms must specify the action URL.


### PR DESCRIPTION
- UsernameIdorScanner.java > Minor changes to accommodate Custom Payloads functionality.
- UsernameIdorScannerUnitTest.java > Added a test method to check for a default payload.
- ExtensionPayloader.java > Extension added as bridge between pscanrulesBeta and the Custom Payloads addon (as was done with ascanrulesAlpha).
- Messages.properties > Added keys/values necessary for ExtensionPayloader.
- pscanbeta.html > Updated help entry.
- pscanrulesBeta.gradle.kts > Added dependency details, etc.
- CHANGELOG.md > Added "change" entry.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>