### PR TITLE
Issue 5837: Add High Threshold Handling

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Migrate an input file from Beta to Release that were missed during previous promotions.
   - This addresses errors such as `[ZAP-PassiveScanner] ERROR org.zaproxy.zap.extension.pscanrules.InformationDisclosureInURL  - No such file: .... /xml/URL-information-disclosure-messages.txt`
 - 'Application Error' scan rule now supports custom payloads when used in conjunction with the Custom Payloads addon.
+- Timestamp Disclosure scan rule now only considers potential timestamps within plus or minus one year when used at High threshold (Issue 5837).
 
 ## [26] - 2020-01-17
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanner.java
@@ -20,6 +20,8 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -32,6 +34,7 @@ import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpHeaderField;
 import org.parosproxy.paros.network.HttpMessage;
@@ -167,6 +170,15 @@ public class TimestampDisclosureScanner extends PluginPassiveScanner {
 
                         if (evidence != null && evidence.length() > 0) {
                             // we found something.. potentially
+                            if (AlertThreshold.HIGH.equals(this.getAlertThreshold())) {
+                                Instant foundInstant =
+                                        Instant.ofEpochSecond(Long.parseLong(evidence));
+                                ZonedDateTime now = ZonedDateTime.now();
+                                if (!(foundInstant.isAfter(now.minusYears(1).toInstant())
+                                        && foundInstant.isBefore(now.plusYears(1).toInstant()))) {
+                                    continue;
+                                }
+                            }
                             Alert alert =
                                     new Alert(
                                             getPluginId(),

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -192,7 +192,8 @@ is not greater than 8 characters in length then the parameter is ignored
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TestInfoSessionIdURL.java">TestInfoSessionIdURL.java</a>
 
 <H2>Timestamp Disclosure</H2>
-A timestamp was disclosed by the application/web server.
+A timestamp was disclosed by the application/web server.<br>
+At HIGH threshold this rule does not alert on potential timestamps that are not within a range of plus or minus one year.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanner.java">TimestampDisclosureScanner.java</a>
 


### PR DESCRIPTION
Timestamp Disclosure scan rule now only considers potential timestamps within plus or minus one year when used at High threshold.

Fixes zaproxy/zaproxy#5837

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>