### PR TITLE
ascanrules: update ZAP to 2.9.0

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.9.0.
 - Command Injection, Test Path Traversal, Test Cross Site ScriptV2 and Remote File Include rules are updated to include payloads for Null Byte Injection (Issue 3877).
 - Updated owasp.org references (Issue 5962).
 

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -6,7 +6,7 @@ description = "The release quality Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.7.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflow.java
@@ -134,14 +134,14 @@ public class BufferOverflow extends AbstractAppParamPlugin {
             if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR
                     && chkerrorheader.contains(checkStringHeader1)) {
                 log.debug("Found Header");
-                bingo(
-                        getRisk(),
-                        Alert.CONFIDENCE_MEDIUM,
-                        this.getBaseMsg().getRequestHeader().getURI().toString(),
-                        param,
-                        msg.getRequestHeader().toString(),
-                        this.getOther(),
-                        msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setUri(this.getBaseMsg().getRequestHeader().getURI().toString())
+                        .setParam(param)
+                        .setEvidence(msg.getRequestHeader().toString())
+                        .setOtherInfo(getOther())
+                        .setMessage(msg)
+                        .raise();
                 return;
             }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionPlugin.java
@@ -262,18 +262,13 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
                                         + "]");
                     }
 
-                    // Now create the alert message
-                    this.bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString(MESSAGE_PREFIX + "name.php"),
-                            getDescription(),
-                            null,
-                            paramName,
-                            phpPayload,
-                            null,
-                            getSolution(),
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(Constant.messages.getString(MESSAGE_PREFIX + "name.php"))
+                            .setParam(paramName)
+                            .setAttack(phpPayload)
+                            .setMessage(msg)
+                            .raise();
 
                     // All done. No need to look for vulnerabilities on subsequent
                     // parameters on the same request (to reduce performance impact)
@@ -356,18 +351,13 @@ public class CodeInjectionPlugin extends AbstractAppParamPlugin {
                                         + "]");
                     }
 
-                    // Now create the alert message
-                    this.bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString(MESSAGE_PREFIX + "name.asp"),
-                            getDescription(),
-                            null,
-                            paramName,
-                            aspPayload,
-                            null,
-                            getSolution(),
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(Constant.messages.getString(MESSAGE_PREFIX + "name.asp"))
+                            .setParam(paramName)
+                            .setAttack(aspPayload)
+                            .setMessage(msg)
+                            .raise();
                     return true;
                 }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionPlugin.java
@@ -598,16 +598,13 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
                                         + "]");
                     }
 
-                    // Now create the alert message
-                    this.bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            msg.getRequestHeader().getURI().toString(),
-                            paramName,
-                            paramValue,
-                            null,
-                            matcher.group(),
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(paramName)
+                            .setAttack(paramValue)
+                            .setEvidence(matcher.group())
+                            .setMessage(msg)
+                            .raise();
 
                     // All done. No need to look for vulnerabilities on subsequent
                     // payloads on the same request (to reduce performance impact)
@@ -700,16 +697,12 @@ public class CommandInjectionPlugin extends AbstractAppParamPlugin {
                                         + "]");
                     }
 
-                    // Now create the alert message
-                    this.bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            msg.getRequestHeader().getURI().toString(),
-                            paramName,
-                            paramValue,
-                            null,
-                            null,
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(paramName)
+                            .setAttack(paramValue)
+                            .setMessage(msg)
+                            .raise();
 
                     // All done. No need to look for vulnerabilities on subsequent
                     // payloads on the same request (to reduce performance impact)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatString.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatString.java
@@ -222,23 +222,21 @@ public class FormatString extends AbstractAppParamPlugin {
                 HttpResponseBody secondAttackResponseBody = msg.getResponseBody();
                 if (secondAttackResponseBody.length() > initialResponseLength + 20
                         && msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK) {
-                    bingo(
-                            getRisk(),
-                            Alert.CONFIDENCE_MEDIUM,
-                            null,
-                            param,
-                            secondAttackPayload,
-                            getError('2'),
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(secondAttackPayload)
+                            .setOtherInfo(getError('2'))
+                            .setMessage(msg)
+                            .raise();
                 } else {
-                    bingo(
-                            getRisk(),
-                            Alert.CONFIDENCE_MEDIUM,
-                            null,
-                            param,
-                            initialAttackPayload,
-                            getError('1'),
-                            intialAttackMsg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(initialAttackPayload)
+                            .setOtherInfo(getError('1'))
+                            .setMessage(intialAttackMsg)
+                            .raise();
                 }
                 return;
             }
@@ -283,14 +281,13 @@ public class FormatString extends AbstractAppParamPlugin {
                 return; // Something went wrong, no point continuing
             }
             if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR) {
-                bingo(
-                        getRisk(),
-                        Alert.CONFIDENCE_MEDIUM,
-                        null,
-                        param,
-                        microsoftAttackMessage,
-                        getError('3'),
-                        msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(microsoftAttackMessage)
+                        .setOtherInfo(getError('3'))
+                        .setMessage(msg)
+                        .raise();
             }
             return;
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWEBINF.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWEBINF.java
@@ -228,25 +228,20 @@ public class SourceCodeDisclosureWEBINF extends AbstractHostPlugin {
                             log.debug("Source Code Disclosure alert for: " + classname);
                         }
 
-                        // bingo.
-                        bingo(
-                                Alert.RISK_HIGH,
-                                Alert.CONFIDENCE_MEDIUM,
-                                Constant.messages.getString(
-                                        "ascanrules.sourcecodedisclosurewebinf.name"),
-                                Constant.messages.getString(
-                                        "ascanrules.sourcecodedisclosurewebinf.desc"),
-                                null, // originalMessage.getRequestHeader().getURI().getURI(),
-                                null, // parameter being attacked: none.
-                                "", // attack
-                                javaSourceCode, // extrainfo
-                                Constant.messages.getString(
-                                        "ascanrules.sourcecodedisclosurewebinf.soln"),
-                                "", // evidence, highlighted in the message
-                                classfilemsg // raise the alert on the classfile, rather than on the
-                                // web.xml (or other file where the class reference was
-                                // found).
-                                );
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setName(
+                                        Constant.messages.getString(
+                                                "ascanrules.sourcecodedisclosurewebinf.name"))
+                                .setDescription(
+                                        Constant.messages.getString(
+                                                "ascanrules.sourcecodedisclosurewebinf.desc"))
+                                .setOtherInfo(javaSourceCode)
+                                .setSolution(
+                                        Constant.messages.getString(
+                                                "ascanrules.sourcecodedisclosurewebinf.soln"))
+                                .setMessage(classfilemsg)
+                                .raise();
 
                         // and add the referenced classes to the list of classes to look for!
                         // so that we catch as much source code as possible.
@@ -277,23 +272,23 @@ public class SourceCodeDisclosureWEBINF extends AbstractHostPlugin {
                             if (propsfilemsg.getResponseHeader().getStatusCode()
                                     == HttpStatus.SC_OK) {
                                 // Holy sheet.. we found a properties file
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        Constant.messages.getString(
-                                                "ascanrules.sourcecodedisclosurewebinf.propertiesfile.name"),
-                                        Constant.messages.getString(
-                                                "ascanrules.sourcecodedisclosurewebinf.propertiesfile.desc"),
-                                        null, // originalMessage.getRequestHeader().getURI().getURI(),
-                                        null, // parameter being attacked: none.
-                                        "", // attack
-                                        Constant.messages.getString(
-                                                "ascanrules.sourcecodedisclosurewebinf.propertiesfile.extrainfo",
-                                                classURI), // extrainfo
-                                        Constant.messages.getString(
-                                                "ascanrules.sourcecodedisclosurewebinf.propertiesfile.soln"),
-                                        "", // evidence, highlighted in the message
-                                        propsfilemsg);
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setName(
+                                                Constant.messages.getString(
+                                                        "ascanrules.sourcecodedisclosurewebinf.propertiesfile.name"))
+                                        .setDescription(
+                                                Constant.messages.getString(
+                                                        "ascanrules.sourcecodedisclosurewebinf.propertiesfile.desc"))
+                                        .setOtherInfo(
+                                                Constant.messages.getString(
+                                                        "ascanrules.sourcecodedisclosurewebinf.propertiesfile.extrainfo",
+                                                        classURI))
+                                        .setSolution(
+                                                Constant.messages.getString(
+                                                        "ascanrules.sourcecodedisclosurewebinf.propertiesfile.soln"))
+                                        .setMessage(propsfilemsg)
+                                        .raise();
                             }
                         }
                         // do not return at this point.. there may be multiple classes referenced.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestCrossSiteScriptV2.java
@@ -256,15 +256,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                     }
                     if (contexts2.size() > 0) {
                         // Yep, its vulnerable
-                        bingo(
-                                Alert.RISK_HIGH,
-                                Alert.CONFIDENCE_LOW,
-                                null,
-                                param,
-                                contexts2.get(0).getTarget(),
-                                "",
-                                contexts2.get(0).getTarget(),
-                                contexts2.get(0).getMsg());
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_LOW)
+                                .setParam(param)
+                                .setAttack(contexts2.get(0).getTarget())
+                                .setEvidence(contexts2.get(0).getTarget())
+                                .setMessage(contexts2.get(0).getMsg())
+                                .raise();
                         attackWorked = true;
                     }
 
@@ -296,15 +294,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                             if (context2.getTagAttribute() != null
                                     && context2.isInScriptAttribute()) {
                                 // Yep, its vulnerable
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        context2.getTarget(),
-                                        "",
-                                        contexts2.get(0).getTarget(),
-                                        context2.getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(context2.getTarget())
+                                        .setEvidence(context2.getTarget())
+                                        .setMessage(context2.getMsg())
+                                        .raise();
                                 attackWorked = true;
                                 break;
                             }
@@ -326,15 +322,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                         for (HtmlContext ctx : contexts2) {
                             if (ctx.isInUrlAttribute()) {
                                 // Yep, its vulnerable
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        ctx.getTarget(),
-                                        "",
-                                        ctx.getTarget(),
-                                        ctx.getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(ctx.getTarget())
+                                        .setEvidence(ctx.getTarget())
+                                        .setMessage(ctx.getMsg())
+                                        .raise();
                                 attackWorked = true;
                                 break;
                             }
@@ -360,15 +354,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                         }
 
                         if (contexts2.size() > 0) {
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    null,
-                                    param,
-                                    contexts2.get(0).getTarget(),
-                                    "",
-                                    contexts2.get(0).getTarget(),
-                                    contexts2.get(0).getMsg());
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(contexts2.get(0).getTarget())
+                                    .setEvidence(contexts2.get(0).getTarget())
+                                    .setMessage(contexts2.get(0).getMsg())
+                                    .raise();
                             attackWorked = true;
                         }
                         if (!attackWorked) {
@@ -393,15 +385,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                             }
                             if (contexts2.size() > 0) {
                                 // Yep, its vulnerable
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        contexts2.get(0).getTarget(),
-                                        "",
-                                        contexts2.get(0).getTarget(),
-                                        contexts2.get(0).getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(contexts2.get(0).getTarget())
+                                        .setEvidence(contexts2.get(0).getTarget())
+                                        .setMessage(contexts2.get(0).getMsg())
+                                        .raise();
                                 attackWorked = true;
                             }
                             if (!attackWorked) {
@@ -432,15 +422,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                         }
                         if (contexts2.size() > 0) {
                             // Yep, its vulnerable
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    null,
-                                    param,
-                                    contexts2.get(0).getTarget(),
-                                    "",
-                                    contexts2.get(0).getTarget(),
-                                    contexts2.get(0).getMsg());
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(contexts2.get(0).getTarget())
+                                    .setEvidence(contexts2.get(0).getTarget())
+                                    .setMessage(contexts2.get(0).getMsg())
+                                    .raise();
                             attackWorked = true;
                         }
                         if (!attackWorked) {
@@ -464,15 +452,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                         }
                         if (contexts2.size() > 0) {
                             // Yep, its vulnerable
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    null,
-                                    param,
-                                    contexts2.get(0).getTarget(),
-                                    "",
-                                    contexts2.get(0).getTarget(),
-                                    contexts2.get(0).getMsg());
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(contexts2.get(0).getTarget())
+                                    .setEvidence(contexts2.get(0).getTarget())
+                                    .setMessage(contexts2.get(0).getMsg())
+                                    .raise();
                             attackWorked = true;
                         }
 
@@ -493,15 +479,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                     }
                     if (contexts2.size() > 0) {
                         // Yep, its vulnerable
-                        bingo(
-                                Alert.RISK_HIGH,
-                                Alert.CONFIDENCE_MEDIUM,
-                                null,
-                                param,
-                                contexts2.get(0).getTarget(),
-                                "",
-                                contexts2.get(0).getTarget(),
-                                contexts2.get(0).getMsg());
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(param)
+                                .setAttack(contexts2.get(0).getTarget())
+                                .setEvidence(contexts2.get(0).getTarget())
+                                .setMessage(contexts2.get(0).getMsg())
+                                .raise();
                         attackWorked = true;
                     }
 
@@ -523,15 +507,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                             }
                             if (contexts2.size() > 0) {
                                 // Yep, its vulnerable
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        contexts2.get(0).getTarget(),
-                                        "",
-                                        contexts2.get(0).getTarget(),
-                                        contexts2.get(0).getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(contexts2.get(0).getTarget())
+                                        .setEvidence(contexts2.get(0).getTarget())
+                                        .setMessage(contexts2.get(0).getMsg())
+                                        .raise();
                                 attackWorked = true;
                             }
                             if (attackWorked || isStop()) {
@@ -551,15 +533,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                                 if ("body".equalsIgnoreCase(context2.getParentTag())
                                         || "b".equalsIgnoreCase(context2.getParentTag())) {
                                     // Yep, its vulnerable
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            contexts2.get(0).getTarget(),
-                                            "",
-                                            contexts2.get(0).getTarget(),
-                                            contexts2.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(contexts2.get(0).getTarget())
+                                            .setEvidence(contexts2.get(0).getTarget())
+                                            .setMessage(contexts2.get(0).getMsg())
+                                            .raise();
                                     attackWorked = true;
                                     break;
                                 }
@@ -578,16 +558,16 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                                                 true);
                                 if (contexts3 != null && contexts3.size() > 0) {
                                     attackWorked = true;
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            getURLEncode(
-                                                    getURLEncode(contexts3.get(0).getTarget())),
-                                            "",
-                                            GENERIC_SCRIPT_ALERT,
-                                            contexts3.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(
+                                                    getURLEncode(
+                                                            getURLEncode(
+                                                                    contexts3.get(0).getTarget())))
+                                            .setEvidence(GENERIC_SCRIPT_ALERT)
+                                            .setMessage(contexts3.get(0).getMsg())
+                                            .raise();
                                 }
                                 break;
                             }
@@ -615,15 +595,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                             }
                             if (contexts2.size() > 0) {
                                 // Yep, its vulnerable
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        contexts2.get(0).getTarget(),
-                                        "",
-                                        contexts2.get(0).getTarget(),
-                                        contexts2.get(0).getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(contexts2.get(0).getTarget())
+                                        .setEvidence(contexts2.get(0).getTarget())
+                                        .setMessage(contexts2.get(0).getMsg())
+                                        .raise();
                                 attackWorked = true;
                             }
                             if (attackWorked || isStop()) {
@@ -646,15 +624,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                             }
                             if (contexts2.size() > 0) {
                                 // Yep, its vulnerable
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        contexts2.get(0).getTarget(),
-                                        "",
-                                        contexts2.get(0).getTarget(),
-                                        contexts2.get(0).getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(contexts2.get(0).getTarget())
+                                        .setEvidence(contexts2.get(0).getTarget())
+                                        .setMessage(contexts2.get(0).getMsg())
+                                        .raise();
                                 attackWorked = true;
                             }
                         } else {
@@ -667,15 +643,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                                             context,
                                             HtmlContext.IGNORE_IN_SCRIPT);
                             if (contextsA != null && contextsA.size() > 0) {
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        contextsA.get(0).getTarget(),
-                                        "",
-                                        contextsA.get(0).getTarget(),
-                                        contextsA.get(0).getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(contextsA.get(0).getTarget())
+                                        .setEvidence(contextsA.get(0).getTarget())
+                                        .setMessage(contextsA.get(0).getMsg())
+                                        .raise();
                                 attackWorked = true;
                                 break;
                             }
@@ -698,15 +672,13 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                                     if (ctx.getParentTag() != null) {
                                         // Yep, its vulnerable
                                         if (ctx.getMsg().getResponseHeader().isHtml()) {
-                                            bingo(
-                                                    Alert.RISK_HIGH,
-                                                    Alert.CONFIDENCE_MEDIUM,
-                                                    null,
-                                                    param,
-                                                    ctx.getTarget(),
-                                                    "",
-                                                    ctx.getTarget(),
-                                                    contexts2.get(0).getMsg());
+                                            newAlert()
+                                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                    .setParam(param)
+                                                    .setAttack(ctx.getTarget())
+                                                    .setEvidence(ctx.getTarget())
+                                                    .setMessage(contexts2.get(0).getMsg())
+                                                    .raise();
                                         } else {
                                             HttpMessage ctx2Message = contexts2.get(0).getMsg();
                                             if (StringUtils.containsIgnoreCase(
@@ -714,37 +686,37 @@ public class TestCrossSiteScriptV2 extends AbstractAppParamPlugin {
                                                             .getResponseHeader()
                                                             .getHeader(HttpHeader.CONTENT_TYPE),
                                                     "json")) {
-                                                bingo(
-                                                        Alert.RISK_LOW,
-                                                        Alert.CONFIDENCE_LOW,
-                                                        Constant.messages.getString(
-                                                                MESSAGE_PREFIX + "json.name"),
-                                                        Constant.messages.getString(
-                                                                MESSAGE_PREFIX + "json.desc"),
-                                                        ctx2Message
-                                                                .getRequestHeader()
-                                                                .getURI()
-                                                                .toString(),
-                                                        param,
-                                                        GENERIC_SCRIPT_ALERT,
-                                                        Constant.messages.getString(
-                                                                MESSAGE_PREFIX
-                                                                        + "otherinfo.nothtml"),
-                                                        getSolution(),
-                                                        "",
-                                                        ctx2Message);
+                                                newAlert()
+                                                        .setRisk(Alert.RISK_LOW)
+                                                        .setConfidence(Alert.CONFIDENCE_LOW)
+                                                        .setName(
+                                                                Constant.messages.getString(
+                                                                        MESSAGE_PREFIX
+                                                                                + "json.name"))
+                                                        .setDescription(
+                                                                Constant.messages.getString(
+                                                                        MESSAGE_PREFIX
+                                                                                + "json.desc"))
+                                                        .setParam(param)
+                                                        .setAttack(GENERIC_SCRIPT_ALERT)
+                                                        .setOtherInfo(
+                                                                Constant.messages.getString(
+                                                                        MESSAGE_PREFIX
+                                                                                + "otherinfo.nothtml"))
+                                                        .setMessage(ctx2Message)
+                                                        .raise();
                                             } else {
-                                                bingo(
-                                                        Alert.RISK_HIGH,
-                                                        Alert.CONFIDENCE_LOW,
-                                                        null,
-                                                        param,
-                                                        ctx.getTarget(),
-                                                        Constant.messages.getString(
-                                                                MESSAGE_PREFIX
-                                                                        + "otherinfo.nothtml"),
-                                                        ctx.getTarget(),
-                                                        ctx2Message);
+                                                newAlert()
+                                                        .setConfidence(Alert.CONFIDENCE_LOW)
+                                                        .setParam(param)
+                                                        .setAttack(ctx.getTarget())
+                                                        .setOtherInfo(
+                                                                Constant.messages.getString(
+                                                                        MESSAGE_PREFIX
+                                                                                + "otherinfo.nothtml"))
+                                                        .setEvidence(ctx.getTarget())
+                                                        .setMessage(ctx2Message)
+                                                        .raise();
                                             }
                                         }
                                         attackWorked = true;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestDirectoryBrowsing.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestDirectoryBrowsing.java
@@ -135,14 +135,11 @@ public class TestDirectoryBrowsing extends AbstractAppPlugin {
         }
 
         if (result) {
-            bingo(
-                    Alert.RISK_MEDIUM,
-                    reliability,
-                    msg.getRequestHeader().getURI().toString(),
-                    "",
-                    evidence.toString(),
-                    "",
-                    msg);
+            newAlert()
+                    .setConfidence(reliability)
+                    .setAttack(evidence.toString())
+                    .setMessage(msg)
+                    .raise();
         }
     }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestExternalRedirect.java
@@ -282,16 +282,14 @@ public class TestExternalRedirect extends AbstractAppParamPlugin {
                                         + "]");
                     }
 
-                    // Now create the alert message
-                    this.bingo(
-                            getRisk(),
-                            Alert.CONFIDENCE_MEDIUM,
-                            null,
-                            param,
-                            payload,
-                            getRedirectionReason(redirectType),
-                            redirectUrl,
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(payload)
+                            .setOtherInfo(getRedirectionReason(redirectType))
+                            .setEvidence(redirectUrl)
+                            .setMessage(msg)
+                            .raise();
 
                     // All done. No need to look for vulnerabilities on subsequent
                     // parameters on the same request (to reduce performance impact)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestInjectionCRLF.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestInjectionCRLF.java
@@ -124,14 +124,13 @@ public class TestInjectionCRLF extends AbstractAppParamPlugin {
 
         Matcher matcher = patternCookieTamper.matcher(msg.getResponseHeader().toString());
         if (matcher.find()) {
-            bingo(
-                    Alert.RISK_MEDIUM,
-                    Alert.CONFIDENCE_MEDIUM,
-                    null,
-                    param,
-                    matcher.group(),
-                    attack,
-                    msg);
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setParam(param)
+                    .setAttack(matcher.group())
+                    .setOtherInfo(attack)
+                    .setMessage(msg)
+                    .raise();
             return true;
         }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestParameterTamper.java
@@ -213,7 +213,13 @@ public class TestParameterTamper extends AbstractAppParamPlugin {
         }
 
         if (issueFound) {
-            bingo(Alert.RISK_MEDIUM, confidence, null, param, attack, "", sb.toString(), msg);
+            newAlert()
+                    .setConfidence(confidence)
+                    .setParam(param)
+                    .setAttack(attack)
+                    .setEvidence(sb.toString())
+                    .setMessage(msg)
+                    .raise();
         }
 
         return issueFound;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPathTraversal.java
@@ -544,14 +544,12 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
                         // raise an alert
                         // since the filename has likely been picked up and used as a file name from
                         // the parameter
-                        bingo(
-                                Alert.RISK_HIGH,
-                                Alert.CONFIDENCE_MEDIUM,
-                                null,
-                                param,
-                                prefixedUrlfilename,
-                                null,
-                                msg);
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(param)
+                                .setAttack(prefixedUrlfilename)
+                                .setMessage(msg)
+                                .raise();
 
                         // All done. No need to look for vulnerabilities on subsequent parameters
                         // on the same request (to reduce performance impact)
@@ -674,15 +672,13 @@ public class TestPathTraversal extends AbstractAppParamPlugin {
 
         // if the output matches, and we get a 200
         if ((msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK) && match != null) {
-            bingo(
-                    Alert.RISK_HIGH,
-                    Alert.CONFIDENCE_MEDIUM,
-                    null,
-                    param,
-                    newValue,
-                    null,
-                    match,
-                    msg);
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setParam(param)
+                    .setAttack(newValue)
+                    .setEvidence(match)
+                    .setMessage(msg)
+                    .raise();
 
             // All done. No need to look for vulnerabilities on subsequent parameters
             // on the same request (to reduce performance impact)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSAttack.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestPersistentXSSAttack.java
@@ -226,14 +226,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                     if (context2.getTagAttribute() != null
                                             && context2.isInScriptAttribute()) {
                                         // Yep, its vulnerable
-                                        bingo(
-                                                Alert.RISK_HIGH,
-                                                Alert.CONFIDENCE_MEDIUM,
-                                                null,
-                                                param,
-                                                context2.getTarget(),
-                                                otherInfo,
-                                                context2.getMsg());
+                                        newAlert()
+                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                .setParam(param)
+                                                .setAttack(context2.getTarget())
+                                                .setOtherInfo(otherInfo)
+                                                .setMessage(context2.getMsg())
+                                                .raise();
                                         attackWorked = true;
                                         break;
                                     }
@@ -261,15 +260,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                 for (HtmlContext ctx : contexts2) {
                                     if (ctx.isInUrlAttribute()) {
                                         // Yep, its vulnerable
-                                        bingo(
-                                                Alert.RISK_HIGH,
-                                                Alert.CONFIDENCE_MEDIUM,
-                                                null,
-                                                param,
-                                                ctx.getTarget(),
-                                                "",
-                                                ctx.getTarget(),
-                                                ctx.getMsg());
+                                        newAlert()
+                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                .setParam(param)
+                                                .setAttack(ctx.getTarget())
+                                                .setEvidence(ctx.getTarget())
+                                                .setMessage(ctx.getMsg())
+                                                .raise();
                                         attackWorked = true;
                                         break;
                                     }
@@ -296,14 +293,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                 }
 
                                 if (contexts2.size() > 0) {
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            contexts2.get(0).getTarget(),
-                                            otherInfo,
-                                            contexts2.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(contexts2.get(0).getTarget())
+                                            .setOtherInfo(otherInfo)
+                                            .setMessage(contexts2.get(0).getMsg())
+                                            .raise();
                                     attackWorked = true;
                                 }
                                 if (!attackWorked) {
@@ -331,14 +327,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
 
                                 if (contexts2.size() > 0) {
                                     // Yep, its vulnerable
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            contexts2.get(0).getTarget(),
-                                            otherInfo,
-                                            contexts2.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(contexts2.get(0).getTarget())
+                                            .setOtherInfo(otherInfo)
+                                            .setMessage(contexts2.get(0).getMsg())
+                                            .raise();
                                     attackWorked = true;
                                 }
                                 if (!attackWorked) {
@@ -366,14 +361,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
 
                                 if (contexts2.size() > 0) {
                                     // Yep, its vulnerable
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            contexts2.get(0).getTarget(),
-                                            otherInfo,
-                                            contexts2.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(contexts2.get(0).getTarget())
+                                            .setOtherInfo(otherInfo)
+                                            .setMessage(contexts2.get(0).getMsg())
+                                            .raise();
                                     attackWorked = true;
                                 }
                                 if (!attackWorked) {
@@ -398,14 +392,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
 
                             if (contexts2.size() > 0) {
                                 // Yep, its vulnerable
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        null,
-                                        param,
-                                        contexts2.get(0).getTarget(),
-                                        otherInfo,
-                                        contexts2.get(0).getMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(contexts2.get(0).getTarget())
+                                        .setOtherInfo(otherInfo)
+                                        .setMessage(contexts2.get(0).getMsg())
+                                        .raise();
                                 attackWorked = true;
                             } else {
                                 // Maybe they're blocking script tags
@@ -419,14 +412,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                                 HtmlContext.IGNORE_HTML_COMMENT);
                                 if (contexts2 != null && contexts2.size() > 0) {
                                     // Yep, its vulnerable
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            contexts2.get(0).getTarget(),
-                                            otherInfo,
-                                            contexts2.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(contexts2.get(0).getTarget())
+                                            .setOtherInfo(otherInfo)
+                                            .setMessage(contexts2.get(0).getMsg())
+                                            .raise();
                                     attackWorked = true;
                                 }
                             }
@@ -449,14 +441,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
 
                                 if (contexts2.size() > 0) {
                                     // Yep, its vulnerable
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            contexts2.get(0).getTarget(),
-                                            otherInfo,
-                                            contexts2.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(contexts2.get(0).getTarget())
+                                            .setOtherInfo(otherInfo)
+                                            .setMessage(contexts2.get(0).getMsg())
+                                            .raise();
                                     attackWorked = true;
                                 } else {
                                     // Maybe they're blocking script tags
@@ -476,15 +467,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                                             .equalsIgnoreCase(
                                                                     context2.getParentTag())) {
                                                 // Yep, its vulnerable
-                                                bingo(
-                                                        Alert.RISK_HIGH,
-                                                        Alert.CONFIDENCE_MEDIUM,
-                                                        null,
-                                                        param,
-                                                        contexts2.get(0).getTarget(),
-                                                        "",
-                                                        contexts2.get(0).getTarget(),
-                                                        contexts2.get(0).getMsg());
+                                                newAlert()
+                                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                        .setParam(param)
+                                                        .setAttack(contexts2.get(0).getTarget())
+                                                        .setEvidence(contexts2.get(0).getTarget())
+                                                        .setMessage(contexts2.get(0).getMsg())
+                                                        .raise();
                                                 attackWorked = true;
                                                 break;
                                             }
@@ -504,19 +493,18 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                                             true);
                                             if (contexts3 != null && contexts3.size() > 0) {
                                                 attackWorked = true;
-                                                bingo(
-                                                        Alert.RISK_HIGH,
-                                                        Alert.CONFIDENCE_MEDIUM,
-                                                        null,
-                                                        param,
-                                                        getURLEncode(
+                                                newAlert()
+                                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                        .setParam(param)
+                                                        .setAttack(
                                                                 getURLEncode(
-                                                                        contexts3
-                                                                                .get(0)
-                                                                                .getTarget())),
-                                                        "",
-                                                        GENERIC_SCRIPT_ALERT,
-                                                        contexts3.get(0).getMsg());
+                                                                        getURLEncode(
+                                                                                contexts3
+                                                                                        .get(0)
+                                                                                        .getTarget())))
+                                                        .setEvidence(GENERIC_SCRIPT_ALERT)
+                                                        .setMessage(contexts3.get(0).getMsg())
+                                                        .raise();
                                             }
                                             break;
                                         }
@@ -544,14 +532,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
 
                                 if (contexts2.size() > 0) {
                                     // Yep, its vulnerable
-                                    bingo(
-                                            Alert.RISK_HIGH,
-                                            Alert.CONFIDENCE_MEDIUM,
-                                            null,
-                                            param,
-                                            contexts2.get(0).getTarget(),
-                                            otherInfo,
-                                            contexts2.get(0).getMsg());
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(contexts2.get(0).getTarget())
+                                            .setOtherInfo(otherInfo)
+                                            .setMessage(contexts2.get(0).getMsg())
+                                            .raise();
                                     attackWorked = true;
                                 } else if ("script".equalsIgnoreCase(context.getParentTag())) {
                                     // its in a script tag...
@@ -570,14 +557,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                     }
                                     if (contexts2.size() > 0) {
                                         // Yep, its vulnerable
-                                        bingo(
-                                                Alert.RISK_HIGH,
-                                                Alert.CONFIDENCE_MEDIUM,
-                                                null,
-                                                param,
-                                                contexts2.get(0).getTarget(),
-                                                otherInfo,
-                                                contexts2.get(0).getMsg());
+                                        newAlert()
+                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                .setParam(param)
+                                                .setAttack(contexts2.get(0).getTarget())
+                                                .setOtherInfo(otherInfo)
+                                                .setMessage(contexts2.get(0).getMsg())
+                                                .raise();
                                         attackWorked = true;
                                     }
                                 } else {
@@ -591,15 +577,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                                     context,
                                                     0);
                                     if (contextsA != null && contextsA.size() > 0) {
-                                        bingo(
-                                                Alert.RISK_HIGH,
-                                                Alert.CONFIDENCE_MEDIUM,
-                                                null,
-                                                param,
-                                                contextsA.get(0).getTarget(),
-                                                "",
-                                                contextsA.get(0).getTarget(),
-                                                contextsA.get(0).getMsg());
+                                        newAlert()
+                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                .setParam(param)
+                                                .setAttack(contextsA.get(0).getTarget())
+                                                .setEvidence(contextsA.get(0).getTarget())
+                                                .setMessage(contextsA.get(0).getMsg())
+                                                .raise();
                                         attackWorked = true;
                                         break;
                                     }
@@ -625,15 +609,13 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                         if (ctx.getParentTag() != null) {
                                             // Yep, its vulnerable
                                             if (ctx.getMsg().getResponseHeader().isHtml()) {
-                                                bingo(
-                                                        Alert.RISK_HIGH,
-                                                        Alert.CONFIDENCE_MEDIUM,
-                                                        null,
-                                                        param,
-                                                        ctx.getTarget(),
-                                                        "",
-                                                        ctx.getTarget(),
-                                                        contexts2.get(0).getMsg());
+                                                newAlert()
+                                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                        .setParam(param)
+                                                        .setAttack(ctx.getTarget())
+                                                        .setEvidence(ctx.getTarget())
+                                                        .setMessage(contexts2.get(0).getMsg())
+                                                        .raise();
                                             } else {
                                                 HttpMessage ctx2Message = contexts2.get(0).getMsg();
                                                 if (StringUtils.containsIgnoreCase(
@@ -641,37 +623,38 @@ public class TestPersistentXSSAttack extends AbstractAppParamPlugin {
                                                                 .getResponseHeader()
                                                                 .getHeader(HttpHeader.CONTENT_TYPE),
                                                         "json")) {
-                                                    bingo(
-                                                            Alert.RISK_LOW,
-                                                            Alert.CONFIDENCE_LOW,
-                                                            Constant.messages.getString(
-                                                                    MESSAGE_PREFIX + "json.name"),
-                                                            Constant.messages.getString(
-                                                                    MESSAGE_PREFIX + "json.desc"),
-                                                            ctx2Message
-                                                                    .getRequestHeader()
-                                                                    .getURI()
-                                                                    .toString(),
-                                                            param,
-                                                            GENERIC_SCRIPT_ALERT,
-                                                            Constant.messages.getString(
-                                                                    MESSAGE_PREFIX
-                                                                            + "otherinfo.nothtml"),
-                                                            getSolution(),
-                                                            "",
-                                                            ctx2Message);
+                                                    newAlert()
+                                                            .setRisk(Alert.RISK_LOW)
+                                                            .setConfidence(Alert.CONFIDENCE_LOW)
+                                                            .setName(
+                                                                    Constant.messages.getString(
+                                                                            MESSAGE_PREFIX
+                                                                                    + "json.name"))
+                                                            .setDescription(
+                                                                    Constant.messages.getString(
+                                                                            MESSAGE_PREFIX
+                                                                                    + "json.desc"))
+                                                            .setParam(param)
+                                                            .setAttack(GENERIC_SCRIPT_ALERT)
+                                                            .setOtherInfo(
+                                                                    Constant.messages.getString(
+                                                                            MESSAGE_PREFIX
+                                                                                    + "otherinfo.nothtml"))
+                                                            .setSolution(getSolution())
+                                                            .setMessage(ctx2Message)
+                                                            .raise();
                                                 } else {
-                                                    bingo(
-                                                            Alert.RISK_HIGH,
-                                                            Alert.CONFIDENCE_LOW,
-                                                            null,
-                                                            param,
-                                                            ctx.getTarget(),
-                                                            Constant.messages.getString(
-                                                                    MESSAGE_PREFIX
-                                                                            + "otherinfo.nothtml"),
-                                                            ctx.getTarget(),
-                                                            ctx2Message);
+                                                    newAlert()
+                                                            .setConfidence(Alert.CONFIDENCE_LOW)
+                                                            .setParam(param)
+                                                            .setAttack(ctx.getTarget())
+                                                            .setOtherInfo(
+                                                                    Constant.messages.getString(
+                                                                            MESSAGE_PREFIX
+                                                                                    + "otherinfo.nothtml"))
+                                                            .setEvidence(ctx.getTarget())
+                                                            .setMessage(ctx2Message)
+                                                            .raise();
                                                 }
                                             }
                                             attackWorked = true;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestRemoteFileInclude.java
@@ -235,15 +235,13 @@ public class TestRemoteFileInclude extends AbstractAppParamPlugin {
                                     "Not reporting alert - same title as original: "
                                             + matcher.group());
                         } else {
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    null,
-                                    param,
-                                    prefix + target,
-                                    null,
-                                    matcher.group(),
-                                    msg);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(prefix + target)
+                                    .setEvidence(matcher.group())
+                                    .setMessage(msg)
+                                    .raise();
                             // All done. No need to look for vulnerabilities on subsequent
                             // parameters on the same request (to reduce performance impact)
                             return;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestSQLInjection.java
@@ -718,18 +718,15 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                                 // raise the alert, and save the attack string for the
                                 // "Authentication Bypass" alert, if necessary
                                 sqlInjectionAttack = sqlErrValue;
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        getName() + " - " + errorPatternRDBMS,
-                                        getDescription(),
-                                        null,
-                                        param,
-                                        sqlInjectionAttack,
-                                        extraInfo,
-                                        getSolution(),
-                                        sb.toString(),
-                                        msg1);
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setName(getName() + " - " + errorPatternRDBMS)
+                                        .setParam(param)
+                                        .setAttack(sqlInjectionAttack)
+                                        .setOtherInfo(extraInfo)
+                                        .setEvidence(sb.toString())
+                                        .setMessage(msg1)
+                                        .raise();
 
                                 // log it, as the RDBMS may be useful to know later (in subsequent
                                 // checks, when we need to determine RDBMS specific behaviour, for
@@ -1110,18 +1107,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                             // raise the alert, and save the attack string for the "Authentication
                             // Bypass" alert, if necessary
                             sqlInjectionAttack = sqlBooleanAndTrueValue;
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    getName(),
-                                    getDescription(),
-                                    null, // url
-                                    param,
-                                    sqlInjectionAttack,
-                                    extraInfo,
-                                    getSolution(),
-                                    "",
-                                    msg2);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(sqlInjectionAttack)
+                                    .setOtherInfo(extraInfo)
+                                    .setMessage(msg2)
+                                    .raise();
 
                             sqlInjectionFoundForUrl = true;
 
@@ -1237,18 +1229,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                                 // raise the alert, and save the attack string for the
                                 // "Authentication Bypass" alert, if necessary
                                 sqlInjectionAttack = orValue;
-                                bingo(
-                                        Alert.RISK_HIGH,
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        getName(),
-                                        getDescription(),
-                                        null, // url
-                                        param,
-                                        sqlInjectionAttack,
-                                        extraInfo,
-                                        getSolution(),
-                                        "",
-                                        msg2);
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setAttack(sqlInjectionAttack)
+                                        .setOtherInfo(extraInfo)
+                                        .setMessage(msg2)
+                                        .raise();
 
                                 sqlInjectionFoundForUrl = true;
                                 // booleanBasedSqlInjectionFoundForParam = true;  //causes us to
@@ -1445,18 +1432,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                         // raise the alert, and save the attack string for the "Authentication
                         // Bypass" alert, if necessary
                         sqlInjectionAttack = sqlBooleanOrTrueValue;
-                        bingo(
-                                Alert.RISK_HIGH,
-                                Alert.CONFIDENCE_MEDIUM,
-                                getName(),
-                                getDescription(),
-                                null, // url
-                                param,
-                                sqlInjectionAttack,
-                                extraInfo,
-                                getSolution(),
-                                "",
-                                msg2);
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(param)
+                                .setAttack(sqlInjectionAttack)
+                                .setOtherInfo(extraInfo)
+                                .setMessage(msg2)
+                                .raise();
 
                         sqlInjectionFoundForUrl = true;
 
@@ -1699,18 +1681,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                             // raise the alert, and save the attack string for the "Authentication
                             // Bypass" alert, if necessary
                             sqlInjectionAttack = modifiedParamValue;
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    getName(),
-                                    getDescription(),
-                                    null, // url
-                                    param,
-                                    sqlInjectionAttack,
-                                    extraInfo,
-                                    getSolution(),
-                                    "",
-                                    msg5);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(sqlInjectionAttack)
+                                    .setOtherInfo(extraInfo)
+                                    .setMessage(msg5)
+                                    .raise();
 
                             sqlInjectionFoundForUrl = true;
                             break; // No further need to loop
@@ -1778,18 +1755,15 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                             Constant.messages.getString(MESSAGE_PREFIX + "authbypass.desc");
 
                     // raise the alert, using the attack string stored earlier for this purpose
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            vulnname,
-                            vulndesc,
-                            refreshedmessage.getRequestHeader().getURI().getURI(), // url
-                            param,
-                            sqlInjectionAttack,
-                            "",
-                            getSolution(),
-                            "",
-                            getBaseMsg());
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(vulnname)
+                            .setDescription(vulndesc)
+                            .setUri(refreshedmessage.getRequestHeader().getURI().getURI())
+                            .setParam(param)
+                            .setAttack(sqlInjectionAttack)
+                            .setMessage(getBaseMsg())
+                            .raise();
                 } // not a login page
             } // no sql Injection Found For Url
 
@@ -1825,18 +1799,15 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                                 MESSAGE_PREFIX + "alert.errorbased.extrainfo",
                                 rdbms.getName(),
                                 errorPattern.toString());
-                bingo(
-                        Alert.RISK_HIGH,
-                        Alert.CONFIDENCE_MEDIUM,
-                        getName() + " - " + rdbms.getName(),
-                        getDescription(),
-                        null,
-                        parameter,
-                        attack,
-                        extraInfo,
-                        getSolution(),
-                        sb.toString(),
-                        msg1);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setName(getName() + " - " + rdbms.getName())
+                        .setParam(parameter)
+                        .setAttack(attack)
+                        .setOtherInfo(extraInfo)
+                        .setEvidence(sb.toString())
+                        .setMessage(msg1)
+                        .raise();
 
                 // log it, as the RDBMS may be useful to know later (in subsequent checks, when we
                 // need to determine RDBMS specific behaviour, for instance)
@@ -1886,18 +1857,16 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                                 MESSAGE_PREFIX + "alert.unionbased.extrainfo",
                                 rdbms.getName(),
                                 errorPattern.toString());
-                bingo(
-                        Alert.RISK_HIGH,
-                        Alert.CONFIDENCE_MEDIUM,
-                        getName() + " - " + rdbms.getName(),
-                        getDescription(),
-                        uri.getEscapedURI(),
-                        parameter,
-                        attack,
-                        extraInfo,
-                        getSolution(),
-                        matcherSQLUnion.group(),
-                        msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setName(getName() + " - " + rdbms.getName())
+                        .setUri(uri.getEscapedURI())
+                        .setParam(parameter)
+                        .setAttack(attack)
+                        .setOtherInfo(extraInfo)
+                        .setEvidence(matcherSQLUnion.group())
+                        .setMessage(msg)
+                        .raise();
 
                 // log it, as the RDBMS may be useful to know later (in subsequent checks, when we
                 // need to determine RDBMS specific behaviour, for instance)
@@ -2003,18 +1972,13 @@ public class TestSQLInjection extends AbstractAppParamPlugin {
                     // raise the alert, and save the attack string for the "Authentication Bypass"
                     // alert, if necessary
                     sqlInjectionAttack = modifiedParamValue;
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName(),
-                            getDescription(),
-                            null, // url
-                            param,
-                            sqlInjectionAttack,
-                            extraInfo,
-                            getSolution(),
-                            "",
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(sqlInjectionAttack)
+                            .setOtherInfo(extraInfo)
+                            .setMessage(msg)
+                            .raise();
                     // SQL Injection has been found
                     sqlInjectionFoundForUrl = true;
                     return;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestServerSideInclude.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/TestServerSideInclude.java
@@ -150,15 +150,13 @@ public class TestServerSideInclude extends AbstractAppParamPlugin {
 
             StringBuilder evidence = new StringBuilder();
             if (matchBodyPattern(message, testEvidence, evidence)) {
-                bingo(
-                        Alert.RISK_HIGH,
-                        Alert.CONFIDENCE_MEDIUM,
-                        null,
-                        parameter,
-                        value,
-                        null,
-                        evidence.toString(),
-                        message);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(parameter)
+                        .setAttack(value)
+                        .setEvidence(evidence.toString())
+                        .setMessage(message)
+                        .raise();
                 return true;
             }
         } catch (IOException e) {


### PR DESCRIPTION
Use new method to raise alerts in the scan rules.