### PR TITLE
zest: update Zest library and prepare release

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [32] - 2020-01-24
+### Changed
+- Update Zest library to 0.14.2, to correctly ignore cert checks.
 
 ## [31] - 2020-01-17
 ### Added
@@ -221,6 +222,7 @@ Sender scripts. (Issue 5590)
 
 - Updated for 2.1.0
 
+[32]: https://github.com/zaproxy/zap-extensions/releases/zest-v32
 [31]: https://github.com/zaproxy/zap-extensions/releases/zest-v31
 [30]: https://github.com/zaproxy/zap-extensions/releases/zest-v30
 [29]: https://github.com/zaproxy/zap-extensions/releases/zest-v29

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -87,7 +87,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 
     /** */
     public ZestZapRunner(ExtensionZest extension, ZestScriptWrapper wrapper) {
-        super();
+        super(Default.TIMEOUT_IN_SECONDS, true);
         log.debug("Constructor");
         this.extension = extension;
         this.wrapper = wrapper;

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -34,7 +34,7 @@ zapAddOn {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("selenium")!!)
-    implementation("org.mozilla:zest:0.14.1") {
+    implementation("org.mozilla:zest:0.14.2") {
         // Provided by Selenium add-on.
         exclude(group = "org.seleniumhq.selenium")
         exclude(group = "com.codeborne", module = "phantomjsdriver")


### PR DESCRIPTION
Update Zest library to 0.14.2, to correctly ignore cert checks.
Update ZestZapRunner to ignore cert checks (e.g. when proxying through
ZAP).
Add release date and link to tag.