### PR TITLE
Fix pscanrulesAlpha: SubResourceIntegrityAttributeScanner NPE

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Added links to the code in the help.
+- Fixed NullPointerException in Sub Resource Integrity Attribute Missing scan rule (Issue 5789).
 
 ## [26] - 2019-12-16
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScannerTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScannerTest.java
@@ -145,6 +145,54 @@ public class SubResourceIntegrityAttributeScannerTest
     }
 
     @Test
+    public void shouldNotRaiseAlertGivenElementIsServedRelatively()
+            throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg =
+                buildMessage(
+                        "<!doctype html>\n"
+                                + "<html lang=\"en\">\n"
+                                + "  <head>\n"
+                                + "    <link href=\"/dashboard/stylesheets/normalize.css\" rel=\"stylesheet\" type=\"text/css\" />\n"
+                                + "  </head>\n"
+                                + "  <body class=\"index\">\n"
+                                + "  </body>\n"
+                                + "</html>");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertGivenElementIsInline() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg =
+                buildMessage(
+                        "<!doctype html>\n"
+                                + "<html lang=\"en\">\n"
+                                + "  <body class=\"index\">\n"
+                                + "    <div id=\"fb-root\"></div>\n"
+                                + "    <script>(function(d, s, id) {\n"
+                                + "      var js, fjs = d.getElementsByTagName(s)[0];\n"
+                                + "      if (d.getElementById(id)) return;\n"
+                                + "      js = d.createElement(s); js.id = id;\n"
+                                + "      js.src = \"//connect.facebook.net/en_US/all.js#xfbml=1&appId=277385395761685\";\n"
+                                + "      fjs.parentNode.insertBefore(js, fjs);\n"
+                                + "    }(document, 'script', 'facebook-jssdk'));</script>"
+                                + "  </body>\n"
+                                + "</html>");
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
     public void shouldIgnoreInvalidFormattedHostname() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =


### PR DESCRIPTION
- SubResourceIntegrityAttributeScanner > Modify `getHost` to handle relative paths and elements without src attributes.
- SubResourceIntegrityAttributeScannerTest > Add tests.

Fixes zaproxy/zaproxy#5789

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>