### PR TITLE
pscanrules (all), ascanrules (all), retire, encoder: prepare releases

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [35] - 2020-06-01
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 - Command Injection, Test Path Traversal, Test Cross Site ScriptV2 and Remote File Include rules are updated to include payloads for Null Byte Injection (Issue 3877).
@@ -207,5 +207,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 
+[35]: https://github.com/zaproxy/zap-extensions/releases/ascanrules-v35
 [34]: https://github.com/zaproxy/zap-extensions/releases/ascanrules-v34
 [33]: https://github.com/zaproxy/zap-extensions/releases/ascanrules-v33

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [28] - 2020-06-01
 ### Added
 - Add repo URL.
 - Add links to the code in the help.
@@ -195,6 +195,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First version, including persistent XSS tests
 
+[28]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesAlpha-v28
 [27]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesAlpha-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesAlpha-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesAlpha-v25

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [28] - 2020-06-01
 ### Added
 - Add info and repo URLs.
 - Add links to the code in the help.
@@ -205,6 +205,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated to support new addon format
 
+[28]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v28
 [27]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v25

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.0] - 2020-06-01
 
 ### Added
 - Help information.
@@ -15,4 +15,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First version.
 
+[0.2.0]: https://github.com/zaproxy/zap-extensions/releases/encoder-v0.2.0
 [0.1.0]: https://github.com/zaproxy/zap-extensions/releases/encoder-v0.1.0

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [29] - 2020-06-01
 ### Changed
 - Updated owasp.org references (Issue 5962).
 - Correct spelling of "frame-ancestors" in the alert details of the CSP scan rule wildcard directive check (Issue 6014).
@@ -188,6 +188,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 
+[29]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v29
 [28]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v28
 [27]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v26

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [27] - 2020-06-01
 ### Added
 - Added links to the code in the help.
 - Add info and repo URLs.
@@ -231,6 +231,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated User Controlled Open Redirect, Cookie and Charset rules after testing with
 - http://www.testcases.org/watcher/ test pages.
 
+[27]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesAlpha-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesAlpha-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesAlpha-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesAlpha-v24

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [22] - 2020-06-01
 ### Added
 - Added links to the code in the help.
 - Add info and repo URLs.
@@ -161,6 +161,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated to support new addon format
 
+[22]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v22
 [21]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v21
 [20]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v20
 [19]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v19

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [0.2.0] - 2020-06-01
 ### Changed
 - URLs which were previously included as 'other info' are now properly included as alert 'references'.
 - CVE numbers are now included as part of 'other info'.
@@ -12,4 +12,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - First release.
 
+[0.2.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.2.0
 [0.1.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.1.0


### PR DESCRIPTION
Update changelog with release date and link to tag.

* ascanrules v35
* ascanrulesBeta v28
* ascanrulesAlpha v28
* encoder v0.2.0
* pscanrules v29
* pascanrulesBeta v22
* pscanrulesAlpha v27
* retire v0.2.0

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>