### PR TITLE
Issue 6212: Add Scan Rule UnitTests

### DIFF
--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)
+    testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/CloudMetadataScanRuleUnitTest.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Unit test for {@link CloudMetadataScanRule}. */
+public class CloudMetadataScanRuleUnitTest extends ActiveScannerTest<CloudMetadataScanRule> {
+
+    @Override
+    protected CloudMetadataScanRule createScanner() {
+        return new CloudMetadataScanRule();
+    }
+
+    @Test
+    public void shouldNotAlertIfResponseIsNot200Ok() throws Exception {
+        // Given
+        String path = "/latest/meta-data/";
+        String body = "<html><head></head><H>404 - Not Found</H1><html>";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.UNAUTHORIZED, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+        assertEquals(1, httpMessagesSent.size());
+    }
+
+    @Test
+    public void shouldAlertIfResponseIs200Ok() throws Exception {
+        // Given
+        String path = "/latest/meta-data/";
+        // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
+        String body = "<html><head></head><H></H1>ami-id\nami-launch-index<html>";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_HIGH, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_LOW, alert.getConfidence());
+        assertEquals("169.154.169.254", alert.getAttack());
+        assertEquals(1, httpMessagesSent.size());
+    }
+
+    private static NanoServerHandler createHandler(String path, Response response) {
+        return new NanoServerHandler(path) {
+            @Override
+            protected Response serve(IHTTPSession session) {
+                return response;
+            }
+        };
+    }
+}

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/EnvFileScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/EnvFileScanRuleUnitTest.java
@@ -1,0 +1,36 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import org.zaproxy.addon.commonlib.AbstractAppFilePluginUnitTest;
+
+/** Unit test for {@link EnvFileScanRule}. */
+public class EnvFileScanRuleUnitTest extends AbstractAppFilePluginUnitTest<EnvFileScanRule> {
+
+    @Override
+    protected EnvFileScanRule createScanner() {
+        return new EnvFileScanRule();
+    }
+
+    @Override
+    protected void setUpMessages() {
+        mockMessages(new ExtensionAscanRulesAlpha());
+    }
+}

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation("org.jsoup:jsoup:1.13.1")
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)
+    testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
     testImplementation("org.apache.commons:commons-lang3:3.9")

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HtAccesScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HtAccesScanRuleUnitTest.java
@@ -1,0 +1,139 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesBeta;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.AbstractAppFilePluginUnitTest;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Unit test for {@link HtAccessScanRule}. */
+public class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAccessScanRule> {
+
+    private static final String URL = "/.htaccess";
+    private static final String HTACCESS_BODY = "order allow,deny";
+
+    private static final String DEFAULT_BODY =
+            "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
+                    + "<html><head></head><body>\n"
+                    + "<h1>Error Log for testing</h1>\n"
+                    + "<p>Blah blah blah.</p>\n"
+                    + "</body></html>";
+
+    @Override
+    protected HtAccessScanRule createScanner() {
+        return new HtAccessScanRule();
+    }
+
+    @BeforeEach
+    public void setup() {
+        this.setBody(HTACCESS_BODY);
+    }
+
+    @Override
+    protected void setUpMessages() {
+        mockMessages(new ExtensionAscanRulesBeta());
+    }
+
+    @Test
+    public void shouldNotAlertIfNonHtaccessFileFoundStdThreshold() throws Exception {
+        // Given
+        nano.addHandler(new MiscOkResponse());
+        HttpMessage message = getHttpMessage(URL);
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfNonHtaccessFileFoundLowThreshold() throws Exception {
+        // Given
+        nano.addHandler(new MiscOkResponse());
+        HttpMessage message = getHttpMessage(URL);
+        rule.init(message, parent);
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"application/json", "application/xml"})
+    public void shouldNotAlertIfResponseIsJsonOrXml(String contentType) throws Exception {
+        // Given
+        nano.addHandler(new MiscOkResponse(URL, contentType));
+        HttpMessage message = getHttpMessage(URL);
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertIfResponseIsEmpty() throws Exception {
+        // Given
+        nano.addHandler(new MiscOkResponse(""));
+        HttpMessage message = getHttpMessage(URL);
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    private static class MiscOkResponse extends NanoServerHandler {
+
+        String contentType = "text.html";
+        String content = DEFAULT_BODY;
+
+        public MiscOkResponse() {
+            super(URL);
+        }
+
+        public MiscOkResponse(String content) {
+            super(URL);
+            this.content = content;
+        }
+
+        public MiscOkResponse(String path, String contentType) {
+            super(path);
+            this.contentType = contentType;
+        }
+
+        @Override
+        protected Response serve(IHTTPSession session) {
+            return newFixedLengthResponse(Response.Status.OK, contentType, content);
+        }
+    }
+}

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
@@ -50,7 +50,7 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
      * resource bundle ({@link Constant#messages}).
      *
      * @param filename the name of the file to check if it's present.
-     * @param messagePrefix the messages prefix.
+     * @param messagePrefix the messages prefix (including the trailing period).
      */
     protected AbstractAppFilePlugin(String filename, String messagePrefix) {
         this.filename = filename;
@@ -221,5 +221,9 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
                 .setEvidence(msg.getResponseHeader().getPrimeHeader())
                 .setMessage(msg)
                 .raise();
+    }
+
+    public String getFilename() {
+        return filename;
     }
 }

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/AbstractAppFilePluginUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/AbstractAppFilePluginUnitTest.java
@@ -1,0 +1,297 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Unit test for {@link AbstractAppFilePlugin}. */
+public abstract class AbstractAppFilePluginUnitTest<T extends AbstractAppFilePlugin>
+        extends ActiveScannerTestUtils<AbstractAppFilePlugin> {
+
+    private String body;
+
+    public AbstractAppFilePluginUnitTest() {
+        this.body = "<html><head></head><H>Awesome Content</H1>Some text...<html>";
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    @Test
+    public void shouldGeneratePathWithFileNameWhenOriginalPathIsNothing() throws Exception {
+        // Given
+        String path = "";
+        Response response = newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body);
+        this.nano.addHandler(createHandler(path, response));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(
+                "/" + rule.getFilename(),
+                httpMessagesSent.get(0).getRequestHeader().getURI().getPath());
+    }
+
+    @Test
+    public void shouldGeneratePathWithFileNameWhenOriginalPathIsSlash() throws Exception {
+        // Given
+        String path = "/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(
+                "/" + rule.getFilename(),
+                httpMessagesSent.get(0).getRequestHeader().getURI().getPath());
+    }
+
+    @Test
+    public void shouldGeneratePathWithFileNameWhenOriginalPathDoesNotEndInSlash() throws Exception {
+        // Given
+        String path = "/foo/bar";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(
+                "/foo/" + rule.getFilename(),
+                httpMessagesSent.get(0).getRequestHeader().getURI().getPath());
+    }
+
+    @Test
+    public void shouldGeneratePathWithFileNameWhenOriginalPathDoesEndInSlash() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertEquals(1, httpMessagesSent.size());
+        assertEquals(
+                "/foo/bar/" + rule.getFilename(),
+                httpMessagesSent.get(0).getRequestHeader().getURI().getPath());
+    }
+
+    @Test
+    public void shouldCleanupOriginalRequestWhenMakingAppFileRequest()
+            throws HttpMalformedHeaderException {
+        // Given
+        String path = "/";
+        nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage message = getHttpMessage(path);
+        message.getRequestHeader().setMethod("POST");
+        message.getRequestBody().setBody("foo=bar");
+        message.getRequestHeader()
+                .addHeader(HttpHeader.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        HttpMessage sentMessage = httpMessagesSent.get(0);
+        assertThat(sentMessage.getRequestHeader().getMethod(), is(equalTo("GET")));
+        assertThat(
+                sentMessage.getRequestHeader().getHeaderValues(HttpHeader.CONTENT_TYPE),
+                is(equalTo(Collections.emptyList())));
+        assertThat(sentMessage.getRequestBody().length(), is(equalTo(0)));
+    }
+
+    @Test
+    public void shouldAlertWhenRequestIsSuccessful() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(1, httpMessagesSent.size());
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_MEDIUM, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_MEDIUM, alert.getConfidence());
+    }
+
+    @Test
+    public void shouldNotAlertWhenRequestIsNotSuccessful() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.INTERNAL_ERROR, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertWhenRequestIsNotSuccessfulEvenAtLowThreshold() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.INTERNAL_ERROR, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotAlertWhenRequestIsUnauthorized() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.UNAUTHORIZED, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertWhenRequestIsUnauthorizedAtLowThreshold() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.UNAUTHORIZED, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(1, httpMessagesSent.size());
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_INFO, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_LOW, alert.getConfidence());
+    }
+
+    @Test
+    public void shouldNotAlertWhenRequestIsForbidden() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.FORBIDDEN, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldAlertWhenRequestIsForbiddenAtLowThreshold() throws Exception {
+        // Given
+        String path = "/foo/bar/";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.UNAUTHORIZED, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(1, httpMessagesSent.size());
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_INFO, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_LOW, alert.getConfidence());
+    }
+
+    private static NanoServerHandler createHandler(String path, Response response) {
+        return new NanoServerHandler(path) {
+            @Override
+            protected Response serve(IHTTPSession session) {
+                return response;
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Add UnitTests and testing components for `CloudMetadataScanRule`, `EnvFileScanRule` (via AbstractAppFilePlugin), and `HtAccessScanRule`.

Fixes zaproxy/zaproxy#6212

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>