### PR TITLE
Fix 5725: Spider Check for JSON/YAML'ish content

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Improve content checks when spidering for specifications (Issue 5725).
 
 ## [15] - 2020-01-17
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
@@ -19,7 +19,9 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
+import java.util.Locale;
 import net.htmlparser.jericho.Source;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.network.HttpHeader;
@@ -64,11 +66,18 @@ public class OpenApiSpider extends SpiderParser {
     @Override
     public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
         try {
-            String contentType = message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE);
-            if (contentType.toLowerCase().startsWith("text")
-                    && message.getResponseBody().toString().toLowerCase().startsWith("swagger:")) {
+            String contentType =
+                    message.getResponseHeader()
+                            .getHeader(HttpHeader.CONTENT_TYPE)
+                            .toLowerCase(Locale.ROOT);
+            String responseBodyStart =
+                    StringUtils.left(message.getResponseBody().toString(), 250)
+                            .toLowerCase(Locale.ROOT);
+            if (contentType.startsWith("application/vnd.oai.openapi")) {
                 return true;
-            } else if (contentType.toLowerCase().startsWith("application")) {
+            } else if ((contentType.contains("json") || contentType.contains("yaml"))
+                    && (responseBodyStart.contains("swagger")
+                            || responseBodyStart.contains("openapi"))) {
                 return true;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Content type check in canParseResource(Httpmessage, String, boolean) is made more specific. Fixes zaproxy/zaproxy#5725.

Signed-off-by: Akshath Kothari <akshath.kothari@gmail.com>