### PR TITLE
GraphQL: Set Optional Arguments Enabled by Default

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Bug Fixes.
 - Enhanced Support for Script Input Vectors.
 - Options are now exposed through the API.
+- Optional Arguments are enabled by default.
 
 ## [0.1.0] - 2020-08-28
 - First Version

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
@@ -239,7 +239,7 @@ public class GraphQlParam extends VersionedAbstractParam {
     protected void parseImpl() {
         maxQueryDepth = getInt(PARAM_MAX_QUERY_DEPTH, 5);
         maxArgsDepth = getInt(PARAM_MAX_ARGS_DEPTH, 5);
-        optionalArgsEnabled = getBoolean(PARAM_OPTIONAL_ARGS, false);
+        optionalArgsEnabled = getBoolean(PARAM_OPTIONAL_ARGS, true);
         argsType =
                 ArgsTypeOption.valueOf(getString(PARAM_ARGS_TYPE, ArgsTypeOption.BOTH.toString()));
         querySplitType =


### PR DESCRIPTION
- As discussed on Friday, enable optional arguments by default, for convenience when scanning small schemas using the zap-api-scan docker script.

Signed-off-by: ricekot <ricekot@gmail.com>