### PR TITLE
Avoid flagging missing SRI attribute when HTML asset is inline

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Fixed bug where Sub Resource Integrity Attribute Missing scan rule alerts even when HTML asset is inline (Issue 6047).
+
 ## [27] - 2020-06-01
 ### Added
 - Added links to the code in the help.

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
@@ -69,7 +69,7 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner 
                     element.getAttributeValue(
                             SupportedElements.valueOf(element.getName().toUpperCase(Locale.ROOT))
                                     .attribute);
-            if (url == null) {
+            if (url == null || url.startsWith("data:")) {
                 return Optional.of(origin);
             }
             URI uri = null;

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
@@ -208,6 +208,23 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
         assertThat(alertsRaised.size(), equalTo(1));
     }
 
+    @Test
+    public void shouldNotRaiseAlertGivenHtmlAssetIsInline() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg =
+                buildMessage(
+                        "<html><head>"
+                                + "<script src=\"data:,\"></script>"
+                                + "<link href=\"data:,\">"
+                                + "</head><body></body></html>");
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
     private static HttpMessage buildMessage(String body) throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://example.com/ HTTP/1.1");


### PR DESCRIPTION
Resolves zaproxy/zaproxy#6047.