### PR TITLE
ascanrules: correct tech check in SQL Injection

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
 - Command Injection, Test Path Traversal, Test Cross Site ScriptV2 and Remote File Include rules are updated to include payloads for Null Byte Injection (Issue 3877).
 
 ### Fixed
 - Fix typo in the help page.
 - Use correct risk (`HIGH`) in External Redirect, to run earlier in the scan.
+- Correct tech check in SQL Injection scan rule, which could cause it to be skipped with imported contexts (Issue 5918).
 
 ## [34] - 2020-01-17
 ### Added

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -463,7 +463,7 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
         }
 
         for (Tech tech : technologies.getIncludeTech()) {
-            if (tech.getParent() == Tech.Db) {
+            if (Tech.Db.equals(tech.getParent())) {
                 return true;
             }
         }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjectionUnitTest.java
@@ -82,6 +82,16 @@ public class TestSQLInjectionUnitTest extends ActiveScannerAppParamTest<TestSQLI
     }
 
     @Test
+    public void shouldTargetDbChildTechsWithNonBuiltInTechInstances() {
+        // Given
+        TechSet techSet = techSet(new Tech(new Tech("Db"), "SomeDb"));
+        // When
+        boolean targets = rule.targets(techSet);
+        // Then
+        assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
     public void shouldNotTargetNonDbTechs() {
         // Given
         TechSet techSet = techSetWithout(techsOf(Tech.Db));


### PR DESCRIPTION
Do not check the `Db` tech by reference since imported contexts use new
`Tech` instances.

Fix zaproxy/zaproxy#5918 - Skipped plugin TestSQLInjection with imported
Context