### PR TITLE
customreport: Fix Report Write Failure When Path Contains '#'

### DIFF
--- a/addOns/customreport/CHANGELOG.md
+++ b/addOns/customreport/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.9.0.
 - Add Evidence to report (Issue 6151).
 - Make Parameter and Attack fields optional.
+- Fix bug to allow writing reports with file path containing '#' (Issue 6267).
 
 ## [5] - 2019-08-30
 

--- a/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/ReportGenerator.java
+++ b/addOns/customreport/src/main/java/org/zaproxy/zap/extension/customreport/ReportGenerator.java
@@ -26,6 +26,7 @@
 // ZAP: 2015/11/16 Issue 1804: Disable processing of XML external entities by default
 // ZAP: 2015/11/16 Issue 1555: Rework inclusion of HTML tags in reports
 // ZAP: 2019/05/08 Normalise format/indentation.
+// ZAP: 2020/10/29 Issue 6267: Fix bug to allow writing reports with file path containing '#'.
 package org.zaproxy.zap.extension.customreport;
 
 import java.io.BufferedReader;
@@ -81,7 +82,7 @@ public class ReportGenerator {
             Transformer transformer = tFactory.newTransformer(stylesource);
 
             // Make the transformation and write to the output file
-            StreamResult result = new StreamResult(outFile);
+            StreamResult result = new StreamResult(outFile.getPath());
             transformer.transform(source, result);
 
         } catch (TransformerException e) {
@@ -116,7 +117,7 @@ public class ReportGenerator {
                 Transformer transformer = tFactory.newTransformer(stylesource);
 
                 DOMSource source = new DOMSource(doc);
-                StreamResult result = new StreamResult(outfile);
+                StreamResult result = new StreamResult(outfile.getPath());
                 transformer.transform(source, result);
 
             } catch (TransformerException
@@ -261,7 +262,7 @@ public class ReportGenerator {
             Transformer transformer = tFactory.newTransformer(stylesource);
 
             DOMSource source = new DOMSource(doc);
-            StreamResult result = new StreamResult(outfile);
+            StreamResult result = new StreamResult(outfile.getPath());
             transformer.transform(source, result);
 
         } catch (TransformerException


### PR DESCRIPTION
- See zaproxy/zaproxy#6267.

Signed-off-by: ricekot <ricekot@gmail.com>