### PR TITLE
CSP Scan Rule Improvements

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changes
+- The CSP scan rule now checks if the form-action directive allows wildcards.
+- The CSP scan rule now includes further information in the description of allowed wildcard directives alerts when the impacted directive is one (or more) which doesn't fallback to default-src.
 
 ## [29] - 2020-06-01
 ### Changed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -179,8 +179,9 @@ pscanrules.crossdomainscriptinclusionscanner.soln=Ensure JavaScript source files
 
 pscanrules.cspscanner.name=CSP Scanner
 pscanrules.cspscanner.desc=Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks. Including (but not limited to) Cross Site Scripting (XSS), and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page \u2014 covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
+pscanrules.cspscanner.desc.extended=\n\nThe directive(s): {0} are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.
 pscanrules.cspscanner.otherinfo=The response contained multiple CSP headers, these were merged (intersected) into a single policy for evaluation:\n{0}\nNote: The highlighting and evidence for this alert may be inaccurate due to these multiple headers.
-pscanrules.cspscanner.refs=http://www.w3.org/TR/CSP2/\nhttp://www.w3.org/TR/CSP/\nhttp://caniuse.com/#search=content+security+policy\nhttp://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation
+pscanrules.cspscanner.refs=http://www.w3.org/TR/CSP2/\nhttp://www.w3.org/TR/CSP/\nhttp://caniuse.com/#search=content+security+policy\nhttp://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
 pscanrules.cspscanner.soln=Ensure that your web server, application server, load balancer, etc. is properly configured to set the Content-Security-Policy header.
 pscanrules.cspscanner.notices.name=Notices
 pscanrules.cspscanner.notices.errors=Errors:

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScannerUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScannerUnitTest.java
@@ -23,12 +23,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
 public class ContentSecurityPolicyScannerUnitTest
         extends PassiveScannerTest<ContentSecurityPolicyScanner> {
+
+    private static final String REASONABLE_POLICY =
+            "default-src 'self'; script-src 'self' "
+                    + "storage.googleapis.com cdn.temasys.io cdn.tiny.cloud *.google-analytics.com; "
+                    + "style-src 'self' *.googleapis.com; font-src 'self' data: *.googleapis.com "
+                    + "fonts.gstatic.com; frame-ancestors 'none'; worker-src 'self'; form-action 'none'";
+    private static final String HTTP_HEADER_CSP = "Content-Security-Policy";
 
     @Override
     protected ContentSecurityPolicyScanner createScanner() {
@@ -36,20 +47,33 @@ public class ContentSecurityPolicyScannerUnitTest
     }
 
     @Test
-    public void exampleBadCsp() throws HttpMalformedHeaderException {
+    public void shouldNotRaiseAlertOnNonHtmlAtMediumThreshold() {
         // Given
-        HttpMessage msg = new HttpMessage();
-        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        HttpMessage msg = createHttpMessage("report-uri /__cspreport__");
+        msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "image/png");
+        // When
+        rule.setAlertThreshold(AlertThreshold.MEDIUM);
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
 
-        msg.setResponseBody("<html></html>");
-        msg.setResponseHeader(
-                "HTTP/1.1 200 OK\r\n"
-                        + "Server: Apache-Coyote/1.1\r\n"
-                        + "Content-Security-Policy: default-src: 'none'; report_uri /__cspreport__\r\n"
-                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
-                        + "Content-Length: "
-                        + msg.getResponseBody().length()
-                        + "\r\n");
+    @Test
+    public void shouldRaiseAlertOnNonHtmlAtLowThreshold() {
+        // Given
+        HttpMessage msg = createHttpMessage("report-uri /__cspreport__");
+        msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "image/png");
+        // When
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+    }
+
+    @Test
+    public void shouldAlertWhenCspContainsSyntaxIssues() {
+        // Given
+        HttpMessage msg = createHttpMessage("default-src: 'none'; report_uri /__cspreport__");
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -76,12 +100,49 @@ public class ContentSecurityPolicyScannerUnitTest
                         "The following directives either allow wildcard sources (or ancestors), are not "
                                 + "defined, or are overly broadly defined: \nscript-src, script-src-elem, script-src-attr"
                                 + ", style-src, style-src-elem, style-src-attr, img-src, connect-src, frame-src, "
-                                + "frame-ancestors, font-src, media-src, object-src, manifest-src, worker-src, prefetch-src"));
+                                + "frame-ancestors, font-src, media-src, object-src, manifest-src, worker-src, prefetch-src, form-action"
+                                + "\n\nThe directive(s): frame-ancestors, form-action are among the directives that do "
+                                + "not fallback to default-src, missing/excluding them is the same as allowing anything."));
         assertThat(
                 alertsRaised.get(1).getEvidence(),
                 equalTo("default-src: 'none'; report_uri /__cspreport__"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    public void shouldAlertWithCspWarningNoticesWhenApplicable() {
+        // Given
+        HttpMessage msg = createHttpMessage("default-src none; report-to csp-endpoint ");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+
+        assertThat(alertsRaised.get(0).getName(), equalTo("CSP Scanner: Notices"));
+        assertThat(
+                alertsRaised.get(0).getDescription(),
+                equalTo(
+                        "Warnings:\n"
+                                + "1:13: This host name is unusual, and likely meant to be a keyword that is missing the required quotes: 'none'.\n"));
+        assertThat(
+                alertsRaised.get(0).getEvidence(),
+                equalTo("default-src none; report-to csp-endpoint"));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    public void shouldRaiseAlertAtInfoRiskWhenOnlyInformationalNotices() {
+        // Given
+        HttpMessage msg = createHttpMessage("report-uri /__cspreport__");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.get(0).getName(), equalTo("CSP Scanner: Notices"));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }
 
     @Test
@@ -110,7 +171,9 @@ public class ContentSecurityPolicyScannerUnitTest
                 alertsRaised.get(0).getDescription(),
                 equalTo(
                         "The following directives either allow wildcard sources (or ancestors), "
-                                + "are not defined, or are overly broadly defined: \nframe-ancestors"));
+                                + "are not defined, or are overly broadly defined: \nframe-ancestors, form-action"
+                                + "\n\nThe directive(s): frame-ancestors, form-action are among the directives that "
+                                + "do not fallback to default-src, missing/excluding them is the same as allowing anything."));
 
         assertThat(
                 alertsRaised.get(0).getEvidence(),
@@ -127,20 +190,10 @@ public class ContentSecurityPolicyScannerUnitTest
     }
 
     @Test
-    public void shouldAlertOnWildcardFrameAncestorsDirective() throws HttpMalformedHeaderException {
+    public void shouldAlertOnWildcardFrameAncestorsDirective() {
         // Given
-        HttpMessage msg = new HttpMessage();
-        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
-
-        msg.setResponseBody("<html></html>");
-        msg.setResponseHeader(
-                "HTTP/1.1 200 OK\r\n"
-                        + "Server: Apache-Coyote/1.1\r\n"
-                        + "Content-Security-Policy: frame-ancestors *; default-src 'self'\r\n"
-                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
-                        + "Content-Length: "
-                        + msg.getResponseBody().length()
-                        + "\r\n");
+        HttpMessage msg =
+                createHttpMessage("frame-ancestors *; default-src 'self'; form-action 'none'");
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -151,35 +204,99 @@ public class ContentSecurityPolicyScannerUnitTest
                 alertsRaised.get(0).getDescription(),
                 equalTo(
                         "The following directives either allow wildcard sources (or ancestors), are not "
-                                + "defined, or are overly broadly defined: \nframe-ancestors"));
+                                + "defined, or are overly broadly defined: \nframe-ancestors"
+                                + "\n\nThe directive(s): frame-ancestors are among the directives that do not "
+                                + "fallback to default-src, missing/excluding them is the same as allowing anything."));
         assertThat(
                 alertsRaised.get(0).getEvidence(),
-                equalTo("frame-ancestors *; default-src 'self'"));
+                equalTo("frame-ancestors *; default-src 'self'; form-action 'none'"));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
     }
 
     @Test
-    public void shouldNotAlertOnReasonableCsp() throws HttpMalformedHeaderException {
+    public void shouldNotAlertOnReasonableCsp() {
         // Given
-        HttpMessage msg = new HttpMessage();
-        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
-
-        msg.setResponseBody("<html></html>");
-        msg.setResponseHeader(
-                "HTTP/1.1 200 OK\r\n"
-                        + "Server: Apache-Coyote/1.1\r\n"
-                        + "Content-Security-Policy: default-src 'self'; script-src 'self' "
-                        + "storage.googleapis.com cdn.temasys.io cdn.tiny.cloud *.google-analytics.com; "
-                        + "style-src 'self' *.googleapis.com; font-src 'self' data: *.googleapis.com "
-                        + "fonts.gstatic.com; frame-ancestors 'none'; worker-src 'self'\r\n"
-                        + "Content-Type: text/html;charset=ISO-8859-1\r\n"
-                        + "Content-Length: "
-                        + msg.getResponseBody().length()
-                        + "\r\n");
+        HttpMessage msg = createHttpMessageWithReasonableCsp(HTTP_HEADER_CSP);
         // When
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"X-Content-Security-Policy", "X-WebKit-CSP"})
+    public void shouldRaiseAlertOnLegacyCspHeader(String input) {
+        // Given
+        HttpMessage msg = createHttpMessageWithReasonableCsp(input);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getName(), equalTo("CSP Scanner: " + input));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenCspIncludesScriptUnsafeInline() {
+        // Given
+        HttpMessage msg = createHttpMessage("script-src 'unsafe-inline'");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+        // Verify the specific alert
+        assertThat(alertsRaised.get(1).getName(), equalTo("CSP Scanner: script-src unsafe-inline"));
+        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @Test
+    public void shouldRaiseAlertWhenCspIncludesStyleUnsafeInline() {
+        // Given
+        HttpMessage msg = createHttpMessage("style-src 'unsafe-inline'");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(2));
+        // Verify the specific alert
+        assertThat(alertsRaised.get(1).getName(), equalTo("CSP Scanner: style-src unsafe-inline"));
+        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    private HttpMessage createHttpMessageWithReasonableCsp(String cspHeaderName) {
+        return createHttpMessage(cspHeaderName, REASONABLE_POLICY);
+    }
+
+    private HttpMessage createHttpMessage(String cspPolicy) {
+        return createHttpMessage(HTTP_HEADER_CSP, cspPolicy);
+    }
+
+    private HttpMessage createHttpMessage(String cspHeaderName, String cspPolicy) {
+        HttpMessage msg = new HttpMessage();
+
+        String header = !cspHeaderName.isEmpty() ? cspHeaderName : HTTP_HEADER_CSP;
+
+        try {
+            msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+
+            msg.setResponseBody("<html></html>");
+            msg.setResponseHeader(
+                    "HTTP/1.1 200 OK\r\n"
+                            + "Server: Apache-Coyote/1.1\r\n"
+                            + header
+                            + ":"
+                            + cspPolicy
+                            + "\r\n"
+                            + "Content-Type: text/html;charset=ISO-8859-1\r\n"
+                            + "Content-Length: "
+                            + msg.getResponseBody().length()
+                            + "\r\n");
+        } catch (HttpMalformedHeaderException e) {
+            throw new RuntimeException(e);
+        }
+        return msg;
     }
 }


### PR DESCRIPTION
- The CSP scan rule now checks if the form-action directive allows wildcards.
- The CSP scan rule now includes further information in the description of allowed wildcard directives alerts when the impacted directive is one (or more) which doesn't fallback to default-src.
- CHANGELOG and Messages.properties updated as necessary to support the improvements.
- UnitTest increased coverage from 75.7% to 99%.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>