### PR TITLE
Use OpenAPI examples to generate Values in Requests on behalf of SDA SE

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Map Structure support for OpenAPI v3.0 (Issue 5863).
+- Using OpenAPI Example values for value generation in request bodies and urls (Issue 5168).
 
 ### Changed
 - Improve content checks when spidering for specifications (Issue 5725).

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -9,7 +9,7 @@ zapAddOn {
     zapVersion.set("2.9.0")
 
     manifest {
-        author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak, Marcin Spiewak and SDA SE Open Industry Solutions")
+        author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak, Marcin Spiewak, and SDA SE Open Industry Solutions")
         url.set("https://www.zaproxy.org/docs/desktop/addons/openapi-support/")
     }
 

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -9,7 +9,7 @@ zapAddOn {
     zapVersion.set("2.9.0")
 
     manifest {
-        author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak and Marcin Spiewak")
+        author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak, Marcin Spiewak and SDA SE Open Industry Solutions")
         url.set("https://www.zaproxy.org/docs/desktop/addons/openapi-support/")
     }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
@@ -111,7 +111,8 @@ public class BodyGenerator {
                 return Json.mapper().writeValueAsString(schema.getExample());
             } catch (JsonProcessingException e) {
                 LOG.warn(
-                        "Failed to encode Example Object. Falling back to default example generation");
+                        "Failed to encode Example Object. Falling back to default example generation",
+                        e);
             }
         }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.zap.extension.openapi.generators;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
@@ -100,8 +102,23 @@ public class BodyGenerator {
     }
 
     private String generateFromArraySchema(ArraySchema schema) {
+        if (schema.getExample() instanceof String) {
+            return (String) schema.getExample();
+        }
+
         StringBuilder json = new StringBuilder();
+
+        if (schema.getExample() instanceof Iterable) {
+            try {
+                return Json.mapper().writeValueAsString(schema.getExample());
+            } catch (JsonProcessingException e) {
+                LOG.warn(
+                        "Failed to encode Example Object. Falling back to default example generation");
+            }
+        }
+
         json.append(generate(schema.getItems()));
+
         return createJsonArrayWith(json.toString());
     }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
@@ -106,8 +106,6 @@ public class BodyGenerator {
             return (String) schema.getExample();
         }
 
-        StringBuilder json = new StringBuilder();
-
         if (schema.getExample() instanceof Iterable) {
             try {
                 return Json.mapper().writeValueAsString(schema.getExample());
@@ -117,9 +115,7 @@ public class BodyGenerator {
             }
         }
 
-        json.append(generate(schema.getItems()));
-
-        return createJsonArrayWith(json.toString());
+        return createJsonArrayWith(generate(schema.getItems()));
     }
 
     @SuppressWarnings("rawtypes")

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -140,8 +140,8 @@ public class DataGenerator {
 
     public String generateValue(String name, Schema<?> schema, boolean isPath) {
         String value = "";
-        if (hasExample(schema)) {
-            value = getExample(schema).toString();
+        if (schema.getExample() != null) {
+            value = schema.getExample().toString();
         } else if (isEnumValue(schema)) {
             value = getEnumValue(schema);
         } else if (isDateTime(schema)) {
@@ -205,14 +205,6 @@ public class DataGenerator {
             value = ((StringSchema) schema).getEnum().get(0);
         }
         return value;
-    }
-
-    public boolean hasExample(Schema<?> schema) {
-        return schema.getExample() != null;
-    }
-
-    public Object getExample(Schema<?> schema) {
-        return schema.getExample();
     }
 
     public boolean isPath(String type) {

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -66,23 +66,27 @@ public class DataGenerator {
     }
 
     public String generate(String name, Parameter parameter) {
+        String defaultValue = generateDefaultValue(parameter);
+        return generateParam(name, defaultValue, parameter);
+    }
+
+    private static String generateDefaultValue(Parameter parameter) {
         List<String> enumValues = null;
         if (parameter.getSchema() instanceof StringSchema) {
             enumValues = ((StringSchema) (parameter.getSchema())).getEnum();
         }
-        String defaultValue = generateDefaultValue(enumValues, parameter.getSchema().getDefault());
-        return generateParam(name, defaultValue, parameter);
-    }
 
-    private static String generateDefaultValue(List<String> anEnum, Object defaultValue) {
-        if (defaultValue != null) {
-            String strValue = defaultValue.toString();
+        if (parameter.getSchema().getDefault() != null) {
+            String strValue = parameter.getSchema().getDefault().toString();
             if (!strValue.isEmpty()) {
                 return strValue;
             }
         }
-        if (anEnum != null && !anEnum.isEmpty()) {
-            return anEnum.get(0);
+        if (enumValues != null && !enumValues.isEmpty()) {
+            return enumValues.get(0);
+        }
+        if (parameter.getExample() != null) {
+            return parameter.getExample().toString();
         }
         return "";
     }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -140,13 +140,13 @@ public class DataGenerator {
 
     public String generateValue(String name, Schema<?> schema, boolean isPath) {
         String value = "";
-        if (isEnumValue(schema)) {
+        if (hasExample(schema)) {
+            value = getExample(schema).toString();
+        } else if (isEnumValue(schema)) {
             value = getEnumValue(schema);
-        }
-        if (isDateTime(schema)) {
+        } else if (isDateTime(schema)) {
             value = "1970-01-01T00:00:00.001Z";
-        }
-        if (isDate(schema)) {
+        } else if (isDate(schema)) {
             value = "1970-01-01";
         }
 
@@ -205,6 +205,14 @@ public class DataGenerator {
             value = ((StringSchema) schema).getEnum().get(0);
         }
         return value;
+    }
+
+    public boolean hasExample(Schema<?> schema) {
+        return schema.getExample() != null;
+    }
+
+    public Object getExample(Schema<?> schema) {
+        return schema.getExample();
     }
 
     public boolean isPath(String type) {

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/PathGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/PathGenerator.java
@@ -38,11 +38,10 @@ public class PathGenerator {
                     continue;
                 }
                 String parameterType = parameter.getIn();
+                String value = dataGenerator.generate(parameter.getName(), parameter);
                 if ("query".equals(parameterType)) {
-                    String value = dataGenerator.generate(parameter.getName(), parameter);
                     queryString += parameter.getName() + "=" + value + "&";
                 } else if ("path".equals(parameterType)) {
-                    String value = dataGenerator.generate(parameter.getName(), parameter);
                     String newPath =
                             operationModel
                                     .getPath()

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/PathGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/PathGenerator.java
@@ -38,10 +38,11 @@ public class PathGenerator {
                     continue;
                 }
                 String parameterType = parameter.getIn();
-                String value = dataGenerator.generate(parameter.getName(), parameter);
                 if ("query".equals(parameterType)) {
+                    String value = dataGenerator.generate(parameter.getName(), parameter);
                     queryString += parameter.getName() + "=" + value + "&";
                 } else if ("path".equals(parameterType)) {
+                    String value = dataGenerator.generate(parameter.getName(), parameter);
                     String newPath =
                             operationModel
                                     .getPath()

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractServerTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractServerTest.java
@@ -59,11 +59,11 @@ public abstract class AbstractServerTest extends AbstractOpenApiTest {
         // Check all of the expected URLs have been accessed and with the right data
         assertTrue(accessedUrls.containsKey("POST " + baseUrl + "/pet"));
         assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
                 accessedUrls.get("POST " + baseUrl + "/pet"));
         assertTrue(accessedUrls.containsKey("PUT " + baseUrl + "/pet"));
         assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
                 accessedUrls.get("PUT " + baseUrl + "/pet"));
         assertTrue(
                 accessedUrls.containsKey("GET " + baseUrl + "/pet/findByStatus?status=available"));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractServerTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractServerTest.java
@@ -59,11 +59,11 @@ public abstract class AbstractServerTest extends AbstractOpenApiTest {
         // Check all of the expected URLs have been accessed and with the right data
         assertTrue(accessedUrls.containsKey("POST " + baseUrl + "/pet"));
         assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
                 accessedUrls.get("POST " + baseUrl + "/pet"));
         assertTrue(accessedUrls.containsKey("PUT " + baseUrl + "/pet"));
         assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
                 accessedUrls.get("PUT " + baseUrl + "/pet"));
         assertTrue(
                 accessedUrls.containsKey("GET " + baseUrl + "/pet/findByStatus?status=available"));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
@@ -319,7 +319,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
         // Then
         assertThat(converter.getErrorMessages(), is(empty()));
         assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\",\"x\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\",\"x\":\"John Doe\"}],\"status\":\"available\"}",
                 accessedUrls.get("POST http://" + host + "/PetStore/pet"));
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
@@ -319,7 +319,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
         // Then
         assertThat(converter.getErrorMessages(), is(empty()));
         assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\",\"x\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\",\"x\":\"John Doe\"}],\"status\":\"available\"}",
                 accessedUrls.get("POST http://" + host + "/PetStore/pet"));
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
@@ -391,6 +391,51 @@ public class OpenApiUnitTest extends AbstractServerTest {
         checkPetStoreRequestsValGen(accessedUrls, "localhost:" + nano.getListeningPort());
     }
 
+    @Test
+    public void shouldExplorePetStoreYamlWithExamples()
+            throws NullPointerException, IOException, SwaggerException {
+        String test = "/PetStoreYamlExamples/";
+        String defnName = "defn.yaml";
+
+        this.nano.addHandler(new DefnServerHandler(test, defnName, "PetStore_defn_examples.yaml"));
+
+        Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        HttpMessage defnMsg = this.getHttpMessage(test + defnName);
+        SwaggerConverter converter =
+                new SwaggerConverter(
+                        requestor.getResponseBody(defnMsg.getRequestHeader().getURI()), null);
+        // No parsing errors
+        assertThat(converter.getErrorMessages(), is(empty()));
+
+        final Map<String, String> accessedUrls = new HashMap<String, String>();
+        RequesterListener listener =
+                new RequesterListener() {
+                    @Override
+                    public void handleMessage(HttpMessage message, int initiator) {
+                        accessedUrls.put(
+                                message.getRequestHeader().getMethod()
+                                        + " "
+                                        + message.getRequestHeader().getURI().toString(),
+                                message.getRequestBody().toString());
+                    }
+                };
+        requestor.addListener(listener);
+        requestor.run(converter.getRequestModels());
+
+        assertEquals(accessedUrls.size(), 2);
+
+        assertTrue(
+                accessedUrls.containsKey(
+                        "GET http://localhost:"
+                                + nano.getListeningPort()
+                                + "/PetStore/pet/findByStatus?status=available"));
+        assertTrue(
+                accessedUrls.containsKey(
+                        "GET http://localhost:"
+                                + nano.getListeningPort()
+                                + "/PetStore/pet/42424242"));
+    }
+
     private void checkPetStoreRequestsValGen(Map<String, String> accessedUrls, String host) {
         // Check all of the expected URLs have been accessed and with the right data
         assertTrue(accessedUrls.containsKey("POST http://" + host + "/PetStore/pet"));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -140,7 +140,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
         Assert.assertEquals(
-                "p1=p1&p2=%7B%22id%22%3A10%2C%22category%22%3A%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%2C%22name%22%3A%22John+Doe%22%2C%22photoUrls%22%3A%5B%22John+Doe%22%5D%2C%22tags%22%3A%5B%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%5D%7D",
+                "p1=p1&p2=%7B%22id%22%3A10%2C%22category%22%3A%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%2C%22name%22%3A%22doggie%22%2C%22photoUrls%22%3A%5B%22John+Doe%22%5D%2C%22tags%22%3A%5B%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%5D%7D",
                 requestBody);
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -302,7 +302,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldUseExampleInRequest() throws IOException {
+    public void shouldUseExample() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
         String request =
                 new RequestModelConverter()

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -336,6 +336,44 @@ public class BodyGeneratorUnitTest {
                 "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":3,\"name\":\"Fluffy\"}]", request);
     }
 
+    @Test
+    public void shouldGenerateArraysFromFullArrayExampleFormattedAsString() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/pets-with-array-full-example-string",
+                                        openAPI.getPaths()
+                                                .get("/pets-with-array-full-example-string")
+                                                .getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+
+        Assert.assertEquals(
+                "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":512,\"name\":\"Fawkes\"}]", request);
+    }
+
+    @Test
+    public void shouldGenerateArraysFromFullArrayExampleFormattedAsYAML() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/pets-with-array-full-example-yaml",
+                                        openAPI.getPaths()
+                                                .get("/pets-with-array-full-example-yaml")
+                                                .getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+
+        Assert.assertEquals(
+                "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":512,\"name\":\"Fawkes\"}]", request);
+    }
+
     private OpenAPI parseResource(String fileName) throws IOException {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -110,7 +110,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
         Assert.assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
                 requestBody);
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -317,6 +317,25 @@ public class BodyGeneratorUnitTest {
         Assert.assertEquals("{\"age\":3,\"name\":\"Fluffy\"}", request);
     }
 
+    @Test
+    public void shouldGenerateArraysFromExamples() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/pets-with-array-example",
+                                        openAPI.getPaths()
+                                                .get("/pets-with-array-example")
+                                                .getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+
+        Assert.assertEquals(
+                "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":3,\"name\":\"Fluffy\"}]", request);
+    }
+
     private OpenAPI parseResource(String fileName) throws IOException {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -302,7 +302,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldUseExampleFromRequest() throws IOException {
+    public void shouldUseExampleInRequest() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
         String request =
                 new RequestModelConverter()

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -301,6 +301,22 @@ public class BodyGeneratorUnitTest {
                 request);
     }
 
+    @Test
+    public void shouldUseExampleFromRequest() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/pets-with-example",
+                                        openAPI.getPaths().get("/pets-with-example").getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+
+        Assert.assertEquals("{\"age\":3,\"name\":\"Fluffy\"}", request);
+    }
+
     private OpenAPI parseResource(String fileName) throws IOException {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -110,7 +110,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
         Assert.assertEquals(
-                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"doggie\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
+                "{\"id\":10,\"category\":{\"id\":10,\"name\":\"John Doe\"},\"name\":\"John Doe\",\"photoUrls\":[\"John Doe\"],\"tags\":[{\"id\":10,\"name\":\"John Doe\"}],\"status\":\"available\"}",
                 requestBody);
     }
 
@@ -140,7 +140,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
         Assert.assertEquals(
-                "p1=p1&p2=%7B%22id%22%3A10%2C%22category%22%3A%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%2C%22name%22%3A%22doggie%22%2C%22photoUrls%22%3A%5B%22John+Doe%22%5D%2C%22tags%22%3A%5B%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%5D%7D",
+                "p1=p1&p2=%7B%22id%22%3A10%2C%22category%22%3A%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%2C%22name%22%3A%22John+Doe%22%2C%22photoUrls%22%3A%5B%22John+Doe%22%5D%2C%22tags%22%3A%5B%7B%22id%22%3A10%2C%22name%22%3A%22John+Doe%22%7D%5D%7D",
                 requestBody);
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -184,8 +184,6 @@ public class OpenApiUnitTest extends AbstractServerTest {
         requestor.addListener(listener);
         requestor.run(converter.getRequestModels());
 
-        System.out.println(accessedUrls.keySet());
-
         assertTrue(
                 "Should use OpenAPI Example Values in URL Path when crawling urls",
                 accessedUrls.containsKey(

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -153,6 +153,55 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
+    public void shouldExplorePetStoreYamlWithExamples()
+            throws NullPointerException, IOException, SwaggerException {
+        String test = "/PetStoreYamlExamples/";
+        String defnName = "defn.yaml";
+
+        this.nano.addHandler(
+                new DefnServerHandler(test, defnName, "PetStore_defn_with_examples.yaml"));
+
+        Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        HttpMessage defnMsg = this.getHttpMessage(test + defnName);
+        SwaggerConverter converter =
+                new SwaggerConverter(
+                        requestor.getResponseBody(defnMsg.getRequestHeader().getURI()), null);
+        // No parsing errors
+        assertThat(converter.getErrorMessages(), is(empty()));
+
+        final Map<String, String> accessedUrls = new HashMap<String, String>();
+        RequesterListener listener =
+                new RequesterListener() {
+                    @Override
+                    public void handleMessage(HttpMessage message, int initiator) {
+                        accessedUrls.put(
+                                message.getRequestHeader().getMethod()
+                                        + " "
+                                        + message.getRequestHeader().getURI().toString(),
+                                message.getRequestBody().toString());
+                    }
+                };
+        requestor.addListener(listener);
+        requestor.run(converter.getRequestModels());
+
+        System.out.println(accessedUrls.keySet());
+
+        assertTrue(
+                "Should use OpenAPI Example Values in URL Path when crawling urls",
+                accessedUrls.containsKey(
+                        "GET http://localhost:"
+                                + this.nano.getListeningPort()
+                                + "/PetStore/store/order/42424242"));
+
+        assertTrue(
+                "Should use OpenAPI Example Values in URL Query when crawling urls",
+                accessedUrls.containsKey(
+                        "GET http://localhost:"
+                                + this.nano.getListeningPort()
+                                + "/PetStore/user/login?username=kermit&password=thefrog"));
+    }
+
+    @Test
     public void shouldExplorePetStoreWithDefaultUrl()
             throws NullPointerException, IOException, SwaggerException {
         // Given

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.json
@@ -983,8 +983,7 @@
                "$ref":"#/definitions/Category"
             },
             "name":{
-               "type":"string",
-               "example":"doggie"
+               "type":"string"
             },
             "photoUrls":{
                "type":"array",

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.yaml
@@ -667,7 +667,6 @@ definitions:
         $ref: "#/definitions/Category"
       name:
         type: "string"
-        example: "doggie"
       photoUrls:
         type: "array"
         xml:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_examples.yaml
@@ -1,0 +1,163 @@
+---
+swagger: "2.0"
+info:
+  description: "This is a sample server Petstore server.  You can find out more about\
+    \ Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\
+    \  For this sample, you can use the api key `special-key` to test the authorization\
+    \ filters."
+  version: "1.0.0"
+  title: "Swagger Petstore"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: localhost:@@@PORT@@@
+basePath: /PetStore
+tags:
+- name: "pet"
+  description: "Everything about your Pets"
+  externalDocs:
+    description: "Find out more"
+    url: "http://swagger.io"
+- name: "store"
+  description: "Access to Petstore orders"
+- name: "user"
+  description: "Operations about user"
+  externalDocs:
+    description: "Find out more about our store"
+    url: "http://swagger.io"
+schemes:
+- "http"
+paths:
+  /pet/findByStatus:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by status"
+      description: "Multiple status values can be provided with comma separated strings"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "status"
+        in: "query"
+        description: "Status values that need to be considered for filter"
+        x-example: "available"
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/{petId}:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet by ID"
+      description: "Returns a single pet"
+      operationId: "getPetById"
+      produces:
+      - "application/xml"
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet to return"
+        required: true
+        type: "integer"
+        format: "int64"
+        x-example: 42424242
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - api_key: []
+securityDefinitions:
+  petstore_auth:
+    type: "oauth2"
+    authorizationUrl: "http://petstore.swagger.io/oauth/dialog"
+    flow: "implicit"
+    scopes:
+      write:pets: "modify pets in your account"
+      read:pets: "read your pets"
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+definitions:
+  Category:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Category"
+  Tag:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Tag"
+  Pet:
+    type: "object"
+    required:
+    - "name"
+    - "photoUrls"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      category:
+        $ref: "#/definitions/Category"
+      name:
+        type: "string"
+      photoUrls:
+        type: "array"
+        xml:
+          name: "photoUrl"
+          wrapped: true
+        items:
+          type: "string"
+      tags:
+        type: "array"
+        xml:
+          name: "tag"
+          wrapped: true
+        items:
+          $ref: "#/definitions/Tag"
+      status:
+        type: "string"
+        description: "pet status in the store"
+        enum:
+        - "available"
+        - "pending"
+        - "sold"
+    xml:
+      name: "Pet"
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_loop.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_loop.yaml
@@ -669,7 +669,6 @@ definitions:
         $ref: "#/definitions/Category"
       name:
         type: "string"
-        example: "doggie"
       photoUrls:
         type: "array"
         xml:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_host.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_host.json
@@ -982,8 +982,7 @@
                "$ref":"#/definitions/Category"
             },
             "name":{
-               "type":"string",
-               "example":"doggie"
+               "type":"string"
             },
             "photoUrls":{
                "type":"array",

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_schemes.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_schemes.json
@@ -980,8 +980,7 @@
                "$ref":"#/definitions/Category"
             },
             "name":{
-               "type":"string",
-               "example":"doggie"
+               "type":"string"
             },
             "photoUrls":{
                "type":"array",

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Complex_object_in_form_data.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Complex_object_in_form_data.yaml
@@ -45,7 +45,6 @@ components:
           "$ref": "#/components/schemas/Category"
         name:
           type: string
-          example: doggie
         photoUrls:
           type: array
           xml:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
@@ -30,6 +30,48 @@ paths:
       responses:
         '201':
           description: Created
+  # Array has a example formatted as string, which describes the full array instead of examples for the individual properties
+  /pets-with-array-full-example-string:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  age:
+                    type: integer
+                  name:
+                    type: string
+              example: '[{"age":3,"name":"Fluffy"},{"age":512,"name":"Fawkes"}]'
+      responses:
+        '201':
+          description: Created
+  # Array has a example formatted , which describes the full array instead of examples for the individual properties
+  /pets-with-array-full-example-yaml:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  age:
+                    type: integer
+                  name:
+                    type: string
+              example:
+                - age: 3
+                  name: "Fluffy"
+                - age: 512
+                  name: "Fawkes"
+      responses:
+        '201':
+          description: Created
 components:
   schemas:
     Pet:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+paths:
+  /pets-with-example:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+components:
+  schemas:
+    Pet:
+      type: object
+      properties: 
+        age: 
+          type: integer
+          example: 3
+        name:
+          type: string
+          example: Fluffy

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
@@ -1,6 +1,17 @@
-# E
 openapi: 3.0.0
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        age:
+          type: integer
+          example: 3
+        name:
+          type: string
+          example: Fluffy
 paths:
+  # Using Examples defined in a references schema
   /pets-with-example:
     post:
       requestBody:
@@ -11,6 +22,7 @@ paths:
       responses:
         '201':
           description: Created
+  # Using an Array with examples for the properties described in the items
   /pets-with-array-example:
     post:
       requestBody:
@@ -30,7 +42,7 @@ paths:
       responses:
         '201':
           description: Created
-  # Array has a example formatted as string, which describes the full array instead of examples for the individual properties
+  # Using an Array has a example formatted as string
   /pets-with-array-full-example-string:
     post:
       requestBody:
@@ -49,7 +61,7 @@ paths:
       responses:
         '201':
           description: Created
-  # Array has a example formatted , which describes the full array instead of examples for the individual properties
+  # Array has an example formatted as a yaml array
   /pets-with-array-full-example-yaml:
     post:
       requestBody:
@@ -72,15 +84,3 @@ paths:
       responses:
         '201':
           description: Created
-components:
-  schemas:
-    Pet:
-      type: object
-      properties: 
-        age: 
-          type: integer
-          example: 3
-        name:
-          type: string
-          example: Fluffy
-

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
@@ -1,3 +1,4 @@
+# E
 openapi: 3.0.0
 paths:
   /pets-with-example:
@@ -7,6 +8,25 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+  /pets-with-array-example:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  age:
+                    type: integer
+                    example: 3
+                  name:
+                    type: string
+                    example: Fluffy
       responses:
         '201':
           description: Created
@@ -21,3 +41,4 @@ components:
         name:
           type: string
           example: Fluffy
+

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.json
@@ -944,8 +944,7 @@
                   "$ref": "#/components/schemas/Category"
                },
                "name": {
-                  "type": "string",
-                  "example": "doggie"
+                  "type": "string"
                },
                "photoUrls": {
                   "type": "array",

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.yaml
@@ -620,7 +620,6 @@ components:
           "$ref": "#/components/schemas/Category"
         name:
           type: string
-          example: doggie
         photoUrls:
           type: array
           xml:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_loop.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_loop.yaml
@@ -662,7 +662,6 @@ components:
           $ref: "#/components/schemas/Category"
         name:
           type: string
-          example: doggie
         photoUrls:
           type: array
           xml:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_no_servers.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_no_servers.json
@@ -939,8 +939,7 @@
                   "$ref": "#/components/schemas/Category"
                },
                "name": {
-                  "type": "string",
-                  "example": "doggie"
+                  "type": "string"
                },
                "photoUrls": {
                   "type": "array",

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
@@ -1,0 +1,689 @@
+---
+openapi: 3.0.0
+servers:
+  - url: http://localhost:@@@PORT@@@/PetStore
+info:
+  description: 'This is a sample server Petstore server.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  version: 1.0.0
+  title: Swagger Petstore
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  "/pet":
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: ''
+      operationId: addPet
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        "$ref": "#/components/requestBodies/Pet"
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: ''
+      operationId: updatePet
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        "$ref": "#/components/requestBodies/Pet"
+  "/pet/findByStatus":
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - available
+                - pending
+                - sold
+              default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  "/pet/findByTags":
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: Muliple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: true
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      deprecated: true
+  "/pet/{petId}":
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  description: Updated name of the pet
+                  type: string
+                status:
+                  description: Updated status of the pet
+                  type: string
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ApiResponse"
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+  "/store/inventory":
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  "/store/order":
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: ''
+      operationId: placeOrder
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Order"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '400':
+          description: Invalid Order
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Order"
+        description: order placed for purchasing the pet
+        required: true
+  "/store/order/{orderId}":
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value >= 1 and <= 10. Other
+        values will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of pet that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 10
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Order"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with positive integer value.
+        Negative or non-integer values will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  "/user":
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+        description: Created user object
+        required: true
+  "/user/createWithArray":
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithArrayInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        "$ref": "#/components/requestBodies/UserArray"
+  "/user/createWithList":
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: ''
+      operationId: createUsersWithListInput
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        "$ref": "#/components/requestBodies/UserArray"
+  "/user/login":
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: true
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  "/user/logout":
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      responses:
+        default:
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: 'The name that needs to be fetched. Use user1 for testing. '
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/User"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Updated user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be updated
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid user supplied
+        '404':
+          description: User not found
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+        description: Updated user object
+        required: true
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        petId:
+          type: integer
+          format: int64
+        quantity:
+          type: integer
+          format: int32
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+        complete:
+          type: boolean
+          default: false
+      xml:
+        name: Order
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        email:
+          type: string
+        password:
+          type: string
+        phone:
+          type: string
+        userStatus:
+          type: integer
+          format: int32
+          description: User Status
+      xml:
+        name: User
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: Tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+        category:
+          "$ref": "#/components/schemas/Category"
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          xml:
+            name: photoUrl
+            wrapped: true
+          items:
+            type: string
+        tags:
+          type: array
+          xml:
+            name: tag
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: Pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+      description: Pet object that needs to be added to the store
+      required: true
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              "$ref": "#/components/schemas/User"
+      description: List of user object
+      required: true
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
@@ -326,6 +326,7 @@ paths:
           in: path
           description: ID of pet that needs to be fetched
           required: true
+          example: 42424242
           schema:
             type: integer
             format: int64
@@ -419,12 +420,14 @@ paths:
           in: query
           description: The user name for login
           required: true
+          example: "kermit"
           schema:
             type: string
         - name: password
           in: query
           description: The password for login in clear text
           required: true
+          example: "thefrog"
           schema:
             type: string
       responses:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
@@ -623,7 +623,6 @@ components:
           "$ref": "#/components/schemas/Category"
         name:
           type: string
-          example: doggie
         photoUrls:
           type: array
           xml:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Petstore_defn_variable_in_server_definition.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Petstore_defn_variable_in_server_definition.yaml
@@ -625,7 +625,6 @@ components:
           "$ref": "#/components/schemas/Category"
         name:
           type: string
-          example: doggie
         photoUrls:
           type: array
           xml:


### PR DESCRIPTION
Using Example values from the imported API Definition for Request values.

Closes zaproxy/zaproxy#5168

Changes made on behalf of SDA SE

## Notes

OpenAPI 2 didn't support examples in the path or query sections of requests. The in official fallback was to use a property called `x-example` or `x-examples` to specify multiple examples. The `x-example` properties are also supported by this change, as the automatic OpenAPI 2 => 3 conversion upgrades these to the official OpenAPI 3 `example` property automatically.

## Limitations

This implementation currently only supports examples using the single value `example` property not the `examples` property. The `examples` object is basically a map of named examples where the key is the name. See: https://swagger.io/docs/specification/adding-examples/

I guess the best thing to do here would probably be to pick the first alphabetically first key in the `examples` object. To keep it predictable which one Zap will pick.

## Open Todos

- [x] Support Example values in Request Bodies
- [x] Add test for Request Path Value
- [x] Add test for Request Query Parameter Value
- [x] Add test for Value in Request Body 
- [ ] ~~Support for `examples` property. Should probably pick the first example.~~
- [ ] ~~Add test for example using multiple `examples`~~