### PR TITLE
Update icons location in wappalyzer GitHub action

### DIFF
--- a/.github/workflows/create_wappalyzer_update.yml
+++ b/.github/workflows/create_wappalyzer_update.yml
@@ -31,9 +31,9 @@ jobs:
         git checkout -b $BRANCH_STAMP
         cd ..
         rm -rf zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/icons
-        chmod -R 664 wappalyzer/src/icons/*.*
-        rm -rf wappalyzer/src/icons/converted/
-        cp -R wappalyzer/src/icons/ zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/icons
+        chmod -R 664 wappalyzer/src/drivers/webextension/images/icons/*.*
+        rm -rf wappalyzer/src/drivers/webextension/images/icons/converted/
+        cp -R wappalyzer/src/drivers/webextension/images/icons/ zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/icons
         cp -f wappalyzer/src/apps.json zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources
         cd zap-extensions
         ./gradlew :addOns:wappalyzer:updateChangelog --change="- Updated with upstream Wappalyzer icon and pattern changes."


### PR DESCRIPTION
Per: https://github.com/AliasIO/wappalyzer/commits/master/src (May 27th commits) the location of icons in the upstream repo has been changed.

https://github.com/AliasIO/wappalyzer/commit/b7f4d81866220b63d6791f85da25f2530d69d196#diff-25d902c24283ab8cfbac54dfa101ad31
And
https://github.com/AliasIO/wappalyzer/commit/eb8284884795992752b7c2514f75d50280cb9eb1#diff-25d902c24283ab8cfbac54dfa101ad31

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>