### PR TITLE
Bugfix for groovy.lang.MissingMethodException

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
  - Correctly handle other HTTP message locations.
+ - Fixed error when missing getRequiredParamsNames and getOptionalParamsNames
  
 ### Changed
 - Update minimum ZAP version to 2.9.0.

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/FuzzerHttpMessageScriptProcessorAdapter.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/FuzzerHttpMessageScriptProcessorAdapter.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.fuzz.httpfuzzer.processors;
 
 import java.util.Collections;
 import java.util.Map;
-import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.fuzz.httpfuzzer.HttpFuzzResult;
@@ -125,22 +124,11 @@ public class FuzzerHttpMessageScriptProcessorAdapter implements HttpFuzzerMessag
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
         if (extensionScript != null) {
             try {
-                scriptProcessor =
-                        extensionScript.getInterface(
-                                scriptWrapper, HttpFuzzerProcessorScript.class);
-                if (scriptProcessor != null) {
-                    validateRequiredParameters();
-                } else {
-                    extensionScript.handleFailedScriptInterface(
-                            scriptWrapper,
-                            Constant.messages.getString(
-                                    "fuzz.httpfuzzer.processor.scriptProcessor.warnNoInterface.message",
-                                    scriptWrapper.getName()));
-                }
+                scriptProcessor = HttpFuzzerProcessorScriptProxy.create(scriptWrapper);
             } catch (Exception e) {
-                handleScriptException(e);
                 throw new ProcessingException("Failed to instantiate the script processor:", e);
             }
+            validateRequiredParameters();
         }
     }
 

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix links in script templates.
+- Fix missing parameter functions in template
 
 ## 2 - 2018-04-19
 

--- a/addOns/groovy/src/main/zapHomeFiles/scripts/templates/httpfuzzerprocessor/FuzzerHttpProcessorDefaultTemplate.groovy
+++ b/addOns/groovy/src/main/zapHomeFiles/scripts/templates/httpfuzzerprocessor/FuzzerHttpProcessorDefaultTemplate.groovy
@@ -62,3 +62,20 @@ boolean processResult(HttpFuzzerTaskProcessorUtils utils, HttpFuzzResult fuzzRes
     return true
 }
 
+/**
+ * This function is called during the script loading to obtain a list of the names of the required configuration parameters,
+ * that will be shown in the Add Message Processor Dialog for configuration. They can be used
+ * to input dynamic data into the script, from the user interface
+*/
+String[] getRequiredParamsNames(){
+	return [];
+}
+
+/**
+ * This function is called during the script loading to obtain a list of the names of the optional configuration parameters,
+ * that will be shown in the Add Message Processor Dialog for configuration. They can be used
+ * to input dynamic data into the script, from the user interface
+*/
+String[] getOptionalParamsNames(){
+	return [];
+}

--- a/addOns/groovy/src/main/zapHomeFiles/scripts/templates/httpfuzzerprocessor/FuzzerHttpProcessorDefaultTemplate.groovy
+++ b/addOns/groovy/src/main/zapHomeFiles/scripts/templates/httpfuzzerprocessor/FuzzerHttpProcessorDefaultTemplate.groovy
@@ -32,6 +32,12 @@ void processMessage(HttpFuzzerTaskProcessorUtils utils, HttpMessage message) {
     // To add a message previously sent to results, with custom state:
     //    utils.addMessageToResults("Type Of Message", myMessage, "Key Custom State", "Value Custom State")
     // The states' value is shown in the column 'State' of fuzzer results tab
+    // To get the values of the parameters configured in the Add Message Processor Dialog.
+    //    utils.getParameters() 
+    // A map is returned, having as keys the parameters names (as returned by the getRequiredParamsNames()
+    // and getOptionalParamsNames() functions below)
+    // To get the value of a specific configured script parameter
+    //    utils.getParameters().get("exampleParam1")
 
     // Process fuzzed message...
     message.getRequestHeader().setHeader("X-Unique-Id", count.toString())


### PR DESCRIPTION
Bugfix for Template raising Exception
```
ERROR org.zaproxy.zap.extension.scripts.OutputPanel  - groovy.lang.MissingMethodException: No signature of method: org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.getRequiredParamsNames() is applicable for argument types: () values: []
java.lang.RuntimeException: groovy.lang.MissingMethodException: No signature of method: org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.getRequiredParamsNames() is applicable for argument types: () values: []
```