### PR TITLE
ascanrulesAlpha: ELMAH scan rule add content check

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added Hidden Files Finder (issue 4585) largely based on Snallygaster by Hanno Böck, also supports use of the Custom Payloads addon.
 
+### Changed
+- Elmah scan rule updated to include a response content check, and vary alert confidence values accordingly.
+
 ## [26] - 2019-10-31
 
 ### Added

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ElmahScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ElmahScanner.java
@@ -169,17 +169,22 @@ public class ElmahScanner extends AbstractHostPlugin {
         }
         int statusCode = newRequest.getResponseHeader().getStatusCode();
         if (statusCode == HttpStatusCode.OK) {
-            raiseAlert(newRequest, getRisk(), "");
+            boolean hasContent = newRequest.getResponseBody().toString().contains("Error Log for");
+            raiseAlert(
+                    newRequest,
+                    getRisk(),
+                    hasContent ? Alert.CONFIDENCE_HIGH : Alert.CONFIDENCE_MEDIUM,
+                    "");
         } else if (statusCode == HttpStatusCode.UNAUTHORIZED
                 || statusCode == HttpStatusCode.FORBIDDEN) {
-            raiseAlert(newRequest, Alert.RISK_INFO, getOtherInfo());
+            raiseAlert(newRequest, Alert.RISK_INFO, Alert.CONFIDENCE_LOW, getOtherInfo());
         }
     }
 
-    private void raiseAlert(HttpMessage msg, int risk, String otherInfo) {
+    private void raiseAlert(HttpMessage msg, int risk, int confidence, String otherInfo) {
         bingo(
                 risk, // Risk
-                Alert.CONFIDENCE_HIGH, // Confidence
+                confidence, // Confidence
                 getName(), // Name
                 getDescription(), // Description
                 msg.getRequestHeader().getURI().toString(), // URI


### PR DESCRIPTION
Elmah scan rule updated to include a response content check, and vary alert confidence values accordingly.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>