### PR TITLE
encoder: Remove dependence on core Encoder class

### DIFF
--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64Decoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64Decoder.java
@@ -20,11 +20,13 @@
 package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.io.IOException;
+import java.util.Base64;
 
 public class Base64Decoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws IOException {
-        return getEncoder().getBase64Decode(value);
+        // Converts value to byte[] assuming StandardCharsets.ISO_8859_1
+        return new String(Base64.getDecoder().decode(value));
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64Encoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64Encoder.java
@@ -20,11 +20,13 @@
 package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.io.IOException;
+import java.util.Base64;
 
 public class Base64Encoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws IOException {
-        return getEncoder().getBase64Encode(value);
+        // Returns based on StandardCharsets.ISO_8859_1
+        return Base64.getEncoder().encodeToString(value.getBytes());
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64UrlDecoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64UrlDecoder.java
@@ -20,11 +20,13 @@
 package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.io.IOException;
+import java.util.Base64;
 
 public class Base64UrlDecoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws IOException {
-        return getEncoder().getBase64urlDecode(value);
+        // Converts value to byte[] assuming StandardCharsets.ISO_8859_1
+        return new String(Base64.getUrlDecoder().decode(value));
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64UrlEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Base64UrlEncoder.java
@@ -20,11 +20,13 @@
 package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.io.IOException;
+import java.util.Base64;
 
 public class Base64UrlEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws IOException {
-        return getEncoder().getBase64urlEncode(value);
+        // Returns based on StandardCharsets.ISO_8859_1
+        return Base64.getUrlEncoder().encodeToString(value.getBytes());
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/DefaultEncodeDecodeProcessor.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/DefaultEncodeDecodeProcessor.java
@@ -19,20 +19,10 @@
  */
 package org.zaproxy.addon.encoder.processors.predefined;
 
-import org.parosproxy.paros.extension.encoder.Encoder;
 import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessor;
 import org.zaproxy.addon.encoder.processors.EncodeDecodeResult;
 
 public abstract class DefaultEncodeDecodeProcessor implements EncodeDecodeProcessor {
-
-    private Encoder encoder;
-
-    protected Encoder getEncoder() {
-        if (encoder == null) {
-            encoder = new Encoder();
-        }
-        return encoder;
-    }
 
     @Override
     public EncodeDecodeResult process(String value) {

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HexStringEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HexStringEncoder.java
@@ -23,6 +23,19 @@ public class HexStringEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) {
-        return getEncoder().getHexString(value.getBytes());
+        return getHexString(value.getBytes());
+    }
+
+    protected static String getHexString(byte[] buf) {
+        StringBuilder sb = new StringBuilder(20);
+        for (int i = 0; i < buf.length; i++) {
+            int digit = buf[i] & 0xFF;
+            String hexDigit = Integer.toHexString(digit).toUpperCase();
+            if (hexDigit.length() == 1) {
+                sb.append('0');
+            }
+            sb.append(hexDigit);
+        }
+        return sb.toString();
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HtmlStringEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/HtmlStringEncoder.java
@@ -19,10 +19,12 @@
  */
 package org.zaproxy.addon.encoder.processors.predefined;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 public class HtmlStringEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) {
-        return getEncoder().getHTMLString(value);
+        return StringEscapeUtils.escapeHtml(value);
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/JavaScriptStringEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/JavaScriptStringEncoder.java
@@ -19,10 +19,12 @@
  */
 package org.zaproxy.addon.encoder.processors.predefined;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 public class JavaScriptStringEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) {
-        return getEncoder().getJavaScriptString(value);
+        return StringEscapeUtils.escapeJavaScript(value);
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Md5Hasher.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Md5Hasher.java
@@ -19,13 +19,19 @@
  */
 package org.zaproxy.addon.encoder.processors.predefined;
 
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class Md5Hasher extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws NoSuchAlgorithmException {
-        byte[] hashSHA1 = getEncoder().getHashMD5(value.getBytes());
-        return getEncoder().getHexString(hashSHA1);
+        return HexStringEncoder.getHexString(getHashMD5(value.getBytes()));
+    }
+
+    private byte[] getHashMD5(byte[] buf) throws NoSuchAlgorithmException {
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        md5.update(buf);
+        return md5.digest();
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Sha1Hasher.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Sha1Hasher.java
@@ -19,13 +19,19 @@
  */
 package org.zaproxy.addon.encoder.processors.predefined;
 
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 public class Sha1Hasher extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws NoSuchAlgorithmException {
-        byte[] hashSHA1 = getEncoder().getHashSHA1(value.getBytes());
-        return getEncoder().getHexString(hashSHA1);
+        return HexStringEncoder.getHexString(getHashSHA1(value.getBytes()));
+    }
+
+    private byte[] getHashSHA1(byte[] buf) throws NoSuchAlgorithmException {
+        MessageDigest sha = MessageDigest.getInstance("SHA-1");
+        sha.update(buf);
+        return sha.digest();
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/UrlDecoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/UrlDecoder.java
@@ -20,11 +20,23 @@
 package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 
 public class UrlDecoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws IOException {
-        return getEncoder().getURLDecode(value);
+        return getURLDecode(value);
+    }
+
+    protected String getURLDecode(String msg) {
+        String result = "";
+        try {
+            result = URLDecoder.decode(msg, "UTF8");
+        } catch (UnsupportedEncodingException e) {
+            // Nothing to do
+        }
+        return result;
     }
 }

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/UrlEncoder.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/UrlEncoder.java
@@ -20,11 +20,23 @@
 package org.zaproxy.addon.encoder.processors.predefined;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 public class UrlEncoder extends DefaultEncodeDecodeProcessor {
 
     @Override
     protected String processInternal(String value) throws IOException {
-        return getEncoder().getURLEncode(value);
+        return getURLEncode(value);
+    }
+
+    private String getURLEncode(String msg) {
+        String result = "";
+        try {
+            result = URLEncoder.encode(msg, "UTF8");
+        } catch (UnsupportedEncodingException e) {
+            // Nothing to do
+        }
+        return result;
     }
 }


### PR DESCRIPTION
Use direct or local calls instead of depending on core Encoder class.

Base64 charset/breaklines options still needs to be handled. The plan is to do that in another PR.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>