### PR TITLE
Add Import Functionality for GraphQL Schemas

### DIFF
--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -14,3 +14,16 @@ zapAddOn {
         messages.set(file("src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties"))
     }
 }
+
+dependencies {
+    compileOnly("org.zaproxy:zap:2.10.0-SNAPSHOT")
+
+    implementation("com.google.code.gson:gson:2.8.6")
+    implementation("com.graphql-java:graphql-java:15.0")
+}
+
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParseFilter.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParseFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import static org.zaproxy.zap.spider.filters.ParseFilter.FilterResult;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.spider.filters.ParseFilter;
+
+public class GraphQlParseFilter extends ParseFilter {
+
+    @Override
+    public FilterResult filtered(HttpMessage message) {
+        if (MessageValidator.validate(message) != MessageValidator.Result.INVALID) {
+            return FilterResult.WANTED;
+        }
+        return FilterResult.NOT_FILTERED;
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -19,49 +19,119 @@
  */
 package org.zaproxy.addon.graphql;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import graphql.introspection.IntrospectionQuery;
+import graphql.introspection.IntrospectionResultToSchema;
+import graphql.language.Document;
+import graphql.schema.idl.SchemaPrinter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
-import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.extension.history.ExtensionHistory;
-import org.parosproxy.paros.model.HistoryReference;
-import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpSender;
-import org.zaproxy.zap.utils.ThreadUtils;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.network.HttpRequestBody;
 
 public class GraphQlParser {
 
     private static final Logger LOG = Logger.getLogger(GraphQlParser.class);
+    private static final String THREAD_PREFIX = "ZAP-GraphQL-Parser";
+    private static AtomicInteger threadId = new AtomicInteger();
 
-    public static void parse(URI uri) {
-        HttpMessage msg;
-        try {
-            msg = new HttpMessage(uri);
-            HttpSender sender =
-                    new HttpSender(
-                            Model.getSingleton().getOptionsParam().getConnectionParam(),
-                            true,
-                            HttpSender.MANUAL_REQUEST_INITIATOR);
-            sender.sendAndReceive(msg, true);
-        } catch (Exception e) {
-            LOG.error("Unable to send request.", e);
-            return;
-        }
+    private final URI endpointUrl;
+    private final Requestor requestor;
 
-        // Add the message to the history panel and sites tree
-        ExtensionHistory extHistory =
-                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+    public GraphQlParser(String endpointUrlStr, int initiator) throws URIException {
+        this(UrlBuilder.build(endpointUrlStr), initiator);
+    }
+
+    public GraphQlParser(URI endpointUrl, int initiator) {
+        this.endpointUrl = endpointUrl;
+        requestor = new Requestor(initiator);
+    }
+
+    public void introspect() throws IOException {
+        JsonObject msgBodyJson = new JsonObject();
+        msgBodyJson.addProperty("query", IntrospectionQuery.INTROSPECTION_QUERY);
+        HttpRequestBody msgBody = new HttpRequestBody(msgBodyJson.toString());
+
+        HttpRequestHeader msgHeader =
+                new HttpRequestHeader(HttpRequestHeader.POST, endpointUrl, "HTTP/1.1");
+        msgHeader.setHeader("Accept", "application/json");
+        msgHeader.setHeader("Content-Type", "application/json");
+        msgHeader.setContentLength(msgBody.length());
+
+        HttpMessage importMessage = new HttpMessage(msgHeader, msgBody);
+        requestor.send(importMessage);
+
         try {
-            ThreadUtils.invokeAndWait(
-                    () -> {
-                        extHistory.addHistory(msg, HistoryReference.TYPE_ZAP_USER);
-                        Model.getSingleton()
-                                .getSession()
-                                .getSiteTree()
-                                .addPath(msg.getHistoryRef(), msg);
-                    });
-        } catch (Exception e) {
-            LOG.error("Could not add message to sites tree.", e);
+            Map<String, Object> result =
+                    new Gson()
+                            .fromJson(
+                                    importMessage.getResponseBody().toString(),
+                                    new TypeToken<Map<String, Object>>() {}.getType());
+            @SuppressWarnings("unchecked")
+            Document schema =
+                    new IntrospectionResultToSchema()
+                            .createSchemaDefinition((Map<String, Object>) result.get("data"));
+            String schemaSdl = new SchemaPrinter().print(schema);
+            parse(schemaSdl);
+        } catch (JsonSyntaxException e) {
+            throw new IOException("The response was not valid JSON.");
         }
+    }
+
+    public void importUrl(String schemaUrlStr) throws IOException {
+        importUrl(UrlBuilder.build(schemaUrlStr));
+    }
+
+    public void importUrl(URI schemaUrl) throws IOException {
+        HttpMessage importMessage = new HttpMessage(schemaUrl);
+        if (MessageValidator.validate(importMessage) == MessageValidator.Result.VALID_SCHEMA) {
+            requestor.send(importMessage);
+            parse(importMessage.getResponseBody().toString());
+        } else {
+            throw new IOException("Invalid Schema at " + schemaUrl);
+        }
+    }
+
+    public void importFile(String filePath) throws IOException {
+        File file = new File(filePath);
+        if (!file.exists()) {
+            throw new FileNotFoundException(
+                    Constant.messages.getString("graphql.error.filenotfound"));
+        }
+        if (!file.canRead() || !file.isFile()) {
+            throw new IOException(Constant.messages.getString("graphql.error.importfile"));
+        }
+        String schemaSdl = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+        parse(schemaSdl);
+    }
+
+    public void parse(String schema) {
+        Thread t =
+                new Thread(THREAD_PREFIX + threadId.incrementAndGet()) {
+                    @Override
+                    public void run() {
+                        LOG.error("endpointUrl: " + endpointUrl.toString());
+                        LOG.error("schema: " + schema);
+                        LOG.error("Import was successful.");
+                    }
+                };
+        t.start();
+    }
+
+    public void addRequesterListener(RequesterListener listener) {
+        requestor.addListener(listener);
     }
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlSpider.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlSpider.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import net.htmlparser.jericho.Source;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.spider.parser.SpiderParser;
+
+public class GraphQlSpider extends SpiderParser {
+
+    private static final Logger LOG = Logger.getLogger(GraphQlSpider.class);
+
+    @Override
+    public boolean parseResource(HttpMessage message, Source source, int depth) {
+        try {
+            GraphQlParser parser =
+                    new GraphQlParser(
+                            message.getRequestHeader().getURI(), HttpSender.SPIDER_INITIATOR);
+            parser.addRequesterListener(new HistoryPersister());
+            parser.introspect();
+        } catch (Exception e) {
+            LOG.debug(e.getMessage(), e);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
+        String uri = message.getRequestHeader().getURI().toString();
+        switch (MessageValidator.validate(message)) {
+            case VALID_ENDPOINT:
+                LOG.debug("Found GraphQl endpoint at: " + uri);
+                return true;
+            case VALID_SCHEMA:
+                LOG.debug("Found GraphQL schema at: " + uri);
+                break;
+        }
+        return false;
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/HistoryPersister.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/HistoryPersister.java
@@ -1,0 +1,69 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.utils.ThreadUtils;
+
+public class HistoryPersister implements RequesterListener {
+
+    private static final Logger LOG = Logger.getLogger(ExtensionGraphQl.class);
+
+    @Override
+    public void handleMessage(final HttpMessage message, int initiator) {
+        // Add the message to the history panel and sites tree
+        final HistoryReference historyRef;
+
+        try {
+            historyRef =
+                    new HistoryReference(
+                            Model.getSingleton().getSession(),
+                            initiator == HttpSender.SPIDER_INITIATOR
+                                    ? HistoryReference.TYPE_SPIDER
+                                    : HistoryReference.TYPE_ZAP_USER,
+                            message);
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            return;
+        }
+
+        final ExtensionHistory extHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+        try {
+            ThreadUtils.invokeAndWait(
+                    () -> {
+                        extHistory.addHistory(historyRef);
+                        Model.getSingleton()
+                                .getSession()
+                                .getSiteTree()
+                                .addPath(historyRef, message);
+                    });
+        } catch (Exception e) {
+            LOG.error("Could not add message to sites tree.", e);
+            return;
+        }
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportFromFileDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportFromFileDialog.java
@@ -35,18 +35,17 @@ public class ImportFromFileDialog extends ImportFromAbstractDialog {
 
     private JButton buttonChooseFile;
 
-    public ImportFromFileDialog(JFrame parent, ExtensionGraphQl caller) {
+    public ImportFromFileDialog(JFrame parent) {
         super(
                 parent,
-                caller,
                 Constant.messages.getString(MESSAGE_PREFIX + "title"),
                 Constant.messages.getString(MESSAGE_PREFIX + "labelfile"));
     }
 
     @Override
-    protected void addFromFields(GridBagConstraints constraints) {
+    protected void addSchemaFields(GridBagConstraints constraints) {
         constraints.gridwidth = 2;
-        super.addFromFields(constraints);
+        super.addSchemaFields(constraints);
 
         constraints.gridx = 3;
         constraints.gridwidth = 1;
@@ -66,14 +65,14 @@ public class ImportFromFileDialog extends ImportFromAbstractDialog {
                         int state = filechooser.showOpenDialog(View.getSingleton().getMainFrame());
                         if (state == JFileChooser.APPROVE_OPTION) {
                             try {
-                                getFromField()
+                                getSchemaField()
                                         .setText(filechooser.getSelectedFile().getCanonicalPath());
                                 Model.getSingleton()
                                         .getOptionsParam()
                                         .setUserDirectory(filechooser.getCurrentDirectory());
-                            } catch (IOException ex) {
+                            } catch (IOException e1) {
                                 showWarningDialog(
-                                        Constant.messages.getString(MESSAGE_PREFIX + "badfile"));
+                                        Constant.messages.getString("graphql.error.filenotfound"));
                             }
                         }
                     });
@@ -83,11 +82,12 @@ public class ImportFromFileDialog extends ImportFromAbstractDialog {
 
     @Override
     protected boolean importDefinition() {
-        /* TO DO:
-         * Import schema definition from file path; and
-         * Send it to the parser.
-         */
-        showWarningDialog(Constant.messages.getString("graphql.importfromdialog.message"));
+        try {
+            getParser().importFile(getSchemaField().getText());
+            return true;
+        } catch (IOException e) {
+            showWarningDialog(e.getMessage());
+        }
         return false;
     }
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportFromUrlDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportFromUrlDialog.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.graphql;
 
+import java.io.IOException;
 import javax.swing.JFrame;
 import org.parosproxy.paros.Constant;
 
@@ -27,26 +28,25 @@ public class ImportFromUrlDialog extends ImportFromAbstractDialog {
     private static final long serialVersionUID = 1L;
     private static final String MESSAGE_PREFIX = "graphql.importfromurldialog.";
 
-    public ImportFromUrlDialog(JFrame parent, ExtensionGraphQl caller) {
+    public ImportFromUrlDialog(JFrame parent) {
         super(
                 parent,
-                caller,
                 Constant.messages.getString(MESSAGE_PREFIX + "title"),
                 Constant.messages.getString(MESSAGE_PREFIX + "labelurl"));
     }
 
     @Override
     protected boolean importDefinition() {
-        if (!getFromField().getText().isEmpty()) {
-            if (validateUrl(getFromField())) {
-                /* TO DO:
-                 * Import schema definition from provided url; and
-                 * Send it to the parser.
-                 */
-                showWarningDialog(Constant.messages.getString("graphql.importfromdialog.message"));
-            }
-            return false;
-        } else GraphQlParser.parse(getEndpointUri());
-        return true;
+        try {
+            if (getSchemaField().getText().isEmpty()) {
+                getParser().introspect();
+            } else getParser().importUrl(getSchemaField().getText());
+            return true;
+        } catch (IOException e) {
+            showWarningDialog(
+                    Constant.messages.getString("graphql.error.invalidurl", e.getMessage()));
+            getSchemaField().requestFocusInWindow();
+        }
+        return false;
     }
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/MessageValidator.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/MessageValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import java.util.Locale;
+import org.apache.commons.lang.StringUtils;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+public final class MessageValidator {
+
+    protected enum Result {
+        INVALID,
+        VALID_SCHEMA,
+        VALID_ENDPOINT
+    };
+
+    private MessageValidator() {}
+
+    protected static Result validate(HttpMessage message) {
+        String uri = message.getRequestHeader().getURI().toString();
+        String contentType =
+                message.getResponseHeader()
+                        .getHeader(HttpHeader.CONTENT_TYPE)
+                        .toLowerCase(Locale.ROOT);
+
+        if (uri.endsWith(".graphql")
+                || uri.endsWith(".graphqls")
+                || contentType.startsWith("application/graphql")) {
+            return Result.VALID_SCHEMA;
+        }
+
+        String responseBodyStart =
+                StringUtils.left(message.getResponseBody().toString(), 250)
+                        .toLowerCase(Locale.ROOT);
+        if (responseBodyStart.contains("__schema") || responseBodyStart.contains("graphql")) {
+            return Result.VALID_ENDPOINT;
+        }
+
+        return Result.INVALID;
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/RequesterListener.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/RequesterListener.java
@@ -1,0 +1,27 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import org.parosproxy.paros.network.HttpMessage;
+
+public interface RequesterListener {
+
+    void handleMessage(HttpMessage message, int initiator);
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/Requestor.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/Requestor.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.httpclient.URI;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.network.HttpRedirectionValidator;
+import org.zaproxy.zap.network.HttpRequestConfig;
+
+public class Requestor {
+
+    private final int initiator;
+    private List<RequesterListener> listeners = new ArrayList<RequesterListener>();
+    private HttpSender sender;
+    private final HttpRequestConfig requestConfig;
+    private static final Logger LOG = Logger.getLogger(Requestor.class);
+
+    public Requestor(int initiator) {
+        this.initiator = initiator;
+        sender =
+                new HttpSender(
+                        Model.getSingleton().getOptionsParam().getConnectionParam(),
+                        true,
+                        initiator);
+        requestConfig =
+                HttpRequestConfig.builder().setRedirectionValidator(new MessageHandler()).build();
+    }
+
+    public void send(HttpMessage message) {
+        try {
+            sender.sendAndReceive(message, requestConfig);
+        } catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    public void addListener(RequesterListener listener) {
+        this.listeners.add(listener);
+    }
+
+    public void removeListener(RequesterListener listener) {
+        this.listeners.remove(listener);
+    }
+
+    /** Notifies the {@link #listeners} of the messages sent. */
+    private class MessageHandler implements HttpRedirectionValidator {
+
+        @Override
+        public void notifyMessageReceived(HttpMessage message) {
+            for (RequesterListener listener : listeners) {
+                try {
+                    listener.handleMessage(message, initiator);
+                } catch (Exception e) {
+                    LOG.error(e.getMessage(), e);
+                }
+            }
+        }
+
+        @Override
+        public boolean isValid(URI redirection) {
+            return true;
+        }
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/UrlBuilder.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/UrlBuilder.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+
+public final class UrlBuilder {
+
+    private UrlBuilder() {}
+
+    public static URI build(String urlStr) throws URIException {
+        if (urlStr.isEmpty()) {
+            throw new URIException("URL cannot be empty.");
+        } else if ("http://".equals(urlStr) || "https://".equals(urlStr)) {
+            throw new URIException("URL is incomplete.");
+        }
+        try {
+            new URL(urlStr);
+            return new URI(urlStr, true);
+        } catch (MalformedURLException | URIException e) {
+            throw new URIException(e.getMessage());
+        }
+    }
+}

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/graphql.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/graphql.html
@@ -10,25 +10,26 @@ GraphQL Support
 <H1>GraphQL Support</H1>
 This add-on allows you to import GraphQL definitions.
 <br><br>
-The add-on will automatically detect any GraphQL definitions and spider them as long as they are in scope.
+The add-on will automatically detect any GraphQL definitions and spider them as long as they are in scope. <br>
+The spider is supported on ZAP 2.10.0 and later.
 
 <H2>UI</H2>
 2 menu items are added to the Import menu:
 <ul>
-<li>Import a GraphQL schema from the local file system</li>
+<li>Import a GraphQL schema from a File</li>
 <li>Import a GraphQL schema from a URL</li>
 </ul>
 
 <h3>Endpoint URL Format</h3>
 The Endpoint URL has the following format:<br>
 <code>scheme://authority/path</code><br>
-with all URI components mandatory when not importing from URL.
+with all URI components mandatory when importing from file.
 
 <H2>API</H2>
 The following operations are added to the API:
 <ul>
-<li>ACTION importFile (file, endurl)</li>
-<li>ACTION importUrl (url)</li>
+<li>ACTION importFile (endurl*, file*)</li>
+<li>ACTION importUrl (endurl*, url)</li>
 </ul>
 <code>endurl</code> supports the <code>Endpoint URL</code> format explained earlier.
 
@@ -37,9 +38,9 @@ The definitions will be imported synchronously and any warnings will be returned
 <H2>Command Line</H2>
 The following Command Line options are added:
 <ul>
-<li>-graphqlfile &lt;filename&gt;  : Imports a GraphQL definition from the specified file name</li>
-<li>-graphqlurl &lt;url&gt;  : Imports a GraphQL definition from the specified URL</li>
-<li>-graphqlendurl &lt;url&gt;  : The Endpoint URL</li>
+<li>-graphqlfile &lt;filename&gt;  : Imports a GraphQL definition from a File</li>
+<li>-graphqlurl &lt;url&gt;  : Imports a GraphQL definition from a URL</li>
+<li>-graphqlendurl &lt;url&gt;  : Sets the Endpoint URL</li>
 </ul>
 
 The definitions will be imported synchronously and any warnings will be displayed on the command line.

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -3,12 +3,13 @@
 graphql.api.action.importFile = Imports a GraphQL Schema from a File.
 graphql.api.action.importFile.param.file = The File That Contains the GraphQL Schema.
 graphql.api.action.importFile.param.endurl = The Endpoint URL.
-graphql.api.action.importUrl = Retrieves a GraphQL Schema from a URL.
+graphql.api.action.importUrl = Imports a GraphQL Schema from a URL.
 graphql.api.action.importUrl.param.url = The URL Locating the GraphQL Schema.
+graphql.api.action.importUrl.param.endurl = The Endpoint URL.
 
-graphql.cmdline.file.help = Imports a GraphQL Schema from the Specified File Name.
-graphql.cmdline.url.help = Retrieves a GraphQL Schema from the Specified URL.
-graphql.cmdline.endurl.help = The Endpoint URL. Refer to the help for supported format.
+graphql.cmdline.file.help = Imports a GraphQL Schema from a File
+graphql.cmdline.url.help = Imports a GraphQL Schema from a URL
+graphql.cmdline.endurl.help = Sets the Endpoint URL
 
 graphql.desc = Allows you to inspect and attack GraphQL endpoints.
 graphql.topmenu.import.importgraphql = Import a GraphQL Schema from a File
@@ -18,8 +19,6 @@ graphql.topmenu.import.importremotegraphql.tooltip = The URL that locates a Grap
 
 graphql.importfromdialog.message = TO DO: Import and Parse Schema
 graphql.importfromdialog.importbutton = Import
-graphql.importfromdialog.url.invalid = Please enter a valid URL.\n{0}\n{1} 
-graphql.importfromdialog.url.empty = Endpoint URL cannot be empty.
 graphql.importfromdialog.pasteaction = Paste
 graphql.importfromdialog.labelendpoint = Endpoint URL
 
@@ -28,5 +27,9 @@ graphql.importfromurldialog.labelurl = Schema URL (Optional)
 
 graphql.importfromfiledialog.title = Import a GraphQL Schema from a File
 graphql.importfromfiledialog.labelfile = Schema File
-graphql.importfromfiledialog.badfile = Cannot find the specified file.
 graphql.importfromfiledialog.choosefilebutton = Choose File
+
+graphql.error.importfile = An error occurred while importing from file.
+graphql.error.filenotfound = Cannot find the specified file.
+graphql.error.emptyendurl = Endpoint URL must be specified.
+graphql.error.invalidurl = Please enter a valid URL.\n{0}


### PR DESCRIPTION
- Add import functionality to the UI, API, and the CLI.
- Schema in SDL can now be imported.
- Import via Introspection also works.
- Rename fieldFrom to fieldSchema for clarity.
- Add Spider Checks

Signed-off-by: ricekot <ricekot@gmail.com>