### PR TITLE
openapi: extract base class for import dialogue

### DIFF
--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromAbstractDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromAbstractDialog.java
@@ -1,0 +1,159 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JTextField;
+import org.apache.commons.httpclient.URI;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.AbstractDialog;
+import org.parosproxy.paros.view.View;
+
+abstract class ImportFromAbstractDialog extends AbstractDialog {
+
+    private static final long serialVersionUID = 1L;
+    private static final String MESSAGE_PREFIX = "openapi.importfromdialog.";
+
+    private final JTextField fieldFrom = new JTextField(35);
+    private final JTextField fieldTarget = new JTextField(35);
+
+    protected final ExtensionOpenApi caller;
+
+    public ImportFromAbstractDialog(
+            JFrame parent, ExtensionOpenApi caller, String title, String fromFieldLabel) {
+        super(parent, true);
+        this.setTitle(title);
+        this.caller = caller;
+        centreDialog();
+
+        setLayout(new GridBagLayout());
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.anchor = GridBagConstraints.WEST;
+        constraints.insets = new Insets(5, 5, 5, 5);
+
+        JButton buttonImport =
+                new JButton(Constant.messages.getString(MESSAGE_PREFIX + "importbutton"));
+        buttonImport.addActionListener(
+                e -> {
+                    if (validateTargetUrl() && importDefinition()) {
+                        setVisible(false);
+                        dispose();
+                    }
+                });
+        JButton buttonCancel = new JButton(Constant.messages.getString("all.button.cancel"));
+        buttonCancel.addActionListener(
+                e -> {
+                    setVisible(false);
+                    dispose();
+                });
+
+        constraints.gridx = 0;
+        constraints.gridy = 0;
+        add(new JLabel(fromFieldLabel), constraints);
+
+        constraints.gridx = 1;
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.weightx = 1.0;
+        constraints.gridwidth = 3;
+        setContextMenu(fieldFrom);
+        addFromFields(constraints);
+
+        constraints.weightx = 0;
+        constraints.gridwidth = 1;
+        constraints.gridx = 0;
+        constraints.gridy = 1;
+        add(new JLabel(Constant.messages.getString(MESSAGE_PREFIX + "labeltarget")), constraints);
+
+        constraints.gridx = 1;
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.weightx = 1.0;
+        constraints.gridwidth = 3;
+        add(fieldTarget, constraints);
+
+        constraints.gridwidth = 1;
+        constraints.gridy = 2;
+        constraints.anchor = GridBagConstraints.CENTER;
+        add(buttonCancel, constraints);
+        constraints.gridx = 2;
+        constraints.gridy = 2;
+        constraints.anchor = GridBagConstraints.CENTER;
+        add(buttonImport, constraints);
+
+        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        pack();
+        setVisible(true);
+    }
+
+    private boolean validateTargetUrl() {
+        String target = fieldTarget.getText();
+        if (target.isEmpty()) {
+            return true;
+        }
+
+        try {
+            new URI("http://" + target, true);
+        } catch (Exception e) {
+            showWarningDialog(
+                    Constant.messages.getString(MESSAGE_PREFIX + "badoverride", e.getMessage()));
+            fieldTarget.requestFocusInWindow();
+            return false;
+        }
+        return true;
+    }
+
+    protected JTextField getFromField() {
+        return fieldFrom;
+    }
+
+    protected JTextField getTargetField() {
+        return fieldTarget;
+    }
+
+    protected void addFromFields(GridBagConstraints constraints) {
+        add(fieldFrom, constraints);
+    }
+
+    protected abstract boolean importDefinition();
+
+    protected void showWarningDialog(String message) {
+        View.getSingleton().showWarningDialog(this, message);
+    }
+
+    protected void showWarningInvalidUrl(String url) {
+        showWarningDialog(Constant.messages.getString(MESSAGE_PREFIX + "invalidurl", url));
+    }
+
+    private static void setContextMenu(JTextField field) {
+        JMenuItem paste =
+                new JMenuItem(Constant.messages.getString(MESSAGE_PREFIX + "pasteaction"));
+        paste.addActionListener(e -> field.paste());
+
+        JPopupMenu jPopupMenu = new JPopupMenu();
+        jPopupMenu.add(paste);
+        field.setComponentPopupMenu(jPopupMenu);
+    }
+}

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromUrlDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromUrlDialog.java
@@ -19,151 +19,56 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.Point;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.JButton;
 import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JTextField;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.extension.AbstractDialog;
-import org.parosproxy.paros.view.View;
 
-public class ImportFromUrlDialog extends AbstractDialog implements ActionListener {
+public class ImportFromUrlDialog extends ImportFromAbstractDialog {
 
     private static final long serialVersionUID = -7074394202143400215L;
     private static final String MESSAGE_PREFIX = "openapi.importfromurldialog.";
 
-    private ExtensionOpenApi caller;
-
-    private JTextField fieldURL = new JTextField(30);
-    private JTextField siteOverride = new JTextField(30);
-
-    private JButton buttonCancel = new JButton(Constant.messages.getString("all.button.cancel"));
-    private JButton buttonImport =
-            new JButton(Constant.messages.getString(MESSAGE_PREFIX + "importbutton"));
-
     public ImportFromUrlDialog(JFrame parent, ExtensionOpenApi caller) {
-        super(parent, true);
-        this.setTitle(Constant.messages.getString(MESSAGE_PREFIX + "title"));
-        this.caller = caller;
-        if (parent != null) {
-            Dimension parentSize = parent.getSize();
-            Point p = parent.getLocation();
-            setLocation(p.x + parentSize.width / 4, p.y + parentSize.height / 4);
-        }
-        // set up layout
-        setLayout(new GridBagLayout());
-        GridBagConstraints constraints = new GridBagConstraints();
-        constraints.anchor = GridBagConstraints.WEST;
-        constraints.insets = new Insets(5, 5, 5, 5);
-
-        buttonImport.addActionListener(this);
-        buttonCancel.addActionListener(
-                new ActionListener() {
-                    @Override
-                    public void actionPerformed(ActionEvent e) {
-                        ImportFromUrlDialog.this.setVisible(false);
-                        ImportFromUrlDialog.this.dispose();
-                    }
-                });
-
-        // add components to the frame
-        constraints.gridx = 0;
-        constraints.gridy = 0;
-        add(new JLabel(Constant.messages.getString(MESSAGE_PREFIX + "labelurl")), constraints);
-
-        constraints.gridx = 1;
-        constraints.fill = GridBagConstraints.HORIZONTAL;
-        constraints.weightx = 1.0;
-        constraints.gridwidth = 2;
-        fieldURL = addContextMenu(fieldURL);
-        add(fieldURL, constraints);
-
-        constraints.gridx = 0;
-        constraints.gridy = 1;
-        add(new JLabel(Constant.messages.getString(MESSAGE_PREFIX + "labeloverride")), constraints);
-
-        constraints.gridx = 1;
-        constraints.fill = GridBagConstraints.HORIZONTAL;
-        constraints.weightx = 1.0;
-        constraints.gridwidth = 2;
-        add(siteOverride, constraints);
-
-        constraints.gridwidth = 1;
-        constraints.gridy = 2;
-        constraints.anchor = GridBagConstraints.CENTER;
-        add(buttonCancel, constraints);
-        constraints.gridx = 2;
-        constraints.gridy = 2;
-        constraints.anchor = GridBagConstraints.CENTER;
-        add(buttonImport, constraints);
-
-        setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-        pack();
-        setVisible(true);
+        super(
+                parent,
+                caller,
+                Constant.messages.getString(MESSAGE_PREFIX + "title"),
+                Constant.messages.getString(MESSAGE_PREFIX + "labelurl"));
     }
 
-    /* Action executed by import button. */
     @Override
-    public void actionPerformed(ActionEvent e) {
-        if (caller != null) {
-            String url = fieldURL.getText();
-            String override = siteOverride.getText();
-
-            if (override.length() > 0) {
-                // Check the siteOverride looks ok
-                try {
-                    new URI("http://" + siteOverride, true);
-                } catch (Exception e1) {
-                    View.getSingleton()
-                            .showWarningDialog(
-                                    thisDialog,
-                                    Constant.messages.getString(
-                                            MESSAGE_PREFIX + "badoverride", e1.getMessage()));
-                    return;
-                }
-            }
-
-            /* Calls a parsing task in a new thread. */
-            try {
-                caller.importOpenApiDefinition(new URI(url, false), override, true);
-            } catch (URIException ex) {
-                View.getSingleton()
-                        .showWarningDialog(
-                                thisDialog, Constant.messages.getString(MESSAGE_PREFIX + "badurl"));
-            }
+    protected boolean importDefinition() {
+        String url = getFromField().getText();
+        if (url.isEmpty()) {
+            showWarningDialog(Constant.messages.getString(MESSAGE_PREFIX + "urlerror.empty"));
+            getFromField().requestFocusInWindow();
+            return false;
         }
-        setVisible(false);
-        dispose();
+
+        URI uri;
+        try {
+            uri = new URI(url, false);
+        } catch (URIException e) {
+            showWarningDialog(
+                    Constant.messages.getString(
+                            MESSAGE_PREFIX + "urlerror.invalid", e.getLocalizedMessage()));
+            getFromField().requestFocusInWindow();
+            return false;
+        }
+
+        if (!isSupportedScheme(uri.getScheme())) {
+            showWarningDialog(Constant.messages.getString("openapi.unsupportedscheme", url));
+            getFromField().requestFocusInWindow();
+            return false;
+        }
+
+        caller.importOpenApiDefinition(uri, getTargetField().getText(), true);
+
+        return true;
     }
 
-    /* Adds a context menu to URL text field with "paste" option. */
-    public JTextField addContextMenu(final JTextField field) {
-        JPopupMenu jPopupMenu = new JPopupMenu();
-        String actionName = Constant.messages.getString(MESSAGE_PREFIX + "pasteaction");
-        @SuppressWarnings("serial")
-        Action pasteAction =
-                new AbstractAction(actionName) {
-
-                    public void actionPerformed(ActionEvent e) {
-                        field.paste();
-                    }
-                };
-        JMenuItem paste = new JMenuItem(pasteAction);
-        jPopupMenu.add(paste);
-        field.setComponentPopupMenu(jPopupMenu);
-        return field;
+    private static boolean isSupportedScheme(String scheme) {
+        return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
     }
 }

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -12,13 +12,16 @@ openapi.topmenu.import.importopenapi.tooltip = The file must be a formal describ
 openapi.topmenu.import.importremoteopenapi = Import an Open API definition from a URL
 openapi.topmenu.import.importremoteopenapi.tooltip = The file must be a formal described OpenApi file.
 
-openapi.importfromurldialog.pasteaction = Paste
-openapi.importfromurldialog.labeloverride = Override Host:
+openapi.importfromdialog.labeltarget = Override Host:
+openapi.importfromdialog.importbutton = Import
+openapi.importfromdialog.pasteaction = Paste
+openapi.importfromdialog.invalidurl = Invalid URL:\n{0}
+openapi.importfromdialog.badoverride = Invalid Override Host: this should be of the form "host" or "host:port":\n{0}
+
 openapi.importfromurldialog.labelurl = URL Pointing to OpenAPI defn:
-openapi.importfromurldialog.importbutton = Import
 openapi.importfromurldialog.title = Import OpenAPI Definition from URL
-openapi.importfromurldialog.badurl = Invalid URL
-openapi.importfromurldialog.badoverride = Invalid Override Host: this should be of the form "host" or "host:port":\n{0}
+openapi.importfromurldialog.urlerror.empty = The URL to import is empty.
+openapi.importfromurldialog.urlerror.invalid = The URL to import is invalid:\n{0}
 
 openapi.io.error = Failed to access specified definition
 openapi.parse.error = Failed to parse OpenAPI definition.\n\n{0}
@@ -31,3 +34,5 @@ openapi.import.error = Failed to access URL: {0} : {1} : {2}
 openapi.swaggerconverter.parse.defn.exception = Failed to parse swagger defn {0}
 openapi.swaggerconverter.default.host.exception = Default host required but not provided.
 openapi.swaggerconverter.default.scheme.exception = Default scheme required but not provided.
+
+openapi.unsupportedscheme = The scheme of the URL is not HTTP or HTTPS:\n{0}


### PR DESCRIPTION
To avoid duplicating the dialogue for file import (#2152).
Add more URL validations:
 - Don't try to import if the URL is empty;
 - Check that the URL is HTTP/HTTPS.