### PR TITLE
Add External Trigger support for retirejs and wappalyzer jobs

### DIFF
--- a/.github/workflows/create_retirejs_update.yml
+++ b/.github/workflows/create_retirejs_update.yml
@@ -3,10 +3,16 @@ name: Create Retirejs Update PR
 on:
   schedule:
     - cron:  '0 4 2 * *'
+  repository_dispatch:
+    types: retirejs
+  # Trigger using CURL or similar such as:
+  # curl -XPOST -u "<replace_username>:<replace_personal_access_token>" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/zaproxy/zap-extensions/dispatches --data '{"event_type": "retirejs"}'
+  # Replace the username and personal access token, including angled brackets
 
 jobs:
   create_pr:
     name: Create Pull Request
+    if: github.actor == 'kingthorin' || github.actor == 'psiinon' || github.actor == 'thc202'
     runs-on: ubuntu-latest
     steps:
     - name: Build Feature Branch and Raise PR

--- a/.github/workflows/create_wappalyzer_update.yml
+++ b/.github/workflows/create_wappalyzer_update.yml
@@ -3,10 +3,16 @@ name: Create Wappalyzer Update PR
 on:
   schedule:
     - cron:  '0 4 3 * *'
+  repository_dispatch:
+    types: wappalyzer
+  # Trigger using CURL or similar such as:
+  # curl -XPOST -u "<replace_username>:<replace_personal_access_token>" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/zaproxy/zap-extensions/dispatches --data '{"event_type": "wappalyzer"}'
+  # Replace the username and personal access token, including angled brackets
 
 jobs:
   create_pr:
     name: Create Pull Request
+    if: github.actor == 'kingthorin' || github.actor == 'psiinon' || github.actor == 'thc202'
     runs-on: ubuntu-latest
     steps:
     - name: Build Feature Branch and Raise PR


### PR DESCRIPTION
Wappalyzer and Retirejs create update PR jobs now support being triggered by a web request.

https://github.community/t/who-will-be-the-github-actor-when-a-workflow-runs-on-a-schedule/17369/2 seems to suggest that it's whoever commits the job that is `github.actor` for the scheduled invocation. So that if actor check should be fine for the monthly cron use.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>