### PR TITLE
pscanrules: CSP Merge (Intersect) Multiple Headers

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - 'CSP Scanner' rule upgrade salvation library to v2.7.1.
+- 'CSP Scanner' rule now merges (intersects) multiple CSP header fields to more accurately evaluate policies and prevent parsing issues (Issue 5931).
 - 'X-Frame-Options Header Scanner' replace now invalid MSDN reference link with MDN link on X-Frame-Options (Issue 5867).
 
 ## [27] - 2020-02-11

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -103,6 +103,9 @@ The Content Security Policy (CSP) Scanner adds a passive scan rule which parses 
 or weakness. This scanner leverages Shape Security's <a href="https://github.com/shapesecurity/salvation">Salvation</a> 
 library to perform it's parsing and assessment of CSPs.
 <p>
+Note: If multiple CSP headers are encountered they are merged (intersected) into a single policy for analysis, check the 'Other Info' field of alerts 
+for further details.
+<p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanner.java">ContentSecurityPolicyScanner.java</a>
 
 <H2>CSRF Countermeasures</H2>

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -175,6 +175,7 @@ pscanrules.crossdomainscriptinclusionscanner.soln=Ensure JavaScript source files
 
 pscanrules.cspscanner.name=CSP Scanner
 pscanrules.cspscanner.desc=Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks. Including (but not limited to) Cross Site Scripting (XSS), and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page \u2014 covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
+pscanrules.cspscanner.otherinfo=The response contained multiple CSP headers, these were merged (intersected) into a single policy for evaluation:\n{0}\nNote: The highlighting and evidence for this alert may be inaccurate due to these multiple headers.
 pscanrules.cspscanner.refs=http://www.w3.org/TR/CSP2/\nhttp://www.w3.org/TR/CSP/\nhttp://caniuse.com/#search=content+security+policy\nhttp://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation
 pscanrules.cspscanner.soln=Ensure that your web server, application server, load balancer, etc. is properly configured to set the Content-Security-Policy header.
 pscanrules.cspscanner.notices.name=Notices

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScannerUnitTest.java
@@ -83,4 +83,46 @@ public class ContentSecurityPolicyScannerUnitTest
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }
+
+    @Test
+    public void shouldIntersectMultipleCspHeaders() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+
+        msg.setResponseBody("<html></html>");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Server: Apache-Coyote/1.1\r\n"
+                        + "Content-Security-Policy: default-src 'self'; script-src www.example.com\r\n"
+                        + "Content-Security-Policy: script-src *; style-src *:80\r\n"
+                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                        + "Content-Length: "
+                        + msg.getResponseBody().length()
+                        + "\r\n");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+
+        assertThat(alertsRaised.get(0).getName(), equalTo("CSP Scanner: Wildcard Directive"));
+        assertThat(
+                alertsRaised.get(0).getDescription(),
+                equalTo(
+                        "The following directives either allow wildcard sources (or ancestors), "
+                                + "are not defined, or are overly broadly defined: \nframe-ancestor"));
+
+        assertThat(
+                alertsRaised.get(0).getEvidence(),
+                equalTo("default-src 'self'; script-src www.example.com"));
+        assertThat(
+                alertsRaised.get(0).getOtherInfo(),
+                equalTo(
+                        "The response contained multiple CSP headers, "
+                                + "these were merged (intersected) into a single policy for evaluation:\ndefault-src 'self'; "
+                                + "script-src www.example.com; style-src\nNote: The highlighting and evidence for this alert "
+                                + "may be inaccurate due to these multiple headers."));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
 }


### PR DESCRIPTION
- Update ContentSecurityPolcyScanner to handle multiple CSP headers via merge (intersect).
- Add a unit test to validate the change in functionality.
- Add note to help entry.
- Update CHANGELOG.
- Add supporting key/value to messages.properties.

Fixes zaproxy/zaproxy#5931

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>