### PR TITLE
Add BINList Support

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 'CSP Scanner' rule upgrade salvation library to v2.7.1.
 - 'CSP Scanner' rule now merges (intersects) multiple CSP header fields to more accurately evaluate policies and prevent parsing issues (Issue 5931).
 - 'X-Frame-Options Header Scanner' replace now invalid MSDN reference link with MDN link on X-Frame-Options (Issue 5867).
+- 'Information Disclosure Referrer' scan rule added support for looking up evidence against an Open Source Bank Identification Number List. Confidence is now modified based on whether the lookup is successful or not. Additional details are added to 'Other Info' if available (Issue 5842).
 
 ## [27] - 2020-02-11
 

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -137,6 +137,11 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 Identifies the existence of sensitive details within the Referrer header field of HTTP requests
 (this may include parameters, document names, directory names, etc.).
 <p>
+Note: In the case of suspected credit card identifiers in the Referrer value, the potential credit card numbers are looked up against a Bank Identification
+Number List (BINList). If a match is found the alert is raised at High confidence and additional details are added to the 'Other Information' field in the alert,
+otherwise the alerts will have Medium confidence.
+See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for more information.
+<p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanner.java">InformationDisclosureReferrerScanner.java</a>
 
 <H2>Information Disclosure: Suspicious Comments</H2>

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -66,6 +66,10 @@ pscanrules.informationdisclosurereferrerscanner.otherinfo.cc=The URL in the HTTP
 pscanrules.informationdisclosurereferrerscanner.otherinfo.email=The URL in the HTTP referrer header field contains email address(es).
 pscanrules.informationdisclosurereferrerscanner.otherinfo.ssn=The URL in the HTTP referrer header field appears to contain US Social Security Number(s).
 pscanrules.informationdisclosurereferrerscanner.soln=Do not pass sensitive information in URIs.
+pscanrules.informationdisclosurereferrerscanner.bin.field=Bank Identification Number:
+pscanrules.informationdisclosurereferrerscanner.brand.field=Brand:
+pscanrules.informationdisclosurereferrerscanner.category.field=Category:
+pscanrules.informationdisclosurereferrerscanner.issuer.field=Issuer:
 
 pscanrules.informationdisclosuresuspiciouscomments.name=Information Disclosure - Suspicious Comments
 pscanrules.informationdisclosuresuspiciouscomments.desc=The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScannerUnitTest.java
@@ -239,7 +239,16 @@ public class InformationDisclosureReferrerScannerUnitTest
         assertEquals(sensitiveValue, alertsRaised.get(0).getEvidence());
         assertEquals(
                 Constant.messages.getString(
-                        InformationDisclosureReferrerScanner.MESSAGE_PREFIX + "otherinfo.cc"),
+                                InformationDisclosureReferrerScanner.MESSAGE_PREFIX
+                                        + "otherinfo.cc")
+                        + '\n'
+                        + "Bank Identification Number: 601100"
+                        + '\n'
+                        + "Brand: DISCOVER"
+                        + '\n'
+                        + "Category: PLATINUM"
+                        + '\n'
+                        + "Issuer: DISCOVER",
                 alertsRaised.get(0).getOtherInfo());
     }
 

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - 'Servlet Parameter Pollution' scan rule will now only scan responses for in Context URLs for which the Technology JSP/Serlet is applicable.
 - Updated owasp.org references (Issue 5962).
+- 'PII Disclosure' added support for looking up evidence against an Open Source Bank Identification Number List. Confidence is now modified based on whether the lookup is successful or not. Additional details are added to 'Other Info' if available (Issue 5842).
 
 ## [21] - 2019-12-16
 

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -73,6 +73,11 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 <H2>PII Disclosure</H2>
 PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number.
 <p>
+Note: In the case of suspected credit card values, the potential credit card numbers are looked up against a Bank Identification Number List 
+(BINList). If a match is found the alert is raised at High confidence and additional details are added to the 'Other Information' field in the 
+alert, otherwise the alerts will have Medium confidence.
+See: <a href="https://github.com/iannuttall/binlist-data">binlist-data</a> for more information.
+<p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanner.java">PiiScanner.java</a>
 
 <H2>Retrieved from Cache</H2>

--- a/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -55,6 +55,10 @@ pscanbeta.linktarget.soln=Do not use a target attribute, or if you have to then 
 pscanbeta.piiscanner.name = PII Disclosure
 pscanbeta.piiscanner.desc = The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
 pscanbeta.piiscanner.extrainfo = Credit Card Type detected: {0}
+pscanbeta.piiscanner.bin.field=Bank Identification Number:
+pscanbeta.piiscanner.brand.field=Brand:
+pscanbeta.piiscanner.category.field=Category:
+pscanbeta.piiscanner.issuer.field=Issuer:
 
 pscanbeta.retrievedfromcache.name = Retrieved from Cache
 pscanbeta.retrievedfromcache.desc = The content was retrieved from a shared cache. If the response data is sensitive, personal or user-specific, this may result in sensitive information being leaked. In some cases, this may even result in a user gaining complete control of the session of another user, depending on the configuration of the caching components in use in their environment. This is primarily an issue where caching servers such as "proxy" caches are configured on the local network. This configuration is typically found in corporate or educational environments, for instance. 

--- a/sharedutils/sharedutils.gradle.kts
+++ b/sharedutils/sharedutils.gradle.kts
@@ -13,6 +13,10 @@ dependencies {
     val zap = "org.zaproxy:zap:2.7.0"
     compileOnly(zap)
 
+    implementation("org.apache.commons:commons-csv:1.8")
+    implementation("commons-io:commons-io:2.6")
+    implementation("org.apache.commons:commons-collections4:4.4")
+
     testImplementation(project(":testutils"))
     testImplementation(zap)
 }

--- a/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/PiiUtils.java
+++ b/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/PiiUtils.java
@@ -19,8 +19,13 @@
  */
 package org.zaproxy.zap.sharedutils;
 
+import org.zaproxy.zap.sharedutils.binlist.BinList;
+import org.zaproxy.zap.sharedutils.binlist.BinRecord;
+
 /** A utility class for dealing with PII. */
 public final class PiiUtils {
+
+    private static BinList binList;
 
     private PiiUtils() {}
 
@@ -45,5 +50,16 @@ public final class PiiUtils {
             sum += digit;
         }
         return (sum % 10) == 0;
+    }
+
+    private static BinList getBinList() {
+        if (binList == null) {
+            binList = new BinList();
+        }
+        return binList;
+    }
+
+    public static BinRecord getBinRecord(String candidate) {
+        return getBinList().get(candidate);
     }
 }

--- a/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/binlist/BinList.java
+++ b/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/binlist/BinList.java
@@ -1,0 +1,90 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.sharedutils.binlist;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.collections4.Trie;
+import org.apache.commons.collections4.trie.PatriciaTrie;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.io.input.BOMInputStream;
+import org.apache.log4j.Logger;
+
+public class BinList {
+
+    private static final Logger LOGGER = Logger.getLogger(BinList.class);
+    private static final String BINLIST = "binlist-data.csv";
+
+    private static Trie<String, BinRecord> binList = new PatriciaTrie<>();
+
+    public BinList() {
+        loadList();
+    }
+
+    private static void loadList() {
+        Iterable<CSVRecord> records;
+        try (InputStream in = BinList.class.getResourceAsStream(BINLIST);
+                BOMInputStream bomStream = new BOMInputStream(in);
+                InputStreamReader inStream =
+                        new InputStreamReader(bomStream, StandardCharsets.UTF_8)) {
+            records = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(inStream).getRecords();
+        } catch (NullPointerException | IOException e) {
+            LOGGER.warn("Exception while loading: " + BINLIST, e);
+            return;
+        }
+        fillList(records);
+    }
+
+    private static void fillList(Iterable<CSVRecord> records) {
+        for (CSVRecord record : records) {
+            binList.put(
+                    record.get("bin"),
+                    new BinRecord(
+                            record.get("bin"),
+                            record.get("brand"),
+                            record.get("category"),
+                            record.get("issuer")));
+        }
+    }
+
+    public BinRecord get(String candidate) {
+        BinRecord binRec;
+        binRec = binList.get(candidate);
+        // Per https://github.com/iannuttall/binlist-data the collection should have BINs 6-8 but
+        // based on my searching there are actually entries 5-8. The following are ordered based
+        // on count of occurrence
+        if (binRec == null) {
+            binRec = binList.get(candidate.substring(0, 6));
+        }
+        if (binRec == null) {
+            binRec = binList.get(candidate.substring(0, 8));
+        }
+        if (binRec == null) {
+            binRec = binList.get(candidate.substring(0, 5));
+        }
+        if (binRec == null) {
+            binRec = binList.get(candidate.substring(0, 7));
+        }
+        return binRec;
+    }
+}

--- a/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/binlist/BinRecord.java
+++ b/sharedutils/src/main/java/org/zaproxy/zap/sharedutils/binlist/BinRecord.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.sharedutils.binlist;
+
+public class BinRecord {
+    String bin;
+    String brand;
+    String category;
+    String issuer;
+
+    BinRecord(String bin, String brand, String category, String issuer) {
+        this.bin = bin;
+        this.brand = brand;
+        this.category = category;
+        this.issuer = issuer;
+    }
+
+    public String getBin() {
+        return bin;
+    }
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder recString = new StringBuilder(75);
+        recString.append("BIN: ").append(bin).append('\n');
+        recString.append("Brand: ").append(brand).append('\n');
+        recString.append("Category: ").append(category).append('\n');
+        recString.append("Issuer: ").append(issuer);
+        return recString.toString();
+    }
+}


### PR DESCRIPTION
- sharedutils > Add classes and functionality to load BINList and retrieve entries. This leverages a compressible collection structure from Apache commons collections (PatriciaTrie).
- pscanrulesBeta > Change PiiScanner to leverage the new functionality and lookup evidence against the BINList. If a match is found raise at High confidence and with additional details included in otherinfo, otherwise Medium confidence.
- pscanrules > Change InformationDisclosureReferrerScanner to leverage the new functionality and lookup evidence against the BINList. If a match is found raise at High confidence and with additional details included in otherinfo, otherwise Medium confidence.

Fixes zaproxy/zaproxy#5842

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>