### PR TITLE
openapi: use default values in bodies

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Handle cookie parameters (Issue 6045).
+- Use default values in `x-www-form-urlencoded` and `json` bodies (Issue 6095).
 
 ### Changed
 - Show import exceptions in the Output tab (Issue 6042).

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiDefaultValuesTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiDefaultValuesTest.java
@@ -1,0 +1,102 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.v3;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.extension.openapi.AbstractServerTest;
+import org.zaproxy.zap.extension.openapi.converter.Converter;
+import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerConverter;
+import org.zaproxy.zap.extension.openapi.network.RequesterListener;
+import org.zaproxy.zap.extension.openapi.network.Requestor;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Test usage of default values. */
+class OpenApiDefaultValuesTest extends AbstractServerTest {
+
+    @Test
+    void shouldUseDefaultValues() throws Exception {
+        // Given
+        this.nano.addHandler(new PlainResponseServerHandler());
+
+        Converter converter =
+                new SwaggerConverter(
+                        getHtml(
+                                "openapi_default_values.yaml",
+                                new String[][] {{"PORT", String.valueOf(nano.getListeningPort())}}),
+                        null);
+        List<HttpMessage> accessedMessages = new ArrayList<>();
+        RequesterListener listener = (message, initiator) -> accessedMessages.add(message);
+
+        Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        requestor.addListener(listener);
+        // When
+        requestor.run(converter.getRequestModels());
+        // Then
+        HttpMessage message = accessedMessages.get(0);
+        assertThat(
+                message.getRequestHeader().getURI().getPath(),
+                is(equalTo("/parameters/path/DefaultValue/")));
+
+        message = accessedMessages.get(1);
+        assertThat(
+                message.getRequestHeader().getURI().getQuery(), is(equalTo("Name=DefaultValue")));
+
+        message = accessedMessages.get(2);
+        assertThat(message.getRequestHeader().getHeader("Name"), is(equalTo("DefaultValue")));
+
+        message = accessedMessages.get(3);
+        assertThat(
+                message.getRequestHeader().getHeader("Cookie"), is(equalTo("Name=DefaultValue")));
+
+        message = accessedMessages.get(4);
+        assertThat(
+                message.getRequestBody().toString(),
+                is(equalTo("NameA=DefaultValue&NameB=true&NameC=2")));
+
+        message = accessedMessages.get(5);
+        assertThat(
+                message.getRequestBody().toString(),
+                is(equalTo("{\"NameA\":\"DefaultValue\",\"NameB\":true,\"NameC\":2}")));
+    }
+
+    private static class PlainResponseServerHandler extends NanoServerHandler {
+
+        public PlainResponseServerHandler() {
+            super("");
+        }
+
+        @Override
+        protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
+            consumeBody(session);
+            return newFixedLengthResponse(Status.OK, NanoHTTPD.MIME_PLAINTEXT, "");
+        }
+    }
+}

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.json
@@ -154,8 +154,7 @@
                         "available",
                         "pending",
                         "sold"
-                     ],
-                     "default":"available"
+                     ]
                   },
                   "collectionFormat":"multi"
                }
@@ -895,8 +894,7 @@
                ]
             },
             "complete":{
-               "type":"boolean",
-               "default":false
+               "type":"boolean"
             }
          },
          "xml":{

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn.yaml
@@ -110,7 +110,6 @@ paths:
           - "available"
           - "pending"
           - "sold"
-          default: "available"
         collectionFormat: "multi"
       responses:
         200:
@@ -607,7 +606,6 @@ definitions:
         - "delivered"
       complete:
         type: "boolean"
-        default: false
     xml:
       name: "Order"
   Category:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_loop.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_loop.yaml
@@ -110,7 +110,6 @@ paths:
           - "available"
           - "pending"
           - "sold"
-          default: "available"
         collectionFormat: "multi"
       responses:
         200:
@@ -607,7 +606,6 @@ definitions:
         - "delivered"
       complete:
         type: "boolean"
-        default: false
     xml:
       name: "Order"
   Category:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_host.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_host.json
@@ -153,8 +153,7 @@
                         "available",
                         "pending",
                         "sold"
-                     ],
-                     "default":"available"
+                     ]
                   },
                   "collectionFormat":"multi"
                }
@@ -894,8 +893,7 @@
                ]
             },
             "complete":{
-               "type":"boolean",
-               "default":false
+               "type":"boolean"
             }
          },
          "xml":{

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_schemes.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/PetStore_defn_no_schemes.json
@@ -151,8 +151,7 @@
                         "available",
                         "pending",
                         "sold"
-                     ],
-                     "default":"available"
+                     ]
                   },
                   "collectionFormat":"multi"
                }
@@ -892,8 +891,7 @@
                ]
             },
             "complete":{
-               "type":"boolean",
-               "default":false
+               "type":"boolean"
             }
          },
          "xml":{

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.json
@@ -120,8 +120,7 @@
                            "available",
                            "pending",
                            "sold"
-                        ],
-                        "default": "available"
+                        ]
                      }
                   }
                }
@@ -856,8 +855,7 @@
                   ]
                },
                "complete": {
-                  "type": "boolean",
-                  "default": false
+                  "type": "boolean"
                }
             },
             "xml": {

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn.yaml
@@ -84,7 +84,6 @@ paths:
                 - available
                 - pending
                 - sold
-              default: available
       responses:
         '200':
           description: successful operation
@@ -560,7 +559,6 @@ components:
             - delivered
         complete:
           type: boolean
-          default: false
       xml:
         name: Order
     Category:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_all_relative_urls.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_all_relative_urls.yaml
@@ -37,7 +37,6 @@ paths:
                 - available
                 - pending
                 - sold
-              default: available
       responses:
         '200':
           description: successful operation

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_loop.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_loop.yaml
@@ -82,7 +82,6 @@ paths:
                 - available
                 - pending
                 - sold
-              default: available
       responses:
         "200":
           description: successful operation
@@ -600,7 +599,6 @@ components:
             - delivered
         complete:
           type: boolean
-          default: false
       xml:
         name: Order
     Category:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_no_servers.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_no_servers.json
@@ -115,8 +115,7 @@
                            "available",
                            "pending",
                            "sold"
-                        ],
-                        "default": "available"
+                        ]
                      }
                   }
                }
@@ -851,8 +850,7 @@
                   ]
                },
                "complete": {
-                  "type": "boolean",
-                  "default": false
+                  "type": "boolean"
                }
             },
             "xml": {

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/PetStore_defn_with_examples.yaml
@@ -84,7 +84,6 @@ paths:
                 - available
                 - pending
                 - sold
-              default: available
       responses:
         '200':
           description: successful operation
@@ -563,7 +562,6 @@ components:
             - delivered
         complete:
           type: boolean
-          default: false
       xml:
         name: Order
     Category:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Petstore_defn_variable_in_server_definition.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Petstore_defn_variable_in_server_definition.yaml
@@ -89,7 +89,6 @@ paths:
                 - available
                 - pending
                 - sold
-              default: available
       responses:
         '200':
           description: successful operation
@@ -565,7 +564,6 @@ components:
             - delivered
         complete:
           type: boolean
-          default: false
       xml:
         name: Order
     Category:

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_default_values.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_default_values.yaml
@@ -1,0 +1,99 @@
+openapi: 3.0.0
+servers:
+  - url: http://localhost:@@@PORT@@@/
+paths:
+  /parameters/path/{Name}/:
+    get:
+      operationId: parameters/path
+      parameters:
+      - in: path
+        name: Name
+        schema:
+          type: string
+          default: DefaultValue
+      responses:
+        default:
+          content:
+            text/plain: {}
+  /parameters/query:
+    get:
+      operationId: parameters/query
+      parameters:
+      - in: query
+        name: Name
+        schema:
+          type: string
+          default: DefaultValue
+      responses:
+        default:
+          content:
+            text/plain: {}
+  /parameters/header:
+    get:
+      operationId: parameters/header
+      parameters:
+      - in: header
+        name: Name
+        schema:
+          type: string
+          default: DefaultValue
+      responses:
+        default:
+          content:
+            text/plain: {}
+  /parameters/cookie:
+    post:
+      operationId: parameters/cookie
+      parameters:
+      - in: cookie
+        name: Name
+        schema:
+          type: string
+          default: DefaultValue
+      responses:
+        default:
+          content:
+            text/plain: {}
+  /body/x-www-form-urlencoded:
+    post:
+      operationId: body/x-www-form-urlencoded
+      requestBody:
+        content:
+          'application/x-www-form-urlencoded':
+            schema:
+              properties:
+                NameA:
+                  type: string
+                  default: DefaultValue
+                NameB:
+                  type: boolean
+                  default: true
+                NameC:
+                  type: integer
+                  default: 2
+      responses:
+        default:
+          content:
+            text/plain: {}
+  /body/json/object:
+    post:
+      operationId: body/json
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              properties:
+                NameA:
+                  type: string
+                  default: DefaultValue
+                NameB:
+                  type: boolean
+                  default: true
+                NameC:
+                  type: integer
+                  default: 2
+      responses:
+        default:
+          content:
+            text/plain: {}
+


### PR DESCRIPTION
Change DataGenerator to use the default values of the body properties
too.

Fix zaproxy/zaproxy#6095.