### PR TITLE
Remove redundant extension URLs

### DIFF
--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.accessControl;
 
 import java.awt.Dimension;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -188,15 +186,6 @@ public class ExtensionAccessControl extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("accessControl.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.alertFilters;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -261,15 +259,6 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /**

--- a/addOns/allinonenotes/src/main/java/org/zaproxy/zap/extension/allinonenotes/ExtensionAllInOneNotes.java
+++ b/addOns/allinonenotes/src/main/java/org/zaproxy/zap/extension/allinonenotes/ExtensionAllInOneNotes.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.allinonenotes;
 import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.Box;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -248,14 +246,5 @@ public class ExtensionAllInOneNotes extends ExtensionAdaptor implements SessionC
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/payloader/ExtensionPayloader.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/payloader/ExtensionPayloader.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrulesAlpha.payloader;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -85,15 +83,6 @@ public class ExtensionPayloader extends ExtensionAdaptor {
     @Override
     public String getAuthor() {
         return Constant.ZAP_TEAM;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/payloader/ExtensionPayloader.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/payloader/ExtensionPayloader.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta.payloader;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -84,15 +82,6 @@ public class ExtensionPayloader extends ExtensionAdaptor {
     @Override
     public String getAuthor() {
         return Constant.ZAP_TEAM;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/ExtensionBeanShell.java
+++ b/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/ExtensionBeanShell.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.beanshell;
 
 import java.awt.Dimension;
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -106,14 +104,5 @@ public class ExtensionBeanShell extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("beanshell.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
@@ -23,7 +23,6 @@ import com.sittinglittleduck.DirBuster.BaseCase;
 import java.awt.EventQueue;
 import java.io.File;
 import java.io.FilenameFilter;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -535,15 +534,6 @@ public class ExtensionBruteForce extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("bruteforce.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.bugtracker;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -117,14 +115,5 @@ public class ExtensionBugTracker extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/cmss/src/main/java/org/zaproxy/zap/extension/cmss/CMSSTopMenu.java
+++ b/addOns/cmss/src/main/java/org/zaproxy/zap/extension/cmss/CMSSTopMenu.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.cmss;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ResourceBundle;
 import javax.swing.JMenuItem;
 import org.parosproxy.paros.Constant;
@@ -92,14 +90,5 @@ public class CMSSTopMenu extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return messages.getString("ext.topmenu.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
+++ b/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/ExtensionCustomReport.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.customreport;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -204,15 +202,6 @@ public class ExtensionCustomReport extends ExtensionAdaptor {
     @Override
     public String getAuthor() {
         return "\n Author: Chienli Ma";
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     void dialogClosed() {

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/ExtensionFormHandler.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/ExtensionFormHandler.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.formhandler;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -124,14 +122,5 @@ public class ExtensionFormHandler extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".options.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.frontendscanner;
 import java.awt.EventQueue;
 import java.awt.event.ItemEvent;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -188,15 +186,6 @@ public class ExtensionFrontEndScanner extends ExtensionAdaptor implements ProxyL
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/gettingStarted/src/main/java/org/zaproxy/zap/extension/gettingStarted/ExtensionGettingStarted.java
+++ b/addOns/gettingStarted/src/main/java/org/zaproxy/zap/extension/gettingStarted/ExtensionGettingStarted.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.gettingStarted;
 
 import java.awt.*;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -97,14 +95,5 @@ public class ExtensionGettingStarted extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("gettingStarted.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/groovy/src/main/java/org/zaproxy/zap/extension/groovy/ExtensionGroovy.java
+++ b/addOns/groovy/src/main/java/org/zaproxy/zap/extension/groovy/ExtensionGroovy.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.groovy;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -102,15 +100,6 @@ public class ExtensionGroovy extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("groovy.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/highlighter/src/main/java/org/zaproxy/zap/extension/highlighter/ExtensionHighlighter.java
+++ b/addOns/highlighter/src/main/java/org/zaproxy/zap/extension/highlighter/ExtensionHighlighter.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.highlighter;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -65,14 +63,5 @@ public class ExtensionHighlighter extends ExtensionAdaptor {
     @Override
     public String getAuthor() {
         return Constant.ZAP_TEAM;
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/httpsInfo/src/main/java/org/zaproxy/zap/extension/httpsinfo/ExtensionHttpsInfo.java
+++ b/addOns/httpsInfo/src/main/java/org/zaproxy/zap/extension/httpsinfo/ExtensionHttpsInfo.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.httpsinfo;
 
 import java.awt.CardLayout;
 import java.awt.Component;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -139,15 +137,6 @@ public class ExtensionHttpsInfo extends ExtensionAdaptor implements SessionChang
     @Override
     public String getDescription() {
         return Constant.messages.getString("httpsinfo.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     protected int getTabIndex(String tabName) {

--- a/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
+++ b/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
@@ -25,8 +25,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.JFileChooser;
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
@@ -229,14 +227,5 @@ public class ExtensionImportUrls extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("importurls.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/ExtensionInvoke.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/ExtensionInvoke.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.invoke;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -98,14 +96,5 @@ public class ExtensionInvoke extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("invoke.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
+++ b/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.jruby;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -167,15 +165,6 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
     @Override
     public String getDescription() {
         return Constant.messages.getString("jruby.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
+++ b/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.jython;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -157,15 +155,6 @@ public class ExtensionJython extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("jython.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/onlineMenu/src/main/java/org/zaproxy/zap/extension/onlineMenu/ExtensionOnlineMenu.java
+++ b/addOns/onlineMenu/src/main/java/org/zaproxy/zap/extension/onlineMenu/ExtensionOnlineMenu.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.onlineMenu;
 
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.KeyStroke;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -184,14 +182,5 @@ public class ExtensionOnlineMenu extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.openapi;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.httpclient.URI;
@@ -327,15 +325,6 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     @Override
     public String getDescription() {
         return Constant.messages.getString("openapi.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     private CommandLineArgument[] getCommandLineArguments() {

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ExtensionPlugNHack.java
@@ -23,8 +23,6 @@ import java.awt.Dimension;
 import java.awt.EventQueue;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -437,15 +435,6 @@ public class ExtensionPlugNHack extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("plugnhack.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     private PopupMenuOpenAndMonitorUrl getPopupMenuOpenAndMonitorUrl() {

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/ExtensionPortScan.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.portscan;
 
 import java.awt.EventQueue;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -273,15 +271,6 @@ public class ExtensionPortScan extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("ports.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -89,8 +89,6 @@ public class ExtensionQuickStart extends ExtensionAdaptor
                             QuickStartSubPanel.class.getResource(
                                     RESOURCES + "/document-pdf-text.png")));
 
-    protected static final String SCRIPT_CONSOLE_HOME_PAGE = Constant.ZAP_HOMEPAGE;
-
     private static final String DEFAULT_NEWS_PAGE_URL_PREFIX = "https://bit.ly/owaspzap-news-";
     private static final String DEV_NEWS_PAGE = "dev";
 
@@ -318,15 +316,6 @@ public class ExtensionQuickStart extends ExtensionAdaptor
     @Override
     public String getUIName() {
         return Constant.messages.getString("quickstart.name");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public void attack(URL url, boolean useStdSpider) {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/ExtensionQuickStartAjaxSpider.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/ExtensionQuickStartAjaxSpider.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart.ajaxspider;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -110,15 +108,6 @@ public class ExtensionQuickStartAjaxSpider extends ExtensionAdaptor {
     @Override
     public String getUIName() {
         return Constant.messages.getString("quickstart.ajaxspider.name");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public ExtensionQuickStart getExtQuickStart() {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/hud/ExtensionQuickStartHud.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/hud/ExtensionQuickStartHud.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.quickstart.hud;
 
 import java.lang.reflect.Method;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -130,15 +128,6 @@ public class ExtensionQuickStartHud extends ExtensionAdaptor implements Plugable
     @Override
     public String getUIName() {
         return Constant.messages.getString("quickstart.launch.name");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public ExtensionQuickStart getExtQuickStart() {

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/ExtensionQuickStartLaunch.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.quickstart.launch;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -211,15 +209,6 @@ public class ExtensionQuickStartLaunch extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("quickstart.launch.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     private ExtensionQuickStart getExtQuickStart() {

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ExtensionRegExTester.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ExtensionRegExTester.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.regextester;
 
 import java.lang.ref.WeakReference;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import org.parosproxy.paros.Constant;
@@ -106,14 +104,5 @@ public class ExtensionRegExTester extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("regextester.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.replacer;
 
 import java.awt.*;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.regex.Pattern;
 import javax.swing.*;
 import org.apache.log4j.Logger;
@@ -107,15 +105,6 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ExtensionRequester.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ExtensionRequester.java
@@ -20,8 +20,6 @@
 package org.zaproxy.zap.extension.requester;
 
 import java.awt.Component;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.ImageIcon;
 import javax.swing.SwingUtilities;
 import org.parosproxy.paros.Constant;
@@ -153,14 +151,5 @@ public class ExtensionRequester extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("requester.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/reveal/src/main/java/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
+++ b/addOns/reveal/src/main/java/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.reveal;
 
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 import javax.swing.ImageIcon;
@@ -238,14 +236,5 @@ public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
     @Override
     public String getDescription() {
         return Constant.messages.getString("reveal.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.revisit;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -180,15 +178,6 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLExtension.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLExtension.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.saml;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.*;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -36,15 +34,6 @@ import org.zaproxy.zap.view.popup.ExtensionPopupMenuMessageContainer;
 public class SAMLExtension extends ExtensionAdaptor {
 
     protected static final Logger log = Logger.getLogger(SAMLExtension.class);
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
-    }
 
     @Override
     public String getAuthor() {

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ExtensionScriptsUI.java
@@ -23,8 +23,6 @@ import java.awt.EventQueue;
 import java.awt.event.MouseAdapter;
 import java.io.Writer;
 import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -535,15 +533,6 @@ public class ExtensionScriptsUI extends ExtensionAdaptor implements ScriptEventL
     @Override
     public String getDescription() {
         return Constant.messages.getString("scripts.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /*

--- a/addOns/simpleexample/src/main/java/org/zaproxy/zap/extension/simpleexample/ExtensionSimpleExample.java
+++ b/addOns/simpleexample/src/main/java/org/zaproxy/zap/extension/simpleexample/ExtensionSimpleExample.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.simpleexample;
 import java.awt.CardLayout;
 import java.awt.Font;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Files;
 import javax.swing.ImageIcon;
 import javax.swing.JTextPane;
@@ -195,14 +193,5 @@ public class ExtensionSimpleExample extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.soap;
 
 import java.awt.event.KeyEvent;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.swing.JFileChooser;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -179,14 +177,5 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("soap.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
@@ -44,9 +44,4 @@ public class ExtensionImportWSDLTestCase extends TestUtils {
     public void getDescriptionTest() {
         assertNotNull(extension.getDescription());
     }
-
-    @Test
-    public void getURLTest() {
-        assertNotNull(extension.getURL());
-    }
 }

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -21,9 +21,7 @@ package org.zaproxy.zap.extension.spiderAjax;
 
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -408,17 +406,6 @@ public class ExtensionAjax extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return this.getMessages().getString("spiderajax.desc");
-    }
-
-    /** @return the url of the proj */
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            logger.error(e);
-            return null;
-        }
     }
 
     SpiderThread createSpiderThread(

--- a/addOns/tips/src/main/java/org/zaproxy/zap/extension/tips/ExtensionTipsAndTricks.java
+++ b/addOns/tips/src/main/java/org/zaproxy/zap/extension/tips/ExtensionTipsAndTricks.java
@@ -22,8 +22,6 @@ package org.zaproxy.zap.extension.tips;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -134,15 +132,6 @@ public class ExtensionTipsAndTricks extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /**

--- a/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/ExtensionTlsDebug.java
+++ b/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/ExtensionTlsDebug.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.tlsdebug;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -70,15 +69,6 @@ public class ExtensionTlsDebug extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("tlsdebug.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     public void launchDebug(URL url) throws IOException {

--- a/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
+++ b/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/ExtensionTokenGen.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.tokengen;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -374,15 +372,6 @@ public class ExtensionTokenGen extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return getMessages().getString("tokengen.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     private class SessionChangedListenerImpl implements SessionChangedListener {

--- a/addOns/viewstate/src/main/java/org/zaproxy/zap/extension/viewstate/ExtensionHttpPanelViewStateView.java
+++ b/addOns/viewstate/src/main/java/org/zaproxy/zap/extension/viewstate/ExtensionHttpPanelViewStateView.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.viewstate;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -158,15 +156,6 @@ public class ExtensionHttpPanelViewStateView extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("viewstate.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     /** No database tables used, so all supported */

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -21,8 +21,6 @@ package org.zaproxy.zap.extension.wappalyzer;
 
 import java.awt.EventQueue;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -179,15 +177,6 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     @Override
     public String getDescription() {
         return Constant.messages.getString("wappalyzer.desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_HOMEPAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 
     @Override

--- a/addOns/wavsepRpt/src/main/java/org/zaproxy/zap/extension/wavsepRpt/ExtensionWavsepReport.java
+++ b/addOns/wavsepRpt/src/main/java/org/zaproxy/zap/extension/wavsepRpt/ExtensionWavsepReport.java
@@ -22,9 +22,7 @@ package org.zaproxy.zap.extension.wavsepRpt;
 import java.awt.CardLayout;
 import java.io.File;
 import java.io.PrintWriter;
-import java.net.MalformedURLException;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -512,14 +510,5 @@ public class ExtensionWavsepReport extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public URL getURL() {
-        try {
-            return new URL(Constant.ZAP_EXTENSIONS_PAGE);
-        } catch (MalformedURLException e) {
-            return null;
-        }
     }
 }


### PR DESCRIPTION
The links point to generic/main pages that don't provide any information
about the extensions.