### PR TITLE
Some improvements for the FrontEndScanner

### DIFF
--- a/addOns/frontendscanner/frontendscanner.gradle.kts
+++ b/addOns/frontendscanner/frontendscanner.gradle.kts
@@ -10,3 +10,7 @@ zapAddOn {
         url.set("https://www.zaproxy.org/docs/desktop/addons/front-end-scanner/")
     }
 }
+
+dependencies {
+    testImplementation(project(":testutils"))
+}

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
@@ -32,20 +32,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.swing.ImageIcon;
-import net.htmlparser.jericho.Element;
-import net.htmlparser.jericho.OutputDocument;
-import net.htmlparser.jericho.Source;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
-import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.extension.history.ProxyListenerLog;
-import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
@@ -55,7 +48,7 @@ import org.zaproxy.zap.view.ZapToggleButton;
  * A ZAP extension which allow to run scripts in the browser to detect vulnerabilities in web
  * applications relying heavily on Javascript.
  */
-public class ExtensionFrontEndScanner extends ExtensionAdaptor implements ProxyListener {
+public class ExtensionFrontEndScanner extends ExtensionAdaptor {
 
     // The name is public so that other extensions can access it
     public static final String NAME = "ExtensionFrontEndScanner";
@@ -77,8 +70,9 @@ public class ExtensionFrontEndScanner extends ExtensionAdaptor implements ProxyL
     private ScriptType passiveScriptType;
     private ExtensionScript extensionScript;
 
-    private FrontEndScannerOptions options;
     private FrontEndScannerAPI api;
+    private FrontEndScannerOptions options;
+    private FrontEndScannerProxyListener proxyListener;
 
     private static final Logger LOGGER = Logger.getLogger(ExtensionFrontEndScanner.class);
 
@@ -105,6 +99,8 @@ public class ExtensionFrontEndScanner extends ExtensionAdaptor implements ProxyL
         this.api = new FrontEndScannerAPI(this);
         this.api.addApiOptions(options);
 
+        this.proxyListener = new FrontEndScannerProxyListener(api, options);
+
         this.extensionScript =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionScript.class);
     }
@@ -113,7 +109,7 @@ public class ExtensionFrontEndScanner extends ExtensionAdaptor implements ProxyL
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 
-        extensionHook.addProxyListener(this);
+        extensionHook.addProxyListener(this.proxyListener);
 
         extensionHook.addOptionsParamSet(options);
         extensionHook.addApiImplementor(api);
@@ -186,64 +182,6 @@ public class ExtensionFrontEndScanner extends ExtensionAdaptor implements ProxyL
     @Override
     public String getDescription() {
         return Constant.messages.getString(PREFIX + ".desc");
-    }
-
-    @Override
-    public boolean onHttpRequestSend(HttpMessage msg) {
-        return true;
-    }
-
-    @Override
-    public boolean onHttpResponseReceive(HttpMessage msg) {
-        if (options.isEnabled() && msg.getResponseHeader().isHtml()) {
-            try {
-                String html = msg.getResponseBody().toString();
-
-                Source document = new Source(html);
-                List<Element> heads = document.getAllElements("head");
-                Element head = heads.isEmpty() ? null : heads.get(0);
-
-                if (head != null && msg.getHistoryRef() != null) {
-                    String host = msg.getRequestHeader().getHeader("host");
-                    String frontEndApiUrl =
-                            API.getInstance().getCallBackUrl(this.api, "https://" + host);
-
-                    int historyReferenceId = msg.getHistoryRef().getHistoryId();
-
-                    StringBuilder injectedContentBuilder =
-                            new StringBuilder(200)
-                                    .append("<script src='")
-                                    .append(frontEndApiUrl)
-                                    .append("?action=getFile")
-                                    .append("&filename=front-end-scanner.js")
-                                    .append("&historyReferenceId=")
-                                    .append(historyReferenceId)
-                                    .append("'></script>");
-
-                    String injectedContent = injectedContentBuilder.toString();
-
-                    OutputDocument newResponseBody = new OutputDocument(document);
-                    int insertPosition = head.getChildElements().get(0).getBegin();
-                    newResponseBody.insert(insertPosition, injectedContent);
-
-                    msg.getResponseBody().setBody(newResponseBody.toString());
-
-                    int newLength = msg.getResponseBody().length();
-                    msg.getResponseHeader().setContentLength(newLength);
-                } else {
-                    LOGGER.debug("<head></head> is missing in the response");
-                }
-            } catch (Exception e) {
-                LOGGER.error(e.getMessage(), e);
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public int getArrangeableListenerOrder() {
-        // Need to run after the HistoryReference has been saved to the database
-        return ProxyListenerLog.PROXY_LISTENER_ORDER + 42;
     }
 
     @Override

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
@@ -36,6 +36,10 @@ public class FrontEndScannerProxyListener implements ProxyListener {
     private final FrontEndScannerAPI api;
     private final FrontEndScannerOptions options;
 
+    private static final String[] CSP_HEADERS = {
+        "Content-Security-Policy", "X-Content-Security-Policy", "X-WebKit-CSP"
+    };
+
     public FrontEndScannerProxyListener(FrontEndScannerAPI api, FrontEndScannerOptions options) {
         this.api = api;
         this.options = options;
@@ -83,6 +87,10 @@ public class FrontEndScannerProxyListener implements ProxyListener {
 
                     int newLength = msg.getResponseBody().length();
                     msg.getResponseHeader().setContentLength(newLength);
+
+                    for (String header : CSP_HEADERS) {
+                        msg.getResponseHeader().setHeader(header, null);
+                    }
                 } else {
                     LOGGER.debug("<head></head> is missing in the response");
                 }

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
@@ -1,0 +1,101 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.frontendscanner;
+
+import java.util.List;
+import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.OutputDocument;
+import net.htmlparser.jericho.Source;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.core.proxy.ProxyListener;
+import org.parosproxy.paros.extension.history.ProxyListenerLog;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.api.API;
+
+/** The {@link ProxyListener} the {@link ExtensionFrontEndScanner} relies on. */
+public class FrontEndScannerProxyListener implements ProxyListener {
+    private static final Logger LOGGER = Logger.getLogger(FrontEndScannerProxyListener.class);
+
+    private final FrontEndScannerAPI api;
+    private final FrontEndScannerOptions options;
+
+    public FrontEndScannerProxyListener(FrontEndScannerAPI api, FrontEndScannerOptions options) {
+        this.api = api;
+        this.options = options;
+    }
+
+    @Override
+    public boolean onHttpRequestSend(HttpMessage msg) {
+        return true;
+    }
+
+    @Override
+    public boolean onHttpResponseReceive(HttpMessage msg) {
+        if (options.isEnabled() && msg.getResponseHeader().isHtml()) {
+            try {
+                String html = msg.getResponseBody().toString();
+
+                Source document = new Source(html);
+                List<Element> heads = document.getAllElements("head");
+                Element head = heads.isEmpty() ? null : heads.get(0);
+
+                if (head != null && msg.getHistoryRef() != null) {
+                    String host = msg.getRequestHeader().getHeader("host");
+                    String frontEndApiUrl =
+                            API.getInstance().getCallBackUrl(this.api, "https://" + host);
+
+                    int historyReferenceId = msg.getHistoryRef().getHistoryId();
+
+                    StringBuilder injectedContentBuilder =
+                            new StringBuilder(200)
+                                    .append("<script src='")
+                                    .append(frontEndApiUrl)
+                                    .append("?action=getFile")
+                                    .append("&filename=front-end-scanner.js")
+                                    .append("&historyReferenceId=")
+                                    .append(historyReferenceId)
+                                    .append("'></script>");
+
+                    String injectedContent = injectedContentBuilder.toString();
+
+                    OutputDocument newResponseBody = new OutputDocument(document);
+                    int insertPosition = head.getChildElements().get(0).getBegin();
+                    newResponseBody.insert(insertPosition, injectedContent);
+
+                    msg.getResponseBody().setBody(newResponseBody.toString());
+
+                    int newLength = msg.getResponseBody().length();
+                    msg.getResponseHeader().setContentLength(newLength);
+                } else {
+                    LOGGER.debug("<head></head> is missing in the response");
+                }
+            } catch (Exception e) {
+                LOGGER.error(e.getMessage(), e);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int getArrangeableListenerOrder() {
+        // Need to run after the HistoryReference has been saved to the database
+        return ProxyListenerLog.PROXY_LISTENER_ORDER + 42;
+    }
+}

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
@@ -76,7 +76,7 @@ public class FrontEndScannerProxyListener implements ProxyListener {
                     String injectedContent = injectedContentBuilder.toString();
 
                     OutputDocument newResponseBody = new OutputDocument(document);
-                    int insertPosition = head.getChildElements().get(0).getBegin();
+                    int insertPosition = getInsertPosition(head);
                     newResponseBody.insert(insertPosition, injectedContent);
 
                     msg.getResponseBody().setBody(newResponseBody.toString());
@@ -91,6 +91,20 @@ public class FrontEndScannerProxyListener implements ProxyListener {
             }
         }
         return true;
+    }
+
+    private static int getInsertPosition(Element head) {
+        // The payload needs to be inserted in front of as many elements as possible;
+        // But still after the `<meta>` tag (if there is any).
+
+        List<Element> metaElements = head.getAllElements("meta");
+        int size = metaElements.size();
+
+        if (size == 0) {
+            return head.getChildElements().get(0).getBegin();
+        } else {
+            return metaElements.get(size - 1).getEnd();
+        }
     }
 
     @Override

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
@@ -56,35 +56,17 @@ public class FrontEndScannerProxyListener implements ProxyListener {
             try {
                 String html = msg.getResponseBody().toString();
 
-                Source document = new Source(html);
-                List<Element> heads = document.getAllElements("head");
-                Element head = heads.isEmpty() ? null : heads.get(0);
-
-                if (head != null && msg.getHistoryRef() != null) {
+                if (msg.getHistoryRef() != null) {
                     String host = msg.getRequestHeader().getHeader("host");
                     String frontEndApiUrl =
                             API.getInstance().getCallBackUrl(this.api, "https://" + host);
 
                     int historyReferenceId = msg.getHistoryRef().getHistoryId();
+                    String scriptToInject = getScriptToInject(frontEndApiUrl, historyReferenceId);
 
-                    StringBuilder injectedContentBuilder =
-                            new StringBuilder(200)
-                                    .append("<script src='")
-                                    .append(frontEndApiUrl)
-                                    .append("?action=getFile")
-                                    .append("&filename=front-end-scanner.js")
-                                    .append("&historyReferenceId=")
-                                    .append(historyReferenceId)
-                                    .append("'></script>");
-
-                    String injectedContent = injectedContentBuilder.toString();
-
-                    OutputDocument newResponseBody = new OutputDocument(document);
-                    int insertPosition = getInsertPosition(head);
-                    newResponseBody.insert(insertPosition, injectedContent);
+                    OutputDocument newResponseBody = makeNewDocument(html, scriptToInject);
 
                     msg.getResponseBody().setBody(newResponseBody.toString());
-
                     int newLength = msg.getResponseBody().length();
                     msg.getResponseHeader().setContentLength(newLength);
 
@@ -92,7 +74,7 @@ public class FrontEndScannerProxyListener implements ProxyListener {
                         msg.getResponseHeader().setHeader(header, null);
                     }
                 } else {
-                    LOGGER.debug("<head></head> is missing in the response");
+                    LOGGER.debug("No historyRef found in the HttpMessage.");
                 }
             } catch (Exception e) {
                 LOGGER.error(e.getMessage(), e);
@@ -101,18 +83,65 @@ public class FrontEndScannerProxyListener implements ProxyListener {
         return true;
     }
 
-    private static int getInsertPosition(Element head) {
+    private static OutputDocument makeNewDocument(String originalHtml, String scriptToInject) {
+        Source document = new Source(originalHtml);
+
+        List<Element> heads = document.getAllElements("head");
+        Element head = heads.isEmpty() ? null : heads.get(0);
+        List<Element> htmls = document.getAllElements("html");
+        Element html = htmls.isEmpty() ? null : htmls.get(0);
+
+        int insertPosition = getInsertPosition(head, html);
+
+        StringBuilder contentToInjectBuilder = new StringBuilder(scriptToInject);
+
+        if (head == null) {
+            contentToInjectBuilder.insert(0, "<head>");
+            contentToInjectBuilder.append("</head>");
+        }
+
+        OutputDocument newHtml = new OutputDocument(document);
+        newHtml.insert(insertPosition, contentToInjectBuilder.toString());
+
+        return newHtml;
+    }
+
+    private static int getInsertPosition(Element head, Element html) {
         // The payload needs to be inserted in front of as many elements as possible;
         // But still after the `<meta>` tag (if there is any).
+        if (head == null) {
+            return (html == null) ? 0 : html.getStartTag().getEnd();
+        }
+
+        List<Element> headChildren = head.getChildElements();
+        int numberOfChildren = headChildren.size();
+
+        if (numberOfChildren == 0) {
+            return head.getStartTag().getEnd();
+        }
 
         List<Element> metaElements = head.getAllElements("meta");
-        int size = metaElements.size();
+        int numberOfMetaTags = metaElements.size();
 
-        if (size == 0) {
+        if (numberOfMetaTags == 0) {
             return head.getChildElements().get(0).getBegin();
         } else {
-            return metaElements.get(size - 1).getEnd();
+            return metaElements.get(numberOfMetaTags - 1).getEnd();
         }
+    }
+
+    private static String getScriptToInject(String frontEndApiUrl, int historyReferenceId) {
+        StringBuilder scriptToInjectBuilder =
+                new StringBuilder(200)
+                        .append("<script src='")
+                        .append(frontEndApiUrl)
+                        .append("?action=getFile")
+                        .append("&filename=front-end-scanner.js")
+                        .append("&historyReferenceId=")
+                        .append(historyReferenceId)
+                        .append("'></script>");
+
+        return scriptToInjectBuilder.toString();
     }
 
     @Override

--- a/addOns/frontendscanner/src/main/javahelp/org/zaproxy/zap/extension/frontendscanner/resources/help/contents/frontendscanner.html
+++ b/addOns/frontendscanner/src/main/javahelp/org/zaproxy/zap/extension/frontendscanner/resources/help/contents/frontendscanner.html
@@ -11,6 +11,8 @@ Front-End Scanner
 
 When installed and enabled, the Front-End Scanner add-on tampers with all HTTP responses passing through ZAP to inject a piece of JavaScript code containing custom logic, utility functions and scripts that ZAP users wish to run in the browser to help them audit front-end applications.
 
+<STRONG>Note:</STRONG> to be able to fully work, the add-on automatically removes CSP headers from webpages.
+
 
 <H2>Add a script to be run in the browser</H2>
 

--- a/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
+++ b/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
@@ -136,4 +136,80 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
 
         assertTrue(result.matches(expectedHtmlFormat));
     }
+
+    @Test
+    public void testInjectionShouldBeSuccessfulWithoutHead() {
+        // Given
+        String htmlBody = "<!doctype html><html lang='en'><body></body></head></html>";
+        msg.setResponseBody(htmlBody);
+
+        // When
+        frontEndScannerProxyListener.onHttpResponseReceive(msg);
+
+        // Then
+        String expectedHtmlFormat =
+                "<!doctype html><html lang='en'><head><script src='https:\\/\\/"
+                        + HOSTNAME
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></head></html>";
+        String result = msg.getResponseBody().toString();
+
+        assertTrue(result.matches(expectedHtmlFormat));
+    }
+
+    @Test
+    public void testInjectionShouldBeSuccessfulWithEmptyHead() {
+        // Given
+        String htmlBody = "<!doctype html><html lang='en'><head></head><body></body></html>";
+        msg.setResponseBody(htmlBody);
+
+        // When
+        frontEndScannerProxyListener.onHttpResponseReceive(msg);
+
+        // Then
+        String expectedHtmlFormat =
+                "<!doctype html><html lang='en'><head><script src='https:\\/\\/"
+                        + HOSTNAME
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
+        String result = msg.getResponseBody().toString();
+
+        assertTrue(result.matches(expectedHtmlFormat));
+    }
+
+    @Test
+    public void testInjectionShouldBeSuccessfulWithoutHtmlTag() {
+        // Given
+        String htmlBody = "<head></head><body></body>";
+        msg.setResponseBody(htmlBody);
+
+        // When
+        frontEndScannerProxyListener.onHttpResponseReceive(msg);
+
+        // Then
+        String expectedHtmlFormat =
+                "<head><script src='https:\\/\\/"
+                        + HOSTNAME
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body>";
+        String result = msg.getResponseBody().toString();
+
+        assertTrue(result.matches(expectedHtmlFormat));
+    }
+
+    @Test
+    public void testInjectionShouldBeSuccessfulWithoutHtmlNorHeadTag() {
+        // Given
+        String htmlBody = "<body></body>";
+        msg.setResponseBody(htmlBody);
+
+        // When
+        frontEndScannerProxyListener.onHttpResponseReceive(msg);
+
+        // Then
+        String expectedHtmlFormat =
+                "<head><script src='https:\\/\\/"
+                        + HOSTNAME
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body>";
+        String result = msg.getResponseBody().toString();
+
+        assertTrue(result.matches(expectedHtmlFormat));
+    }
 }

--- a/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
+++ b/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.frontendscanner;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link FrontEndScannerProxyListener}. */
+public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
+
+    private static final String HOSTNAME = "example.com";
+
+    private FrontEndScannerProxyListener frontEndScannerProxyListener;
+    private HttpMessage msg;
+
+    @BeforeEach
+    public void setUp() throws URIException, HttpMalformedHeaderException {
+        FrontEndScannerAPI api = mock(FrontEndScannerAPI.class);
+        FrontEndScannerOptions options = mock(FrontEndScannerOptions.class);
+        when(options.isEnabled()).thenReturn(true);
+
+        HistoryReference ref = mock(HistoryReference.class);
+        when(ref.getHistoryId()).thenReturn(42);
+
+        frontEndScannerProxyListener = new FrontEndScannerProxyListener(api, options);
+
+        msg = new HttpMessage(new URI("https", HOSTNAME, "/", ""));
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
+        msg.setHistoryRef(ref);
+    }
+
+    @Test
+    public void testInjectTheFrontEndTrackerBeforeOtherScriptsInHeadTag() {
+        // Given
+        String htmlBody =
+                "<!doctype html><html lang='en'><head><script></script></head><body></body></html>";
+        msg.setResponseBody(htmlBody);
+
+        // When
+        frontEndScannerProxyListener.onHttpResponseReceive(msg);
+
+        // Then
+        String expectedHtmlFormat =
+                "<!doctype html><html lang='en'><head><script src='https:\\/\\/"
+                        + HOSTNAME
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><script><\\/script><\\/head><body><\\/body></html>";
+        String result = msg.getResponseBody().toString();
+
+        assertTrue(result.matches(expectedHtmlFormat));
+    }
+}

--- a/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
+++ b/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
@@ -76,4 +76,43 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
 
         assertTrue(result.matches(expectedHtmlFormat));
     }
+
+    @Test
+    public void testInjectAfterMetaTagInHeadTag() {
+        // Given
+        String htmlBody = "<!doctype html><html lang='en'><head><meta></head><body></body></html>";
+        msg.setResponseBody(htmlBody);
+
+        // When
+        frontEndScannerProxyListener.onHttpResponseReceive(msg);
+
+        // Then
+        String expectedHtmlFormat =
+                "<!doctype html><html lang='en'><head><meta><script src='https:\\/\\/"
+                        + HOSTNAME
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
+        String result = msg.getResponseBody().toString();
+
+        assertTrue(result.matches(expectedHtmlFormat));
+    }
+
+    @Test
+    public void testInjectAfterAllMetaTagsInHeadTag() {
+        // Given
+        String htmlBody =
+                "<!doctype html><html lang='en'><head><meta><meta></head><body></body></html>";
+        msg.setResponseBody(htmlBody);
+
+        // When
+        frontEndScannerProxyListener.onHttpResponseReceive(msg);
+
+        // Then
+        String expectedHtmlFormat =
+                "<!doctype html><html lang='en'><head><meta><meta><script src='https:\\/\\/"
+                        + HOSTNAME
+                        + "\\/zapCallBackUrl\\/-?[0-9]+\\?action=getFile&filename=front-end-scanner.js&historyReferenceId=42'><\\/script><\\/head><body><\\/body></html>";
+        String result = msg.getResponseBody().toString();
+
+        assertTrue(result.matches(expectedHtmlFormat));
+    }
 }


### PR DESCRIPTION
3 features in 1 PR:
  * solution for zaproxy/zaproxy#4897
  * ~brutal~ easy fix for zaproxy/zaproxy#4893
  * deal with "corner cases" in `<head>`: when it's not present, and when it's empty