### PR TITLE
viewstate: prepare release

### DIFF
--- a/addOns/viewstate/CHANGELOG.md
+++ b/addOns/viewstate/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [2] - 2020-07-07
 ### Added
 - Add help.
 - Add info and repo URLs.
@@ -18,3 +18,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 
+[2]: https://github.com/zaproxy/zap-extensions/releases/viewstate-v2


### PR DESCRIPTION
Add release date and link to tag.

---
For the leak fix, which prevents the requester add-on from being properly unloaded.