### PR TITLE
graphql, soap: script updates

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Fix clashes in variable names. See [PR#2550](https://github.com/zaproxy/zap-extensions/pull/2550) for details.
 - Fix a bug where the "GraphQL Support.js" script was enabled when ZAP was restarted even if it had been disabled and saved before.
+- Fix a bug where sites tree entries were not showing parameters because of the script.
 
 ## [0.1.0] - 2020-08-28
 - First Version

--- a/addOns/graphql/src/main/zapHomeFiles/scripts/scripts/variant/GraphQL Support.js
+++ b/addOns/graphql/src/main/zapHomeFiles/scripts/scripts/variant/GraphQL Support.js
@@ -91,6 +91,9 @@ function setParameter(helper, msg, param, value, escaped) {
 
 function getLeafName(helper, nodeName, msg) {
 	parseParameters(helper, msg)
+	if (helper.getParamList().isEmpty()) {
+		return null;
+	}
 	return helper.getStandardLeafName(nodeName, msg, helper.getParamList())
 }
 

--- a/addOns/soap/src/main/zapHomeFiles/scripts/scripts/variant/SOAP Support.js
+++ b/addOns/soap/src/main/zapHomeFiles/scripts/scripts/variant/SOAP Support.js
@@ -7,6 +7,9 @@ function parseParameters(helper, msg) { }
 function setParameter(helper, msg, param, value, escaped) { }
 
 function getLeafName(helper, nodeName, msg) {
+	if (helper.getParamList().isEmpty()) {
+		return null;
+	}
 	return helper.getStandardLeafName(nodeName, msg, helper.getParamList());
 }
 


### PR DESCRIPTION
As discussed on IRC. 
Fix a bug where sites tree entries were not showing parameters because of the scripts.
(The changelog for the soap add-on was not updated because the script was added only recently .)

Signed-off-by: ricekot <ricekot@gmail.com>