### PR TITLE
tlsdebug: replace hardcoded colour

### DIFF
--- a/addOns/tlsdebug/CHANGELOG.md
+++ b/addOns/tlsdebug/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Use appropriate colour in dark mode (Issue 5542).
 
 ## 3 - 2018-10-15
 

--- a/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
+++ b/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
@@ -40,6 +40,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.KeyStroke;
+import javax.swing.UIManager;
 import javax.swing.border.EtchedBorder;
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
@@ -92,7 +93,7 @@ public class TlsDebugPanel extends AbstractPanel implements Tab {
         JPanel panelContent = new JPanel(new GridBagLayout());
         this.add(panelContent, BorderLayout.NORTH);
 
-        panelContent.setBackground(Color.white);
+        panelContent.setBackground(new Color(UIManager.getColor("TextField.background").getRGB()));
         panelContent.setBorder(BorderFactory.createEtchedBorder(EtchedBorder.RAISED));
 
         panelContent.add(


### PR DESCRIPTION
Use the background colour of the text field instead of hardcoding white.

Part of zaproxy/zaproxy#5542.