### PR TITLE
Use newer ZAP version for API generation

### DIFF
--- a/addOns/accessControl/accessControl.gradle.kts
+++ b/addOns/accessControl/accessControl.gradle.kts
@@ -9,4 +9,9 @@ zapAddOn {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/access-control-testing/")
     }
+
+    apiClientGen {
+        api.set("org.zaproxy.zap.extension.accessControl.AccessControlAPI")
+        messages.set(file("src/main/resources/org/zaproxy/zap/extension/accessControl/resources/Messages.properties"))
+    }
 }

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAPI.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAPI.java
@@ -62,6 +62,11 @@ public class AccessControlAPI extends ApiImplementor {
 
     private static final Logger LOGGER = Logger.getLogger(AccessControlAPI.class);
 
+    /** Provided only for API client generator usage. */
+    public AccessControlAPI() {
+        this(null);
+    }
+
     public AccessControlAPI(ExtensionAccessControl extension) {
         this.extension = extension;
         this.addApiAction(

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -42,7 +42,7 @@ subprojects {
         toolVersion = jacocoToolVersion
     }
 
-    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.8.0"))
+    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.9.0"))
 
     zapAddOn {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })

--- a/addOns/exportreport/exportreport.gradle.kts
+++ b/addOns/exportreport/exportreport.gradle.kts
@@ -9,6 +9,11 @@ zapAddOn {
         author.set("Goran Sarenkapa - JordanGS")
         url.set("https://www.zaproxy.org/docs/desktop/addons/export-report/")
     }
+
+    apiClientGen {
+        api.set("org.zaproxy.zap.extension.exportreport.ExportReportAPI")
+        messages.set(file("src/main/resources/org/zaproxy/zap/extension/exportreport/resources/Messages.properties"))
+    }
 }
 
 dependencies {

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/ExportReportAPI.java
@@ -62,6 +62,11 @@ public class ExportReportAPI extends ApiImplementor {
 
     private ExtensionExportReport extension;
 
+    /** Provided only for API client generator usage. */
+    public ExportReportAPI() {
+        this(null);
+    }
+
     public ExportReportAPI(ExtensionExportReport extension) {
         super();
         this.extension = extension;

--- a/addOns/revisit/revisit.gradle.kts
+++ b/addOns/revisit/revisit.gradle.kts
@@ -9,4 +9,9 @@ zapAddOn {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/revisit/")
     }
+
+    apiClientGen {
+        api.set("org.zaproxy.zap.extension.revisit.RevisitAPI")
+        messages.set(file("src/main/resources/org/zaproxy/zap/extension/revisit/resources/Messages.properties"))
+    }
 }

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RevisitAPI.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RevisitAPI.java
@@ -51,6 +51,11 @@ public class RevisitAPI extends ApiImplementor {
 
     private ExtensionRevisit extension;
 
+    /** Provided only for API client generator usage. */
+    public RevisitAPI() {
+        this(null);
+    }
+
     public RevisitAPI(ExtensionRevisit extension) {
         super();
         this.extension = extension;

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
@@ -43,6 +43,11 @@ public class WappalyzerAPI extends ApiImplementor {
 
     private ExtensionWappalyzer extension = null;
 
+    /** Provided only for API client generator usage. */
+    public WappalyzerAPI() {
+        this(null);
+    }
+
     public WappalyzerAPI(ExtensionWappalyzer ext) {
         this.extension = ext;
         this.addApiView(new ApiView(VIEW_LIST_SITES));

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -9,6 +9,11 @@ zapAddOn {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/technology-detection/")
     }
+
+    apiClientGen {
+        api.set("org.zaproxy.zap.extension.wappalyzer.WappalyzerAPI")
+        messages.set(file("src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties"))
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Configure the build to use 2.9.0 for API generation.
Add API client generation configuration and default API constructors
to `accessControl`, `exportreport`, `revisit`, and `wappalyzer`.