### PR TITLE
Fix handling of other HTTP message locations when fuzzing

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+ - Correctly handle other HTTP message locations.
+ 
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -53,6 +53,8 @@ import org.zaproxy.zap.extension.search.ExtensionSearch;
 import org.zaproxy.zap.extension.search.HttpSearcher;
 import org.zaproxy.zap.extension.search.SearchResult;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
+import org.zaproxy.zap.model.DefaultTextHttpMessageLocation;
+import org.zaproxy.zap.model.MessageLocation;
 
 public class ExtensionHttpFuzzer extends ExtensionAdaptor {
 
@@ -102,7 +104,14 @@ public class ExtensionHttpFuzzer extends ExtensionAdaptor {
         httpFuzzerHandler = new HttpFuzzerHandler();
 
         MessageLocationReplacers.getInstance()
-                .addReplacer(HttpMessage.class, new TextHttpMessageLocationReplacerFactory());
+                .addReplacer(
+                        HttpMessage.class,
+                        new TextHttpMessageLocationReplacerFactory() {
+                            @Override
+                            public Class<? extends MessageLocation> getTargetMessageLocation() {
+                                return DefaultTextHttpMessageLocation.class;
+                            }
+                        });
     }
 
     @Override

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -53,8 +53,6 @@ import org.zaproxy.zap.extension.search.ExtensionSearch;
 import org.zaproxy.zap.extension.search.HttpSearcher;
 import org.zaproxy.zap.extension.search.SearchResult;
 import org.zaproxy.zap.extension.users.ExtensionUserManagement;
-import org.zaproxy.zap.model.DefaultTextHttpMessageLocation;
-import org.zaproxy.zap.model.MessageLocation;
 
 public class ExtensionHttpFuzzer extends ExtensionAdaptor {
 
@@ -104,14 +102,7 @@ public class ExtensionHttpFuzzer extends ExtensionAdaptor {
         httpFuzzerHandler = new HttpFuzzerHandler();
 
         MessageLocationReplacers.getInstance()
-                .addReplacer(
-                        HttpMessage.class,
-                        new TextHttpMessageLocationReplacerFactory() {
-                            @Override
-                            public Class<? extends MessageLocation> getTargetMessageLocation() {
-                                return DefaultTextHttpMessageLocation.class;
-                            }
-                        });
+                .addReplacer(HttpMessage.class, new TextHttpMessageLocationReplacerFactory());
     }
 
     @Override

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
@@ -40,8 +40,6 @@ import org.zaproxy.zap.extension.fuzz.messagelocations.MultipleMessageLocationsB
 import org.zaproxy.zap.extension.fuzz.messagelocations.MultipleMessageLocationsDepthFirstReplacer;
 import org.zaproxy.zap.extension.fuzz.messagelocations.MultipleMessageLocationsReplacer;
 import org.zaproxy.zap.extension.fuzz.payloads.PayloadGeneratorMessageLocation;
-import org.zaproxy.zap.model.MessageLocation;
-import org.zaproxy.zap.model.TextHttpMessageLocation;
 import org.zaproxy.zap.view.messagecontainer.MessageContainer;
 import org.zaproxy.zap.view.messagecontainer.SelectableContentMessageContainer;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
@@ -136,10 +134,6 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
                 fuzzDialogue.getFuzzerMessageProcessors());
     }
 
-    protected Class<? extends MessageLocation> getMessageLocationClass() {
-        return TextHttpMessageLocation.class;
-    }
-
     @SuppressWarnings("unchecked")
     private HttpFuzzer createFuzzer(
             HttpMessage message,
@@ -152,7 +146,9 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
 
         MessageLocationReplacer<HttpMessage> replacer =
                 MessageLocationReplacers.getInstance()
-                        .getMLR(HttpMessage.class, this.getMessageLocationClass());
+                        .getMLR(
+                                HttpMessage.class,
+                                fuzzLocations.get(0).getMessageLocation().getClass());
 
         replacer.init(message);
 
@@ -181,7 +177,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
                 processors);
     }
 
-    protected String createFuzzerName(HttpMessage message) {
+    private String createFuzzerName(HttpMessage message) {
         String uri = message.getRequestHeader().getURI().toString();
         if (uri.length() > 30) {
             uri = uri.substring(0, 14) + ".." + uri.substring(uri.length() - 15, uri.length());
@@ -244,7 +240,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
     }
 
     @SuppressWarnings("unchecked")
-    protected <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
+    public <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
             void addFuzzerMessageProcessorUIHandler(
                     HttpFuzzerMessageProcessorUIHandler<T1, T2> processorUIHandler) {
         messageProcessors.add(
@@ -252,7 +248,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
                         processorUIHandler);
     }
 
-    protected <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
+    public <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
             void removeFuzzerMessageProcessorUIHandler(
                     HttpFuzzerMessageProcessorUIHandler<T1, T2> processorUIHandler) {
         messageProcessors.remove(processorUIHandler);

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
@@ -240,7 +240,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
     }
 
     @SuppressWarnings("unchecked")
-    public <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
+    protected <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
             void addFuzzerMessageProcessorUIHandler(
                     HttpFuzzerMessageProcessorUIHandler<T1, T2> processorUIHandler) {
         messageProcessors.add(
@@ -248,7 +248,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
                         processorUIHandler);
     }
 
-    public <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
+    protected <T1 extends HttpFuzzerMessageProcessor, T2 extends HttpFuzzerMessageProcessorUI<T1>>
             void removeFuzzerMessageProcessorUIHandler(
                     HttpFuzzerMessageProcessorUIHandler<T1, T2> processorUIHandler) {
         messageProcessors.remove(processorUIHandler);

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
@@ -40,6 +41,7 @@ import org.zaproxy.zap.extension.fuzz.messagelocations.MultipleMessageLocationsB
 import org.zaproxy.zap.extension.fuzz.messagelocations.MultipleMessageLocationsDepthFirstReplacer;
 import org.zaproxy.zap.extension.fuzz.messagelocations.MultipleMessageLocationsReplacer;
 import org.zaproxy.zap.extension.fuzz.payloads.PayloadGeneratorMessageLocation;
+import org.zaproxy.zap.model.MessageLocation;
 import org.zaproxy.zap.model.TextHttpMessageLocation;
 import org.zaproxy.zap.view.messagecontainer.MessageContainer;
 import org.zaproxy.zap.view.messagecontainer.SelectableContentMessageContainer;
@@ -135,6 +137,10 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
                 fuzzDialogue.getFuzzerMessageProcessors());
     }
 
+    protected Class<? extends MessageLocation> getMessageLocationClass() {
+        return TextHttpMessageLocation.class;
+    }
+
     @SuppressWarnings("unchecked")
     private HttpFuzzer createFuzzer(
             HttpMessage message,
@@ -147,7 +153,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
 
         MessageLocationReplacer<HttpMessage> replacer =
                 MessageLocationReplacers.getInstance()
-                        .getMLR(HttpMessage.class, TextHttpMessageLocation.class);
+                        .getMLR(HttpMessage.class, this.getMessageLocationClass());
 
         replacer.init(message);
 
@@ -176,7 +182,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
                 processors);
     }
 
-    private String createFuzzerName(HttpMessage message) {
+    protected String createFuzzerName(HttpMessage message) {
         String uri = message.getRequestHeader().getURI().toString();
         if (uri.length() > 30) {
             uri = uri.substring(0, 14) + ".." + uri.substring(uri.length() - 15, uri.length());

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/messagelocations/MessageLocationReplacers.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/messagelocations/MessageLocationReplacers.java
@@ -76,6 +76,31 @@ public class MessageLocationReplacers {
         }
     }
 
+    private static <T> T getFactory(
+            Map<Class<? extends MessageLocation>, T> factories, Class<?> clazz) {
+        if (!MessageLocation.class.isAssignableFrom(clazz)) {
+            return null;
+        }
+
+        T factory = factories.get(clazz);
+        if (factory != null) {
+            return factory;
+        }
+
+        factory = getFactory(factories, clazz.getSuperclass());
+        if (factory != null) {
+            return factory;
+        }
+
+        for (Class<?> interfaceClazz : clazz.getInterfaces()) {
+            factory = getFactory(factories, interfaceClazz);
+            if (factory != null) {
+                return factory;
+            }
+        }
+        return null;
+    }
+
     public <T extends Message, T1 extends MessageLocation> MessageLocationReplacer<T> getMLR(
             Class<T> messageClass, Class<T1> messageLocationClass) {
 
@@ -84,7 +109,7 @@ public class MessageLocationReplacers {
         if (replacers != null) {
             @SuppressWarnings("unchecked")
             MessageLocationReplacerFactory<T> replacerFactory =
-                    (MessageLocationReplacerFactory<T>) replacers.get(messageLocationClass);
+                    (MessageLocationReplacerFactory<T>) getFactory(replacers, messageLocationClass);
             return replacerFactory.createReplacer();
         }
 


### PR DESCRIPTION
For more information please have a look at PR: https://github.com/SasanLabs/owasp-zap-jwt-addon/pull/6/files?diff=split&w=1#diff-eb7bf36677e406a2ac8688229c232a94R52

Commit with the difference:
https://github.com/SasanLabs/owasp-zap-jwt-addon/pull/6/commits/6448f54108a5262dc799437a514cf7442415ca0f