### PR TITLE
scripts: hide menu item if not applicable

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
  - Terminology
+ - Do not show the Enable/Disable Script menu item if the script can't be enabled/disabled, in some
+ look and feels it could show an empty menu item (Issue 6256).
 
 ## [26] - 2020-01-17
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupEnableDisableScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupEnableDisableScript.java
@@ -123,7 +123,7 @@ public class PopupEnableDisableScript extends ExtensionPopupMenuItem {
                             }
                         }
                     }
-                    return true;
+                    return enable != null;
                 }
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);


### PR DESCRIPTION
Change `PopupEnableDisableScript` to only be visible if the there's at
least one script that can be enabled/disabled.

Fix zaproxy/zaproxy#6256.