### PR TITLE
fuzz: prevent adding null fuzz handlers

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Prevent adding null fuzz handlers, which would cause exceptions when selecting the fuzz message.
 
 ## [13.0.1] - 2020-09-08
 ### Fixed

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.prefs.Preferences;
 import javax.swing.AbstractAction;
@@ -584,7 +585,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
 
     public <M extends Message, F extends Fuzzer<M>> void addFuzzerHandler(
             FuzzerHandler<M, F> fuzzerHandler) {
-        fuzzerHandlers.add(fuzzerHandler);
+        fuzzerHandlers.add(Objects.requireNonNull(fuzzerHandler));
 
         if (defaultFuzzerHandler == null) {
             defaultFuzzerHandler = fuzzerHandler;


### PR DESCRIPTION
Validate that the fuzz handler being added is non-null to fail earlier,
otherwise it would fail later when trying to select a message to fuzz.