### PR TITLE
zest: update Zest library

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Update Zest library to 0.14.1 to restore proxying capability, in the previous version the proxy settings were ignored.
 
 ## [30] - 2019-12-06
 

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -34,7 +34,7 @@ zapAddOn {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("selenium")!!)
-    implementation("org.mozilla:zest:0.14.0") {
+    implementation("org.mozilla:zest:0.14.1") {
         // Provided by Selenium add-on.
         exclude(group = "org.seleniumhq.selenium")
         exclude(group = "com.codeborne", module = "phantomjsdriver")


### PR DESCRIPTION
Update Zest library to 0.14.1, to restore proxying capability.