### PR TITLE
encoder: Adapt to 2.10 core

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Promoted to Beta.
 - Added Info URL to manifest.
+- Target ZAP 2.10. Remove "Advanced" from labels, titles, and name.
 
 ## [0.3.0] - 2020-09-14
 

--- a/addOns/encoder/encoder.gradle.kts
+++ b/addOns/encoder/encoder.gradle.kts
@@ -11,5 +11,6 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/encode-decode-hash/")
+        notBeforeVersion.set("2.10.0")
     }
 }

--- a/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
+++ b/addOns/encoder/src/main/resources/org/zaproxy/addon/encoder/resources/Messages.properties
@@ -1,9 +1,9 @@
 # This file defines the default (English) variants of all of the internationalised messages
 
-encoder.name = Encoder Addon
-encoder.desc = Adds support for scriptable encoders to ZAP.
+encoder.name=Encoder Addon
+encoder.desc=Adds support for scriptable encoders to ZAP.
 
-encoder.tools.menu.encdec=Advanced Encode/Decode/Hash...
+encoder.tools.menu.encdec=Encode/Decode/Hash...
 
 
 encoder.dialog.title=Encode/Decode/Hash
@@ -28,12 +28,12 @@ encoder.dialog.reset.button.title=Reset
 encoder.dialog.reset.button.tooltip=Reset all tabs and output panels to default.
 encoder.dialog.reset.confirm=All Encode/Decode/Hash tabs and output panels will be restored to their default state. Continue?
 
-encoder.optionspanel.name  = Advanced Encode/Decode
-encoder.optionspanel.base64 = Base64
-encoder.optionspanel.base64.charset = Charset:
-encoder.optionspanel.base64.breaklines = Break Lines:
+encoder.optionspanel.name=Encode/Decode
+encoder.optionspanel.base64=Base64
+encoder.optionspanel.base64.charset=Charset:
+encoder.optionspanel.base64.breaklines=Break Lines:
 
-encoder.popup.title=Advanced Encode/Decode/Hash...
+encoder.popup.title=Encode/Decode/Hash...
 encoder.popup.delete=Delete Output Panel
 
 encoder.predefined.base64decode=Base64 Decode


### PR DESCRIPTION
Part of zaproxy/zaproxy#5996

- Build file set ZAP version 2.10.
- Remove "Advanced" from resource key values.
- Make resource key value pairs consistent (equals sign with no spaces on either side).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>