### PR TITLE
openapi: fix merge/build with relative path

### DIFF
--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilder.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilder.java
@@ -25,7 +25,8 @@ import java.net.URISyntaxException;
 /** A simple URI builder, from strings containing (optionally) scheme, authority, and path. */
 public class UriBuilder {
 
-    private static final String PATH_SEPARATOR = "/";
+    private static final char PATH_SEPARATOR_CHAR = '/';
+    private static final String PATH_SEPARATOR = String.valueOf(PATH_SEPARATOR_CHAR);
     private static final String AUTHORITY_SEPARATOR = "//";
     private static final String SCHEME_SEPARATOR = ":" + AUTHORITY_SEPARATOR;
     private static final int NOT_FOUND = -1;
@@ -116,7 +117,7 @@ public class UriBuilder {
             return 0;
         }
 
-        int idxPath = originalUri.indexOf(PATH_SEPARATOR, idxScheme);
+        int idxPath = originalUri.indexOf(PATH_SEPARATOR_CHAR, idxScheme);
         if (idxPath != NOT_FOUND) {
             path = originalUri.substring(idxPath);
             return idxPath;
@@ -204,7 +205,7 @@ public class UriBuilder {
             path =
                     other.path.endsWith(PATH_SEPARATOR)
                             ? other.path + path
-                            : other.path + PATH_SEPARATOR + path;
+                            : other.path + PATH_SEPARATOR_CHAR + path;
             appendPath = false;
         } else {
             path = nonNullOf(path, other.path);
@@ -242,6 +243,9 @@ public class UriBuilder {
         StringBuilder strBuilder =
                 new StringBuilder().append(scheme).append(SCHEME_SEPARATOR).append(authority);
         if (path != null) {
+            if (!path.endsWith(PATH_SEPARATOR)) {
+                strBuilder.append(PATH_SEPARATOR_CHAR);
+            }
             strBuilder.append(path);
         }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
@@ -633,6 +633,74 @@ public class UriBuilderUnitTest {
     }
 
     @Test
+    public void shouldBuildAfterMergeRelativePathWithNoPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = UriBuilder.parse("relativePath");
+                    UriBuilder otherUrlBuilder = method.parse("http://example.com");
+                    // When
+                    String url = uriBuilder.merge(otherUrlBuilder).build();
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method,
+                            url,
+                            is(equalTo("http://example.com/relativePath")));
+                });
+    }
+
+    @Test
+    public void shouldBuildAfterMergeRelativePathWithEmptyPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = UriBuilder.parse("relativePath");
+                    UriBuilder otherUrlBuilder = method.parse("http://example.com/");
+                    // When
+                    String url = uriBuilder.merge(otherUrlBuilder).build();
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method,
+                            url,
+                            is(equalTo("http://example.com/relativePath")));
+                });
+    }
+
+    @Test
+    public void shouldBuildAfterMergeAbsolutePathWithNoPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = UriBuilder.parse("/absolutePath");
+                    UriBuilder otherUrlBuilder = method.parse("http://example.com");
+                    // When
+                    String url = uriBuilder.merge(otherUrlBuilder).build();
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method,
+                            url,
+                            is(equalTo("http://example.com/absolutePath")));
+                });
+    }
+
+    @Test
+    public void shouldBuildAfterMergeAbsolutePathWithEmptyPath() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = UriBuilder.parse("/absolutePath");
+                    UriBuilder otherUrlBuilder = method.parse("http://example.com/");
+                    // When
+                    String url = uriBuilder.merge(otherUrlBuilder).build();
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method,
+                            url,
+                            is(equalTo("http://example.com/absolutePath")));
+                });
+    }
+
+    @Test
     public void shouldBuildRemovingSlashAtTheEnd() {
         PARSE_METHODS.forEach(
                 method -> {


### PR DESCRIPTION
Make sure the relative path is added to the URI with the path separator.
Use char path separator where possible.