### PR TITLE
Backup File Disclosure Tweaks

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 - Add links to the code in the help.
 
+### Changed
+- Backup File Disclosure scan rule - updated CWE to 530, added reference links to alerts, made sure WASC and CWE identifiers are included in alerts.
+
 ## [27] - 2019-12-16
 
 ### Added

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
@@ -300,10 +300,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 
     @Override
     public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
+        return Constant.messages.getString("ascanbeta.backupfiledisclosure.desc");
     }
 
     @Override
@@ -321,17 +318,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 
     @Override
     public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
+        return Constant.messages.getString("ascanbeta.backupfiledisclosure.refs");
     }
 
     @Override
@@ -420,7 +407,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
 
     @Override
     public int getCweId() {
-        return 425; // Direct Request ('Forced Browsing')
+        return 530; // CWE-530: Exposure of Backup File to an Unauthorized Control Sphere
     }
 
     @Override
@@ -760,7 +747,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
                             Alert.RISK_MEDIUM,
                             Alert.CONFIDENCE_MEDIUM,
                             Constant.messages.getString("ascanbeta.backupfiledisclosure.name"),
-                            Constant.messages.getString("ascanbeta.backupfiledisclosure.desc"),
+                            getDescription(),
                             requestmsg
                                     .getRequestHeader()
                                     .getURI()
@@ -776,6 +763,9 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
                                     "ascanbeta.backupfiledisclosure.evidence",
                                     originalURI,
                                     candidateBackupFileURI.getURI()),
+                            getReference(),
+                            getCweId(),
+                            getWascId(),
                             requestmsg // originalMessage
                             );
                 }
@@ -820,7 +810,7 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
                             Alert.RISK_MEDIUM,
                             Alert.CONFIDENCE_MEDIUM,
                             Constant.messages.getString("ascanbeta.backupfiledisclosure.name"),
-                            Constant.messages.getString("ascanbeta.backupfiledisclosure.desc"),
+                            getDescription(),
                             requestmsg
                                     .getRequestHeader()
                                     .getURI()
@@ -836,6 +826,9 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
                                     "ascanbeta.backupfiledisclosure.evidence",
                                     originalURI,
                                     candidateBackupFileURI.getURI()),
+                            getReference(),
+                            getCweId(),
+                            getWascId(),
                             requestmsg // originalMessage
                             );
                 }

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -11,6 +11,7 @@ ascanbeta.backupfiledisclosure.name = Backup File Disclosure
 ascanbeta.backupfiledisclosure.desc = A backup of the file was disclosed by the web server
 ascanbeta.backupfiledisclosure.soln = Do not edit files in-situ on the web server, and ensure that un-necessary files (including hidden files) are removed from the web server.
 ascanbeta.backupfiledisclosure.evidence = A backup of [{0}] is available at [{1}]
+ascanbeta.backupfiledisclosure.refs = https://cwe.mitre.org/data/definitions/530.html\nhttps://wiki.owasp.org/index.php/Review_Old,_Backup_and_Unreferenced_Files_for_Sensitive_Information_(OTG-CONFIG-004)
 
 ascanbeta.cookieslack.name = Cookie Slack Detector
 ascanbeta.cookieslack.desc = Repeated GET requests: drop a different cookie each time, followed by normal request with all cookies to stabilize session, compare responses against original baseline GET. This can reveal areas where cookie based authentication/attributes are not actually enforced.


### PR DESCRIPTION
- Updated CWE to [530](https://cwe.mitre.org/data/definitions/530.html), added reference links to alerts, made sure WASC and CWE identifiers are included in alerts.
- Updated CHANGELOG.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>