### PR TITLE
websocket: disable table sorting

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Disable table sort in WebSockets panel, not working properly (Issue 1661).
 
 ## [20] - 2019-07-23
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesView.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesView.java
@@ -30,7 +30,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
 import org.apache.log4j.Logger;
 import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.view.View;
@@ -65,7 +64,9 @@ public class WebSocketMessagesView implements Runnable {
     public void setModel(WebSocketMessagesViewModel model) {
         this.model = model;
         view.setModel(model);
-        view.setRowSorter(new TableRowSorter<>(model));
+        // XXX Don't allow sorting for now, does not work properly:
+        // https://github.com/zaproxy/zaproxy/issues/1661
+        // view.setRowSorter(new TableRowSorter<>(model));
     }
 
     /**
@@ -100,6 +101,11 @@ public class WebSocketMessagesView implements Runnable {
             new TableColumnManager(view);
 
             view.revalidate();
+
+            // XXX Don't allow sorting for now, does not work properly:
+            // https://github.com/zaproxy/zaproxy/issues/1661
+            view.setRowSorter(null);
+            view.setSortable(false);
         }
         return view;
     }


### PR DESCRIPTION
The sorting does not work properly.

Part of zaproxy/zaproxy#1661.