### PR TITLE
encoder: Add help content

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Help information.
+
 
 ## [0.1.0] - 2020-05-20
 

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>
+Advanced Encode / Decode / Hash dialog
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Advanced Encode / Decode / Hash dialog</H1>
+
+<p>
+This allows you to encode, decode or hash text.
+
+<H2>Common Fields</H2>
+The dialog has one field that is common to all of the tabs:
+
+<H3>Text to be encoded/decoded/hashed:</H3>
+This field is for the text that you want to be encoded, decoded or hashed.<br/>
+If any text is selected when the dialog is invoked then it will be put in this field.
+The other fields will be updated dynamically if you change the text<br/>
+
+<H2>Toolbar</H2>
+
+<ul>
+  <li><img src="../../ui-tab--plus.png"></src> Add New Tab - Adds a new tab to the dialog.</li>
+  <li><img src="../../ui-tab--delete.png"></src> Remove Selected Tab - Removes the selected (or current) tab from the dialog.</li>
+  <li><img src="../../ui-output--plus.png"></src> Add Output Panel to Current Tab - Adds an output panel to the current tab.</li>
+  <li>Reset - Reset all the tabs/panels to their default state.</li>
+</ul>
+
+<H2>Default Dialog Tabs & Panels</H2>
+In its default state the Encode/Decode/Hash dialog displays tabs and output panels with the following setup:
+
+<H3>Encode tab fields</H3>
+
+<ul>
+  <li>Base 64 Encode</li>
+  <li>Base 64 URL Encode</li>
+  <li>URL Encode</li>
+  <li>ASCII Hex Encode</li>
+  <li>HTML Encode</li>
+  <li>JavaScript Encode</li>
+</ul>
+
+<H3>Decode tab fields</H3>
+
+<ul>
+  <li>Base 64 Decode</li>
+  <li>Base 64 URL Decode</li>
+  <li>URL Decode</li>
+  <li>ASCII Hex Decode</li>
+  <li>HTML Decode</li>
+  <li>JavaScript Decode</li>
+</ul>
+
+<H3>Hash tab fields</H3>
+
+<ul>
+  <li>SHA1 Hash</li>
+  <li>MD5 Hash</li>
+</ul>
+
+<H3>Illegal UTF-8</H3>
+
+<ul>
+  <li>2 byte</li>
+  <li>3 byte</li>
+  <li>4 byte</li>
+</ul>
+
+<H3>Unicode</H3>
+
+<ul>
+  <li>Escaped Text</li>
+  <li>Unescaped Text</li>
+</ul>
+
+<H2>Predefined Encode / Decode / Hash Processors</H2>
+
+<H3>Encoders</H3>
+
+<H4>2 byte Illegal UTF-8</H4>
+Will display with an illegal UTF-8 character sequence with 2 bytes.
+
+<H4>3 byte Illegal UTF-8</H4>
+Will display illegal UTF-8 character sequence with 3 bytes.
+
+<H4>4 byte Illegal UTF-8</H4>
+Will display an illegal UTF-8 character sequence with 4 bytes.
+
+<H4>ASCII Hex Encode</H4>
+Will display the ASCII hex encoding of the text you enter.
+
+<H3>Base 64 Encode</H3>
+Will display the base 64 encoding of the text you enter.<br/>
+
+<H3>Base 64 URL Encode</H3>
+Will display the base 64 URL encoding of the text you enter. Base64URL is a modification to the primary base 64 standard
+the purpose of which is the ability to use the encoding result as filename or URL address. Base64URL is described in 
+<a href="https://tools.ietf.org/html/rfc4648">RFC 4648</a>, which notes that the standard base 64 alphabet includes characters that are invalid for 
+URLs and file names (for example: plus sign and question mark are problematic). 
+The main standard will encode <code>&lt;&lt;???&gt;&gt;</code> to <code>PDw/Pz8+Pg==</code> while Base64URL will convert it to <code>PDw_Pz8-Pg</code>.
+
+<H4>Escaped Unicode Text</H4>
+Will display escaped Unicode characters. For example, the text
+<code>A&ccedil;ores</code> would be encoded as <code>%u0041%u00e7%u006f%u0072%u0065%u0073</code>.
+
+<H4>HTML Encode</H4>
+Will display the HTML encoding of the text you enter. For example, the text
+<code>&quot;pi&ntilde;ata&quot;</code> would be encoded as <code>&amp;quot;pi&amp;ntilde;ata&amp;quot;</code>.
+
+<H4>JavaScript Encode</H4>
+Will display escaped JavaScript literals of the text you enter. For example, the text
+<code>&quot;2&#65504;&quot;</code> would be encoded as <code>\&quot;2\uFFE0\&quot;</code>.
+
+<H4>URL Encode</H4>
+Will display the URL encoding of the text you enter.
+
+<H4>Unescaped Unicode Text</H4>
+Will display the unescaped Unicode characters. For example, the text
+<code>%u0041%u00e7%u006f%u0072%u0065%u0073</code> would be decoded as <code>A&ccedil;ores</code>.
+
+<H3>Decoders</H3>
+
+<H4>ASCII Hex Decode</H4>
+Will display the ASCII hex decoding of the text you enter.<br/>
+If there is no valid decoding then the field will be disabled.
+
+<H4>Base 64 Decode</H4>
+Will display the base 64 decoding of the text you enter.<br/>
+
+<H4>Base 64 URL Decode</H4>
+Will display the base 64 URL decoding of the text you enter. Base64URL is a modification to the primary base 64 standard 
+the purpose of which is the ability to use the encoding result as filename or URL address. Base64URL is described in 
+<a href="https://tools.ietf.org/html/rfc4648">RFC 4648</a>, which notes that the standard base 64 alphabet includes characters that are invalid for 
+URLs and file names (for example: plus sign and question mark are problematic). 
+
+<H4>HTML Decode</H4>
+Will display the HTML decoding of the text you enter. For example, the text
+<code>&amp;quot;pi&amp;ntilde;ata&amp;quot;</code> would be decoded as <code>&quot;pi&ntilde;ata&quot;</code>.
+
+<H4>JavaScript Decode</H4>
+Will display the unescaped JavaScript literals of the text you enter. For example, the text
+<code>\&quot;2\uFFE0\&quot;</code> would be decoded as <code>&quot;2&#65504;&quot;</code>.
+
+<H4>URL Decode</H4>
+Will display the URL decoding of the text you enter.
+
+<H3>Hashers</H3>
+
+<H4>MD5 Hash</H4>
+Will display the MD5 hash of the text you enter.
+
+<H4>SHA1 Hash</H4>
+Will display the SHA1 hash of the text you enter.
+
+<H3>Custom</H3>
+Custom "Encode/Decode" scripts can be created/added to the Scripts Tree and used by custom Output Panels.
+
+<H2>Accessed via</H2>
+<table>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
+Tools menu 'Advanced Encode/Decode/Hash...' item</td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
+Many text areas such as the Output tab, Scripts console, Request and Response panels via 'Advanced Encode/Decode/Hash...' 
+right click menu item</td></tr>
+</table>
+
+</BODY>
+</HTML>

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/helpset.hs
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/helpset.hs
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE helpset
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
+<helpset version="2.0" xml:lang="en-GB">
+  <title>Encode/Decode/Hash Add-on</title>
+
+  <maps>
+     <homeID>encoder</homeID>
+     <mapref location="map.jhm"/>
+  </maps>
+
+  <view>
+    <name>TOC</name>
+    <label>Contents</label>
+    <type>org.zaproxy.zap.extension.help.ZapTocView</type>
+    <data>toc.xml</data>
+  </view>
+
+  <view>
+    <name>Index</name>
+    <label>Index</label>
+    <type>javax.help.IndexView</type>
+    <data>index.xml</data>
+  </view>
+
+  <view>
+    <name>Search</name>
+    <label>Search</label>
+    <type>javax.help.SearchView</type>
+    <data engine="com.sun.java.help.search.DefaultSearchEngine">
+      JavaHelpSearch
+    </data>
+  </view>
+
+  <view>
+    <name>Favorites</name>
+    <label>Favorites</label>
+    <type>javax.help.FavoritesView</type>
+  </view>
+</helpset>

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/index.xml
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/index.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE index
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Index Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/index_2_0.dtd">
+
+<index version="2.0">
+    <!-- index entries are merged (sorted) into core index -->
+	<indexitem text="Encode/Decode/Hash" target="encoder" />
+</index>

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/map.jhm
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/map.jhm
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE map
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Map Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/map_1_0.dtd">
+
+<map version="1.0">
+    <mapID target="encoder" url="contents/encoder.html" />
+</map>

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/toc.xml
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/toc.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE toc
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp TOC Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/toc_2_0.dtd">
+
+<toc version="2.0">
+	<tocitem text="ZAP User Guide" tocid="toplevelitem">
+		<tocitem text="Add Ons" tocid="addons">
+			<tocitem text="Encode/Decode/Hash" target="encoder"/>
+		</tocitem>
+	</tocitem>
+</toc>

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -10,7 +10,7 @@ encoder.dialog.title=Encode/Decode/Hash
 encoder.dialog.addtab=Add New Tab
 encoder.dialog.deletetab=Remove Selected Tab
 encoder.dialog.addoutput=Add New Output Panel to Current Tab
-encoder.dialog.field.input.label=Text to be encoded/decoded/hashed
+encoder.dialog.field.input.label=Text to be encoded/decoded/hashed:
 encoder.dialog.encodedecode.notfound=encoder/decoder/hash... not found, disabled or an error occurred
 
 encoder.scripts.type.encodedecode=Encode/Decode


### PR DESCRIPTION
- Copy and update primary help content from zap-core-help.
- Make one minor UI string change adding a colon at the end of the input text label.

Part of: zaproxy/zaproxy#5996

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>