### PR TITLE
testutils: remove support for older ZAP versions

### DIFF
--- a/testutils/src/main/resources/Messages.properties
+++ b/testutils/src/main/resources/Messages.properties
@@ -1,1 +1,0 @@
-# Dummy file, required by core (<= 2.7.0) on Java 9+


### PR DESCRIPTION
Remove test setup required for older ZAP versions, all the add-ons are
now targeting 2.9.0.