### PR TITLE
wappalyzer: Add export button and handle multi-select

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Added
+- Export button.
+
+### Changed
+- Allow multi-select of rows to facilitate copy/paste, only show context menu if a single row is selected.
 
 ## [14] - 2019-10-02
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
@@ -145,4 +145,9 @@ public class Application {
     public void setIcon(ImageIcon icon) {
         this.icon = icon;
     }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
 }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import javax.swing.JMenuItem;
+import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
@@ -46,7 +47,9 @@ public class PopupMenuEvidence extends ExtensionPopupMenuItem {
     public boolean isEnableForComponent(Component invoker) {
         clearSubMenus();
 
-        if (invoker.getName() != null && invoker.getName().equals(TechPanel.PANEL_NAME)) {
+        if (invoker.getName() != null
+                && invoker.getName().equals(TechPanel.PANEL_NAME)
+                && ((JXTable) invoker).getSelectedRows().length < 2) {
             Application app = extension.getSelectedApp();
             if (app != null) {
                 for (AppPattern p : app.getUrl()) {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidenceSearch.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidenceSearch.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.wappalyzer;
 
 import java.awt.Component;
 import java.util.regex.Pattern;
+import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
@@ -57,7 +58,9 @@ public class PopupMenuEvidenceSearch extends ExtensionPopupMenuItem {
 
     @Override
     public boolean isEnableForComponent(Component invoker) {
-        if (invoker.getName() != null && invoker.getName().equals(TechPanel.PANEL_NAME)) {
+        if (invoker.getName() != null
+                && invoker.getName().equals(TechPanel.PANEL_NAME)
+                && ((JXTable) invoker).getSelectedRows().length < 2) {
             this.setEnabled(true);
             return true;
         }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechTableModel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechTableModel.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
-import javax.swing.ImageIcon;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
@@ -40,7 +39,6 @@ public class TechTableModel extends AbstractTableModel {
     public TechTableModel() {
         super();
         columnNames = new Vector<>();
-        columnNames.add(Constant.messages.getString("wappalyzer.table.header.icon"));
         columnNames.add(Constant.messages.getString("wappalyzer.table.header.name"));
         columnNames.add(Constant.messages.getString("wappalyzer.table.header.version"));
         columnNames.add(Constant.messages.getString("wappalyzer.table.header.category"));
@@ -79,21 +77,18 @@ public class TechTableModel extends AbstractTableModel {
         ApplicationMatch app = apps.get(row);
         switch (col) {
             case 0:
-                obj = app.getApplication().getIcon();
+                obj = app.getApplication();
                 break;
             case 1:
-                obj = app.getApplication().getName();
-                break;
-            case 2:
                 obj = app.getVersion();
                 break;
-            case 3:
+            case 2:
                 obj = categoriesToString(app.getApplication().getCategories());
                 break;
-            case 4:
+            case 3:
                 obj = app.getApplication().getWebsite();
                 break;
-            case 5:
+            case 4:
                 obj = listToString(app.getApplication().getImplies());
                 break;
                 // case 5: obj = app.getConfidence(); break;
@@ -184,7 +179,7 @@ public class TechTableModel extends AbstractTableModel {
     public Class<? extends Object> getColumnClass(int c) {
         switch (c) {
             case 0:
-                return ImageIcon.class;
+                return Application.class;
             case 1:
                 return String.class;
             case 2:
@@ -192,8 +187,6 @@ public class TechTableModel extends AbstractTableModel {
             case 3:
                 return String.class;
             case 4:
-                return String.class;
-            case 5:
                 return String.class;
         }
         return null;

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -17,7 +17,11 @@ It works in a very similar way to the Wappalyzer browser add-ons with the follow
 <H2>The Technology Tab</H2>
 This tab shows all of the detected technologies for the site selected.<br>
 Right clicking on a technology will display a 'Show evidence' menu under which are all of the regexes used to detect it.<br>
-Selecting a regex will switch to the 'Search' tab and search through the history for that regex.
+Selecting a regex will switch to the 'Search' tab and search through the history for that regex. Note: If multiple rows are selected
+the menu will not be displayed.
+<p>
+Beside the site selection drop down is an Export button which can be used to export a CSV (comma separated values) file based on the
+table information currently being displayed.
 
 <H2>External Links</H2>
 <table>

--- a/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -8,7 +8,6 @@ wappalyzer.name = Wappalyzer - Technology Detection
 
 wappalyzer.search.popup		= Show Evidence
 
-wappalyzer.table.header.icon		=
 wappalyzer.table.header.name		= Technology
 wappalyzer.table.header.version		= Version
 wappalyzer.table.header.category	= Categories


### PR DESCRIPTION
- CHANGELOG.md > Added change info.
- PopupMenuEvidence*.java > Added handling for multi-select (disable menu if multiple rows selected.)
- Techpanel > Add export button. Added icon to "Name" column which is now actually `Application` not string and uses a new custom renderer.
- TechTableModel > Removed icon column, made the new first column "Name" be based on `Application`.
- Messages.properties > Removed now un-used icon key.
- wappalyzer.html > Updated to note the multi-select behavior of the context menu, and mention the export button.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>