### PR TITLE
webdrivers: use correct arch, prepare release

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [15] - 2019-12-16
+### Fixed
+- Bundle correct geckodriver binary for respective architecture (Issue 5763).
 
 ## [14] - 2019-12-12
 ### Changed
@@ -76,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[15]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v15
 [14]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v14
 [13]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v12

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [15] - 2019-12-16
+### Fixed
+- Bundle correct geckodriver binary for respective architecture (Issue 5763).
 
 ## [14] - 2019-12-12
 ### Changed
@@ -79,6 +80,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[15]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v15
 [14]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v14
 [13]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v13
 [12]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v12

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 dependencies {
-    implementation("io.github.bonigarcia:webdrivermanager:3.3.0")
+    implementation("io.github.bonigarcia:webdrivermanager:3.7.1")
     implementation("com.diffplug.spotless:spotless-plugin-gradle:3.20.0")
 }
 


### PR DESCRIPTION
Change `DownloadWebDriver` to use a custom `FirefoxDriverManager` to
ignore cached binaries of different architecture than the one being
requested, affects only geckodriver which has 32/64bits binaries for
Linux and Windows.
Update WebDriverManager to latest version.
Add release dates and links to tags.

Fix zaproxy/zaproxy#5763 - WebDriver add-ons might bundle binaries with
incorrect architecture