### PR TITLE
requester: warn on malformed messages

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Warn when unable to save (malformed) HTTP message (Issue 4235).
 
 ## [4] - 2020-07-15
 ### Added

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualRequestEditorPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualRequestEditorPanel.java
@@ -141,8 +141,20 @@ public abstract class ManualRequestEditorPanel extends JPanel implements Tab {
                         public void actionPerformed(ActionEvent e) {
                             btnSend.setEnabled(false);
 
-                            // save current message (i.e. set payload/body)
-                            getRequestPanel().saveData();
+                            try {
+                                getRequestPanel().saveData();
+                            } catch (Exception e1) {
+                                StringBuilder warnMessage = new StringBuilder(150);
+                                warnMessage.append(
+                                        Constant.messages.getString("requester.warn.datainvalid"));
+                                String exceptionMessage = e1.getLocalizedMessage();
+                                if (exceptionMessage != null && !exceptionMessage.isEmpty()) {
+                                    warnMessage.append('\n').append(exceptionMessage);
+                                }
+                                View.getSingleton().showWarningDialog(warnMessage.toString());
+                                btnSend.setEnabled(true);
+                                return;
+                            }
 
                             Mode mode = Control.getSingleton().getMode();
                             if (mode.equals(Mode.safe)) {

--- a/addOns/requester/src/main/resources/org/zaproxy/zap/extension/requester/resources/Messages.properties
+++ b/addOns/requester/src/main/resources/org/zaproxy/zap/extension/requester/resources/Messages.properties
@@ -7,3 +7,5 @@ requester.toolsmenu.label = Open Message in Requester Tab...
 
 requester.optionspanel.name	= Requester
 requester.optionspanel.option.autoFocus.label = Set focus on Requester after adding a new tab
+
+requester.warn.datainvalid = Unable to set the data to the message.


### PR DESCRIPTION
Catch exception that might be thrown when saving the request panel and
inform the user.

Part of zaproxy/zaproxy#4235.