### PR TITLE
Extract more sharedutil methods

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Timestamp Disclosure scan rule now only considers potential timestamps within plus or minus one year when used at High threshold (Issue 5837).
 - 'Application Error' scan rule's patterns file `application_errors.xml` is now copied to ZAP's home directory, which means it is editable by the user. As well as being more consistent with other similar input files.
 - 'Information Disclosure - Sensitive Information in URL' correct evidence field for some alerts, and enhance other info details (Issue 5832).
+- Maintenance changes.
 
 ### Removed
 - 'Header XSS Protection' was deprecated and removed (Issue 5849).

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanner.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.sharedutils.PiiUtils;
 
 public class InformationDisclosureReferrerScanner extends PluginPassiveScanner {
 
@@ -214,7 +215,10 @@ public class InformationDisclosureReferrerScanner extends PluginPassiveScanner {
     private String doesContainCreditCard(String creditCard) {
         Matcher matcher = creditCardPattern.matcher(creditCard);
         if (matcher.find()) {
-            return matcher.group();
+            String candidate = matcher.group();
+            if (PiiUtils.isValidLuhn(candidate)) {
+                return candidate;
+            }
         }
         return null;
     }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScannerUnitTest.java
@@ -189,7 +189,6 @@ public class InformationDisclosureReferrerScannerUnitTest
 
         // Given
         String sensitiveParamName = "passWord";
-        String sensitiveValue = "whatsup";
         String testReferer = "http://example.org/?passWord=whatsup&hl=en";
         HttpMessage msg = createHttpMessageWithRespBody(testReferer);
 

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - 'PII Disclosure scanner' alerts and help entry renamed 'PII Disclosure' for clarity and proper title caps.
 - 'PII Disclosure' added further false positive handling with regard to exponential numbers such as 2.4670000000000001E-2 or 2.4670000000000001E2.
+- Maintenance changes.
 
 ## [21] - 2019-12-16
 

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -17,5 +17,7 @@ zapAddOn {
 dependencies {
     implementation("com.google.re2j:re2j:1.2")
 
+    implementation(project(":sharedutils"))
+
     testImplementation(project(":testutils"))
 }

--- a/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/PiiUtils.java
+++ b/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/PiiUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.sharedutils;
+
+/** A utility class for dealing with PII. */
+public final class PiiUtils {
+
+    private PiiUtils() {}
+
+    /**
+     * Checks whether a particular {@code String} input will pass a Credit Card Luhn validation
+     * check.
+     *
+     * @param inStr the value to be checked.
+     * @return {@code true} if the value passes the Luhn check, {@code false} otherwise.
+     */
+    public static boolean isValidLuhn(String inStr) {
+        int sum = 0;
+        int parity = inStr.length() % 2;
+        for (int index = 0; index < inStr.length(); index++) {
+            int digit = Integer.parseInt(inStr.substring(index, index + 1));
+            if ((index % 2) == parity) {
+                digit *= 2;
+                if (digit > 9) {
+                    digit -= 9;
+                }
+            }
+            sum += digit;
+        }
+        return (sum % 10) == 0;
+    }
+}


### PR DESCRIPTION
- Created PiiUtils from the PiiScanner.
- Modify PiiScanner to use the shared utils, remove TODO note.
- Modify InformationDisclosureReferrerScanner to use the shared utils.
InformationDisclosureReferrerScannerUnitTest removed an un-used local variable in one of the tests (call it a clean code activity).
- Add generic "Maintenance changes" note to CHANGELOGs.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>