### PR TITLE
Correct CSP directive name frame-ancestors

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated owasp.org references (Issue 5962).
+- Correct spelling of "frame-ancestors" in the alert details of the CSP scan rule wildcard directive check (Issue 6014).
 
 ## [28] - 2020-04-08
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanner.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanner.java
@@ -307,7 +307,7 @@ public class ContentSecurityPolicyScanner extends PluginPassiveScanner {
             allowedSources.add("frame-src");
         }
         if (pol.allowsFrameAncestor(PARSED_WILDCARD_URI)) {
-            allowedSources.add("frame-ancestor");
+            allowedSources.add("frame-ancestors");
         }
         if (pol.allowsFontFromSource(PARSED_WILDCARD_URI)) {
             allowedSources.add("font-src");


### PR DESCRIPTION
Related to zaproxy/zaproxy#6014

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>