### PR TITLE
quickstart: replace hardcoded colour

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Use appropriate colour in dark mode (Issue 5542).
 
 ## [28] - 2020-02-04
 ### Added

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart;
 
-import java.awt.Color;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -82,8 +81,7 @@ public class AttackPanel extends QuickStartSubPanel {
 
     @Override
     public JPanel getDescriptionPanel() {
-        JPanel panel = new JPanel(new GridBagLayout());
-        panel.setBackground(Color.WHITE);
+        JPanel panel = new QuickStartBackgroundPanel();
         panel.add(
                 QuickStartHelper.getWrappedLabel("quickstart.attack.panel.message1"),
                 LayoutHelper.getGBC(0, 0, 2, 1.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));
@@ -100,8 +98,7 @@ public class AttackPanel extends QuickStartSubPanel {
     @Override
     public JPanel getContentPanel() {
         if (contentPanel == null) {
-            contentPanel = new JPanel(new GridBagLayout());
-            contentPanel.setBackground(Color.WHITE);
+            contentPanel = new QuickStartBackgroundPanel();
             int formPanelY = 0;
 
             contentPanel.add(

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart;
 
-import java.awt.Color;
-import java.awt.GridBagLayout;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
@@ -77,8 +75,7 @@ public class DefaultExplorePanel extends QuickStartSubPanel {
 
     @Override
     public JPanel getDescriptionPanel() {
-        JPanel panel = new JPanel(new GridBagLayout());
-        panel.setBackground(Color.WHITE);
+        JPanel panel = new QuickStartBackgroundPanel();
 
         panel.add(
                 QuickStartHelper.getWrappedLabel("quickstart.launch.panel.default.message1"),
@@ -97,8 +94,7 @@ public class DefaultExplorePanel extends QuickStartSubPanel {
     @Override
     public JPanel getContentPanel() {
         if (contentPanel == null) {
-            contentPanel = new JPanel(new GridBagLayout());
-            contentPanel.setBackground(Color.WHITE);
+            contentPanel = new QuickStartBackgroundPanel();
             int formPanelY = 0;
 
             JPanel savePanel = QuickStartHelper.getHorizontalPanel();
@@ -237,8 +233,7 @@ public class DefaultExplorePanel extends QuickStartSubPanel {
 
     @Override
     public JPanel getFooterPanel() {
-        JPanel panel = new JPanel(new GridBagLayout());
-        panel.setBackground(Color.WHITE);
+        JPanel panel = new QuickStartBackgroundPanel();
         panel.add(
                 QuickStartHelper.getWrappedLabel("quickstart.explore.panel.footer"),
                 LayoutHelper.getGBC(0, 0, 1, 1.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/LearnMorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/LearnMorePanel.java
@@ -19,11 +19,9 @@
  */
 package org.zaproxy.zap.extension.quickstart;
 
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Desktop;
 import java.awt.Font;
-import java.awt.GridBagLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.font.TextAttribute;
@@ -66,8 +64,7 @@ public class LearnMorePanel extends QuickStartSubPanel {
 
     @Override
     public JPanel getDescriptionPanel() {
-        JPanel panel = new JPanel(new GridBagLayout());
-        panel.setBackground(Color.WHITE);
+        JPanel panel = new QuickStartBackgroundPanel();
         panel.add(
                 QuickStartHelper.getWrappedLabel("quickstart.learn.panel.message1"),
                 LayoutHelper.getGBC(0, 0, 2, 1.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));
@@ -90,8 +87,7 @@ public class LearnMorePanel extends QuickStartSubPanel {
     @Override
     public JPanel getContentPanel() {
         if (contentPanel == null) {
-            contentPanel = new JPanel(new GridBagLayout());
-            contentPanel.setBackground(Color.WHITE);
+            contentPanel = new QuickStartBackgroundPanel();
             int formPanelY = 0;
 
             ExtensionHelp extHelp =

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartBackgroundPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartBackgroundPanel.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.quickstart;
+
+import java.awt.Color;
+import java.awt.GridBagLayout;
+import javax.swing.UIManager;
+import org.jdesktop.swingx.JXPanel;
+
+/**
+ * The base panel for quick start panels.
+ *
+ * <p>Uses a custom background colour.
+ *
+ * @see #getBackgroundColor()
+ */
+public class QuickStartBackgroundPanel extends JXPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static Color backgroundColor;
+
+    /**
+     * Constructs a {@code QuickStartBackgroundPanel} with the custom colour and a {@link
+     * GridBagLayout}.
+     */
+    public QuickStartBackgroundPanel() {
+        super(new GridBagLayout());
+
+        setBackground(getBackgroundColor());
+    }
+
+    /**
+     * Gets the background colour that should be used by quick start panels and other components
+     * displayed in them.
+     *
+     * @return the custom background colour for quick start panels.
+     */
+    public static Color getBackgroundColor() {
+        if (backgroundColor == null) {
+            backgroundColor = new Color(UIManager.getColor("TextField.background").getRGB());
+        }
+        return backgroundColor;
+    }
+}

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartHelper.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartHelper.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart;
 
-import java.awt.Color;
 import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 import org.parosproxy.paros.Constant;
@@ -30,16 +29,14 @@ import org.zaproxy.zap.utils.ZapLabel;
 public class QuickStartHelper {
 
     public static JPanel getHorizontalPanel() {
-        JPanel panel = new JPanel();
-        BoxLayout layout = new BoxLayout(panel, BoxLayout.X_AXIS);
-        panel.setLayout(layout);
-        panel.setBackground(Color.WHITE);
+        JPanel panel = new QuickStartBackgroundPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
         return panel;
     }
 
     public static ZapLabel getWrappedLabel(String key) {
         ZapLabel label = new ZapLabel(Constant.messages.getString(key));
-        label.setBackground(Color.WHITE);
+        label.setBackground(QuickStartBackgroundPanel.getBackgroundColor());
         label.setLineWrap(true);
         label.setWrapStyleWord(true);
         return label;

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -24,7 +24,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -99,7 +98,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
         this.setMnemonic(Constant.messages.getChar("quickstart.panel.mnemonic"));
         this.setLayout(new BorderLayout());
 
-        panelContent = new JXPanel(new GridBagLayout());
+        panelContent = new QuickStartBackgroundPanel();
         panelContent.setScrollableHeightHint(ScrollableSizeHint.FIT);
 
         jScrollPane = new JScrollPane();
@@ -112,11 +111,10 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 
         this.add(jScrollPane, BorderLayout.CENTER);
 
-        panelContent.setBackground(Color.white);
         panelContent.setBorder(BorderFactory.createEtchedBorder(EtchedBorder.RAISED));
 
         JLabel topTitle = new JLabel(Constant.messages.getString("quickstart.top.panel.title"));
-        topTitle.setBackground(Color.WHITE);
+        topTitle.setBackground(panelContent.getBackground());
         topTitle.setFont(FontUtils.getFont(Size.much_larger));
         topTitle.setHorizontalAlignment(SwingConstants.CENTER);
         panelContent.add(
@@ -141,7 +139,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
                 LayoutHelper.getGBC(0, ++panelY, 4, 1.0D, new Insets(5, 5, 5, 5))); // Spacer
 
         buttonPanel = new JPanel(new FlowLayout());
-        buttonPanel.setBackground(Color.white);
+        buttonPanel.setBackground(panelContent.getBackground());
         buttonPanel.add(this.getAttackButton());
         buttonPanel.add(this.getExploreButton());
         buttonPanel.add(this.getLearnMoreButton());
@@ -293,8 +291,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 
     private JXPanel getNewsPanel() {
         if (newsPanel == null) {
-            newsPanel = new JXPanel(new GridBagLayout());
-            newsPanel.setBackground(Color.WHITE);
+            newsPanel = new QuickStartBackgroundPanel();
             if (newsItem != null) {
                 this.showNews(newsItem);
             }
@@ -304,11 +301,10 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
 
     private void showNews(NewsItem newsItem) {
 
-        JXPanel innerPanel = new JXPanel(new GridBagLayout());
+        JXPanel innerPanel = new QuickStartBackgroundPanel();
 
         CloseButton closeButton = new CloseButton();
-        JPanel closePanel = new JPanel(new GridBagLayout());
-        closePanel.setBackground(Color.WHITE);
+        JPanel closePanel = new QuickStartBackgroundPanel();
         closePanel.add(new JLabel(""), LayoutHelper.getGBC(0, 0, 1, 1.0D)); // Spacer
         closePanel.add(closeButton, LayoutHelper.getGBC(1, 0, 1, 0.0D));
         closeButton.setVerticalAlignment(SwingConstants.TOP);
@@ -337,7 +333,6 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
                 BorderFactory.createTitledBorder(
                         BorderFactory.createLineBorder(Color.RED),
                         Constant.messages.getString("quickstart.label.news")));
-        innerPanel.setBackground(Color.WHITE);
         innerPanel.add(
                 new JLabel(newsItem.getText()),
                 LayoutHelper.getGBC(0, 0, 1, 0.0D, new Insets(5, 5, 5, 5)));

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartSubPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartSubPanel.java
@@ -19,9 +19,7 @@
  */
 package org.zaproxy.zap.extension.quickstart;
 
-import java.awt.Color;
 import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -30,7 +28,6 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.EtchedBorder;
-import org.jdesktop.swingx.JXPanel;
 import org.jdesktop.swingx.ScrollableSizeHint;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -38,7 +35,7 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.FontUtils.Size;
 import org.zaproxy.zap.view.LayoutHelper;
 
-public abstract class QuickStartSubPanel extends JXPanel {
+public abstract class QuickStartSubPanel extends QuickStartBackgroundPanel {
 
     private static final long serialVersionUID = 1L;
 
@@ -54,18 +51,14 @@ public abstract class QuickStartSubPanel extends JXPanel {
     }
 
     private void initialize() {
-        this.setLayout(new GridBagLayout());
         this.setScrollableHeightHint(ScrollableSizeHint.PREFERRED_STRETCH);
-        this.setBackground(Color.white);
         this.setBorder(BorderFactory.createEtchedBorder(EtchedBorder.RAISED));
 
-        JPanel topPanel = new JPanel();
-        BoxLayout layout = new BoxLayout(topPanel, BoxLayout.X_AXIS);
-        topPanel.setLayout(layout);
-        topPanel.setBackground(Color.WHITE);
+        JPanel topPanel = new QuickStartBackgroundPanel();
+        topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.X_AXIS));
         topPanel.add(getBackButton());
         JLabel topTitle = new JLabel(Constant.messages.getString(this.getTitleKey()));
-        topTitle.setBackground(Color.WHITE);
+        topTitle.setBackground(topPanel.getBackground());
         topTitle.setFont(FontUtils.getFont(Size.much_larger));
         topPanel.add(Box.createHorizontalGlue());
         topPanel.add(topTitle);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ajaxspider/AjaxSpiderExplorer.java
@@ -19,8 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart.ajaxspider;
 
-import java.awt.Color;
-import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.URI;
@@ -34,6 +32,7 @@ import javax.swing.JPanel;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.zaproxy.zap.extension.quickstart.PlugableSpider;
+import org.zaproxy.zap.extension.quickstart.QuickStartBackgroundPanel;
 import org.zaproxy.zap.extension.quickstart.QuickStartParam;
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ProvidedBrowserUI;
@@ -139,8 +138,7 @@ public class AjaxSpiderExplorer implements PlugableSpider {
     @Override
     public JPanel getPanel() {
         if (panel == null) {
-            panel = new JPanel(new GridBagLayout());
-            panel.setBackground(Color.WHITE);
+            panel = new QuickStartBackgroundPanel();
             panel.add(
                     getSelectCheckBox(),
                     LayoutHelper.getGBC(0, 0, 1, 0.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.quickstart.launch;
 
-import java.awt.Color;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
@@ -46,6 +45,7 @@ import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.quickstart.ExtensionQuickStart;
 import org.zaproxy.zap.extension.quickstart.PlugableHud;
+import org.zaproxy.zap.extension.quickstart.QuickStartBackgroundPanel;
 import org.zaproxy.zap.extension.quickstart.QuickStartHelper;
 import org.zaproxy.zap.extension.quickstart.QuickStartPanel;
 import org.zaproxy.zap.extension.quickstart.QuickStartSubPanel;
@@ -100,8 +100,7 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
 
     @Override
     public JPanel getDescriptionPanel() {
-        JPanel panel = new JPanel(new GridBagLayout());
-        panel.setBackground(Color.WHITE);
+        JPanel panel = new QuickStartBackgroundPanel();
         panel.add(
                 QuickStartHelper.getWrappedLabel("quickstart.launch.panel.message1"),
                 LayoutHelper.getGBC(0, 0, 2, 1.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));
@@ -126,9 +125,8 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
     @Override
     public JPanel getContentPanel() {
         if (this.contentPanel == null) {
-            contentPanel = new JXPanel(new GridBagLayout());
+            contentPanel = new QuickStartBackgroundPanel();
             contentPanel.setScrollableHeightHint(ScrollableSizeHint.PREFERRED_STRETCH);
-            contentPanel.setBackground(Color.white);
             int offset = 0;
             contentPanel.add(
                     new JLabel(Constant.messages.getString("quickstart.label.exploreurl")),
@@ -279,8 +277,7 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
             }
         }
 
-        JPanel hudPanel = new JPanel(new GridBagLayout());
-        hudPanel.setBackground(Color.WHITE);
+        JPanel hudPanel = new QuickStartBackgroundPanel();
         hudPanel.add(getHudCheckbox(), LayoutHelper.getGBC(0, 0, 1, 0));
         hudPanel.add(getHudIsInScopeOnly(), LayoutHelper.getGBC(1, 0, 1, 0));
         hudPanel.add(new JLabel(), LayoutHelper.getGBC(1, 0, 2, 1.0));
@@ -388,8 +385,7 @@ public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
 
     @Override
     public JPanel getFooterPanel() {
-        JPanel panel = new JPanel(new GridBagLayout());
-        panel.setBackground(Color.WHITE);
+        JPanel panel = new QuickStartBackgroundPanel();
         panel.add(
                 new JLabel(Constant.messages.getString("quickstart.panel.launch.manual")),
                 LayoutHelper.getGBC(0, 0, 5, 1.0D, new Insets(5, 5, 5, 5)));


### PR DESCRIPTION
Use the background colour of the text field instead of hardcoding white.
Extract a class for the panel with the custom background.

Part of zaproxy/zaproxy#5542.