### PR TITLE
jython: update Jython library

### DIFF
--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Update Jython from 2.7.1 to 2.7.2.
 - Update the help to mention the bundled Jython version.
 - Jython templates now includes an extender script (getInputsFromuser.py) for setting global script variables based on user input.
 

--- a/addOns/jython/jython.gradle.kts
+++ b/addOns/jython/jython.gradle.kts
@@ -15,7 +15,7 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("org.python:jython-standalone:2.7.1")
+    implementation("org.python:jython-standalone:2.7.2")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
+++ b/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/ExtensionJython.java
@@ -22,11 +22,7 @@ package org.zaproxy.zap.extension.jython;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 import javax.swing.ImageIcon;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
@@ -40,8 +36,6 @@ public class ExtensionJython extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionJython";
     public static final ImageIcon PYTHON_ICON;
-
-    private static final Logger LOGGER = Logger.getLogger(ExtensionJython.class);
 
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
 
@@ -60,7 +54,6 @@ public class ExtensionJython extends ExtensionAdaptor {
 
     private ExtensionScript extScript = null;
     private JythonOptionsParam jythonOptionsParam;
-    private CountDownLatch engineLoaderCDL;
 
     public ExtensionJython() {
         super(NAME);
@@ -73,60 +66,13 @@ public class ExtensionJython extends ExtensionAdaptor {
 
         this.jythonOptionsParam = new JythonOptionsParam();
 
-        ScriptEngineManager mgr = new ScriptEngineManager();
-
-        ScriptEngine se = mgr.getEngineByExtension("py");
-
-        if (se == null) {
-            if (getView() == null) {
-                engineLoaderCDL = new CountDownLatch(1);
-            }
-
-            Thread engineLoaderThread =
-                    new Thread(
-                            new Runnable() {
-
-                                @Override
-                                public void run() {
-                                    try {
-                                        LOGGER.info("Loading Jython engine...");
-                                        getExtScript()
-                                                .registerScriptEngineWrapper(
-                                                        new JythonEngineWrapper(
-                                                                jythonOptionsParam,
-                                                                new PyScriptEngineFactory()));
-                                        LOGGER.info("Jython engine loaded.");
-                                    } finally {
-                                        if (engineLoaderCDL != null) {
-                                            engineLoaderCDL.countDown();
-                                        }
-                                    }
-                                }
-                            });
-            engineLoaderThread.setName("ZAP-Jython-EngineLoader");
-            engineLoaderThread.start();
-        }
+        getExtScript()
+                .registerScriptEngineWrapper(
+                        new JythonEngineWrapper(jythonOptionsParam, new PyScriptEngineFactory()));
 
         extensionHook.addOptionsParamSet(this.jythonOptionsParam);
         if (null != super.getView()) {
             extensionHook.getHookView().addOptionPanel(new JythonOptionsPanel());
-        }
-    }
-
-    @Override
-    public void postInit() {
-        super.postInit();
-
-        if (engineLoaderCDL != null) {
-            try {
-                LOGGER.info("Waiting for Jython engine to load...");
-                engineLoaderCDL.await();
-            } catch (InterruptedException e) {
-                LOGGER.warn("Interrupted while waiting for the Jython engine to load.");
-                Thread.currentThread().interrupt();
-            } finally {
-                engineLoaderCDL = null;
-            }
         }
     }
 

--- a/addOns/jython/src/main/javahelp/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
+++ b/addOns/jython/src/main/javahelp/org/zaproxy/zap/extension/jython/resources/help/contents/jython.html
@@ -10,7 +10,7 @@ Python Scripting
 <H1>Python Scripting</H1>
 <p>
 	The Python Scripting add-on allows you to integrate Python scripts in ZAP.<br>
-	It's bundled Jython 2.7.1.
+	It's bundled Jython 2.7.2.
 </p>
 <p>
 	When you create a new script you will be given the option to use Python, as well as the option to choose from various Python templates.


### PR DESCRIPTION
Update to latest version, 2.7.2, for improvements and fixes (addresses
"illegal reflective access" warnings with newer Java versions).
Remove workaround for slow engine start up, no longer required.

Part of zaproxy/zaproxy#2602.