### PR TITLE
pscanrules: CSP scan rule upgrade salvation to 2.7.2

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [28] - 2020-04-08
 
 ### Changed
-- 'CSP Scanner' rule upgrade salvation library to v2.7.1.
+- 'CSP Scanner' rule upgrade salvation library to v2.7.2.
 - 'CSP Scanner' rule now merges (intersects) multiple CSP header fields to more accurately evaluate policies and prevent parsing issues (Issue 5931).
 - 'X-Frame-Options Header Scanner' replace now invalid MSDN reference link with MDN link on X-Frame-Options (Issue 5867).
 - 'Information Disclosure Referrer' scan rule added support for looking up evidence against an Open Source Bank Identification Number List. Confidence is now modified based on whether the lookup is successful or not. Additional details are added to 'Other Info' if available (Issue 5842).

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -36,7 +36,7 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.shapesecurity:salvation:2.7.1")
+    implementation("com.shapesecurity:salvation:2.7.2")
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 


### PR DESCRIPTION
Changelog tweaked, 2.7.1 revision wasn't released yet.

Minor upstream changes:
https://github.com/shapesecurity/salvation/compare/v2.7.1..v2.7.2

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>