### PR TITLE
ascanrulesBeta: update ZAP to 2.9.0

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add links to the code in the help.
 
 ### Changed
+- Update minimum ZAP version to 2.9.0.
 - Backup File Disclosure scan rule - updated CWE to 530, added reference links to alerts, made sure WASC and CWE identifiers are included in alerts.
 - Maintenance changes.
 - Updated owasp.org references (Issue 5962).

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -6,7 +6,7 @@ description = "The beta quality Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.8.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ApacheRangeHeaderDos.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ApacheRangeHeaderDos.java
@@ -130,20 +130,11 @@ public class ApacheRangeHeaderDos extends AbstractAppPlugin {
             }
 
             if (newRequest.getResponseHeader().getStatusCode() == HttpStatusCode.PARTIAL_CONTENT) {
-                bingo(
-                        getRisk(), // Risk
-                        Alert.CONFIDENCE_MEDIUM, // Confidence/Reliability
-                        getName(), // Name
-                        getDescription(), // Description
-                        newRequest.getRequestHeader().getURI().toString(), // URI
-                        null, // Param
-                        "", // Attack
-                        "", // OtherInfo
-                        getSolution(), // Solution
-                        newRequest.getResponseHeader().getPrimeHeader(), // Evidence
-                        getCweId(), // CWE ID
-                        getWascId(), // WASC ID
-                        newRequest); // HTTPMessage
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setEvidence(newRequest.getResponseHeader().getPrimeHeader())
+                        .setMessage(newRequest)
+                        .raise();
             }
         }
     }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosure.java
@@ -743,31 +743,20 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
                                         && nonexistfilemsg.getResponseHeader().getStatusCode()
                                                 != requestStatusCode
                                         && (!Arrays.equals(disclosedData, nonexistfilemsgdata))))) {
-                    bingo(
-                            Alert.RISK_MEDIUM,
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString("ascanbeta.backupfiledisclosure.name"),
-                            getDescription(),
-                            requestmsg
-                                    .getRequestHeader()
-                                    .getURI()
-                                    .getURI(), // originalMessage.getRequestHeader().getURI().getURI(),
-                            null, // parameter being attacked: none.
-                            candidateBackupFileURI.getURI(), // attack
-                            originalMessage
-                                    .getRequestHeader()
-                                    .getURI()
-                                    .getURI(), // new String (disclosedData),  //extrainfo
-                            Constant.messages.getString("ascanbeta.backupfiledisclosure.soln"),
-                            Constant.messages.getString(
-                                    "ascanbeta.backupfiledisclosure.evidence",
-                                    originalURI,
-                                    candidateBackupFileURI.getURI()),
-                            getReference(),
-                            getCweId(),
-                            getWascId(),
-                            requestmsg // originalMessage
-                            );
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setAttack(candidateBackupFileURI.getURI())
+                            .setOtherInfo(originalMessage.getRequestHeader().getURI().getURI())
+                            .setSolution(
+                                    Constant.messages.getString(
+                                            "ascanbeta.backupfiledisclosure.soln"))
+                            .setEvidence(
+                                    Constant.messages.getString(
+                                            "ascanbeta.backupfiledisclosure.evidence",
+                                            originalURI,
+                                            candidateBackupFileURI.getURI()))
+                            .setMessage(requestmsg)
+                            .raise();
                 }
 
                 if (isStop()) {
@@ -806,31 +795,23 @@ public class BackupFileDisclosure extends AbstractAppPlugin {
                                                 != requestStatusCode
                                         && (!Arrays.equals(
                                                 disclosedData, nonexistparentmsgdata))))) {
-                    bingo(
-                            Alert.RISK_MEDIUM,
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString("ascanbeta.backupfiledisclosure.name"),
-                            getDescription(),
-                            requestmsg
-                                    .getRequestHeader()
-                                    .getURI()
-                                    .getURI(), // originalMessage.getRequestHeader().getURI().getURI(),
-                            null, // parameter being attacked: none.
-                            candidateBackupFileURI.getURI(), // attack
-                            originalMessage
-                                    .getRequestHeader()
-                                    .getURI()
-                                    .getURI(), // new String (disclosedData),  //extrainfo
-                            Constant.messages.getString("ascanbeta.backupfiledisclosure.soln"),
-                            Constant.messages.getString(
-                                    "ascanbeta.backupfiledisclosure.evidence",
-                                    originalURI,
-                                    candidateBackupFileURI.getURI()),
-                            getReference(),
-                            getCweId(),
-                            getWascId(),
-                            requestmsg // originalMessage
-                            );
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(
+                                    Constant.messages.getString(
+                                            "ascanbeta.backupfiledisclosure.name"))
+                            .setAttack(candidateBackupFileURI.getURI())
+                            .setOtherInfo(originalMessage.getRequestHeader().getURI().getURI())
+                            .setSolution(
+                                    Constant.messages.getString(
+                                            "ascanbeta.backupfiledisclosure.soln"))
+                            .setEvidence(
+                                    Constant.messages.getString(
+                                            "ascanbeta.backupfiledisclosure.evidence",
+                                            originalURI,
+                                            candidateBackupFileURI.getURI()))
+                            .setMessage(requestmsg)
+                            .raise();
                 }
 
                 if (isStop()) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanner.java
@@ -181,25 +181,21 @@ public class CrossDomainScanner extends AbstractHostPlugin {
                 String domain = exprAllowAccessFromDomainNodes.item(i).getNodeValue();
                 if (domain.equals("*")) {
                     // oh dear me.
-                    bingo(
-                            getRisk(),
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString(MESSAGE_PREFIX_ADOBE_READ + "name"),
-                            Constant.messages.getString(MESSAGE_PREFIX_ADOBE + "desc"),
-                            crossdomainmessage
-                                    .getRequestHeader()
-                                    .getURI()
-                                    .getURI(), // the url field
-                            "", // parameter being attacked: none.
-                            "", // attack
-                            Constant.messages.getString(
-                                    MESSAGE_PREFIX_ADOBE_READ + "extrainfo",
-                                    "/" + ADOBE_CROSS_DOMAIN_POLICY_FILE), // extrainfo
-                            Constant.messages.getString(
-                                    MESSAGE_PREFIX_ADOBE_READ + "soln"), // solution
-                            "<allow-access-from domain=\"*\"", // evidence
-                            crossdomainmessage // the message on which to place the alert
-                            );
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(
+                                    Constant.messages.getString(MESSAGE_PREFIX_ADOBE_READ + "name"))
+                            .setDescription(
+                                    Constant.messages.getString(MESSAGE_PREFIX_ADOBE + "desc"))
+                            .setOtherInfo(
+                                    Constant.messages.getString(
+                                            MESSAGE_PREFIX_ADOBE_READ + "extrainfo",
+                                            "/" + ADOBE_CROSS_DOMAIN_POLICY_FILE))
+                            .setSolution(
+                                    Constant.messages.getString(MESSAGE_PREFIX_ADOBE_READ + "soln"))
+                            .setEvidence("<allow-access-from domain=\"*\"")
+                            .setMessage(crossdomainmessage)
+                            .raise();
                 }
             }
             // check for cross domain send (upload) access
@@ -216,25 +212,21 @@ public class CrossDomainScanner extends AbstractHostPlugin {
                 String domain = exprRequestHeadersFromDomainNodes.item(i).getNodeValue();
                 if (domain.equals("*")) {
                     // oh dear, dear me.
-                    bingo(
-                            getRisk(),
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString(MESSAGE_PREFIX_ADOBE_SEND + "name"),
-                            Constant.messages.getString(MESSAGE_PREFIX_ADOBE + "desc"),
-                            crossdomainmessage
-                                    .getRequestHeader()
-                                    .getURI()
-                                    .getURI(), // the url field
-                            "", // parameter being attacked: none.
-                            "", // attack
-                            Constant.messages.getString(
-                                    MESSAGE_PREFIX_ADOBE_SEND + "extrainfo",
-                                    "/" + ADOBE_CROSS_DOMAIN_POLICY_FILE), // extrainfo
-                            Constant.messages.getString(
-                                    MESSAGE_PREFIX_ADOBE_SEND + "soln"), // solution
-                            "<allow-http-request-headers-from domain=\"*\"", // evidence
-                            crossdomainmessage // the message on which to place the alert
-                            );
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(
+                                    Constant.messages.getString(MESSAGE_PREFIX_ADOBE_SEND + "name"))
+                            .setDescription(
+                                    Constant.messages.getString(MESSAGE_PREFIX_ADOBE + "desc"))
+                            .setOtherInfo(
+                                    Constant.messages.getString(
+                                            MESSAGE_PREFIX_ADOBE_SEND + "extrainfo",
+                                            "/" + ADOBE_CROSS_DOMAIN_POLICY_FILE))
+                            .setSolution(
+                                    Constant.messages.getString(MESSAGE_PREFIX_ADOBE_SEND + "soln"))
+                            .setEvidence("<allow-http-request-headers-from domain=\"*\"")
+                            .setMessage(crossdomainmessage)
+                            .raise();
                 }
             }
         } catch (SAXException | IOException e) {
@@ -289,24 +281,23 @@ public class CrossDomainScanner extends AbstractHostPlugin {
                                 "Bingo! "
                                         + SILVERLIGHT_CROSS_DOMAIN_POLICY_FILE
                                         + ", at /access-policy/cross-domain-access/policy/allow-from/domain/@uri");
-                    bingo(
-                            getRisk(),
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString(MESSAGE_PREFIX_SILVERLIGHT + "name"),
-                            Constant.messages.getString(MESSAGE_PREFIX_SILVERLIGHT + "desc"),
-                            clientaccesspolicymessage
-                                    .getRequestHeader()
-                                    .getURI()
-                                    .getURI(), // the url field
-                            "", // parameter being attacked: none.
-                            "", // attack
-                            Constant.messages.getString(
-                                    MESSAGE_PREFIX_SILVERLIGHT + "extrainfo"), // extrainfo
-                            Constant.messages.getString(
-                                    MESSAGE_PREFIX_SILVERLIGHT + "soln"), // solution
-                            "<domain uri=\"*\"", // evidence
-                            clientaccesspolicymessage // the message on which to place the alert
-                            );
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(
+                                    Constant.messages.getString(
+                                            MESSAGE_PREFIX_SILVERLIGHT + "name"))
+                            .setDescription(
+                                    Constant.messages.getString(
+                                            MESSAGE_PREFIX_SILVERLIGHT + "desc"))
+                            .setOtherInfo(
+                                    Constant.messages.getString(
+                                            MESSAGE_PREFIX_SILVERLIGHT + "extrainfo"))
+                            .setSolution(
+                                    Constant.messages.getString(
+                                            MESSAGE_PREFIX_SILVERLIGHT + "soln"))
+                            .setEvidence("<domain uri=\"*\"")
+                            .setMessage(clientaccesspolicymessage)
+                            .raise();
                 }
             }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/Csrftokenscan.java
@@ -240,15 +240,13 @@ public class Csrftokenscan extends AbstractAppPlugin {
                                     Constant.messages.getString(
                                             MESSAGE_PREFIX + "extrainfo.annotation");
                         }
-                        bingo(
-                                risk,
-                                Alert.CONFIDENCE_MEDIUM,
-                                getBaseMsg().getRequestHeader().getURI().toString(),
-                                "", // No param
-                                "", // No attack
-                                otherInfo,
-                                evidence,
-                                getBaseMsg());
+                        newAlert()
+                                .setRisk(risk)
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setOtherInfo(otherInfo)
+                                .setEvidence(evidence)
+                                .setMessage(getBaseMsg())
+                                .raise();
                     }
                 }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ElmahScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ElmahScanner.java
@@ -182,19 +182,12 @@ public class ElmahScanner extends AbstractHostPlugin {
     }
 
     private void raiseAlert(HttpMessage msg, int risk, int confidence, String otherInfo) {
-        bingo(
-                risk, // Risk
-                confidence, // Confidence
-                getName(), // Name
-                getDescription(), // Description
-                msg.getRequestHeader().getURI().toString(), // URI
-                null, // Param
-                "", // Attack
-                otherInfo, // OtherInfo
-                getSolution(), // Solution
-                msg.getResponseHeader().getPrimeHeader(), // Evidence
-                getCweId(), // CWE ID
-                getWascId(), // WASC ID
-                msg); // HTTPMessage
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setOtherInfo(otherInfo)
+                .setEvidence(msg.getResponseHeader().getPrimeHeader())
+                .setMessage(msg)
+                .raise();
     }
 }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionPlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionPlugin.java
@@ -199,16 +199,13 @@ public class ExpressionLanguageInjectionPlugin extends AbstractAppParamPlugin {
                                 + payload
                                 + "]");
 
-                // Now create the alert message
-                this.bingo(
-                        Alert.RISK_HIGH,
-                        Alert.CONFIDENCE_MEDIUM,
-                        msg.getRequestHeader().getURI().toString(),
-                        paramName,
-                        payload,
-                        null,
-                        addedString,
-                        msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(paramName)
+                        .setAttack(payload)
+                        .setEvidence(addedString)
+                        .setMessage(msg)
+                        .raise();
             }
 
         } catch (IOException ex) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanner.java
@@ -116,20 +116,12 @@ public class GetForPostScanner extends AbstractAppPlugin {
         }
 
         if (newRequest.getResponseBody().equals(baseMsg.getResponseBody())) {
-            bingo(
-                    getRisk(), // Risk
-                    Alert.CONFIDENCE_HIGH, // Confidence
-                    getName(), // Name
-                    getDescription(), // Description
-                    baseMsg.getRequestHeader().getURI().toString(), // URI
-                    null, // Param
-                    "", // Attack
-                    "", // OtherInfo
-                    getSolution(), // Solution
-                    newRequest.getRequestHeader().getPrimeHeader(), // Evidence
-                    getCweId(), // CWE ID
-                    getWascId(), // WASC ID
-                    newRequest); // HTTPMessage
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_HIGH)
+                    .setUri(baseMsg.getRequestHeader().getURI().toString())
+                    .setEvidence(newRequest.getRequestHeader().getPrimeHeader())
+                    .setMessage(newRequest)
+                    .raise();
         }
     }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HPP.java
@@ -293,21 +293,13 @@ public class HPP extends AbstractAppPlugin {
         }
         log.debug("Page vulnerable to HPP attacks");
         String attack = Constant.messages.getString("ascanbeta.HTTPParamPoll.alert.attack");
-        try {
-            bingo(
-                    Alert.RISK_MEDIUM,
-                    Alert.CONFIDENCE_MEDIUM,
-                    attack,
-                    getDescription(),
-                    getBaseMsg().getRequestHeader().getURI().getURI(),
-                    vulnParams,
-                    attack,
-                    getReference(),
-                    getSolution(),
-                    getBaseMsg());
-        } catch (URIException e) {
-            log.error(e.getMessage(), e);
-        }
+        newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setName(attack)
+                .setParam(vulnParams)
+                .setAttack(attack)
+                .setMessage(getBaseMsg())
+                .raise();
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanner.java
@@ -1016,18 +1016,11 @@ public class HeartBleedActiveScanner extends AbstractHostPlugin {
                         String extraInfo =
                                 Constant.messages.getString(
                                         MESSAGE_PREFIX + "extrainfo", tlsNames[tlsIndex]);
-                        bingo(
-                                getRisk(),
-                                Alert.CONFIDENCE_MEDIUM,
-                                getName(),
-                                getDescription(),
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
-                                "", // param
-                                "", // attack
-                                extraInfo,
-                                getSolution(),
-                                "", // evidence
-                                getBaseMsg());
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setOtherInfo(extraInfo)
+                                .setMessage(getBaseMsg())
+                                .raise();
                     }
                     if (is != null) is.close();
                     if (os != null) os.close();

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySite.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpOnlySite.java
@@ -99,21 +99,14 @@ public class HttpOnlySite extends AbstractHostPlugin {
         String newUri = newRequest.getRequestHeader().getURI().toString();
         String otherInfoDetail =
                 Constant.messages.getString(MESSAGE_PREFIX + "otherinfo." + message);
-        bingo(
-                getRisk(), // Risk
-                Alert.CONFIDENCE_MEDIUM, // Confidence/Reliability
-                getName(), // Name
-                getDescription(), // Description
-                getBaseMsg().getRequestHeader().getURI().toString(), // Original URI
-                null, // Param
-                "", // Attack
-                Constant.messages.getString(
-                        MESSAGE_PREFIX + "otherinfo", otherInfoDetail, newUri), // OtherInfo
-                getSolution(), // Solution
-                "", // Evidence
-                getCweId(), // CWE ID
-                getWascId(), // WASC ID
-                newRequest); // HTTPMessage
+        newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                .setOtherInfo(
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "otherinfo", otherInfoDetail, newUri))
+                .setMessage(newRequest)
+                .raise();
     }
 
     public URI constructURI(String redirect, URI oldURI) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpoxyScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpoxyScanner.java
@@ -116,22 +116,15 @@ public class HttpoxyScanner extends AbstractAppPlugin {
 
                     if (listener.isMsgReceived()) {
                         // the server is vulnerable
-                        bingo(
-                                getRisk(), // Risk
-                                Alert.CONFIDENCE_HIGH, // Confidence/Reliability
-                                getName(), // Name
-                                getDescription(), // Description
-                                getBaseMsg().getRequestHeader().getURI().toString(), // Original URI
-                                null, // Param
-                                "Proxy: " + hostPort, // Attack
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "otherinfo",
-                                        listener.getMsgUrl()), // OtherInfo
-                                getSolution(), // Solution
-                                "", // Evidence
-                                getCweId(), // CWE ID
-                                getWascId(), // WASC ID
-                                newRequest); // HTTPMessage
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_HIGH)
+                                .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                                .setAttack("Proxy: " + hostPort)
+                                .setOtherInfo(
+                                        Constant.messages.getString(
+                                                MESSAGE_PREFIX + "otherinfo", listener.getMsgUrl()))
+                                .setMessage(newRequest)
+                                .raise();
 
                         // no point in continuing
                         return;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanner.java
@@ -149,20 +149,13 @@ public class HttpsAsHttpScanner extends AbstractAppPlugin {
 
             String newUri = newRequest.getRequestHeader().getURI().toString();
 
-            bingo(
-                    getRisk(), // Risk
-                    Alert.CONFIDENCE_MEDIUM, // Confidence/Reliability
-                    getName(), // Name
-                    getDescription(), // Description
-                    getBaseMsg().getRequestHeader().getURI().toString(), // Original URI
-                    null, // Param
-                    "", // Attack
-                    Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", newUri), // OtherInfo
-                    getSolution(), // Solution
-                    newUri, // Evidence
-                    getCweId(), // CWE ID
-                    getWascId(), // WASC ID
-                    newRequest); // HTTPMessage
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                    .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", newUri))
+                    .setEvidence(newUri)
+                    .setMessage(newRequest)
+                    .raise();
         }
     }
 }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHTTPMethod.java
@@ -194,22 +194,24 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
                 enabledMethodsSet.remove(
                         HttpRequestHeader
                                 .DELETE); // We don't actually want to make a DELETE request
-                bingo(
-                        Alert.RISK_MEDIUM,
-                        Alert.CONFIDENCE_MEDIUM,
-                        Constant.messages.getString(
-                                "ascanbeta.insecurehttpmethod.detailed.name",
-                                HttpRequestHeader.DELETE),
-                        Constant.messages.getString(
-                                "ascanbeta.insecurehttpmethod.desc", HttpRequestHeader.DELETE),
-                        null,
-                        null, // parameter being attacked: none.
-                        "", // attack
-                        Constant.messages.getString(
-                                "ascanbeta.insecurehttpmethod.extrainfo", allowedmethods),
-                        Constant.messages.getString("ascanbeta.insecurehttpmethod.soln"),
-                        HttpRequestHeader.DELETE,
-                        optionsmsg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setName(
+                                Constant.messages.getString(
+                                        "ascanbeta.insecurehttpmethod.detailed.name",
+                                        HttpRequestHeader.DELETE))
+                        .setDescription(
+                                Constant.messages.getString(
+                                        "ascanbeta.insecurehttpmethod.desc",
+                                        HttpRequestHeader.DELETE))
+                        .setOtherInfo(
+                                Constant.messages.getString(
+                                        "ascanbeta.insecurehttpmethod.extrainfo", allowedmethods))
+                        .setSolution(
+                                Constant.messages.getString("ascanbeta.insecurehttpmethod.soln"))
+                        .setEvidence(HttpRequestHeader.DELETE)
+                        .setMessage(optionsmsg)
+                        .raise();
             }
 
             if (attackStrength == AttackStrength.HIGH || attackStrength == AttackStrength.INSANE) {
@@ -307,20 +309,21 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
                     if (raiseAlert) {
                         log.debug("Raising alert for Insecure HTTP Method");
 
-                        bingo(
-                                riskLevel,
-                                Alert.CONFIDENCE_MEDIUM,
-                                Constant.messages.getString(
-                                        "ascanbeta.insecurehttpmethod.detailed.name",
-                                        insecureMethod),
-                                description,
-                                null, // originalMessage.getRequestHeader().getURI().getURI(),
-                                null, // parameter being attacked: none.
-                                "", // attack
-                                extraInfo,
-                                Constant.messages.getString("ascanbeta.insecurehttpmethod.soln"),
-                                evidence,
-                                alertMessage);
+                        newAlert()
+                                .setRisk(riskLevel)
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setName(
+                                        Constant.messages.getString(
+                                                "ascanbeta.insecurehttpmethod.detailed.name",
+                                                insecureMethod))
+                                .setDescription(description)
+                                .setOtherInfo(extraInfo)
+                                .setSolution(
+                                        Constant.messages.getString(
+                                                "ascanbeta.insecurehttpmethod.soln"))
+                                .setEvidence(evidence)
+                                .setMessage(alertMessage)
+                                .raise();
                     }
                 }
             }
@@ -374,22 +377,23 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
 
         // if the response *body* from the TRACE request contains the cookie,we're in business :)
         if (msg.getResponseBody().toString().contains(randomcookievalue)) {
-            bingo(
-                    Alert.RISK_MEDIUM,
-                    Alert.CONFIDENCE_MEDIUM,
-                    Constant.messages.getString(
-                            "ascanbeta.insecurehttpmethod.detailed.name", method),
-                    Constant.messages.getString(
-                            "ascanbeta.insecurehttpmethod.trace.exploitable.desc", method),
-                    msg.getRequestHeader().getURI().getURI(),
-                    null, // parameter being attacked: none.
-                    "", // attack
-                    Constant.messages.getString(
-                            "ascanbeta.insecurehttpmethod.trace.exploitable.extrainfo",
-                            randomcookievalue),
-                    Constant.messages.getString("ascanbeta.insecurehttpmethod.soln"),
-                    randomcookievalue,
-                    msg);
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setName(
+                            Constant.messages.getString(
+                                    "ascanbeta.insecurehttpmethod.detailed.name", method))
+                    .setDescription(
+                            Constant.messages.getString(
+                                    "ascanbeta.insecurehttpmethod.trace.exploitable.desc", method))
+                    .setUri(msg.getRequestHeader().getURI().getURI())
+                    .setOtherInfo(
+                            Constant.messages.getString(
+                                    "ascanbeta.insecurehttpmethod.trace.exploitable.extrainfo",
+                                    randomcookievalue))
+                    .setSolution(Constant.messages.getString("ascanbeta.insecurehttpmethod.soln"))
+                    .setEvidence(randomcookievalue)
+                    .setMessage(msg)
+                    .raise();
         }
     }
 
@@ -469,24 +473,26 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
                 Matcher m = thirdPartyContentPattern.matcher(response);
                 if (m.matches()) {
                     log.debug("Response matches expected third party pattern!");
-                    bingo(
-                            Alert.RISK_MEDIUM,
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString(
-                                    "ascanbeta.insecurehttpmethod.detailed.name",
-                                    HttpRequestHeader.CONNECT),
-                            Constant.messages.getString(
-                                    "ascanbeta.insecurehttpmethod.connect.exploitable.desc",
-                                    HttpRequestHeader.CONNECT),
-                            null,
-                            null, // parameter being attacked: none.
-                            "", // attack
-                            Constant.messages.getString(
-                                    "ascanbeta.insecurehttpmethod.connect.exploitable.extrainfo",
-                                    thirdpartyHost),
-                            Constant.messages.getString("ascanbeta.insecurehttpmethod.soln"),
-                            response, // evidence,
-                            this.getBaseMsg());
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(
+                                    Constant.messages.getString(
+                                            "ascanbeta.insecurehttpmethod.detailed.name",
+                                            HttpRequestHeader.CONNECT))
+                            .setDescription(
+                                    Constant.messages.getString(
+                                            "ascanbeta.insecurehttpmethod.connect.exploitable.desc",
+                                            HttpRequestHeader.CONNECT))
+                            .setOtherInfo(
+                                    Constant.messages.getString(
+                                            "ascanbeta.insecurehttpmethod.connect.exploitable.extrainfo",
+                                            thirdpartyHost))
+                            .setSolution(
+                                    Constant.messages.getString(
+                                            "ascanbeta.insecurehttpmethod.soln"))
+                            .setEvidence(response)
+                            .setMessage(this.getBaseMsg())
+                            .raise();
                     return;
                 } else {
                     log.debug("Response does *not* match expected third party pattern");
@@ -603,19 +609,17 @@ public class InsecureHTTPMethod extends AbstractAppPlugin {
         }
         try {
 
-            bingo(
-                    riskLevel,
-                    Alert.CONFIDENCE_MEDIUM,
-                    Constant.messages.getString(
-                            "ascanbeta.insecurehttpmethod.detailed.name", httpMethod),
-                    exploitableDesc,
-                    msg.getRequestHeader().getURI().getURI(),
-                    null, /* parameter being attacked: none */
-                    "", /* attack */
-                    exploitableExtraInfo, /* extra info */
-                    "", /* solution */
-                    evidence, /* evidence, highlighted in the message */
-                    msg);
+            newAlert()
+                    .setRisk(riskLevel)
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setName(
+                            Constant.messages.getString(
+                                    "ascanbeta.insecurehttpmethod.detailed.name", httpMethod))
+                    .setDescription(exploitableDesc)
+                    .setOtherInfo(exploitableExtraInfo)
+                    .setEvidence(evidence)
+                    .setMessage(msg)
+                    .raise();
         } catch (Exception e) {
         }
     }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflow.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflow.java
@@ -196,14 +196,14 @@ public class IntegerOverflow extends AbstractAppParamPlugin {
             sendAndReceive(msg);
             if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR) {
                 log.debug("Found Header");
-                bingo(
-                        getRisk(),
-                        Alert.CONFIDENCE_MEDIUM,
-                        this.getBaseMsg().getRequestHeader().getURI().toString(),
-                        param,
-                        returnAttack,
-                        this.getError(type),
-                        msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setUri(this.getBaseMsg().getRequestHeader().getURI().toString())
+                        .setParam(param)
+                        .setAttack(returnAttack)
+                        .setOtherInfo(this.getError(type))
+                        .setMessage(msg)
+                        .raise();
                 return true;
             }
         } catch (IOException e) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOraclePlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOraclePlugin.java
@@ -212,16 +212,13 @@ public class PaddingOraclePlugin extends AbstractAppParamPlugin {
                                             + "]");
                         }
 
-                        // Now create the alert message
-                        this.bingo(
-                                Alert.RISK_HIGH,
-                                Alert.CONFIDENCE_MEDIUM,
-                                msg.getRequestHeader().getURI().toString(),
-                                paramName,
-                                msg.getRequestHeader().getURI().toString(),
-                                null,
-                                msg.getResponseHeader().getReasonPhrase(),
-                                msg);
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(paramName)
+                                .setAttack(msg.getRequestHeader().getURI().toString())
+                                .setEvidence(msg.getResponseHeader().getReasonPhrase())
+                                .setMessage(msg)
+                                .raise();
                     }
 
                     // Otherwise check the response with the last bit changed
@@ -246,16 +243,13 @@ public class PaddingOraclePlugin extends AbstractAppParamPlugin {
                                                 + "]");
                             }
 
-                            // Now create the alert message
-                            this.bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    msg.getRequestHeader().getURI().toString(),
-                                    paramName,
-                                    msg.getRequestHeader().getURI().toString(),
-                                    null,
-                                    pattern,
-                                    msg);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(paramName)
+                                    .setAttack(msg.getRequestHeader().getURI().toString())
+                                    .setEvidence(pattern)
+                                    .setMessage(msg)
+                                    .raise();
 
                             // All done. No need to look for vulnerabilities on subsequent
                             // parameters on the same request (to reduce performance impact)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanner.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
@@ -557,8 +556,8 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
                     if (serverHeader == null) serverHeader = "";
 
                     String poweredBy;
-                    Vector<String> poweredByList = responseHeader.getHeaders("X-Powered-By");
-                    if (poweredByList != null)
+                    List<String> poweredByList = responseHeader.getHeaderValues("X-Powered-By");
+                    if (!poweredByList.isEmpty())
                         poweredBy = poweredByList.toString(); // uses format: "[a,b,c]"
                     else poweredBy = "";
                     String serverDetails =
@@ -812,23 +811,20 @@ public class ProxyDisclosureScanner extends AbstractAppPlugin {
                 // there are multiple messages on which the issue could have been raised, but each
                 // individual atatck message
                 // tells only a small part of the story. Explain it in the "extra info" instead.
-                bingo(
-                        endToEndTraceEnabled || proxyTraceEnabled ? Alert.RISK_HIGH : getRisk(),
-                        Alert.CONFIDENCE_MEDIUM,
-                        getName(),
-                        Constant.messages.getString(
-                                MESSAGE_PREFIX + "desc",
-                                step2numberOfNodes - 1 + silentProxySet.size()),
-                        getBaseMsg().getRequestHeader().getURI().getURI(), // url
-                        "", // there is no parameter of interest
-                        getAttack(), // the attack. who'd have thunk it?
-                        extraInfo, // extra info.. all the detail of the proxy, etc.
-                        getSolution(),
-                        "", // evidence
-                        this.getCweId(),
-                        this.getWascId(),
-                        getBaseMsg() // the message on which we place the alert
-                        );
+                newAlert()
+                        .setRisk(
+                                endToEndTraceEnabled || proxyTraceEnabled
+                                        ? Alert.RISK_HIGH
+                                        : getRisk())
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setDescription(
+                                Constant.messages.getString(
+                                        MESSAGE_PREFIX + "desc",
+                                        step2numberOfNodes - 1 + silentProxySet.size()))
+                        .setAttack(getAttack())
+                        .setOtherInfo(extraInfo)
+                        .setMessage(getBaseMsg())
+                        .raise();
             }
 
         } catch (Exception e) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanner.java
@@ -646,20 +646,14 @@ public class RelativePathConfusionScanner extends AbstractAppPlugin {
                 }
 
                 // alert it..
-                bingo(
-                        getRisk(),
-                        Alert.CONFIDENCE_MEDIUM,
-                        getName(),
-                        getDescription(),
-                        getBaseMsg().getRequestHeader().getURI().getURI(),
-                        null, // parameter being attacked: none.
-                        hackedUri.getURI(), // the attack is the URL itself
-                        extraInfo,
-                        getSolution(),
-                        relativeReferenceEvidence,
-                        this.getCweId(),
-                        this.getWascId(),
-                        hackedMessage);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                        .setAttack(hackedUri.getURI())
+                        .setOtherInfo(extraInfo)
+                        .setEvidence(relativeReferenceEvidence)
+                        .setMessage(hackedMessage)
+                        .raise();
 
                 if (log.isDebugEnabled()) {
                     log.debug(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCVE20121823.java
@@ -171,22 +171,19 @@ public class RemoteCodeExecutionCVE20121823 extends AbstractAppPlugin {
                 }
 
                 // bingo.
-                bingo(
-                        Alert.RISK_HIGH,
-                        Alert.CONFIDENCE_MEDIUM,
-                        Constant.messages.getString(
-                                "ascanbeta.remotecodeexecution.cve-2012-1823.name"),
-                        Constant.messages.getString(
-                                "ascanbeta.remotecodeexecution.cve-2012-1823.desc"),
-                        null, // originalMessage.getRequestHeader().getURI().getURI(),
-                        null, // parameter being attacked: none.
-                        payload, // attack: none (it's not a parameter being attacked)
-                        responseBody, // extrainfo
-                        Constant.messages.getString(
-                                "ascanbeta.remotecodeexecution.cve-2012-1823.soln"),
-                        responseBody, // evidence, highlighted in the message
-                        attackmsg // raise the alert on the attack message
-                        );
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setDescription(
+                                Constant.messages.getString(
+                                        "ascanbeta.remotecodeexecution.cve-2012-1823.desc"))
+                        .setAttack(payload)
+                        .setOtherInfo(responseBody)
+                        .setSolution(
+                                Constant.messages.getString(
+                                        "ascanbeta.remotecodeexecution.cve-2012-1823.soln"))
+                        .setEvidence(responseBody)
+                        .setMessage(attackmsg)
+                        .raise();
                 return true;
             }
         } catch (Exception e) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionHypersonic.java
@@ -400,18 +400,15 @@ public class SQLInjectionHypersonic extends AbstractAppParamPlugin {
                                     paramName,
                                     newTimeBasedInjectionValue);
 
-                    // raise the alert
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName() + " - Time Based",
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().getURI(), // url
-                            paramName,
-                            attack,
-                            extraInfo,
-                            getSolution(),
-                            msgAttack);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(getName() + " - Time Based")
+                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setParam(paramName)
+                            .setAttack(attack)
+                            .setOtherInfo(extraInfo)
+                            .setMessage(msgAttack)
+                            .raise();
 
                     if (log.isDebugEnabled()) {
                         log.debug(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMsSQL.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMsSQL.java
@@ -250,18 +250,14 @@ public class SQLInjectionMsSQL extends AbstractAppParamPlugin {
                                     paramValue,
                                     originalTimeUsed);
 
-                    // raise the alert
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName(),
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().toString(),
-                            paramName,
-                            newTimeBasedInjectionValue,
-                            extraInfo,
-                            getSolution(),
-                            msgAttack);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                            .setParam(paramName)
+                            .setAttack(newTimeBasedInjectionValue)
+                            .setOtherInfo(extraInfo)
+                            .setMessage(msgAttack)
+                            .raise();
 
                     if (log.isDebugEnabled()) {
                         log.debug(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionMySQL.java
@@ -437,17 +437,14 @@ public class SQLInjectionMySQL extends AbstractAppParamPlugin {
                                     originalTimeUsed);
 
                     // raise the alert
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName(),
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().getURI(), // url
-                            paramName,
-                            newTimeBasedInjectionValue,
-                            extraInfo,
-                            getSolution(),
-                            msg3);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setParam(paramName)
+                            .setAttack(newTimeBasedInjectionValue)
+                            .setOtherInfo(extraInfo)
+                            .setMessage(msg3)
+                            .raise();
 
                     if (this.debugEnabled)
                         log.debug(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionOracle.java
@@ -319,18 +319,15 @@ public class SQLInjectionOracle extends AbstractAppParamPlugin {
                                     paramName,
                                     newTimeBasedInjectionValue);
 
-                    // raise the alert
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName() + " - Time Based",
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().getURI(), // url
-                            paramName,
-                            attack,
-                            extraInfo,
-                            getSolution(),
-                            msgAttack);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setName(getName() + " - Time Based")
+                            .setParam(paramName)
+                            .setAttack(attack)
+                            .setOtherInfo(extraInfo)
+                            .setMessage(msgAttack)
+                            .raise();
 
                     if (log.isDebugEnabled()) {
                         log.debug(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionPostgresql.java
@@ -385,18 +385,15 @@ public class SQLInjectionPostgresql extends AbstractAppParamPlugin {
                                     paramName,
                                     newTimeBasedInjectionValue);
 
-                    // raise the alert
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName() + " - Time Based",
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().getURI(), // url
-                            paramName,
-                            attack,
-                            extraInfo,
-                            getSolution(),
-                            msgAttack);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(getName() + " - Time Based")
+                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setParam(paramName)
+                            .setAttack(attack)
+                            .setOtherInfo(extraInfo)
+                            .setMessage(msgAttack)
+                            .raise();
 
                     if (log.isDebugEnabled()) {
                         log.debug(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionSQLite.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SQLInjectionSQLite.java
@@ -457,20 +457,15 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
                                             "ascanbeta.sqlinjection.sqlite.alert.errorbased.extrainfo",
                                             errorMessagePattern);
                             // raise the alert
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    getName(),
-                                    getDescription(),
-                                    getBaseMsg().getRequestHeader().getURI().getURI(), // url
-                                    paramName,
-                                    newTimeBasedInjectionValue,
-                                    extraInfo,
-                                    getSolution(),
-                                    errorMessagePattern.toString(),
-                                    this.getCweId(),
-                                    this.getWascId(),
-                                    msgDelay);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                                    .setParam(paramName)
+                                    .setAttack(newTimeBasedInjectionValue)
+                                    .setOtherInfo(extraInfo)
+                                    .setEvidence(errorMessagePattern.toString())
+                                    .setMessage(msgDelay)
+                                    .raise();
 
                             if (this.debugEnabled)
                                 log.debug(
@@ -625,21 +620,15 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
                                     originalParamValue,
                                     originalTimeUsed);
 
-                    // raise the alert
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName(),
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().getURI(), // url
-                            paramName,
-                            detectableDelayParameter,
-                            extraInfo,
-                            getSolution(),
-                            extraInfo /*as evidence*/,
-                            this.getCweId(),
-                            this.getWascId(),
-                            detectableDelayMessage);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setParam(paramName)
+                            .setAttack(detectableDelayParameter)
+                            .setOtherInfo(extraInfo)
+                            .setEvidence(extraInfo)
+                            .setMessage(detectableDelayMessage)
+                            .raise();
 
                     if (this.debugEnabled)
                         log.debug(
@@ -790,24 +779,23 @@ public class SQLInjectionSQLite extends AbstractAppParamPlugin {
                                                             Constant.messages.getString(
                                                                     "ascanbeta.sqlinjection.sqlite.alert.versionnumber.extrainfo",
                                                                     versionNumber);
-                                                    // raise the alert
-                                                    bingo(
-                                                            Alert.RISK_HIGH,
-                                                            Alert.CONFIDENCE_MEDIUM,
-                                                            getName() + " - " + versionNumber,
-                                                            getDescription(),
-                                                            getBaseMsg()
-                                                                    .getRequestHeader()
-                                                                    .getURI()
-                                                                    .getURI(), // url
-                                                            paramName,
-                                                            unionAttack,
-                                                            extraInfo,
-                                                            getSolution(),
-                                                            versionNumber /*as evidence*/,
-                                                            this.getCweId(),
-                                                            this.getWascId(),
-                                                            unionAttackMessage);
+                                                    newAlert()
+                                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                            .setName(
+                                                                    getName()
+                                                                            + " - "
+                                                                            + versionNumber)
+                                                            .setUri(
+                                                                    getBaseMsg()
+                                                                            .getRequestHeader()
+                                                                            .getURI()
+                                                                            .getURI())
+                                                            .setParam(paramName)
+                                                            .setAttack(unionAttack)
+                                                            .setOtherInfo(extraInfo)
+                                                            .setEvidence(versionNumber)
+                                                            .setMessage(unionAttackMessage)
+                                                            .raise();
                                                     break unionLoops;
                                                 }
                                             }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixation.java
@@ -461,21 +461,21 @@ public class SessionFixation extends AbstractAppPlugin {
                                 Constant.messages.getString(
                                         "ascanbeta.sessionidsentinsecurely.soln");
 
-                        // call bingo with some extra info, indicating that the alert is
+                        // raise alert with some extra info, indicating that the alert is
                         // not specific to Session Fixation, but has its own title and description
                         // (etc.)
                         // the alert here is "Session id sent insecurely", or words to that effect.
-                        bingo(
-                                risk,
-                                Alert.CONFIDENCE_MEDIUM,
-                                vulnname,
-                                vulndesc,
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
-                                currentHtmlParameter.getName(),
-                                attack,
-                                extraInfo,
-                                vulnsoln,
-                                getBaseMsg());
+                        newAlert()
+                                .setRisk(risk)
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setName(vulnname)
+                                .setDescription(vulndesc)
+                                .setParam(currentHtmlParameter.getName())
+                                .setAttack(attack)
+                                .setOtherInfo(extraInfo)
+                                .setSolution(vulnsoln)
+                                .setMessage(getBaseMsg())
+                                .raise();
 
                         if (log.isDebugEnabled()) {
                             String logMessage =
@@ -524,22 +524,22 @@ public class SessionFixation extends AbstractAppPlugin {
                                         + Constant.messages.getString(
                                                 "ascanbeta.sessionidaccessiblebyjavascript.alert.extrainfo.loginpage"));
 
-                        // call bingo with some extra info, indicating that the alert is
+                        // raise alert with some extra info, indicating that the alert is
                         // not specific to Session Fixation, but has its own title and description
                         // (etc.)
                         // the alert here is "Session id accessible in Javascript", or words to that
                         // effect.
-                        bingo(
-                                Alert.RISK_LOW,
-                                Alert.CONFIDENCE_MEDIUM,
-                                vulnname,
-                                vulndesc,
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
-                                currentHtmlParameter.getName(),
-                                attack,
-                                extraInfo,
-                                vulnsoln,
-                                getBaseMsg());
+                        newAlert()
+                                .setRisk(Alert.RISK_LOW)
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setName(vulnname)
+                                .setDescription(vulndesc)
+                                .setParam(currentHtmlParameter.getName())
+                                .setAttack(attack)
+                                .setOtherInfo(extraInfo)
+                                .setSolution(vulnsoln)
+                                .setMessage(getBaseMsg())
+                                .raise();
 
                         if (log.isDebugEnabled()) {
                             String logMessage =
@@ -716,22 +716,22 @@ public class SessionFixation extends AbstractAppPlugin {
                                                     "ascanbeta.sessionidexpiry.alert.extrainfo.loginpage"));
                         }
 
-                        // call bingo with some extra info, indicating that the alert is
+                        // raise alert with some extra info, indicating that the alert is
                         // not specific to Session Fixation, but has its own title and description
                         // (etc.)
                         // the alert here is "Session Id Expiry Time is excessive", or words to that
                         // effect.
-                        bingo(
-                                sessionExpiryRiskLevel,
-                                Alert.CONFIDENCE_MEDIUM,
-                                vulnname,
-                                vulndesc,
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
-                                currentHtmlParameter.getName(),
-                                attack,
-                                extraInfo,
-                                vulnsoln,
-                                getBaseMsg());
+                        newAlert()
+                                .setRisk(sessionExpiryRiskLevel)
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setName(vulnname)
+                                .setDescription(vulndesc)
+                                .setParam(currentHtmlParameter.getName())
+                                .setAttack(attack)
+                                .setOtherInfo(extraInfo)
+                                .setSolution(vulnsoln)
+                                .setMessage(getBaseMsg())
+                                .raise();
 
                         if (log.isDebugEnabled()) {
                             String logMessage =
@@ -944,14 +944,14 @@ public class SessionFixation extends AbstractAppPlugin {
                                                     "ascanbeta.sessionfixation.alert.cookie.extrainfo.loginpage"));
                         }
 
-                        bingo(
-                                Alert.RISK_INFO,
-                                Alert.CONFIDENCE_MEDIUM,
-                                msg2Initial.getRequestHeader().getURI().getURI(),
-                                currentHtmlParameter.getName(),
-                                attack,
-                                extraInfo,
-                                msg2Initial);
+                        newAlert()
+                                .setRisk(Alert.RISK_INFO)
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(currentHtmlParameter.getName())
+                                .setAttack(attack)
+                                .setOtherInfo(extraInfo)
+                                .setMessage(msg2Initial)
+                                .raise();
                         logSessionFixation(
                                 msg2Initial,
                                 currentHtmlParameter.getType().toString(),
@@ -1151,17 +1151,17 @@ public class SessionFixation extends AbstractAppPlugin {
                             // description (etc.)
                             // the alert here is "Session id exposed in url", or words to that
                             // effect.
-                            bingo(
-                                    Alert.RISK_MEDIUM,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    vulnname,
-                                    vulndesc,
-                                    getBaseMsg().getRequestHeader().getURI().getURI(),
-                                    currentHtmlParameter.getName(),
-                                    attack,
-                                    extraInfo,
-                                    vulnsoln,
-                                    getBaseMsg());
+                            newAlert()
+                                    .setRisk(Alert.RISK_MEDIUM)
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setName(vulnname)
+                                    .setDescription(vulndesc)
+                                    .setParam(currentHtmlParameter.getName())
+                                    .setAttack(attack)
+                                    .setOtherInfo(extraInfo)
+                                    .setSolution(vulnsoln)
+                                    .setMessage(getBaseMsg())
+                                    .raise();
 
                             if (log.isDebugEnabled()) {
                                 String logMessage =
@@ -1357,14 +1357,14 @@ public class SessionFixation extends AbstractAppPlugin {
                             risk = Alert.RISK_LOW;
                         }
 
-                        bingo(
-                                risk,
-                                Alert.CONFIDENCE_MEDIUM,
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
-                                currentHtmlParameter.getName(),
-                                attack,
-                                extraInfo,
-                                getBaseMsg());
+                        newAlert()
+                                .setRisk(risk)
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(currentHtmlParameter.getName())
+                                .setAttack(attack)
+                                .setOtherInfo(extraInfo)
+                                .setMessage(getBaseMsg())
+                                .raise();
                         logSessionFixation(
                                 getBaseMsg(),
                                 (isPseudoUrlParameter ? "pseudo " : "")

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanner.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ShellShockScanner.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
-import java.util.Vector;
+import java.util.List;
 import org.apache.commons.configuration.ConversionException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -106,22 +106,20 @@ public class ShellShockScanner extends AbstractAppParamPlugin {
             setParameter(msg1, paramName, attack);
             sendAndReceive(msg1, false); // do not follow redirects
 
-            Vector<String> ssHeaders = msg1.getResponseHeader().getHeaders(attackHeader);
-            if (ssHeaders != null && ssHeaders.size() > 0) {
+            List<String> ssHeaders = msg1.getResponseHeader().getHeaderValues(attackHeader);
+            if (!ssHeaders.isEmpty()) {
                 for (String header : ssHeaders) {
                     if (header.contains(evidence)) {
-                        bingo(
-                                getRisk(),
-                                Alert.CONFIDENCE_MEDIUM,
-                                this.getName(),
-                                this.getDescription(),
-                                null, // originalMessage.getRequestHeader().getURI().getURI(),
-                                paramName, // parameter being attacked
-                                attack,
-                                Constant.messages.getString("ascanbeta.shellshock.extrainfo"),
-                                this.getSolution(),
-                                evidence,
-                                msg1);
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(paramName)
+                                .setAttack(attack)
+                                .setOtherInfo(
+                                        Constant.messages.getString(
+                                                "ascanbeta.shellshock.extrainfo"))
+                                .setEvidence(evidence)
+                                .setMessage(msg1)
+                                .raise();
                         return;
                     }
                 }
@@ -154,19 +152,17 @@ public class ShellShockScanner extends AbstractAppParamPlugin {
                 }
             }
             if (vulnerable) {
-                bingo(
-                        getRisk(),
-                        Alert.CONFIDENCE_MEDIUM,
-                        this.getName(),
-                        this.getDescription(),
-                        null, // originalMessage.getRequestHeader().getURI().getURI(),
-                        paramName, // parameter being attacked
-                        attack,
-                        Constant.messages.getString("ascanbeta.shellshock.extrainfo"),
-                        this.getSolution(),
-                        Constant.messages.getString(
-                                "ascanbeta.shellshock.timingbased.evidence", attackElapsedTime),
-                        msg2);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(paramName)
+                        .setAttack(attack)
+                        .setOtherInfo(Constant.messages.getString("ascanbeta.shellshock.extrainfo"))
+                        .setEvidence(
+                                Constant.messages.getString(
+                                        "ascanbeta.shellshock.timingbased.evidence",
+                                        attackElapsedTime))
+                        .setMessage(msg2)
+                        .raise();
                 return;
             }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieDetector.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SlackerCookieDetector.java
@@ -106,20 +106,11 @@ public class SlackerCookieDetector extends AbstractAppPlugin {
             sendAndReceive(msg, false);
             if (msg.getResponseBody().length() != baseResponseLength) {
                 sessionNoLongerGood = true;
-                bingo(
-                        Alert.RISK_INFO,
-                        // reliability:
-                        Alert.CONFIDENCE_LOW,
-                        msg.getRequestHeader().getURI().toString(),
-                        // parameter:
-                        null,
-                        // Attack:
-                        null,
-                        // Other info:
-                        getSessionDestroyedText(oneCookie.getName()),
-                        // Evidence:
-                        null,
-                        msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_LOW)
+                        .setOtherInfo(getSessionDestroyedText(oneCookie.getName()))
+                        .setMessage(msg)
+                        .raise();
             }
         } catch (IOException io) {
             log.debug("Blew up trying to refresh session with all cookies: " + io.getMessage());
@@ -208,20 +199,12 @@ public class SlackerCookieDetector extends AbstractAppPlugin {
 
         int riskLevel = calculateRisk(cookiesThatDoNOTMakeADifference, otherInfoBuff);
 
-        bingo(
-                riskLevel,
-                // reliability:
-                Alert.CONFIDENCE_LOW,
-                msg.getRequestHeader().getURI().toString(),
-                // parameter:
-                null,
-                // Attack:
-                null,
-                // Other info:
-                otherInfoBuff.toString(),
-                // Evidence:
-                null,
-                msg);
+        newAlert()
+                .setRisk(riskLevel)
+                .setConfidence(Alert.CONFIDENCE_LOW)
+                .setOtherInfo(otherInfoBuff.toString())
+                .setMessage(msg)
+                .raise();
     }
 
     private StringBuilder createOtherInfoText(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCVE20121823.java
@@ -176,24 +176,17 @@ public class SourceCodeDisclosureCVE20121823 extends AbstractAppPlugin {
                     }
 
                     // bingo.
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            Constant.messages.getString(
-                                    "ascanbeta.sourcecodedisclosurecve-2012-1823.name"),
-                            Constant.messages.getString(
-                                    "ascanbeta.sourcecodedisclosurecve-2012-1823.desc"),
-                            null, // originalMessage.getRequestHeader().getURI().getURI(),
-                            null, // parameter being attacked: none.
-                            "", // attack: none (it's not a parameter being attacked)
-                            sourceCode, // extrainfo
-                            Constant.messages.getString(
-                                    "ascanbeta.sourcecodedisclosurecve-2012-1823.soln"),
-                            "", // evidence, highlighted in the message  (cannot use the source code
-                            // here, since it is encoded in the message response, and so will
-                            // not match up)
-                            attackmsg // raise the alert on the attack message
-                            );
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setDescription(
+                                    Constant.messages.getString(
+                                            "ascanbeta.sourcecodedisclosurecve-2012-1823.desc"))
+                            .setOtherInfo(sourceCode)
+                            .setSolution(
+                                    Constant.messages.getString(
+                                            "ascanbeta.sourcecodedisclosurecve-2012-1823.soln"))
+                            .setMessage(attackmsg)
+                            .raise();
                 }
             }
         } catch (Exception e) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusion.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusion.java
@@ -351,27 +351,29 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 
                             // if we get to here, is is very likely that we have source file
                             // inclusion attack. alert it.
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.name"),
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.desc"),
-                                    getBaseMsg().getRequestHeader().getURI().getURI(),
-                                    paramname,
-                                    prefixedUrlfilename,
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.extrainfo",
-                                            prefixedUrlfilename,
-                                            NON_EXISTANT_FILENAME,
-                                            randomversussourcefilenamematchpercentage,
-                                            this.thresholdPercentage),
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.soln"),
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.evidence"),
-                                    sourceattackmsg);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setDescription(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.desc"))
+                                    .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                                    .setParam(paramname)
+                                    .setAttack(prefixedUrlfilename)
+                                    .setOtherInfo(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.lfibased.extrainfo",
+                                                    prefixedUrlfilename,
+                                                    NON_EXISTANT_FILENAME,
+                                                    randomversussourcefilenamematchpercentage,
+                                                    this.thresholdPercentage))
+                                    .setSolution(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.lfibased.soln"))
+                                    .setEvidence(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.lfibased.evidence"))
+                                    .setMessage(sourceattackmsg)
+                                    .raise();
                             // All done on this parameter
                             return;
                         } else {
@@ -460,27 +462,29 @@ public class SourceCodeDisclosureFileInclusion extends AbstractAppParamPlugin {
 
                             // if we get to here, is is very likely that we have source file
                             // inclusion attack. alert it.
-                            bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.name"),
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.desc"),
-                                    getBaseMsg().getRequestHeader().getURI().getURI(),
-                                    paramname,
-                                    prefixedUrlfilename,
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.extrainfo",
-                                            prefixedUrlfilename,
-                                            NON_EXISTANT_FILENAME,
-                                            randomversussourcefilenamematchpercentage,
-                                            this.thresholdPercentage),
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.soln"),
-                                    Constant.messages.getString(
-                                            "ascanbeta.sourcecodedisclosure.lfibased.evidence"),
-                                    sourceattackmsg);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setDescription(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.desc"))
+                                    .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                                    .setParam(paramname)
+                                    .setAttack(prefixedUrlfilename)
+                                    .setOtherInfo(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.lfibased.extrainfo",
+                                                    prefixedUrlfilename,
+                                                    NON_EXISTANT_FILENAME,
+                                                    randomversussourcefilenamematchpercentage,
+                                                    this.thresholdPercentage))
+                                    .setSolution(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.lfibased.soln"))
+                                    .setEvidence(
+                                            Constant.messages.getString(
+                                                    "ascanbeta.sourcecodedisclosure.lfibased.evidence"))
+                                    .setMessage(sourceattackmsg)
+                                    .raise();
 
                             // All done. No need to look for vulnerabilities on subsequent
                             // parameters on the same request (to reduce performance impact)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGit.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGit.java
@@ -428,19 +428,13 @@ public class SourceCodeDisclosureGit extends AbstractAppPlugin {
                     // we cannot meaningfully raise an alert on any one file, except perhaps the
                     // file on which the attack was launched.
                     // it's the least worst way of doing it, IMHO.
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            getName(),
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().getURI(),
-                            null, // parameter being attacked: none.
-                            null, // attack
-                            new String(
-                                    disclosedData), // Constant.messages.getString("ascanbeta.sourcecodedisclosure.gitbased.extrainfo", filename, StringUtils.join(gitURIs,", ")),  	//extraInfo
-                            getSolution(),
-                            getEvidence(filename, gitURIs),
-                            originalMessage);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setOtherInfo(new String(disclosedData))
+                            .setEvidence(getEvidence(filename, gitURIs))
+                            .setMessage(originalMessage)
+                            .raise();
                     return true;
                 }
                 // does not match the extension

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSVN.java
@@ -367,18 +367,14 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
                 if (evidence != null) {
                     // if we get to here, is is very likely that we have source file inclusion
                     // attack. alert it.
-                    bingo(
-                            Alert.RISK_MEDIUM,
-                            getConfidence(attackmsgResponseStatusCode),
-                            getName(),
-                            getDescription(),
-                            getBaseMsg().getRequestHeader().getURI().getURI(),
-                            null,
-                            attackFilename,
-                            getExtraInfo(urlfilename, attackFilename),
-                            getSolution(),
-                            evidence,
-                            svnsourcefileattackmsg);
+                    newAlert()
+                            .setConfidence(getConfidence(attackmsgResponseStatusCode))
+                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setAttack(attackFilename)
+                            .setOtherInfo(getExtraInfo(urlfilename, attackFilename))
+                            .setEvidence(evidence)
+                            .setMessage(svnsourcefileattackmsg)
+                            .raise();
                     // if we found one, do not even try the "super" method, which tries each of the
                     // parameters,
                     // since this is slow, and we already found an instance
@@ -651,22 +647,23 @@ public class SourceCodeDisclosureSVN extends AbstractAppPlugin {
                                             if (evidence != null) {
                                                 // if we get to here, is is very likely that we have
                                                 // source file inclusion attack. alert it.
-                                                bingo(
-                                                        Alert.RISK_MEDIUM,
-                                                        getConfidence(
-                                                                svnSourceFileAttackMsgStatusCode),
-                                                        getName(),
-                                                        getDescription(),
-                                                        getBaseMsg()
-                                                                .getRequestHeader()
-                                                                .getURI()
-                                                                .getURI(),
-                                                        null,
-                                                        attackFilename,
-                                                        getExtraInfo(urlfilename, attackFilename),
-                                                        getSolution(),
-                                                        evidence,
-                                                        svnSourceFileAttackMsg);
+                                                newAlert()
+                                                        .setConfidence(
+                                                                getConfidence(
+                                                                        svnSourceFileAttackMsgStatusCode))
+                                                        .setUri(
+                                                                getBaseMsg()
+                                                                        .getRequestHeader()
+                                                                        .getURI()
+                                                                        .getURI())
+                                                        .setAttack(attackFilename)
+                                                        .setOtherInfo(
+                                                                getExtraInfo(
+                                                                        urlfilename,
+                                                                        attackFilename))
+                                                        .setEvidence(evidence)
+                                                        .setMessage(svnSourceFileAttackMsg)
+                                                        .raise();
                                                 // do not return.. need to tidy up first
                                             } else {
                                                 if (log.isDebugEnabled())

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TestUserAgent.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TestUserAgent.java
@@ -167,13 +167,11 @@ public class TestUserAgent extends AbstractAppPlugin {
     }
 
     private void createAlert(HttpMessage newMsg, String userAgent) {
-        bingo(
-                getRisk(),
-                Alert.CONFIDENCE_MEDIUM,
-                getBaseMsg().getRequestHeader().getURI().toString(),
-                USER_AGENT_PARAM_NAME,
-                userAgent,
-                "",
-                newMsg);
+        newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setParam(USER_AGENT_PARAM_NAME)
+                .setAttack(userAgent)
+                .setMessage(newMsg)
+                .raise();
     }
 }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumeration.java
@@ -748,17 +748,16 @@ public class UsernameEnumeration extends AbstractAppPlugin {
                                 Constant.messages.getString("ascanbeta.usernameenumeration.soln");
 
                         // call bingo with some extra info, indicating that the alert is
-                        bingo(
-                                Alert.RISK_INFO,
-                                Alert.CONFIDENCE_LOW,
-                                vulnname,
-                                vulndesc,
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
-                                currentHtmlParameter.getName(),
-                                attack,
-                                extraInfo,
-                                vulnsoln,
-                                getBaseMsg());
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_LOW)
+                                .setName(vulnname)
+                                .setDescription(vulndesc)
+                                .setParam(currentHtmlParameter.getName())
+                                .setAttack(attack)
+                                .setOtherInfo(extraInfo)
+                                .setSolution(vulnsoln)
+                                .setMessage(getBaseMsg())
+                                .raise();
 
                     } else {
                         if (this.debugEnabled)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XXEPlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XXEPlugin.java
@@ -310,16 +310,12 @@ public class XXEPlugin extends AbstractAppPlugin implements ChallengeCallbackPlu
                         matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
                         if (matcher.find()) {
 
-                            // Alert the vulnerability to the main core
-                            this.bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    null, // URI
-                                    null, // param
-                                    payload, // attack
-                                    null, // otherinfo
-                                    matcher.group(), // evidence
-                                    msg);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setAttack(payload)
+                                    .setEvidence(matcher.group())
+                                    .setMessage(msg)
+                                    .raise();
                         }
                     }
 
@@ -379,16 +375,12 @@ public class XXEPlugin extends AbstractAppPlugin implements ChallengeCallbackPlu
                         matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
                         if (matcher.find()) {
 
-                            // Alert the vulnerability to the main core
-                            this.bingo(
-                                    Alert.RISK_HIGH,
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    null, // URI
-                                    null, // param
-                                    payload, // attack
-                                    null, // otherinfo
-                                    matcher.group(), // evidence
-                                    msg);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setAttack(payload)
+                                    .setEvidence(matcher.group())
+                                    .setMessage(msg)
+                                    .raise();
                         }
                     }
 
@@ -425,16 +417,12 @@ public class XXEPlugin extends AbstractAppPlugin implements ChallengeCallbackPlu
 
             String evidence = callbackImplementor.getCallbackUrl(challenge);
 
-            // Alert the vulnerability to the main core
-            this.bingo(
-                    Alert.RISK_HIGH,
-                    Alert.CONFIDENCE_MEDIUM,
-                    null, // URI
-                    null, // param
-                    getCallbackAttackPayload(challenge), // attack
-                    null, // otherinfo
-                    evidence, // evidence
-                    targetMessage);
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setAttack(getCallbackAttackPayload(challenge))
+                    .setEvidence(evidence)
+                    .setMessage(targetMessage)
+                    .raise();
         }
     }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionPlugin.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionPlugin.java
@@ -269,18 +269,12 @@ public class XpathInjectionPlugin extends AbstractAppParamPlugin {
                                             + "]");
                         }
 
-                        // Now create the alert message
-                        this.bingo(
-                                Alert.RISK_HIGH,
-                                Alert.CONFIDENCE_HIGH,
-                                getName(),
-                                getDescription(),
-                                null,
-                                paramName,
-                                evilPayload,
-                                null,
-                                getSolution(),
-                                msg);
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_HIGH)
+                                .setParam(paramName)
+                                .setAttack(evilPayload)
+                                .setMessage(msg)
+                                .raise();
 
                         // All done. No need to look for vulnerabilities on subsequent
                         // parameters on the same request (to reduce performance impact)


### PR DESCRIPTION
Use new method to raise alerts in the scan rules.
Use new method `HttpHeader#getHeaderValues`.