### PR TITLE
ascanrulesBeta: fix message key in XxeScanRule

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
  - Terminology
+ - Correct reason shown when the XML External Entity Attack scan rule is skipped.
 
 ## [31] - 2020-09-02
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
@@ -174,7 +174,7 @@ public class XxeScanRule extends AbstractAppPlugin implements ChallengeCallbackP
             // The callback extension is not available, cant do anything :(
             getParent()
                     .pluginSkipped(
-                            this, Constant.messages.getString("ascanbeta.xxeplugin.nocallback"));
+                            this, Constant.messages.getString(MESSAGE_PREFIX + "nocallback"));
         }
     }
 

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
@@ -21,14 +21,29 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
 
 public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
 
     @Override
     protected XxeScanRule createScanner() {
         return new XxeScanRule();
+    }
+
+    @Test
+    public void shouldSkipScanRuleIfExtensionCallbackIsNotEnabled() {
+        // Given
+        HttpMessage message = mock(HttpMessage.class);
+        // When
+        rule.init(message, parent);
+        // Then
+        verify(parent).pluginSkipped(eq(rule), anyString());
     }
 
     @Test

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/ActiveScannerTestUtils.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.testutils;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -132,35 +133,36 @@ public abstract class ActiveScannerTestUtils<T extends AbstractPlugin> extends T
         alertsRaised = new ArrayList<>();
         httpMessagesSent = new ArrayList<>();
         parent =
-                new HostProcess(
-                        "localhost:" + port,
-                        parentScanner,
-                        scannerParam,
-                        connectionParam,
-                        scanPolicy,
-                        ruleConfigParam) {
-                    @Override
-                    public void alertFound(Alert arg1) {
-                        alertsRaised.add(arg1);
-                    }
+                spy(
+                        new HostProcess(
+                                "localhost:" + port,
+                                parentScanner,
+                                scannerParam,
+                                connectionParam,
+                                scanPolicy,
+                                ruleConfigParam) {
+                            @Override
+                            public void alertFound(Alert arg1) {
+                                alertsRaised.add(arg1);
+                            }
 
-                    @Override
-                    public void notifyNewMessage(HttpMessage msg) {
-                        httpMessagesSent.add(msg);
-                        countMessagesSent++;
-                    }
+                            @Override
+                            public void notifyNewMessage(HttpMessage msg) {
+                                httpMessagesSent.add(msg);
+                                countMessagesSent++;
+                            }
 
-                    @Override
-                    public void notifyNewMessage(Plugin plugin) {
-                        countMessagesSent++;
-                    }
+                            @Override
+                            public void notifyNewMessage(Plugin plugin) {
+                                countMessagesSent++;
+                            }
 
-                    @Override
-                    public void notifyNewMessage(Plugin plugin, HttpMessage msg) {
-                        httpMessagesSent.add(msg);
-                        countMessagesSent++;
-                    }
-                };
+                            @Override
+                            public void notifyNewMessage(Plugin plugin, HttpMessage msg) {
+                                httpMessagesSent.add(msg);
+                                countMessagesSent++;
+                            }
+                        });
 
         rule = createScanner();
         if (rule.getConfig() == null) {


### PR DESCRIPTION
Use correct message prefix when getting the reason why the `XxeScanRule`
was skipped.