### PR TITLE
Issue 5832: Clarify URL Info Disclosure

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - This addresses errors such as `[ZAP-PassiveScanner] ERROR org.zaproxy.zap.extension.pscanrules.InformationDisclosureInURL  - No such file: .... /xml/URL-information-disclosure-messages.txt`
 - 'Application Error' scan rule now supports custom payloads when used in conjunction with the Custom Payloads addon.
 - Timestamp Disclosure scan rule now only considers potential timestamps within plus or minus one year when used at High threshold (Issue 5837).
--  'Application Error' scan rule's patterns file `application_errors.xml` is now copied to ZAP's home directory, which means it is editable by the user. As well as being more consistent with other similar input files.
+- 'Application Error' scan rule's patterns file `application_errors.xml` is now copied to ZAP's home directory, which means it is editable by the user. As well as being more consistent with other similar input files.
+- 'Information Disclosure - Sensitive Information in URL' correct evidence field for some alerts, and enhance other info details (Issue 5832).
 
 ### Removed
 - 'Header XSS Protection' was deprecated and removed (Issue 5849).

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInURL.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInURL.java
@@ -61,13 +61,17 @@ public class InformationDisclosureInURL extends PluginPassiveScanner {
     public void scanHttpRequestSend(HttpMessage msg, int id) {
         TreeSet<HtmlParameter> urlParams = msg.getUrlParams();
         for (HtmlParameter urlParam : urlParams) {
-            if (doesParamNameContainsSensitiveInformation(urlParam.getName())) {
+            String match = doesParamNameContainsSensitiveInformation(urlParam.getName());
+            if (match != null) {
                 this.raiseAlert(
                         msg,
                         id,
                         urlParam.getName(),
-                        urlParam.getValue(),
-                        Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.sensitiveinfo"));
+                        urlParam.getName(),
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "otherinfo.sensitiveinfo",
+                                match,
+                                urlParam.getName()));
             }
             if (isCreditCard(urlParam.getValue())) {
                 this.raiseAlert(
@@ -139,7 +143,7 @@ public class InformationDisclosureInURL extends PluginPassiveScanner {
         return strings;
     }
 
-    private boolean doesParamNameContainsSensitiveInformation(String paramName) {
+    private String doesParamNameContainsSensitiveInformation(String paramName) {
         if (InformationDisclosureInURL.messages == null) {
             InformationDisclosureInURL.messages =
                     loadFile(
@@ -150,10 +154,10 @@ public class InformationDisclosureInURL extends PluginPassiveScanner {
         String ciParamName = paramName.toLowerCase();
         for (String msg : InformationDisclosureInURL.messages) {
             if (ciParamName.contains(msg)) {
-                return true;
+                return msg;
             }
         }
-        return false;
+        return null;
     }
 
     @Override

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -53,7 +53,7 @@ pscanrules.informationdisclosuredebugerrors.soln=Disable debugging messages befo
 
 pscanrules.informationdisclosureinurl.name=Information Disclosure - Sensitive Information in URL
 pscanrules.informationdisclosureinurl.desc=The request appeared to contain sensitive information leaked in the URL. This can violate PCI and most organizational compliance policies. You can configure the list of strings for this check to add or remove values specific to your environment.
-pscanrules.informationdisclosureinurl.otherinfo.sensitiveinfo=The URL contains potentially sensitive information.
+pscanrules.informationdisclosureinurl.otherinfo.sensitiveinfo=The URL contains potentially sensitive information. The following string was found via the pattern: {0}\n{1}
 pscanrules.informationdisclosureinurl.otherinfo.cc=The URL appears to contain credit card information.
 pscanrules.informationdisclosureinurl.otherinfo.email=The URL contains email address(es).
 pscanrules.informationdisclosureinurl.otherinfo.ssn=The URL appears to contain US Social Security Number(s)

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInURLUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInURLUnitTest.java
@@ -93,11 +93,7 @@ public class InformationDisclosureInURLUnitTest
         // Then
         assertEquals(1, alertsRaised.size());
         assertEquals(sensitiveParamName, alertsRaised.get(0).getParam());
-        assertEquals(sensitiveValue, alertsRaised.get(0).getEvidence());
-        assertEquals(
-                Constant.messages.getString(
-                        InformationDisclosureInURL.MESSAGE_PREFIX + "otherinfo.sensitiveinfo"),
-                alertsRaised.get(0).getOtherInfo());
+        assertEquals(sensitiveParamName, alertsRaised.get(0).getEvidence());
     }
 
     @Test


### PR DESCRIPTION
- 'Information Disclosure - Sensitive Information in URL'
  - Expanded details in 'otherinfo' field.
  - Corrected evidence matching (paramnames are checked so paramnames should be evidence [not param values]).

Fixes zaproxy/zaproxy#5832

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>