### PR TITLE
openapi: update tests for JUnit 5, prepare release

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [16] - 2020-06-09
 ### Added
 - Map Structure support for OpenAPI v3.0 (Issue 5863).
 - Using OpenAPI Example values for value generation in request bodies and urls (Issue 5168).
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First Version
 
+[16]: https://github.com/zaproxy/zap-extensions/releases/openapi-v16
 [15]: https://github.com/zaproxy/zap-extensions/releases/openapi-v15
 [14]: https://github.com/zaproxy/zap-extensions/releases/openapi-v14
 [13]: https://github.com/zaproxy/zap-extensions/releases/openapi-v13

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -315,7 +315,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
 
-        Assert.assertEquals("{\"age\":3,\"name\":\"Fluffy\"}", request);
+        assertEquals("{\"age\":3,\"name\":\"Fluffy\"}", request);
     }
 
     @Test
@@ -333,8 +333,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
 
-        Assert.assertEquals(
-                "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":3,\"name\":\"Fluffy\"}]", request);
+        assertEquals("[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":3,\"name\":\"Fluffy\"}]", request);
     }
 
     @Test
@@ -352,7 +351,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
 
-        Assert.assertEquals(
+        assertEquals(
                 "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":512,\"name\":\"Fawkes\"}]", request);
     }
 
@@ -371,7 +370,7 @@ public class BodyGeneratorUnitTest {
                                 generators)
                         .getBody();
 
-        Assert.assertEquals(
+        assertEquals(
                 "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":512,\"name\":\"Fawkes\"}]", request);
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -186,18 +186,18 @@ public class OpenApiUnitTest extends AbstractServerTest {
         requestor.run(converter.getRequestModels());
 
         assertTrue(
-                "Should use OpenAPI Example Values in URL Path when crawling urls",
                 accessedUrls.containsKey(
                         "GET http://localhost:"
                                 + this.nano.getListeningPort()
-                                + "/PetStore/store/order/42424242"));
+                                + "/PetStore/store/order/42424242"),
+                "Should use OpenAPI Example Values in URL Path when crawling urls");
 
         assertTrue(
-                "Should use OpenAPI Example Values in URL Query when crawling urls",
                 accessedUrls.containsKey(
                         "GET http://localhost:"
                                 + this.nano.getListeningPort()
-                                + "/PetStore/user/login?username=kermit&password=thefrog"));
+                                + "/PetStore/user/login?username=kermit&password=thefrog"),
+                "Should use OpenAPI Example Values in URL Query when crawling urls");
     }
 
     @Test


### PR DESCRIPTION
Update the new tests for JUnit 5.
Add release date and link to tag.