### PR TITLE
Retire: Change "info" to proper references & change otherinfo handling

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+### Changed
+- URLs which were previously included as 'other info' are now properly included as alert 'references'.
+- CVE numbers are now included as part of 'other info'.
+
 ## [0.1.0] - 2020-05-20
 ### Changed
 - First release.

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -1,4 +1,4 @@
-version = "0.1.0"
+version = "0.2.0"
 description = "Retire.js"
 
 zapAddOn {

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
@@ -19,10 +19,15 @@
  */
 package org.zaproxy.addon.retire;
 
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class Result {
-    HashSet<String> info = new HashSet<String>();
+    public static final String INFO = "info";
+    public static final String CVE = "CVE";
+
+    Map<String, Set<String>> info = new HashMap<>();
     String version;
     String filename;
     String evidence;
@@ -31,7 +36,7 @@ public class Result {
     public Result(
             final String filename,
             final String version,
-            final HashSet<String> info,
+            final Map<String, Set<String>> info,
             String evidence) {
         this.filename = filename;
         this.version = version;
@@ -39,7 +44,7 @@ public class Result {
         this.evidence = evidence;
     }
 
-    public HashSet<String> getInfo() {
+    public Map<String, Set<String>> getInfo() {
         return info;
     }
 

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -20,6 +20,8 @@
 package org.zaproxy.addon.retire;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
 import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -79,13 +81,13 @@ public class RetireScanRule extends PluginPassiveScanner {
                                     + ", more info at:"
                                     + result.getInfo());
                 }
-                StringBuilder formattedInfo = new StringBuilder();
-                for (String info : result.getInfo()) {
-                    formattedInfo.append("* " + info + "\n");
-                }
+
+                String otherInfo = getDetails(Result.CVE, result.getInfo());
+
                 if (result.hasOtherInfo()) {
-                    formattedInfo.append(result.getOtherinfo());
+                    otherInfo = otherInfo + result.getOtherinfo();
                 }
+
                 newAlert()
                         .setRisk(Alert.RISK_MEDIUM)
                         .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -94,7 +96,8 @@ public class RetireScanRule extends PluginPassiveScanner {
                                         "retire.rule.desc",
                                         result.getFilename(),
                                         result.getVersion()))
-                        .setOtherInfo(formattedInfo.toString())
+                        .setOtherInfo(otherInfo)
+                        .setReference(getDetails(Result.INFO, result.getInfo()))
                         .setSolution(
                                 Constant.messages.getString(
                                         "retire.rule.soln", result.getFilename()))
@@ -104,6 +107,17 @@ public class RetireScanRule extends PluginPassiveScanner {
                         .raise();
             }
         }
+    }
+
+    private String getDetails(String key, Map<String, Set<String>> info) {
+        if (info.isEmpty() || !info.containsKey(key)) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String item : info.get(key)) {
+            sb.append(item).append('\n');
+        }
+        return sb.toString();
     }
 
     @Override

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.parosproxy.paros.Constant;
@@ -135,7 +136,7 @@ public class Repo {
      */
     private Result scanHash(String hash) {
         // Testable URL: https://ajax.googleapis.com/ajax/libs/dojo/1.1.1/dojo/dojo.js
-        HashSet<String> results = new HashSet<String>();
+        Map<String, Set<String>> results = new HashMap<>();
         for (Map.Entry<String, RepoEntry> repoEntry : entries.entrySet()) {
             Map<String, String> hashes = repoEntry.getValue().getExtractors().getHashes();
 
@@ -165,7 +166,7 @@ public class Repo {
      * FileName OR FileURL OR FileContent
      */
     private Result scan(String extractorType, String input) {
-        HashSet<String> results = new HashSet<String>();
+        Map<String, Set<String>> results = new HashMap<>();
         // reading each entry for JS libraries in repo
         for (Map.Entry<String, RepoEntry> repoEntry : entries.entrySet()) {
             List<String> extractors = repoEntry.getValue().getExtractors().get(extractorType);
@@ -239,11 +240,13 @@ public class Repo {
      * If YES returns the HashSet of vulnerability info.
      * else returns an empty HashSet.
      */
-    private static HashSet<String> isVersionVulnerable(
+    private static Map<String, Set<String>> isVersionVulnerable(
             List<Vulnerability> vulnerabilities, String versionString) {
         // Do a match for each of the above vulnerabilities
-        HashSet<String> results = new HashSet<String>();
+        Map<String, Set<String>> results = new HashMap<>();
         ListIterator<Vulnerability> viterator = vulnerabilities.listIterator();
+        Set<String> cve = new HashSet<>();
+        Set<String> info = new HashSet<>();
 
         while (viterator.hasNext()) {
             boolean isVulnerable = false;
@@ -264,10 +267,10 @@ public class Repo {
                 }
             }
             if (isVulnerable) {
-                List<String> infoList = vnext.getInfo();
-                for (String info : infoList) {
-                    results.add(info);
-                }
+                cve.addAll(vnext.getIdentifiers().getCve());
+                results.put(Result.CVE, cve);
+                info.addAll(vnext.getInfo());
+                results.put(Result.INFO, info);
             }
         }
         return results;

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -53,7 +53,13 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().contentEquals("/1.2.19/angular.min.js"));
+        assertTrue(alertsRaised.get(0).getEvidence().equals("/1.2.19/angular.min.js"));
+        assertTrue(
+                alertsRaised
+                        .get(0)
+                        .getReference()
+                        .equals(
+                                "https://github.com/angular/angular.js/commit/8f31f1ff43b673a24f84422d5c13d6312b2c4d94\n"));
     }
 
     @Test
@@ -65,7 +71,12 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().contentEquals("jquery-3.1.1.min.js"));
+        assertTrue(alertsRaised.get(0).getEvidence().equals("jquery-3.1.1.min.js"));
+        assertTrue(
+                alertsRaised
+                        .get(0)
+                        .getReference()
+                        .equals("https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/\n"));
     }
 
     @Test
@@ -83,6 +94,11 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         // Then
         assertEquals(1, alertsRaised.size());
         assertTrue(alertsRaised.get(0).getEvidence().equals("* Bootstrap v3.3.7"));
+        assertTrue(
+                alertsRaised
+                        .get(0)
+                        .getReference()
+                        .equals("https://github.com/twbs/bootstrap/issues/20184\n"));
     }
 
     @Test
@@ -104,8 +120,16 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
                         .get(0)
                         .getOtherInfo()
                         .equals(
-                                "* http://example.com/hash-test-entry\n"
+                                "CVE-XXXX-XXX2\n"
+                                        + "CVE-XXXX-XXX1\n"
+                                        + "CVE-XXXX-XXX0\n"
                                         + "The library matched the known vulnerable hash e19cea51d7542303f6e8949a0ae27dd3509ea566."));
+        assertTrue(
+                alertsRaised
+                        .get(0)
+                        .getReference()
+                        .equals(
+                                "http://example.com/hash-test-entry\nhttp://example.com/hash-test-entry2\n"));
     }
 
     @Test

--- a/addOns/retire/src/test/resources/org/zaproxy/addon/retire/testrepository.json
+++ b/addOns/retire/src/test/resources/org/zaproxy/addon/retire/testrepository.json
@@ -25,11 +25,21 @@
 				"below" : "0.0.2",
 				"severity" : "low",
 				"identifiers" : {
-					"CVE" : [ "CVE-XXXX-XXXX" ],
+					"CVE" : [ "CVE-XXXX-XXX0", "CVE-XXXX-XXX1" ],
 					"bug" : "4321",
 					"summary" : "bug summary"
 				},
-				"info" : [ "http://example.com/hash-test-entry" ]
+				"info" : [ "http://example.com/hash-test-entry", "http://example.com/hash-test-entry2" ]
+			},
+			{
+				"below" : "0.0.3",
+				"severity" : "low",
+				"identifiers" : {
+					"CVE" : [ "CVE-XXXX-XXX2", "CVE-XXXX-XXX0" ],
+					"bug" : "1234",
+					"summary" : "bug summary"
+				},
+				"info" : [ "http://example.com/hash-test-entry", "http://example.com/hash-test-entry2" ]
 			}
 		],
 		"extractors" : {


### PR DESCRIPTION
- Prepare next dev iteration.
- Repo, Result, RetireScanRule, RetireScanRuleUnitTest: Changes to accommodate new behavior. Per alert (result) CVEs and info/references are collected/used as a Set.
- testrepository.json: Update so that one of the libraries has vulns with overlapping (non-unique) CVE and info (ref) details.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>