### PR TITLE
retire/wappalyzer: prepare next dev iteration & set URL (retire)

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+
 ## [0.3.0] - 2020-06-15
 ### Changed
 - Add-on promoted to Beta.

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -1,6 +1,6 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "0.3.0"
+version = "0.4.0"
 description = "Retire.js"
 
 zapAddOn {
@@ -10,6 +10,7 @@ zapAddOn {
 
     manifest {
         author.set("Nikita Mundhada and the ZAP Dev Team")
+        url.set("https://www.zaproxy.org/docs/desktop/addons/retire.js/")
         bundle {
             baseName.set("org.zaproxy.addon.retire.resources.Messages")
             prefix.set("retire")

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+
 ## [20.0.0] - 2020-06-15
 ### Changed
 - Update RE2/J library to latest version (1.4).

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -1,6 +1,6 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "20.0.0"
+version = "20.1.0"
 description = "Technology detection using Wappalyzer: wappalyzer.com"
 
 zapAddOn {


### PR DESCRIPTION
- Both: Update version and changelog
- retire: set URL to web help content

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>