### PR TITLE
Fix IndexOutOfBounds Exception when showing tabs

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update RE2/J library to latest version (1.4).
 
+### Fixed
+- Fixed an exception which was occurring when the tab was shown during install.
+
 ## [19] - 2020-06-09
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -379,12 +379,15 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     public void postInstall() {
         super.postInstall();
         if (getView() != null) {
-            getTechPanel().setTabFocus();
-            // Un-comment to test icon rendering
-            /*
-             * getApplications() .forEach( app -> addApplicationsToSite( "http://localhost", new
-             * ApplicationMatch(app)));
-             */
+            EventQueue.invokeLater(
+                    () -> {
+                        getTechPanel().setTabFocus();
+                        // Un-comment to test icon rendering
+                        /*
+                         * getApplications() .forEach( app -> addApplicationsToSite( "http://localhost",
+                         * new ApplicationMatch(app)));
+                         */
+                    });
         }
     }
 }

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Correctly handle API request without parameters.
+- Fixed an exception which was occurring when the tab was shown when a handshake response was first encountered during a ZAP session.
 
 ## [21] - 2020-01-17
 ### Added

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.websocket;
 
+import java.awt.EventQueue;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -741,10 +742,13 @@ public class ExtensionWebSocket extends ExtensionAdaptor
             logger.debug(
                     "Got WebSockets upgrade request. Handle socket connection over to WebSockets extension.");
             if (focusWebSocketsTabOnHandshake) {
-                // Show the tab in case its been closed
-                this.getWebSocketPanel().setTabFocus();
                 // Don't constantly request focus on the tab, once is enough.
                 focusWebSocketsTabOnHandshake = false;
+                EventQueue.invokeLater(
+                        () -> {
+                            // Show the tab in case its been closed
+                            this.getWebSocketPanel().setTabFocus();
+                        });
             }
 
             if (method != null) {


### PR DESCRIPTION
- In wappalyzer (postInstall) and websocket (onHandshakeResponse) when extension panels/tabs are shown ensure it's done in EDT thus preventing the exception that was manifesting.
- Add a Fix entry to the CHANGELOGs.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>