### PR TITLE
Add passive scan rule for dangerous js functions

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added links to the code in the help.
 - Add info and repo URLs.
+- Add JS Function Scanner
 
 ### Fixed
 - Fixed NullPointerException in Sub Resource Integrity Attribute Missing scan rule (Issue 5789).

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -7,10 +7,27 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
+        extensions {
+            register("org.zaproxy.zap.extension.pscanrulesAlpha.payloader.ExtensionPayloader") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.zap.extension.pscanrulesAlpha.payloader"))
+                }
+                dependencies {
+                    addOns {
+                        register("custompayloads") {
+                            version.set("0.9.*")
+                        }
+                    }
+                }
+            }
+        }
         url.set("https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-alpha/")
     }
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("custompayloads")!!)
+
+    testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -90,7 +90,7 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
                 msg.getRequestHeader().getURI().toString(),
                 "", // Param, not relevant for this example vulnerability
                 "", // Attack, not relevant for passive vulnerabilities
-                this.getOtherInfo(),
+                "",
                 this.getSolution(),
                 this.getReference(),
                 evidence, // Evidence
@@ -152,10 +152,6 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
     }
 
     private String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    private String getOtherInfo() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -57,6 +57,9 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (!msg.getResponseHeader().isHtml() && !msg.getResponseHeader().isJavaScript()) {
+            return;
+        }
         if (patterns == null) {
             patterns = getPatterns();
         }
@@ -94,7 +97,7 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
                 this.getSolution(),
                 this.getReference(),
                 evidence,
-                0, // CWE Id - return 0 if no relevant one
+                749, // CWE-749: Exposed Dangerous Method or Function
                 0, // WASC Id - return 0 if no relevant one
                 msg);
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -85,6 +85,9 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
             while ((el = source.getNextElement(offset, HTMLElementName.SCRIPT)) != null) {
                 String elStr = el.toString();
                 searchPatterns(evidence, elStr);
+                if (evidence.length() != 0) {
+                    break;
+                }
                 offset = el.getEnd();
             }
         } else if (msg.getResponseHeader().isJavaScript()) {
@@ -143,7 +146,7 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
                 while ((line = reader.readLine()) != null) {
                     line = line.trim();
                     if (!line.startsWith("#") && line.length() > 0) {
-                        addPatterns(line, defaultPatterns);
+                        addPattern(line, defaultPatterns);
                     }
                 }
             }
@@ -162,11 +165,11 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
     private static void loadPayload() {
         patterns = new HashSet<>(defaultPatterns);
         for (String line : getJsFunctionPayloads().get()) {
-            addPatterns(line, patterns);
+            addPattern(line, patterns);
         }
     }
 
-    private static void addPatterns(String line, Set<Pattern> set) {
+    private static void addPattern(String line, Set<Pattern> set) {
         set.add(Pattern.compile(Pattern.quote(line), Pattern.CASE_INSENSITIVE));
     }
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -80,14 +80,16 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
                 offset = el.getEnd();
             }
         } else if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isJavaScript()) {
-            String content = msg.getResponseBody().toString();
-            for (Pattern pattern : patterns) {
-                if (pattern.matcher(content).find()) {
-                    evidence.append(pattern.toString());
-                    evidence.append(" found in js file:");
-                    evidence.append("\n");
-                    evidence.append(content);
-                    evidence.append("\n");
+            String[] lines = msg.getResponseBody().toString().split("\n");
+            for (String line : lines) {
+                for (Pattern pattern : patterns) {
+                    if (pattern.matcher(line).find()) {
+                        evidence.append(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "otherinfo", pattern, line));
+                        evidence.append("\n");
+                        break; // Only need to record this line once
+                    }
                 }
             }
         }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -26,11 +26,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
-
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
-import net.htmlparser.jericho.StartTagType;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -23,10 +23,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -58,8 +57,8 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
 
     private static Supplier<Iterable<String>> payloadProvider = DEFAULT_PAYLOAD_PROVIDER;
 
-    private static Set<Pattern> defaultPatterns = null;
-    private static Set<Pattern> patterns = null;
+    private static List<Pattern> defaultPatterns = null;
+    private static List<Pattern> patterns = null;
     private PassiveScanThread parent = null;
 
     @Override
@@ -129,7 +128,7 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
     }
 
     private static void createDefaultPatterns() {
-        defaultPatterns = new HashSet<>();
+        defaultPatterns = new ArrayList<>();
         try {
             File f =
                     new File(
@@ -163,14 +162,14 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
     }
 
     private static void loadPayload() {
-        patterns = new HashSet<>(defaultPatterns);
+        patterns = new ArrayList<>(defaultPatterns);
         for (String line : getJsFunctionPayloads().get()) {
             addPattern(line, patterns);
         }
     }
 
-    private static void addPattern(String line, Set<Pattern> set) {
-        set.add(Pattern.compile(Pattern.quote(line), Pattern.CASE_INSENSITIVE));
+    private static void addPattern(String line, List<Pattern> list) {
+        list.add(Pattern.compile(Pattern.quote(line), Pattern.CASE_INSENSITIVE));
     }
 
     public static void setPayloadProvider(Supplier<Iterable<String>> provider) {

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -1,0 +1,148 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import net.htmlparser.jericho.Source;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+/** Passive Scan Rule for Dangerous JS Functions https://github.com/zaproxy/zaproxy/issues/5673 */
+public class JSFunctionPassiveScanner extends PluginPassiveScanner {
+
+    /** Prefix for internationalized messages used by this rule */
+    private static final String MESSAGE_PREFIX = "pscanalpha.jsfunction.";
+
+    private static final String FUNC_LIST = "xml/js-function-list.txt";
+    private static final Logger LOGGER = Logger.getLogger(JSFunctionPassiveScanner.class);
+    private static final int PLUGIN_ID = 10110;
+
+    private PassiveScanThread parent = null;
+    private List<String> functions = null;
+
+    @Override
+    public void scanHttpRequestSend(HttpMessage msg, int id) {
+        // This rule only scans responses received
+    }
+
+    @Override
+    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (this.functions == null) {
+            this.functions = loadFunctions();
+        }
+        String content = source.toString();
+
+        for (String func : this.functions) {
+            if (content.toLowerCase().contains(func.toLowerCase())) {
+                raiseAlert(msg, id, content);
+            }
+        }
+    }
+
+    private void raiseAlert(HttpMessage msg, int id, String evidence) {
+        Alert alert =
+                new Alert(getPluginId(), Alert.RISK_MEDIUM, Alert.CONFIDENCE_MEDIUM, getName());
+        alert.setDetail(
+                this.getDescription(),
+                msg.getRequestHeader().getURI().toString(),
+                "", // Param, not relevant for this example vulnerability
+                "", // Attack, not relevant for passive vulnerabilities
+                this.getOtherInfo(),
+                this.getSolution(),
+                this.getReference(),
+                evidence, // Evidence
+                0, // CWE Id - return 0 if no relevant one
+                0, // WASC Id - Info leakage (return 0 if no relevant one)
+                msg);
+
+        parent.raiseAlert(id, alert);
+    }
+
+    private List<String> loadFunctions() {
+        List<String> strings = new ArrayList<String>();
+        BufferedReader reader = null;
+        File f = new File(Constant.getZapHome() + File.separator + FUNC_LIST);
+        if (!f.exists()) {
+            LOGGER.error("No such file: " + f.getAbsolutePath());
+            return strings;
+        }
+        try {
+            String line;
+            reader = new BufferedReader(new FileReader(f));
+            while ((line = reader.readLine()) != null) {
+                if (!line.startsWith("#") && line.length() > 0) {
+                    strings.add(line);
+                }
+            }
+        } catch (IOException e) {
+            LOGGER.error(
+                    "Error on opening/reading example error file. Error: " + e.getMessage(), e);
+        } finally {
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    LOGGER.debug("Error on closing the file reader. Error: " + e.getMessage(), e);
+                }
+            }
+        }
+        return strings;
+    }
+
+    @Override
+    public void setParent(PassiveScanThread parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    private String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    private String getOtherInfo() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    private String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    private String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    @Override
+    public int getPluginId() {
+        return PLUGIN_ID;
+    }
+}

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -167,7 +167,7 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
     }
 
     private static void addPatterns(String line, Set<Pattern> set) {
-        set.add(Pattern.compile("\\b" + Pattern.quote(line) + "\\b", Pattern.CASE_INSENSITIVE));
+        set.add(Pattern.compile(Pattern.quote(line), Pattern.CASE_INSENSITIVE));
     }
 
     public static void setPayloadProvider(Supplier<Iterable<String>> provider) {

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java
@@ -88,14 +88,14 @@ public class JSFunctionPassiveScanner extends PluginPassiveScanner {
         alert.setDetail(
                 this.getDescription(),
                 msg.getRequestHeader().getURI().toString(),
-                "", // Param, not relevant for this example vulnerability
+                "", // Param, not relevant for this vulnerability
                 "", // Attack, not relevant for passive vulnerabilities
-                "",
+                "", // Other info not specified in message bundle
                 this.getSolution(),
                 this.getReference(),
-                evidence, // Evidence
+                evidence,
                 0, // CWE Id - return 0 if no relevant one
-                0, // WASC Id - Info leakage (return 0 if no relevant one)
+                0, // WASC Id - return 0 if no relevant one
                 msg);
 
         parent.raiseAlert(id, alert);

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 The ZAP Development Team
+ * Copyright 2020 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
@@ -87,11 +87,11 @@ public class ExtensionPayloader extends ExtensionAdaptor {
 
     @Override
     public String getDescription() {
-        return Constant.messages.getString("pscanrules.payloader.desc");
+        return Constant.messages.getString("pscanalpha.payloader.desc");
     }
 
     @Override
     public String getUIName() {
-        return Constant.messages.getString("pscanrules.payloader.name");
+        return Constant.messages.getString("pscanalpha.payloader.name");
     }
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
@@ -1,0 +1,97 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2019 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha.payloader;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.custompayloads.ExtensionCustomPayloads;
+import org.zaproxy.zap.extension.custompayloads.PayloadCategory;
+import org.zaproxy.zap.extension.pscanrulesAlpha.JSFunctionPassiveScanner;
+
+public class ExtensionPayloader extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtensionPayloaderPscanRulesAlphaRelease";
+    private static final List<Class<? extends Extension>> DEPENDENCIES;
+    private static ExtensionCustomPayloads ecp;
+    private PayloadCategory jsFuncCategory;
+
+    static {
+        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
+        dependencies.add(ExtensionCustomPayloads.class);
+        DEPENDENCIES = Collections.unmodifiableList(dependencies);
+    }
+
+    public ExtensionPayloader() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        super.hook(extensionHook);
+
+        ecp =
+                Control.getSingleton()
+                        .getExtensionLoader()
+                        .getExtension(ExtensionCustomPayloads.class);
+        jsFuncCategory =
+                new PayloadCategory(
+                        JSFunctionPassiveScanner.JS_FUNCTION_PAYLOAD_CATEGORY,
+                        JSFunctionPassiveScanner.DEFAULT_FUNCTIONS);
+        ecp.addPayloadCategory(jsFuncCategory);
+        JSFunctionPassiveScanner.setPayloadProvider(() -> jsFuncCategory.getPayloadsIterator());
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        JSFunctionPassiveScanner.setPayloadProvider(null);
+        ecp.removePayloadCategory(jsFuncCategory);
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public String getAuthor() {
+        return Constant.ZAP_TEAM;
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("pscanrules.payloader.desc");
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("pscanrules.payloader.name");
+    }
+}

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -86,6 +86,8 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 <H2>Dangerous JS Functions</H2>
 This scanner checks for any dangerous JS functions present in a site response.<br>
 For more details see: https://github.com/zaproxy/zaproxy/issues/5673
+<p><strong>Note:</strong> If the Custom Payloads addon is installed you can add your own function names (payloads) in the Custom Payloads options panel.
+They will also be searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the amount of time needed to passively scan.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java">JSFunctionPassiveScanner.java</a>
 

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -87,7 +87,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 This scanner checks for any dangerous JS functions present in a site response.<br>
 For more details see: https://github.com/zaproxy/zaproxy/issues/5673
 <p>
- Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java">JSFunctionPassiveScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java">JSFunctionPassiveScanner.java</a>
 
 </BODY>
 </HTML>

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -83,5 +83,11 @@ It helps mitigate an attack where the CDN has been compromised and content has b
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanner.java">SubResourceIntegrityAttributeScanner.java</a>
 
+<H2>Dangerous JS Functions</H2>
+This scanner checks for any dangerous JS functions present in a site response.<br>
+For more details see: https://github.com/zaproxy/zaproxy/issues/5673
+<p>
+ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java">JSFunctionPassiveScanner.java</a>
+
 </BODY>
 </HTML>

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -85,8 +85,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 
 <H2>Dangerous JS Functions</H2>
 This scanner checks for any dangerous JS functions present in a site response.<br>
-For more details see: https://github.com/zaproxy/zaproxy/issues/5673
-<p><strong>Note:</strong> If the Custom Payloads addon is installed you can add your own function names (payloads) in the Custom Payloads options panel.
+<strong>Note:</strong> If the Custom Payloads addon is installed you can add your own function names (payloads) in the Custom Payloads options panel.
 They will also be searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the amount of time needed to passively scan.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java">JSFunctionPassiveScanner.java</a>

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -86,7 +86,6 @@ pscanalpha.jsfunction.name=Dangerous JS Functions
 pscanalpha.jsfunction.desc=A dangerous JS function seems to be in use that would leave the site vulnerable.
 pscanalpha.jsfunction.soln=See the references for security advice on the use of these functions.
 pscanalpha.jsfunction.refs=https://angular.io/guide/security
-pscanalpha.jsfunction.otherinfo=The following comment/snippet was identified via the pattern: {0}\n{1}
 
 pscanalpha.payloader.name=Passive Scan Rules Alpha Custom Payloads
 pscanalpha.payloader.desc=Provides support for custom payloads in scan rules.

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -86,3 +86,4 @@ pscanalpha.jsfunction.name=Dangerous JS Functions
 pscanalpha.jsfunction.desc=A dangerous JS function seems to be in use that would leave the site vulnerable.
 pscanalpha.jsfunction.soln=See the references for security advice on the use of these functions.
 pscanalpha.jsfunction.refs=https://angular.io/guide/security
+pscanalpha.jsfunction.otherinfo=The following comment/snippet was identified via the pattern: {0}\n{1}

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -81,3 +81,9 @@ pscanalpha.sri-integrity.name=Sub Resource Integrity Attribute Missing
 pscanalpha.sri-integrity.desc=The integrity attribute is missing on a script or link tag served by an external server. The integrity tag prevents an attacker who have gained access to this server from injecting a malicious content. 
 pscanalpha.sri-integrity.soln=Provide a valid integrity attribute to the tag.
 pscanalpha.sri-integrity.refs=https://developer.mozilla.org/en/docs/Web/Security/Subresource_Integrity
+
+pscanalpha.jsfunction.name=Dangerous JS Functions
+pscanalpha.jsfunction.desc=A dangerous JS function seems to be in use that would leave the site vulnerable.
+pscanalpha.jsfunction.other=
+pscanalpha.jsfunction.soln=
+pscanalpha.jsfunction.refs=https://github.com/danielmiessler/SecLists/issues/367

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -87,3 +87,6 @@ pscanalpha.jsfunction.desc=A dangerous JS function seems to be in use that would
 pscanalpha.jsfunction.soln=See the references for security advice on the use of these functions.
 pscanalpha.jsfunction.refs=https://angular.io/guide/security
 pscanalpha.jsfunction.otherinfo=The following comment/snippet was identified via the pattern: {0}\n{1}
+
+pscanalpha.payloader.name=Passive Scan Rules Alpha Custom Payloads
+pscanalpha.payloader.desc=Provides support for custom payloads in scan rules.

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -84,5 +84,5 @@ pscanalpha.sri-integrity.refs=https://developer.mozilla.org/en/docs/Web/Security
 
 pscanalpha.jsfunction.name=Dangerous JS Functions
 pscanalpha.jsfunction.desc=A dangerous JS function seems to be in use that would leave the site vulnerable.
-pscanalpha.jsfunction.soln=
-pscanalpha.jsfunction.refs=https://github.com/danielmiessler/SecLists/issues/367
+pscanalpha.jsfunction.soln=See the references for security advice on the use of these functions.
+pscanalpha.jsfunction.refs=https://angular.io/guide/security

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -84,6 +84,5 @@ pscanalpha.sri-integrity.refs=https://developer.mozilla.org/en/docs/Web/Security
 
 pscanalpha.jsfunction.name=Dangerous JS Functions
 pscanalpha.jsfunction.desc=A dangerous JS function seems to be in use that would leave the site vulnerable.
-pscanalpha.jsfunction.other=
 pscanalpha.jsfunction.soln=
 pscanalpha.jsfunction.refs=https://github.com/danielmiessler/SecLists/issues/367

--- a/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
+++ b/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
@@ -1,10 +1,11 @@
 # This file lists all dangerous JS functions being scanned for.
-# Searching is done via whole word match on each line item [e.g. 'eval' below will match with '$eval()'].
 bypassSecurityTrustHtml
 bypassSecurityTrustScript
 bypassSecurityTrustStyle
 bypassSecurityTrustUrl
 bypassSecurityTrustResourceUrl
 trustAsHtml
+$sce.trustAsHtml
+$eval
+$evalAsync
 eval
-evalAsync

--- a/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
+++ b/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
@@ -1,12 +1,10 @@
-# This file lists all dangerous JS functions being scanned for
-# Angular Functions
+# This file lists all dangerous JS functions being scanned for.
+# Searching is done via regex per whole word match on each line item [e.g. 'eval' will match with '$eval()'].
 bypassSecurityTrustHtml
 bypassSecurityTrustScript
 bypassSecurityTrustStyle
 bypassSecurityTrustUrl
 bypassSecurityTrustResourceUrl
 trustAsHtml
-$eval
-$evalAsync
-# Generic JS Functions
 eval
+evalAsync

--- a/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
+++ b/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
@@ -1,4 +1,5 @@
 # This file lists all dangerous JS functions being scanned for
+# Angular Functions
 bypassSecurityTrustHtml
 bypassSecurityTrustScript
 bypassSecurityTrustStyle
@@ -7,3 +8,5 @@ bypassSecurityTrustResourceUrl
 trustAsHtml
 $eval
 $evalAsync
+# Generic JS Functions
+eval

--- a/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
+++ b/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
@@ -1,5 +1,5 @@
 # This file lists all dangerous JS functions being scanned for.
-# Searching is done via regex per whole word match on each line item [e.g. 'eval' will match with '$eval()'].
+# Searching is done via whole word match on each line item [e.g. 'eval' below will match with '$eval()'].
 bypassSecurityTrustHtml
 bypassSecurityTrustScript
 bypassSecurityTrustStyle

--- a/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
+++ b/addOns/pscanrulesAlpha/src/main/zapHomeFiles/xml/js-function-list.txt
@@ -1,0 +1,9 @@
+# This file lists all dangerous JS functions being scanned for
+bypassSecurityTrustHtml
+bypassSecurityTrustScript
+bypassSecurityTrustStyle
+bypassSecurityTrustUrl
+bypassSecurityTrustResourceUrl
+trustAsHtml
+$eval
+$evalAsync

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -185,6 +185,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
     }
 
     @Test
@@ -199,6 +200,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
     }
 
     private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -21,7 +21,9 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.nio.file.Files;
@@ -69,6 +70,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
     }
 
     @Test
@@ -86,6 +88,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getEvidence(), "bypassSecurityTrustHtml");
     }
 
     @Test
@@ -120,9 +123,9 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
     public void shouldAlertGivenCustomPayloadFunctionMatch()
             throws HttpMalformedHeaderException, URIException {
         // Given
-        String body = "Some text <script>badFunction()</script>\nLine 2\n";
+        String body = "Some text <script>$badFunction()</script>\nLine 2\n";
         HttpMessage msg = createHttpMessageWithRespBody(body, "text/html;charset=ISO-8859-1");
-        List<String> functions = Collections.singletonList("badFunction");
+        List<String> functions = Collections.singletonList("$badFunction");
         JSFunctionPassiveScanner.setPayloadProvider(() -> functions);
 
         // When
@@ -130,6 +133,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getEvidence(), "$badFunction");
     }
 
     @Test
@@ -155,7 +159,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
         String body =
                 "<h1>Some text <script>Something innocent happening here</script></h1>\n"
                         + "<p><b>Just some words going on</b>\n"
-                        + "<script>eval()</script></p>\n";
+                        + "<script>$eval()</script></p>\n";
         HttpMessage msg = createHttpMessageWithRespBody(body, "text/html;charset=ISO-8859-1");
 
         // When
@@ -163,6 +167,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
+        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
     }
 
     @Test

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -185,7 +186,9 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
+        assertTrue(
+                alertsRaised.get(0).getEvidence().equals("bypassSecurityTrustHtml")
+                        || alertsRaised.get(0).getEvidence().equals("eval"));
     }
 
     @Test
@@ -200,7 +203,9 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals(alertsRaised.get(0).getEvidence(), "bypassSecurityTrustHtml");
+        assertTrue(
+                alertsRaised.get(0).getEvidence().equals("bypassSecurityTrustHtml")
+                        || alertsRaised.get(0).getEvidence().equals("eval"));
     }
 
     private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -200,7 +200,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
+        assertEquals(alertsRaised.get(0).getEvidence(), "bypassSecurityTrustHtml");
     }
 
     private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -29,6 +29,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -120,6 +122,22 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, empty());
+    }
+
+    @Test
+    public void shouldAlertGivenCustomPayloadFunctionMatch()
+            throws HttpMalformedHeaderException, URIException {
+        // Given
+        String body = "Some text <script>badFunction()</script>\nLine 2\n";
+        HttpMessage msg = createHttpMessageWithRespBody(body, "text/html;charset=ISO-8859-1");
+        List<String> functions = Collections.singletonList("badFunction");
+        JSFunctionPassiveScanner.setPayloadProvider(() -> functions);
+
+        // When
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+
+        // Then
+        assertThat(alertsRaised, hasSize(1));
     }
 
     private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,7 +70,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
+        assertEquals("eval", alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -89,7 +88,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals(alertsRaised.get(0).getEvidence(), "bypassSecurityTrustHtml");
+        assertEquals("bypassSecurityTrustHtml", alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -134,7 +133,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals(alertsRaised.get(0).getEvidence(), "$badFunction");
+        assertEquals("$badFunction", alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -168,7 +167,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals(alertsRaised.get(0).getEvidence(), "eval");
+        assertEquals("eval", alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -186,9 +185,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertTrue(
-                alertsRaised.get(0).getEvidence().equals("bypassSecurityTrustHtml")
-                        || alertsRaised.get(0).getEvidence().equals("eval"));
+        assertEquals("eval", alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -203,9 +200,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertTrue(
-                alertsRaised.get(0).getEvidence().equals("bypassSecurityTrustHtml")
-                        || alertsRaised.get(0).getEvidence().equals("eval"));
+        assertEquals("bypassSecurityTrustHtml", alertsRaised.get(0).getEvidence());
     }
 
     private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScannerUnitTest.java
@@ -1,0 +1,72 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrulesAlpha;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.*;
+
+import net.htmlparser.jericho.Source;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+
+public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunctionPassiveScanner> {
+
+    @Override
+    protected JSFunctionPassiveScanner createScanner() {
+        return new JSFunctionPassiveScanner();
+    }
+
+    @Test
+    public void shouldRaiseAlertGivenMatch() throws URIException {
+        // Test value in message taken from xml/js-function-list.txt
+        HttpMessage msg = createMessage("bypassSecurityTrustScript");
+        Source source = createSource(msg);
+
+        rule.scanHttpResponseReceive(msg, -1, source);
+
+        assertThat(alertsRaised, hasSize(1));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertGivenNoMatch() throws URIException {
+        HttpMessage msg = createMessage("");
+        Source source = createSource(msg);
+
+        rule.scanHttpResponseReceive(msg, -1, source);
+
+        assertThat(alertsRaised, empty());
+    }
+
+    private HttpMessage createMessage(String content) throws URIException {
+        HttpRequestHeader requestHeader = new HttpRequestHeader();
+        requestHeader.setURI(new URI("http://test.com", false));
+
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(requestHeader);
+        msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_FOUND);
+        msg.setResponseBody("<html><body>" + content + "</body></html>");
+        return msg;
+    }
+}


### PR DESCRIPTION
Resolves zaproxy/zaproxy#5673

Hello, I'm hoping to get feedback on my initial implementation of the pscan rule. I'm assuming converting the DOM source into a string and checking if it contains methods in the list should be sufficient?

Additionally, I don't know how to test the feature properly. The list of functions are loaded from a file and so whenever I try to test it in my dev environment the function list would be empty (since in deployment the files are loaded from `Constant.getZapHome`)