### PR TITLE
zest: use core method to set pop up menu

### DIFF
--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.zest;
 
-import java.awt.Component;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -31,7 +30,6 @@ import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.swing.JComponent;
 import javax.swing.JPopupMenu;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -98,7 +96,6 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.script.ScriptNode;
 
 public class ZestZapUtils {
@@ -1130,30 +1127,6 @@ public class ZestZapUtils {
             return ((ZestElementWrapper) node.getUserObject()).getShadowLevel();
         }
         return 0;
-    }
-
-    // TODO remove once targeting core version that allows to set the pop up menu into the fields of
-    // StandardFieldsDialog.
-    public static void setMainPopupMenu(Component component) {
-        if (component instanceof JComponent) {
-            ((JComponent) component).setComponentPopupMenu(getPopupMenu());
-        }
-    }
-
-    private static JPopupMenu getPopupMenu() {
-        if (popupMenu == null) {
-            popupMenu =
-                    new JPopupMenu() {
-
-                        private static final long serialVersionUID = 1L;
-
-                        @Override
-                        public void show(Component invoker, int x, int y) {
-                            View.getSingleton().getPopupMenu().show(invoker, x, y);
-                        }
-                    };
-        }
-        return popupMenu;
     }
 
     public static boolean isValidVariableName(String name) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
@@ -49,7 +49,6 @@ import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
-import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
 public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog {
@@ -142,12 +141,12 @@ public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog
                         priorities,
                         priorityToStr(ZestActionFail.Priority.valueOf(za.getPriority())));
             }
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_MESSAGE));
+            setFieldMainPopupMenu(FIELD_MESSAGE);
 
         } else if (action instanceof ZestActionPrint) {
             ZestActionPrint za = (ZestActionPrint) action;
             this.addMultilineField(FIELD_MESSAGE, za.getMessage());
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_MESSAGE));
+            setFieldMainPopupMenu(FIELD_MESSAGE);
 
         } else if (action instanceof ZestActionSleep) {
             ZestActionSleep za = (ZestActionSleep) action;
@@ -172,7 +171,7 @@ public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog
             ZestActionGlobalVariableSet za = (ZestActionGlobalVariableSet) action;
             addTextField(FIELD_GLOBAL_VAR, za.getGlobalVariableName());
             addMultilineField(FIELD_GLOBAL_VAR_VALUE, za.getValue());
-            ZestZapUtils.setMainPopupMenu(getField(FIELD_GLOBAL_VAR_VALUE));
+            setFieldMainPopupMenu(FIELD_GLOBAL_VAR_VALUE);
         } else if (action instanceof ZestActionGlobalVariableRemove) {
             ZestActionGlobalVariableRemove za = (ZestActionGlobalVariableRemove) action;
             addTextField(FIELD_GLOBAL_VAR, za.getGlobalVariableName());

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssertionsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssertionsDialog.java
@@ -109,7 +109,7 @@ public class ZestAssertionsDialog extends StandardFieldsDialog implements ZestDi
             this.addCheckBoxField(FIELD_EXACT, za.isCaseExact());
             this.addCheckBoxField(FIELD_INVERSE, za.isInverse());
 
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE));
+            setFieldMainPopupMenu(FIELD_VALUE);
 
         } else if (assertion.getRootExpression() instanceof ZestExpressionRegex) {
             ZestExpressionRegex za = (ZestExpressionRegex) assertion.getRootExpression();

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
@@ -174,7 +174,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
                     FIELD_VARIABLE, this.getVariableNames(true), assign.getVariableName(), true);
             this.addTextField(FIELD_STRING, za.getString());
 
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_STRING));
+            setFieldMainPopupMenu(FIELD_STRING);
 
         } else if (assign instanceof ZestAssignReplace) {
             ZestAssignReplace za = (ZestAssignReplace) assign;
@@ -185,8 +185,8 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
             this.addCheckBoxField(FIELD_REGEX, za.isRegex());
             this.addCheckBoxField(FIELD_EXACT, za.isCaseExact());
 
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_REPLACE));
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_REPLACEMENT));
+            setFieldMainPopupMenu(FIELD_REPLACE);
+            setFieldMainPopupMenu(FIELD_REPLACEMENT);
 
         } else if (assign instanceof ZestAssignCalc) {
             ZestAssignCalc za = (ZestAssignCalc) assign;
@@ -203,7 +203,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
                     },
                     ZestZapUtils.calcOperationToLabel(za.getOperation()));
 
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_STRING));
+            setFieldMainPopupMenu(FIELD_STRING);
 
         } else if (assign instanceof ZestAssignFromElement) {
             ZestAssignFromElement za = (ZestAssignFromElement) assign;
@@ -252,15 +252,11 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
             this.addFieldListener(
                     FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR, e -> initElementsSelector());
 
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_FROM_ELEMENT_FILTER_BY_ELEMENT_NAME));
-            ZestZapUtils.setMainPopupMenu(
-                    this.getField(FIELD_FROM_ELEMENT_FILTER_BY_ATTRIBUTE_NAME));
-            ZestZapUtils.setMainPopupMenu(
-                    this.getField(FIELD_FROM_ELEMENT_FILTER_BY_ATTRIBUTE_VALUE));
-            ZestZapUtils.setMainPopupMenu(
-                    this.getField(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_INDEX));
-            ZestZapUtils.setMainPopupMenu(
-                    this.getField(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR_ATTRIBUTE_NAME));
+            setFieldMainPopupMenu(FIELD_FROM_ELEMENT_FILTER_BY_ELEMENT_NAME);
+            setFieldMainPopupMenu(FIELD_FROM_ELEMENT_FILTER_BY_ATTRIBUTE_NAME);
+            setFieldMainPopupMenu(FIELD_FROM_ELEMENT_FILTER_BY_ATTRIBUTE_VALUE);
+            setFieldMainPopupMenu(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_INDEX);
+            setFieldMainPopupMenu(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR_ATTRIBUTE_NAME);
         } else if (assign instanceof ZestAssignGlobalVariable) {
             ZestAssignGlobalVariable za = (ZestAssignGlobalVariable) assign;
             addTextField(FIELD_VARIABLE, assign.getVariableName());

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementAssignDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementAssignDialog.java
@@ -60,7 +60,7 @@ public class ZestClientElementAssignDialog extends ZestClientElementDialog imple
             this.setTitle(
                     Constant.messages.getString("zest.dialog.clientElementAssign.edit.title"));
         }
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_ATTRIBUTE));
+        setFieldMainPopupMenu(FIELD_ATTRIBUTE);
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementDialog.java
@@ -30,7 +30,6 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
-import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
 public abstract class ZestClientElementDialog extends StandardFieldsDialog implements ZestDialog {
@@ -90,7 +89,7 @@ public abstract class ZestClientElementDialog extends StandardFieldsDialog imple
         this.addComboField(FIELD_ELEMENT_TYPE, getElementTypeFields(), clientType);
         this.addTextField(FIELD_ELEMENT, client.getElement());
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_ELEMENT));
+        setFieldMainPopupMenu(FIELD_ELEMENT);
     }
 
     private List<String> getElementTypeFields() {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementSendKeysDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementSendKeysDialog.java
@@ -28,7 +28,6 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
-import org.zaproxy.zap.extension.zest.ZestZapUtils;
 
 public class ZestClientElementSendKeysDialog extends ZestClientElementDialog implements ZestDialog {
 
@@ -60,7 +59,7 @@ public class ZestClientElementSendKeysDialog extends ZestClientElementDialog imp
                     Constant.messages.getString("zest.dialog.clientElementSendKeys.edit.title"));
         }
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE));
+        setFieldMainPopupMenu(FIELD_VALUE);
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
@@ -130,7 +130,7 @@ public class ZestClientLaunchDialog extends StandardFieldsDialog implements Zest
 
         this.addTableField(1, this.getParamsTable(), buttons);
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_URL));
+        setFieldMainPopupMenu(FIELD_URL);
     }
 
     private List<String[]> getCapabilities(ZestClientLaunch client) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientScreenshotDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientScreenshotDialog.java
@@ -30,7 +30,6 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
-import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
 public class ZestClientScreenshotDialog extends StandardFieldsDialog implements ZestDialog {
@@ -83,7 +82,7 @@ public class ZestClientScreenshotDialog extends StandardFieldsDialog implements 
         this.addTextField(FIELD_FILE_PATH, client.getFilePath());
         this.addTextField(FIELD_VARIABLE_NAME, client.getVariableName());
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VARIABLE_NAME));
+        setFieldMainPopupMenu(FIELD_VARIABLE_NAME);
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
@@ -34,7 +34,6 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
-import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.StandardFieldsDialog;
@@ -94,7 +93,7 @@ public class ZestClientSwitchToFrameDialog extends StandardFieldsDialog implemen
         this.addNumberField(FIELD_FRAME_INDEX, -1, 1024, client.getFrameIndex());
         this.addCheckBoxField(FIELD_PARENT_FRAME, client.isParent());
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_FRAME_NAME));
+        setFieldMainPopupMenu(FIELD_FRAME_NAME);
 
         // Only allow one choice to be selected
         ((ZapTextField) getField(FIELD_FRAME_NAME))

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowHandleDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowHandleDialog.java
@@ -77,7 +77,7 @@ public class ZestClientWindowHandleDialog extends StandardFieldsDialog implement
         this.addTextField(FIELD_URL, client.getUrl());
         this.addCheckBoxField(FIELD_REGEX, client.isRegex());
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_URL));
+        setFieldMainPopupMenu(FIELD_URL);
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestControlDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestControlDialog.java
@@ -29,7 +29,6 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
-import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
 public class ZestControlDialog extends StandardFieldsDialog implements ZestDialog {
@@ -76,7 +75,7 @@ public class ZestControlDialog extends StandardFieldsDialog implements ZestDialo
         if (control instanceof ZestControlReturn) {
             ZestControlReturn za = (ZestControlReturn) control;
             this.addTextField(FIELD_VALUE, za.getValue());
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE));
+            setFieldMainPopupMenu(FIELD_VALUE);
         }
         this.addPadding();
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
@@ -23,7 +23,6 @@ import java.awt.Dimension;
 import java.awt.Window;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
-import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
 public class ZestCookieDialog extends StandardFieldsDialog implements ZestDialog {
@@ -71,10 +70,10 @@ public class ZestCookieDialog extends StandardFieldsDialog implements ZestDialog
         this.addTextField(FIELD_PARAM_PATH, path);
         this.addPadding();
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_DOMAIN));
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_NAME));
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_VALUE));
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_PATH));
+        setFieldMainPopupMenu(FIELD_PARAM_DOMAIN);
+        setFieldMainPopupMenu(FIELD_PARAM_NAME);
+        setFieldMainPopupMenu(FIELD_PARAM_VALUE);
+        setFieldMainPopupMenu(FIELD_PARAM_PATH);
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestExpressionDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestExpressionDialog.java
@@ -124,7 +124,7 @@ public class ZestExpressionDialog extends StandardFieldsDialog implements ZestDi
             this.addTextField(FIELD_VALUE, za.getValue());
             this.addCheckBoxField(FIELD_EXACT, za.isCaseExact());
 
-            ZestZapUtils.setMainPopupMenu(this.getField(FIELD_VALUE));
+            setFieldMainPopupMenu(FIELD_VALUE);
 
         } else if (expression instanceof ZestExpressionStatusCode) {
             ZestExpressionStatusCode za = (ZestExpressionStatusCode) expression;
@@ -171,7 +171,7 @@ public class ZestExpressionDialog extends StandardFieldsDialog implements ZestDi
                     ZestClientElementDialog.FIELD_ELEMENT_TYPE, getElementTypeFields(), clientType);
             this.addTextField(ZestClientElementDialog.FIELD_ELEMENT, zc.getElement());
 
-            ZestZapUtils.setMainPopupMenu(this.getField(ZestClientElementDialog.FIELD_ELEMENT));
+            setFieldMainPopupMenu(ZestClientElementDialog.FIELD_ELEMENT);
         }
         this.addCheckBoxField(FIELD_INVERSE, expression.isInverse());
         this.addPadding();

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
@@ -208,7 +208,7 @@ public class ZestLoopDialog extends StandardFieldsDialog implements ZestDialog {
                 ZestClientElementDialog.FIELD_ELEMENT_TYPE, getElementTypeFields(), clientType);
         this.addTextField(ZestClientElementDialog.FIELD_ELEMENT, loop.getElement());
 
-        ZestZapUtils.setMainPopupMenu(this.getField(ZestClientElementDialog.FIELD_ELEMENT));
+        setFieldMainPopupMenu(ZestClientElementDialog.FIELD_ELEMENT);
     }
 
     private void drawLoopRegexDialog(ZestLoopRegex loop) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestParameterDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestParameterDialog.java
@@ -65,8 +65,8 @@ public class ZestParameterDialog extends StandardFieldsDialog implements ZestDia
         this.addTextField(FIELD_PARAM_VALUE, value);
         this.addPadding();
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_NAME));
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_PARAM_VALUE));
+        setFieldMainPopupMenu(FIELD_PARAM_NAME);
+        setFieldMainPopupMenu(FIELD_PARAM_VALUE);
     }
 
     @Override

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
@@ -140,9 +140,9 @@ public class ZestRequestDialog extends StandardFieldsDialog implements ZestDialo
         this.addMultilineField(0, FIELD_HEADERS, request.getHeaders());
         this.addMultilineField(0, FIELD_BODY, request.getData());
 
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_URL));
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_HEADERS));
-        ZestZapUtils.setMainPopupMenu(this.getField(FIELD_BODY));
+        setFieldMainPopupMenu(FIELD_URL);
+        setFieldMainPopupMenu(FIELD_HEADERS);
+        setFieldMainPopupMenu(FIELD_BODY);
 
         // Cookies tab
         List<JButton> buttons = new ArrayList<JButton>();


### PR DESCRIPTION
Replace add-on code with core method that sets the pop up menu into
the dialogue fields.