### PR TITLE
fuzz: properly handle no default category selected

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+ - Fix exception when saving the options with no default category selected (Issue 6136).
 
 ## [13.0.0] - 2020-08-17
 ### Added

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
@@ -451,7 +451,7 @@ public class FuzzOptionsPanel extends AbstractParamPanel {
         }
 
         defaultCategoryComboBox.setSelectedItem(category);
-        if (!category.equals(defaultCategoryComboBox.getSelectedItem())) {
+        if (category != null && !category.equals(defaultCategoryComboBox.getSelectedItem())) {
             defaultCategoryComboBox.setSelectedIndex(-1);
         }
 
@@ -479,7 +479,7 @@ public class FuzzOptionsPanel extends AbstractParamPanel {
         FuzzOptions options = ((OptionsParam) optionParams).getParamSet(FuzzOptions.class);
 
         String selectedCategory = (String) defaultCategoryComboBox.getSelectedItem();
-        if (selectedCategory.equals(customCategoryName)) {
+        if (customCategoryName.equals(selectedCategory)) {
             selectedCategory = null;
         }
         options.setCustomDefaultCategory(selectedCategory == null);

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzerPayloadGeneratorUIHandler.java
@@ -404,8 +404,9 @@ public class FuzzerPayloadGeneratorUIHandler
             fileFuzzersCheckBoxTree.collapseAll();
 
             TreePath treePath = null;
-            if (!extensionFuzz.getFuzzOptions().isCustomDefaultCategory()) {
-                String defaultCategory = extensionFuzz.getFuzzOptions().getDefaultCategoryName();
+            String defaultCategory = extensionFuzz.getFuzzOptions().getDefaultCategoryName();
+            if (defaultCategory != null
+                    && !extensionFuzz.getFuzzOptions().isCustomDefaultCategory()) {
                 root = (DefaultMutableTreeNode) fileFuzzersCheckBoxTree.getModel().getRoot();
                 @SuppressWarnings("unchecked")
                 Enumeration<TreeNode> nodes = root.breadthFirstEnumeration();


### PR DESCRIPTION
Check that the default category is selected (non-null) before using it.

Fix zaproxy/zaproxy#6136.