### PR TITLE
wappalyzer: Update dependency

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 - Update with Wappalyzer icon and pattern changes.
+- Maintenance changes.
 
 ### Added
 - The Wappalyzer toolbar now has a toggle button to allow users to enable/disable the passive scanner simply from the GUI (Issue 5846).

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -17,7 +17,7 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.google.re2j:re2j:1.2")
+    implementation("com.google.re2j:re2j:1.3")
 
     val batikVersion = "1.12"
     implementation("org.apache.xmlgraphics:batik-anim:$batikVersion")


### PR DESCRIPTION
- com.google.re2j:re2j [1.2 -> 1.3]

Tested, all unit tests pass, and tested live without issue.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>