### PR TITLE
pscanrulesBeta: Update dependencies

### DIFF
--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -15,7 +15,7 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.google.re2j:re2j:1.2")
+    implementation("com.google.re2j:re2j:1.3")
 
     implementation(project(":sharedutils"))
 


### PR DESCRIPTION
- com.google.re2j:re2j [1.2 -> 1.3] - Used by PiiScanner

Tested unit tests all pass.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>