### PR TITLE
spiderAjax: unregister event publisher

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.9.0.
 - Maintenance changes.
 
+### Fixed
+- Unregister the event publisher when the add-on is uninstalled.
+
 ## [23.1.0] - 2020-01-17
 ### Added
 - Add repo URL.

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -134,6 +134,8 @@ public class ExtensionAjax extends ExtensionAdaptor {
             getSpiderPanel().stopScan();
             getSpiderPanel().unload();
 
+            SpiderEventPublisher.unregisterPublisher();
+
             getView()
                     .getMainFrame()
                     .getMainFooterPanel()

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderEventPublisher.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderEventPublisher.java
@@ -41,6 +41,13 @@ public class SpiderEventPublisher extends ScanEventPublisher {
         return publisher;
     }
 
+    static synchronized void unregisterPublisher() {
+        if (publisher == null) {
+            return;
+        }
+        ZAP.getEventBus().unregisterPublisher(publisher);
+    }
+
     public static void publishScanEvent(String event, int scanId) {
         SpiderEventPublisher publisher = getPublisher();
         publisher.publishScanEvent(publisher, event, scanId);


### PR DESCRIPTION
Unregister the event publisher when the extension is unloaded otherwise
it would lead to a leak and exceptions after updating the add-on.