### PR TITLE
testutils: update ZAP to 2.9.0

### DIFF
--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScannerUnitTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.users.User;
 
 public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdorScanner> {
 
@@ -46,7 +48,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
     @Before
     public void before() throws URIException {
 
-        rule.setUsers("guest");
+        when(passiveScanData.getUsers()).thenReturn(Arrays.asList(new User(1, "guest")));
 
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
@@ -66,7 +68,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
         // Given
         msg.setResponseBody("Some text <h1>Some Title Element</h1>");
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 0);
     }
@@ -77,7 +79,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
         msg.setResponseBody(
                 "Some text <h1>Some Title Element</h1><i>adb831a7fdd83dd1e2a309ce7591dff8</i>");
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 0);
     }
@@ -88,7 +90,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
         msg.setResponseBody(
                 "Some text <h1>Some Title Element</h1><i>084E0343A0486fF05530DF6C705C8Bb4</i>");
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 1);
         assertEquals(alertsRaised.get(0).getEvidence(), "084E0343A0486fF05530DF6C705C8Bb4");
@@ -100,7 +102,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
         msg.setResponseBody(
                 "Some text <h1>Some Title Element</h1><b>84983c60f7daadc1cb8698621f802c0d9f9a3c3c295c810748fb048115c186ec</b>");
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 1);
         assertEquals(alertsRaised.get(0).getEvidence(), GUEST_SHA1);
@@ -118,7 +120,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
                         + GUEST_SHA1
                         + "</b>");
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 2);
         assertEquals(alertsRaised.get(0).getEvidence(), GUEST_SHA1);
@@ -135,7 +137,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
                         + "pulvinar convallis. Maecenas laoreet fermentum tempor. "
                         + "Nulla et.</p>");
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 1);
         assertEquals(alertsRaised.get(0).getEvidence(), GUEST_MD5);
@@ -147,7 +149,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
         msg.getResponseHeader().setHeader("X-Test-Thing", ADMIN_MD5);
         msg.setResponseBody("Some text <h1>Some Title Element</h1>");
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 1);
         assertEquals(alertsRaised.get(0).getEvidence(), ADMIN_MD5);
@@ -161,7 +163,7 @@ public class UsernameIdorScannerUnitTest extends PassiveScannerTest<UsernameIdor
         List<String> testUsers = Arrays.asList("foobar");
         UsernameIdorScanner.setPayloadProvider(() -> testUsers);
         // When
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 1);
         assertEquals(alertsRaised.get(0).getEvidence(), FOOBAR_MD2);

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScannerUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScannerUnitTest.java
@@ -162,10 +162,6 @@ public class ServletParameterPollutionScannerUnitTest
         assertEquals(expected, alertsRaised.size());
     }
 
-    private void scanHttpResponseReceive(HttpMessage msg) {
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
-    }
-
     private HttpMessage createHttpMessageFromHtml(String html) throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET " + URI + " HTTP/1.1");

--- a/testutils/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTestHelper.java
+++ b/testutils/src/main/java/org/zaproxy/zap/extension/pscan/PassiveScanTestHelper.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscan;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpMessage;
+
+public final class PassiveScanTestHelper {
+
+    private PassiveScanTestHelper() {}
+
+    public static void init(
+            PluginPassiveScanner rule,
+            PassiveScanThread parent,
+            HttpMessage message,
+            PassiveScanData passiveScanData) {
+        HistoryReference historyRef = mock(HistoryReference.class);
+        when(historyRef.getHistoryId()).thenReturn(1);
+        message.setHistoryRef(historyRef);
+        rule.init(parent, message, passiveScanData);
+    }
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/PassiveScannerTestUtils.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,8 @@ import org.junit.Before;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
+import org.zaproxy.zap.extension.pscan.PassiveScanData;
+import org.zaproxy.zap.extension.pscan.PassiveScanTestHelper;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -45,6 +48,7 @@ public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends 
 
     protected T rule;
     protected PassiveScanThread parent;
+    protected PassiveScanData passiveScanData = mock(PassiveScanData.class);
     protected List<Alert> alertsRaised;
 
     public PassiveScannerTestUtils() {
@@ -83,6 +87,22 @@ public abstract class PassiveScannerTestUtils<T extends PassiveScanner> extends 
     }
 
     protected abstract T createScanner();
+
+    protected void scanHttpRequestSend(HttpMessage msg) {
+        initRule(msg);
+        rule.scanHttpRequestSend(msg, -1);
+    }
+
+    protected void scanHttpResponseReceive(HttpMessage msg) {
+        initRule(msg);
+        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+    }
+
+    private void initRule(HttpMessage msg) {
+        if (rule instanceof PluginPassiveScanner) {
+            PassiveScanTestHelper.init((PluginPassiveScanner) rule, parent, msg, passiveScanData);
+        }
+    }
 
     protected Source createSource(HttpMessage msg) {
         return new Source(msg.getResponseBody().toString());

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -78,7 +78,6 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
-import org.zaproxy.zap.utils.ClassLoaderUtil;
 import org.zaproxy.zap.utils.I18N;
 
 /**
@@ -162,12 +161,13 @@ public abstract class TestUtils {
      * @throws Exception if an error occurred while setting up the dirs or core classes.
      * @see #setUpMessages()
      */
+    @SuppressWarnings("deprecation")
     protected void setUpZap() throws Exception {
         Constant.setZapInstall(zapInstallDir);
         Constant.setZapHome(zapHomeDir);
 
         File langDir = new File(Constant.getZapInstall(), "lang");
-        ClassLoaderUtil.addFile(langDir.getAbsolutePath());
+        org.zaproxy.zap.utils.ClassLoaderUtil.addFile(langDir.getAbsolutePath());
 
         Control control = mock(Control.class, withSettings().lenient());
         when(control.getExtensionLoader()).thenReturn(mock(ExtensionLoader.class));

--- a/testutils/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/testutils/src/main/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -12,7 +12,7 @@ java {
 val nanohttpdVersion = "2.3.1"
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.7.0")
+    compileOnly("org.zaproxy:zap:2.9.0")
 
     api("junit:junit:4.11")
 


### PR DESCRIPTION
Allow to test scan rules that use new core features (i.e. raise alerts
through the alert builder and use `PassiveScanData`).
Update `UsernameIdorScanner` as example.