### PR TITLE
retire: Upstream update

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [0.3.1] - 2020-06-18
+### Changed
+- Updated from upstream with new identifications, including: CVE-2020-7676 for angular < 1.8.0
 
 ## [0.3.0] - 2020-06-15
 ### Changed
@@ -19,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - First release.
 
+[0.4.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.3.1
 [0.3.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.3.0
 [0.2.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.2.0
 [0.1.0]: https://github.com/zaproxy/zap-extensions/releases/retire-v0.1.0

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -1,6 +1,6 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "0.4.0"
+version = "0.3.1"
 description = "Retire.js"
 
 zapAddOn {

--- a/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/jsrepository.json
+++ b/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/jsrepository.json
@@ -864,6 +864,15 @@
 		"bowername": [ "angularjs", "angular.js" ],
 		"vulnerabilities" : [
 			{
+				"below" : "1.8.0",
+				"severity": "medium",
+				"identifiers": {
+					"summary": "angular.js prior to 1.8.0 allows cross site scripting. The regex-based input HTML replacement may turn sanitized code into unsanitized one.",
+					"CVE": [ "CVE-2020-7676" ] 
+				},
+				"info" : [ "https://nvd.nist.gov/vuln/detail/CVE-2020-7676" ]	
+			},	
+			{
 				"below" : "1.7.9",
 				"severity": "medium",
 				"identifiers": {


### PR DESCRIPTION
- "Add CVE-2020-7676 for angular < 1.8.0".
  - https://github.com/RetireJS/retire.js/commit/bb639d52783247f6578be6c021e521a9cbb99815
- CHANGELOG change note added & updated for release (tag link, date, etc).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>