### PR TITLE
openapi: fix NPE when unable to get the definition

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correct parent dialogue when choosing the file to import (Issue 6041).
 - Properly handle no schema when generating the request body (Issue 6042).
+- Return API error `illegal_parameter` (instead of `internal_error`) when unable to get the OpenAPI definition from the provided URL.
 
 ## [16] - 2020-06-09
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -157,7 +157,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
      * @param initViaUi {@code true} if the import is being done through the GUI, {@code false}
      *     otherwise.
      * @return the list of errors, if any. Returns {@code null} if the import is being done through
-     *     the GUI.
+     *     the GUI, or, if not done through the GUI the target was not accessed (caused by an {@code
+     *     IOException}).
      * @throws InvalidUrlException if the target URL is not valid.
      */
     public List<String> importOpenApiDefinition(

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
@@ -108,6 +108,11 @@ public class OpenApiAPI extends ApiImplementor {
                         extension.importOpenApiDefinition(
                                 new URI(params.getString(PARAM_URL), false), override, false);
 
+                if (errors == null) {
+                    throw new ApiException(
+                            ApiException.Type.ILLEGAL_PARAMETER, "Failed to access the target.");
+                }
+
                 ApiResponseList result = new ApiResponseList(name);
                 for (String error : errors) {
                     result.addItem(new ApiResponseElement("warning", error));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
@@ -1,0 +1,102 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+import net.sf.json.JSONObject;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.model.DefaultNameValuePair;
+import org.zaproxy.zap.model.NameValuePair;
+
+/** Unit test for {@link OpenApiAPI}. */
+public class OpenApiAPIUnitTest extends AbstractServerTest {
+
+    private ExtensionOpenApi extension;
+
+    private OpenApiAPI openApiAPI;
+
+    @BeforeEach
+    public void prepare() {
+        extension = mock(ExtensionOpenApi.class);
+        openApiAPI = new OpenApiAPI(extension);
+    }
+
+    @Test
+    public void shouldThrowBadActionIfActionUnknown() {
+        // Given
+        String actionName = "_NotKnownAction_";
+        // When / Then
+        ApiException exception =
+                assertThrows(
+                        ApiException.class, () -> openApiAPI.handleApiAction(actionName, params()));
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_ACTION)));
+    }
+
+    @Nested
+    class ApiImportUrl {
+
+        private static final String ACTION = "importUrl";
+
+        @Test
+        public void shouldThrowIllegalParameterIfFailedToAccessTarget() {
+            // Given
+            JSONObject params = params(param("url", "http://not-reachable.example.com"));
+            given(extension.importOpenApiDefinition(any(URI.class), eq(""), eq(false)))
+                    .willReturn(null);
+            // When / Then
+            ApiException exception =
+                    assertThrows(
+                            ApiException.class, () -> openApiAPI.handleApiAction(ACTION, params));
+            assertThat(exception.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
+            assertThat(exception.toString(), containsString("Failed to access the target."));
+        }
+    }
+
+    private static JSONObject params(NameValuePair... params) {
+        if (params == null || params.length == 0) {
+            return JSONObject.fromObject(new HashMap<>());
+        }
+
+        return JSONObject.fromObject(
+                Arrays.asList(params).stream()
+                        .collect(
+                                Collectors.toMap(NameValuePair::getName, NameValuePair::getValue)));
+    }
+
+    private static NameValuePair param(String name, String value) {
+        return new DefaultNameValuePair(name, value);
+    }
+}


### PR DESCRIPTION
Check the return value for null when importing the OpenAPI definition
through the API, it's null when unable to access/get the definition
(`IOException`).