### PR TITLE
ascanrulesAlpha: HiddenFilesScanRule add other match handling

### DIFF
--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HexString.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HexString.java
@@ -1,0 +1,51 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Duplicated from Replacer addon. */
+class HexString {
+    private static final Pattern HEX_VALUE = Pattern.compile("\\\\?\\\\x\\p{XDigit}{2}");
+    private static final String ESCAPED_ESCAPE_CHAR = "\\\\";
+
+    static String compile(String binaryRegex) {
+        Matcher matcher = HEX_VALUE.matcher(binaryRegex);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String value = matcher.group();
+            if (!value.startsWith(ESCAPED_ESCAPE_CHAR)) {
+                value = convertByte(value.substring(2));
+            }
+            matcher.appendReplacement(sb, value);
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String convertByte(String value) {
+        return Matcher.quoteReplacement(
+                new String(
+                        new byte[] {(byte) Integer.parseInt(value, 16)},
+                        StandardCharsets.US_ASCII));
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -59,11 +59,30 @@ If the response code is 401 (Unauthorized) or 403 (Forbidden) then an alert is r
 For custom payloads only the response status code is checked. If there is a requirement to include a content check then it is also possible to add payloads to 
 the <code>json/hidden_files.json</code> file in ZAP's user directory.
 <p>
-TODO:
-<ul>
-  <li>Implement support for checking byte arrays in responses.</li>
-  <li>Implement support for "not" conditions in content checks.</li>
-</ul>
+The following describes the fields of the JSON entries. The only field that is required is path.
+<pre><code>
+{
+  "path":"some/path/without/leading/slash.ext",
+  "content":["content you want to find in responses"],
+  "not_content":["content you do not want the response to have"],
+  "binary":"\\x01\\x00",
+  "links":["https:\\example.com\relevant\reference.html],
+  "type":"short_identifier",
+  "source":"attribution_not_used_by_output_or_checks"
+}
+</code></pre>
+
+<p>
+The following is an example JSON entry:
+<pre><code>
+{
+  "path":"CVS/root",
+  "content":[":"],
+  "not_content":["<"],
+  "type":"cvs_dir",
+  "source":"snallygaster"
+}
+</code></pre>
 
 <H2>HTTP Only Site</H2>
 This active scanner checks whether an HTTP site is served under HTTPS.

--- a/addOns/ascanrulesAlpha/src/main/zapHomeFiles/json/hidden_files.json
+++ b/addOns/ascanrulesAlpha/src/main/zapHomeFiles/json/hidden_files.json
@@ -3,14 +3,12 @@
     {
       "path":"lfm.php",
       "content":["Lazy File Manager"],
-      "links":[],
       "type":"lfm_php",
       "source":"snallygaster"
     },
     {
       "path":".idea/WebServers.xml",
       "content":["name=\"WebServers\""],
-      "links":[],
       "type":"idea",
       "source":"snallygaster"
     },
@@ -37,9 +35,15 @@
     },
     {
       "path":".svn/entries",
-      "content":[],
       "links":["https://www.oreilly.com/library/view/version-control-with/9780596510336/ch08s02s01.html"],
       "type":"svn_dir",
+      "source":"snallygaster"
+    },
+    {
+      "path":"CVS/root",
+      "content":[":"],
+      "not_content":["<"],
+      "type":"cvs_dir",
       "source":"snallygaster"
     },
     {
@@ -50,157 +54,154 @@
       "source":"snallygaster"	
     },
     {
+      "path":"core",
+      "binary":"\\x7fELF",
+      "links":["https://en.wikipedia.org/wiki/Core_dump"],
+      "type":"coredump",
+      "source":"snallygaster"	
+    },
+    {
       "path":"sftp-config.json",
       "content":["\"type\":","ftp","\"save_before_upload\""],
-      "links":[],
       "type":"sftp_config",
       "source":"snallygaster"
     },
     {
       "path":"WS_FTP.ini",
       "content":["[_config_]"],
-      "links":[],
       "type":"wsftp_ini",
       "source":"snallygaster"
     },
     {
       "path":"ws_ftp.ini",
       "content":["[_config_]"],
-      "links":[],
       "type":"wsftp_ini",
       "source":"snallygaster"
     },
     {
       "path":"WS_FTP.INI",
       "content":["[_config_]"],
-      "links":[],
       "type":"wsftp_ini",
       "source":"snallygaster"
     },
     {
       "path":"filezilla.xml",
       "content":["<FileZilla"],
-      "links":[],
       "type":"filezilla_xml",
       "source":"snallygaster"
     },
     {
       "path":"sitemanager.xml",
       "content":["<FileZilla"],
-      "links":[],
       "type":"filezilla_xml",
       "source":"snallygaster"
     },
     {
       "path":"FileZilla.xml",
       "content":["<FileZilla"],
-      "links":[],
       "type":"filezilla_xml",
       "source":"snallygaster"
     },
     {
       "path":"winscp.ini",
       "content":["[Configuration]"],
-      "links":[],
       "type":"winscp_ini",
       "source":"snallygaster"
     },
     {
       "path":"WinSCP.ini",
       "content":["[Configuration]"],
-      "links":[],
       "type":"winscp_ini",
+      "source":"snallygaster"
+    },
+    {
+      "path":".DS_Store",
+      "binary":"\\x00\\x00\\x00\\x01Bud1",
+      "type":"ds_store",
       "source":"snallygaster"
     },
     {
       "path":"DEADJOE",
       "content":["in JOE when it aborted"],
-      "links":[],
       "type":"deadjoe",
       "source":"snallygaster"
     },
     {
       "path":"sites/default/private/files/backup_migrate/scheduled/test.txt",
       "content":["this file should not be publicly accessible"],
-      "links":[],
       "type":"drupal_backup_migrate",
       "source":"snallygaster"
     },
     {
       "path":"app/etc/local.xml",
       "content":["<config","Mage"],
-      "links":[],
       "type":"magento_config",
       "source":"snallygaster"
     },
     {
       "path":"server.key",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":"privatekey.key",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":"myserver.key",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":"key.pem",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":"id_rsa",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":"id_dsa",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":".ssh/id_rsa",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":".ssh/id_dsa",
       "content":["BEGIN","PRIVATE KEY"],
-      "links":[],
       "type":"keys",
       "source":"snallygaster"
     },
     {
       "path":"adminer.php",
       "content":["adminer.org"],
-      "links":[],
       "type":"adminer",
       "source":"snallygaster"
     },
     {
       "path":"CHANGELOG.txt",
       "content":["Drupal "],
-      "links":[],
       "type":"drupal",
+      "source":"snallygaster"
+    },
+    {
+      "path":"sites/default/files/.ht.sqlite",
+      "binary":"SQLite format",
+      "type":"drupaldb",
       "source":"snallygaster"
     }
   ]

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRuleUnitTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertThat;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -66,9 +67,10 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         String testPath = "foo/test.php";
         List<String> contents = Arrays.asList("Awesome");
         List<String> links = Arrays.asList("https://example.org");
-        HiddenFile hiddenFile = new HiddenFile(testPath, contents, links, "test_php");
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, Collections.emptyList(), "", links, "test_php");
 
-        this.nano.addHandler(new OkResponseWithReqPath(servePath));
+        this.nano.addHandler(new OkResponse(servePath));
         this.nano.addHandler(
                 new StaticContentServerHandler(
                         '/' + testPath,
@@ -93,16 +95,18 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertIfTestedUrlRespondsForbidden() throws HttpMalformedHeaderException {
+    public void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsForbidden()
+            throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
 
         String testPath = "foo/test.php";
         List<String> contents = Arrays.asList("Awesome");
         List<String> links = Collections.emptyList();
-        HiddenFile hiddenFile = new HiddenFile(testPath, contents, links, "test_php");
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, Collections.emptyList(), "", links, "test_php");
 
-        this.nano.addHandler(new OkResponseWithReqPath(servePath));
+        this.nano.addHandler(new OkResponse(servePath));
         this.nano.addHandler(new ForbiddenResponseWithReqPath("/" + testPath));
 
         HttpMessage msg = this.getHttpMessage(servePath);
@@ -129,10 +133,11 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         String testPath = "foo/test.php";
         List<String> contents = Arrays.asList("Awesome");
         List<String> links = Collections.emptyList();
-        HiddenFile hiddenFile = new HiddenFile(testPath, contents, links, "test_php");
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, Collections.emptyList(), "", links, "test_php");
 
-        this.nano.addHandler(new OkResponseWithReqPath(servePath));
-        this.nano.addHandler(new ForbiddenResponseWithReqPath("/fred.php"));
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(new OkResponse("/fred.php"));
 
         HttpMessage msg = this.getHttpMessage(servePath);
 
@@ -147,7 +152,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldAlertWithMediumConfidenceIfContentStringsDontAllMatch()
+    public void shouldAlertWithLowConfidenceIfContentStringsDontAllMatch()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -155,10 +160,11 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         String testPath = "foo/test.php";
         List<String> contents = Arrays.asList("Site", "StringNotFound");
         List<String> links = Collections.emptyList();
-        HiddenFile hiddenFile = new HiddenFile(testPath, contents, links, "test_php");
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, Collections.emptyList(), "", links, "test_php");
 
-        this.nano.addHandler(new OkResponseWithReqPath(servePath));
-        this.nano.addHandler(new OkResponseWithReqPath("/" + testPath));
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(new OkResponse("/" + testPath));
 
         HttpMessage msg = this.getHttpMessage(servePath);
 
@@ -172,7 +178,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         Alert alert = alertsRaised.get(0);
         assertEquals(1, httpMessagesSent.size());
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
-        assertEquals(Alert.CONFIDENCE_MEDIUM, alertsRaised.get(0).getConfidence());
+        assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
         assertEquals(hiddenFile.getType(), alert.getOtherInfo());
         assertEquals(rule.getReference(), alert.getReference());
     }
@@ -186,10 +192,11 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         String testPath = "foo/test.php";
         List<String> contents = Arrays.asList("Site", "Text");
         List<String> links = Collections.emptyList();
-        HiddenFile hiddenFile = new HiddenFile(testPath, contents, links, "test_php");
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, Collections.emptyList(), "", links, "test_php");
 
-        this.nano.addHandler(new OkResponseWithReqPath(servePath));
-        this.nano.addHandler(new OkResponseWithReqPath("/" + testPath));
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(new OkResponse("/" + testPath));
 
         HttpMessage msg = this.getHttpMessage(servePath);
 
@@ -209,7 +216,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertIfTestedUrlRespondsOkToCustomPayloadWithoutRelevantContent()
+    public void shouldRaiseAlertWithHighConfidenceIfTestedUrlRespondsOkToCustomPayload()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -217,7 +224,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         String testPath = "foo/test.php";
         List<String> testPaths = Arrays.asList(testPath);
 
-        this.nano.addHandler(new OkResponseWithReqPath(servePath));
+        this.nano.addHandler(new OkResponse(servePath));
         this.nano.addHandler(
                 new StaticContentServerHandler(
                         '/' + testPath,
@@ -235,7 +242,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         Alert alert = alertsRaised.get(0);
         assertEquals(1, httpMessagesSent.size());
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
-        assertEquals(Alert.CONFIDENCE_MEDIUM, alertsRaised.get(0).getConfidence());
+        assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
         assertEquals(rule.getReference(), alert.getReference());
     }
 
@@ -248,10 +255,11 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         String testPath = "foo/test.php";
         List<String> contents = Arrays.asList("Site", "Text");
         List<String> links = Collections.emptyList();
-        HiddenFile hiddenFile = new HiddenFile(testPath, contents, links, "test_php");
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, Collections.emptyList(), "", links, "test_php");
 
-        this.nano.addHandler(new OkResponseWithReqPath(servePath));
-        this.nano.addHandler(new NotFoundResponseWithReqPath("/" + testPath));
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(new NotFoundResponse("/" + testPath));
 
         HttpMessage msg = this.getHttpMessage(servePath);
 
@@ -263,6 +271,153 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         // Then
         assertThat(alertsRaised, hasSize(0));
         assertEquals(1, httpMessagesSent.size());
+    }
+
+    @Test
+    public void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantContentAndAppropriateNotContent()
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/shouldAlert";
+
+        String testPath = "CVS/root";
+        List<String> contents = Arrays.asList(":");
+        List<String> notContents = Arrays.asList("<");
+        List<String> links = Collections.emptyList();
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, notContents, "", links, "cvs_dir");
+
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(
+                new StaticContentServerHandler(
+                        '/' + testPath,
+                        ":pserver:anonymous@duma.cvs.sourceforge.net:/cvsroot/duma"));
+
+        HttpMessage msg = this.getHttpMessage(servePath);
+
+        rule.init(msg, this.parent);
+        HiddenFilesScanRule.addTestPayload(hiddenFile);
+
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
+        assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
+        assertEquals(rule.getReference(), alert.getReference());
+    }
+
+    @Test
+    public void
+            shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithRelevantContentButDoesContainNotContent()
+                    throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/shouldAlert";
+
+        String testPath = "CVS/root";
+        List<String> contents = Arrays.asList(":");
+        List<String> notContents = Arrays.asList("<");
+        List<String> links = Collections.emptyList();
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, notContents, "", links, "cvs_dir");
+
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(
+                new StaticContentServerHandler(
+                        '/' + testPath,
+                        "<html>pserver:anonymous@duma.cvs.sourceforge.net:/cvsroot/duma"));
+
+        HttpMessage msg = this.getHttpMessage(servePath);
+
+        rule.init(msg, this.parent);
+        HiddenFilesScanRule.addTestPayload(hiddenFile);
+
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
+        assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
+        assertEquals(rule.getReference(), alert.getReference());
+    }
+
+    @Test
+    public void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantBinContent()
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/shouldAlert";
+
+        String testPath = ".DS_Store";
+        String validDSStoreBinString =
+                new String(new byte[] {0, 0, 0, 1, 'B', 'u', 'd', '1'}, StandardCharsets.US_ASCII);
+        HiddenFile hiddenFile =
+                new HiddenFile(
+                        testPath,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        validDSStoreBinString,
+                        Collections.emptyList(),
+                        "ds_store");
+
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(new OkBinResponse('/' + testPath, validDSStoreBinString));
+
+        HttpMessage msg = this.getHttpMessage(servePath);
+
+        rule.init(msg, this.parent);
+        HiddenFilesScanRule.addTestPayload(hiddenFile);
+
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
+        assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
+        assertEquals(rule.getReference(), alert.getReference());
+    }
+
+    @Test
+    public void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithoutRelevantBinContent()
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/shouldAlert";
+
+        String testPath = ".DS_Store";
+        String validDSStoreBinString =
+                new String(new byte[] {0, 0, 0, 1, 'B', 'u', 'd', '1'}, StandardCharsets.US_ASCII);
+        String invalidDSStoreBinString =
+                new String(new byte[] {0, 0, 0, 2, 'B', 'u', 'd', '2'}, StandardCharsets.US_ASCII);
+        HiddenFile hiddenFile =
+                new HiddenFile(
+                        testPath,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        validDSStoreBinString,
+                        Collections.emptyList(),
+                        "ds_store");
+
+        this.nano.addHandler(new OkResponse(servePath));
+        this.nano.addHandler(new OkBinResponse('/' + testPath, invalidDSStoreBinString));
+
+        HttpMessage msg = this.getHttpMessage(servePath);
+
+        rule.init(msg, this.parent);
+        HiddenFilesScanRule.addTestPayload(hiddenFile);
+
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
+        assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
+        assertEquals(rule.getReference(), alert.getReference());
     }
 
     private static class ForbiddenResponseWithReqPath extends NanoServerHandler {
@@ -293,13 +448,13 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         }
     }
 
-    private static class NotFoundResponseWithReqPath extends NanoServerHandler {
+    private static class NotFoundResponse extends NanoServerHandler {
 
         private static final String NOT_FOUND_RESPONSE =
                 "<!DOCTYPE html\">\n"
                         + "<html><head></head><H>Four oh four</H1>Not found... <html>";
 
-        public NotFoundResponseWithReqPath(String path) {
+        public NotFoundResponse(String path) {
             super(path);
         }
 
@@ -310,13 +465,20 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
         }
     }
 
-    private static class OkResponseWithReqPath extends StaticContentServerHandler {
+    private static class OkResponse extends StaticContentServerHandler {
 
         private static final String OK_RESPONSE =
                 "<!DOCTYPE html\">\n" + "<html><head></head><H>Site Title</H1>Site Text... <html>";
 
-        public OkResponseWithReqPath(String path) {
+        public OkResponse(String path) {
             super(path, OK_RESPONSE);
+        }
+    }
+
+    private static class OkBinResponse extends StaticContentServerHandler {
+
+        public OkBinResponse(String path, String content) {
+            super(path, content);
         }
     }
 }


### PR DESCRIPTION
- hidden_files.json > Updated with CVS payload, and "not_content" element. Updated with various other payloads which leverage new "binary" element.
- HiddenFilesScanRule.java > Refactored to read and handle "not_content" and "binary" elements in HiddenFiles. Extracted convenience methods for doesMatch, doesNotMatch, and doesBinaryMatch.
- HiddenFilesScanFuleUnitTest.java > Added unit tests for new negative content checks, and binary checks, revised behavior when only a path matches (or path and partial content) [now Low confidence].
- ascanalpha.html > Remove todo notes, added JSON info and examples.
- HexString > Duplicated from Replacer addon, to facilitate binary matching.

Fixes zaproxy/zaproxy#4585

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>