### PR TITLE
SOAP Add-on Sites Tree Fix

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Various fixes (related to Issue 4832 and other testing).
 - Fix exception with Java 9+ (Issue 4037).
+- SOAP operations are no longer overwritten in sites tree (Issue 1867).
 
 ## 3 - 2017-03-31
 

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -17,7 +17,8 @@ zapAddOn {
 
 dependencies {
     implementation("com.predic8:soa-model-core:1.6.0")
-    implementation("com.sun.xml.ws:jaxws-rt:2.3.2")
+    implementation("jakarta.xml.soap:jakarta.xml.soap-api:1.4.2")
+    implementation("com.sun.xml.messaging.saaj:saaj-impl:1.5.2")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRule.java
@@ -19,11 +19,7 @@
  */
 package org.zaproxy.zap.extension.soap;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import javax.xml.soap.MessageFactory;
-import javax.xml.soap.MimeHeaders;
 import javax.xml.soap.SOAPBody;
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPFault;
@@ -160,13 +156,7 @@ public class SOAPActionSpoofingActiveScanRule extends AbstractAppPlugin {
 
         SOAPMessage soapMsg = null;
         try {
-            MessageFactory factory = MessageFactory.newInstance();
-            soapMsg =
-                    factory.createMessage(
-                            new MimeHeaders(),
-                            new ByteArrayInputStream(
-                                    responseContent.getBytes(
-                                            Charset.forName(msg.getResponseBody().getCharset()))));
+            soapMsg = SoapMessageFactory.createMessage(msg.getResponseBody());
 
             /* Looks for fault code. */
             SOAPBody body = soapMsg.getSOAPBody();
@@ -184,14 +174,8 @@ public class SOAPActionSpoofingActiveScanRule extends AbstractAppPlugin {
             if (bodyList.getLength() <= 0) return EMPTY_RESPONSE;
 
             /* Prepares original request to compare it. */
-            String originalContent = originalMsg.getResponseBody().toString();
             SOAPMessage originalSoapMsg =
-                    factory.createMessage(
-                            new MimeHeaders(),
-                            new ByteArrayInputStream(
-                                    originalContent.getBytes(
-                                            Charset.forName(
-                                                    originalMsg.getResponseBody().getCharset()))));
+                    SoapMessageFactory.createMessage(originalMsg.getResponseBody());
 
             /* Comparison between original response body and attack response body. */
             SOAPBody originalBody = originalSoapMsg.getSOAPBody();

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SitesTreeHelper.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SitesTreeHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.soap;
+
+import java.io.IOException;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPMessage;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.w3c.dom.NodeList;
+
+public class SitesTreeHelper {
+
+    private static final Logger LOG = Logger.getLogger(ExtensionImportWSDL.class);
+
+    /**
+     * Returns a node name based on the SOAP version and the operation name in the provided message.
+     * If the SOAP message is malformed, an empty string is returned.
+     *
+     * @param message The message for which a node name is required.
+     */
+    public static String getNodeName(HttpMessage message) {
+        try {
+            SOAPMessage soapMsg = SoapMessageFactory.createMessage(message.getRequestBody());
+            if (soapMsg == null) {
+                return "";
+            }
+            NodeList nodeList = soapMsg.getSOAPBody().getChildNodes();
+            StringBuilder leafName = new StringBuilder();
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                if (nodeList.item(i).getLocalName() != null) {
+                    leafName.append(nodeList.item(i).getLocalName()).append(", ");
+                }
+            }
+            // Remove the extra ", " at the end.
+            leafName.setLength(leafName.length() - 2);
+            // Append SOAP Version.
+            leafName.append(
+                    message.getRequestHeader().getHeader("SOAPAction") == null
+                            ? " (v1.2)"
+                            : " (v1.1)");
+            return leafName.toString();
+        } catch (SOAPException | IOException e) {
+            LOG.warn("Malformed SOAP Message.");
+            return "";
+        }
+    }
+}

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SoapMessageFactory.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SoapMessageFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.soap;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPConstants;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPMessage;
+import org.parosproxy.paros.network.HttpBody;
+
+public class SoapMessageFactory {
+
+    public static SOAPMessage createMessage(HttpBody messageBody)
+            throws IOException, SOAPException {
+        ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(SoapMessageFactory.class.getClassLoader());
+
+            String content = messageBody.toString();
+            if (content.contains(SOAPConstants.URI_NS_SOAP_1_1_ENVELOPE)) {
+                return MessageFactory.newInstance(SOAPConstants.SOAP_1_1_PROTOCOL)
+                        .createMessage(null, new ByteArrayInputStream(messageBody.getBytes()));
+            } else if (content.contains(SOAPConstants.URI_NS_SOAP_1_2_ENVELOPE)) {
+                return MessageFactory.newInstance(SOAPConstants.SOAP_1_2_PROTOCOL)
+                        .createMessage(null, new ByteArrayInputStream(messageBody.getBytes()));
+            } else {
+                return null;
+            }
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldClassLoader);
+        }
+    }
+}

--- a/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
+++ b/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
@@ -40,3 +40,5 @@ soap.importfromurldialog.pasteaction=Paste
 soap.importfromurldialog.labelURL=URL pointing to .wsdl file:
 soap.importfromurldialog.importButton=Import
 soap.importfromurldialog.actionName=Import WSDL file from URL
+
+soap.script.description = Script for representing each SOAP operation uniquely in the Sites Tree.

--- a/addOns/soap/src/main/zapHomeFiles/scripts/scripts/variant/SOAP Support.js
+++ b/addOns/soap/src/main/zapHomeFiles/scripts/scripts/variant/SOAP Support.js
@@ -1,0 +1,27 @@
+/*
+Script for representing each SOAP operation uniquely in the Sites Tree.
+*/
+
+function parseParameters(helper, msg) { }
+
+function setParameter(helper, msg, param, value, escaped) { }
+
+function getLeafName(helper, nodeName, msg) {
+	return helper.getStandardLeafName(nodeName, msg, helper.getParamList());
+}
+
+function getTreePath(helper, msg) {
+	var nodeName = Java.type('org.zaproxy.zap.extension.soap.SitesTreeHelper').getNodeName(msg);
+	if (nodeName == '') {
+		// Not a SOAP message
+		return null;
+	}
+	var uri = msg.getRequestHeader().getURI();
+	var path = uri.getPath() != null ? uri.getPath().split('/') : [];
+	var list = [];
+	for (var x = 1; x < path.length; x++) {
+		list.push(path[x]);
+	}
+	list.push(nodeName);
+	return list;
+}

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/Sample.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/Sample.java
@@ -82,7 +82,7 @@ public class Sample {
                         + "SOAPAction: urn:sayHelloWorld \r\n"
                         + "Host: 192.168.145.131:8443\r\n");
         msg.setRequestBody(
-                "<?xml version=\"1.0 \" encoding= \"UTF-8\" ?>\r\n"
+                "<?xml version=\"1.0\" encoding= \"UTF-8\" ?>\r\n"
                         + "<s11:Envelope xmlns:s11='http://schemas.xmlsoap.org/soap/envelope/'>\r\n"
                         + "\t<s11:Body>\r\n"
                         + "\t\t<ns:sayHelloWorld xmlns:ns='http://main.soaptest.org'>\r\n"
@@ -147,6 +147,29 @@ public class Sample {
                         + "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">"
                         + "<soapenv:Body>"
                         + "</soapenv:Envelope>");
+        return msg;
+    }
+
+    public static HttpMessage setSoapVersionTwoRequest(HttpMessage msg)
+            throws HttpMalformedHeaderException {
+        msg.setRequestHeader(
+                "POST https://www.example.com/Soap12Endpoint/ HTTP/1.1"
+                        + "User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0;)"
+                        + "Pragma: no-cache"
+                        + "Cache-Control: no-cache"
+                        + "Content-Length: 275"
+                        + "Content-Type: application/soap+xml; charset=UTF-8; action= https://www.example.com/xml/sayHelloWorld"
+                        + "Host: www.example.com");
+        msg.setRequestBody(
+                "<?xml version='1.0' encoding= 'UTF-8' ?>"
+                        + "<s12:Envelope xmlns:s12='http://www.w3.org/2003/05/soap-envelope'>"
+                        + "<s12:Body>"
+                        + "<ns:sayHelloWorld xmlns:ns='http://main.soaptest.org'>"
+                        + "<ns:args0>paramValue</ns:args0>"
+                        + "</ns:sayHelloWorld>"
+                        + "</s12:Body>"
+                        + "</s12:Envelope>");
+        msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
         return msg;
     }
 }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SitesTreeHelperTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SitesTreeHelperTestCase.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.soap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.TestUtils;
+
+public class SitesTreeHelperTestCase extends TestUtils {
+    HttpMessage message;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        setUpZap();
+        message = new HttpMessage();
+    }
+
+    @Test
+    public void getNodeNameForSoapV1Message() throws Exception {
+        // Given
+        Sample.setOriginalRequest(message);
+        // When
+        String nodeName = SitesTreeHelper.getNodeName(message);
+        // Then
+        assertEquals(nodeName, "sayHelloWorld (v1.1)");
+    }
+
+    @Test
+    public void getNodeNameForSoapV2Message() throws Exception {
+        // Given
+        Sample.setSoapVersionTwoRequest(message);
+        // When
+        String nodeName = SitesTreeHelper.getNodeName(message);
+        // Then
+        assertEquals(nodeName, "sayHelloWorld (v1.2)");
+    }
+}


### PR DESCRIPTION
- Add node names in the sites tree via a variant script.
- Fix a bug where some classes were not being loaded correctly with Java 9+.
- Resolves zaproxy/zaproxy#1867.

Signed-off-by: ricekot <ricekot@gmail.com>