### PR TITLE
HFF, AbstractAppFilePlugin, & ELMAH appropriately use GET requests

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- 'Hidden File Finder' ensure that test requests are appropriately rebuilt for this scan rule (Issue 6129).
 
 ## [29] - 2020-08-13
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/HiddenFilesScanRule.java
@@ -38,7 +38,9 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
 /**
@@ -155,6 +157,9 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
                             baseUri.getPort(),
                             generatePath(baseUri.getPath(), file.getPath()));
             testMsg.getRequestHeader().setURI(testUri);
+            testMsg.getRequestHeader().setMethod(HttpRequestHeader.GET);
+            testMsg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+            testMsg.setRequestBody("");
             sendAndReceive(testMsg);
             return testMsg;
         } catch (URIException uEx) {

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- ELMAH Information Leak ensure that test requests are appropriately rebuilt for this scan rule (Issue 6129).
 
 ## [30] - 2020-07-23
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ElmahScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ElmahScanRule.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
@@ -117,6 +118,8 @@ public class ElmahScanRule extends AbstractHostPlugin {
 
         HttpMessage newRequest = getNewMsg();
         newRequest.getRequestHeader().setMethod(HttpRequestHeader.GET);
+        newRequest.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+        newRequest.setRequestBody("");
         URI baseUri = getBaseMsg().getRequestHeader().getURI();
         URI elmahUri = null;
         try {

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- AbstractAppFilePlugin > ensure that test requests are appropriately rebuilt for this type of scan rule (Issue 6129). This will make the following Alpha and Beta active scan rules slightly more accurate:
+  - Trace.axd, .env File, .htaccess file
 
 ## [1.1.0] - 2020-08-04
 ### Changed

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
@@ -113,6 +114,8 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
 
         HttpMessage newRequest = getNewMsg();
         newRequest.getRequestHeader().setMethod(HttpRequestHeader.GET);
+        newRequest.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+        newRequest.setRequestBody("");
         URI baseUri = getBaseMsg().getRequestHeader().getURI();
         URI newUri = null;
         try {


### PR DESCRIPTION
- Ensure that requests sent by file presence rules are GET, with no body, and no content-type.
- Update CHANGELOGs.
- Update UnitTest for HFF.

Fixes zaproxy/zaproxy#6129

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>