### PR TITLE
zest: update ZAP to 2.9.0

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.9.0.
 
 ## [32] - 2020-01-24
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -25,8 +25,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -204,7 +202,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             this.zestEngineFactory = new ZestScriptEngineFactory();
             se = zestEngineFactory.getScriptEngine();
         }
-        zestEngineWrapper = new ZestEngineWrapper(se, defaultTemplates);
+        zestEngineWrapper = new ZestEngineWrapper(zestEngineFactory, defaultTemplates);
         this.getExtScript().registerScriptEngineWrapper(zestEngineWrapper);
 
         this.getExtScript().addListener(this);
@@ -533,22 +531,8 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     }
 
     @Override
-    public String getAuthor() {
-        return Constant.ZAP_TEAM;
-    }
-
-    @Override
     public String getDescription() {
         return Constant.messages.getString("zest.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public ScriptNode add(ZestScriptWrapper script, boolean display) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
@@ -77,19 +77,13 @@ public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
     @Override
     public void alertFound(Alert alert) {
         // Override this as we can put in more info from the script and message
-        sas.raiseAlert(
-                alert.getRisk(),
-                alert.getConfidence(),
-                alert.getName(),
-                script.getDescription(),
-                msg.getRequestHeader().getURI().toString(),
-                param,
-                "",
-                "",
-                "",
-                "",
-                -1,
-                -1,
-                msg);
+        sas.newAlert()
+                .setRisk(alert.getRisk())
+                .setConfidence(alert.getConfidence())
+                .setName(alert.getName())
+                .setDescription(script.getDescription())
+                .setParam(param)
+                .setMessage(msg)
+                .raise();
     }
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestEngineWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestEngineWrapper.java
@@ -22,9 +22,9 @@ package org.zaproxy.zap.extension.zest;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import javax.script.ScriptEngine;
 import javax.swing.ImageIcon;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
+import org.mozilla.zest.impl.ZestScriptEngineFactory;
 import org.zaproxy.zap.extension.script.DefaultEngineWrapper;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
@@ -32,8 +32,8 @@ public class ZestEngineWrapper extends DefaultEngineWrapper {
 
     private final List<Path> defaultTemplates;
 
-    public ZestEngineWrapper(ScriptEngine engine, List<Path> defaultTemplates) {
-        super(engine);
+    public ZestEngineWrapper(ZestScriptEngineFactory engineFactory, List<Path> defaultTemplates) {
+        super(engineFactory);
 
         if (defaultTemplates == null) {
             throw new IllegalArgumentException("Parameter defaultTemplates must not be null.");

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
@@ -66,19 +66,12 @@ public class ZestPassiveRunner extends ZestZapRunner implements PassiveScript {
     @Override
     public void alertFound(Alert alert) {
         // Override this as we can put in more info from the script and message
-        sps.raiseAlert(
-                alert.getRisk(),
-                alert.getConfidence(),
-                alert.getName(),
-                script.getDescription(),
-                msg.getRequestHeader().getURI().toString(),
-                "",
-                "",
-                "",
-                "",
-                "",
-                -1,
-                -1,
-                msg);
+        sps.newAlert()
+                .setRisk(alert.getRisk())
+                .setConfidence(alert.getConfidence())
+                .setName(alert.getName())
+                .setDescription(script.getDescription())
+                .setMessage(msg)
+                .raise();
     }
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
@@ -57,9 +57,7 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
     private ZestScriptWrapper script = null;
     private static final Logger logger = Logger.getLogger(ZestSequenceRunner.class);
 
-    // TODO Replace the value (17) with HistoryReference.TYPE_SEQUENCE_TEMPORARY once released with
-    // core
-    private static final int SEQUENCE_HISTORY_TYPE = 17;
+    private static final int SEQUENCE_HISTORY_TYPE = HistoryReference.TYPE_SEQUENCE_TEMPORARY;
 
     private static final Map<String, String> EMPTYPARAMS = new HashMap<String, String>();
     private AbstractPlugin currentPlugin = null;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -210,19 +210,14 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
             } else if (ZestActionFail.Priority.HIGH.name().equals(zaf.getPriority())) {
                 risk = Alert.RISK_HIGH;
             }
-            Alert alert =
-                    new Alert(FAIL_ACTION_PLUGIN_ID, risk, Alert.CONFIDENCE_MEDIUM, e.getMessage());
-
-            if (lastHref != null) {
-                alert.setHistoryRef(lastHref);
-                try {
-                    alert.setUri(lastHref.getURI().toString());
-                    alert.setMessage(lastHref.getHttpMessage());
-                } catch (Exception e1) {
-                    log.error(e1.getMessage(), e1);
-                }
-            }
-            this.alertFound(alert);
+            Alert.Builder alertBuilder =
+                    Alert.builder()
+                            .setPluginId(FAIL_ACTION_PLUGIN_ID)
+                            .setRisk(risk)
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(e.getMessage())
+                            .setHistoryRef(lastHref);
+            this.alertFound(alertBuilder.build());
         }
 
         if (View.isInitialised()) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.zest.dialogs;
 import java.awt.CardLayout;
 import java.awt.Dimension;
 import java.awt.event.MouseAdapter;
-import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.util.LinkedList;
 import java.util.List;
@@ -278,29 +277,13 @@ public class ZestDialogManager extends AbstractPanel {
                                     }
                                 }
                             }
-                        } else {
-                            // Single click
-                            displayHttpMessageOfSelectedNode();
                         }
                     }
                 };
         this.scriptUI.addMouseListener(mouseListener);
 
         treeSelectionListener = e -> displayHttpMessageOfSelectedNode();
-        // TODO remove reflection (and single click logic above, redundant) once available in
-        // targeted ZAP version.
-        // this.scriptUI.addSelectionListener(treeSelectionListener);
-        Method addSelectionListenerMethod;
-        try {
-            addSelectionListenerMethod =
-                    ScriptUI.class.getDeclaredMethod(
-                            "addSelectionListener", TreeSelectionListener.class);
-            addSelectionListenerMethod.invoke(this.scriptUI, treeSelectionListener);
-        } catch (NoSuchMethodException ignore) {
-            // Ignore, older versions don't have the method.
-        } catch (Exception e) {
-            logger.debug("Failed to add tree selection listener.", e);
-        }
+        scriptUI.addSelectionListener(treeSelectionListener);
     }
 
     private void displayHttpMessageOfSelectedNode() {
@@ -819,18 +802,7 @@ public class ZestDialogManager extends AbstractPanel {
 
     public void unload() {
         scriptUI.removeMouseListener(mouseListener);
-        // TODO remove reflection once available in targeted ZAP version.
-        // this.scriptUI.removeSelectionListener(treeSelectionListener);
-        try {
-            Method addSelectionListenerMethod =
-                    ScriptUI.class.getDeclaredMethod(
-                            "removeSelectionListener", TreeSelectionListener.class);
-            addSelectionListenerMethod.invoke(this.scriptUI, treeSelectionListener);
-        } catch (NoSuchMethodException ignore) {
-            // Ignore, older versions don't have the method.
-        } catch (Exception e) {
-            logger.debug("Failed to remove tree selection listener.", e);
-        }
+        scriptUI.removeSelectionListener(treeSelectionListener);
 
         if (scriptDialog != null) {
             scriptDialog.dispose();

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -168,7 +168,7 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
     private List<String> getSites() {
         List<String> list = new ArrayList<String>();
         list.add(""); // Always start with the blank option
-        SiteNode siteRoot = (SiteNode) Model.getSingleton().getSession().getSiteTree().getRoot();
+        SiteNode siteRoot = Model.getSingleton().getSession().getSiteTree().getRoot();
         if (siteRoot != null && siteRoot.getChildCount() > 0) {
             SiteNode child = (SiteNode) siteRoot.getFirstChild();
             while (child != null) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
@@ -299,7 +299,7 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
     private List<String> getSites() {
         List<String> list = new ArrayList<String>();
         list.add(""); // Always start with the blank option
-        SiteNode siteRoot = (SiteNode) Model.getSingleton().getSession().getSiteTree().getRoot();
+        SiteNode siteRoot = Model.getSingleton().getSession().getSiteTree().getRoot();
         if (siteRoot != null && siteRoot.getChildCount() > 0) {
             SiteNode child = (SiteNode) siteRoot.getFirstChild();
             while (child != null) {

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -17,7 +17,7 @@ description = "A graphical security scripting language, ZAPs macro language on s
 zapAddOn {
     addOnName.set("Zest - Graphical Security Scripting Language")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("ZAP Dev Team")


### PR DESCRIPTION
Use new core features.
Address deprecations and unnecessary casts.
Remove redundant author/URL in the extension.