### PR TITLE
testutils: check scan rules have i18n'ed name

### DIFF
--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -43,7 +44,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     protected CookieHttpOnlyScanRule createScanner() {
         rule = new CookieHttpOnlyScanRule();
         // Mock the model and options
-        model = mock(Model.class);
+        model = mock(Model.class, withSettings().lenient());
         OptionsParam options = new OptionsParam();
         ZapXmlConfiguration conf = new ZapXmlConfiguration();
         options.load(conf);

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -106,7 +106,7 @@ public abstract class TestUtils {
      *
      * <p>Lazily initialised, in {@link #mockMessages(Extension)}.
      */
-    private static ResourceBundle extensionResourceBundle;
+    protected static ResourceBundle extensionResourceBundle;
 
     /**
      * A HTTP test server.


### PR DESCRIPTION
Check that active and passive scan rules have a non-empty i18n'ed name.
Tweak mock in `CookieHttpOnlyScanRuleUnitTest` to be lenient, not used
when checking the scan rule name.