### PR TITLE
zest: properly separate header fields when editing

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 
+### Fixed
+- Make sure the header fields are separated with CRLF when edited in the UI.
+
 ## [32] - 2020-01-24
 ### Changed
 - Update Zest library to 0.14.2, to correctly ignore cert checks.

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
@@ -166,7 +166,10 @@ public class ZestRequestDialog extends StandardFieldsDialog implements ZestDialo
                     0,
                     Integer.MAX_VALUE,
                     (int) request.getResponse().getResponseTimeInMs());
-            this.addMultilineField(2, FIELD_RESP_HEADERS, request.getResponse().getHeaders());
+            this.addMultilineField(
+                    2,
+                    FIELD_RESP_HEADERS,
+                    request.getResponse().getHeaders().replaceAll("\r\n", "\n"));
             this.addMultilineField(2, FIELD_RESP_BODY, request.getResponse().getBody());
         } else {
             this.addComboField(
@@ -211,7 +214,7 @@ public class ZestRequestDialog extends StandardFieldsDialog implements ZestDialo
             }
         }
         this.request.setMethod(this.getStringValue(FIELD_METHOD));
-        this.request.setHeaders(this.getStringValue(FIELD_HEADERS));
+        this.request.setHeaders(this.getStringValue(FIELD_HEADERS).replaceAll("\r?\n", "\r\n"));
         this.request.setFollowRedirects(this.getBoolValue(FIELD_FOLLOW_REDIR));
         this.request.setData(this.getStringValue(FIELD_BODY));
 


### PR DESCRIPTION
Make sure the header fields are separated with CRLFs when setting them
to the script as the editor might just add LFs, also, normalise them to
LFs when reading from the script.

----
From OWASP ZAP User Group: https://groups.google.com/d/topic/zaproxy-users/BSENsfc5Zs4/discussion