### PR TITLE
CsrfTokenScanRule Ignore Non-HTML & Prepare Release

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -3,8 +3,12 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [30] - 2020-07-23
+### Changed
+- Anti-CSRF Tokens Check address potential false positives by only analyzing HTML responses (Issue 6089).
+
 ## [29] - 2020-07-22
-### Change
+### Changed
 - Maintenance Changes.
 - Backup File Disclosure: don't raise issues for non-success codes unless at LOW threshold (Issue 6059).
 - ELMAH Information Leak: don't raise issues unless content looks good unless at LOW threshold (Issue 6076).
@@ -212,6 +216,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated to support new addon format
 
+[30]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v30
 [29]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v29
 [28]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v28
 [27]: https://github.com/zaproxy/zap-extensions/releases/ascanrulesBeta-v27

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -1,6 +1,6 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "29"
+version = "30"
 description = "The beta quality Active Scanner rules"
 
 zapAddOn {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
@@ -131,8 +131,9 @@ public class CsrfTokenScanRule extends AbstractAppPlugin {
      */
     @Override
     public void scan() {
-        if (AlertThreshold.HIGH.equals(getAlertThreshold()) && !getBaseMsg().isInScope()) {
-            return; // At HIGH threshold return if the msg isn't in scope
+        if ((AlertThreshold.HIGH.equals(getAlertThreshold()) && !getBaseMsg().isInScope())
+                || !getBaseMsg().getResponseHeader().isHtml()) {
+            return;
         }
 
         boolean vuln = false;

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -40,7 +40,7 @@ SilverLight's clientaccesspolicy.xml.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CrossDomainScanRule.java">CrossDomainScanRule.java</a>
 
 <H2>CSRF Token</H2>
-Scans for the existence of Anti-CSRF tokens. <br>
+Scans HTML based messages for the existence of Anti-CSRF tokens. <br>
 Alerts on requests which do not appear to contain Anti-CSRF tokens.<br>
 At HIGH alert threshold only scans messages which are in scope.<br>
 Post 2.5.0 you can specify a comma separated list of identifiers in the 


### PR DESCRIPTION
- ascanrulesBeta.gradle.kts > Update version for next iteration.
- CHANGELOG > Update for next iteration and add change note.
- CsrfTokenScanRule > Add conditional to bail if the original message was non-HTML.
- CsrfTokenScanRuleUnitTest > Add a new test method to assert the new behavior, that no message is sent when the content-type of the original isn't HTML.

Fixes zaproxy/zaproxy#6089

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>