### PR TITLE
retire & testutils: Adapt to 2.10 core enhancements

### DIFF
--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -6,11 +6,11 @@ description = "Retire.js"
 zapAddOn {
     addOnName.set("Retire.js")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
 
     manifest {
         author.set("Nikita Mundhada and the ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/retire.js/")
+        zapVersion.set("2.10.0")
         bundle {
             baseName.set("org.zaproxy.addon.retire.resources.Messages")
             prefix.set("retire")
@@ -22,7 +22,15 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
+
         implementation("com.google.code.gson:gson:2.8.6")
 
         testImplementation(project(":testutils"))

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -30,7 +30,6 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.retire.model.Repo;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -60,11 +59,13 @@ public class RetireScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+        if (!getHelper().isPage200(msg)) {
             return;
         }
         String uri = msg.getRequestHeader().getURI().toString();
-        if (!msg.getResponseHeader().isImage() && !uri.endsWith(".css")) {
+        if (!msg.getResponseHeader().isImage()
+                && !msg.getRequestHeader().isCss()
+                && !msg.getResponseHeader().isCss()) {
             Result result = getRepo().scanJS(msg);
             if (result == null) {
                 if (LOGGER.isDebugEnabled()) {
@@ -110,6 +111,7 @@ public class RetireScanRule extends PluginPassiveScanner {
                 .setCweId(829); // CWE-829: Inclusion of Functionality from Untrusted Control Sphere
     }
 
+    @Override
     public List<Alert> getExampleAlerts() {
         List<Alert> alerts = new ArrayList<Alert>();
         alerts.add(

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -95,7 +95,11 @@ public abstract class TestUtils {
     @TempDir protected static Path tempDir;
 
     static {
-        Config.LoggerProvider = ZAP.JERICHO_LOGGER_PROVIDER;
+        try {
+            Config.LoggerProvider = ZAP.JERICHO_LOGGER_PROVIDER;
+        } catch (NoSuchFieldError ignore) {
+            // Newer core versions no longer provide/need it.
+        }
     }
 
     private static String zapInstallDir;
@@ -122,6 +126,7 @@ public abstract class TestUtils {
         Path installDir = Files.createDirectory(tempDir.resolve("install"));
         Path xmlDir = Files.createDirectory(installDir.resolve("xml"));
         Files.createFile(xmlDir.resolve("log4j.properties"));
+        Files.createFile(xmlDir.resolve("log4j2.properties"));
 
         zapInstallDir = installDir.toAbsolutePath().toString();
         zapHomeDir = Files.createDirectory(tempDir.resolve("home")).toAbsolutePath().toString();


### PR DESCRIPTION
- retire.gradle.kts > Set compatibility as ZAP 2.10, and depend on ZAP 2.10 snapshot.
- RetireScanRule > Leverage new request/response header isCss() methods, and CustomPages.Type.OK_200 handling.
- RetireScanRuleUnitTest > Additional coverage.
- TestUtils > Changed to accomodate newer core logging infrastructure.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>