### PR TITLE
openapi: Update dependencies

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Improve content checks when spidering for specifications (Issue 5725).
 - Update minimum ZAP version to 2.9.0.
+- Maintenance changes.
 
 ## [15] - 2020-01-17
 ### Added

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -28,8 +28,8 @@ configurations {
 }
 
 dependencies {
-    implementation("io.swagger.parser.v3:swagger-parser:2.0.16")
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.48") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.0.18")
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.50") {
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")


### PR DESCRIPTION
- io.swagger:swagger-compat-spec-parser [1.0.48 -> 1.0.50]
- io.swagger.parser.v3:swagger-parser [2.0.16 -> 2.0.18]

Tested all unit tests pass.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>