### PR TITLE
webdrivers: update ChromeDriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [14] - 2019-12-12
+### Changed
+- Update ChromeDriver to v79.0.3945.36.
 
 ## [13] - 2019-10-23
 ### Changed
@@ -72,6 +73,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[14]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v14
 [13]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v12
 [11]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v11

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,7 +9,7 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 78.0.3904.70</li>
+    <li>Chrome - ChromeDriver 79.0.3945.36</li>
     <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [14] - 2019-12-12
+### Changed
+- Update ChromeDriver to v79.0.3945.36.
 
 ## [13] - 2019-10-23
 ### Changed
@@ -72,6 +73,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[14]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v14
 [13]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v12
 [11]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v11

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,7 +9,7 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 78.0.3904.70</li>
+    <li>Chrome - ChromeDriver 79.0.3945.36</li>
     <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.26.0"
-val chromeDriverVersion = "78.0.3904.70"
+val chromeDriverVersion = "79.0.3945.36"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [14] - 2019-12-12
+### Changed
+- Update ChromeDriver to v79.0.3945.36.
 
 ## [13] - 2019-10-23
 ### Changed
@@ -75,6 +76,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[14]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v14
 [13]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v12
 [11]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v11

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,7 +9,7 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 78.0.3904.70</li>
+    <li>Chrome - ChromeDriver 79.0.3945.36</li>
     <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 


### PR DESCRIPTION
Update ChromeDriver to 79.0.3945.36.
Add release dates and links to tags.