### PR TITLE
jruby: update ZAP to 2.9.0

### DIFF
--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update the help to mention the bundled JRuby version.
+- Update minimum ZAP version to 2.9.0.
 
 ### Fixed
 - Fix link in a script template.

--- a/addOns/jruby/jruby.gradle.kts
+++ b/addOns/jruby/jruby.gradle.kts
@@ -6,7 +6,7 @@ description = "Allows Ruby to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Ruby Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
+++ b/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/ExtensionJruby.java
@@ -24,8 +24,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
+import javax.script.ScriptEngineFactory;
 import javax.swing.ImageIcon;
 import org.jruby.embed.jsr223.JRubyEngineFactory;
 import org.parosproxy.paros.Constant;
@@ -62,7 +61,7 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
     }
 
     private ExtensionScript extScript = null;
-    private ScriptEngine rubyScriptEngine = null;
+    private ScriptEngineFactory scriptEngineFactory;
     private JrubyEngineWrapper engineWrapper;
 
     public ExtensionJruby() {
@@ -74,12 +73,9 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 
-        if (this.getRubyScriptEngine() == null) {
-            JRubyEngineFactory factory = new JRubyEngineFactory();
-            this.rubyScriptEngine = factory.getScriptEngine();
-            engineWrapper = new JrubyEngineWrapper(this.rubyScriptEngine, getDefaultTemplates());
-            this.getExtScript().registerScriptEngineWrapper(engineWrapper);
-        }
+        this.scriptEngineFactory = new JRubyEngineFactory();
+        engineWrapper = new JrubyEngineWrapper(scriptEngineFactory, getDefaultTemplates());
+        this.getExtScript().registerScriptEngineWrapper(engineWrapper);
 
         this.getExtScript().addListener(this);
     }
@@ -116,34 +112,21 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
     public void unload() {
         super.unload();
 
-        if (rubyScriptEngine != null) {
-            String engineName = rubyScriptEngine.getFactory().getEngineName();
-            for (ScriptType type : this.getExtScript().getScriptTypes()) {
-                for (ScriptWrapper script : this.getExtScript().getScripts(type)) {
-                    if (script.getEngineName().equals(engineName)) {
-                        if (script instanceof JrubyScriptWrapper) {
-                            ScriptNode node =
-                                    this.getExtScript().getTreeModel().getNodeForScript(script);
-                            node.setUserObject(((JrubyScriptWrapper) script).getOriginal());
-                        }
+        String engineName = scriptEngineFactory.getEngineName();
+        for (ScriptType type : this.getExtScript().getScriptTypes()) {
+            for (ScriptWrapper script : this.getExtScript().getScripts(type)) {
+                if (script.getEngineName().equals(engineName)) {
+                    if (script instanceof JrubyScriptWrapper) {
+                        ScriptNode node =
+                                this.getExtScript().getTreeModel().getNodeForScript(script);
+                        node.setUserObject(((JrubyScriptWrapper) script).getOriginal());
                     }
                 }
             }
         }
 
+        getExtScript().removeScriptEngineWrapper(engineWrapper);
         getExtScript().removeListener(this);
-
-        if (engineWrapper != null) {
-            getExtScript().removeScriptEngineWrapper(engineWrapper);
-        }
-    }
-
-    private ScriptEngine getRubyScriptEngine() {
-        if (this.rubyScriptEngine == null) {
-            ScriptEngineManager mgr = new ScriptEngineManager();
-            this.rubyScriptEngine = mgr.getEngineByExtension("rb");
-        }
-        return this.rubyScriptEngine;
     }
 
     private ExtensionScript getExtScript() {
@@ -155,11 +138,6 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
                                     .getExtension(ExtensionScript.NAME);
         }
         return extScript;
-    }
-
-    @Override
-    public String getAuthor() {
-        return Constant.ZAP_TEAM;
     }
 
     @Override
@@ -185,11 +163,7 @@ public class ExtensionJruby extends ExtensionAdaptor implements ScriptEventListe
     @Override
     public void scriptAdded(ScriptWrapper script, boolean arg1) {
 
-        if (this.getRubyScriptEngine() != null
-                && this.getRubyScriptEngine()
-                        .getFactory()
-                        .getEngineName()
-                        .equals(script.getEngineName())) {
+        if (scriptEngineFactory.getEngineName().equals(script.getEngineName())) {
 
             // Replace the standard ScriptWrapper with a JrubyScriptWrapper as
             // JRuby seems to handle interfaces differently from other JSR223 languages

--- a/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/JrubyEngineWrapper.java
+++ b/addOns/jruby/src/main/java/org/zaproxy/zap/extension/jruby/JrubyEngineWrapper.java
@@ -22,7 +22,7 @@ package org.zaproxy.zap.extension.jruby;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
 import javax.swing.ImageIcon;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.zaproxy.zap.extension.script.DefaultEngineWrapper;
@@ -32,8 +32,8 @@ public class JrubyEngineWrapper extends DefaultEngineWrapper {
 
     private final List<Path> defaultTemplates;
 
-    public JrubyEngineWrapper(ScriptEngine engine, List<Path> defaultTemplates) {
-        super(engine);
+    public JrubyEngineWrapper(ScriptEngineFactory engineFactory, List<Path> defaultTemplates) {
+        super(engineFactory);
 
         if (defaultTemplates == null) {
             throw new IllegalArgumentException("Parameter defaultTemplates must not be null.");


### PR DESCRIPTION
Address deprecation.
Use the `ScriptEngineFactory` directly, remove code no longer needed.
Remove redundant author in the extension.