### PR TITLE
wappalyzer: fail on parsing exception of apps.json

### DIFF
--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -55,14 +55,18 @@ public class WappalyzerJsonParser {
     private static final int SIZE = 16;
 
     private static final Logger logger = Logger.getLogger(WappalyzerJsonParser.class);
-    private PatternErrorHandler patternErrorHandler;
+    private final PatternErrorHandler patternErrorHandler;
+    private final ParsingExceptionHandler parsingExceptionHandler;
 
     public WappalyzerJsonParser() {
-        patternErrorHandler = (pattern, e) -> logger.error("Invalid pattern syntax " + pattern, e);
+        this(
+                (pattern, e) -> logger.error("Invalid pattern syntax " + pattern, e),
+                e -> logger.error(e.getMessage(), e));
     }
 
-    public WappalyzerJsonParser(PatternErrorHandler peh) {
+    WappalyzerJsonParser(PatternErrorHandler peh, ParsingExceptionHandler parsingExceptionHandler) {
         this.patternErrorHandler = peh;
+        this.parsingExceptionHandler = parsingExceptionHandler;
     }
 
     public WappalyzerData parseDefaultAppsJson() throws IOException {
@@ -152,7 +156,7 @@ public class WappalyzerJsonParser {
             }
 
         } catch (Exception e) {
-            logger.error(e.getMessage(), e);
+            parsingExceptionHandler.handleException(e);
         }
 
         return result;
@@ -339,5 +343,9 @@ public class WappalyzerJsonParser {
             return (int) Double.parseDouble(confidence) * 100;
         }
         return Integer.parseInt(confidence);
+    }
+
+    interface ParsingExceptionHandler {
+        void handleException(Exception e);
     }
 }

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
@@ -33,11 +33,14 @@ public class WappalyzerAppsJsonParseUnitTest {
     public void test() throws IOException {
         // Given
         List<String> errs = new ArrayList<>();
+        List<Exception> parsingExceptions = new ArrayList<>();
         // When
         WappalyzerJsonParser parser =
-                new WappalyzerJsonParser((pattern, e) -> errs.add(e.toString()));
+                new WappalyzerJsonParser(
+                        (pattern, e) -> errs.add(e.toString()), parsingExceptions::add);
         parser.parseDefaultAppsJson();
         // Then
         assertEquals(Collections.emptyList(), errs);
+        assertEquals(Collections.emptyList(), parsingExceptions);
     }
 }


### PR DESCRIPTION
Change `WappalyzerAppsJsonParseUnitTest` to fail if there was any
exception while parsing the `apps.json` file instead of logging an
error, which would go unnoticed in the tests.
Change `WappalyzerJsonParser` to allow to customise the behaviour when
an exception is thrown while parsing the file, log by default.