### PR TITLE
Scan Rule Tweaks

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- The Relative Path Confusion scan rule no longer treats 'href="#"' as a problematic use.
 
 ### Fixed
  - Terminology

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -357,10 +357,13 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin {
                                 // and scheme are inferred)
                                 // if it starts with "//, it's a reference to the host and path (but
                                 // not the scheme), and it's essentially an absolute reference..
+                                // if it starts with or is simply "#" it is either a fragment link
+                                // or JS invocation
                                 if (!loadingHtmlAttribute.equals("style")) {
                                     if (!attributeUpper.startsWith("HTTP://")
                                             && !attributeUpper.startsWith("HTTPS://")
-                                            && !attributeUpper.startsWith("/")) {
+                                            && !attributeUpper.startsWith("/")
+                                            && !attributeUpper.startsWith("#")) {
                                         // it's a relative reference..
                                         relativeReferenceFound = true;
                                         // Note: since we parsed the HTML, and are reconstructing

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,9 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The CSP scan rule now checks if the form-action directive allows wildcards.
 - The CSP scan rule now includes further information in the description of allowed wildcard directives alerts when the impacted directive is one (or more) which doesn't fallback to default-src.
 - Maintenance changes.
-- Changed ViewState and XFrameOption rules to return example alerts for the docs
+- Changed ViewState and XFrameOption rules to return example alerts for the docs.
 - Handle an IllegalArgumentException that could occur in the CSP scan rule if multiple CSP headers were present and one (or more) had a report-uri directive when trying to merge them.
 - Allow to ignore cookies in same site and loosely scoped scan rules.
+- The Application Error scan rule will not alert on web assembly responses.
 
 ## [29] - 2020-06-01
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -178,7 +178,8 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
             }
             raiseAlert(msg, id, msg.getResponseHeader().getPrimeHeader(), Alert.RISK_LOW);
 
-        } else if (status != HttpStatusCode.NOT_FOUND) {
+        } else if (status != HttpStatusCode.NOT_FOUND
+                && !msg.getResponseHeader().hasContentType("application/wasm")) {
             String body = msg.getResponseBody().toString();
             for (String payload : getCustomPayloads().get()) {
                 if (body.contains(payload)) {

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
@@ -248,6 +249,25 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
         Alert result = alertsRaised.get(0);
         assertThat(result.getEvidence(), equalTo(expectedEvidence));
         validateAlert(result);
+    }
+
+    @Test
+    public void
+            shouldNotRaiseAlertForResponseCodeOkAndContentTypeWebAssemblyWhenFilePayloadPresent()
+                    throws HttpMalformedHeaderException {
+        // Given
+        // String from standard XML file
+        String expectedEvidence = "Microsoft OLE DB Provider for ODBC Drivers";
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(REQUEST_HEADER);
+        msg.setResponseHeader(createResponseHeader(OK));
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "application/wasm");
+        msg.setResponseBody(expectedEvidence);
+        ApplicationErrorScanRule.setPayloadProvider(() -> Arrays.asList(expectedEvidence));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
     }
 
     private static void validateAlert(Alert alert) {


### PR DESCRIPTION
- pscanrules : ApplicationErrorScanRule > Will not alert on web assembly responses (web assembly is likely to contain error strings). Added Unit Test and change note in CHANGELOG.
- ascanrulesBeta : RelativePathConfusionScanRule > No longer treats 'href="#"' as a relative path. Added change note to CHANGELOG.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>