### PR TITLE
Correct active scan rules' risk

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - Fix typo in the help page.
+- Use correct risk (`HIGH`) in External Redirect, to run earlier in the scan.
 
 ## [34] - 2020-01-17
 ### Added

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
@@ -284,7 +284,7 @@ public class TestExternalRedirect extends AbstractAppParamPlugin {
 
                     // Now create the alert message
                     this.bingo(
-                            Alert.RISK_HIGH,
+                            getRisk(),
                             Alert.CONFIDENCE_MEDIUM,
                             null,
                             param,
@@ -509,7 +509,7 @@ public class TestExternalRedirect extends AbstractAppParamPlugin {
      */
     @Override
     public int getRisk() {
-        return Alert.RISK_MEDIUM;
+        return Alert.RISK_HIGH;
     }
 
     /**

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Backup File Disclosure scan rule - updated CWE to 530, added reference links to alerts, made sure WASC and CWE identifiers are included in alerts.
 
+### Fixed
+- Use correct risk (`INFO`) in User Agent Fuzzer, to run later in the scan.
+
 ## [27] - 2019-12-16
 
 ### Added

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TestUserAgent.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TestUserAgent.java
@@ -80,6 +80,11 @@ public class TestUserAgent extends AbstractAppPlugin {
     }
 
     @Override
+    public int getRisk() {
+        return Alert.RISK_INFO;
+    }
+
+    @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
@@ -163,7 +168,7 @@ public class TestUserAgent extends AbstractAppPlugin {
 
     private void createAlert(HttpMessage newMsg, String userAgent) {
         bingo(
-                Alert.RISK_INFO,
+                getRisk(),
                 Alert.CONFIDENCE_MEDIUM,
                 getBaseMsg().getRequestHeader().getURI().toString(),
                 USER_AGENT_PARAM_NAME,

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/TestUserAgentUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/TestUserAgentUnitTest.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2018 The ZAP Development Team
+ * Copyright 2020 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.ascanrules;
+package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -26,19 +26,19 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 
-/** Unit test for {@link TestExternalRedirect}. */
-public class TestExternalRedirectUnitTest extends ActiveScannerAppParamTest<TestExternalRedirect> {
+/** Unit test for {@link TestUserAgent}. */
+public class TestUserAgentUnitTest extends ActiveScannerTest<TestUserAgent> {
 
     @Override
-    protected TestExternalRedirect createScanner() {
-        return new TestExternalRedirect();
+    protected TestUserAgent createScanner() {
+        return new TestUserAgent();
     }
 
     @Test
-    public void shouldHaveHighRisk() {
+    public void shouldHaveInfoRisk() {
         // Given / When
         int risk = rule.getRisk();
         // Then
-        assertThat(risk, is(equalTo(Alert.RISK_HIGH)));
+        assertThat(risk, is(equalTo(Alert.RISK_INFO)));
     }
 }


### PR DESCRIPTION
Use the same risk that the scan rules use to raise the alerts:
 - `TestExternalRedirect` → `HIGH`;
 - `TestUserAgent` → `INFO`.

(Both were using the default, `MEDIUM`.)
Replace the risk constant with the getter when raising the alerts.