### PR TITLE
Fix 5834: Information Disclosure: Suspicious Comments

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Minimum ZAP version is now 2.9.0. (Various scan rules adjusted to address core deprecations.)
 - 'Username Hash Found' scan rule now uses updated core functionality to retrieve configured users.
 - Tweak help for 'Cookie HttpOnly' scan rule.
+- 'Information Disclosure: Suspicious Comments' if matched within script block or JS response raise Alert with Low confidence.
 - Migrate an input file from Beta to Release that were missed during previous promotions.
   - This addresses errors such as `[ZAP-PassiveScanner] ERROR org.zaproxy.zap.extension.pscanrules.InformationDisclosureInURL  - No such file: .... /xml/URL-information-disclosure-messages.txt`
 

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -11,7 +11,8 @@ Passive Scan Rules
 The following release quality passive scan rules are included in this add-on:
 
 <H2>Application Errors</H2>        
-Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string.<br>
+Check server responses for HTTP 500 - Internal Server Error type responses or those that contain a known error string. 
+<strong>Note:</strong> Matches made within script blocks or files are against the entire content not only comments.<br>
 At HIGH Threshold don’t alert on HTTP 500 (but do for other error patterns).<br>
 For Internal Server Error (HTTP 500) the Alert is set to Low risk and in other case it is set to Medium risk.
 <p>

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -74,7 +74,8 @@ pscanrules.informationdisclosurereferrerscanner.otherinfo.ssn=The URL in the HTT
 pscanrules.informationdisclosurereferrerscanner.soln=Do not pass sensitive information in URIs.
 
 pscanrules.informationdisclosuresuspiciouscomments.name=Information Disclosure - Suspicious Comments
-pscanrules.informationdisclosuresuspiciouscomments.desc=The response appears to contain suspicious comments which may help an attacker.
+pscanrules.informationdisclosuresuspiciouscomments.desc=The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.
+pscanrules.informationdisclosuresuspiciouscomments.otherinfo=The following comment/snippet was identified via the pattern: {0}\n{1}
 pscanrules.informationdisclosuresuspiciouscomments.soln=Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.
 
 pscanrules.insecureauthentication.name=Weak Authentication Method

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsUnitTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.Test;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -95,6 +96,7 @@ public class InformationDisclosureSuspiciousCommentsUnitTest
 
         // Then
         assertEquals(1, alertsRaised.size());
+        assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
     }
 
     @Test
@@ -152,6 +154,7 @@ public class InformationDisclosureSuspiciousCommentsUnitTest
 
         // Then
         assertEquals(1, alertsRaised.size());
+        assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
     }
 
     @Test


### PR DESCRIPTION
* When matching in JavaScript or script blocks alerts at Low confidence.
* All alerts now contain more specific "other info" details.
* Updated UnitTest to assert new confidence detail.
* Updated changelog with change details.
* Messages.properties updated with new key/value to facilitate "other info" enhancement.

Fixes zaproxy/zaproxy#5834

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>