### PR TITLE
requester: sync with core features

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -7,9 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add help.
 - Add info and repo URLs.
+- Allow to disable cookies (Issue 4934).
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+
+### Fixed
+- Add the requests to the Sites tree to be able to active scan them (Issue 5778).
+- Enforce the mode when sending the request and following redirections.
 
 ## 3 - 2018-10-15
 

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ExtensionRequester.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ExtensionRequester.java
@@ -57,6 +57,8 @@ public class ExtensionRequester extends ExtensionAdaptor {
         super.hook(extensionHook);
         extensionHook.addOptionsParamSet(getOptionsParam());
         if (getView() != null) {
+            extensionHook.addOptionsChangedListener(getRequesterPanel());
+
             ExtensionHookView hookView = extensionHook.getHookView();
             hookView.addWorkPanel(getRequesterPanel());
             hookView.addOptionPanel(getOptionsPanel());

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
@@ -40,6 +40,7 @@ import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -134,7 +135,7 @@ public class ManualHttpRequestEditorPanel extends ManualRequestEditorPanel {
     }
 
     @Override
-    protected MessageSender getMessageSender() {
+    protected HttpPanelSender getMessageSender() {
         return sender;
     }
 
@@ -300,7 +301,7 @@ public class ManualHttpRequestEditorPanel extends ManualRequestEditorPanel {
         try {
             URI uri = new URI("http://www.any_domain_name.org/path", true);
             msg.setRequestHeader(
-                    new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP10));
+                    new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11));
             setMessage(msg);
         } catch (HttpMalformedHeaderException e) {
             logger.error(e.getMessage(), e);
@@ -636,16 +637,22 @@ public class ManualHttpRequestEditorPanel extends ManualRequestEditorPanel {
     }
 
     public void addPersistentConnectionListener(PersistentConnectionListener listener) {
-        ((HttpPanelSender) getMessageSender()).addPersistentConnectionListener(listener);
+        getMessageSender().addPersistentConnectionListener(listener);
     }
 
     public void removePersistentConnectionListener(PersistentConnectionListener listener) {
-        ((HttpPanelSender) getMessageSender()).removePersistentConnectionListener(listener);
+        getMessageSender().removePersistentConnectionListener(listener);
     }
 
     public void beforeClose() {
         HttpPanelManager panelManager = HttpPanelManager.getInstance();
         panelManager.removeRequestPanel(getRequestPanel());
         panelManager.removeResponsePanel(getResponsePanel());
+    }
+
+    void optionsChanged(OptionsParam optionsParam) {
+        getMessageSender()
+                .setButtonTrackingSessionStateEnabled(
+                        optionsParam.getConnectionParam().isHttpStateEnabled());
     }
 }

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/NumberedTabbedPane.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/NumberedTabbedPane.java
@@ -20,12 +20,14 @@
 package org.zaproxy.zap.extension.requester;
 
 import java.awt.Component;
+import java.util.function.Consumer;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JTabbedPane;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import org.parosproxy.paros.model.OptionsParam;
 
 public abstract class NumberedTabbedPane extends JTabbedPane {
 
@@ -74,9 +76,17 @@ public abstract class NumberedTabbedPane extends JTabbedPane {
     }
 
     void unload() {
+        processEditorPanels(ManualHttpRequestEditorPanel::beforeClose);
+    }
+
+    private void processEditorPanels(Consumer<ManualHttpRequestEditorPanel> consumer) {
         int editorPanels = getTabCount() - 1;
         for (int i = 0; i < editorPanels; i++) {
-            ((ManualHttpRequestEditorPanel) getComponentAt(i)).beforeClose();
+            consumer.accept((ManualHttpRequestEditorPanel) getComponentAt(i));
         }
+    }
+
+    void optionsChanged(OptionsParam optionsParam) {
+        processEditorPanels(panel -> panel.optionsChanged(optionsParam));
     }
 }

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/RequesterPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/RequesterPanel.java
@@ -23,9 +23,11 @@ import java.awt.GridLayout;
 import java.awt.event.KeyEvent;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
+import org.parosproxy.paros.extension.OptionsChangedListener;
+import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class RequesterPanel extends AbstractPanel {
+public class RequesterPanel extends AbstractPanel implements OptionsChangedListener {
 
     private static final long serialVersionUID = 1L;
 
@@ -62,5 +64,10 @@ public class RequesterPanel extends AbstractPanel {
 
     void unload() {
         getRequesterNumberedTabbedPane().unload();
+    }
+
+    @Override
+    public void optionsChanged(OptionsParam optionsParam) {
+        getRequesterNumberedTabbedPane().optionsChanged(optionsParam);
     }
 }


### PR DESCRIPTION
Apply the changes done in core manual request editor:
 - Add the requests to the Sites tree (to be able to scan them);
 - Reset the user when resending the message;
 - Use HTTP/1.1 in the default message;
 - Allow to disable cookies;
 - Enforce the mode (e.g. protected, safe);
 - Dynamically enable/disable the session tracking button when the
 option changes.

Fix zaproxy/zaproxy#5778 - It is not possible attack a history entry
generated by Requester tab
Fix zaproxy/zaproxy#4934 - Requester - Allow to disable cookies