### PR TITLE
pscanrulesBeta: CSP Missing scan rule adjust risk and confidence

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [23] - 2020-11-18
 ### Changed
 - Update RE2/J library to latest version (1.5).
 - Maintenance changes.
@@ -167,6 +167,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated to support new addon format
 
+[23]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v23
 [22]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v22
 [21]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v21
 [20]: https://github.com/zaproxy/zap-extensions/releases/pscanrulesBeta-v20

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update RE2/J library to latest version (1.4).
 - Maintenance changes.
+- Content Security Policy header missing scan rule changed to Medium risk in order to align with other CSP findings, and confidence to High (Issue 6301).
 
 ## [22] - 2020-06-01
 ### Added

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update RE2/J library to latest version (1.4).
+- Update RE2/J library to latest version (1.5).
 - Maintenance changes.
 - Content Security Policy header missing scan rule changed to Medium risk in order to align with other CSP findings, and confidence to High (Issue 6301).
 

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -21,7 +21,7 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.google.re2j:re2j:1.4")
+    implementation("com.google.re2j:re2j:1.5")
 
     compileOnly(parent!!.childProjects.get("commonlib")!!)
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
@@ -118,8 +118,8 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
             // Always report if the latest header isnt found,
             // but only report if the older ones arent present at Low threshold
             newAlert()
-                    .setRisk(Alert.RISK_LOW)
-                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setRisk(Alert.RISK_MEDIUM)
+                    .setConfidence(Alert.CONFIDENCE_HIGH)
                     .setDescription(getAlertAttribute("desc"))
                     .setSolution(getAlertAttribute("soln"))
                     .setReference(getAlertAttribute("refs"))
@@ -132,7 +132,7 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
             newAlert()
                     .setName(getAlertAttribute("ro.name"))
                     .setRisk(Alert.RISK_INFO)
-                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setConfidence(Alert.CONFIDENCE_HIGH)
                     .setDescription(getAlertAttribute("ro.desc"))
                     .setSolution(getAlertAttribute("soln"))
                     .setReference(getAlertAttribute("ro.refs"))

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRuleUnitTest.java
@@ -203,7 +203,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
 
         // Then
         assertThat(alertsRaised.size(), is(2));
-        assertCSPAlertAttributes(alertsRaised.get(0), "", Alert.RISK_LOW);
+        assertCSPAlertAttributes(alertsRaised.get(0), "", Alert.RISK_MEDIUM);
         assertCSPAlertAttributes(alertsRaised.get(1), "ro.", Alert.RISK_INFO);
     }
 
@@ -223,7 +223,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
 
     private void assertContentSecurityPolicyAlertRaised() {
         assertThat(alertsRaised.size(), is(1));
-        assertCSPAlertAttributes(alertsRaised.get(0), "", Alert.RISK_LOW);
+        assertCSPAlertAttributes(alertsRaised.get(0), "", Alert.RISK_MEDIUM);
     }
 
     private static void assertCSPAlertAttributes(Alert alert, String key, int expectedRisk) {
@@ -232,7 +232,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
         assertThat(alert.getDescription(), is(getLocalisedString(key + "desc")));
         assertThat(alert.getReference(), is(getLocalisedString(key + "refs")));
         assertThat(alert.getSolution(), is(getLocalisedString("soln")));
-        assertThat(alert.getConfidence(), is(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alert.getConfidence(), is(Alert.CONFIDENCE_HIGH));
         assertThat(alert.getCweId(), is(16));
         assertThat(alert.getWascId(), is(15));
         assertThat(alert.getUri(), is(URI));


### PR DESCRIPTION
- ContentSecurityPolicyMissingScanRule - Adjust risk to medium to align with other CSP findings. Adjust confidence to High, it's pretty solid whether or not headers exist.
- ContenSecurityPolicyMissingScanRuleUnitTest - Updated to assert new values.
- CHANGELOG - Change note added.

Fixes zaproxy/zaproxy#6301

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>