### PR TITLE
ascanrules: SQLi fix FP/FN & Address Java 8 todos

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Improved PowerShell injection control patterns to reduce false positives.
 - Maintenance changes.
 - Added links to the code in the help.
+- Issue 5271: Fix SQLi false positive (and potential false negative) when response bodies contain injection strings.
 
 ## [33] - 2019-06-07
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -811,11 +811,11 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                         // value is 1
                         // set the parameter value to a string value like "3-2", if the original
                         // parameter value was "1"
-                        int paramPlusTwo = addWithOverflowCheck(paramAsInt, 2);
+                        int paramPlusTwo = Math.addExact(paramAsInt, 2);
                         String modifiedParamValueForAdd = String.valueOf(paramPlusTwo) + "-2";
                         // set the parameter value to a string value like "4-2", if the original
                         // parameter value was "1"
-                        int paramPlusThree = addWithOverflowCheck(paramAsInt, 3);
+                        int paramPlusThree = Math.addExact(paramAsInt, 3);
                         String modifiedParamValueConfirmForAdd =
                                 String.valueOf(paramPlusThree) + "-2";
                         // Do the attack for ADD variant
@@ -836,11 +836,11 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                                 && countExpressionBasedRequests < doExpressionMaxRequests) {
                             // set the parameter value to a string value like "2/2", if the original
                             // parameter value was "1"
-                            int paramMultTwo = multiplyWithOverflowCheck(paramAsInt, 2);
+                            int paramMultTwo = Math.multiplyExact(paramAsInt, 2);
                             String modifiedParamValueForMult = String.valueOf(paramMultTwo) + "/2";
                             // set the parameter value to a string value like "4/2", if the original
                             // parameter value was "1"
-                            int paramMultFour = multiplyWithOverflowCheck(paramAsInt, 4);
+                            int paramMultFour = Math.multiplyExact(paramAsInt, 4);
                             String modifiedParamValueConfirmForMult =
                                     String.valueOf(paramMultFour) + "/2";
                             // Do the attack for MULT variant
@@ -1939,12 +1939,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
         String modifiedExpressionOutputStripped =
                 stripOffOriginalAndAttackParam(
                         modifiedExpressionOutputUnstripped, originalParam, modifiedParamValue);
-        String normalBodyOutput = mResBodyNormalStripped;
+        String normalBodyOutputStripped = stripOff(mResBodyNormalStripped, modifiedParamValue);
 
         if (!sqlInjectionFoundForUrl && countExpressionBasedRequests < doExpressionMaxRequests) {
             // if the results of the modified request match the original query, we may be onto
             // something.
-            if (modifiedExpressionOutputStripped.compareTo(normalBodyOutput) == 0) {
+
+            if (modifiedExpressionOutputStripped.compareTo(normalBodyOutputStripped) == 0) {
                 if (this.debugEnabled) {
                     log.debug(
                             "Check 4, STRIPPED html output for modified expression parameter ["
@@ -1983,7 +1984,10 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                                 originalParam,
                                 modifiedParamValueConfirm);
 
-                if (confirmExpressionOutputStripped.compareTo(normalBodyOutput) != 0) {
+                normalBodyOutputStripped =
+                        stripOff(mResBodyNormalStripped, modifiedParamValueConfirm);
+
+                if (confirmExpressionOutputStripped.compareTo(normalBodyOutputStripped) != 0) {
                     // the confirm query did not return the same results.  This means that arbitrary
                     // queries are not all producing the same page output.
                     // this means the fact we earier reproduced the original page output with a
@@ -2079,42 +2083,6 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
             return msg;
         }
         return result;
-    }
-
-    // TODO:replace addWithOverflowCheck method with Math.addExact when targeting JAVA 8
-    /**
-     * add two numbers with Arithmetic Overflow check
-     *
-     * @param firstNumber
-     * @param secondNumber
-     * @return
-     */
-    private static int addWithOverflowCheck(int firstNumber, int secondNumber) {
-        long result = ((long) firstNumber) + ((long) secondNumber);
-        if (result > Integer.MAX_VALUE) {
-            throw new ArithmeticException("Overflow occurred");
-        } else if (result < Integer.MIN_VALUE) {
-            throw new ArithmeticException("Underflow occurred");
-        }
-        return (int) result;
-    }
-
-    // TODO:replace multiplyWithOverflowCheck method with Math.multiplyExact when targeting JAVA 8
-    /**
-     * multiply two numbers with Arithmetic Overflow check
-     *
-     * @param firstNumber
-     * @param secondNumber
-     * @return
-     */
-    private static int multiplyWithOverflowCheck(int firstNumber, int secondNumber) {
-        long result = ((long) firstNumber) * ((long) secondNumber);
-        if (result > Integer.MAX_VALUE) {
-            throw new ArithmeticException("Overflow occurred");
-        } else if (result < Integer.MIN_VALUE) {
-            throw new ArithmeticException("Underflow occurred");
-        }
-        return (int) result;
     }
 
     @Override

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
@@ -161,6 +161,28 @@ public class TestSQLInjectionUnitTest extends ActiveScannerAppParamTest<TestSQLI
     }
 
     @Test
+    public void shouldNotAlertIfSumConfirmationExpressionIsNotSuccessfulAndIsReflectedInResponse()
+            throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(
+                new ExpressionBasedHandler(
+                        "/",
+                        param,
+                        ExpressionBasedHandler.Expression.SUM,
+                        true,
+                        ExpressionBasedHandler.Expression.SUM.confirmationExpression));
+        rule.init(
+                getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.SUM.value),
+                parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
     public void shouldAlertIfMultExpressionsAreSuccessful() throws Exception {
         // Given
         String param = "id";
@@ -218,9 +240,31 @@ public class TestSQLInjectionUnitTest extends ActiveScannerAppParamTest<TestSQLI
         String param = "id";
         nano.addHandler(
                 new ExpressionBasedHandler(
-                        "/", param, ExpressionBasedHandler.Expression.SUM, true));
+                        "/", param, ExpressionBasedHandler.Expression.MULT, true));
         rule.init(
-                getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.SUM.value),
+                getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.MULT.value),
+                parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(greaterThan(1)));
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfMultConfirmationExpressionIsNotSuccessfulAndReflectedInResponse()
+            throws Exception {
+        // Given
+        String param = "id";
+        nano.addHandler(
+                new ExpressionBasedHandler(
+                        "/",
+                        param,
+                        ExpressionBasedHandler.Expression.MULT,
+                        true,
+                        ExpressionBasedHandler.Expression.MULT.confirmationExpression));
+        rule.init(
+                getHttpMessage("/?" + param + "=" + ExpressionBasedHandler.Expression.MULT.value),
                 parent);
         // When
         rule.scan();
@@ -249,6 +293,7 @@ public class TestSQLInjectionUnitTest extends ActiveScannerAppParamTest<TestSQLI
         private final String param;
         private final Expression expression;
         private final boolean confirmationFails;
+        private String contentAddition = "";
 
         public ExpressionBasedHandler(String path, String param, Expression expression) {
             this(path, param, expression, false);
@@ -261,6 +306,16 @@ public class TestSQLInjectionUnitTest extends ActiveScannerAppParamTest<TestSQLI
             this.param = param;
             this.expression = expression;
             this.confirmationFails = confirmationFails;
+        }
+
+        public ExpressionBasedHandler(
+                String parth,
+                String param,
+                Expression expression,
+                boolean confirmationFails,
+                String contentAddition) {
+            this(parth, param, expression, confirmationFails);
+            this.contentAddition = contentAddition;
         }
 
         @Override
@@ -282,7 +337,7 @@ public class TestSQLInjectionUnitTest extends ActiveScannerAppParamTest<TestSQLI
         }
 
         protected String getContent(String value) {
-            return "Some Content";
+            return "Some Content " + contentAddition;
         }
     }
 }


### PR DESCRIPTION
- Fix false positive/false negative conditions when the response bodies contain the test expressions.
- Address Java 8 todos, leverage Math functions now that Java 8 is being targeted.
- UnitTests simplify seeming reflected content inclusions, add reflected variants of shouldNotAlert tests.
- Updated CHANGELOG.

Fixes zaproxy/zaproxy#5271

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>