### PR TITLE
pscanrulesAlpha: Update to take advantage of 2.10 core

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- Now targeting ZAP 2.10.
+- The In Page Banner Information Leak scan rule and Site Isolation scan rule now support Custom Page definitions.
 
 ## [29] - 2020-11-16
 

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -3,10 +3,11 @@ description = "The alpha quality Passive Scanner rules"
 
 zapAddOn {
     addOnName.set("Passive scanner rules (alpha)")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
+        notBeforeVersion.set("2.10.0")
         extensions {
             register("org.zaproxy.zap.extension.pscanrulesAlpha.payloader.ExtensionPayloader") {
                 classnames {
@@ -25,7 +26,15 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
+
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
     testImplementation(parent!!.childProjects.get("custompayloads")!!)

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
@@ -59,9 +59,8 @@ public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner {
         int statusCode = msg.getResponseHeader().getStatusCode();
         // If LOW and 200 then check or if isClientError or isServerError check
         if ((this.getAlertThreshold().equals(AlertThreshold.LOW)
-                        && HttpStatusCode.isSuccess(statusCode))
-                || (HttpStatusCode.isClientError(statusCode)
-                        || HttpStatusCode.isServerError(statusCode))) {
+                        && (HttpStatusCode.isSuccess(statusCode) || getHelper().isPage200(msg)))
+                || (getHelper().isClientError(msg) || getHelper().isServerError(msg))) {
             for (BannerPattern patt : BannerPattern.values()) {
                 Matcher bannerMatcher = patt.getPattern().matcher(msg.getResponseBody().toString());
                 boolean found = bannerMatcher.find();

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
@@ -81,7 +81,8 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
         // However, successful responses are associated to a resource
         // that should be protected.
         // Only consider HTTP Status code 2XX to avoid a False Positive
-        if (!HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode())) {
+        if (!HttpStatusCode.isSuccess(msg.getResponseHeader().getStatusCode())
+                || getHelper().isPage200(msg)) {
             return;
         }
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRuleUnitTest.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -54,6 +56,9 @@ public class InPageBannerInfoLeakScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage("");
         msg.getResponseHeader().setStatusCode(HttpStatusCode.TEMPORARY_REDIRECT);
+        given(passiveScanData.isPage200(any())).willReturn(false);
+        given(passiveScanData.isClientError(any())).willReturn(false);
+        given(passiveScanData.isServerError(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -65,6 +70,9 @@ public class InPageBannerInfoLeakScanRuleUnitTest
         // Given
         String squidBanner = "Squid/2.5.STABLE4";
         HttpMessage msg = createMessage(squidBanner);
+        given(passiveScanData.isPage200(any())).willReturn(false);
+        given(passiveScanData.isClientError(any())).willReturn(true);
+        given(passiveScanData.isServerError(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -78,6 +86,25 @@ public class InPageBannerInfoLeakScanRuleUnitTest
         String apacheBanner = "Apache/2.4.17";
         HttpMessage msg = createMessage(apacheBanner);
         msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+        given(passiveScanData.isPage200(any())).willReturn(false);
+        given(passiveScanData.isClientError(any())).willReturn(false);
+        given(passiveScanData.isServerError(any())).willReturn(false);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertIfResponseHasRelevantContentWithCustomPage200()
+            throws URIException {
+        // Given - Default threshold (MEDIUM)
+        String apacheBanner = "Apache/2.4.17";
+        HttpMessage msg = createMessage(apacheBanner);
+        msg.getResponseHeader().setStatusCode(HttpStatusCode.TEMPORARY_REDIRECT);
+        given(passiveScanData.isPage200(any())).willReturn(true);
+        given(passiveScanData.isClientError(any())).willReturn(false);
+        given(passiveScanData.isServerError(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -91,6 +118,9 @@ public class InPageBannerInfoLeakScanRuleUnitTest
         String jettyBanner = "Jetty://9.4z-SNAPSHOT";
         HttpMessage msg = createMessage(jettyBanner);
         msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+        given(passiveScanData.isPage200(any())).willReturn(false);
+        given(passiveScanData.isClientError(any())).willReturn(false);
+        given(passiveScanData.isServerError(any())).willReturn(false);
         rule.setAlertThreshold(AlertThreshold.LOW);
         // When
         scanHttpResponseReceive(msg);

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
@@ -22,6 +22,8 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
@@ -37,6 +39,47 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertGivenSiteIsIsolatedWhenSuccessIdentifiedByCustomPage()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader(
+                "HTTP/1.1 400 OK\r\n"
+                        + "Cross-Origin-Resource-Policy: same-origin\r\n"
+                        + "Cross-Origin-Embedder-Policy: require-corp\r\n"
+                        + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(true);
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotRaiseAlertGivenSiteIsIsolatedWhenSuccessAndIdentifiedByCustomPage()
+            throws Exception {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET / HTTP/1.1");
+        msg.setResponseHeader(
+                "HTTP/1.1 200 OK\r\n"
+                        + "Cross-Origin-Resource-Policy: same-origin\r\n"
+                        + "Cross-Origin-Embedder-Policy: require-corp\r\n"
+                        + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(true);
 
         // When
         scanHttpResponseReceive(msg);
@@ -54,6 +97,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                 "HTTP/1.1 200 OK\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -98,6 +142,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: unexpected\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -120,6 +165,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-SITE\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -143,6 +189,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: cross-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -157,6 +204,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader("HTTP/1.1 500 Internal Server Error\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -175,6 +223,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Access-Control-Allow-Origin: *\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -193,6 +242,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Content-Type: application/xml\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -216,6 +266,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: unsafe-none\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -238,6 +289,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Content-Type: text/html;charset=utf-8\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -261,6 +313,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "Cross-Origin-Resource-Policy: same-origin\r\n"
                         + "Cross-Origin-Embedder-Policy: require-corp\r\n"
                         + "Cross-Origin-Opener-Policy: same-origin-allow-popups\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -284,6 +337,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                 "HTTP/1.1 200 OK\r\n"
                         + "Content-Type: application/json\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -302,6 +356,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
         msg.setRequestHeader("GET / HTTP/1.1");
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n" + "Cross-Origin-Resource-Policy: same-origin\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);
@@ -321,6 +376,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
                         + "cross-origin-embedder-policy: require-corp;report-to=\"coep\"\r\n"
                         + "cross-origin-opener-policy: same-origin;report-to=\"coop\"\r\n"
                         + "Cross-Origin-Resource-Policy: same-origin;report-to=\"corp\"\r\n");
+        given(passiveScanData.isPage200(any())).willReturn(false);
 
         // When
         scanHttpResponseReceive(msg);


### PR DESCRIPTION
- Update scan rules to leverage new Custom Pages functionality.
- Update scan rule unit tests to account for the changes.
- Update build file to target ZAP 2.10 and leverage the core snapshot library.
- Update CHANGELOG with a change note about the updates.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>