### PR TITLE
wappalyzer: correct script check

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct script matching, check only script elements (Issue 6054).
 
 ## [20.0.0] - 2020-06-15
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -122,13 +122,17 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
         }
         checkBodyMatches(msg);
         checkMetaElementsMatches(source);
-        checkScriptMatches(msg);
+        checkScriptElementsMatches(source);
     }
 
-    private void checkScriptMatches(HttpMessage msg) {
-        String body = msg.getResponseBody().toString();
-        for (AppPattern p : currentApp.getScript()) {
-            addIfMatches(p, body);
+    private void checkScriptElementsMatches(Source source) {
+        for (Element scriptElement : source.getAllElements(HTMLElementName.SCRIPT)) {
+            for (AppPattern appPattern : currentApp.getScript()) {
+                String src = scriptElement.getAttributeValue("src");
+                if (src != null && !src.isEmpty()) {
+                    addIfMatches(appPattern, src);
+                }
+            }
         }
     }
 

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -82,18 +82,35 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void testModernizr() throws HttpMalformedHeaderException {
+    public void shouldMatchScriptElement() throws HttpMalformedHeaderException {
+        // Given
         HttpMessage msg = makeHttpMessage();
-
         msg.setResponseBody(
                 "<html>"
                         + "<script type='text/javascript' src='libs/modernizr.min.js?ver=4.1.1'>"
                         + "</script>"
                         + "</html>");
+
+        // When
         scan(msg);
 
+        // Then
         assertFoundAppCount("https://www.example.com", 1);
         assertFoundApp("https://www.example.com", "Modernizr");
+    }
+
+    @Test
+    public void shouldNotMatchScriptElementContentIfNotOnScriptElement()
+            throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = makeHttpMessage();
+        msg.setResponseBody("<html><body>libs/modernizr.min.js?ver=4.1.1</body></html>");
+
+        // When
+        scan(msg);
+
+        // Then
+        assertNull(getDefaultHolder().getAppsForSite("https://www.example.com"));
     }
 
     @Test


### PR DESCRIPTION
Check only the src attribute of script elements not the whole response.

Fix zaproxy/zaproxy#6054 - Wappalyzer regexes being applied to the wrong
elements