### PR TITLE
encoder: Add rot13 example script & SHA256 Predefined

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- rot13.js example script.
+- SHA256 predefined processor.
 
 ## [0.2.0] - 2020-06-01
 

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/EncodeDecodeProcessors.java
@@ -43,6 +43,7 @@ import org.zaproxy.addon.encoder.processors.predefined.JavaScriptStringDecoder;
 import org.zaproxy.addon.encoder.processors.predefined.JavaScriptStringEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.Md5Hasher;
 import org.zaproxy.addon.encoder.processors.predefined.Sha1Hasher;
+import org.zaproxy.addon.encoder.processors.predefined.Sha256Hasher;
 import org.zaproxy.addon.encoder.processors.predefined.UnicodeDecoder;
 import org.zaproxy.addon.encoder.processors.predefined.UnicodeEncoder;
 import org.zaproxy.addon.encoder.processors.predefined.UrlDecoder;
@@ -79,6 +80,7 @@ public class EncodeDecodeProcessors {
 
         addPredefined("md5hash", new Md5Hasher());
         addPredefined("sha1hash", new Sha1Hasher());
+        addPredefined("sha256hash", new Sha256Hasher());
 
         addPredefined("illegalutf8with2byteencoder", new IllegalUTF8With2ByteEncoder());
         addPredefined("illegalutf8with3byteencoder", new IllegalUTF8With3ByteEncoder());

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Sha256Hasher.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/processors/predefined/Sha256Hasher.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.encoder.processors.predefined;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class Sha256Hasher extends DefaultEncodeDecodeProcessor {
+
+    @Override
+    protected String processInternal(String value) throws NoSuchAlgorithmException {
+        return HexStringEncoder.getHexString(getHashSHA256(value.getBytes()));
+    }
+
+    private byte[] getHashSHA256(byte[] buf) throws NoSuchAlgorithmException {
+        MessageDigest sha = MessageDigest.getInstance("SHA-256");
+        sha.update(buf);
+        return sha.digest();
+    }
+}

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -57,6 +57,7 @@ In its default state the Encode/Decode/Hash dialog displays tabs and output pane
 <H3>Hash tab fields</H3>
 
 <ul>
+  <li>SHA256 Hash</li>
   <li>SHA1 Hash</li>
   <li>MD5 Hash</li>
 </ul>
@@ -154,6 +155,9 @@ Will display the MD5 hash of the text you enter.
 
 <H4>SHA1 Hash</H4>
 Will display the SHA1 hash of the text you enter.
+
+<H4>SHA256 Hash</H4>
+Will display the SHA256 hash of the text you enter.
 
 <H3>Custom</H3>
 Custom "Encode/Decode" scripts can be created/added to the Scripts Tree and used by custom Output Panels.

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -52,6 +52,7 @@ encoder.predefined.urldecode=URL Decode
 encoder.predefined.urlencode=URL Encode
 encoder.predefined.md5hash=MD5 Hash
 encoder.predefined.sha1hash=SHA1 Hash
+encoder.predefined.sha256hash=SHA256 Hash
 encoder.predefined.illegalutf8with2byteencoder=2 Byte Illegal UTF8
 encoder.predefined.illegalutf8with3byteencoder=3 Byte Illegal UTF8
 encoder.predefined.illegalutf8with4byteencoder=4 Byte Illegal UTF8

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/encoder-default.xml
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/encoder-default.xml
@@ -63,6 +63,10 @@
             <outputpanels>
                 <outputpanel>
                     <name/>
+                    <processorId>encoder.predefined.sha256hash</processorId>
+                </outputpanel>
+                <outputpanel>
+                    <name/>
                     <processorId>encoder.predefined.sha1hash</processorId>
                 </outputpanel>
                 <outputpanel>

--- a/addOns/encoder/src/main/zapHomeFiles/scripts/templates/encode-decode/rot13.js
+++ b/addOns/encoder/src/main/zapHomeFiles/scripts/templates/encode-decode/rot13.js
@@ -1,0 +1,27 @@
+// This ROT13 example only handles upper and lower case A to Z (no numbers, punctuation, or extended chars)
+var EncodeDecodeResult = Java.type("org.zaproxy.addon.encoder.processors.EncodeDecodeResult");
+
+function process(value){
+  return new EncodeDecodeResult(rot13(value));
+}
+
+function rot(chr, start, val) {
+  return String.fromCharCode(((chr-start+val)%(val*2))+start);
+}
+
+function rot13(inStr) {
+  var outArray = [], chr, idx = inStr.length,
+  a = 'a'.charCodeAt(), z = a + 26,
+  A = 'A'.charCodeAt(), Z = A + 26;
+  while(idx--) {
+    chr = inStr.charCodeAt(idx);
+    if (chr>=a && chr<z) { 
+      outArray[idx] = rot(chr, a, 13); 
+    } else if (chr>=A && chr<Z) { 
+      outArray[idx] = rot(chr, A, 13);
+    } else { 
+      outArray[idx] = inStr.charAt(idx); 
+    }
+  }
+  return outArray.join('');
+}


### PR DESCRIPTION
- Added a ROT13 example script.
- Added a SHA256 predefined processor.

Part of: zaproxy/zaproxy#5996

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>