### PR TITLE
Adjust Risk and Confidence on some User Controlled value pscan rules

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 'Servlet Parameter Pollution' scan rule will now only scan responses for in Context URLs for which the Technology JSP/Serlet is applicable.
 - Updated owasp.org references (Issue 5962).
 - 'PII Disclosure' added support for looking up evidence against an Open Source Bank Identification Number List. Confidence is now modified based on whether the lookup is successful or not. Additional details are added to 'Other Info' if available (Issue 5842).
+- Changed to set Risk Info and Confidence Low for the following passive scan rules: User Controlled Cookie, User Controlled JavaScript Event, and User Controlled Charset.
 
 ## [21] - 2019-12-16
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanner.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanner.java
@@ -192,8 +192,8 @@ public class UserControlledCharsetScanner extends PluginPassiveScanner {
     private void raiseAlert(
             HttpMessage msg, int id, String tag, String attr, HtmlParameter param, String charset) {
         newAlert()
-                .setRisk(Alert.RISK_MEDIUM)
-                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setRisk(Alert.RISK_INFO)
+                .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(getDescriptionMessage())
                 .setParam(param.getName())
                 .setOtherInfo(getExtraInfoMessage(tag, attr, param, charset))

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanner.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanner.java
@@ -150,8 +150,8 @@ public class UserControlledCookieScanner extends PluginPassiveScanner {
 
     private void raiseAlert(HttpMessage msg, int id, HtmlParameter param, String cookie) {
         newAlert()
-                .setRisk(Alert.RISK_MEDIUM)
-                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setRisk(Alert.RISK_INFO)
+                .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(getDescriptionMessage())
                 .setParam(param.getName())
                 .setOtherInfo(getExtraInfoMessage(msg, param, cookie))

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanner.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanner.java
@@ -173,8 +173,8 @@ public class UserControlledJavascriptEventScanner extends PluginPassiveScanner {
             Attribute htmlAttribute,
             HtmlParameter param) {
         newAlert()
-                .setRisk(Alert.RISK_MEDIUM)
-                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setRisk(Alert.RISK_INFO)
+                .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(getDescriptionMessage())
                 .setParam(param.getName())
                 .setOtherInfo(getExtraInfoMessage(msg, htmlAttribute, param))


### PR DESCRIPTION
- UserControlledCookieScanner, UserControlledJavascriptEventScanner, and UserControlledCharsetScanner > Changed to set Risk Info and Confidence Low for these passive scanners.
- CHANGELOG > Added note to unreleased section.

Fixes zaproxy/zaproxy#5333

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>