### PR TITLE
Sonar Fixes

### DIFF
--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java
@@ -449,7 +449,7 @@ public class MongoDbInjectionScanRule extends AbstractAppParamPlugin {
                     index++;
                 } catch (SocketTimeoutException ex) {
                     hadTimeout = true;
-                    if (phase == INSERT_LONG_TIME) {
+                    if (INSERT_LONG_TIME.equals(phase)) {
                         // Timeout: 40s --> 14 <= n. tuples < 40
                         timeShort /= 3;
                         timeLong /= 3;

--- a/addOns/customreport/CHANGELOG.md
+++ b/addOns/customreport/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Add info and repo URLs.
+- Maintenance changes.
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.

--- a/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/AlertsPanel.java
+++ b/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/AlertsPanel.java
@@ -132,7 +132,7 @@ public class AlertsPanel extends JPanel {
                     public void itemStateChanged(java.awt.event.ItemEvent e) {
                         boolean selected = (ItemEvent.SELECTED == e.getStateChange());
                         for (JCheckBox selection : selections) {
-                            if (alertTypeRisk.get(selection.getName()) == riskName) {
+                            if (alertTypeRisk.get(selection.getName()).equals(riskName)) {
                                 selection.setSelected(selected);
                             }
                         }

--- a/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/ReportLastScan.java
+++ b/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/ReportLastScan.java
@@ -288,7 +288,7 @@ public class ReportLastScan {
         for (int i = 0; i < extensionCount; i++) {
             Extension extension = loader.getExtension(i);
             if (extension instanceof XmlReporterExtension
-                    && extension.getName() != "ExtensionAlert") {
+                    && !extension.getName().equals("ExtensionAlert")) {
                 String xml_temp = ((XmlReporterExtension) extension).getXml(site);
                 extensionXml.append(xml_temp);
             }

--- a/addOns/exportreport/CHANGELOG.md
+++ b/addOns/exportreport/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option to specify active scan id in API.
 - Added option to specify inclusion of passive alerts in API and command line.
 - Add info and repo URLs.
+- Maintenance changes.
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/FrameExportReport.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/FrameExportReport.java
@@ -127,7 +127,7 @@ public class FrameExportReport extends AbstractFrame implements ActionListener {
             }
         }
         if (e.getSource() == this.btnNext) {
-            if (btnNext.getText() == FINISH) {
+            if (FINISH.equals(btnNext.getText())) {
                 extension.generateReport();
             }
 

--- a/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/filechooser/ReportFilter.java
+++ b/addOns/exportreport/src/main/java/org/zaproxy/zap/extension/exportreport/filechooser/ReportFilter.java
@@ -48,7 +48,7 @@ public class ReportFilter extends FileFilter {
         if (f.isFile()) {
             String ext = Utils.getExtension(f);
             if (ext != null) {
-                if (search != Utils.ALL) {
+                if (!Utils.ALL.equals(search)) {
                     if (ext.equalsIgnoreCase(list.getExtension(search))) {
                         return true;
                     }
@@ -71,7 +71,7 @@ public class ReportFilter extends FileFilter {
     @Override
     public String getDescription() {
         String strExtension = "";
-        if (search != Utils.ALL) {
+        if (!Utils.ALL.equals(search)) {
             strExtension = String.format(" (*%s)", list.getExtension(search));
         } else {
             strExtension = Constant.messages.getString("exportreport.message.notice.all") + " (";

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Maintenance changes.
 
 ## [12] - 2020-01-17
 ### Added

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
@@ -479,7 +479,7 @@ public class FuzzOptionsPanel extends AbstractParamPanel {
         FuzzOptions options = ((OptionsParam) optionParams).getParamSet(FuzzOptions.class);
 
         String selectedCategory = (String) defaultCategoryComboBox.getSelectedItem();
-        if (selectedCategory == customCategoryName) {
+        if (selectedCategory.equals(customCategoryName)) {
             selectedCategory = null;
         }
         options.setCustomDefaultCategory(selectedCategory == null);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
@@ -62,17 +62,13 @@ public class XDebugTokenScanRule extends PluginPassiveScanner {
 
         // Check "Link" variant first as it's of greater concern/convenience.
         if (responseHasHeader(msg, X_DEBUG_TOKEN_LINK_HEADER)) {
-            for (String xdtl : getHeaders(msg, X_DEBUG_TOKEN_LINK_HEADER)) {
-                raiseAlert(msg, xdtl);
-                return; // No need to continue
-            }
+            raiseAlert(msg, getHeaders(msg, X_DEBUG_TOKEN_LINK_HEADER).get(0));
+            return;
         }
         // Check non-Link variant
         if (responseHasHeader(msg, X_DEBUG_TOKEN_HEADER)) {
-            for (String xdt : getHeaders(msg, X_DEBUG_TOKEN_HEADER)) {
-                raiseAlert(msg, xdt);
-                return; // No need to continue
-            }
+            raiseAlert(msg, getHeaders(msg, X_DEBUG_TOKEN_HEADER).get(0));
+            return;
         }
 
         if (LOGGER.isDebugEnabled()) {

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Add info and repo URLs.
+- Maintenance changes.
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/ExtensionRevisit.java
@@ -346,7 +346,7 @@ public class ExtensionRevisit extends ExtensionAdaptor implements ProxyListener 
         if (msg2 == null) {
             return false;
         }
-        if (!msg.getRequestHeader().getMethod().equals(msg.getRequestHeader().getMethod())) {
+        if (!msg.getRequestHeader().getMethod().equals(msg2.getRequestHeader().getMethod())) {
             // Different methods
             return false;
         }

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Maintenance changes.
 
 ## [23.1.0] - 2020-01-17
 ### Added

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
@@ -512,7 +512,7 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
             return Constant.messages.getString("spiderajax.scandialog.nobrowser.error");
         }
 
-        if (Browser.PHANTOM_JS.getId() == selectedBrowser) {
+        if (Browser.PHANTOM_JS.getId().equals(selectedBrowser)) {
             String host = startUri.getHost();
             if ("localhost".equalsIgnoreCase(host)
                     || "127.0.0.1".equals(host)

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
@@ -122,7 +122,7 @@ public class AjaxSpiderResultsTableModel
                     @Override
                     public void run() {
                         final int row = resources.size();
-                        idsToRows.put(Integer.valueOf(entry.getHistoryId()), Integer.valueOf(row));
+                        idsToRows.put(entry.getHistoryId(), Integer.valueOf(row));
                         resources.add(entry);
                         fireTableRowsInserted(row, row);
                     }

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Maintenance changes.
 
 ### Fixed
 - Correctly handle API request without parameters.

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/contents/MessageContent.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/contents/MessageContent.java
@@ -74,7 +74,7 @@ public class MessageContent extends WebSocketContent {
                                 .getReadablePayload()
                                 .compareTo(that.getMessage().getReadablePayload());
                 if (compareResult == 0
-                        && this.getMessage().isOutgoing != that.getMessage().isOutgoing) {
+                        && !this.getMessage().isOutgoing.equals(that.getMessage().isOutgoing)) {
                     compareResult = that.getMessage().isOutgoing ? 1 : -1;
                 }
             } catch (InvalidUtf8Exception ignored) {

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Maintenance changes.
 
 ### Fixed
 - Make sure the header fields are separated with CRLF when edited in the UI.

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
@@ -131,7 +131,7 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
 
         if (scrMsg != null) {
             String reqBodyFromScript = scrMsg.getRequestBody().toString();
-            if (reqBodyFromScript == null || reqBodyFromScript == "") {
+            if (reqBodyFromScript == null || reqBodyFromScript.isEmpty()) {
                 return;
             }
             String[] nameValuePairs = reqBodyFromScript.split("&");

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
@@ -269,7 +269,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
     private void initElementsSelector() {
         String value = this.getStringValue(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR);
         getField(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR_ATTRIBUTE_NAME)
-                .setEnabled(value == FROM_ELEMENT_SELECTOR_ATTRIBUTE);
+                .setEnabled(FROM_ELEMENT_SELECTOR_ATTRIBUTE.equals(value));
     }
 
     private void addFieldListenerToSetEnabledOnCheckedChanged(
@@ -402,9 +402,9 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
             za.atIndex(index, reverse);
 
             String value = this.getStringValue(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR);
-            if (value == FROM_ELEMENT_SELECTOR_CONTENT) {
+            if (FROM_ELEMENT_SELECTOR_CONTENT.equals(value)) {
                 za.selectContent();
-            } else if (value == FROM_ELEMENT_SELECTOR_ATTRIBUTE) {
+            } else if (FROM_ELEMENT_SELECTOR_ATTRIBUTE.equals(value)) {
                 String attributeName =
                         getStringValue(
                                 FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR_ATTRIBUTE_NAME);
@@ -526,7 +526,7 @@ public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDi
             }
 
             String value = this.getStringValue(FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR);
-            if (value == FROM_ELEMENT_SELECTOR_ATTRIBUTE
+            if (FROM_ELEMENT_SELECTOR_ATTRIBUTE.equals(value)
                     && this.isEmptyField(
                             FIELD_FROM_ELEMENT_FILTERED_ELEMENTS_SELECTOR_ATTRIBUTE_NAME)) {
                 return Constant.messages.getString(


### PR DESCRIPTION
- ZestSequenceRUnner & ZestAssignmentDialog > String content check should use .isEmpty vs double-double-quote. (Added CHANGELOG entry.)
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntKMVuKkC1XNoNuM&resolved=false&rules=java%3AS4973&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSLG7WlkO9R-U5SQp&resolved=false&rules=java%3AS4973&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSLG7WlkO9R-U5SQq&resolved=false&rules=java%3AS4973&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSLG7WlkO9R-U5SQr&resolved=false&rules=java%3AS4973&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSLG7WlkO9R-U5SQs&resolved=false&rules=java%3AS4973&types=BUG
- MessageContent > Booleans should use .equals for comparison. (Added CHANGELOG entry.)
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSJyMWlkO9R-U5SNo&resolved=false&rules=java%3AS4973&types=BUG
- AjaxSpiderDialog > Strings should use .equals for comparison.
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntNrVuKkC1XNoNzV&resolved=false&rules=java%3AS4973&types=BUG
- FuzzOptionsPanel > Strings should use .equals for comparison. (Added CHANGELOG entry.)
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntFvVuKkC1XNoNlY&resolved=false&rules=java%3AS4973&types=BUG
- MongoDbInjectionScanRule > Strings should use .equals for comparison. (CHANGELOG already contains "maintenance changes" entry)
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSMouWlkO9R-U5SZ7&resolved=false&rules=java%3AS4973&types=BUG
- AlertsPanel & ReportLastScan > Strings to use .equals for comparison. (CHANGELOG entry added).
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntwrVuKkC1XNoPF7&resolved=false&rules=java%3AS4973&types=BUG
- FrameExportReport & ReportFilter > Strings to use .equals for comparison. (CHANGELOG entry added).
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntchVuKkC1XNoOOD&resolved=false&rules=java%3AS4973&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntakVuKkC1XNoOLW&resolved=false&rules=java%3AS4973&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntakVuKkC1XNoOLX&resolved=false&rules=java%3AS4973&types=BUG
- XDebugTokenScanRule > No need to loop when bailing on first occurrence. (CHANGELOG already contains "Maintenance changes" entry.)
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSOa5WlkO9R-U5Ske&resolved=false&rules=java%3AS1751&types=BUG
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSOa5WlkO9R-U5Skf&resolved=false&rules=java%3AS1751&types=BUG
- AjaxSpiderResultsTableModel > Remove un-necessary boxing/un-boxing. (Added CHANGELOG note.)
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AW0_ntNiVuKkC1XNoNzJ&resolved=false&rules=java%3AS2153&types=BUG
- ExtensionRevisit > Fix mistaken rightside/leftside identical comparison. (Added CHANGELOG entry.)
https://sonarcloud.io/project/issues?id=zaproxy_zap-extensions&open=AXKGSN0tWlkO9R-U5SeO&resolved=false&rules=java%3AS1764&types=BUG