### PR TITLE
commonlib: Adjust AbstractAppFilePlugin non-200 handling

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- AbstractAppFilePlugin > don't raise issues for responses other than 200 - Ok unless at LOW threshold (Issue 6077). This will make the following Alpha and Beta active scan rules slightly less False Positive prone:
+  - Trace.axd, .env File, .htaccess file
 
 ## [1.0.0] - 2020-05-21
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
@@ -178,10 +178,11 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
         }
         int statusCode = newRequest.getResponseHeader().getStatusCode();
         if (statusCode == HttpStatusCode.OK) {
-            raiseAlert(newRequest, getRisk(), "");
-        } else if (statusCode == HttpStatusCode.UNAUTHORIZED
-                || statusCode == HttpStatusCode.FORBIDDEN) {
-            raiseAlert(newRequest, Alert.RISK_INFO, getOtherInfo());
+            raiseAlert(newRequest, getRisk(), Alert.CONFIDENCE_MEDIUM, "");
+        } else if (this.getAlertThreshold().equals(AlertThreshold.LOW)
+                && (statusCode == HttpStatusCode.UNAUTHORIZED
+                        || statusCode == HttpStatusCode.FORBIDDEN)) {
+            raiseAlert(newRequest, Alert.RISK_INFO, Alert.CONFIDENCE_LOW, getOtherInfo());
         }
     }
 
@@ -209,10 +210,10 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
         return newPath;
     }
 
-    private void raiseAlert(HttpMessage msg, int risk, String otherInfo) {
+    private void raiseAlert(HttpMessage msg, int risk, int confidence, String otherInfo) {
         newAlert()
                 .setRisk(risk)
-                .setConfidence(Alert.CONFIDENCE_HIGH)
+                .setConfidence(confidence)
                 .setOtherInfo(otherInfo)
                 .setEvidence(msg.getResponseHeader().getPrimeHeader())
                 .setMessage(msg)


### PR DESCRIPTION
- AbstractAppFilePlugin > Only alert for 401/403 responses at Low threshold.
- CHANGELOG > Add a change note.

Fixes zaproxy/zaproxy#6077

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>