### PR TITLE
wappalyzer: Add API

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Export button.
+- API with three views:
+  - listSites: Lists the sites that there are application (technology) details for [similar to the host:port drop down menu in the GUI].
+  - listAll: Lists all sites and their associated applications (technologies).
+  - listSite: Lists all the applications (technologies) for a given site [host:port] identifier.
 
 ### Changed
 - Allow multi-select of rows to facilitate copy/paste, only show context menu if a single row is selected.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -29,6 +29,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import javax.swing.ImageIcon;
 import javax.swing.tree.TreeNode;
@@ -81,11 +82,12 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     }
 
     private WappalyzerPassiveScanner passiveScanner;
+    private WappalyzerAPI api;
 
     /**
-     * TODO Implementaion Version handling Confidence handling Add API calls - need to test for
-     * daemon mode (esp revisits) Issues Handle load session - store tech in db? Sites pull down not
-     * populated if no tech found - is this actually a problem? One pattern still fails to compile
+     * TODO Implementaion Version handling Confidence handling - need to test for daemon mode (esp
+     * revisits) Issues Handle load session - store tech in db? Sites pull down not populated if no
+     * tech found - is this actually a problem? One pattern still fails to compile
      */
     public ExtensionWappalyzer() {
         super(NAME);
@@ -120,6 +122,9 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
             extensionHook.getHookView().addStatusPanel(getTechPanel());
             extensionHook.getHookMenu().addPopupMenuItem(this.getPopupMenuEvidence());
         }
+
+        this.api = new WappalyzerAPI(this);
+        extensionHook.addApiImplementor(this.api);
 
         ExtensionPassiveScan extPScan =
                 Control.getSingleton()
@@ -224,6 +229,10 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
             return this.getTechPanel().getCurrentSite();
         }
         return null;
+    }
+
+    public Set<String> getSites() {
+        return Collections.unmodifiableSet(siteTechMap.keySet());
     }
 
     private ExtensionSearch getExtensionSearch() {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
@@ -1,0 +1,106 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.wappalyzer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import net.sf.json.JSONObject;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+import org.zaproxy.zap.extension.api.ApiResponseList;
+import org.zaproxy.zap.extension.api.ApiResponseSet;
+import org.zaproxy.zap.extension.api.ApiView;
+
+public class WappalyzerAPI extends ApiImplementor {
+
+    public static final String PREFIX = "wappalyzer";
+
+    private static final String VIEW_LIST_SITES = "listSites";
+    private static final String VIEW_LIST_ALL = "listAll";
+    private static final String VIEW_LIST_SITE = "listSite";
+
+    private static final String PARAM_SITE = "site";
+
+    private ExtensionWappalyzer extension = null;
+
+    public WappalyzerAPI(ExtensionWappalyzer ext) {
+        this.extension = ext;
+        this.addApiView(new ApiView(VIEW_LIST_SITES));
+        this.addApiView(new ApiView(VIEW_LIST_ALL));
+        this.addApiView(new ApiView(VIEW_LIST_SITE, new String[] {PARAM_SITE}));
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
+        ApiResponse result = null;
+        if (VIEW_LIST_SITES.equals(name)) {
+            result = sitesToList(name, extension.getSites());
+        } else if (VIEW_LIST_ALL.equals(name)) {
+            ApiResponseList sitesList = new ApiResponseList(name);
+            for (String site : extension.getSites()) {
+                sitesList.addItem(getAppListForSite(site));
+            }
+            result = sitesList;
+        } else if (VIEW_LIST_SITE.equals(name)) {
+            String site = getParam(params, PARAM_SITE, "");
+            validateSite(site);
+            result = getAppListForSite(site);
+        }
+        return result;
+    }
+
+    private void validateSite(String site) throws ApiException {
+        if (site.isEmpty() || !site.contains(":")) {
+            throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_SITE);
+        }
+        if (!extension.getSites().contains(site)) {
+            throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SITE);
+        }
+    }
+
+    private ApiResponseList getAppListForSite(String site) {
+        ApiResponseList resultList = new ApiResponseList(site);
+        TechTableModel ttm = extension.getTechModelForSite(site);
+        for (int i = 0; i < ttm.getRowCount(); i++) {
+            Map<String, String> map = new HashMap<>();
+            map.put("name", ((Application) ttm.getValueAt(i, 0)).toString());
+            map.put("version", (String) ttm.getValueAt(i, 1));
+            map.put("category", (String) ttm.getValueAt(i, 2));
+            map.put("website", (String) ttm.getValueAt(i, 3));
+            map.put("implies", (String) ttm.getValueAt(i, 4));
+            resultList.addItem(new ApiResponseSet<String>("app", map));
+        }
+        return resultList;
+    }
+
+    private ApiResponseList sitesToList(String name, Set<String> sites) {
+        ApiResponseList resultList = new ApiResponseList(name);
+        sites.forEach((site) -> resultList.addItem(new ApiResponseElement("site", site)));
+        return resultList;
+    }
+}

--- a/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -1,5 +1,10 @@
 # This file defines the default (English) variants of all of the internationalised messages
 
+wappalyzer.api.view.listAll = Lists all sites and their associated applications (technologies).
+wappalyzer.api.view.listSite = Lists all the applications (technologies) associated with a specific site.
+wappalyzer.api.view.listSite.site = The site for which the applications (technologies) should be returned (in the form host:port, where host is either a name or IP). (See the listSites).
+wappalyzer.api.view.listSites =  Lists all the sites recognized by the wappalyzer addon (in the form host:port, where host is either a name or IP).
+
 wappalyzer.desc	= Technology detection using Wappalyzer - http://wappalyzer.com/
 wappalyzer.panel.mnemonic = t
 wappalyzer.panel.title = Technology


### PR DESCRIPTION
- ExtensionWappalyzer > Hook the api. (Remove todo about API calls.)
- WappalyzerAPI > Brand new, with a few views.
- Messages.properties > Add API and param descriptions (param won't be applicable until targeting next zap version [likely 2.9]).
- CHANGELOG > Added details of the new API(s).

Fixes zaproxy/zaproxy#5761

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>