### PR TITLE
Update add-on plugin

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -10,7 +10,7 @@ import org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog
 
 plugins {
     jacoco
-    id("org.zaproxy.add-on") version "0.3.0" apply false
+    id("org.zaproxy.add-on") version "0.4.0" apply false
 }
 
 description = "Common configuration of the add-ons."


### PR DESCRIPTION
Update add-on plugin to 0.4.0 to properly generate the add-on manifest.
The add-ons `ascanrulesBeta` and `ascanrulesAlpha` were not declaring in
the manifest the scan rules that extended `AbstractAppFilePlugin`.