### PR TITLE
wappalyzer & retire: Promote to Release

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -6,14 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
+- Add-on promoted to Release.
 
 ## [0.4.0] - 2020-08-04
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.3.1] - 2020-06-18
 ### Changed

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -5,7 +5,7 @@ description = "Retire.js"
 
 zapAddOn {
     addOnName.set("Retire.js")
-    addOnStatus.set(AddOnStatus.BETA)
+    addOnStatus.set(AddOnStatus.RELEASE)
     zapVersion.set("2.9.0")
 
     manifest {

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
-
-
+- Add-on promoted to Release.
 
 ## [20.3.0] - 2020-09-30
 ### Changed

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -5,7 +5,7 @@ description = "Technology detection using Wappalyzer: wappalyzer.com"
 
 zapAddOn {
     addOnName.set("Wappalyzer - Technology Detection")
-    addOnStatus.set(AddOnStatus.BETA)
+    addOnStatus.set(AddOnStatus.RELEASE)
     zapVersion.set("2.9.0")
 
     manifest {


### PR DESCRIPTION
- Updated CHANGELOG and build file promoting Wappalyzer and Retire.js add-ons to Release.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>