### PR TITLE
soap: ScanRule Consistency

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,15 +4,17 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
 - Internationalise file filter description.
 - Dynamically unload the add-on.
-- Various fixes (related to Issue 4832 and other testing).
 - Change default accelerator for "Import a WSDL file from local file system".
-- Fix exception with Java 9+ (Issue 4037).
 - Update minimum ZAP version to 2.9.0.
 - Add import menus to (new) top level Import menu instead of Tools menu.
 - Maintenance changes.
+
+### Fixed
+- Various fixes (related to Issue 4832 and other testing).
+- Fix exception with Java 9+ (Issue 4037).
 
 ## 3 - 2017-03-31
 

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
@@ -39,15 +39,15 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
- * SOAP Action Spoofing Active Scanner
+ * SOAP Action Spoofing Active scan rule
  *
  * @author Albertov91
  */
-public class SOAPActionSpoofingActiveScanner extends AbstractAppPlugin {
+public class SOAPActionSpoofingActiveScanRule extends AbstractAppPlugin {
 
     private static final String MESSAGE_PREFIX = "soap.soapactionspoofing.";
 
-    private static final Logger LOG = Logger.getLogger(SOAPActionSpoofingActiveScanner.class);
+    private static final Logger LOG = Logger.getLogger(SOAPActionSpoofingActiveScanRule.class);
 
     public static final int INVALID_FORMAT = -3;
     public static final int FAULT_CODE = -2;

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRule.java
@@ -33,15 +33,15 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 
 /**
- * SOAP XML Injection Active Scanner
+ * SOAP XML Injection Active scan rule
  *
  * @author Albertov91
  */
-public class SOAPXMLInjectionActiveScanner extends AbstractAppParamPlugin {
+public class SOAPXMLInjectionActiveScanRule extends AbstractAppParamPlugin {
 
     private static final String MESSAGE_PREFIX = "soap.soapxmlinjection.";
 
-    private static final Logger LOG = Logger.getLogger(SOAPXMLInjectionActiveScanner.class);
+    private static final Logger LOG = Logger.getLogger(SOAPXMLInjectionActiveScanRule.class);
 
     @Override
     public int getId() {

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
@@ -29,7 +29,7 @@ import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 /** @author albertov91 */
-public class WSDLFilePassiveScanner extends PluginPassiveScanner {
+public class WSDLFilePassiveScanRule extends PluginPassiveScanner {
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "soap.wsdlfilepscan.";

--- a/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
+++ b/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
@@ -3,11 +3,11 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-SOAP Scanner
+SOAP Add-on
 </TITLE>
 </HEAD>
 <BODY>
-<H1>SOAP Scanner</H1>
+<H1>SOAP Add-on</H1>
 This add-on imports and scans WSDL files containing SOAP endpoints.
 <h2>Importing</H2>
 The add-on will automatically detect any SOAP definitions and spider them as long as they are in scope.
@@ -20,7 +20,7 @@ The add-on will automatically detect any SOAP definitions and spider them as lon
 These operations are also available via the API.
 
 <h2>Scanning</H2>
-The scans rules added by this add-on are:
+The scan rules added by this add-on are:
 <ul>
 <li>Action Spoofing : <a href="http://www.ws-attacks.org/index.php/SOAPAction_Spoofing">http://www.ws-attacks.org/index.php/SOAPAction_Spoofing</a></li>
 <li>XML Injection : <a href="http://www.ws-attacks.org/index.php/XML_Injection">http://www.ws-attacks.org/index.php/XML_Injection</a></li>

--- a/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
+++ b/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
@@ -30,10 +30,10 @@ soap.soapxmlinjection.refs=http://www.ws-attacks.org/index.php/XML_Injection
 soap.soapxmlinjection.warn1=Response has not SOAP format after XML Injection attack.
 soap.soapxmlinjection.warn2=Response content has been altered after XML Injection attack.
 
-soap.wsdlfilepscan.name=WSDL File Passive Scanner
+soap.wsdlfilepscan.name=WSDL File Detection
 soap.wsdlfilepscan.desc=A WSDL File has been detected.
 soap.wsdlfilepscan.other=A WSDL File has been detected.
-soap.wsdlfilepscan.soln=Make your WSDL files visible only for technical issues (p.e. testing purposes).
+soap.wsdlfilepscan.soln=Make your WSDL files visible only for technical issues (ex: testing purposes).
 soap.wsdlfilepscan.refs= No references.
 
 soap.importfromurldialog.pasteaction=Paste

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class SOAPActionSpoofingActiveScannerTestCase {
+public class SOAPActionSpoofingActiveScanRuleTestCase {
 
     private HttpMessage originalMsg = new HttpMessage();
     private HttpMessage modifiedMsg = new HttpMessage();
@@ -44,26 +44,26 @@ public class SOAPActionSpoofingActiveScannerTestCase {
 
     @Test
     public void scanResponseTest() throws Exception {
-        SOAPActionSpoofingActiveScanner scanner = new SOAPActionSpoofingActiveScanner();
+        SOAPActionSpoofingActiveScanRule scanner = new SOAPActionSpoofingActiveScanRule();
 
         /* Positive cases. */
         int result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == SOAPActionSpoofingActiveScanner.SOAPACTION_EXECUTED);
+        assertTrue(result == SOAPActionSpoofingActiveScanRule.SOAPACTION_EXECUTED);
 
         Sample.setOriginalResponse(modifiedMsg);
         result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == SOAPActionSpoofingActiveScanner.SOAPACTION_IGNORED);
+        assertTrue(result == SOAPActionSpoofingActiveScanRule.SOAPACTION_IGNORED);
 
         /* Negative cases. */
         result = scanner.scanResponse(new HttpMessage(), originalMsg);
-        assertTrue(result == SOAPActionSpoofingActiveScanner.EMPTY_RESPONSE);
+        assertTrue(result == SOAPActionSpoofingActiveScanRule.EMPTY_RESPONSE);
 
         Sample.setEmptyBodyResponse(modifiedMsg);
         result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == SOAPActionSpoofingActiveScanner.EMPTY_RESPONSE);
+        assertTrue(result == SOAPActionSpoofingActiveScanRule.EMPTY_RESPONSE);
 
         Sample.setInvalidFormatResponse(modifiedMsg);
         result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == SOAPActionSpoofingActiveScanner.INVALID_FORMAT);
+        assertTrue(result == SOAPActionSpoofingActiveScanRule.INVALID_FORMAT);
     }
 }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class WSDLFilePassiveScannerTestCase {
+public class WSDLFilePassiveScanRuleTestCase {
     private HttpMessage wsdlMsg = new HttpMessage();
 
     @BeforeEach
@@ -46,7 +46,7 @@ public class WSDLFilePassiveScannerTestCase {
     public void isWsdlTest()
             throws NoSuchMethodException, SecurityException, IllegalAccessException,
                     IllegalArgumentException, InvocationTargetException {
-        WSDLFilePassiveScanner scanner = new WSDLFilePassiveScanner();
+        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
         /* Positive case. */
         boolean result = scanner.isWsdl(wsdlMsg);
         assertTrue(result);


### PR DESCRIPTION
- Scan Rule class names.
- Scan Rule unittest names.
- Help content.
- CHANGELOG split Fixed and Changed items, already contained "Maintenance changes" item.

Part of: zaproxy/zaproxy#6049

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>