### PR TITLE
webdrivers: update ChromeDriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [17] - 2020-02-05
+### Changed
+- Update ChromeDriver to v80.0.3987.16.
 
 ## [16] - 2020-01-17
 ### Added
@@ -84,6 +85,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[17]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v17
 [16]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v16
 [15]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v15
 [14]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v14

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,7 +9,7 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 79.0.3945.36</li>
+    <li>Chrome - ChromeDriver 80.0.3987.16</li>
     <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [16] - 2020-02-05
+### Changed
+- Update ChromeDriver to 80.0.3987.16.
 
 ## [15] - 2020-01-17
 ### Added
@@ -80,6 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[16]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v16
 [15]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v15
 [14]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v14
 [13]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v13

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,7 +9,7 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 79.0.3945.36</li>
+    <li>Chrome - ChromeDriver 80.0.3987.16</li>
     <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.26.0"
-val chromeDriverVersion = "79.0.3945.36"
+val chromeDriverVersion = "80.0.3987.16"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [17] - 2020-02-05
+### Changed
+- Update ChromeDriver to 80.0.3987.16.
 
 ## [16] - 2020-01-17
 ### Added
@@ -87,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[17]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v17
 [16]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v16
 [15]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v15
 [14]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v14

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,7 +9,7 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 79.0.3945.36</li>
+    <li>Chrome - ChromeDriver 80.0.3987.16</li>
     <li>Firefox - geckodriver 0.26.0</li>
 </ul>
 


### PR DESCRIPTION
- Update ChromeDriver to 80.0.3987.16

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>