### PR TITLE
Switch retire and wappalyzer jobs manual trigger

### DIFF
--- a/.github/workflows/create_retirejs_update.yml
+++ b/.github/workflows/create_retirejs_update.yml
@@ -3,11 +3,7 @@ name: Create Retirejs Update PR
 on:
   schedule:
     - cron:  '0 4 2 * *'
-  repository_dispatch:
-    types: retirejs
-  # Trigger using CURL or similar such as:
-  # curl -XPOST -u "<replace_username>:<replace_personal_access_token>" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/zaproxy/zap-extensions/dispatches --data '{"event_type": "retirejs"}'
-  # Replace the username and personal access token, including angled brackets
+  workflow_dispatch:
 
 jobs:
   create_pr:

--- a/.github/workflows/create_wappalyzer_update.yml
+++ b/.github/workflows/create_wappalyzer_update.yml
@@ -3,11 +3,7 @@ name: Create Wappalyzer Update PR
 on:
   schedule:
     - cron:  '0 4 3 * *'
-  repository_dispatch:
-    types: wappalyzer
-  # Trigger using CURL or similar such as:
-  # curl -XPOST -u "<replace_username>:<replace_personal_access_token>" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/zaproxy/zap-extensions/dispatches --data '{"event_type": "wappalyzer"}'
-  # Replace the username and personal access token, including angled brackets
+  workflow_dispatch:
 
 jobs:
   create_pr:


### PR DESCRIPTION
Instead of using web requests (repository_dispatch) use the new web UI manual run functionality (workflow_displatch). Per:
https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>