### PR TITLE
Retire.js GitHub Action Fix

### DIFF
--- a/.github/workflows/create_retirejs_update.yml
+++ b/.github/workflows/create_retirejs_update.yml
@@ -32,7 +32,7 @@ jobs:
         cd ..
         cp -f retire.js/repository/jsrepository.json zap-extensions/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources
         cd zap-extensions
-        ./gradlew :addOns:retirejs:updateChangelog --change="- Updated with upstream retire.js pattern changes."
+        ./gradlew :addOns:retire:updateChangelog --change="- Updated with upstream retire.js pattern changes."
         git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
         git add .
         git commit -m "retire.js Update $SHORT_DATE" -m "Updates based on $SRC_BASE"


### PR DESCRIPTION
Following: https://github.com/zaproxy/zap-extensions/runs/729601355?check_suite_focus=true
The project is "retire" not "retirejs".

Luckily nothing was actually missed, there hasn't been an upstream update since April 12.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>