### PR TITLE
codedex: remove unnecessary extends

### DIFF
--- a/addOns/codedx/CHANGELOG.md
+++ b/addOns/codedx/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 - Change info URL to link to the site.
+- Maintenance changes.
 
 ## [8] - 2019-08-23
 

--- a/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/ExtensionAlertHttp.java
+++ b/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/ExtensionAlertHttp.java
@@ -26,16 +26,14 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.report.ReportGenerator;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.alert.ExtensionAlert;
 
-public class ExtensionAlertHttp extends ExtensionAlert {
+public class ExtensionAlertHttp {
 	
 	private static final Logger LOGGER = Logger.getLogger(ExtensionAlertHttp.class);
 
     public ExtensionAlertHttp() {
     }
 
-    @Override
     public String getXml(SiteNode site) {
         StringBuilder xml = new StringBuilder();
         xml.append("<alerts>");


### PR DESCRIPTION
Change `ExtensionAlertHttp` to not extend `ExtensionAlert`, not needed
and it could end up in the add-on manifest (and thus being loaded as an
actual `Extension`).