### PR TITLE
webdrivers: update ChromeDriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [20] - 2020-09-16
+### Changed
+- Update ChromeDriver to 85.0.4183.87.
 
 ## [19] - 2020-07-29
 ### Changed
@@ -98,6 +99,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[20]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v20
 [19]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v19
 [18]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v18
 [17]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v17

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,7 +9,7 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 84.0.4147.30</li>
+    <li>Chrome - ChromeDriver 85.0.4183.87</li>
     <li>Firefox - geckodriver 0.27.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [19] - 2020-09-16
+### Changed
+- Update ChromeDriver to 85.0.4183.87.
 
 ## [18] - 2020-07-29
 ### Changed
@@ -94,6 +95,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[19]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v19
 [18]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v18
 [17]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v17
 [16]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v16

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,7 +9,7 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 84.0.4147.30</li>
+    <li>Chrome - ChromeDriver 85.0.4183.87</li>
     <li>Firefox - geckodriver 0.27.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.27.0"
-val chromeDriverVersion = "84.0.4147.30"
+val chromeDriverVersion = "85.0.4183.87"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [20] - 2020-09-16
+### Changed
+- Update ChromeDriver to 85.0.4183.87.
 
 ## [19] - 2020-07-29
 ### Changed
@@ -101,6 +102,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[20]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v20
 [19]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v19
 [18]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v18
 [17]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v17

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,7 +9,7 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 84.0.4147.30</li>
+    <li>Chrome - ChromeDriver 85.0.4183.87.</li>
     <li>Firefox - geckodriver 0.27.0</li>
 </ul>
 


### PR DESCRIPTION
Update ChromeDriver to 85.0.4183.87.
Add release dates and links to tags.

Should address zaproxy/zaproxy#6174.