### PR TITLE
6203: Remove status code check in XXE, extract Local File Reflection and Local File Inclusion

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- XML External Entity Attack scan rule changed to skip only Remote File Inclusion Attack when Callback extension is not available.
 - Maintenance changes.
 - The Relative Path Confusion scan rule no longer treats 'href="#"' as a problematic use.
 

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- XML External Entity Attack scan rule changed to parse response body irrespective of the HTTP response status code. (Issue 6203)
 - XML External Entity Attack scan rule changed to skip only Remote File Inclusion Attack when Callback extension is not available.
 - Maintenance changes.
 - The Relative Path Confusion scan rule no longer treats 'href="#"' as a problematic use.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
@@ -31,7 +31,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.callback.ExtensionCallback;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
@@ -62,7 +61,7 @@ public class XxeScanRule extends AbstractAppPlugin implements ChallengeCallbackP
                     + "  <!ENTITY zapxxe SYSTEM \"{0}\">\n"
                     + "]>\n";
 
-    private static final String ATTACK_BODY = "<foo>" + ATTACK_ENTITY + "</foo>";
+    protected static final String ATTACK_BODY = "<foo>" + ATTACK_ENTITY + "</foo>";
 
     // XML standard from W3C Consortium
     // ---------------------------------------------
@@ -250,19 +249,16 @@ public class XxeScanRule extends AbstractAppPlugin implements ChallengeCallbackP
                     sendAndReceive(msg);
 
                     // Parse the result
-                    if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK) {
+                    response = msg.getResponseBody().toString();
+                    matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
+                    if (matcher.find()) {
 
-                        response = msg.getResponseBody().toString();
-                        matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
-                        if (matcher.find()) {
-
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setAttack(payload)
-                                    .setEvidence(matcher.group())
-                                    .setMessage(msg)
-                                    .raise();
-                        }
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setAttack(payload)
+                                .setEvidence(matcher.group())
+                                .setMessage(msg)
+                                .raise();
                     }
 
                     // Check if the scan has been stopped
@@ -315,19 +311,16 @@ public class XxeScanRule extends AbstractAppPlugin implements ChallengeCallbackP
                     sendAndReceive(msg);
 
                     // Parse the result
-                    if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK) {
+                    response = msg.getResponseBody().toString();
+                    matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
+                    if (matcher.find()) {
 
-                        response = msg.getResponseBody().toString();
-                        matcher = LOCAL_FILE_PATTERNS[idx].matcher(response);
-                        if (matcher.find()) {
-
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setAttack(payload)
-                                    .setEvidence(matcher.group())
-                                    .setMessage(msg)
-                                    .raise();
-                        }
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setAttack(payload)
+                                .setEvidence(matcher.group())
+                                .setMessage(msg)
+                                .raise();
                     }
 
                     // Check if the scan has been stopped

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRule.java
@@ -168,16 +168,6 @@ public class XxeScanRule extends AbstractAppPlugin implements ChallengeCallbackP
         return Alert.RISK_HIGH;
     }
 
-    @Override
-    public void init() {
-        if (ChallengeCallbackImplementor.getExtensionCallback() == null) {
-            // The callback extension is not available, cant do anything :(
-            getParent()
-                    .pluginSkipped(
-                            this, Constant.messages.getString(MESSAGE_PREFIX + "nocallback"));
-        }
-    }
-
     /**
      * Scan rule to check for XXE vulnerabilities. It checks both for local and remote using the ZAP
      * API and also a new model based on parameter substitution
@@ -199,29 +189,32 @@ public class XxeScanRule extends AbstractAppPlugin implements ChallengeCallbackP
             // using an external bouncing site, in this case we use
             // the ZAP API as a server for the vulnerability check
             // using a challenge/response model based on a random string
-            //
-            String challenge = randomString(CHALLENGE_LENGTH);
 
-            try {
-                // Prepare the attack message
-                msg = getNewMsg();
-                payload = getCallbackAttackPayload(challenge);
-                msg.setRequestBody(payload);
+            // Skip XXE Remote File Inclusion Attack when callback extension is not available.
+            if (ChallengeCallbackImplementor.getExtensionCallback() != null) {
+                String challenge = randomString(CHALLENGE_LENGTH);
 
-                // Register the callback for future actions
-                callbackImplementor.registerCallback(challenge, this, msg);
+                try {
+                    // Prepare the attack message
+                    msg = getNewMsg();
+                    payload = getCallbackAttackPayload(challenge);
+                    msg.setRequestBody(payload);
 
-                // All we need has been done...
-                sendAndReceive(msg);
+                    // Register the callback for future actions
+                    callbackImplementor.registerCallback(challenge, this, msg);
 
-            } catch (IOException ex) {
-                // Do not try to internationalise this.. we need an error message in any event..
-                // if it's in English, it's still better than not having it at all.
-                log.warn(
-                        "XXE Injection vulnerability check failed for payload ["
-                                + payload
-                                + "] due to an I/O error",
-                        ex);
+                    // All we need has been done...
+                    sendAndReceive(msg);
+
+                } catch (IOException ex) {
+                    // Do not try to internationalise this.. we need an error message in any event..
+                    // if it's in English, it's still better than not having it at all.
+                    log.warn(
+                            "XXE Injection vulnerability check failed for payload ["
+                                    + payload
+                                    + "] due to an I/O error",
+                            ex);
+                }
             }
 
             // Check if we've to do only basic analysis (only remote should be done)...

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -328,6 +328,5 @@ ascanbeta.xsltinjection.portscan.otherinfo = Port scanning may be possible.
 ascanbeta.xsltinjection.command.otherinfo = Command execution may be possible.
 
 ascanbeta.xxe.name=XML External Entity Attack
-ascanbeta.xxe.nocallback=callback functionality not available
 
 ascanbeta.xpathinjection.name=XPath Injection

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
@@ -19,10 +19,23 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+import fi.iki.elonen.NanoHTTPD;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.NanoServerHandler;
 
 public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
 
@@ -105,5 +118,102 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
                         + "    </comment>\n"
                         + "</comments>";
         assertThat(payload, is(expectedPayload));
+    }
+
+    @Test
+    public void shouldScanOnlyIfRequestContentTypeIsXml() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = this.getHttpMessage("/test");
+        msg.getRequestHeader().setHeader("Content-Type", "application/json");
+        // The mismatch in request body and content-type is intentional.
+        // For any reason if the rule fails to check the Content-Type, then createLfrPayload() will
+        // send a message converting the XML body into an attack payload.
+        // This may not happen, if the request body is not XML.
+        msg.setRequestBody("<?xml version=\"1.0\"?><comment><text>test</text></comment>");
+        msg.getRequestHeader().setMethod("POST");
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, equalTo(0));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = NanoHTTPD.Response.Status.class,
+            names = {"OK", "BAD_REQUEST"})
+    public void shouldAlertWhenLocalFileReflectedInResponse(NanoHTTPD.Response.Status status)
+            throws HttpMalformedHeaderException {
+        // Given
+        String test = "/test";
+        String responseBody = "<foo>root:*:0:0:System Administrator:/var/root:/bin/sh</foo>";
+        this.nano.addHandler(createNanoHandler(test, status, responseBody));
+        HttpMessage msg = getXmlPostMessage(test);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        String localFileInclusionAttackPayload =
+                MessageFormat.format(XxeScanRule.ATTACK_HEADER, "file:///etc/passwd")
+                        + "<comment><text>&zapxxe;</text></comment>";
+        List<Alert> alertList =
+                alertsRaised.stream()
+                        .filter(alert -> alert.getAttack().equals(localFileInclusionAttackPayload))
+                        .collect(Collectors.toList());
+        assertThat(alertList.size(), equalTo(1));
+        Alert alert = alertList.get(0);
+        assertThat(alert.getEvidence(), equalTo("root:*:0:0"));
+        assertThat(alert.getRisk(), equalTo(Alert.RISK_HIGH));
+        assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = NanoHTTPD.Response.Status.class,
+            names = {"OK", "BAD_REQUEST"})
+    public void shouldAlertWhenLocalFileIncludedInResponse(NanoHTTPD.Response.Status status)
+            throws HttpMalformedHeaderException {
+        // Given
+        String test = "/test";
+        String responseBody = "[drivers]\n" + "wave=mmdrv.dll";
+        this.nano.addHandler(createNanoHandler(test, status, responseBody));
+        HttpMessage msg = getXmlPostMessage(test);
+        rule.init(msg, parent);
+        // When
+        // Local File Inclusion Attacks is triggered only when AttackStrength is > Medium
+        rule.setAttackStrength(Plugin.AttackStrength.HIGH);
+        rule.scan();
+        // Then
+        String localFileInclusionAttackPayload =
+                MessageFormat.format(XxeScanRule.ATTACK_HEADER, "file:///c:/Windows/system.ini")
+                        + XxeScanRule.ATTACK_BODY;
+        List<Alert> alertList =
+                alertsRaised.stream()
+                        .filter(alert -> alert.getAttack().equals(localFileInclusionAttackPayload))
+                        .collect(Collectors.toList());
+        assertThat(alertList.size(), equalTo(1));
+        Alert alert = alertList.get(0);
+        assertThat(alert.getEvidence(), equalTo("[drivers]"));
+        assertThat(alert.getRisk(), equalTo(Alert.RISK_HIGH));
+        assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+    }
+
+    private NanoServerHandler createNanoHandler(
+            String path, NanoHTTPD.Response.IStatus status, String responseBody) {
+        return new NanoServerHandler(path) {
+            @Override
+            protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
+                consumeBody(session);
+                return newFixedLengthResponse(status, NanoHTTPD.MIME_PLAINTEXT, responseBody);
+            }
+        };
+    }
+
+    private HttpMessage getXmlPostMessage(String path) throws HttpMalformedHeaderException {
+        HttpMessage msg = this.getHttpMessage(path);
+        msg.setRequestBody("<?xml version=\"1.0\"?><comment><text>test</text></comment>");
+        msg.getRequestHeader().setMethod("POST");
+        msg.getRequestHeader().setHeader("Content-Type", "application/xml");
+        return msg;
     }
 }

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
@@ -21,29 +21,14 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.Test;
-import org.parosproxy.paros.network.HttpMessage;
 
 public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
 
     @Override
     protected XxeScanRule createScanner() {
         return new XxeScanRule();
-    }
-
-    @Test
-    public void shouldSkipScanRuleIfExtensionCallbackIsNotEnabled() {
-        // Given
-        HttpMessage message = mock(HttpMessage.class);
-        // When
-        rule.init(message, parent);
-        // Then
-        verify(parent).pluginSkipped(eq(rule), anyString());
     }
 
     @Test


### PR DESCRIPTION
Extracted XXE Local File Reflection and Local File Inclusion to separate methods to enable unit testing.
Removed the check to parse response only when the status code is 200. 
Response is now parsed for XXE reflection/inclution regardless of the status code.
Added unit tests.

Closes zaproxy/zaproxy#6203