### PR TITLE
openapi: allow to default to a path in URI builder

### DIFF
--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilder.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilder.java
@@ -160,6 +160,17 @@ public class UriBuilder {
     }
 
     /**
+     * Sets the path to the given value, if not already set.
+     *
+     * @param value the path to default to.
+     * @return {@code this}, for chaining.
+     */
+    UriBuilder withDefaultPath(String value) {
+        path = nonNullOf(path, value);
+        return this;
+    }
+
+    /**
      * Tells whether or not this builder is empty.
      *
      * <p>A builder is empty when it has no scheme, authority, and path.
@@ -197,6 +208,7 @@ public class UriBuilder {
      *
      * @param other other builder to merge.
      * @return {@code this}, for chaining.
+     * @throws NullPointerException if {@code other} is {@code null}.
      */
     UriBuilder merge(UriBuilder other) {
         scheme = nonNullOf(scheme, other.scheme);

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
@@ -241,7 +241,7 @@ public class UriBuilderUnitTest {
                     // Given
                     String value = "http://example.com";
                     // When
-                    UriBuilder uriBuilder = method.method.apply(value);
+                    UriBuilder uriBuilder = method.parse(value);
                     // Then
                     assertUriComponents(
                             method,
@@ -285,6 +285,23 @@ public class UriBuilderUnitTest {
                             is(equalTo("http")),
                             is(equalTo("example.com")),
                             is(equalTo("/path")));
+                });
+    }
+
+    @Test
+    public void shouldThrowNullPointerIfMergingToNull() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    try {
+                        // Given
+                        UriBuilder uriBuilder = method.parse("");
+                        // When
+                        uriBuilder.merge(null);
+                        fail("Expected NullPointerException");
+                    } catch (NullPointerException e) {
+                        // Then
+                        assertThat("Parsed with: " + method, e, is(not(nullValue())));
+                    }
                 });
     }
 
@@ -528,6 +545,33 @@ public class UriBuilderUnitTest {
                             is(equalTo("https")),
                             is(equalTo("other.example.com")),
                             is(equalTo("/otherpath/")));
+                });
+    }
+
+    @Test
+    public void shouldSetDefaulPathIfNotAlreadySet() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("http://example.com");
+                    // When
+                    uriBuilder.withDefaultPath("path");
+                    // Then
+                    assertThat("Parsed with: " + method, uriBuilder.getPath(), is(equalTo("path")));
+                });
+    }
+
+    @Test
+    public void shouldNotSetDefaulPathIfAlreadySet() {
+        PARSE_METHODS.forEach(
+                method -> {
+                    // Given
+                    UriBuilder uriBuilder = method.parse("http://example.com/path");
+                    // When
+                    uriBuilder.withDefaultPath("otherpath");
+                    // Then
+                    assertThat(
+                            "Parsed with: " + method, uriBuilder.getPath(), is(equalTo("/path")));
                 });
     }
 


### PR DESCRIPTION
Add a method to set a default path (set only if not already set one) to
allow to override the path before merging other paths.
Test that attempting to merge with a null `UriBuilder` results in a NPE,
mention that in the JavaDoc.