### PR TITLE
tips: remove filter related tips

### DIFF
--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## Removed
+- Remove tips related to Filter functionality, it no longer exists.
 
 ## [6] - 2019-06-07
 

--- a/addOns/tips/src/main/javahelp/org/zaproxy/zap/extension/tips/resources/help/contents/tips.html
+++ b/addOns/tips/src/main/javahelp/org/zaproxy/zap/extension/tips/resources/help/contents/tips.html
@@ -65,10 +65,6 @@ A lot of ZAP functionality is context sensitive as best accessed this way. </p>
 <p>Save your ZAP session at the start of a test rather than at the end - the session is stored in a db which will be updated all of the time so you wont have to save it again. </p>
 
 
-<p>Still using Filters? These are being phased out and will be removed in the future.<br>
-Use scripts instead - they are much more powerful. </p>
-
-
 <p>The 'Show / enable' fields 'lightbulb' button on the main toolbar will make hidden fields visible and allow you to edit disabled fields. </p>
 
 

--- a/addOns/tips/src/main/resources/org/zaproxy/zap/extension/tips/resources/Messages.properties
+++ b/addOns/tips/src/main/resources/org/zaproxy/zap/extension/tips/resources/Messages.properties
@@ -15,7 +15,6 @@ A lot of ZAP functionality is context sensitive as best accessed this way.
 tips.tip.gen.004 = Use keyboard shortcuts to speed up your testing - you can define your own combinations via 'Options / Keyboard' which also generates printable shortcut cheatsheets.
 tips.tip.gen.005 = If you are getting too many false positives try changing the threshold for that scan rule to High.\n\
 But also report the problem to us via the ZAP Users Group or Issues so we can investigate it - both of which are linked off the 'Online' menu
-tips.tip.gen.006 = Filters are no longer supported. Use the Replacer option or scripts instead - these are much more powerful.
 tips.tip.gen.007 = Add your target application to a Context using the 'right click' menu: 'Include in Context'.\n\
 This allows you tell ZAP more about the target, such as the authentication, the users and the technology it uses.
 tips.tip.gen.008 = ZAP can display, intercept and even fuzz client side messages including postMessages - 'right click' a subtree in the Sites tree and select a suitable submenu under 'Monitor clients'.\n\


### PR DESCRIPTION
The Filter functionality no longer exists.

Part of zaproxy/zaproxy#5244 - Remove Filter extension