### PR TITLE
openapi: update dependencies

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Show import exceptions in the Output tab (Issue 6042).
+- Maintenance changes.
 
 ### Fixed
 - Correct parent dialogue when choosing the file to import (Issue 6041).

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -28,13 +28,13 @@ configurations {
 }
 
 dependencies {
-    implementation("io.swagger.parser.v3:swagger-parser:2.0.18")
-    implementation("io.swagger:swagger-compat-spec-parser:1.0.50") {
+    implementation("io.swagger.parser.v3:swagger-parser:2.0.21")
+    implementation("io.swagger:swagger-compat-spec-parser:1.0.51") {
         // Not needed:
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    implementation("org.slf4j:slf4j-log4j12:1.7.6") {
+    implementation("org.slf4j:slf4j-log4j12:1.7.30") {
         // Provided by ZAP.
         exclude(group = "log4j")
     }


### PR DESCRIPTION
Update Swagger parsers and transitive dependency to latest versions.