### PR TITLE
graphql: Save Script to Config

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 ### Changed
-- Bug Fixes.
 - Enhanced Support for Script Input Vectors.
 - Options are now exposed through the API.
 - Optional Arguments are enabled by default.
+
+### Fixed
+- Fix clashes in variable names. See [PR#2550](https://github.com/zaproxy/zap-extensions/pull/2550) for details.
+- Fix a bug where the "GraphQL Support.js" script was enabled when ZAP was restarted even if it had been disabled and saved before.
 
 ## [0.1.0] - 2020-08-28
 - First Version

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -206,6 +206,7 @@ public class ExtensionGraphQl extends ExtensionAdaptor
                                 variantType,
                                 true,
                                 scriptPath);
+                script.setLoadOnStart(true);
                 script.reloadScript();
                 extScript.addScript(script, false);
             }


### PR DESCRIPTION
As discussed on IRC, 
fix bug where the "GraphQL Support.js" script
was enabled when ZAP was restarted even
if it had been disabled and saved before.

Signed-off-by: ricekot <ricekot@gmail.com>