### PR TITLE
Normalize site "names"

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - The panel is now shown when the add-on is installed.
+- The site "names" are now normalized based on scheme and authority (including port if non-standard or specifically included). This represents a breaking change for any API code that is using listSite with host:port "names".
 
 ## [15] - 2019-12-20
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import javax.swing.ImageIcon;
 import javax.swing.tree.TreeNode;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -47,6 +49,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
+import org.zaproxy.zap.view.ScanPanel;
 import org.zaproxy.zap.view.SiteMapListener;
 import org.zaproxy.zap.view.SiteMapTreeCellRenderer;
 
@@ -235,6 +238,33 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
         return Collections.unmodifiableSet(siteTechMap.keySet());
     }
 
+    static String normalizeSite(URI uri) {
+        String lead = uri.getScheme() + "://";
+        try {
+            return lead + uri.getAuthority();
+        } catch (URIException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Unable to get authority from: " + uri.toString(), e);
+            }
+            // Shouldn't happen, but sure fallback
+            return ScanPanel.cleanSiteName(uri.toString(), true);
+        }
+    }
+
+    static String normalizeSite(String site) {
+        try {
+            site = normalizeSite(new URI(site == null ? "" : site, false));
+        } catch (URIException ue) {
+            // Shouldn't happen, but sure fallback
+            if (logger.isDebugEnabled()) {
+                logger.debug(
+                        "Falling back to 'CleanSiteName'. Failed to create URI from: " + site, ue);
+            }
+            site = ScanPanel.cleanSiteName(site, true);
+        }
+        return site;
+    }
+
     private ExtensionSearch getExtensionSearch() {
         if (extSearch == null) {
             extSearch =
@@ -256,7 +286,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     @Override
     public void nodeSelected(SiteNode node) {
         // Event from SiteMapListenner
-        this.getTechPanel().nodeSelected(node);
+        this.getTechPanel().siteSelected(normalizeSite(node.getHistoryReference().getURI()));
     }
 
     @Override
@@ -306,10 +336,8 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
         @SuppressWarnings("unchecked")
         Enumeration<TreeNode> en = root.children();
         while (en.hasMoreElements()) {
-            String site = ((SiteNode) en.nextElement()).getNodeName();
-            if (site.indexOf("//") >= 0) {
-                site = site.substring(site.indexOf("//") + 2);
-            }
+            String site =
+                    normalizeSite(((SiteNode) en.nextElement()).getHistoryReference().getURI());
             this.getTechPanel().addSite(site);
         }
     }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -40,11 +40,9 @@ import org.jdesktop.swingx.renderer.MappedValue;
 import org.jdesktop.swingx.renderer.StringValues;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
-import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.SortedComboBoxModel;
 import org.zaproxy.zap.utils.TableExportButton;
-import org.zaproxy.zap.view.ScanPanel;
 
 public class TechPanel extends AbstractPanel {
 
@@ -291,7 +289,6 @@ public class TechPanel extends AbstractPanel {
     }
 
     public void addSite(String site) {
-        site = ScanPanel.cleanSiteName(site, true);
         if (siteModel.getIndexOf(site) < 0) {
             siteModel.addElement(site);
             if (siteModel.getSize() == 2 && currentSite == null) {
@@ -302,19 +299,12 @@ public class TechPanel extends AbstractPanel {
         }
     }
 
-    private void siteSelected(String site) {
-        site = ScanPanel.cleanSiteName(site, true);
+    void siteSelected(String site) {
         if (!site.equals(currentSite)) {
             siteModel.setSelectedItem(site);
             techModel = extension.getTechModelForSite(site);
             this.getTechTable().setModel(techModel);
             currentSite = site;
-        }
-    }
-
-    public void nodeSelected(SiteNode node) {
-        if (node != null) {
-            siteSelected(ScanPanel.cleanSiteName(node, true));
         }
     }
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
@@ -75,9 +75,6 @@ public class WappalyzerAPI extends ApiImplementor {
     }
 
     private void validateSite(String site) throws ApiException {
-        if (site.isEmpty() || !site.contains(":")) {
-            throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_SITE);
-        }
         if (!extension.getSites().contains(site)) {
             throw new ApiException(ApiException.Type.DOES_NOT_EXIST, PARAM_SITE);
         }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -72,10 +72,7 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
             this.currentApp = app;
             checkAppMatches(msg, source);
             if (appMatch != null) {
-                String site =
-                        msg.getRequestHeader().getHostName()
-                                + ":"
-                                + msg.getRequestHeader().getHostPort();
+                String site = ExtensionWappalyzer.normalizeSite(msg.getRequestHeader().getURI());
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Adding " + app.getName() + " to " + site);
                 }

--- a/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -2,8 +2,8 @@
 
 wappalyzer.api.view.listAll = Lists all sites and their associated applications (technologies).
 wappalyzer.api.view.listSite = Lists all the applications (technologies) associated with a specific site.
-wappalyzer.api.view.listSite.site = The site for which the applications (technologies) should be returned (in the form host:port, where host is either a name or IP). (See the listSites).
-wappalyzer.api.view.listSites =  Lists all the sites recognized by the wappalyzer addon (in the form host:port, where host is either a name or IP).
+wappalyzer.api.view.listSite.site = The site for which the applications (technologies) should be returned. (See listSites).
+wappalyzer.api.view.listSites =  Lists all the sites recognized by the wappalyzer addon.
 
 wappalyzer.desc	= Technology detection using Wappalyzer - http://wappalyzer.com/
 wappalyzer.panel.mnemonic = t

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -76,9 +76,9 @@ public class WappalyzerPassiveScannerUnitTest
 
         scan(msg);
 
-        assertFoundAppCount("www.example.com:443", 2);
-        assertFoundApp("www.example.com:443", "Apache");
-        assertFoundApp("www.example.com:443", "PHP", "5.6.34");
+        assertFoundAppCount("https://www.example.com", 2);
+        assertFoundApp("https://www.example.com", "Apache");
+        assertFoundApp("https://www.example.com", "PHP", "5.6.34");
     }
 
     @Test
@@ -92,8 +92,8 @@ public class WappalyzerPassiveScannerUnitTest
                         + "</html>");
         scan(msg);
 
-        assertFoundAppCount("www.example.com:443", 1);
-        assertFoundApp("www.example.com:443", "Modernizr");
+        assertFoundAppCount("https://www.example.com", 1);
+        assertFoundApp("https://www.example.com", "Modernizr");
     }
 
     @Test
@@ -106,7 +106,7 @@ public class WappalyzerPassiveScannerUnitTest
         // When
         scan(msg);
         // Then
-        assertNull(getDefaultHolder().getAppsForSite("www.example.com:443"));
+        assertNull(getDefaultHolder().getAppsForSite("https://www.example.com"));
     }
 
     @Test
@@ -121,9 +121,9 @@ public class WappalyzerPassiveScannerUnitTest
         // When
         scan(msg);
         // Then
-        assertFoundAppCount("www.example.com:443", 2);
-        assertFoundApp("www.example.com:443", "1C-Bitrix"); // Matched
-        assertFoundApp("www.example.com:443", "PHP"); // Implied
+        assertFoundAppCount("https://www.example.com", 2);
+        assertFoundApp("https://www.example.com", "1C-Bitrix"); // Matched
+        assertFoundApp("https://www.example.com", "PHP"); // Implied
     }
 
     private void scan(HttpMessage msg) {


### PR DESCRIPTION
Instead of using host:port use scheme and authority.

Ex:
![image](https://user-images.githubusercontent.com/7570458/72670158-429dab00-3a08-11ea-9841-cbadafe700e6.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>