### PR TITLE
websocket: prevent exception in API implementors

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 
+### Fixed
+- Correctly handle API request without parameters.
+
 ## [21] - 2020-01-17
 ### Added
 - Add info and repo URLs.

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -212,9 +212,11 @@ public class WebSocketAPI extends ApiImplementor {
                                 json = JSONObject.fromObject(message.getReadablePayload());
                                 String component = json.getString("component");
                                 String name = json.getString("name");
-                                JSONObject params = null;
+                                JSONObject params;
                                 if (json.has("params")) {
                                     params = json.getJSONObject("params");
+                                } else {
+                                    params = new JSONObject();
                                 }
                                 JSON response = null;
 


### PR DESCRIPTION
Ensure the parameters object passed to API implementors is not null,
they expect/require non-null object.