### PR TITLE
ascanrulesBeta: tweak msg count in SQLite tests

### DIFF
--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSQLiteScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSQLiteScanRuleUnitTest.java
@@ -45,6 +45,7 @@ public class SqlInjectionSQLiteScanRuleUnitTest
     }
 
     // Give a bit more leeway
+    @Override
     protected int getRecommendMaxNumberMessagesPerParam(Plugin.AttackStrength strength) {
         switch (strength) {
             case LOW:
@@ -53,9 +54,9 @@ public class SqlInjectionSQLiteScanRuleUnitTest
             default:
                 return NUMBER_MSGS_ATTACK_STRENGTH_MEDIUM + 2;
             case HIGH:
-                return NUMBER_MSGS_ATTACK_STRENGTH_HIGH + 4;
+                return NUMBER_MSGS_ATTACK_STRENGTH_HIGH + 10;
             case INSANE:
-                return NUMBER_MSGS_ATTACK_STRENGTH_INSANE + 10;
+                return NUMBER_MSGS_ATTACK_STRENGTH_INSANE + 20;
         }
     }
 


### PR DESCRIPTION
Allow more messages to be sent, the CI builds have been failing because
more messages are being sent than the previous values (the exact number
depends on timing).