### PR TITLE
openapi: add simple URI builder

### DIFF
--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilder.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilder.java
@@ -1,0 +1,276 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.converter.swagger;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/** A simple URI builder, from strings containing (optionally) scheme, authority, and path. */
+public class UriBuilder {
+
+    private static final String PATH_SEPARATOR = "/";
+    private static final String AUTHORITY_SEPARATOR = "//";
+    private static final String SCHEME_SEPARATOR = ":" + AUTHORITY_SEPARATOR;
+    private static final int NOT_FOUND = -1;
+
+    private String originalUri;
+    private String scheme;
+    private String authority;
+    private String path;
+    private boolean appendPath;
+
+    /**
+     * Parses the given value, leniently.
+     *
+     * <p>It parses the following URI components {@code scheme://authority/path}, all optional. If
+     * the value does not have scheme nor path it's parsed as authority.
+     *
+     * @param value the value to parse.
+     * @return the URI builder.
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *     <ul>
+     *       <li>the {@code scheme} component is empty when it shouldn't, for example, {@code
+     *           ://authority};
+     *       <li>the {@code scheme} component is not empty when it should, for example, {@code
+     *           //authority}.
+     *     </ul>
+     */
+    public static UriBuilder parseLenient(String value) {
+        return new UriBuilder(value, true);
+    }
+
+    /**
+     * Parses the given value
+     *
+     * <p>It parses the following URI components {@code scheme://authority/path}, all optional. If
+     * the value does not have scheme it's parsed as path.
+     *
+     * @param value the value to parse.
+     * @return the URI builder.
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *     <ul>
+     *       <li>the {@code scheme} component is empty when it shouldn't, for example, {@code
+     *           ://authority};
+     *       <li>the {@code scheme} component is not empty when it should, for example, {@code
+     *           //authority}.
+     *     </ul>
+     */
+    public static UriBuilder parse(String value) {
+        return new UriBuilder(value, false);
+    }
+
+    private UriBuilder() {}
+
+    private UriBuilder(String value, boolean lenient) {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+
+        originalUri = value;
+
+        int idxScheme = extractScheme();
+        int idxPath = extractPath(idxScheme, lenient);
+        extractAuthority(idxScheme, idxPath);
+    }
+
+    private int extractScheme() {
+        int idxScheme = originalUri.indexOf(SCHEME_SEPARATOR);
+        if (idxScheme != NOT_FOUND) {
+            scheme = originalUri.substring(0, idxScheme);
+            if (scheme.isEmpty()) {
+                throw new IllegalArgumentException("Expected non-empty scheme in: " + originalUri);
+            }
+            return idxScheme + SCHEME_SEPARATOR.length();
+        }
+        idxScheme = originalUri.indexOf(AUTHORITY_SEPARATOR);
+        if (idxScheme != NOT_FOUND) {
+            if (!originalUri.substring(0, idxScheme).isEmpty()) {
+                throw new IllegalArgumentException("Expected no scheme in: " + originalUri);
+            }
+            return idxScheme + AUTHORITY_SEPARATOR.length();
+        }
+        return 0;
+    }
+
+    private int extractPath(int idxScheme, boolean lenient) {
+        if (idxScheme == 0 && !lenient) {
+            path = originalUri;
+            appendPath = !path.startsWith(PATH_SEPARATOR);
+            return 0;
+        }
+
+        int idxPath = originalUri.indexOf(PATH_SEPARATOR, idxScheme);
+        if (idxPath != NOT_FOUND) {
+            path = originalUri.substring(idxPath);
+            return idxPath;
+        }
+        return originalUri.length();
+    }
+
+    private void extractAuthority(int idxScheme, int idxPath) {
+        authority = originalUri.substring(idxScheme, idxPath);
+        if (authority.isEmpty()) {
+            authority = null;
+        }
+    }
+
+    /**
+     * Gets the scheme component, for example, {@code http}.
+     *
+     * @return the scheme, might be {@code null}.
+     */
+    String getScheme() {
+        return scheme;
+    }
+
+    /**
+     * Gets the authority component, for example, {@code example.com}
+     *
+     * @return the scheme, might be {@code null}.
+     */
+    String getAuthority() {
+        return authority;
+    }
+
+    /**
+     * Gets the path component, for example, {@code /absolutePath} or {@code relativePath}.
+     *
+     * @return the scheme, might be {@code null}.
+     */
+    String getPath() {
+        return path;
+    }
+
+    /**
+     * Tells whether or not this builder is empty.
+     *
+     * <p>A builder is empty when it has no scheme, authority, and path.
+     *
+     * @return {@core true} if empty, {@code false} otherwise.
+     */
+    boolean isEmpty() {
+        return scheme == null && authority == null && path == null;
+    }
+
+    /**
+     * Copies this builder.
+     *
+     * @return a copy with the same scheme, authority, and path.
+     */
+    UriBuilder copy() {
+        UriBuilder copy = new UriBuilder();
+        copy.scheme = scheme;
+        copy.authority = authority;
+        copy.path = path;
+        copy.appendPath = appendPath;
+        copy.originalUri = originalUri;
+        return copy;
+    }
+
+    /**
+     * Merges the URI components of the given builder into {@code this} builder.
+     *
+     * <p>It uses the scheme, authority, and path of the given builder if not already set (that is,
+     * {@code null}).
+     *
+     * <p>For non-lenient parsed URLs with relative path, it's appended to the path of the given
+     * builder. For example, the URI {@code v2/} merged with {@code http://example.com/api/} results
+     * in {@code http://example.com/api/v2/}.
+     *
+     * @param other other builder to merge.
+     * @return {@code this}, for chaining.
+     */
+    UriBuilder merge(UriBuilder other) {
+        scheme = nonNullOf(scheme, other.scheme);
+        authority = nonNullOf(authority, other.authority);
+        if (appendPath && other.path != null) {
+            path =
+                    other.path.endsWith(PATH_SEPARATOR)
+                            ? other.path + path
+                            : other.path + PATH_SEPARATOR + path;
+            appendPath = false;
+        } else {
+            path = nonNullOf(path, other.path);
+        }
+
+        return this;
+    }
+
+    private static String nonNullOf(String value, String otherValue) {
+        if (value == null) {
+            return otherValue;
+        }
+        return value;
+    }
+
+    /**
+     * Builds the URI from the components set.
+     *
+     * <p>The path is normalised, by removing {@code .} and {@code ..} segments. The trailing slash
+     * is also removed (if present), the slash is not required as OpenAPI operations' paths already
+     * start with a slash, thus just requiring appending the operation path to the built URI.
+     *
+     * @return the URI.
+     * @throws IllegalArgumentException if any of the conditions is true:
+     *     <ul>
+     *       <li>the {@code scheme} is {@code null};
+     *       <li>the {@code authority} is {@code null};
+     *       <li>the resulting URI is malformed.
+     *     </ul>
+     */
+    String build() {
+        validateNotNull(scheme, "scheme");
+        validateNotNull(authority, "authority");
+
+        StringBuilder strBuilder =
+                new StringBuilder().append(scheme).append(SCHEME_SEPARATOR).append(authority);
+        if (path != null) {
+            strBuilder.append(path);
+        }
+
+        String uri = strBuilder.toString();
+        try {
+            uri = new URI(strBuilder.toString()).normalize().toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Failed to normalise the URI: " + uri, e);
+        }
+
+        if (uri.endsWith(PATH_SEPARATOR)) {
+            return uri.substring(0, uri.length() - PATH_SEPARATOR.length());
+        }
+        return uri;
+    }
+
+    private static void validateNotNull(String object, String name) {
+        if (object == null) {
+            throw new IllegalArgumentException("The " + name + " must not be null.");
+        }
+    }
+
+    /**
+     * Returns the URI parsed originally.
+     *
+     * @see #build()
+     */
+    @Override
+    public String toString() {
+        return originalUri;
+    }
+}

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
@@ -1,0 +1,734 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.converter.swagger;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+/** Unit test for {@link UriBuilder}. */
+public class UriBuilderUnitTest {
+
+    private static final ParseMethod PARSE = new ParseMethod("parse", UriBuilder::parse);
+    private static final ParseMethod PARSE_LENIENT =
+            new ParseMethod("parseLenient", UriBuilder::parseLenient);
+
+    private static final List<ParseMethod> PARSE_METHODS = Arrays.asList(PARSE, PARSE_LENIENT);
+    private static final List<Pair<ParseMethod, ParseMethod>> PARSE_METHODS_MERGE =
+            Arrays.asList(
+                    Pair.of(PARSE, PARSE),
+                    Pair.of(PARSE_LENIENT, PARSE_LENIENT),
+                    Pair.of(PARSE, PARSE_LENIENT),
+                    Pair.of(PARSE_LENIENT, PARSE));
+
+    @Test
+    public void shouldParseWithNullValue() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = null;
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method, uriBuilder, is(nullValue()), is(nullValue()), is(nullValue()));
+                });
+    }
+
+    private static void assertUriComponents(
+            ParseMethod method,
+            UriBuilder uriBuilder,
+            Matcher<Object> schemeMatcher,
+            Matcher<Object> authorityMatcher,
+            Matcher<Object> pathMatcher) {
+        assertUriComponents(method, null, uriBuilder, schemeMatcher, authorityMatcher, pathMatcher);
+    }
+
+    private static void assertUriComponents(
+            ParseMethod method,
+            ParseMethod otherMethod,
+            UriBuilder uriBuilder,
+            Matcher<Object> schemeMatcher,
+            Matcher<Object> authorityMatcher,
+            Matcher<Object> pathMatcher) {
+        String reason = "Parsed with: " + method.name;
+        if (otherMethod != null) {
+            reason += " and " + otherMethod.name;
+        }
+        assertThat(reason, uriBuilder.getScheme(), schemeMatcher);
+        assertThat(reason, uriBuilder.getAuthority(), authorityMatcher);
+        assertThat(reason, uriBuilder.getPath(), pathMatcher);
+    }
+
+    @Test
+    public void shouldParseWithEmptyValue() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "";
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method, uriBuilder, is(nullValue()), is(nullValue()), is(nullValue()));
+                });
+    }
+
+    @Test
+    public void shouldParseWithJustRelativePath() {
+        // Given
+        ParseMethod method = PARSE;
+        String value = "relativePath";
+        // When
+        UriBuilder uriBuilder = method.parse(value);
+        // Then
+        assertUriComponents(
+                method, uriBuilder, is(nullValue()), is(nullValue()), is(equalTo(value)));
+    }
+
+    @Test
+    public void shouldParseLenientWithJustAuthority() {
+        // Given
+        ParseMethod method = PARSE_LENIENT;
+        String value = "authority";
+        // When
+        UriBuilder uriBuilder = method.parse(value);
+        // Then
+        assertUriComponents(
+                method, uriBuilder, is(nullValue()), is(equalTo(value)), is(nullValue()));
+    }
+
+    @Test
+    public void shouldParseWithAbsolutePath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "/absolutePath";
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(nullValue()),
+                            is(nullValue()),
+                            is(equalTo(value)));
+                });
+    }
+
+    @Test
+    public void shouldParseWithAuthorityAndNoScheme() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "//example.com";
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(nullValue()),
+                            is(equalTo("example.com")),
+                            is(nullValue()));
+                });
+    }
+
+    @Test
+    public void shouldParseWithEmptyAuthority() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "//";
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method, uriBuilder, is(nullValue()), is(nullValue()), is(nullValue()));
+                });
+    }
+
+    @Test
+    public void shouldParseWithScheme() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "http://";
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(nullValue()),
+                            is(nullValue()));
+                });
+    }
+
+    @Test
+    public void shouldFailToParseWithEmptyScheme() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    try {
+                        // Given
+                        String value = "://";
+                        // When
+                        UriBuilder.parse(value);
+                        fail("Expected IllegalArgumentException");
+                    } catch (IllegalArgumentException e) {
+                        // Then
+                        assertThat(
+                                "Parsed with: " + method,
+                                e.getMessage(),
+                                containsString("Expected non-empty scheme"));
+                    }
+                });
+    }
+
+    @Test
+    public void shouldFailToParseWithMalformedScheme() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    try {
+                        // Given
+                        String value = "notscheme//";
+                        // When
+                        UriBuilder.parse(value);
+                        fail("Expected IllegalArgumentException");
+                    } catch (IllegalArgumentException e) {
+                        // Then
+                        assertThat(
+                                "Parsed with: " + method,
+                                e.getMessage(),
+                                containsString("Expected no scheme"));
+                    }
+                });
+    }
+
+    @Test
+    public void shouldParseWithSchemeAndAuthority() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "http://example.com";
+                    // When
+                    UriBuilder uriBuilder = method.method.apply(value);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("example.com")),
+                            is(nullValue()));
+                });
+    }
+
+    @Test
+    public void shouldParseWithSchemeAuthorityAndEmptyPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "http://example.com/";
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("example.com")),
+                            is(equalTo("/")));
+                });
+    }
+
+    @Test
+    public void shouldParseWithSchemeAuthorityAndNonEmptyPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    String value = "http://example.com/path";
+                    // When
+                    UriBuilder uriBuilder = method.parse(value);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("example.com")),
+                            is(equalTo("/path")));
+                });
+    }
+
+    @Test
+    public void shouldMergeSchemeIfNull() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse("//example.com/path/");
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("https")),
+                            is(equalTo("example.com")),
+                            is(equalTo("/path/")));
+                });
+    }
+
+    @Test
+    public void shouldNotMergeSchemeIfNotNull() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse("http://example.com/path/");
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("example.com")),
+                            is(equalTo("/path/")));
+                });
+    }
+
+    @Test
+    public void shouldMergeAuthorityIfNull() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse("http://");
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("other.example.com")),
+                            is(not(nullValue())));
+                });
+    }
+
+    @Test
+    public void shouldNotMergeAuthorityIfNotNull() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse("http://example.com");
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("example.com")),
+                            is(not(nullValue())));
+                });
+    }
+
+    @Test
+    public void shouldMergePathIfNull() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse("http://example.com");
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("example.com")),
+                            is(equalTo("/otherpath/")));
+                });
+    }
+
+    @Test
+    public void shouldNotMergePathIfNotNull() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse("http://example.com/");
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("http")),
+                            is(equalTo("example.com")),
+                            is(equalTo("/")));
+                });
+    }
+
+    @Test
+    public void shouldMergeSchemeAuthorityIfJustAbsolutePath() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse("/path");
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("https")),
+                            is(equalTo("other.example.com")),
+                            is(equalTo("/path")));
+                });
+    }
+
+    @Test
+    public void shouldMergeRelativePath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = UriBuilder.parse("relativePath");
+                    UriBuilder otherUrlBuilder =
+                            method.parse("https://other.example.com/otherpath");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(equalTo("https")),
+                            is(equalTo("other.example.com")),
+                            is(equalTo("/otherpath/relativePath")));
+                });
+    }
+
+    @Test
+    public void shouldMergeRelativePathWithPathEndedWithSlash() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = UriBuilder.parse("relativePath");
+                    UriBuilder otherUrlBuilder =
+                            method.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(equalTo("https")),
+                            is(equalTo("other.example.com")),
+                            is(equalTo("/otherpath/relativePath")));
+                });
+    }
+
+    @Test
+    public void shouldMergeRelativePathWithNoPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = UriBuilder.parse("relativePath");
+                    UriBuilder otherUrlBuilder = method.parse("https://other.example.com");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method,
+                            uriBuilder,
+                            is(equalTo("https")),
+                            is(equalTo("other.example.com")),
+                            is(equalTo("relativePath")));
+                });
+    }
+
+    @Test
+    public void shouldMergeSchemeAuthorityAndPathIfAllNull() {
+        PARSE_METHODS_MERGE.forEach(
+                pair -> {
+                    // Given
+                    ParseMethod method1 = pair.getLeft();
+                    ParseMethod method2 = pair.getRight();
+                    UriBuilder uriBuilder = method1.parse(null);
+                    UriBuilder otherUrlBuilder =
+                            method2.parse("https://other.example.com/otherpath/");
+                    // When
+                    uriBuilder.merge(otherUrlBuilder);
+                    // Then
+                    assertUriComponents(
+                            method1,
+                            method2,
+                            uriBuilder,
+                            is(equalTo("https")),
+                            is(equalTo("other.example.com")),
+                            is(equalTo("/otherpath/")));
+                });
+    }
+
+    @Test
+    public void shouldBeEmptyWithoutSchemeAuthorityAndPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("");
+                    // When
+                    boolean empty = uriBuilder.isEmpty();
+                    // Then
+                    assertThat("Parsed with: " + method, empty, is(equalTo(true)));
+                });
+    }
+
+    @Test
+    public void shouldNotBeEmptyWithScheme() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("http://");
+                    // When
+                    boolean empty = uriBuilder.isEmpty();
+                    // Then
+                    assertThat("Parsed with: " + method, empty, is(equalTo(false)));
+                });
+    }
+
+    @Test
+    public void shouldNotBeEmptyWithAuthority() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("//example.com");
+                    // When
+                    boolean empty = uriBuilder.isEmpty();
+                    // Then
+                    assertThat("Parsed with: " + method, empty, is(equalTo(false)));
+                });
+    }
+
+    @Test
+    public void shouldNotBeEmptyWithPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("/path");
+                    // When
+                    boolean empty = uriBuilder.isEmpty();
+                    // Then
+                    assertThat("Parsed with: " + method, empty, is(equalTo(false)));
+                });
+    }
+
+    @Test
+    public void shouldCopy() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder original = method.parse("/path");
+                    // When
+                    UriBuilder copy = original.copy();
+                    // Then
+                    assertUriComponents(
+                            method,
+                            copy,
+                            is(equalTo(original.getScheme())),
+                            is(equalTo(original.getAuthority())),
+                            is(equalTo(original.getPath())));
+                    assertThat(
+                            "Parsed with: " + method,
+                            copy.toString(),
+                            is(equalTo(original.toString())));
+                });
+    }
+
+    @Test
+    public void shouldBuildWithSchemeAndAuthority() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("http://example.com");
+                    // When
+                    String url = uriBuilder.build();
+                    // Then
+                    assertThat("Parsed with: " + method, url, is(equalTo("http://example.com")));
+                });
+    }
+
+    @Test
+    public void shouldBuildWithSchemeAuthorityAndPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("http://example.com/path");
+                    // When
+                    String url = uriBuilder.build();
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method, url, is(equalTo("http://example.com/path")));
+                });
+    }
+
+    @Test
+    public void shouldBuildRemovingSlashAtTheEnd() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("http://example.com/path/");
+                    // When
+                    String url = uriBuilder.build();
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method, url, is(equalTo("http://example.com/path")));
+                });
+    }
+
+    @Test
+    public void shouldBuildNormalisingPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("http://example.com/path/../other/.");
+                    // When
+                    String url = uriBuilder.build();
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method, url, is(equalTo("http://example.com/other")));
+                });
+    }
+
+    @Test
+    public void shouldFailToBuildWithNoScheme() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    try {
+                        // Given
+                        UriBuilder uriBuilder = method.parse("//example.com/");
+                        // When
+                        uriBuilder.build();
+                        fail("Expected IllegalArgumentException");
+                    } catch (IllegalArgumentException e) {
+                        // Then
+                        assertThat(
+                                "Parsed with: " + method, e.getMessage(), containsString("scheme"));
+                    }
+                });
+    }
+
+    @Test
+    public void shouldFailToBuildWithNoAuthority() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    try {
+                        // Given
+                        UriBuilder uriBuilder = method.parse("http://");
+                        // When
+                        uriBuilder.build();
+                        fail("Expected IllegalArgumentException");
+                    } catch (IllegalArgumentException e) {
+                        // Then
+                        assertThat(
+                                "Parsed with: " + method,
+                                e.getMessage(),
+                                containsString("authority"));
+                    }
+                });
+    }
+
+    @Test
+    public void shouldFailToBuildWithMalformedUri() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    try {
+                        // Given
+                        UriBuilder uriBuilder = method.parse("http://x%0");
+                        // When
+                        uriBuilder.build();
+                        fail("Expected IllegalArgumentException");
+                    } catch (IllegalArgumentException e) {
+                        // Then
+                        assertThat(
+                                "Parsed with: " + method,
+                                e.getMessage(),
+                                containsString("normalise"));
+                    }
+                });
+    }
+
+    private static class ParseMethod {
+        final String name;
+        private final Function<String, UriBuilder> method;
+
+        ParseMethod(String name, Function<String, UriBuilder> method) {
+            this.name = name;
+            this.method = method;
+        }
+
+        UriBuilder parse(String value) {
+            return method.apply(value);
+        }
+    }
+}


### PR DESCRIPTION
Allow to parse and merge URI components from several URIs, to implement
overriding functionality (e.g. merge URL present in the definition with
the default URL or the one provided by the user).