### PR TITLE
ascanrulesAlpha: fix NPE in HiddenFilesScanRule

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Change info URL to link to the site.
 - Update ZAP blog links.
 
+### Fixed
+- Fix exception when scanning a message without path with Hidden File Finder.
+
 ## [27] - 2019-12-16
 
 ### Added

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java
@@ -126,7 +126,9 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
 
     private static String generatePath(String baseUriPath, String hiddenFile) {
         String newPath = "";
-        if (baseUriPath.contains("/")) {
+        if (baseUriPath == null) {
+            newPath = "/" + hiddenFile;
+        } else if (baseUriPath.contains("/")) {
             if (baseUriPath.endsWith("/")) {
                 newPath = baseUriPath + hiddenFile;
             } else {

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRuleUnitTest.java
@@ -59,6 +59,25 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
+    public void shouldScanMessageWithoutPath() throws HttpMalformedHeaderException {
+        // Given
+        String path = "";
+        HttpMessage msg = getHttpMessage(path);
+        rule.init(msg, parent);
+        HiddenFilesScanRule.addTestPayload(
+                new HiddenFile(
+                        "",
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        "",
+                        Collections.emptyList(),
+                        "file"));
+        // When
+        rule.scan();
+        // Then = No Exception
+    }
+
+    @Test
     public void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantContent()
             throws HttpMalformedHeaderException {
         // Given


### PR DESCRIPTION
Check if the path is null when creating the new path for the hidden
file.