### PR TITLE
Provide example alerts in Cookie scan rules

### DIFF
--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -135,24 +135,10 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
         this.model = model;
     }
 
-    /**
-     * Gets the CWE ID of the issue(s) raised by the scanner.
-     *
-     * @return the CWE ID,
-     * @see <a href="https://cwe.mitre.org/index.html">CWE - Common Weakness Enumeration</a>
-     */
-    public int getCweId(){
+    public int getCweId() {
         // CWE Id 16 - Configuration
         return 16;
     }
-
-    /**
-     * Gets the WASC ID of the issue(s) raised by the scanner.
-     *
-     * @return the WASC ID,
-     * @see <a href="http://projects.webappsec.org/w/page/13246978/Threat%20Classification">The WASC
-     *     Threat Classification</a>
-     */
 
     public int getWascId() {
         // WASC Id 13 - Info leakage)

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import net.htmlparser.jericho.Source;
@@ -135,13 +136,29 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
         this.model = model;
     }
 
-    public int getCweId() {
+    private int getCweId() {
         // CWE Id 16 - Configuration
         return 16;
     }
 
-    public int getWascId() {
+    private int getWascId() {
         // WASC Id 13 - Info leakage)
         return 13;
+    }
+
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<Alert>();
+        Alert alert =
+                newAlert()
+                        .setRisk(Alert.RISK_LOW)
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setDescription(getDescription())
+                        .setSolution(getSolution())
+                        .setReference(getReference())
+                        .setCweId(getCweId())
+                        .setWascId(getWascId())
+                        .build();
+        alerts.add(alert);
+        return alerts;
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -78,14 +78,14 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
                     continue;
                 }
                 if (!ignoreList.contains(CookieUtils.getCookieName(headerValue))) {
-                    this.raiseAlert(msg, id, headerValue);
+                    this.buildAlert(msg, headerValue).raise();
                 }
             }
         }
     }
 
-    private void raiseAlert(HttpMessage msg, int id, String headerValue) {
-        newAlert()
+    private AlertBuilder buildAlert(HttpMessage msg, String headerValue) {
+        return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription())
@@ -95,9 +95,8 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), headerValue))
-                .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setCweId(16) // CWE-16: Configuration
+                .setWascId(13); // WASC-13: Info leakage
     }
 
     @Override
@@ -136,29 +135,9 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
         this.model = model;
     }
 
-    private int getCweId() {
-        // CWE Id 16 - Configuration
-        return 16;
-    }
-
-    private int getWascId() {
-        // WASC Id 13 - Info leakage)
-        return 13;
-    }
-
     public List<Alert> getExampleAlerts() {
         List<Alert> alerts = new ArrayList<Alert>();
-        Alert alert =
-                newAlert()
-                        .setRisk(Alert.RISK_LOW)
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setDescription(getDescription())
-                        .setSolution(getSolution())
-                        .setReference(getReference())
-                        .setCweId(getCweId())
-                        .setWascId(getWascId())
-                        .build();
-        alerts.add(alert);
+        alerts.add(buildAlert(new HttpMessage(), "").build());
         return alerts;
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -94,8 +94,8 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), headerValue))
-                .setCweId(16) // CWE Id 16 - Configuration
-                .setWascId(13) // WASC Id 13 - Info leakage)
+                .setCweId(getCweId())
+                .setWascId(getWascId())
                 .raise();
     }
 
@@ -133,5 +133,29 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
      */
     protected void setModel(Model model) {
         this.model = model;
+    }
+
+    /**
+     * Gets the CWE ID of the issue(s) raised by the scanner.
+     *
+     * @return the CWE ID,
+     * @see <a href="https://cwe.mitre.org/index.html">CWE - Common Weakness Enumeration</a>
+     */
+    public int getCweId(){
+        // CWE Id 16 - Configuration
+        return 16;
+    }
+
+    /**
+     * Gets the WASC ID of the issue(s) raised by the scanner.
+     *
+     * @return the WASC ID,
+     * @see <a href="http://projects.webappsec.org/w/page/13246978/Threat%20Classification">The WASC
+     *     Threat Classification</a>
+     */
+
+    public int getWascId() {
+        // WASC Id 13 - Info leakage)
+        return 13;
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -99,8 +99,8 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), headerValue))
-                .setCweId(614)
-                .setWascId(13)
+                .setCweId(getCweId())
+                .setWascId(getWascId())
                 .raise();
     }
 
@@ -138,5 +138,29 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
      */
     protected void setModel(Model model) {
         this.model = model;
+    }
+
+    /**
+     * Gets the CWE ID of the issue(s) raised by the scanner.
+     *
+     * @return the CWE ID,
+     * @see <a href="https://cwe.mitre.org/index.html">CWE - Common Weakness Enumeration</a>
+     */
+    public int getCweId(){
+        // CWE Id 614 - Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
+        return 614;
+    }
+
+    /**
+     * Gets the WASC ID of the issue(s) raised by the scanner.
+     *
+     * @return the WASC ID,
+     * @see <a href="http://projects.webappsec.org/w/page/13246978/Threat%20Classification">The WASC
+     *     Threat Classification</a>
+     */
+
+    public int getWascId() {
+        // WASC Id 13 - Info leakage
+        return 13;
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -140,24 +140,10 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
         this.model = model;
     }
 
-    /**
-     * Gets the CWE ID of the issue(s) raised by the scanner.
-     *
-     * @return the CWE ID,
-     * @see <a href="https://cwe.mitre.org/index.html">CWE - Common Weakness Enumeration</a>
-     */
-    public int getCweId(){
+    public int getCweId() {
         // CWE Id 614 - Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
         return 614;
     }
-
-    /**
-     * Gets the WASC ID of the issue(s) raised by the scanner.
-     *
-     * @return the WASC ID,
-     * @see <a href="http://projects.webappsec.org/w/page/13246978/Threat%20Classification">The WASC
-     *     Threat Classification</a>
-     */
 
     public int getWascId() {
         // WASC Id 13 - Info leakage

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -83,14 +83,14 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
                     continue;
                 }
                 if (!ignoreList.contains(CookieUtils.getCookieName(headerValue))) {
-                    this.raiseAlert(msg, id, headerValue);
+                    this.buildAlert(msg, headerValue).raise();
                 }
             }
         }
     }
 
-    private void raiseAlert(HttpMessage msg, int id, String headerValue) {
-        newAlert()
+    private AlertBuilder buildAlert(HttpMessage msg, String headerValue) {
+        return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription())
@@ -100,9 +100,9 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), headerValue))
-                .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setCweId(614) // CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure'
+                // Attribute
+                .setWascId(13); // WASC-13: Info leakage
     }
 
     @Override
@@ -141,29 +141,9 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
         this.model = model;
     }
 
-    private int getCweId() {
-        // CWE Id 614 - Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-        return 614;
-    }
-
-    private int getWascId() {
-        // WASC Id 13 - Info leakage
-        return 13;
-    }
-
     public List<Alert> getExampleAlerts() {
         List<Alert> alerts = new ArrayList<Alert>();
-        Alert alert =
-                newAlert()
-                        .setRisk(Alert.RISK_LOW)
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setDescription(getDescription())
-                        .setSolution(getSolution())
-                        .setReference(getReference())
-                        .setCweId(getCweId())
-                        .setWascId(getWascId())
-                        .build();
-        alerts.add(alert);
+        alerts.add(buildAlert(new HttpMessage(), "").build());
         return alerts;
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import net.htmlparser.jericho.Source;
@@ -140,13 +141,29 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
         this.model = model;
     }
 
-    public int getCweId() {
+    private int getCweId() {
         // CWE Id 614 - Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
         return 614;
     }
 
-    public int getWascId() {
+    private int getWascId() {
         // WASC Id 13 - Info leakage
         return 13;
+    }
+
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<Alert>();
+        Alert alert =
+                newAlert()
+                        .setRisk(Alert.RISK_LOW)
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setDescription(getDescription())
+                        .setSolution(getSolution())
+                        .setReference(getReference())
+                        .setCweId(getCweId())
+                        .setWascId(getWascId())
+                        .build();
+        alerts.add(alert);
+        return alerts;
     }
 }


### PR DESCRIPTION
The CWE id was already managed for these Alerts/ScanRules and within ZAP they were already presented to the user.
However, when visiting the alert detail pages online (https://www.zaproxy.org/docs/alerts/), CWE (and WASC) links were not generated correctly.

The reason is, that the id values were set inline to the alert.
For the script which generates the detail pages however, the getter methods for the ids have to be added publicly to the class.

Note: if this solves the issue, I'll vote for another follow up issue to add this change to the PluginPassiveScanner parent class,
so that the docs will be generated consistently over all Passive Scan Rules.

Fixes zaproxy/zaproxy#6140.