### PR TITLE
pscanrules: CSP Salvation Library Upgrade to 2.7.1

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- 'CSP Scanner' rule upgrade salvation library to v2.7.1.
 
 ## [27] - 2020-02-11
 

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -29,13 +29,13 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.shapesecurity:salvation:2.7.0")
+    implementation("com.shapesecurity:salvation:2.7.1")
     implementation(project(":sharedutils"))
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
-    testImplementation("org.apache.commons:commons-lang3:3.7")
+    testImplementation("org.apache.commons:commons-lang3:3.9")
 }
 
 spotless {


### PR DESCRIPTION
- Tweak pscanrules.gradle.kts to use the updated libarary.
- Add 'change' entry to CHANGELOG

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>