### PR TITLE
pscanrules Alpha: ScanRule Consistency

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -79,22 +79,11 @@ public class Base64Disclosure extends PluginPassiveScanner {
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanalpha.base64disclosure.";
 
-    /**
-     * gets the name of the scanner
-     *
-     * @return
-     */
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    /**
-     * scans the HTTP request sent (in fact, does nothing)
-     *
-     * @param msg
-     * @param id
-     */
     @Override
     public void scanHttpRequestSend(HttpMessage msg, int id) {
         // TODO: implement checks for base64 encoding in the request?
@@ -394,60 +383,28 @@ public class Base64Disclosure extends PluginPassiveScanner {
         }
     }
 
-    /**
-     * sets the parent
-     *
-     * @param parent
-     */
     @Override
     public void setParent(PassiveScanThread parent) {
         // Nothing to do.
     }
 
-    /**
-     * get the id of the scanner
-     *
-     * @return
-     */
     @Override
     public int getPluginId() {
         return 10094;
     }
 
-    /**
-     * get the description of the alert
-     *
-     * @return
-     */
     private String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
 
-    /**
-     * get the solution for the alert
-     *
-     * @return
-     */
     private String getSolution() {
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
-    /**
-     * gets references for the alert
-     *
-     * @return
-     */
     private String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
-    /**
-     * gets extra information associated with the alert
-     *
-     * @param msg
-     * @param arg0
-     * @return
-     */
     private String getExtraInfo(HttpMessage msg, String evidence, byte[] decodeddata) {
         return Constant.messages.getString(
                 MESSAGE_PREFIX + "extrainfo", evidence, new String(decodeddata));

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
@@ -38,7 +38,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  * Detect "storable" and "cacheable" reponses. "Storable" implies that the response can be stored in
  * some manner by the caching server, even if it is not served in response to any requests.
  * "Cacheable" responses are responses that are served by the caching server in response to some
- * request. Unlike "CacheControlScanner", this scanner does not attempt to determine if the various
+ * request. Unlike "CacheControlScanner", this rule does not attempt to determine if the various
  * cache settings are "incorrectly" set (since that depends on the response contents, and on the
  * context), but instead, looks at the conditions defined in rfc7234 to determine if a given request
  * and response are storable by rfc7234 compliant cache servers, and subsequently retrievable from
@@ -72,7 +72,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class CacheableScanner extends PluginPassiveScanner {
+public class CacheableScanRule extends PluginPassiveScanner {
 
     private static final String MESSAGE_PREFIX_STORABILITY_CACHEABILITY =
             "pscanalpha.storabilitycacheability.";
@@ -82,7 +82,7 @@ public class CacheableScanner extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX_STORABLE_CACHEABLE = "pscanalpha.storablecacheable.";
     private static final int PLUGIN_ID = 10049;
 
-    private static final Logger logger = Logger.getLogger(CacheableScanner.class);
+    private static final Logger logger = Logger.getLogger(CacheableScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -91,7 +91,7 @@ public class CacheableScanner extends PluginPassiveScanner {
 
     @Override
     public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
+        // Only checking the response for this scan rule
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java
@@ -37,17 +37,17 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /**
  * An example passive scan rule, for more details see
- * http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
+ * https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/
  *
  * @author psiinon
  */
-public class ExampleFilePassiveScanner extends PluginPassiveScanner {
+public class ExampleFilePassiveScanRule extends PluginPassiveScanner {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanalpha.examplefile.";
 
     private static final String examplePscanFile = "txt/example-pscan-file.txt";
-    private static final Logger logger = Logger.getLogger(ExampleFilePassiveScanner.class);
+    private static final Logger logger = Logger.getLogger(ExampleFilePassiveScanRule.class);
     private List<String> strings = null;
 
     @Override
@@ -58,7 +58,7 @@ public class ExampleFilePassiveScanner extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!Constant.isDevBuild()) {
-            // Only run this example scanner in dev mode
+            // Only run this example scan rule in dev mode
             // Uncomment locally if you want to see these alerts in non dev mode ;)
             return;
         }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java
@@ -32,15 +32,15 @@ import org.zaproxy.zap.model.Vulnerability;
 
 /**
  * An example passive scan rule, for more details see
- * http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
+ * https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/
  *
  * @author psiinon
  */
-public class ExampleSimplePassiveScanner extends PluginPassiveScanner {
+public class ExampleSimplePassiveScanRule extends PluginPassiveScanner {
 
     // wasc_10 is Denial of Service - well, its just an example ;)
     private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_10");
-    private static final Logger logger = Logger.getLogger(ExampleSimplePassiveScanner.class);
+    private static final Logger logger = Logger.getLogger(ExampleSimplePassiveScanRule.class);
 
     private Random rnd = new Random();
 
@@ -66,7 +66,7 @@ public class ExampleSimplePassiveScanner extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!Constant.isDevBuild()) {
-            // Only run this example scanner in dev mode
+            // Only run this example scan rule in dev mode
             // Uncomment locally if you want to see these alerts in non dev mode ;)
             return;
         }
@@ -100,11 +100,11 @@ public class ExampleSimplePassiveScanner extends PluginPassiveScanner {
 
     @Override
     public String getName() {
-        // Strip off the "Example Passive Scanner: " part if implementing a real one ;)
+        // Strip off the "Example Passive Scan Rule: " part if implementing a real one ;)
         if (vuln != null) {
-            return "Example Passive Scanner: " + vuln.getAlert();
+            return "Example Passive Scan Rule: " + vuln.getAlert();
         }
-        return "Example Passive Scanner: Denial of Service";
+        return "Example Passive Scan Rule: Denial of Service";
     }
 
     public String getDescription() {

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java
@@ -33,15 +33,15 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 /**
  * Feature Policy Header Missing passive scan rule https://github.com/zaproxy/zaproxy/issues/4885
  */
-public class FeaturePolicyScanner extends PluginPassiveScanner {
+public class FeaturePolicyScanRule extends PluginPassiveScanner {
 
     private static final String MESSAGE_PREFIX = "pscanalpha.featurepolicymissing.";
-    private static final Logger LOGGER = Logger.getLogger(FeaturePolicyScanner.class);
+    private static final Logger LOGGER = Logger.getLogger(FeaturePolicyScanRule.class);
     private static final int PLUGIN_ID = 10063;
 
     @Override
     public void scanHttpRequestSend(HttpMessage httpMessage, int id) {
-        // Only checking the response for this plugin
+        // Only checking the response for this scan rule
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
@@ -36,9 +36,9 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author kingthorin+owaspzap@gmail.com
  */
-public class InPageBannerInfoLeakScanner extends PluginPassiveScanner {
+public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner {
 
-    private static final Logger LOGGER = Logger.getLogger(InPageBannerInfoLeakScanner.class);
+    private static final Logger LOGGER = Logger.getLogger(InPageBannerInfoLeakScanRule.class);
     private static final int PLUGIN_ID = 10009;
     private static final String MESSAGE_PREFIX = "pscanalpha.inpagebanner.";
 
@@ -49,7 +49,7 @@ public class InPageBannerInfoLeakScanner extends PluginPassiveScanner {
 
     @Override
     public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
+        // Only checking the response for this scan rule
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
@@ -40,14 +40,14 @@ import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** Passive Scan Rule for Dangerous JS Functions https://github.com/zaproxy/zaproxy/issues/5673 */
-public class JSFunctionPassiveScanner extends PluginPassiveScanner {
+public class JsFunctionScanRule extends PluginPassiveScanner {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanalpha.jsfunction.";
 
     public static final String FUNC_LIST_DIR = "txt";
     public static final String FUNC_LIST_FILE = "js-function-list.txt";
-    private static final Logger LOGGER = Logger.getLogger(JSFunctionPassiveScanner.class);
+    private static final Logger LOGGER = Logger.getLogger(JsFunctionScanRule.class);
     private static final int PLUGIN_ID = 10110;
 
     public static final List<String> DEFAULT_FUNCTIONS = Collections.emptyList();

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java
@@ -31,8 +31,8 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
-/** Java Serialized Objects (JSO) scanner. Detect the magic sequence and generate an alert */
-public class JsoScanner extends PluginPassiveScanner {
+/** Java Serialized Objects (JSO) scan rule. Detect the magic sequence and generate an alert */
+public class JsoScanRule extends PluginPassiveScanner {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanalpha.jso.";

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
@@ -37,9 +37,9 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  *
  * @author 70pointer@gmail.com
  */
-public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
+public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
 
-    private static final Logger log = Logger.getLogger(SourceCodeDisclosureScanner.class);
+    private static final Logger log = Logger.getLogger(SourceCodeDisclosureScanRule.class);
 
     /**
      * a consistently ordered map of: a regular expression pattern to the Programming language
@@ -629,23 +629,11 @@ public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanalpha.sourcecodedisclosure.";
 
-    /** construct the class, and register for i18n */
-    /**
-     * gets the name of the scanner
-     *
-     * @return
-     */
     @Override
     public String getName() {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    /**
-     * scans the HTTP request sent (in fact, does nothing)
-     *
-     * @param msg
-     * @param id
-     */
     @Override
     public void scanHttpRequestSend(HttpMessage msg, int id) {
         // do nothing
@@ -701,59 +689,28 @@ public class SourceCodeDisclosureScanner extends PluginPassiveScanner {
         }
     }
 
-    /**
-     * sets the parent
-     *
-     * @param parent
-     */
     @Override
     public void setParent(PassiveScanThread parent) {
         // Nothing to do.
     }
 
-    /**
-     * get the id of the scanner
-     *
-     * @return
-     */
     @Override
     public int getPluginId() {
         return 10099;
     }
 
-    /**
-     * get the description of the alert
-     *
-     * @return
-     */
     private String getDescription() {
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
 
-    /**
-     * get the solution for the alert
-     *
-     * @return
-     */
     private String getSolution() {
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
-    /**
-     * gets references for the alert
-     *
-     * @return
-     */
     private String getReference() {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
-    /**
-     * gets extra information associated with the alert
-     *
-     * @param evidence
-     * @return
-     */
     private String getExtraInfo(String evidence) {
         return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", evidence);
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
@@ -36,7 +36,7 @@ import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** Detect missing attribute integrity in supported elements */
-public class SubResourceIntegrityAttributeScanner extends PluginPassiveScanner {
+public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner {
 
     private enum SupportedElements {
         // From

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/payloader/ExtensionPayloader.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.zaproxy.zap.extension.custompayloads.ExtensionCustomPayloads;
 import org.zaproxy.zap.extension.custompayloads.PayloadCategory;
-import org.zaproxy.zap.extension.pscanrulesAlpha.JSFunctionPassiveScanner;
+import org.zaproxy.zap.extension.pscanrulesAlpha.JsFunctionScanRule;
 
 public class ExtensionPayloader extends ExtensionAdaptor {
 
@@ -58,10 +58,10 @@ public class ExtensionPayloader extends ExtensionAdaptor {
                         .getExtension(ExtensionCustomPayloads.class);
         jsFuncCategory =
                 new PayloadCategory(
-                        JSFunctionPassiveScanner.JS_FUNCTION_PAYLOAD_CATEGORY,
-                        JSFunctionPassiveScanner.DEFAULT_FUNCTIONS);
+                        JsFunctionScanRule.JS_FUNCTION_PAYLOAD_CATEGORY,
+                        JsFunctionScanRule.DEFAULT_FUNCTIONS);
         ecp.addPayloadCategory(jsFuncCategory);
-        JSFunctionPassiveScanner.setPayloadProvider(() -> jsFuncCategory.getPayloadsIterator());
+        JsFunctionScanRule.setPayloadProvider(() -> jsFuncCategory.getPayloadsIterator());
     }
 
     @Override
@@ -71,7 +71,7 @@ public class ExtensionPayloader extends ExtensionAdaptor {
 
     @Override
     public void unload() {
-        JSFunctionPassiveScanner.setPayloadProvider(null);
+        JsFunctionScanRule.setPayloadProvider(null);
         ecp.removePayloadCategory(jsFuncCategory);
     }
 

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -13,7 +13,7 @@ The following alpha quality passive scan rules are included in this add-on:
 This implements an example passive scan rule that loads strings from a file that the user can edit.<br>
 For more details see: <a href="https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/">Hacking ZAP Part 3: Passive Scan Rules</a>.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanner.java">ExampleFilePassiveScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleFilePassiveScanRule.java">ExampleFilePassiveScanRule.java</a>
 
 <H2>Base64 Disclosure</H2>
 <ul>
@@ -26,7 +26,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java">Base64Disclosure.java</a>
 
 <H2>Content Cacheability</H2>
-This scanner analyzes the cache control and pragma headers in HTTP traffic and resports on the cacheability of the requests from a RFC7234 point of view.
+This scan rule analyzes the cache control and pragma headers in HTTP traffic and resports on the cacheability of the requests from a RFC7234 point of view.
 <p>
 Alerts generated:
 <ul>
@@ -35,27 +35,27 @@ Alerts generated:
  <li><b>Storable and Cacheable Content</b></li>
 </ul>
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanner.java">CacheableScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java">CacheableScanRule.java</a>
 
-<H2>Example Passive Scanner: Denial of Service</H2>
+<H2>Example Passive Scan Rule: Denial of Service</H2>
 This implements a very simple example passive scan rule.<br>
 For more details see: <a href="https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/">Hacking ZAP Part 3: Passive Scan Rules</a>.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanner.java">ExampleSimplePassiveScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java">ExampleSimplePassiveScanRule.java</a>
 
 <H2>Feature Policy Header Not Set</H2>
-This scanner checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Feature-Policy" header, 
+This rule checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Feature-Policy" header, 
 and alerts if one is not found.<br>
 Redirects are ignored except at the Low threshold.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanner.java">FeaturePolicyScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java">FeaturePolicyScanRule.java</a>
 
 <H2>In Page Banner Information Leak</H2>
 Analyzes response body content for the presence of web or application server banners (when the responses have error status codes).<br>
 If the Threshold is Low then status 200 - Ok responses are analyzed as well.<br>
 The presence of such banners may facilitate more targeted attacks against known vulnerabilities.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanner.java">InPageBannerInfoLeakScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java">InPageBannerInfoLeakScanRule.java</a>
 
 <H2>Java Serialization Object</H2>
 Java Serialization Object (JSO) is a way to save and exchange objects between Java applications.<br>
@@ -64,25 +64,25 @@ An attacker can also modify the data and exploit JSO to do a Remote Code Executi
 JSO should not be used by Java programs. Strong controls must be done on serialized data.<br>
 JSO are a type of vulnerabilities associated to A8:2017-Insecure Deserialization.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanner.java">JsoScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java">JsoScanRule.java</a>
 
 <H2>Source Code Disclosure</H2>
-Application Source Code was disclosed by the web server
+Application Source Code was disclosed by the web server.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanner.java">SourceCodeDisclosureScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
 
 <H2>Sub Resource Integrity Attribute Missing</H2>
-This scanner checks whether the integrity attribute in the script or the link element served by an external resource (for example: CDN) is missing.<br>
+This rule checks whether the integrity attribute in the script or the link element served by an external resource (for example: CDN) is missing.<br>
 It helps mitigate an attack where the CDN has been compromised and content has been replaced by malicious content.<br>
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanner.java">SubResourceIntegrityAttributeScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java">SubResourceIntegrityAttributeScanRule.java</a>
 
 <H2>Dangerous JS Functions</H2>
-This scanner checks for any dangerous JS functions present in a site response.<br>
+This scan rule checks for any dangerous JS functions present in a site response.<br>
 <strong>Note:</strong> If the Custom Payloads addon is installed you can add your own function names (payloads) in the Custom Payloads options panel.
 They will also be searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the amount of time needed to passively scan.
 <p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JSFunctionPassiveScanner.java">JSFunctionPassiveScanner.java</a>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java">JsFunctionScanRule.java</a>
 
 </BODY>
 </HTML>

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -1,11 +1,11 @@
 # This file defines the default (English) variants of all of the internationalised messages
 pscanalpha.desc = Passive Scan Rules - alpha
 
-pscanalpha.examplefile.name=An example passive scan rule which loads data from a file
-pscanalpha.examplefile.desc=Add more information about the vulnerability here
-pscanalpha.examplefile.other=This is for information that doesnt fit in any of the other sections
-pscanalpha.examplefile.soln=A general description of how to solve the problem
-pscanalpha.examplefile.refs=http://zaproxy.blogspot.co.uk/2014/04/hacking-zap-3-passive-scan-rules.html
+pscanalpha.examplefile.name=An example passive scan rule which loads data from a file.
+pscanalpha.examplefile.desc=Add more information about the vulnerability here.
+pscanalpha.examplefile.other=This is for information that doesnt fit in any of the other sections.
+pscanalpha.examplefile.soln=A general description of how to solve the problem.
+pscanalpha.examplefile.refs=https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/
 
 pscanalpha.featurepolicymissing.name=Feature Policy Header Not Set
 pscanalpha.featurepolicymissing.desc=Feature Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Feature Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/AlertsCacheableScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/AlertsCacheableScanRuleUnitTest.java
@@ -31,7 +31,7 @@ import org.parosproxy.paros.network.HttpMessage;
 /* All test-cases should raise either non-storeable alerts
  * or storeable and non-cacheable alerts.
  */
-public class AlertsCacheableScannerUnitTest extends PassiveScannerTest<CacheableScanner> {
+public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
 
     private void assertNonStoreable(String expectedEvidence) {
         assertThat(alertsRaised.size(), equalTo(1));
@@ -50,8 +50,8 @@ public class AlertsCacheableScannerUnitTest extends PassiveScannerTest<Cacheable
     }
 
     @Override
-    protected CacheableScanner createScanner() {
-        return new CacheableScanner();
+    protected CacheableScanRule createScanner() {
+        return new CacheableScanRule();
     }
 
     @Test

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
@@ -36,7 +36,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 /* All test-cases should raise storeable and cacheable alerts
  * or should verfiy the absence of exceptions.
  */
-public class CacheableScannerUnitTest extends PassiveScannerTest<CacheableScanner> {
+public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
 
     private HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
@@ -68,17 +68,17 @@ public class CacheableScannerUnitTest extends PassiveScannerTest<CacheableScanne
     }
 
     @Override
-    protected CacheableScanner createScanner() {
-        return new CacheableScanner();
+    protected CacheableScanRule createScanner() {
+        return new CacheableScanRule();
     }
 
     @Test
     public void scannerNameShouldMatch() {
-        // Quick test to verify scanner name which is used in the policy dialog but not
+        // Quick test to verify scan rule name which is used in the policy dialog but not
         // alerts
 
         // Given
-        CacheableScanner thisScanner = createScanner();
+        CacheableScanRule thisScanner = createScanner();
         // Then
         assertThat(thisScanner.getName(), equalTo("Content Cacheability"));
     }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRuleUnitTest.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class FeaturePolicyScannerUnitTest extends PassiveScannerTest<FeaturePolicyScanner> {
+public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScanRule> {
 
     private static final String MESSAGE_PREFIX = "pscanalpha.featurepolicymissing.";
     private HttpMessage msg;
@@ -46,8 +46,8 @@ public class FeaturePolicyScannerUnitTest extends PassiveScannerTest<FeaturePoli
     }
 
     @Override
-    protected FeaturePolicyScanner createScanner() {
-        return new FeaturePolicyScanner();
+    protected FeaturePolicyScanRule createScanner() {
+        return new FeaturePolicyScanRule();
     }
 
     @Test

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRuleUnitTest.java
@@ -30,8 +30,8 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class InPageBannerInfoLeakScannerUnitTest
-        extends PassiveScannerTest<InPageBannerInfoLeakScanner> {
+public class InPageBannerInfoLeakScanRuleUnitTest
+        extends PassiveScannerTest<InPageBannerInfoLeakScanRule> {
 
     private HttpMessage createMessage(String banner) throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
@@ -45,8 +45,8 @@ public class InPageBannerInfoLeakScannerUnitTest
     }
 
     @Override
-    protected InPageBannerInfoLeakScanner createScanner() {
-        return new InPageBannerInfoLeakScanner();
+    protected InPageBannerInfoLeakScanRule createScanner() {
+        return new InPageBannerInfoLeakScanRule();
     }
 
     @Test

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
@@ -38,11 +38,11 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunctionPassiveScanner> {
+public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> {
 
     @Override
-    protected JSFunctionPassiveScanner createScanner() {
-        return new JSFunctionPassiveScanner();
+    protected JsFunctionScanRule createScanner() {
+        return new JsFunctionScanRule();
     }
 
     @Override
@@ -51,8 +51,8 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
 
         Path xmlDir =
                 Files.createDirectories(
-                        Paths.get(Constant.getZapHome(), JSFunctionPassiveScanner.FUNC_LIST_DIR));
-        Path testFile = xmlDir.resolve(JSFunctionPassiveScanner.FUNC_LIST_FILE);
+                        Paths.get(Constant.getZapHome(), JsFunctionScanRule.FUNC_LIST_DIR));
+        Path testFile = xmlDir.resolve(JsFunctionScanRule.FUNC_LIST_FILE);
         Files.write(testFile, Arrays.asList("# Test File", "bypassSecurityTrustHtml", "eval"));
     }
 
@@ -123,7 +123,7 @@ public class JSFunctionPassiveScannerUnitTest extends PassiveScannerTest<JSFunct
         String body = "Some text <script>$badFunction()</script>\nLine 2\n";
         HttpMessage msg = createHttpMessageWithRespBody(body, "text/html;charset=ISO-8859-1");
         List<String> functions = Collections.singletonList("$badFunction");
-        JSFunctionPassiveScanner.setPayloadProvider(() -> functions);
+        JsFunctionScanRule.setPayloadProvider(() -> functions);
 
         // When
         scanHttpResponseReceive(msg);

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import java.util.Base64;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
+public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
 
     /* Testing JSO in response */
     @Test
@@ -290,8 +290,8 @@ public class JsoScannerUnitTest extends PassiveScannerTest<JsoScanner> {
     }
 
     @Override
-    protected JsoScanner createScanner() {
-        return new JsoScanner();
+    protected JsoScanRule createScanner() {
+        return new JsoScanRule();
     }
 
     private static class AnObject implements Serializable {

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
@@ -29,8 +29,8 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class SourceCodeDisclosureScannerUnitTest
-        extends PassiveScannerTest<SourceCodeDisclosureScanner> {
+public class SourceCodeDisclosureScanRuleUnitTest
+        extends PassiveScannerTest<SourceCodeDisclosureScanRule> {
 
     private static final String CODE_SQL = "insert into vulnerabilities values(";
     private static final String CODE_PHP = "<?php echo 'evils'; ?>";
@@ -40,8 +40,8 @@ public class SourceCodeDisclosureScannerUnitTest
     private HttpMessage msg;
 
     @Override
-    protected SourceCodeDisclosureScanner createScanner() {
-        return new SourceCodeDisclosureScanner();
+    protected SourceCodeDisclosureScanRule createScanner() {
+        return new SourceCodeDisclosureScanRule();
     }
 
     @BeforeEach
@@ -52,7 +52,7 @@ public class SourceCodeDisclosureScannerUnitTest
 
     @Test
     public void scannerNameShouldMatch() {
-        // Quick test to verify scanner name which is used in the policy dialog but not
+        // Quick test to verify scan rule name which is used in the policy dialog but not
         // alone in alerts
         assertThat(rule.getName(), is(getLocalisedString("name")));
     }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
@@ -27,14 +27,14 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class SubResourceIntegrityAttributeScannerTest
-        extends PassiveScannerTest<SubResourceIntegrityAttributeScanner> {
+public class SubResourceIntegrityAttributeScanRuleUnitTest
+        extends PassiveScannerTest<SubResourceIntegrityAttributeScanRule> {
 
     @Override
-    protected SubResourceIntegrityAttributeScanner createScanner() {
-        SubResourceIntegrityAttributeScanner scanner = new SubResourceIntegrityAttributeScanner();
-        scanner.setConfig(new ZapXmlConfiguration());
-        return scanner;
+    protected SubResourceIntegrityAttributeScanRule createScanner() {
+        SubResourceIntegrityAttributeScanRule rule = new SubResourceIntegrityAttributeScanRule();
+        rule.setConfig(new ZapXmlConfiguration());
+        return rule;
     }
 
     @Test


### PR DESCRIPTION
- Scan Rule class names.
- Scan Rule unittest names.
- Message.properties keys (and some values).
- Help content.
- Remove boilerplate javadoc in one scan rule class.
- Replace blogspot URLs with zaproxy.org.

Part of: zaproxy/zaproxy#6049

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>