### PR TITLE
Wappalyzer job now uses new gradle plugin CHANGELOG functionality

### DIFF
--- a/.github/workflows/create_wappalyzer_update.yml
+++ b/.github/workflows/create_wappalyzer_update.yml
@@ -36,6 +36,7 @@ jobs:
         cp -R wappalyzer/src/icons/ zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/icons
         cp -f wappalyzer/src/apps.json zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources
         cd zap-extensions
+        ./gradlew :addOns:wappalyzer:updateChangelog --change="- Updated with upstream Wappalyzer icon and pattern changes."
         git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
         git add .
         git commit -m "Wappalyzer Update $SHORT_DATE" -m "Updates based on $SRC_BASE"


### PR DESCRIPTION
Per:
- https://github.com/zaproxy/zap-extensions/pull/2386
- https://github.com/zaproxy/gradle-plugin-add-on/pull/28