### PR TITLE
Update blog links and fix typos

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fix typo in the help page.
 
 ## [34] - 2020-01-17
 ### Added

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -114,7 +114,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 
 <H2>Remote File Include</H2>
 
-This rule submits a series of requests with external URLs as parameter values and looks for a match between the the response body and the title of the page
+This rule submits a series of requests with external URLs as parameter values and looks for a match between the response body and the title of the page
 hosted at those URLs. If there is a match between the expected string and the response body, and the header returned a status code of 200, an alert is raised and the scanner
 returns immediately.
 <p>

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Change info URL to link to the site.
+- Update ZAP blog links.
 
 ## [27] - 2019-12-16
 

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -12,7 +12,7 @@ The following alpha quality active scan rules are included in this add-on:
 <H2>An example active scan rule which loads data from a file</H2>
 This implements an example active scan rule that loads strings from a file that the user can edit.<br>
 For more details see: 
-<a href="http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html">Hacking ZAP Part 4: Active Scan Rules.</a>
+<a href="https://www.zaproxy.org/blog/2014-04-30-hacking-zap-4-active-scan-rules/">Hacking ZAP Part 4: Active Scan Rules</a>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java">ExampleFileActiveScanner.java</a>
 
@@ -31,7 +31,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 <H2>Example Active Scanner: Denial of Service</H2>
 This implements a very simple example active scan rule.<br>
 For more details see: 
-<a href="http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-4-active-scan-rules.html">Hacking ZAP Part 4: Active Scan Rules.</a>
+<a href="https://www.zaproxy.org/blog/2014-04-30-hacking-zap-4-active-scan-rules/">Hacking ZAP Part 4: Active Scan Rules</a>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java">ExampleSimpleActiveScanner.java</a>
 

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migrate an input file from Beta to Release that were missed during previous promotions.
   - This addresses errors such as `[ZAP-PassiveScanner] ERROR org.zaproxy.zap.extension.pscanrules.InformationDisclosureInURL  - No such file: .... /xml/URL-information-disclosure-messages.txt`
 
+### Fixed
+- Fix typo in the help page.
+
 ## [26] - 2020-01-17
 
 ### Changed

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -133,7 +133,7 @@ Attempts to identify the existence of sensitive details within the visited URIs 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInURL.java">InformationDisclosureInURL.java</a>
 
 <H2>Information Disclosure: Referrer</H2>
-Identifies the existence of sensitive details within the the Referrer header field of HTTP requests
+Identifies the existence of sensitive details within the Referrer header field of HTTP requests
 (this may include parameters, document names, directory names, etc.).
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanner.java">InformationDisclosureReferrerScanner.java</a>

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added links to the code in the help.
 - Add info and repo URLs.
 
+### Changed
+- Update ZAP blog links.
+
 ### Fixed
 - Fixed NullPointerException in Sub Resource Integrity Attribute Missing scan rule (Issue 5789).
 - Minor spacing issue in help content.

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -11,7 +11,7 @@ The following alpha quality passive scan rules are included in this add-on:
 
 <H2>An example passive scan rule which loads data from a file</H2>
 This implements an example passive scan rule that loads strings from a file that the user can edit.<br>
-For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
+For more details see: <a href="https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/">Hacking ZAP Part 3: Passive Scan Rules</a>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanner.java">ExampleFilePassiveScanner.java</a>
 
@@ -38,7 +38,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 
 <H2>Example Passive Scanner: Denial of Service</H2>
 This implements a very simple example passive scan rule.<br>
-For more details see: http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
+For more details see: <a href="https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/">Hacking ZAP Part 3: Passive Scan Rules</a>.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanner.java">ExampleSimplePassiveScanner.java</a>
 


### PR DESCRIPTION
Link to site blog posts (from zaproxy/zaproxy-website#15).
Remove duplicated "the" (from zaproxy/zaproxy-website#16).