### PR TITLE
zest: handle client requests when authenticating

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Make sure the header fields are separated with CRLF when edited in the UI.
+- Handle client requests when authenticating (Issue 5940).
 
 ## [32] - 2020-01-24
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestAuthenticationRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestAuthenticationRunner.java
@@ -20,21 +20,31 @@
 package org.zaproxy.zap.extension.zest;
 
 import java.io.IOException;
+import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.script.ScriptException;
 import org.apache.commons.httpclient.URI;
+import org.mozilla.zest.core.v1.ZestClient;
 import org.mozilla.zest.core.v1.ZestRequest;
 import org.mozilla.zest.core.v1.ZestResponse;
+import org.mozilla.zest.core.v1.ZestStatement;
 import org.mozilla.zest.core.v1.ZestVariables;
+import org.mozilla.zest.impl.ZestBasicRunner;
+import org.parosproxy.paros.core.proxy.ProxyListener;
+import org.parosproxy.paros.core.proxy.ProxyServer;
+import org.parosproxy.paros.core.proxy.ProxyThread;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.authentication.AuthenticationHelper;
 import org.zaproxy.zap.authentication.GenericAuthenticationCredentials;
 import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType.AuthenticationScript;
 
 public class ZestAuthenticationRunner extends ZestZapRunner implements AuthenticationScript {
+
+    private static final String PROXY_ADDRESS = "127.0.0.1";
 
     private static final String USERNAME = "Username";
     private static final String PASSWORD = "Password";
@@ -89,7 +99,14 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
 
         this.helper = helper;
 
+        ProxyServer proxyServer = null;
         try {
+            if (hasClientStatements()) {
+                proxyServer = new ZestProxyServer(this, helper);
+                int port = proxyServer.startServer(PROXY_ADDRESS, 0, true);
+                this.setProxy(PROXY_ADDRESS, port);
+            }
+
             paramsValues.put(USERNAME, credentials.getParam(USERNAME));
             paramsValues.put(PASSWORD, credentials.getParam(PASSWORD));
 
@@ -116,7 +133,22 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
 
         } catch (Exception e) {
             throw new ScriptException(e);
+        } finally {
+            if (proxyServer != null) {
+                proxyServer.stopServer();
+            }
         }
+    }
+
+    private boolean hasClientStatements() {
+        ZestStatement next = script.getZestScript().getNext();
+        while (next != null) {
+            if (next instanceof ZestClient && next.isEnabled()) {
+                return true;
+            }
+            next = next.getNext();
+        }
+        return false;
     }
 
     @Override
@@ -125,5 +157,65 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
         msg.setRequestingUser(helper.getRequestingUser());
         helper.sendAndReceive(msg, request.isFollowRedirects());
         return ZestZapUtils.toZestResponse(msg);
+    }
+
+    private static class ZestProxyServer extends ProxyServer {
+
+        private final HttpSender httpSender;
+
+        ZestProxyServer(ZestBasicRunner runner, AuthenticationHelper helper) {
+            this.httpSender = helper.getHttpSender();
+            addProxyListener(
+                    new ProxyListener() {
+
+                        @Override
+                        public int getArrangeableListenerOrder() {
+                            return 0;
+                        }
+
+                        @Override
+                        public boolean onHttpRequestSend(HttpMessage msg) {
+                            msg.setRequestingUser(helper.getRequestingUser());
+                            return true;
+                        }
+
+                        @Override
+                        public boolean onHttpResponseReceive(HttpMessage msg) {
+                            runner.setVariable(
+                                    ZestVariables.REQUEST_URL,
+                                    msg.getRequestHeader().getURI().toString());
+                            runner.setVariable(
+                                    ZestVariables.REQUEST_HEADER,
+                                    msg.getRequestHeader().getHeadersAsString());
+                            runner.setVariable(
+                                    ZestVariables.REQUEST_METHOD,
+                                    msg.getRequestHeader().getMethod());
+                            runner.setVariable(
+                                    ZestVariables.REQUEST_BODY, msg.getRequestBody().toString());
+
+                            runner.setVariable(
+                                    ZestVariables.RESPONSE_URL,
+                                    msg.getRequestHeader().getURI().toString());
+                            runner.setVariable(
+                                    ZestVariables.RESPONSE_HEADER,
+                                    msg.getResponseHeader().toString());
+                            runner.setVariable(
+                                    ZestVariables.RESPONSE_BODY, msg.getResponseBody().toString());
+                            return true;
+                        }
+                    });
+        }
+
+        @Override
+        protected ProxyThread createProxyProcess(Socket clientSocket) {
+            return new ZestProxyThread(this, clientSocket, httpSender);
+        }
+
+        private static class ZestProxyThread extends ProxyThread {
+
+            ZestProxyThread(ProxyServer server, Socket socket, HttpSender sender) {
+                super(server, socket, sender);
+            }
+        }
     }
 }


### PR DESCRIPTION
Intercept and handle the client requests as authentication requests.

Fix zaproxy/zaproxy#5940- Zest client side scripts cannot be used for
authentication