### PR TITLE
scripts: tweak help

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Tweak help content.
 
 ## [26] - 2020-01-17
 ### Added

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/console.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/console.html
@@ -14,7 +14,7 @@ It is made up of:
 <li>A text area (top) in which you can write your scripts</li>
 <li>An output text area (bottom) for debug and error messages, with "print" statements.</li>
 </ul>
-You can run 'Stand alone' scripts from within this tab using the 'Run' button on the tab toolbar.<br/>
+You can run 'Stand Alone' scripts from within this tab using the 'Run' button on the tab toolbar.<br/>
 All other types of scripts will be run when enabled or if explicitly invoked.<br/><br/>
 To create a new script or to load or switch scripts see the <a href="tree.html">The Scripts 'tree' tab</a>.  
 <p>
@@ -23,7 +23,7 @@ Right-click in the script area for display and editing options.
 In ZAP versions after 2.7.0 if the script currently displayed in the console is changed by another program then you 
 will be given the option to keep the script in the console or replace it with the changed script.<br>
 If a script is changed by another program when it is not being displayed and has not previously been changed in the script console 
-then that script will loaded and the new contents will be used when the script is run.
+then that script will be loaded and the new contents will be used when the script is run.
 <p>
 Templates can be viewed in the console but cannot be edited.<br/>
 

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/scripts.html
@@ -10,7 +10,7 @@
 The Script Console add-on allows you to run scripts that can be embedded within ZAP and can access internal ZAP data structures.<br/>
 It supports any scripting language that supports JSR 223 (http://www.jcp.org/en/jsr/detail?id=223) , including:
 <ul>
-<li>ECMAScript / Javascript (using <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/">Nashorn engine</a>, included by default)</li>
+<li>ECMAScript / JavaScript (using <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/">Nashorn engine</a>, included by default)</li>
 <li>Zest <a href="https://developer.mozilla.org/en-US/docs/zest">https://developer.mozilla.org/en-US/docs/zest</a> (included by default)</li>
 <li>Groovy <a href="http://groovy-lang.org/">http://groovy-lang.org/</a></li>
 <li>Python <a href="http://www.jython.org">http://www.jython.org</a></li>
@@ -18,7 +18,7 @@ It supports any scripting language that supports JSR 223 (http://www.jcp.org/en/
 <li>and many more...</li> 
 </ul>
 
-<b>WARNING - scripts run with the same permissions as ZAP, so do not run any scripts that you do not trust!</b>
+<strong>WARNING - scripts run with the same permissions as ZAP, so do not run any scripts that you do not trust!</strong>
 
 <H2>Script Types</H2>
 Different types of scripts are supported:
@@ -26,14 +26,16 @@ Different types of scripts are supported:
 <li>Stand Alone - scripts that are self contained and are only run when your start them manually</li>
 <li>Active Rules - these run as part of the Active Scanner and can be individually enabled</li>
 <li>Passive Rules - these run as part of the Passive Scanner and can be individually enabled</li> 
-<li>Proxy Rules - these run 'inline', can change every request and response and can be individually enabled. They can also trigger break points</li> 
+<li>Proxy - these run 'inline', can change every request and response and can be individually enabled. They can also trigger break points</li> 
 <li>HTTP Sender - scripts that run against every request/response sent/received by ZAP. This includes the proxied messages, messages sent during active scanner, fuzzer, ...</li>
-<li>Targeted Rules - scripts that invoked with a target URL and are only run when your start them manually</li>
-<li>Authentication - scripts that invoked when authentication is performed for a Context. To be used, they need to
+<li>Targeted - scripts that are invoked with a target URL and are only run when your start them manually</li>
+<li>Authentication - scripts that are invoked when authentication is performed for a Context. To be used, they need to
 be selected when configuring the Script-Based Authentication Method for a Context. </li> 
-<li>Script Input Vectors  - scripts for defining exactly what ZAP should attack</li>
-<li>Extenders - scripts which can add new functionality, including graphical elements and new API end points</li>
+<li>Script Input Vector - scripts for defining exactly what ZAP should attack</li>
+<li>Extender - scripts which can add new functionality, including graphical elements and new API end points</li>
 </ul>
+<strong>Note:</strong> Add-ons can add additional types of scripts, which should be described in the help of the corresponding add-on.
+<p>
 All scripts that are run automatically are initially 'disabled' - you must enable them via the <a href="tree.html">The Scripts 'tree' tab</a>
 before they will run.<br/>
 If an error occurs when they run then they will be disabled.<br/>
@@ -49,7 +51,7 @@ If your favourite language is not available on the Marketplace then please raise
 
 <H2>Global Variables</H2>
 Variables can be shared between all scripts via the class org.zaproxy.zap.extension.script.ScriptVars.<br/>
-For example in Javascript you can use this class as follows:<br/><br/>
+For example in JavaScript you can use this class as follows:<br/><br/>
 <code>
 org.zaproxy.zap.extension.script.ScriptVars.setGlobalVar("var.name","value")<br/>
 org.zaproxy.zap.extension.script.ScriptVars.getGlobalVar("var.name")<br/>
@@ -57,13 +59,13 @@ org.zaproxy.zap.extension.script.ScriptVars.getGlobalVar("var.name")<br/>
 
 <H2>Script Variables</H2>
 Variables can be shared between separate invocations of the same script via the same org.zaproxy.zap.extension.script.ScriptVars class.<br/>
-For example in Javascript you can use this class as follows:<br/><br/>
+For example in JavaScript you can use this class as follows:<br/><br/>
 <code>
 org.zaproxy.zap.extension.script.ScriptVars.setScriptVar(this.context, "var.name","value")<br/>
 org.zaproxy.zap.extension.script.ScriptVars.getScriptVar(this.context, "var.name")<br/>
 </code>
 <br/>
-Note that these methods are only usable from scripting languages that provide access to the ScriptContext (like Javascript).
+Note that these methods are only usable from scripting languages that provide access to the ScriptContext (like JavaScript).
 For other scripting languages (in ZAP versions after 2.7.0) the variables can be accessed/set by manually specifying
 the name of the script:<br/><br/>
 <code>

--- a/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/tree.html
+++ b/addOns/scripts/src/main/javahelp/org/zaproxy/zap/extension/scripts/resources/help/contents/tree.html
@@ -8,9 +8,9 @@
 <H1>Scripts tree tab</H1>
 <p>
 The Scripts tree tab shows you all of the scripts you currently have loaded organized by type.<br/>
-It also shows you which templates you have available - these cannot but run directly, you use them to create new scripts.<br/>
+It also shows you which templates you have available - these cannot be run directly, you use them to create new scripts.<br/>
 It also allows you to add new scripts, load, save and remove them.<br/>
-The tab include a toolbar which allows you to:
+The tab includes a toolbar which allows you to:
 <ul>
 <li>Load a script from filestore</li>
 <li>Save a script to filestore</li>


### PR DESCRIPTION
Correct names of script types.
Note that add-ons can add scripts types.
Change `Javascript` to `JavaScript`.
Use strong HTML tag instead of b.
Fix typos and grammar.