### PR TITLE
Fix 6082: Session Fixation check flags case insensitively

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance Changes.
 - Backup File Disclosure: don't raise issues for non-success codes unless at LOW threshold (Issue 6059).
 - ELMAH Information Leak: don't raise issues unless content looks good unless at LOW threshold (Issue 6076).
+- Session Fixation scan rule fix potential false positive on session cookie HttpOnly, and Secure flags (Issue 6082).
 
 ## [28] - 2020-06-01
 ### Added

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
@@ -417,7 +417,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     // Check 1: was the session cookie sent and received securely by the server?
                     // If not, alert this fact
                     if ((!msg1Final.getRequestHeader().isSecure())
-                            || (!cookieBack1.getFlags().contains("secure"))) {
+                            || (!containsIgnoreCase(cookieBack1.getFlags(), "secure"))) {
                         // pass the original param value here, not the new value, since we're
                         // displaying the session id exposed in the original message
                         String extraInfo =
@@ -496,7 +496,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     //////////////////////////////////////////////////////////////////////
                     // Check 2: is the session cookie that was set accessible to Javascript?
                     // If so, alert this fact too
-                    if (!cookieBack1.getFlags().contains("httponly") && loginUrl) {
+                    if (!containsIgnoreCase(cookieBack1.getFlags(), "httponly") && loginUrl) {
                         // pass the original param value here, not the new value, since we're
                         // displaying the session id exposed in the original message
                         String extraInfo =
@@ -1570,6 +1570,15 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
         }
         // return them
         return pseudoUrlParams;
+    }
+
+    private static boolean containsIgnoreCase(Set<String> setToCheck, String strToFind) {
+        for (String item : setToCheck) {
+            if (item.equalsIgnoreCase(strToFind)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
- SessionFixationScanRule > Add convenience method for checking `Set<String>` content case insensitively.
- CHANGELOG > Add change entry.

Fixes zaproxy/zaproxy#6082

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>