### PR TITLE
Add conditional handling to add-on update jobs

### DIFF
--- a/.github/workflows/create_retirejs_update.yml
+++ b/.github/workflows/create_retirejs_update.yml
@@ -38,10 +38,15 @@ jobs:
         cd ..
         cp -f retire.js/repository/jsrepository.json zap-extensions/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources
         cd zap-extensions
-        ./gradlew :addOns:retire:updateChangelog --change="- Updated with upstream retire.js pattern changes."
-        git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
-        git add .
-        git commit -m "retire.js Update $SHORT_DATE" -m "Updates based on $SRC_BASE" --signoff
-        git push --set-upstream origin $BRANCH_STAMP
-        # Open the PR
-        hub pull-request --no-edit
+        ## Update the index to be sure git is aware of changes
+        git update-index -q --refresh
+        ## If there are changes: comment, commit, PR
+        if ! git diff-index --quiet HEAD --; then 
+          ./gradlew :addOns:retire:updateChangelog --change="- Updated with upstream retire.js pattern changes."
+          git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
+          git add .
+          git commit -m "retire.js Update $SHORT_DATE" -m "Updates based on $SRC_BASE" --signoff
+          git push --set-upstream origin $BRANCH_STAMP
+          # Open the PR
+          hub pull-request --no-edit
+        fi

--- a/.github/workflows/create_wappalyzer_update.yml
+++ b/.github/workflows/create_wappalyzer_update.yml
@@ -42,10 +42,15 @@ jobs:
         cp -R wappalyzer/src/drivers/webextension/images/icons/ zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/icons
         cp -f wappalyzer/src/apps.json zap-extensions/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources
         cd zap-extensions
-        ./gradlew :addOns:wappalyzer:updateChangelog --change="- Updated with upstream Wappalyzer icon and pattern changes."
-        git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
-        git add .
-        git commit -m "Wappalyzer Update $SHORT_DATE" -m "Updates based on $SRC_BASE" --signoff
-        git push --set-upstream origin $BRANCH_STAMP
-        # Open the PR
-        hub pull-request --no-edit
+        ## Update the index to be sure git is aware of changes
+        git update-index -q --refresh
+        ## If there are changes: comment, commit, PR
+        if ! git diff-index --quiet HEAD --; then
+          ./gradlew :addOns:wappalyzer:updateChangelog --change="- Updated with upstream Wappalyzer icon and pattern changes."
+          git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
+          git add .
+          git commit -m "Wappalyzer Update $SHORT_DATE" -m "Updates based on $SRC_BASE" --signoff
+          git push --set-upstream origin $BRANCH_STAMP
+          # Open the PR
+          hub pull-request --no-edit
+        fi


### PR DESCRIPTION
PRs will now only be created if there are actually changes from upstream.

In follow-up to: https://github.com/zaproxy/zap-extensions/pull/2479

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>