### PR TITLE
pscanrules: Update scan rules to leverage 2.9.0 core

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Minimum ZAP version is now 2.9.0. (Various scan rules adjusted to address core deprecations.)
+- 'Username Hash Found' scan rule now uses updated core functionality to retrieve configured users.
 
 ## [26] - 2020-01-17
 

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -6,7 +6,7 @@ description = "The release quality Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.8.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanner.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import java.util.Vector;
+import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -69,10 +69,10 @@ public class CacheControlScanner extends PluginPassiveScanner {
                 }
             }
 
-            Vector<String> cacheControlVect =
-                    msg.getResponseHeader().getHeaders(HttpHeader.CACHE_CONTROL);
+            List<String> cacheControlList =
+                    msg.getResponseHeader().getHeaderValues(HttpHeader.CACHE_CONTROL);
             String cacheControlHeaders =
-                    (cacheControlVect != null) ? cacheControlVect.toString().toLowerCase() : "";
+                    (!cacheControlList.isEmpty()) ? cacheControlList.toString().toLowerCase() : "";
 
             if (cacheControlHeaders.isEmpty()
                     || // No Cache-Control header at all
@@ -82,8 +82,8 @@ public class CacheControlScanner extends PluginPassiveScanner {
                 this.raiseAlert(msg, id, HttpHeader.CACHE_CONTROL, cacheControlHeaders);
             }
 
-            Vector<String> pragma = msg.getResponseHeader().getHeaders(HttpHeader.PRAGMA);
-            if (pragma != null) {
+            List<String> pragma = msg.getResponseHeader().getHeaderValues(HttpHeader.PRAGMA);
+            if (!pragma.isEmpty()) {
                 for (String pragmaDirective : pragma) {
                     if (pragmaDirective.toLowerCase().indexOf("no-cache") < 0) {
                         this.raiseAlert(msg, id, HttpHeader.PRAGMA, pragmaDirective);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanner.java
@@ -26,7 +26,6 @@ import com.shapesecurity.salvation.data.Policy;
 import com.shapesecurity.salvation.data.URI;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
@@ -93,15 +92,15 @@ public class ContentSecurityPolicyScanner extends PluginPassiveScanner {
 
         // Content-Security-Policy is supported by Chrome 25+, Firefox 23+,
         // Safari 7+, Edge but not Internet Explorer
-        Vector<String> cspOptions = msg.getResponseHeader().getHeaders(HTTP_HEADER_CSP);
-        if (cspOptions != null && !cspOptions.isEmpty()) {
+        List<String> cspOptions = msg.getResponseHeader().getHeaderValues(HTTP_HEADER_CSP);
+        if (!cspOptions.isEmpty()) {
             cspHeaderFound = true;
         }
 
         // X-Content-Security-Policy is an older header, supported by Firefox
         // 4.0+, and IE 10+ (in a limited fashion)
-        Vector<String> xcspOptions = msg.getResponseHeader().getHeaders(HTTP_HEADER_XCSP);
-        if (xcspOptions != null && !xcspOptions.isEmpty()) {
+        List<String> xcspOptions = msg.getResponseHeader().getHeaderValues(HTTP_HEADER_XCSP);
+        if (!xcspOptions.isEmpty()) {
             raiseAlert(
                     msg,
                     Constant.messages.getString(MESSAGE_PREFIX + "xcsp.name"),
@@ -113,8 +112,9 @@ public class ContentSecurityPolicyScanner extends PluginPassiveScanner {
         }
 
         // X-WebKit-CSP is supported by Chrome 14+, and Safari 6+
-        Vector<String> xwkcspOptions = msg.getResponseHeader().getHeaders(HTTP_HEADER_WEBKIT_CSP);
-        if (xwkcspOptions != null && !xwkcspOptions.isEmpty()) {
+        List<String> xwkcspOptions =
+                msg.getResponseHeader().getHeaderValues(HTTP_HEADER_WEBKIT_CSP);
+        if (!xwkcspOptions.isEmpty()) {
             raiseAlert(
                     msg,
                     Constant.messages.getString(MESSAGE_PREFIX + "xwkcsp.name"),

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanner.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import java.util.Vector;
+import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -45,9 +45,9 @@ public class ContentTypeMissingScanner extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getResponseBody().length() > 0) {
-            Vector<String> contentType =
-                    msg.getResponseHeader().getHeaders(HttpHeader.CONTENT_TYPE);
-            if (contentType != null) {
+            List<String> contentType =
+                    msg.getResponseHeader().getHeaderValues(HttpHeader.CONTENT_TYPE);
+            if (!contentType.isEmpty()) {
                 for (String contentTypeDirective : contentType) {
                     if (contentTypeDirective.isEmpty()) {
                         this.raiseAlert(msg, id, contentTypeDirective, false);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanner.java
@@ -19,8 +19,8 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
+import java.util.List;
 import java.util.Set;
-import java.util.Vector;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.collections.iterators.IteratorChain;
 import org.parosproxy.paros.Constant;
@@ -57,15 +57,15 @@ public class CookieHttpOnlyScanner extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         IteratorChain iterator = new IteratorChain();
-        Vector<String> cookies1 = msg.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE);
+        List<String> cookies1 = msg.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE);
 
-        if (cookies1 != null) {
+        if (!cookies1.isEmpty()) {
             iterator.addIterator(cookies1.iterator());
         }
 
-        Vector<String> cookies2 = msg.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE2);
+        List<String> cookies2 = msg.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE2);
 
-        if (cookies2 != null) {
+        if (!cookies2.isEmpty()) {
             iterator.addIterator(cookies2.iterator());
         }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanner.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import java.util.Vector;
+import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -60,9 +60,9 @@ public class CookieSameSiteScanner extends PluginPassiveScanner {
     }
 
     private void checkCookies(HttpMessage msg, int id, String cookieHeader) {
-        Vector<String> cookies = msg.getResponseHeader().getHeaders(cookieHeader);
+        List<String> cookies = msg.getResponseHeader().getHeaderValues(cookieHeader);
 
-        if (cookies == null) {
+        if (cookies.isEmpty()) {
             return;
         }
         for (String cookie : cookies) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanner.java
@@ -19,8 +19,8 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
+import java.util.List;
 import java.util.Set;
-import java.util.Vector;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.collections.iterators.IteratorChain;
 import org.parosproxy.paros.Constant;
@@ -62,15 +62,15 @@ public class CookieSecureFlagScanner extends PluginPassiveScanner {
         }
 
         IteratorChain iterator = new IteratorChain();
-        Vector<String> cookies1 = msg.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE);
+        List<String> cookies1 = msg.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE);
 
-        if (cookies1 != null) {
+        if (!cookies1.isEmpty()) {
             iterator.addIterator(cookies1.iterator());
         }
 
-        Vector<String> cookies2 = msg.getResponseHeader().getHeaders(HttpHeader.SET_COOKIE2);
+        List<String> cookies2 = msg.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE2);
 
-        if (cookies2 != null) {
+        if (!cookies2.isEmpty()) {
             iterator.addIterator(cookies2.iterator());
         }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeaderXssProtectionScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/HeaderXssProtectionScanner.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import java.util.Vector;
+import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -64,10 +64,10 @@ public class HeaderXssProtectionScanner extends PluginPassiveScanner {
             }
         }
         boolean headerPresent = false;
-        Vector<String> xssHeaderProtection =
-                msg.getResponseHeader().getHeaders(HttpHeader.X_XSS_PROTECTION);
+        List<String> xssHeaderProtection =
+                msg.getResponseHeader().getHeaderValues(HttpHeader.X_XSS_PROTECTION);
         boolean possibleXSSCarrier = msg.getResponseBody().length() > 0;
-        if (xssHeaderProtection != null) {
+        if (!xssHeaderProtection.isEmpty()) {
             headerPresent = true;
             if (possibleXSSCarrier) {
                 for (String xssHeaderProtectionParam : xssHeaderProtection) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanner.java
@@ -25,7 +25,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
@@ -65,7 +64,7 @@ public class InformationDisclosureReferrerScanner extends PluginPassiveScanner {
                 && !isRequestedURLSameDomainAsHTTPReferrer(
                         msg.getRequestHeader().getHostName(),
                         msg.getRequestHeader().getHeader(HttpHeader.REFERER))) {
-            Vector<String> referrer = msg.getRequestHeader().getHeaders(HttpHeader.REFERER);
+            List<String> referrer = msg.getRequestHeader().getHeaderValues(HttpHeader.REFERER);
             String evidence;
             for (String referrerValue : referrer) {
                 if ((evidence = doesURLContainsSensitiveInformation(referrerValue)) != null) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScan.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScan.java
@@ -21,8 +21,8 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
-import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
@@ -83,8 +83,8 @@ public class InsecureAuthenticationScan extends PluginPassiveScanner {
             return;
         }
 
-        Vector<String> headers = msg.getRequestHeader().getHeaders(HttpHeader.AUTHORIZATION);
-        if (headers != null) {
+        List<String> headers = msg.getRequestHeader().getHeaderValues(HttpHeader.AUTHORIZATION);
+        if (!headers.isEmpty()) {
             for (Iterator<String> i = headers.iterator(); i.hasNext(); ) {
                 String authHeaderValue = i.next();
                 String authMechanism = null;
@@ -290,9 +290,9 @@ public class InsecureAuthenticationScan extends PluginPassiveScanner {
             // If SSL is used then the use of 'weak' authentication methods isnt really an issue
             return;
         }
-        Vector<String> authHeaders =
-                msg.getResponseHeader().getHeaders(HttpHeader.WWW_AUTHENTICATE);
-        if (authHeaders != null) {
+        List<String> authHeaders =
+                msg.getResponseHeader().getHeaderValues(HttpHeader.WWW_AUTHENTICATE);
+        if (!authHeaders.isEmpty()) {
             for (String auth : authHeaders) {
                 if (auth.toLowerCase().indexOf("basic") > -1
                         || auth.toLowerCase().indexOf("digest") > -1) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanner.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,14 +31,10 @@ import net.htmlparser.jericho.Source;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
-import org.zaproxy.zap.extension.users.ExtensionUserManagement;
-import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.users.User;
 
 public class UsernameIdorScanner extends PluginPassiveScanner {
@@ -62,8 +57,6 @@ public class UsernameIdorScanner extends PluginPassiveScanner {
 
     private List<User> testUsers = null;
 
-    private ExtensionUserManagement extUserMgmt;
-
     @Override
     public void setParent(PassiveScanThread parent) {
         this.parent = parent;
@@ -81,13 +74,7 @@ public class UsernameIdorScanner extends PluginPassiveScanner {
             return testUsers;
         }
 
-        if (getExtensionUserManagement() == null) {
-            return Collections.emptyList();
-        }
-
-        for (Context context : Model.getSingleton().getSession().getContexts()) {
-            usersList.addAll(extUserMgmt.getContextUserAuthManager(context.getIndex()).getUsers());
-        }
+        usersList.addAll(getHelper().getUsers());
         return usersList;
     }
 
@@ -203,23 +190,9 @@ public class UsernameIdorScanner extends PluginPassiveScanner {
         return payloadProvider;
     }
 
-    // The following methods support unit testing
+    // The following method supports unit testing
     protected void setUsers(String username) {
         testUsers = new ArrayList<User>();
         this.testUsers.add(new User(testUsers.size() + 1, username));
-    }
-
-    protected ExtensionUserManagement getExtensionUserManagement() {
-        if (extUserMgmt == null) {
-            extUserMgmt =
-                    Control.getSingleton()
-                            .getExtensionLoader()
-                            .getExtension(ExtensionUserManagement.class);
-        }
-        return extUserMgmt;
-    }
-
-    protected void setExtensionUserManagement(ExtensionUserManagement extensionUserManagement) {
-        this.extUserMgmt = extensionUserManagement;
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanner.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -58,10 +57,10 @@ public class XAspNetVersionScanner extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         for (String header : xAspNetHeaders) {
-            Vector<String> found = msg.getResponseHeader().getHeaders(header);
+            List<String> found = msg.getResponseHeader().getHeaderValues(header);
 
-            if (found != null) {
-                this.raiseAlert(msg, id, found.firstElement());
+            if (!found.isEmpty()) {
+                this.raiseAlert(msg, id, found.get(0));
             }
         }
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanner.java
@@ -19,8 +19,8 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
+import java.util.List;
 import java.util.Locale;
-import java.util.Vector;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -62,9 +62,9 @@ public class XContentTypeOptionsScanner extends PluginPassiveScanner {
                             || HttpStatusCode.isRedirection(responseStatus))) {
                 return;
             }
-            Vector<String> xContentTypeOptions =
-                    msg.getResponseHeader().getHeaders(HttpHeader.X_CONTENT_TYPE_OPTIONS);
-            if (xContentTypeOptions == null) {
+            List<String> xContentTypeOptions =
+                    msg.getResponseHeader().getHeaderValues(HttpHeader.X_CONTENT_TYPE_OPTIONS);
+            if (xContentTypeOptions.isEmpty()) {
                 this.raiseAlert(msg, id, "");
             } else {
                 for (String xContentTypeOptionsDirective : xContentTypeOptions) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanner.java
@@ -116,7 +116,7 @@ public class XDebugTokenScanner extends PluginPassiveScanner {
      * @return boolean status of existence
      */
     private boolean responseHasHeader(HttpMessage msg, String header) {
-        return null != msg.getResponseHeader().getHeaders(header);
+        return !msg.getResponseHeader().getHeaderValues(header).isEmpty();
     }
 
     /**

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanner.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.List;
-import java.util.Vector;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
@@ -76,8 +75,8 @@ public class XFrameOptionScanner extends PluginPassiveScanner {
             }
             // CSP takes precedence
             includedInCsp = false;
-            Vector<String> csp = msg.getResponseHeader().getHeaders("Content-Security-Policy");
-            if (csp != null && csp.toString().contains("frame-ancestors")) {
+            List<String> csp = msg.getResponseHeader().getHeaderValues("Content-Security-Policy");
+            if (!csp.isEmpty() && csp.toString().contains("frame-ancestors")) {
                 // We could do more parsing here, but that will be non trivial
                 includedInCsp = true;
             }
@@ -87,9 +86,9 @@ public class XFrameOptionScanner extends PluginPassiveScanner {
                 return;
             }
 
-            Vector<String> xFrameOption =
-                    msg.getResponseHeader().getHeaders(HttpHeader.X_FRAME_OPTION);
-            if (xFrameOption != null) {
+            List<String> xFrameOption =
+                    msg.getResponseHeader().getHeaderValues(HttpHeader.X_FRAME_OPTION);
+            if (!xFrameOption.isEmpty()) {
                 for (String xFrameOptionParam : xFrameOption) {
                     if (xFrameOptionParam.toLowerCase().indexOf("deny") < 0
                             && xFrameOptionParam.toLowerCase().indexOf("sameorigin") < 0

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanner.java
@@ -80,7 +80,7 @@ public class XPoweredByHeaderInfoLeakScanner extends PluginPassiveScanner {
      * @return boolean status of existence
      */
     private boolean isXPoweredByHeaderExist(HttpMessage msg) {
-        return null != msg.getResponseHeader().getHeaders(HEADER_NAME);
+        return !msg.getResponseHeader().getHeaderValues(HEADER_NAME).isEmpty();
     }
 
     /**

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/payloader/ExtensionPayloader.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.pscanrules.payloader;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -85,15 +83,6 @@ public class ExtensionPayloader extends ExtensionAdaptor {
     @Override
     public String getAuthor() {
         return Constant.ZAP_TEAM;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override


### PR DESCRIPTION
- UsernameIdorScanner > Updated to leverage `getHelper().getUsers`.
- pscanrules.gradle.kts > Updated to use `org.zaproxy:zap:2.9.0`.
- CHANGELOG.md > Added change notes related to core changes and 'Username Hash Found' scan rule change.
&nbsp;
- Various scan rules updated to accommodate core deprecations related to: zaproxy/zaproxy#5756
&nbsp;
- ExtensionPayloader > Removed `getUrl()` use of `Constant.ZAP_HOMEPAGE`.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>