### PR TITLE
wappalyzer: Dependency updates

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
 - Add-on promoted to Release.
+- Dependency updates.
 
 ## [20.3.0] - 2020-09-30
 ### Changed

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -20,9 +20,9 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.google.re2j:re2j:1.4")
+    implementation("com.google.re2j:re2j:1.5")
 
-    val batikVersion = "1.12"
+    val batikVersion = "1.13"
     implementation("org.apache.xmlgraphics:batik-anim:$batikVersion")
     implementation("org.apache.xmlgraphics:batik-bridge:$batikVersion")
     implementation("org.apache.xmlgraphics:batik-ext:$batikVersion")


### PR DESCRIPTION
- re2j 1.4 to 1.5. 
- batik 1.12 to 1.13
- CHANGELOG added change note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>