### PR TITLE
ascanrules: Remove extra newline character

### DIFF
--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -97,7 +97,7 @@ ascanrules.codeinjection.refs=http://cwe.mitre.org/data/definitions/94.html\nhtt
 ascanrules.directorybrowsing.name=Directory Browsing
 ascanrules.directorybrowsing.desc=It is possible to view the directory listing.  Directory listing may reveal hidden scripts, include files, backup source files, etc. which can be accessed to read sensitive information.
 ascanrules.directorybrowsing.soln=Disable directory browsing.  If this is required, make sure the listed files does not induce risks.
-ascanrules.directorybrowsing.refs=http://httpd.apache.org/docs/mod/core.html#options\nhttp://alamo.satlug.org/pipermail/satlug/2002-February/000053.html\n
+ascanrules.directorybrowsing.refs=http://httpd.apache.org/docs/mod/core.html#options\nhttp://alamo.satlug.org/pipermail/satlug/2002-February/000053.html
 
 ascanrules.crlfinjection.name=CRLF Injection
 ascanrules.crlfinjection.desc=Cookie can be set via CRLF injection.  It may also be possible to set arbitrary HTTP response headers. In addition, by carefully crafting the injected response using cross-site script, cache poisoning vulnerability may also exist.

--- a/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
+++ b/addOns/pscanrulesBeta/src/main/resources/org/zaproxy/zap/extension/pscanrulesBeta/resources/Messages.properties
@@ -49,7 +49,7 @@ pscanbeta.insecureformpost.extrainfo=The response to the following request over 
 
 pscanbeta.linktarget.name=Reverse Tabnabbing
 pscanbeta.linktarget.desc=At least one link on this page is vulnerable to Reverse tabnabbing as it uses a target attribute without using both of the "noopener" and "noreferrer" keywords in the "rel" attribute, which allows the target page to take control of this page.
-pscanbeta.linktarget.refs=https://owasp.org/www-community/attacks/Reverse_Tabnabbing\nhttps://dev.to/ben/the-targetblank-vulnerability-by-example\nhttps://mathiasbynens.github.io/rel-noopener/\nhttps://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c\n
+pscanbeta.linktarget.refs=https://owasp.org/www-community/attacks/Reverse_Tabnabbing\nhttps://dev.to/ben/the-targetblank-vulnerability-by-example\nhttps://mathiasbynens.github.io/rel-noopener/\nhttps://medium.com/@jitbit/target-blank-the-most-underestimated-vulnerability-ever-96e328301f4c
 pscanbeta.linktarget.soln=Do not use a target attribute, or if you have to then also add the attribute: rel="noopener noreferrer".
 
 pscanbeta.modernapp.name=Modern Web Application


### PR DESCRIPTION
- Remove extra newline character from the references of the Directory Browsing scan rule. This was resulting in an extra empty bullet point in the [alert docs](https://www.zaproxy.org/docs/alerts/0/):
![image](https://user-images.githubusercontent.com/16446369/97728586-bcb2a280-1af7-11eb-9e26-e567542a33fb.png)

Signed-off-by: ricekot <ricekot@gmail.com>