### PR TITLE
ascanrulesAlpha: update ZAP to 2.9.0

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 'Hidden File Finder' add pattern for vim_settings.xml (CVE-2019-14957).
 
 ### Changed
+- Update minimum ZAP version to 2.9.0.
 - Change info URL to link to the site.
 - Update ZAP blog links.
 - Updated owasp.org references (Issue 5962).

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -3,7 +3,7 @@ description = "The alpha quality Active Scanner rules"
 
 zapAddOn {
     addOnName.set("Active scanner rules (alpha)")
-    zapVersion.set("2.8.0")
+    zapVersion.set("2.9.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanner.java
@@ -103,20 +103,12 @@ public class CloudMetadataScanner extends AbstractHostPlugin {
     }
 
     public void raiseAlert(HttpMessage newRequest) {
-        bingo(
-                getRisk(), // Risk
-                Alert.CONFIDENCE_LOW, // Confidence/Reliability
-                getName(), // Name
-                getDescription(), // Description
-                newRequest.getRequestHeader().getURI().toString(), // Original URI
-                null, // Param
-                METADATA_HOST, // Attack
-                Constant.messages.getString(MESSAGE_PREFIX + "otherinfo"), // OtherInfo
-                getSolution(), // Solution
-                "", // Evidence
-                getCweId(), // CWE ID
-                getWascId(), // WASC ID
-                newRequest); // HTTPMessage
+        newAlert()
+                .setConfidence(Alert.CONFIDENCE_LOW)
+                .setAttack(METADATA_HOST)
+                .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "otherinfo"))
+                .setMessage(newRequest)
+                .raise();
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleFileActiveScanner.java
@@ -154,15 +154,14 @@ public class ExampleFileActiveScanner extends AbstractAppParamPlugin {
                 String evidence;
                 if ((evidence = doesResponseContainString(msg.getResponseBody(), attack)) != null) {
                     // Raise an alert
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            null,
-                            param,
-                            attack,
-                            getOtherInfo(),
-                            evidence,
-                            msg);
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(attack)
+                            .setOtherInfo(getOtherInfo())
+                            .setEvidence(evidence)
+                            .setMessage(msg)
+                            .raise();
                     return;
                 }
             }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExampleSimpleActiveScanner.java
@@ -136,7 +136,12 @@ public class ExampleSimpleActiveScanner extends AbstractAppParamPlugin {
             // For this example we're just going to raise the alert at random!
 
             if (rnd.nextInt(10) == 0) {
-                bingo(Alert.RISK_HIGH, Alert.CONFIDENCE_MEDIUM, null, param, value, null, msg);
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(value)
+                        .setMessage(msg)
+                        .raise();
                 return;
             }
 

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java
@@ -180,21 +180,15 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
     }
 
     private void raiseAlert(HttpMessage msg, int confidence, int risk, HiddenFile file) {
-        bingo(
-                risk, // Risk
-                confidence, // Confidence
-                getAlertName(), // Name
-                getDescription(), // Description
-                msg.getRequestHeader().getURI().toString(), // URI
-                null, // Param
-                "", // Attack
-                getOtherInfo(file.getType()), // OtherInfo
-                getSolution(), // Solution
-                msg.getResponseHeader().getPrimeHeader(), // Evidence
-                getReferences(file), // References
-                getCweId(), // CWE ID
-                getWascId(), // WASC ID
-                msg); // HTTPMessage
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(getAlertName())
+                .setOtherInfo(getOtherInfo(file.getType()))
+                .setEvidence(msg.getResponseHeader().getPrimeHeader())
+                .setReference(getReferences(file))
+                .setMessage(msg)
+                .raise();
     }
 
     @Override

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LDAPInjection.java
@@ -412,19 +412,17 @@ public class LDAPInjection extends AbstractAppParamPlugin {
                     String vulnsoln =
                             Constant.messages.getString(I18N_PREFIX + "ldapinjection.soln");
 
-                    // bingo!
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            vulnname,
-                            vulndesc,
-                            getBaseMsg().getRequestHeader().getURI().getURI(),
-                            paramname,
-                            attack,
-                            extraInfo,
-                            vulnsoln,
-                            vulnevidence,
-                            getBaseMsg());
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(vulnname)
+                            .setDescription(vulndesc)
+                            .setParam(paramname)
+                            .setAttack(attack)
+                            .setOtherInfo(extraInfo)
+                            .setSolution(vulnsoln)
+                            .setEvidence(vulnevidence)
+                            .setMessage(getBaseMsg())
+                            .raise();
 
                     logBoolenInjection(
                             getBaseMsg(), paramname, appendTrueAttack, randomparameterAttack);
@@ -517,19 +515,17 @@ public class LDAPInjection extends AbstractAppParamPlugin {
                     String vulnsoln =
                             Constant.messages.getString(I18N_PREFIX + "ldapinjection.soln");
 
-                    // bingo!
-                    bingo(
-                            Alert.RISK_HIGH,
-                            Alert.CONFIDENCE_MEDIUM,
-                            vulnname,
-                            vulndesc,
-                            getBaseMsg().getRequestHeader().getURI().getURI(),
-                            paramname,
-                            attack,
-                            extraInfo,
-                            vulnsoln,
-                            vulnevidence,
-                            getBaseMsg());
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setName(vulnname)
+                            .setDescription(vulndesc)
+                            .setParam(paramname)
+                            .setAttack(attack)
+                            .setOtherInfo(extraInfo)
+                            .setSolution(vulnsoln)
+                            .setEvidence(vulnevidence)
+                            .setMessage(getBaseMsg())
+                            .raise();
 
                     logBoolenInjection(
                             getBaseMsg(), paramname, hopefullyTrueAttack, randomparameterAttack);
@@ -660,18 +656,17 @@ public class LDAPInjection extends AbstractAppParamPlugin {
 
                 // we know the LDAP implementation, so put it in the title, where it will be
                 // obvious.
-                bingo(
-                        Alert.RISK_HIGH,
-                        Alert.CONFIDENCE_MEDIUM,
-                        vulnname + " - " + LDAP_ERRORS.get(errorPattern),
-                        vulndesc,
-                        getBaseMsg().getRequestHeader().getURI().getURI(),
-                        parameterName,
-                        attack,
-                        extraInfo,
-                        vulnsoln,
-                        errorPattern.toString(),
-                        attackMessage); // use the attack message, rather than the original message.
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setName(vulnname + " - " + LDAP_ERRORS.get(errorPattern))
+                        .setDescription(vulndesc)
+                        .setParam(parameterName)
+                        .setAttack(attack)
+                        .setOtherInfo(extraInfo)
+                        .setSolution(vulnsoln)
+                        .setEvidence(errorPattern.toString())
+                        .setMessage(attackMessage)
+                        .raise();
 
                 if (log.isDebugEnabled()) {
                     String logMessage =

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjection.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjection.java
@@ -290,17 +290,13 @@ public class MongoDbInjection extends AbstractAppParamPlugin {
                         sendAndReceive(counterProofMsg, false);
                         String bodyCounterProof = counterProofMsg.getResponseBody().toString();
                         if (bodyBase.equals(bodyCounterProof)) {
-                            bingo(
-                                    getRisk(),
-                                    Alert.CONFIDENCE_HIGH,
-                                    getName(),
-                                    getDescription(),
-                                    null,
-                                    param,
-                                    paramInj + valueInj,
-                                    getExtraInfo(ALL_DATA_ATTACK),
-                                    getSolution(),
-                                    msgInjAttack);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_HIGH)
+                                    .setParam(param)
+                                    .setAttack(paramInj + valueInj)
+                                    .setOtherInfo(getExtraInfo(ALL_DATA_ATTACK))
+                                    .setMessage(msgInjAttack)
+                                    .raise();
                             isBingo = true;
                             break;
                         }
@@ -351,17 +347,13 @@ public class MongoDbInjection extends AbstractAppParamPlugin {
                         Matcher matcher =
                                 pattern.matcher(msgInjAttack.getResponseBody().toString());
                         if (matcher.find()) {
-                            bingo(
-                                    getRisk(),
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    getName(),
-                                    getDescription(),
-                                    null,
-                                    param,
-                                    valueInj,
-                                    getExtraInfo(CRASH_ATTACK),
-                                    getSolution(),
-                                    msgInjAttack);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(valueInj)
+                                    .setOtherInfo(getExtraInfo(CRASH_ATTACK))
+                                    .setMessage(msgInjAttack)
+                                    .raise();
                             isBingo = true;
                             break;
                         }
@@ -432,33 +424,25 @@ public class MongoDbInjection extends AbstractAppParamPlugin {
                         setParameter(msgInjAttack, param, sleepValueToInj);
                         sendAndReceive(msgInjAttack, false);
                         if (msgInjAttack.getTimeElapsedMillis() >= aveRtt + LONG_TRESHOLD) {
-                            bingo(
-                                    getRisk(),
-                                    Alert.CONFIDENCE_HIGH,
-                                    getName(),
-                                    getDescription(),
-                                    null,
-                                    param,
-                                    sleepValueToInj,
-                                    getExtraInfo(SLEEP_ATTACK),
-                                    getSolution(),
-                                    msgInjAttack);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_HIGH)
+                                    .setParam(param)
+                                    .setAttack(sleepValueToInj)
+                                    .setOtherInfo(getExtraInfo(SLEEP_ATTACK))
+                                    .setMessage(msgInjAttack)
+                                    .raise();
                             isBingo = true;
                             break;
                         }
                     }
                     if (hadTimeout) {
-                        bingo(
-                                getRisk(),
-                                Alert.CONFIDENCE_LOW,
-                                getName(),
-                                getDescription(),
-                                null,
-                                param,
-                                sleepValueToInj,
-                                getExtraInfo(SLEEP_ATTACK),
-                                getSolution(),
-                                msgInjAttack);
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_LOW)
+                                .setParam(param)
+                                .setAttack(sleepValueToInj)
+                                .setOtherInfo(getExtraInfo(SLEEP_ATTACK))
+                                .setMessage(msgInjAttack)
+                                .raise();
                         isBingo = true;
                         break;
                     }
@@ -535,32 +519,24 @@ public class MongoDbInjection extends AbstractAppParamPlugin {
                             sendAndReceive(counterProofMsg, false);
                             String bodyCounterProof = counterProofMsg.getResponseBody().toString();
                             if (bodyBase.equals(bodyCounterProof)) {
-                                bingo(
-                                        getRisk(),
-                                        Alert.CONFIDENCE_HIGH,
-                                        getName(),
-                                        getDescription(),
-                                        null,
-                                        param,
-                                        jpv[0] + jpv[1],
-                                        getExtraInfo(JSON_ATTACK),
-                                        getSolution(),
-                                        msgInjAttack);
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_HIGH)
+                                        .setParam(param)
+                                        .setAttack(jpv[0] + jpv[1])
+                                        .setOtherInfo(getExtraInfo(JSON_ATTACK))
+                                        .setMessage(msgInjAttack)
+                                        .raise();
                                 isBingo = true;
                                 break;
                             }
                         } else {
-                            bingo(
-                                    getRisk(),
-                                    Alert.CONFIDENCE_MEDIUM,
-                                    getName(),
-                                    getDescription(),
-                                    null,
-                                    param,
-                                    jpv[0] + jpv[1],
-                                    getExtraInfo(JSON_ATTACK),
-                                    getSolution(),
-                                    msgInjAttack);
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(jpv[0] + jpv[1])
+                                    .setOtherInfo(getExtraInfo(JSON_ATTACK))
+                                    .setMessage(msgInjAttack)
+                                    .raise();
                             isBingo = true;
                             break;
                         }
@@ -619,17 +595,12 @@ public class MongoDbInjection extends AbstractAppParamPlugin {
                                     && requestUri.getHost().equals(loginUri.getHost())
                                     && requestUri.getPort() == loginUri.getPort()
                                     && requestUri.getPath().equals(loginUri.getPath())) {
-                                bingo(
-                                        getRisk(),
-                                        Alert.CONFIDENCE_MEDIUM,
-                                        getName(),
-                                        getDescription(),
-                                        null,
-                                        param,
-                                        "",
-                                        getExtraInfo(AUTH_BYPASS_ATTACK),
-                                        getSolution(),
-                                        getBaseMsg());
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                        .setParam(param)
+                                        .setOtherInfo(getExtraInfo(AUTH_BYPASS_ATTACK))
+                                        .setMessage(getBaseMsg())
+                                        .raise();
                                 break;
                             }
                         }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/XSLTInjection.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/XSLTInjection.java
@@ -220,20 +220,14 @@ public class XSLTInjection extends AbstractAppParamPlugin {
             String attack,
             String evidence,
             String resourceIdentifier) {
-        bingo(
-                getRisk(),
-                Alert.CONFIDENCE_MEDIUM,
-                getName(),
-                getDescription(),
-                msg.getRequestHeader().getURI().toString(),
-                param,
-                attack,
-                getOtherInfo(resourceIdentifier, evidence),
-                getSolution(),
-                evidence,
-                getCweId(),
-                getWascId(),
-                msg);
+        newAlert()
+                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setParam(param)
+                .setAttack(attack)
+                .setOtherInfo(getOtherInfo(resourceIdentifier, evidence))
+                .setEvidence(evidence)
+                .setMessage(msg)
+                .raise();
     }
 
     @Override


### PR DESCRIPTION
Use new method to raise alerts in the scan rules.