### PR TITLE
Fix Issue 5856: Reduce alerting in Base64 Disclosure

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed NullPointerException in Sub Resource Integrity Attribute Missing scan rule (Issue 5789).
 - Minor spacing issue in help content.
+- Base64 Disclosure do not keep looping after identifying a disclosure (Issue 5856).
 
 ### Removed
 - 'Insecure Component' was deprecated and removed (Issue 5788).

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -332,7 +332,9 @@ public class Base64Disclosure extends PluginPassiveScanner {
                                 13, // Information Leakage
                                 msg);
                         parent.raiseAlert(id, alert);
-                        // do NOT break at this point.. we need to find *all* the issues
+                        if (!macless) {
+                            return;
+                        }
 
                         // if the ViewState is not protected by a MAC, alert it as a High, cos we
                         // can mess with the parameters for sure..
@@ -362,7 +364,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
                                     13, // Information Leakage
                                     msg);
                             parent.raiseAlert(id, alertmacless);
-                            // do NOT break at this point.. we need to find *all* the issues
+                            return;
                         }
                         // TODO: if the ViewState contains sensitive data, alert it (particularly if
                         // running over HTTP)
@@ -392,8 +394,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
                                     13, // Information Leakage
                                     msg);
                             parent.raiseAlert(id, alert);
-                            // do NOT break at this point.. we need to find *all* the potential
-                            // Base64 encoded data in the response..
+                            return;
                         }
                     }
                 }

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -33,7 +33,7 @@ pscanalpha.sourcecodedisclosure.refs=http://blogs.wsj.com/cio/2013/10/08/adobe-s
 pscanalpha.sourcecodedisclosure.extrainfo={0}
 
 pscanalpha.base64disclosure.name=Base64 Disclosure
-pscanalpha.base64disclosure.desc=Base64 encoded data was disclosed by the application/web server
+pscanalpha.base64disclosure.desc=Base64 encoded data was disclosed by the application/web server. Note: in the interests of performance not all base64 strings in the response were analyzed individually, the entire response should be looked at by the analyst/security team/developer(s).
 pscanalpha.base64disclosure.soln=Manually confirm that the Base64 data does not leak sensitive information, and that the data cannot be aggregated/used to exploit other vulnerabilities.
 pscanalpha.base64disclosure.refs=https://www.owasp.org/index.php/Top_10_2013-A6-Sensitive_Data_Exposure\nhttp://projects.webappsec.org/w/page/13246936/Information%20Leakage
 pscanalpha.base64disclosure.extrainfo={1}


### PR DESCRIPTION
Base64Disclosure > Functional change to return after alerting.
CHANGELOG > Added fix note.
Messages.properties > Added note to description.

Fixes zaproxy/zaproxy#5856


Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>