### PR TITLE
Graphql: Dont display script on startup

### DIFF
--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -207,7 +207,7 @@ public class ExtensionGraphQl extends ExtensionAdaptor
                                 true,
                                 scriptPath);
                 script.reloadScript();
-                extScript.addScript(script);
+                extScript.addScript(script, false);
             }
         }
     }


### PR DESCRIPTION
Without this change the graphql script is always displayed on startup, which is not what we want :)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>