### PR TITLE
testutils: consume request body on 404

### DIFF
--- a/testutils/src/main/java/org/zaproxy/zap/testutils/HTTPDTestServer.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/HTTPDTestServer.java
@@ -31,6 +31,7 @@ public class HTTPDTestServer extends NanoHTTPD {
             new NanoServerHandler("") {
                 @Override
                 protected Response serve(IHTTPSession session) {
+                    consumeBody(session);
                     return newFixedLengthResponse(
                             Response.Status.NOT_FOUND,
                             MIME_HTML,


### PR DESCRIPTION
Make sure the request body is consumed in case of 404 to keep the
connection in good state.