### PR TITLE
openapi: text tweaks

### DIFF
--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -1,5 +1,5 @@
 version = "14"
-description = "Imports and spiders Open API definitions."
+description = "Imports and spiders OpenAPI definitions."
 
 zapAddOn {
     addOnName.set("OpenAPI Support")

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -3,20 +3,20 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-Open API Specification Support
+OpenAPI Specification Support
 </TITLE>
 </HEAD>
 <BODY BGCOLOR="#ffffff">
-<H1>Open API Specification Support</H1>
+<H1>OpenAPI Specification Support</H1>
 This add-on allows you to spider and import OpenAPI (Swagger) definitions (versions 1.2 and 2.0).
 <br><br>
-The add-on will automatically detect any Open API definitions and spider them as long as they are in scope.
+The add-on will automatically detect any OpenAPI definitions and spider them as long as they are in scope.
 
 <H2>UI</H2>
 2 menu items are added to the Import menu:
 <ul>
-<li>Import an Open API definition from the local file system</li>
-<li>Import an Open API definition from a URL</li>
+<li>Import an OpenAPI definition from the local file system</li>
+<li>Import an OpenAPI definition from a URL</li>
 </ul>
 The URL Import dialog supports an optional additional field that allows you to override the Host (and port) in the
 definition with an alternative one that you supply.<br>
@@ -34,14 +34,14 @@ The definitions will be imported synchronously and any warnings will be returned
 <H2>Command Line</H2>
 The following Command Line options are added:
 <ul>
-<li>-openapifile &lt;filename&gt;  : Import an Open API definition from the specified file name</li>
-<li>-openapiurl &lt;url&gt;  : Import an Open API definition from the specified URL</li>
+<li>-openapifile &lt;filename&gt;  : Imports an OpenAPI definition from the specified file name</li>
+<li>-openapiurl &lt;url&gt;  : Imports an OpenAPI definition from the specified URL</li>
 </ul>
 
 The definitions will be imported synchronously and any warnings will be displayed on the command line.
 
 <H2>User Specified Values</H2>
-Default values are used when importing Open API definitions.<br>
+Default values are used when importing OpenAPI definitions.<br>
 These can be overridden using the Form Handler add-on which allows you to specify your own values.<br>
 In most cases these will be simple values (like strings and integers) but in some cases you may need to specify structured values, 
 e.g. <pre>{ "id": 0, "name": "Freda" }</pre>

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/helpset.hs
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/helpset.hs
@@ -3,7 +3,7 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
          "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
 <helpset version="2.0" xml:lang="en-GB">
-  <title>Support for the Open API Specification | ZAP Extension</title>
+  <title>Support for the OpenAPI Specification | ZAP Extension</title>
 
   <maps>
      <homeID>top</homeID>

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/toc.xml
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/toc.xml
@@ -6,7 +6,7 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="Open API Specification Support" image="openapi-icon" target="openapi"/>
+			<tocitem text="OpenAPI Specification Support" image="openapi-icon" target="openapi"/>
 		</tocitem>
 	</tocitem>
 </toc>

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -1,16 +1,19 @@
 # This file defines the default (English) variants of all of the internationalised messages
 
-openapi.api.action.importFile = Import an Open API definition from a local file.
-openapi.api.action.importUrl = Import an Open API definition from a URL, hostOverride allows the host to be replaced
+openapi.api.action.importFile = Imports an OpenAPI definition from a local file.
+openapi.api.action.importFile.param.file = The file that contains the OpenAPI definition.
+openapi.api.action.importUrl = Imports an OpenAPI definition from a URL.
+openapi.api.action.importUrl.param.url = The URL locating the OpenAPI definition.
+openapi.api.action.importUrl.param.hostOverride = The host to override the one present in the definition.
 
-openapi.cmdline.file.help = Import an Open API definition from the specified file name
-openapi.cmdline.url.help = Import an Open API definition from the specified URL
+openapi.cmdline.file.help = Imports an OpenAPI definition from the specified file name
+openapi.cmdline.url.help = Imports an OpenAPI definition from the specified URL
 
 openapi.desc = Allows you to spider and import OpenAPI (Swagger) definitions 
-openapi.topmenu.import.importopenapi = Import an Open API definition from the local file system
-openapi.topmenu.import.importopenapi.tooltip = The file must be a formal described OpenApi file.
-openapi.topmenu.import.importremoteopenapi = Import an Open API definition from a URL
-openapi.topmenu.import.importremoteopenapi.tooltip = The file must be a formal described OpenApi file.
+openapi.topmenu.import.importopenapi = Import an OpenAPI definition from the local file system
+openapi.topmenu.import.importopenapi.tooltip = The file must be a formal described OpenAPI definition.
+openapi.topmenu.import.importremoteopenapi = Import an OpenAPI definition from a URL
+openapi.topmenu.import.importremoteopenapi.tooltip = The contents must be a formal described OpenAPI definition.
 
 openapi.importfromdialog.labeltarget = Override Host:
 openapi.importfromdialog.importbutton = Import


### PR DESCRIPTION
Normalise OpenAPI name (`Open API`/`OpenApi` → `OpenAPI`).
Tweak menu tool tips to refer to definition instead of file.
Split API parameters' description from endpoint description.