### PR TITLE
Prepare release of websocket and fuzz add-ons

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [13.0.0] - 2020-08-17
 ### Added
  - Allow to add fuzz specific message components and views to fuzzer dialogue.
 
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Use semantic versioning.
 - Maintenance changes.
 
 ## [12] - 2020-01-17
@@ -113,5 +114,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First version.
 
+[13.0.0]: https://github.com/zaproxy/zap-extensions/releases/fuzz-v13.0.0
 [12]: https://github.com/zaproxy/zap-extensions/releases/fuzz-v12
 [11]: https://github.com/zaproxy/zap-extensions/releases/fuzz-v11

--- a/addOns/fuzz/fuzz.gradle.kts
+++ b/addOns/fuzz/fuzz.gradle.kts
@@ -1,6 +1,13 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "13"
+plugins {
+    `maven-publish`
+    signing
+}
+
+group = "org.zaproxy.addon"
+
+version = "13.0.0"
 description = "Advanced fuzzer for manual testing"
 
 tasks.withType<JavaCompile> {
@@ -8,12 +15,11 @@ tasks.withType<JavaCompile> {
 }
 
 zapAddOn {
-    addOnName.set("AdvFuzzer")
+    addOnName.set("Fuzzer")
     addOnStatus.set(AddOnStatus.BETA)
     zapVersion.set("2.9.0")
 
     manifest {
-        semVer.set("2.0.1")
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/fuzzer/")
     }
@@ -29,4 +35,94 @@ dependencies {
     implementation("dk.brics.automaton:automaton:1.11-8")
 
     testImplementation(project(":testutils"))
+}
+
+val sourceSets = extensions.getByName("sourceSets") as SourceSetContainer
+
+tasks.register<Jar>("javadocJar") {
+    from(tasks.named("javadoc"))
+    archiveClassifier.set("javadoc")
+}
+
+tasks.register<Jar>("sourcesJar") {
+    from(sourceSets.named("main").map { it.allJava })
+    archiveClassifier.set("sources")
+}
+
+val ossrhUsername: String? by project
+val ossrhPassword: String? by project
+
+publishing {
+    repositories {
+        maven {
+            val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            setUrl(provider { if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl })
+
+            if (ossrhUsername != null && ossrhPassword != null) {
+                credentials {
+                    username = ossrhUsername
+                    password = ossrhPassword
+                }
+            }
+        }
+    }
+
+    publications {
+        register<MavenPublication>("addon") {
+            from(components["java"])
+
+            artifact(tasks["sourcesJar"])
+            artifact(tasks["javadocJar"])
+
+            pom {
+                name.set("OWASP ZAP - Fuzzer Add-on")
+                packaging = "jar"
+                description.set(project.description)
+                url.set("https://github.com/zaproxy/zap-extensions")
+                inceptionYear.set("2015")
+
+                organization {
+                    name.set("OWASP")
+                    url.set("https://www.zaproxy.org/")
+                }
+
+                mailingLists {
+                    mailingList {
+                        name.set("OWASP ZAP Developer Group")
+                        post.set("zaproxy-develop@googlegroups.com")
+                        archive.set("https://groups.google.com/group/zaproxy-develop")
+                    }
+                }
+
+                scm {
+                    url.set("https://github.com/zaproxy/zap-extensions")
+                    connection.set("scm:git:https://github.com/zaproxy/zap-extensions.git")
+                    developerConnection.set("scm:git:https://github.com/zaproxy/zap-extensions.git")
+                }
+
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        distribution.set("repo")
+                    }
+                }
+
+                developers {
+                    developer {
+                        id.set("AllAddOnDevs")
+                        name.set("Everyone who has contributed to the add-on")
+                        email.set("zaproxy-develop@googlegroups.com")
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    if (project.hasProperty("signing.keyId")) {
+        sign(publishing.publications["addon"])
+    }
 }

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -3,9 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [22] - 2020-08-17
 ### Changed
 - Update minimum ZAP version to 2.9.0.
+- Allow to use newer versions of Fuzzer add-on.
 - Maintenance changes.
 
 ### Fixed
@@ -155,6 +156,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 
+[22]: https://github.com/zaproxy/zap-extensions/releases/websocket-v22
 [21]: https://github.com/zaproxy/zap-extensions/releases/websocket-v21
 [20]: https://github.com/zaproxy/zap-extensions/releases/websocket-v20
 [19]: https://github.com/zaproxy/zap-extensions/releases/websocket-v19

--- a/addOns/websocket/websocket.gradle.kts
+++ b/addOns/websocket/websocket.gradle.kts
@@ -22,7 +22,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("fuzz") {
-                            semVer.set("2.*")
+                            version.set("2.* | 13.*")
                         }
                     }
                 }


### PR DESCRIPTION
Add release dates and links to tags.
Change fuzz add-on to use semantic versioning and remove "Adv" from the
name.
The add-on will be published to Maven Central with the following
group/id:
 - Group: `org.zaproxy.addon`;
 - Id: `fuzz` (same as the add-on ID).

Change websocket add-on to also target the newer version of fuzz add-on.