### PR TITLE
Fix issue 5841 - PII False Positives on exponential numbers

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added links to the code in the help.
 - Add info and repo URLs.
 
+### Changed
+- 'PII Disclosure scanner' alerts and help entry renamed 'PII Disclosure' for clarity and proper title caps.
+- 'PII Disclosure' added further false positive handling with regard to exponential numbers such as 2.4670000000000001E-2 or 2.4670000000000001E2.
+
 ## [21] - 2019-12-16
 
 ### Added

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -70,7 +70,7 @@ Open redirects are one of the OWASP 2010 Top Ten vulnerabilities. This check loo
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanner.java">UserControlledOpenRedirectScanner.java</a>
 
-<H2>PII Disclosure scanner</H2>
+<H2>PII Disclosure</H2>
 PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanner.java">PiiScanner.java</a>

--- a/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -52,7 +52,7 @@ pscanbeta.linktarget.desc=At least one link on this page is vulnerable to Revers
 pscanbeta.linktarget.refs=https://www.owasp.org/index.php/Reverse_Tabnabbing\nhttps://dev.to/ben/the-targetblank-vulnerability-by-example\nhttps://mathiasbynens.github.io/rel-noopener/\nhttps://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c\n
 pscanbeta.linktarget.soln=Do not use a target attribute, or if you have to then also add the attribute: rel="noopener noreferrer".
 
-pscanbeta.piiscanner.name = PII Scanner
+pscanbeta.piiscanner.name = PII Disclosure
 pscanbeta.piiscanner.desc = The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
 pscanbeta.piiscanner.extrainfo = Credit Card Type detected: {0}
 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScannerCreditCardUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScannerCreditCardUnitTest.java
@@ -75,7 +75,7 @@ public class PiiScannerCreditCardUnitTest extends PassiveScannerTest<PiiScanner>
 
         // Then
         assertThat(alertsRaised.size(), is(1));
-        assertThat(alertsRaised.get(0).getName(), equalTo("PII Scanner"));
+        assertThat(alertsRaised.get(0).getName(), equalTo("PII Disclosure"));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo(cardNumber.replaceAll("\\s+", "")));
     }
 }

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScannerUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScannerUnitTest.java
@@ -61,6 +61,62 @@ public class PiiScannerUnitTest extends PassiveScannerTest<PiiScanner> {
         assertThat(alertsRaised.size(), is(0));
     }
 
+    @Test
+    public void shouldNotRaiseAlertInLeadingLongExponentNumbers() throws Exception {
+        // Given
+        String content =
+                "2.14111111111111111e-2"; // Visa - Extra digit before card number (after decimal)
+        HttpMessage msg = createMsg(content);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertInTrailingLongNegativeExponentNumbers() throws Exception {
+        // Given
+        String content = "2.41111111111111111e-2"; // Visa - Extra digit before e
+        HttpMessage msg = createMsg(content);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertInTrailingLongPositiveExponentNumbers() throws Exception {
+        // Given
+        String content = "2.41111111111111111e2"; // Visa - Extra digit before e
+        HttpMessage msg = createMsg(content);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertInPositiveExponentNumbers() throws Exception {
+        // Given
+        String content = "2.4111111111111111e2"; // Visa - Valid ahead of exponent
+        HttpMessage msg = createMsg(content);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    public void shouldRaiseAlertInPlausiblePeriodDelimitedContent() throws Exception {
+        // Given
+        String content = "1121.4111111111111111.John Smith.808"; // Visa
+        HttpMessage msg = createMsg(content);
+        // When
+        rule.scanHttpResponseReceive(msg, -1, this.createSource(msg));
+        // Then
+        assertThat(alertsRaised.size(), is(1));
+    }
+
     private HttpMessage createMsg(String cardNumber) throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");


### PR DESCRIPTION
Despite the previously added boundary check if number sequences were exactly the right length they may still be flagged as CC even though they may be numbers with exponents. Tweak the alert name to be more clear (from 'PII Disclosure scanner' to 'PII Disclosure'). The scan rule now attempts to grab characters after the matched string and convert to Float, so that values such as 2.4670000000000001E-2 or 2.4670000000000001E2 are no longer considered CCs.

Includes UnitTest updates, help tweak, and change log entries.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>