### PR TITLE
bugtracker: remove options panels when uninstalled

### DIFF
--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.9.0.
 - Maintenance changes.
 
+### Fixed
+- Show correct help page for the options panel.
+- Remove the options panels when the add-on is uninstalled.
+
 ### Removed
 - Remove unused resource message.
 

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTracker.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTracker.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.bugtracker;
 import java.util.Set;
 import javax.swing.JPanel;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.view.AbstractParamPanel;
 
 public abstract class BugTracker {
 
@@ -38,4 +39,6 @@ public abstract class BugTracker {
     public abstract void createDialogs();
 
     public abstract String raise(RaiseSemiAutoIssueDialog dialog);
+
+    public abstract AbstractParamPanel getOptionsPanel();
 }

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzilla.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzilla.java
@@ -486,6 +486,7 @@ public class BugTrackerBugzilla extends BugTracker {
 
     private BugTrackerBugzillaOptionsPanel optionsPanel;
 
+    @Override
     public BugTrackerBugzillaOptionsPanel getOptionsPanel() {
         if (optionsPanel == null) {
             optionsPanel = new BugTrackerBugzillaOptionsPanel();

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzillaOptionsPanel.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzillaOptionsPanel.java
@@ -67,6 +67,6 @@ public class BugTrackerBugzillaOptionsPanel extends AbstractParamPanel {
 
     @Override
     public String getHelpIndex() {
-        return "addon.alertFilter";
+        return "addon.bugtracker.bugtracker";
     }
 }

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
@@ -544,6 +544,7 @@ public class BugTrackerGithub extends BugTracker {
 
     private BugTrackerGithubOptionsPanel optionsPanel;
 
+    @Override
     public BugTrackerGithubOptionsPanel getOptionsPanel() {
         if (optionsPanel == null) {
             optionsPanel = new BugTrackerGithubOptionsPanel();

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubOptionsPanel.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubOptionsPanel.java
@@ -67,6 +67,6 @@ public class BugTrackerGithubOptionsPanel extends AbstractParamPanel {
 
     @Override
     public String getHelpIndex() {
-        return "addon.alertFilter";
+        return "addon.bugtracker.bugtracker";
     }
 }

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
@@ -94,6 +94,14 @@ public class ExtensionBugTracker extends ExtensionAdaptor {
     @Override
     public void unload() {
         super.unload();
+
+        if (hasView()) {
+            bugTrackers.forEach(
+                    bugTracker ->
+                            View.getSingleton()
+                                    .getOptionsDialog("")
+                                    .removeParamPanel(bugTracker.getOptionsPanel()));
+        }
     }
 
     private PopupSemiAutoIssue getPopupMsgRaiseSemiAuto() {


### PR DESCRIPTION
Remove the options panel when the extension is unloaded.
Correct the help key in the options panels.