### PR TITLE
Normalise author name in add-ons

### DIFF
--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -6,7 +6,7 @@ zapAddOn {
     zapVersion.set("2.8.0")
 
     manifest {
-        author.set("ZAP Core Team")
+        author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/custom-payloads/")
     }
 }

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -9,7 +9,7 @@ zapAddOn {
     zapVersion.set("2.8.0")
 
     manifest {
-        author.set("ZAP Core Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak and Marcin Spiewak")
+        author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak and Marcin Spiewak")
         url.set("https://www.zaproxy.org/docs/desktop/addons/openapi-support/")
     }
 

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -6,7 +6,7 @@ zapAddOn {
     zapVersion.set("2.8.0")
 
     manifest {
-        author.set("Alberto (albertov91) + ZAP Core team")
+        author.set("Alberto (albertov91) + ZAP Dev Team")
     }
 
     apiClientGen {


### PR DESCRIPTION
Use `ZAP Dev Team` instead of `ZAP Core Team`, the latter was less used.