### PR TITLE
Fix 5295: Cookie Flag FPs

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- "Cookie HttpOnly", "Cookie Secure Flag", and "Cookie Without SameSite Attribute" scan rules no longer alert on expired (deleted) cookies (Issue 5295).
 
 ## [25] - 2019-12-16
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanner.java
@@ -73,6 +73,9 @@ public class CookieHttpOnlyScanner extends PluginPassiveScanner {
         while (iterator.hasNext()) {
             String headerValue = (String) iterator.next();
             if (!CookieUtils.hasAttribute(headerValue, HTTP_ONLY_COOKIE_ATTRIBUTE)) {
+                if (CookieUtils.isExpired(headerValue)) {
+                    continue;
+                }
                 if (!ignoreList.contains(CookieUtils.getCookieName(headerValue))) {
                     this.raiseAlert(msg, id, headerValue);
                 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanner.java
@@ -64,6 +64,9 @@ public class CookieSameSiteScanner extends PluginPassiveScanner {
             return;
         }
         for (String cookie : cookies) {
+            if (CookieUtils.isExpired(cookie)) {
+                continue;
+            }
             String sameSiteVal =
                     SetCookieUtils.getAttributeValue(cookie, SAME_SITE_COOKIE_ATTRIBUTE);
             if (sameSiteVal == null) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanner.java
@@ -78,6 +78,9 @@ public class CookieSecureFlagScanner extends PluginPassiveScanner {
         while (iterator.hasNext()) {
             String headerValue = (String) iterator.next();
             if (!CookieUtils.hasAttribute(headerValue, SECURE_COOKIE_ATTRIBUTE)) {
+                if (CookieUtils.isExpired(headerValue)) {
+                    continue;
+                }
                 if (!ignoreList.contains(CookieUtils.getCookieName(headerValue))) {
                     this.raiseAlert(msg, id, headerValue);
                 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScannerUnitTest.java
@@ -23,6 +23,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.parosproxy.paros.model.Model;
@@ -171,6 +174,130 @@ public class CookieHttpOnlyScannerUnitTest extends PassiveScannerTest<CookieHttp
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"
                         + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=123; Path=/;\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; secure\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires=Thu, 01-Jan-1970 00:00:00 GMT; Path=/; secure\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+
+        DateTimeFormatter df =
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
+                        .withZone(ZoneOffset.UTC);
+        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
+        String expiry = dateTime.format(df);
+
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires="
+                        + expiry
+                        + "; Path=/; secure\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+
+        DateTimeFormatter df =
+                DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz")
+                        .withZone(ZoneOffset.UTC);
+        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
+        String expiry = dateTime.format(df);
+
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires="
+                        + expiry
+                        + "; Path=/; secure\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void secondCookieNoHttpOnlyAttributeFirstExpired() throws HttpMalformedHeaderException {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: hasatt=test123; expires=Thu, 01-Jan-1970 00:00:00 GMT; Path=/;\r\n"
                         + "Set-Cookie: test=123; Path=/;\r\n"
                         + "Content-Type: text/html;charset=ISO-8859-1\r\n"
                         + "Content-Length: "

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScannerUnitTest.java
@@ -22,6 +22,9 @@ package org.zaproxy.zap.extension.pscanrules;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import org.junit.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -170,6 +173,130 @@ public class CookieSameSiteScannerUnitTest extends PassiveScannerTest<CookieSame
                 "HTTP/1.1 200 OK\r\n"
                         + "Server: Apache-Coyote/1.1\r\n"
                         + "Set-Cookie: test=123; Path=/; SameSite; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires=Thu, 01-Jan-1970 00:00:00 GMT; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+
+        DateTimeFormatter df =
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
+                        .withZone(ZoneOffset.UTC);
+        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
+        String expiry = dateTime.format(df);
+
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires="
+                        + expiry
+                        + "; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+
+        DateTimeFormatter df =
+                DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz")
+                        .withZone(ZoneOffset.UTC);
+        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
+        String expiry = dateTime.format(df);
+
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires="
+                        + expiry
+                        + "; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void secondCookieNoSameSiteAttributeFirstExpired() throws HttpMalformedHeaderException {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: hasatt=test123; expires=Thu, 01-Jan-1970 00:00:00 GMT; Path=/; secure\r\n"
+                        + "Set-Cookie: test=123; Path=/;\r\n"
                         + "Content-Type: text/html;charset=ISO-8859-1\r\n"
                         + "Content-Length: "
                         + msg.getResponseBody().length()

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScannerUnitTest.java
@@ -23,6 +23,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.parosproxy.paros.model.Model;
@@ -170,6 +173,130 @@ public class CookieSecureFlagScannerUnitTest extends PassiveScannerTest<CookieSe
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"
                         + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=123; Path=/;\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires=Thu, 01-Jan-1970 00:00:00 GMT; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+
+        DateTimeFormatter df =
+                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
+                        .withZone(ZoneOffset.UTC);
+        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
+        String expiry = dateTime.format(df);
+
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires="
+                        + expiry
+                        + "; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
+        // Given - value empty and epoch start date
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody("<html></html>");
+
+        DateTimeFormatter df =
+                DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz")
+                        .withZone(ZoneOffset.UTC);
+        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
+        String expiry = dateTime.format(df);
+
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: test=\"\"; expires="
+                        + expiry
+                        + "; Path=/; HttpOnly\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
+    }
+
+    @Test
+    public void secondCookieNoSecureAttributeFirstExpired() throws HttpMalformedHeaderException {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Set-Cookie: hasatt=test123; expires=Thu, 01-Jan-1970 00:00:00 GMT; Path=/; secure\r\n"
                         + "Set-Cookie: test=123; Path=/;\r\n"
                         + "Content-Type: text/html;charset=ISO-8859-1\r\n"
                         + "Content-Length: "


### PR DESCRIPTION
- CookieUtils > Added `isExpired(String)` method.
- CookieHttpOnlyScanner, CookieSecureFlagScanner, CookieSameSiteScanner > Changed to leverage new isExpired method and just return if the cookies are expired (deleted).
- CookieHttpOnlyScannerUnitTest, CookieSecureFlagScannerUnitTest, CookieSameSiteScannerUnitTest > Added unit tests for both space and hyphen delimited dates in support of the new behavior.
- CHANGELOG > Added change entry.

Fixes zaproxy/zaproxy#5295

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>