### PR TITLE
ascanrules: Update Dependencies

### DIFF
--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -15,8 +15,8 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.googlecode.java-diff-utils:diffutils:1.2.1")
-    implementation("org.bitbucket.mstrobel:procyon-compilertools:0.5.25")
+    implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
+    implementation("org.bitbucket.mstrobel:procyon-compilertools:0.5.36")
 
     testImplementation(project(":testutils"))
     testImplementation("org.apache.commons:commons-lang3:3.9")

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -1275,7 +1275,7 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                                             + sqlBooleanAndTrueValue
                                             + "] does NOT match the (refreshed) original results for "
                                             + refreshedmessage.getRequestHeader().getURI());
-                            Patch diffpatch =
+                            Patch<String> diffpatch =
                                     DiffUtils.diff(
                                             new LinkedList<String>(
                                                     Arrays.asList(
@@ -1292,7 +1292,7 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
 
                             // and convert the list of patches to a String, joining using a newline
                             StringBuilder tempDiff = new StringBuilder(250);
-                            for (Delta delta : diffpatch.getDeltas()) {
+                            for (Delta<String> delta : diffpatch.getDeltas()) {
                                 String changeType = null;
                                 if (delta.getType() == Delta.TYPE.CHANGE) {
                                     changeType = "Changed Text";


### PR DESCRIPTION
- com.googlecode.java-diff-utils:diffutils [1.2.1 -> 1.3.0] (Used by TestSQLInjection)
- org.bitbucket.mstrobel:procyon-compilertools [0.5.25 -> 0.5.36] (Used by SourceCodeDisclosureWEBINF)

I didn't update the CHANGELOG further as it already contains a "maintenance changes" entry

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>