### PR TITLE
ascanrulesBeta: Update Dependencies

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Backup File Disclosure scan rule - updated CWE to 530, added reference links to alerts, made sure WASC and CWE identifiers are included in alerts.
+- Maintenance changes.
 
 ## [27] - 2019-12-16
 

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -31,13 +31,13 @@ zapAddOn {
 dependencies {
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
-    implementation("com.googlecode.java-diff-utils:diffutils:1.2.1")
-    implementation("org.jsoup:jsoup:1.7.2")
+    implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
+    implementation("org.jsoup:jsoup:1.13.1")
     implementation(project(":sharedutils"))
 
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
-    testImplementation("org.apache.commons:commons-lang3:3.5")
+    testImplementation("org.apache.commons:commons-lang3:3.9")
 }
 
 spotless {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
@@ -692,7 +692,7 @@ public class UsernameEnumeration extends AbstractAppPlugin {
                         // calculate line level diffs of the 2 Longest Common Substrings to aid the
                         // user in deciding if the match is a false positive
                         // get the diff as a series of patches
-                        Patch diffpatch =
+                        Patch<String> diffpatch =
                                 DiffUtils.diff(
                                         new LinkedList<String>(
                                                 Arrays.asList(
@@ -706,7 +706,7 @@ public class UsernameEnumeration extends AbstractAppPlugin {
                         // and convert the list of patches to a String, joining using a newline
                         // String diffAB = StringUtils.join(diffpatch.getDeltas(), "\n");
                         StringBuilder tempDiff = new StringBuilder(250);
-                        for (Delta delta : diffpatch.getDeltas()) {
+                        for (Delta<String> delta : diffpatch.getDeltas()) {
                             String changeType = null;
                             if (delta.getType() == Delta.TYPE.CHANGE) changeType = "Changed Text";
                             else if (delta.getType() == Delta.TYPE.DELETE)


### PR DESCRIPTION
- com.googlecode.java-diff-utils:diffutils [1.2.1 -> 1.3.0] (Used by UsernameEnumeration)
- org.apache.commons:commons-lang3 [3.5 -> 3.9] (Used in unit tests testImplementation)
- org.jsoup:jsoup [1.7.2 -> 1.13.1] (Used by RelativePathConfusionScanner)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>