### PR TITLE
pscanrulesBeta: SPP Check Tech

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 'PII Disclosure scanner' alerts and help entry renamed 'PII Disclosure' for clarity and proper title caps.
 - 'PII Disclosure' added further false positive handling with regard to exponential numbers such as 2.4670000000000001E-2 or 2.4670000000000001E2.
 - Maintenance changes.
+- 'Servlet Parameter Pollution' scan rule will now only scan responses for in Context URLs for which the Technology JSP/Serlet is applicable.
 
 ## [21] - 2019-12-16
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanner.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanner.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.model.Tech;
 
 /**
  * Servlet Parameter Pollution rule. Suggested by Jeff Williams on the OWASP Leaders List:
@@ -62,7 +63,8 @@ public class ServletParameterPollutionScanner extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (!AlertThreshold.LOW.equals(this.getAlertThreshold())) {
+        if (!AlertThreshold.LOW.equals(this.getAlertThreshold())
+                || !getHelper().getTechSet().includes(Tech.JSP_SERVLET)) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -93,7 +93,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 Searches response content for HTML forms which fail to specify an action element. Version 3 of the 
 Java Servlet spec calls for aggregation of query string and post data elements which may result in 
 unintended handling of user controlled data. This may impact other frameworks and technologies as well.
-<strong>Note:</strong> This scan rule will only analyze responses on LOW Threshold.
+<strong>Note:</strong> This scan rule will only analyze responses on LOW Threshold, and in Context URLs for which the Tech JSP/Servlet is applicable.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanner.java">ServletParameterPollutionScanner.java</a>
 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScannerUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScannerUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -28,6 +29,8 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
 
 public class ServletParameterPollutionScannerUnitTest
         extends PassiveScannerTest<ServletParameterPollutionScanner> {
@@ -42,6 +45,7 @@ public class ServletParameterPollutionScannerUnitTest
     @Before
     public void before() {
         rule.setAlertThreshold(AlertThreshold.LOW);
+        when(passiveScanData.getTechSet()).thenReturn(TechSet.AllTech);
     }
 
     @Test
@@ -105,6 +109,32 @@ public class ServletParameterPollutionScannerUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertNumberOfAlertsRaised(0);
+    }
+
+    @Test
+    public void
+            givenFormWithNoActionAttributeWhenScanHttpResponseReceiveWithTechNotRelevantThenNoAlertRaised()
+                    throws Exception {
+        // Given
+        HttpMessage msg = createHttpMessageFromHtml("<form />");
+        when(passiveScanData.getTechSet()).thenReturn(new TechSet(new Tech[] {Tech.Access}));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertNumberOfAlertsRaised(0);
+    }
+
+    @Test
+    public void
+            givenFormWithNoActionAttributeWhenScanHttpResponseReceiveWithTechRelevantThenAlertRaised()
+                    throws Exception {
+        // Given
+        HttpMessage msg = createHttpMessageFromHtml("<form />");
+        when(passiveScanData.getTechSet()).thenReturn(new TechSet(new Tech[] {Tech.JSP_SERVLET}));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertNumberOfAlertsRaised(1);
     }
 
     @Test


### PR DESCRIPTION
Fixes zaproxy/zaproxy#4454

Update scan rule, unit test, help, and changelog. If the threshold isn't Low or techset doesn't include JSP/Servlet don't scan response.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>