### PR TITLE
wappalyzer: Add technology descriptions to tooltip/API output

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
 - Maintenance changes.
+- When available the description of a given app/technology will show in the tooltip for a row in the table, and be included in detailed API responses.
 
 ## [20.2.0] - 2020-08-04
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
@@ -27,6 +27,7 @@ import javax.swing.ImageIcon;
 public class Application {
 
     private String name;
+    private String description;
     private String website;
     private ImageIcon icon = null;
     private List<String> categories = new ArrayList<String>();
@@ -45,6 +46,14 @@ public class Application {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String getWebsite() {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -26,6 +26,7 @@ import java.awt.Graphics;
 import java.awt.GridBagConstraints;
 import java.awt.event.ItemEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
 import javax.swing.Box;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -174,7 +175,25 @@ public class TechPanel extends AbstractPanel {
 
     protected JXTable getTechTable() {
         if (techTable == null) {
-            techTable = new JXTable(techModel);
+            techTable =
+                    new JXTable(techModel) {
+                        private static final long serialVersionUID = -5249686560976842645L;
+
+                        @Override
+                        public String getToolTipText(MouseEvent e) {
+                            String tip = "";
+                            int rowIndex = rowAtPoint(e.getPoint());
+
+                            if (rowIndex != -1) {
+                                tip =
+                                        techModel
+                                                .getApp(convertRowIndexToModel(rowIndex))
+                                                .getDescription();
+                            }
+
+                            return tip.isEmpty() ? null : tip;
+                        }
+                    };
 
             techTable.setColumnSelectionAllowed(false);
             techTable.setCellSelectionEnabled(false);

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
@@ -91,6 +91,7 @@ public class WappalyzerAPI extends ApiImplementor {
         for (int i = 0; i < ttm.getRowCount(); i++) {
             Map<String, String> map = new HashMap<>();
             map.put("name", ((Application) ttm.getValueAt(i, 0)).toString());
+            map.put("description", ttm.getApp(i).getDescription());
             map.put("version", (String) ttm.getValueAt(i, 1));
             map.put("category", (String) ttm.getValueAt(i, 2));
             map.put("website", (String) ttm.getValueAt(i, 3));

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -115,6 +115,7 @@ public class WappalyzerJsonParser {
 
                 Application app = new Application();
                 app.setName(appName);
+                app.setDescription(appData.optString("description"));
                 app.setWebsite(appData.getString("website"));
                 app.setCategories(
                         this.jsonToCategoryList(result.getCategories(), appData.get("cats")));

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -69,6 +69,15 @@ public class WappalyzerJsonParser {
         return parseJson(getStringResource(ExtensionWappalyzer.RESOURCE + "/apps.json"));
     }
 
+    WappalyzerData parseAppsJson(String path) {
+        try {
+            return parseJson(getStringResource(path));
+        } catch (IOException e) {
+            logger.warn("An error occurred reading the file: " + path);
+        }
+        return null;
+    }
+
     private static String getStringResource(String resourceName) throws IOException {
         InputStream in = null;
         StringBuilder sb = new StringBuilder();

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.wappalyzer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class WappalyzerJsonParserUnitTest {
+
+    @Test
+    public void shouldParseExample() {
+        // Given
+        WappalyzerJsonParser wjp = new WappalyzerJsonParser();
+        WappalyzerData wappData = wjp.parseAppsJson("apps.json");
+        List<String> expectedCategory = new ArrayList<String>(1);
+        expectedCategory.add("Advertising"); // 36 - Advertising
+        // When
+        List<Application> apps = wappData.getApplications();
+        Application app = apps.get(0);
+        // Then
+        assertEquals(1, apps.size());
+        assertTrue(app.getName().equals("Test Entry"));
+        assertTrue(app.getDescription().equals("Test Entry is a test entry for UnitTests"));
+        assertTrue(app.getWebsite().equals("https://www.example.com/testentry"));
+        assertEquals(expectedCategory, app.getCategories());
+        assertEquals(1, app.getHeaders().size());
+        assertEquals(1, app.getUrl().size());
+        assertEquals(2, app.getHtml().size());
+        assertEquals(2, app.getScript().size());
+        assertEquals(0, app.getMetas().size());
+        assertEquals(0, app.getImplies().size());
+        assertTrue(app.getCpe().equals(""));
+        // Ignore Icon
+    }
+}

--- a/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
+++ b/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../schema.json",
+  "technologies": {
+	"Test Entry": {
+      "cats": [
+        36
+      ],
+      "html": [
+        "example\\.com/test\\.html[^>]+></iframe>",
+        "<!-- (?:End )?Test Entry -->"
+      ],
+      "headers": {
+        "Test": "Test Entry"
+      },
+      "icon": "Test Entry.svg",
+      "js": {
+        "Test_Entry_": "",
+        "__test_entry_urls": ""
+      },
+      "scripts": [
+        "testentry\\.com/",
+        "ad\\.ca\\.testentry\\.net"
+      ],
+      "description": "Test Entry is a test entry for UnitTests",
+      "url": "^https?://test\\.example\\.com",
+      "website": "https://www.example.com/testentry"
+    }
+  },
+  "categories": {
+    "1": {
+      "name": "CMS",
+      "priority": 1
+    },
+    "2": {
+      "name": "Message boards",
+      "priority": 1
+    },
+    "36": {
+      "name": "Advertising",
+      "priority": 9
+    }
+  }
+}


### PR DESCRIPTION
- Application > Add description field, getter and setter.
- TechPanel > Add handling for getting the tooltip based on the description.
- WappalyzerAPI > Include the description in detailed API output.
- WappalyzerJsonParser > Set the description when available.
- CHANGELOG > Add a change note.

Ex (my cursor isn't showing but it is on the second row):
![image](https://user-images.githubusercontent.com/7570458/94388252-70e89400-011a-11eb-86e6-23b0d0c163ba.png)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>