### PR TITLE
GraphQL: Add Option For Separated Arguments 

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.1.0] - 2020-08-28
+- First Version
+- Features
+  - Import a GraphQL Schema
+  - Generate Queries from an imported Schema
 
-- Bare-bones add-on (no functionality yet).
+[0.1.0]: https://github.com/zaproxy/zap-extensions/releases/graphql-v0.1.0

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -1,4 +1,4 @@
-version = "0.0.1"
+version = "0.1.0"
 description = "Inspect and attack GraphQL endpoints."
 
 zapAddOn {

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
@@ -31,6 +31,7 @@ public class GraphQlParam extends VersionedAbstractParam {
     private static final String PARAM_MAX_QUERY_DEPTH = PARAM_BASE_KEY + ".maxQueryDepth";
     private static final String PARAM_MAX_ARGS_DEPTH = PARAM_BASE_KEY + ".maxArgsDepth";
     private static final String PARAM_OPTIONAL_ARGS = PARAM_BASE_KEY + ".optionalArgs";
+    private static final String PARAM_ARGS_TYPE = PARAM_BASE_KEY + ".argsType";
     private static final String PARAM_QUERY_SPLIT_TYPE = PARAM_BASE_KEY + ".querySplitType";
     private static final String PARAM_REQUEST_METHOD = PARAM_BASE_KEY + ".requestMethod";
 
@@ -44,19 +45,44 @@ public class GraphQlParam extends VersionedAbstractParam {
 
     public GraphQlParam() {}
 
-    /** For unit tests */
+    /** For unit tests. */
     public GraphQlParam(
             int maxQueryDepth,
             int maxArgsDepth,
             boolean optionalArgsEnabled,
+            ArgsTypeOption argsType,
             QuerySplitOption querySplitType,
             RequestMethodOption requestMethod) {
         this.maxQueryDepth = maxQueryDepth;
         this.maxArgsDepth = maxArgsDepth;
         this.optionalArgsEnabled = optionalArgsEnabled;
+        this.argsType = argsType;
         this.querySplitType = querySplitType;
         this.requestMethod = requestMethod;
     }
+
+    /** This option is used to specify how field arguments should be included. */
+    public enum ArgsTypeOption {
+        /** Arguments are added in-line. */
+        INLINE,
+        /** Arguments are added using variables. */
+        VARIABLES,
+        /** Each request is sent twice - once with in-line arguments and once using variables. */
+        BOTH;
+
+        public String getName() {
+            switch (this) {
+                case INLINE:
+                    return Constant.messages.getString("graphql.options.value.args.inline");
+                case VARIABLES:
+                    return Constant.messages.getString("graphql.options.value.args.variables");
+                case BOTH:
+                    return Constant.messages.getString("graphql.options.value.args.both");
+                default:
+                    return null;
+            }
+        }
+    };
 
     /** This option is used to specify how the queries should be generated and sent. */
     public enum QuerySplitOption {
@@ -109,6 +135,7 @@ public class GraphQlParam extends VersionedAbstractParam {
     private int maxQueryDepth;
     private int maxArgsDepth;
     private boolean optionalArgsEnabled;
+    private ArgsTypeOption argsType;
     private QuerySplitOption querySplitType;
     private RequestMethodOption requestMethod;
 
@@ -137,6 +164,15 @@ public class GraphQlParam extends VersionedAbstractParam {
     public void setOptionalArgsEnabled(boolean optionalArgsEnabled) {
         this.optionalArgsEnabled = optionalArgsEnabled;
         getConfig().setProperty(PARAM_OPTIONAL_ARGS, optionalArgsEnabled);
+    }
+
+    public ArgsTypeOption getArgsType() {
+        return argsType;
+    }
+
+    public void setArgsType(ArgsTypeOption argsType) {
+        this.argsType = argsType;
+        getConfig().setProperty(PARAM_ARGS_TYPE, argsType.toString());
     }
 
     public QuerySplitOption getQuerySplitType() {
@@ -172,6 +208,8 @@ public class GraphQlParam extends VersionedAbstractParam {
         maxQueryDepth = getInt(PARAM_MAX_QUERY_DEPTH, 5);
         maxArgsDepth = getInt(PARAM_MAX_ARGS_DEPTH, 5);
         optionalArgsEnabled = getBoolean(PARAM_OPTIONAL_ARGS, false);
+        argsType =
+                ArgsTypeOption.valueOf(getString(PARAM_ARGS_TYPE, ArgsTypeOption.BOTH.toString()));
         querySplitType =
                 QuerySplitOption.valueOf(
                         getString(PARAM_QUERY_SPLIT_TYPE, QuerySplitOption.LEAF.toString()));

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ParserThread.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ParserThread.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ParserThread extends Thread {
+
+    private AtomicBoolean running = new AtomicBoolean(false);
+
+    public ParserThread(String name) {
+        super(name);
+    }
+
+    public void startParser() {
+        running.set(true);
+        start();
+    }
+
+    public void stopParser() {
+        interrupt();
+        running.set(false);
+    }
+
+    protected boolean isRunning() {
+        return running.get();
+    }
+}

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/graphql.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/graphql.html
@@ -8,7 +8,7 @@ GraphQL Support
 </HEAD>
 <BODY>
 <H1>GraphQL Support</H1>
-This add-on allows you to import GraphQL definitions.
+This add-on allows you to import GraphQL definitions and send queries generated from them.
 <br><br>
 The add-on will automatically detect any GraphQL definitions and spider them as long as they are in scope. <br>
 The spider is supported on ZAP 2.10.0 and later.
@@ -24,6 +24,10 @@ The spider is supported on ZAP 2.10.0 and later.
 The Endpoint URL has the following format:<br>
 <code>scheme://authority/path</code><br>
 with all URI components mandatory when importing from file.
+
+<h3>Options Panel</h3>
+A GraphQL Options Panel is added under Tools -> Options -> GraphQL.
+These options allow you to control the output of the Query Generator.
 
 <H2>API</H2>
 The following operations are added to the API:

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/options.html
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/contents/options.html
@@ -21,13 +21,22 @@
 	
 	If this option is selected then optional (nullable) arguments will be specified too.
 
+	<h2>Specify Arguments</h2>
+
+	Choose how the field arguments should be added in the generated query,
+	<ul>
+		<li>Inline</li>
+		<li>Using Variables</li>
+		<li>Both - each query will be sent twice, once with inline arguments and once with variables</li>
+	</ul>
+
 	<h2>Generate Query For</h2>
 	
 	A separate query may be generated for either of the following in the provided schema, 
 	<ul>
-	<li>each Leaf, that is, each scalar or enum;</li>
-	<li>each field under a root operation type (Query, Mutation or Subscription); or</li>
-	<li>each root operation type.</li>
+		<li>each Leaf, that is, each scalar or enum;</li>
+		<li>each field under a root operation type (Query, Mutation or Subscription); or</li>
+		<li>each root operation type.</li>
 	</ul>
 
 	<h2>Request Method</h2>
@@ -35,9 +44,9 @@
 	The requests made to the endpoint can be of the following types:
 
 	<ul>
-	<li>A POST request with a JSON body (Content-Type: application/json)</li>
-	<li>A POST request with a GraphQL query in the body (Content-Type: application/graphql)</li>
-	<li>A GET request with the query appended to it in a query string</li>
+		<li>A POST request with a JSON body (Content-Type: application/json)</li>
+		<li>A POST request with a GraphQL query in the body (Content-Type: application/graphql)</li>
+		<li>A GET request with the query appended to it in a query string</li>
 	</ul>
 
 	<h2>See also</h2>

--- a/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/toc.xml
+++ b/addOns/graphql/src/main/javahelp/org/zaproxy/addon/graphql/resources/help/toc.xml
@@ -6,7 +6,9 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="GraphQL Support" image="graphql-icon" target="graphql"/>
+			<tocitem text="GraphQL Support" image="graphql-icon" target="graphql">
+				<tocitem text="Options" image="graphql-icon" target="graphql.options"/>
+			</tocitem>
 		</tocitem>
 	</tocitem>
 </toc>

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -34,13 +34,17 @@ graphql.error.filenotfound = Cannot find the specified file.
 graphql.error.emptyendurl = Endpoint URL must be specified.
 graphql.error.invalidurl = Please enter a valid URL.\n{0}
 
-graphql.options.panelName = GraphQL Options
+graphql.options.panelName = GraphQL
 graphql.options.label.queryDepth = Maximum Query Depth:
 graphql.options.label.argsDepth = Maximum Arguments Depth:
 graphql.options.label.split = Generate Query For:
 graphql.options.label.requestMethod = Request Method:
+graphql.options.label.argsType = Specify Arguments:
 graphql.options.label.optionalArgsEnabled = Specify Optional Arguments
 
+graphql.options.value.args.inline = Inline
+graphql.options.value.args.variables = Using Variables
+graphql.options.value.args.both = Both Ways
 graphql.options.value.split.leaf = Each Leaf (Scalar or Enum)
 graphql.options.value.split.rootField = Each Field of a Root Type
 graphql.options.value.split.doNotSplit = Each Root Type

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
@@ -32,48 +32,49 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     @BeforeEach
     public void setup() throws Exception {
         setUpZap();
-        param = new GraphQlParam(5, 5, true, null, null);
+        param = new GraphQlParam(5, 5, true, null, null, null);
     }
 
     @Test
     public void scalarFieldsOnly() throws Exception {
         generator = new GraphQlGenerator(getHtml("scalarFieldsOnly.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ name id age height human } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { name id age height human } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void zeroDepthObjects() throws Exception {
         generator = new GraphQlGenerator(getHtml("zeroDepthObjects.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
-                "{ gymName dumbbell { fixedWeight weight } treadmill { maxSpeed manufacturer } } ";
+                "query { gymName dumbbell { fixedWeight weight } treadmill { maxSpeed manufacturer } } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void nestedObjects() throws Exception {
         generator = new GraphQlGenerator(getHtml("nestedObjects.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ book { id name pageCount author { id firstName lastName } } } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery =
+                "query { book { id name pageCount author { id firstName lastName } } } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void circularRelationship() throws Exception {
         generator = new GraphQlGenerator(getHtml("circularRelationship.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
-                "{ thread { id message { text thread { id message { text thread { id } } } } } } ";
+                "query { thread { id message { text thread { id message { text thread { id } } } } } } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void scalarArguments() throws Exception {
         generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ polygon (sides: 1, regular: true) { perimeter area } } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { polygon (sides: 1, regular: true) { perimeter area } } ";
         assertEquals(query, expectedQuery);
     }
 
@@ -81,25 +82,25 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     public void nonNullableScalarArguments() throws Exception {
         generator =
                 new GraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ getLyrics (song: \"ZAP\", artist: \"ZAP\") } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { getLyrics (song: \"ZAP\", artist: \"ZAP\") } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void enumArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("enumArgument.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ location (direction: NORTH) } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { location (direction: NORTH) } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void listAsArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("listAsArgument.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
-                "{ sum (numbers: [3.14, 3.14, 3.14]) concat (words: [\"ZAP\", \"ZAP\", \"ZAP\"]) "
+                "query { sum (numbers: [3.14, 3.14, 3.14]) concat (words: [\"ZAP\", \"ZAP\", \"ZAP\"]) "
                         + "compare (objects: [{ size: 1, colour: \"ZAP\" }, { size: 1, colour: \"ZAP\" }, { size: 1, colour: \"ZAP\" }]) } ";
         assertEquals(query, expectedQuery);
     }
@@ -107,34 +108,34 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     public void inputObjectArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("inputObjectArgument.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ plot (point: { x: 3.14, y: 3.14 }) } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { plot (point: { x: 3.14, y: 3.14 }) } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void listsAndNonNull() throws Exception {
         generator = new GraphQlGenerator(getHtml("listsAndNonNull.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
-                "{ jellyBean { count } marshmallow { count } nougat { count } pie { count } } ";
+                "query { jellyBean { count } marshmallow { count } nougat { count } pie { count } } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void nonNullableFields() throws Exception {
         generator = new GraphQlGenerator(getHtml("nonNullableFields.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ name phone child { id name school } } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { name phone child { id name school } } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void objectsImplementInterface() throws Exception {
         generator = new GraphQlGenerator(getHtml("objectsImplementInterface.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
-                "{ character { ... on Hero { id name superPower weakness } ... on Villain { id name grudge origin } } } ";
+                "query { character { ... on Hero { id name superPower weakness } ... on Villain { id name grudge origin } } } ";
         assertEquals(query, expectedQuery);
     }
 
@@ -142,9 +143,9 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     public void implementMultipleInterfaces() throws Exception {
         generator =
                 new GraphQlGenerator(getHtml("implementMultipleInterfaces.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
-                "{ someAnimal { ... on Swallow { wingspan speed } } someBird { ... on Swallow { wingspan speed } } } ";
+                "query { someAnimal { ... on Swallow { wingspan speed } } someBird { ... on Swallow { wingspan speed } } } ";
         assertEquals(query, expectedQuery);
     }
 
@@ -152,32 +153,32 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     public void interfaceImplementsInterface() throws Exception {
         generator =
                 new GraphQlGenerator(getHtml("interfaceImplementsInterface.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ picture { ... on Photo { id url thumbnail filter } } } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { picture { ... on Photo { id url thumbnail filter } } } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void unionType() throws Exception {
         generator = new GraphQlGenerator(getHtml("unionType.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
-                "{ firstSearchResult { ... on Photo { height width } ... on Person { name age } } } ";
+                "query { firstSearchResult { ... on Photo { height width } ... on Person { name age } } } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void enumType() throws Exception {
         generator = new GraphQlGenerator(getHtml("enumType.graphql"), null, param);
-        String query = generator.generateFull(GraphQlGenerator.RequestType.QUERY);
-        String expectedQuery = "{ direction } ";
+        String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query { direction } ";
         assertEquals(query, expectedQuery);
     }
 
     @Test
     public void mutation() throws Exception {
         generator = new GraphQlGenerator(getHtml("mutation.graphql"), null, param);
-        String mutation = generator.generateFull(GraphQlGenerator.RequestType.MUTATION);
+        String mutation = generator.generate(GraphQlGenerator.RequestType.MUTATION);
         String expectedMutation =
                 "mutation { createStudent (id: 1, name: \"ZAP\") { id name college { name location } } } ";
         assertEquals(mutation, expectedMutation);
@@ -186,8 +187,71 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     public void subscription() throws Exception {
         generator = new GraphQlGenerator(getHtml("subscription.graphql"), null, param);
-        String subscription = generator.generateFull(GraphQlGenerator.RequestType.SUBSCRIPTION);
+        String subscription = generator.generate(GraphQlGenerator.RequestType.SUBSCRIPTION);
         String expectedSubscription = "subscription { newMessage (roomId: 1) { sender text } } ";
         assertEquals(subscription, expectedSubscription);
+    }
+
+    // Tests for Arguments that use variables (i.e. not inline arguments)
+
+    @Test
+    public void separatedScalarArguments() throws Exception {
+        generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
+        String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery =
+                "query ($polygon_regular: Boolean, $polygon_sides: Int) "
+                        + "{ polygon (sides: $polygon_sides, regular: $polygon_regular) { perimeter area } } ";
+        String expectedVariables = "{\"polygon_regular\": true, \"polygon_sides\": 1}";
+        assertEquals(request[0], expectedQuery);
+        assertEquals(request[1], expectedVariables);
+    }
+
+    @Test
+    public void separatedNonNullableScalarArguments() throws Exception {
+        generator =
+                new GraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"), null, param);
+        String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery =
+                "query ($getLyrics_artist: String!, $getLyrics_song: String!) "
+                        + "{ getLyrics (song: $getLyrics_song, artist: $getLyrics_artist) } ";
+        String expectedVariables = "{\"getLyrics_artist\": \"ZAP\", \"getLyrics_song\": \"ZAP\"}";
+        assertEquals(request[0], expectedQuery);
+        assertEquals(request[1], expectedVariables);
+    }
+
+    @Test
+    public void separatedEnumArgumentVariable() throws Exception {
+        generator = new GraphQlGenerator(getHtml("enumArgument.graphql"), null, param);
+        String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery =
+                "query ($location_direction: Direction) { location (direction: $location_direction) } ";
+        String expectedVariables = "{\"location_direction\": \"NORTH\"}";
+        assertEquals(request[0], expectedQuery);
+        assertEquals(request[1], expectedVariables);
+    }
+
+    @Test
+    public void separatedListAsArgument() throws Exception {
+        generator = new GraphQlGenerator(getHtml("listAsArgument.graphql"), null, param);
+        String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery =
+                "query ($compare_objects: [Object], $concat_words: [String!]!, $sum_numbers: [Float]) "
+                        + "{ sum (numbers: $sum_numbers) concat (words: $concat_words) compare (objects: $compare_objects) } ";
+        String expectedVariables =
+                "{\"compare_objects\": [{ \"size\": 1, \"colour\": \"ZAP\" }, "
+                        + "{ \"size\": 1, \"colour\": \"ZAP\" }, { \"size\": 1, \"colour\": \"ZAP\" }], "
+                        + "\"concat_words\": [\"ZAP\", \"ZAP\", \"ZAP\"], \"sum_numbers\": [3.14, 3.14, 3.14]}";
+        assertEquals(request[0], expectedQuery);
+        assertEquals(request[1], expectedVariables);
+    }
+
+    @Test
+    public void separatedInputObjectArgument() throws Exception {
+        generator = new GraphQlGenerator(getHtml("inputObjectArgument.graphql"), null, param);
+        String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
+        String expectedQuery = "query ($plot_point: Point2D) { plot (point: $plot_point) } ";
+        String expectedVariables = "{\"plot_point\": { \"x\": 3.14, \"y\": 3.14 }}";
+        assertEquals(request[0], expectedQuery);
+        assertEquals(request[1], expectedVariables);
     }
 }


### PR DESCRIPTION
- Added option to provide arguments using variables (i.e. not inline).
- The active scan input vectors for separated arguments are working as expected.

To do:
- [x] Add variables as a query string when specifying separated arguments via an `application/graphql` post request
(see https://stackoverflow.com/q/43675933).
- [x] Add Unit Tests for the separated arguments.
- [x] Be able to generate arguments in both ways at the same time.
- [x] Stop the generator when the session is changed.
- [ ] Add input vectors support for inline arguments.


All inputs / suggestions are appreciated :D.

Signed-off-by: ricekot <ricekot@gmail.com>