### PR TITLE
wappalyzer: Persist enable state

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
+- Wappalyzer's enabled state is now persisted between ZAP sessions.
 
 ### Fixed
 - Fixed the Evidence context menu now functions properly again.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -70,6 +70,8 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     private ExtensionSearch extSearch = null;
 
     private Map<String, TechTableModel> siteTechMap = new HashMap<String, TechTableModel>();
+    private boolean enabled;
+    private WappalyzerParam wappalyzerParam;
 
     private static final Logger logger = Logger.getLogger(ExtensionWappalyzer.class);
 
@@ -107,6 +109,8 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     @Override
     public void init() {
         super.init();
+        enabled = true;
+        wappalyzerParam = new WappalyzerParam();
         passiveScanner = new WappalyzerPassiveScanner(this);
     }
 
@@ -130,12 +134,38 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
 
         this.api = new WappalyzerAPI(this);
         extensionHook.addApiImplementor(this.api);
+        extensionHook.addOptionsParamSet(wappalyzerParam);
 
         ExtensionPassiveScan extPScan =
                 Control.getSingleton()
                         .getExtensionLoader()
                         .getExtension(ExtensionPassiveScan.class);
         extPScan.addPassiveScanner(passiveScanner);
+    }
+
+    @Override
+    public void optionsLoaded() {
+        super.optionsLoaded();
+
+        setWappalyzer(wappalyzerParam.isEnabled());
+    }
+
+    void setWappalyzer(boolean enabled) {
+        if (this.enabled == enabled) {
+            return;
+        }
+        this.enabled = enabled;
+
+        wappalyzerParam.setEnabled(enabled);
+        getPassiveScanner().setEnabled(enabled);
+
+        if (View.isInitialised()) {
+            getTechPanel().getEnableToggleButton().setSelected(enabled);
+        }
+    }
+
+    boolean isWappalyzerEnabled() {
+        return enabled;
     }
 
     private TechPanel getTechPanel() {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -112,6 +112,7 @@ public class TechPanel extends AbstractPanel {
                         false));
         this.setMnemonic(Constant.messages.getChar("wappalyzer.panel.mnemonic"));
         this.add(getPanelCommand(), getPanelCommand().getName());
+        this.getEnableToggleButton().setSelected(extension.isWappalyzerEnabled());
     }
 
     /**
@@ -315,7 +316,7 @@ public class TechPanel extends AbstractPanel {
         return exportButton;
     }
 
-    private ZapToggleButton getEnableToggleButton() {
+    ZapToggleButton getEnableToggleButton() {
         if (enableButton == null) {
             enableButton =
                     new ZapToggleButton(
@@ -339,12 +340,12 @@ public class TechPanel extends AbstractPanel {
                             enableButton.setText(
                                     Constant.messages.getString(
                                             "wappalyzer.toolbar.toggle.state.enabled"));
-                            extension.getPassiveScanner().setEnabled(true);
+                            extension.setWappalyzer(true);
                         } else {
                             enableButton.setText(
                                     Constant.messages.getString(
                                             "wappalyzer.toolbar.toggle.state.disabled"));
-                            extension.getPassiveScanner().setEnabled(false);
+                            extension.setWappalyzer(false);
                         }
                     });
         }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerParam.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerParam.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.wappalyzer;
+
+import org.zaproxy.zap.common.VersionedAbstractParam;
+
+public class WappalyzerParam extends VersionedAbstractParam {
+
+    /**
+     * The version of the configurations. Used to keep track of configurations changes between
+     * releases, if updates are needed.
+     *
+     * <p>It only needs to be updated for configurations changes (not releases of the add-on).
+     */
+    private static final int PARAM_CURRENT_VERSION = 1;
+    /** The base configuration key for all "wappalyzer" configurations. */
+    private static final String PARAM_BASE_KEY = "wappalyzer";
+    /** The configuration key for the state of wappalyzer functionality. */
+    private static final String PARAM_WAPPALYZER_STATE = PARAM_BASE_KEY + ".enabled";
+
+    private static final boolean PARAM_WAPPALYZER_STATE_DEFAULT_VALUE = true;
+
+    private boolean enabled;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        if (this.enabled != enabled) {
+            this.enabled = enabled;
+
+            getConfig().setProperty(PARAM_WAPPALYZER_STATE, Boolean.valueOf(enabled));
+        }
+    }
+
+    @Override
+    protected void parseImpl() {
+        enabled = getBoolean(PARAM_WAPPALYZER_STATE, PARAM_WAPPALYZER_STATE_DEFAULT_VALUE);
+    }
+
+    @Override
+    protected String getConfigVersionKey() {
+        return PARAM_BASE_KEY + VERSION_ATTRIBUTE;
+    }
+
+    @Override
+    protected int getCurrentVersion() {
+        return PARAM_CURRENT_VERSION;
+    }
+
+    @Override
+    protected void updateConfigsImpl(int fileVersion) {
+        // Nothing to do.
+    }
+}

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -23,6 +23,9 @@ the menu will not be displayed.
 Beside the site selection drop down is an Export button which can be used to export a CSV (comma separated values) file based on the
 table information currently being displayed. There is also a toggle button which allows users to easily Enable/Disable the Wappalyzer
 passive scanner.
+<p>
+The toolbar includes an enable/disable toggle button which controls whether the technology detection passive scan rule is functioning or not. 
+This enabled state is persisted between ZAP sessions.
 
 <H2>External Links</H2>
 <table>


### PR DESCRIPTION
* ExtensionWappalyzer - Add necessary variables and functionality to handle enable state.
* TechPanel - The enable toggle is associate with the param (enable state).
* WappalyzerParam - New class extending AbstractParam to handle the enable state.
* wappalyzer.html - Updated help content to contain a short bit about the toggle button and persistence.
* CHANGELOG - Added change entry.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>