### PR TITLE
Fix overly broad Angular detection

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update RE2/J library to latest version (1.4).
 
+### Fixed
+- Fixed overly broad Angular detection regex
+
 ## [19] - 2020-06-09
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.

--- a/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/apps.json
+++ b/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/apps.json
@@ -880,7 +880,7 @@
       "script": [
         "angular[.-]([\\d.]*\\d)[^/]*\\.js\\;version:\\1",
         "/([\\d.]+(?:-?rc[.\\d]*)*)/angular(?:\\.min)?\\.js\\;version:\\1",
-        "angular.*\\.js"
+        "\\bangular.{0,30}\\.js"
       ],
       "website": "https://angularjs.org"
     },


### PR DESCRIPTION
Was incorrectly triggering on "rectangular[insert huge script here].js".
I've tried making it a bit more sensible by requiring a word boundary
before 'angular' and limiting the length of the wildcard match to
0-30 characters followed by '.js'.

Signed-off-by: Anders K. Madsen <lillesvin@gmail.com>