### PR TITLE
retire & wappalyzer: Promote to Beta & Prepare releases

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [0.3.0] - 2020-06-15
+### Changed
+- Add-on promoted to Beta.
 
 ## [0.2.0] - 2020-06-01
 ### Changed
@@ -15,5 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - First release.
 
+[0.3.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.3.0
 [0.2.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.2.0
 [0.1.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.1.0

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -1,8 +1,11 @@
+import org.zaproxy.gradle.addon.AddOnStatus
+
 version = "0.3.0"
 description = "Retire.js"
 
 zapAddOn {
     addOnName.set("Retire.js")
+    addOnStatus.set(AddOnStatus.BETA)
     zapVersion.set("2.9.0")
 
     manifest {

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [20.0.0] - 2020-06-15
 ### Changed
 - Update RE2/J library to latest version (1.4).
+- Add-on promoted to Beta.
 
 ### Fixed
 - Fixed an exception which was occurring when the tab was shown during install.
@@ -123,6 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - First version
 
 
+[20.0.0]: https://github.com/zaproxy/zap-extensions/releases/wappalyzer-v20.0.0
 [19]: https://github.com/zaproxy/zap-extensions/releases/wappalyzer-v19
 [18]: https://github.com/zaproxy/zap-extensions/releases/wappalyzer-v18
 [17]: https://github.com/zaproxy/zap-extensions/releases/wappalyzer-v17

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -1,8 +1,11 @@
+import org.zaproxy.gradle.addon.AddOnStatus
+
 version = "20.0.0"
 description = "Technology detection using Wappalyzer: wappalyzer.com"
 
 zapAddOn {
     addOnName.set("Wappalyzer - Technology Detection")
+    addOnStatus.set(AddOnStatus.BETA)
     zapVersion.set("2.9.0")
 
     manifest {


### PR DESCRIPTION
- *.gradle.kts > Now sets Beta status.
- Update changelogs with release date and link to tag.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>