### PR TITLE
callgraph: Update Dependencies

### DIFF
--- a/addOns/callgraph/CHANGELOG.md
+++ b/addOns/callgraph/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Maintenance changes.
 
 ## 4 - 2017-11-24
 

--- a/addOns/callgraph/callgraph.gradle.kts
+++ b/addOns/callgraph/callgraph.gradle.kts
@@ -17,6 +17,5 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("jgraph:jgraph:5.13.0.0")
-    implementation("org.tinyjee.jgraphx:jgraphx:2.0.0.1")
+    implementation("org.tinyjee.jgraphx:jgraphx:3.4.1.3")
 }


### PR DESCRIPTION
- org.tinyjee.jgraphx:jgraphx [2.0.0.1 -> 3.4.1.3]

Removed un-necessary dependency:
 - jgraph:jgraph [5.5.1]

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>