### PR TITLE
Handle SocketTimeoutExceptions in LDAP and Proxy Disclosure Scan Rules

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 
 ### Fixed
- - Terminology
+ - Terminology.
+ - SocketTimeoutException in the LDAP Injection scan rule.
 
 ### Removed
 - The following scan rules were removed and promoted to Beta: Cloud Meta Data, .env File, Hidden Files, XSLT Injection (Issue 6211).

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -219,11 +219,6 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                                 + "] for LDAP Injection");
             }
 
-            // get the response for the "original" unmodified request
-            // this fixes what seems to be a bug in the Zap core, where the request response is not
-            // actually available at this point via "originalmsg"
-            sendAndReceive(originalmsg);
-
             // 1: try error based LDAP injection, for one of the LDAP implementations that we know
             // about
             HttpMessage attackMsg = getNewMsg();

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,8 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 
 ### Fixed
- - Terminology
+ - Terminology.
  - Correct reason shown when the XML External Entity Attack scan rule is skipped.
+ - SocketTimeoutException in the Proxy Disclosure scan rule.
 
 ### Added
 - The following scan rules were promoted to Beta: Cloud Meta Data, .env File, Hidden Files, XSLT Injection (Issue 6211).


### PR DESCRIPTION
- Addressed STEs encountered in specific locations in these two scan rules.
- Added Fix note to the CHANGELOGs.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>