### PR TITLE
Update ZAP to 2.9.0 in DOM XSS and SOAP

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add link to the code in the help.
 
 ### Changed
+- Update minimum ZAP version to 2.9.0.
 - Maintenance changes.
 
 ## [9] - 2019-06-12

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -3,7 +3,7 @@ description = "DOM XSS Active scanner rule"
 
 zapAddOn {
     addOnName.set("DOM XSS Active scanner rule")
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/TestDomXSS.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/TestDomXSS.java
@@ -591,15 +591,13 @@ public class TestDomXSS extends AbstractAppParamPlugin {
                                 + e.getAttributeId();
             }
 
-            bingo(
-                    Alert.RISK_HIGH,
-                    Alert.CONFIDENCE_MEDIUM,
-                    e.getUrl(),
-                    null,
-                    e.getAttack(),
-                    otherInfo,
-                    null,
-                    msg);
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setUri(e.getUrl())
+                    .setAttack(e.getAttack())
+                    .setOtherInfo(otherInfo)
+                    .setMessage(msg)
+                    .raise();
             Stats.incCounter("domxss.attack." + attackVector);
             vulnerable = true;
             return true;

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Various fixes (related to Issue 4832 and other testing).
 - Change default accelerator for "Import a WSDL file from local file system".
 - Fix exception with Java 9+ (Issue 4037).
-- Update minimum ZAP version to 2.8.0.
+- Update minimum ZAP version to 2.9.0.
 - Add import menus to (new) top level Import menu instead of Tools menu.
 - Maintenance changes.
 

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -3,7 +3,7 @@ description = "Imports and scans WSDL files containing SOAP endpoints."
 
 zapAddOn {
     addOnName.set("SOAP Scanner")
-    zapVersion.set("2.8.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("Alberto (albertov91) + ZAP Dev Team")

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanner.java
@@ -236,54 +236,49 @@ public class SOAPActionSpoofingActiveScanner extends AbstractAppPlugin {
     private void raiseAlert(HttpMessage msg, int code) {
         switch (code) {
             case INVALID_FORMAT:
-                bingo(
-                        Alert.RISK_LOW,
-                        Alert.CONFIDENCE_MEDIUM,
-                        null,
-                        null,
-                        null,
-                        Constant.messages.getString(MESSAGE_PREFIX + "invalidFormatMsg"),
-                        msg);
+                newAlert()
+                        .setRisk(Alert.RISK_LOW)
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setOtherInfo(
+                                Constant.messages.getString(MESSAGE_PREFIX + "invalidFormatMsg"))
+                        .setMessage(msg)
+                        .raise();
                 break;
             case FAULT_CODE:
-                bingo(
-                        Alert.RISK_LOW,
-                        Alert.CONFIDENCE_MEDIUM,
-                        null,
-                        null,
-                        null,
-                        Constant.messages.getString(MESSAGE_PREFIX + "faultCodeMsg"),
-                        msg);
+                newAlert()
+                        .setRisk(Alert.RISK_LOW)
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "faultCodeMsg"))
+                        .setMessage(msg)
+                        .raise();
                 break;
             case EMPTY_RESPONSE:
-                bingo(
-                        Alert.RISK_LOW,
-                        Alert.CONFIDENCE_MEDIUM,
-                        null,
-                        null,
-                        null,
-                        Constant.messages.getString(MESSAGE_PREFIX + "emptyResponseMsg"),
-                        msg);
+                newAlert()
+                        .setRisk(Alert.RISK_LOW)
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setOtherInfo(
+                                Constant.messages.getString(MESSAGE_PREFIX + "emptyResponseMsg"))
+                        .setMessage(msg)
+                        .raise();
                 break;
             case SOAPACTION_IGNORED:
-                bingo(
-                        Alert.RISK_INFO,
-                        Alert.CONFIDENCE_MEDIUM,
-                        null,
-                        null,
-                        null,
-                        Constant.messages.getString(MESSAGE_PREFIX + "soapactionIgnoredMsg"),
-                        msg);
+                newAlert()
+                        .setRisk(Alert.RISK_INFO)
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setOtherInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "soapactionIgnoredMsg"))
+                        .setMessage(msg)
+                        .raise();
                 break;
             case SOAPACTION_EXECUTED:
-                bingo(
-                        Alert.RISK_HIGH,
-                        Alert.CONFIDENCE_MEDIUM,
-                        null,
-                        null,
-                        null,
-                        Constant.messages.getString(MESSAGE_PREFIX + "soapactionExecutedMsg"),
-                        msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setOtherInfo(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "soapactionExecutedMsg"))
+                        .setMessage(msg)
+                        .raise();
                 break;
         }
     }

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanner.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanner.java
@@ -113,28 +113,25 @@ public class SOAPXMLInjectionActiveScanner extends AbstractAppParamPlugin {
                      * Response has no SOAP format. It is still notified since it is an unexpected
                      * result.
                      */
-                    bingo(
-                            Alert.RISK_LOW,
-                            Alert.CONFIDENCE_MEDIUM,
-                            null,
-                            null,
-                            finalValue,
-                            Constant.messages.getString(MESSAGE_PREFIX + "warn1"),
-                            attackMsg);
+                    newAlert()
+                            .setRisk(Alert.RISK_LOW)
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setAttack(finalValue)
+                            .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "warn1"))
+                            .setMessage(attackMsg)
+                            .raise();
                 } else if (responsesAreEqual(modifiedMsg, attackMsg)
                         && !(responsesAreEqual(originalMsg, modifiedMsg))) {
                     /*
                      * The attack message has achieved the same result as the modified message, so
                      * XML injection attack worked.
                      */
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            null,
-                            null,
-                            finalValue,
-                            Constant.messages.getString(MESSAGE_PREFIX + "warn2"),
-                            attackMsg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setAttack(finalValue)
+                            .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "warn2"))
+                            .setMessage(attackMsg)
+                            .raise();
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
Use new method to raise alerts in the scan rules.