### PR TITLE
openapi: correct dialogue parent, handle no schema

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Show import exceptions in the Output tab (Issue 6042).
 
+### Fixed
+- Correct parent dialogue when choosing the file to import (Issue 6041).
+- Properly handle no schema when generating the request body (Issue 6042).
 
 ## [16] - 2020-06-09
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -263,10 +263,13 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                                 } else {
                                     exMsg = "";
                                 }
+                                String baseMessage =
+                                        Constant.messages.getString("openapi.parse.error", exMsg);
+                                View.getSingleton().getOutputPanel().append(baseMessage);
+                                View.getSingleton().getOutputPanel().append(e);
                                 View.getSingleton()
                                         .showWarningDialog(
-                                                Constant.messages.getString(
-                                                                "openapi.parse.error", exMsg)
+                                                baseMessage
                                                         + "\n\n"
                                                         + Constant.messages.getString(
                                                                 "openapi.parse.trailer"));

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromFileDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromFileDialog.java
@@ -27,7 +27,6 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.openapi.converter.swagger.InvalidUrlException;
 
 public class ImportFromFileDialog extends ImportFromAbstractDialog {
@@ -65,7 +64,7 @@ public class ImportFromFileDialog extends ImportFromAbstractDialog {
                         JFileChooser filechooser =
                                 new JFileChooser(
                                         Model.getSingleton().getOptionsParam().getUserDirectory());
-                        int state = filechooser.showOpenDialog(View.getSingleton().getMainFrame());
+                        int state = filechooser.showOpenDialog(this);
                         if (state == JFileChooser.APPROVE_OPTION) {
                             try {
                                 getFromField()

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
@@ -69,6 +69,10 @@ public class BodyGenerator {
                     });
 
     public String generate(Schema<?> schema) {
+        if (schema == null) {
+            return "";
+        }
+
         boolean isArray = schema instanceof ArraySchema;
         if (LOG.isDebugEnabled()) {
             LOG.debug("Generate body for object " + schema.getName());

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -36,7 +36,7 @@ openapi.io.error = Failed to access specified definition
 openapi.parse.error = Failed to parse OpenAPI definition.\n\n{0}
 openapi.parse.ok = Successfully parsed OpenAPI definition
 openapi.parse.warn = Parsed OpenAPI definition with warnings - \nsee Output tab for details
-openapi.parse.trailer = Further details may be available in the console or log.
+openapi.parse.trailer = Further details may be available in the Output tab.
 
 openapi.import.error = Failed to access URL: {0} : {1} : {2}
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -374,6 +374,22 @@ public class BodyGeneratorUnitTest {
                 "[{\"age\":3,\"name\":\"Fluffy\"},{\"age\":512,\"name\":\"Fawkes\"}]", request);
     }
 
+    @Test
+    public void shouldGenerateBodyWithNoSchema() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_no_schema.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/media-type-no-schema",
+                                        openAPI.getPaths().get("/media-type-no-schema").getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+
+        assertEquals("", request);
+    }
+
     private OpenAPI parseResource(String fileName) throws IOException {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_no_schema.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_no_schema.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+paths:
+  /media-type-no-schema:
+    post:
+      operationId: mediaTypeNoSchema
+      requestBody:
+        content:
+          '*/*': {}
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
Show exception in the Output tab and tweak message.
Correct parent dialogue when choosing the file to import.
Handle no schema when generating the request body, not required.

Fix zaproxy/zaproxy#6041 - OpenAPI Import Choose File Dialog
appears behind OpenAPI Import dialog
Fix zaproxy/zaproxy#6042 - Error parsing small valid OpenAPI spec