### PR TITLE
bruteforce: use random port in test server

### DIFF
--- a/addOns/bruteforce/bruteforce.gradle.kts
+++ b/addOns/bruteforce/bruteforce.gradle.kts
@@ -19,7 +19,6 @@ zapAddOn {
 
 dependencies {
     testImplementation(project(":testutils"))
-    testImplementation("org.simpleframework:simple:5.0.2")
 }
 
 spotless {


### PR DESCRIPTION
Start the test server with random port to avoid clashes, also, use the
server from `testutils` instead of another server implementation.