### PR TITLE
authstats: dynamically unload the add-on

### DIFF
--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -5,10 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Add repo URLs.
+- Add repo URL.
 
 ### Changed
-- Code change for future ZAP versions.
+- Update minimum ZAP version to 2.9.0.
+- Dynamically unload the add-on.
 - Change info URL to link to the site.
 
 ## 1 - 2016-08-16

--- a/addOns/authstats/authstats.gradle.kts
+++ b/addOns/authstats/authstats.gradle.kts
@@ -3,10 +3,10 @@ description = "Records logged in/out statistics for all contexts in scope."
 
 zapAddOn {
     addOnName.set("Authentication Statistics")
-    zapVersion.set("2.5.0")
+    zapVersion.set("2.9.0")
 
     manifest {
-        author.set("ZAP Core Team")
+        author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/authentication-statistics/")
     }
 }

--- a/addOns/authstats/src/main/java/org/zaproxy/zap/extension/authstats/ExtensionAuthStats.java
+++ b/addOns/authstats/src/main/java/org/zaproxy/zap/extension/authstats/ExtensionAuthStats.java
@@ -49,12 +49,8 @@ public class ExtensionAuthStats extends ExtensionAdaptor implements HttpSenderLi
     @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
-        HttpSender.addListener(this);
-    }
 
-    @Override
-    public String getAuthor() {
-        return Constant.ZAP_TEAM;
+        extensionHook.addHttpSenderListener(this);
     }
 
     @Override
@@ -74,14 +70,7 @@ public class ExtensionAuthStats extends ExtensionAdaptor implements HttpSenderLi
 
     @Override
     public boolean canUnload() {
-        // TODO change when unload() can be implemented
-        return false;
-    }
-
-    @Override
-    public void unload() {
-        super.unload();
-        // TODO change to use HttpSender.removeListener when available
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Change `ExtensionAuthStats` to:
 - Hook the `HttpSenderListener` to be automatically removed when the
extension is unloaded, allowing the extension to be dynamically
unloaded;
 - Remove the author, it will use the one from the add-on.

Update minimum ZAP version to 2.9.0.
Normalise author in the manifest (`ZAP Core Team` → `ZAP Dev Team`).