### PR TITLE
pscanrulesBeta: Update to take advantage of 2.10 core

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now targeting ZAP 2.10.
+- The following scan rules now support Custom Page definitions:
+  - Insecure Form Load
+  - Insecure Form Post
+  - User Controlled Charset
+  - User Controlled HTML Attribute
+  - User Controlled JavaScript Event
 
 ## [23] - 2020-11-18
 ### Changed

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -6,10 +6,11 @@ description = "The beta quality Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
+        notBeforeVersion.set("2.10.0")
         url.set("https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-beta/")
 
         dependencies {
@@ -20,7 +21,15 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
+
     implementation("com.google.re2j:re2j:1.5")
 
     compileOnly(parent!!.childProjects.get("commonlib")!!)

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
@@ -27,7 +27,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -52,9 +51,7 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK
-                || isHttps(msg)
-                || !isResponseHTML(msg, source)) {
+        if (!getHelper().isPage200(msg) || isHttps(msg) || !isResponseHTML(msg, source)) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
@@ -27,7 +27,6 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -52,9 +51,7 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK
-                || !isHttps(msg)
-                || !isResponseHTML(msg, source)) {
+        if (!getHelper().isPage200(msg) || !isHttps(msg) || !isResponseHTML(msg, source)) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
@@ -32,7 +32,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -57,7 +56,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+        if (!getHelper().isPage200(msg)) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
@@ -58,7 +58,7 @@ public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (msg.getResponseHeader().getStatusCode() != 200 || !isResponseHTML(msg, source)) {
+        if (!getHelper().isPage200(msg) || !isResponseHTML(msg, source)) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
@@ -32,7 +32,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -99,7 +98,7 @@ public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner 
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+        if (!getHelper().isPage200(msg)) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRuleUnitTest.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -54,6 +56,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setSecure(true);
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -65,6 +68,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+        given(passiveScanData.isPage200(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -76,6 +80,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -87,6 +92,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -99,6 +105,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
         HttpMessage msg = createMessage();
         msg.setResponseBody(
                 "<html><form name=\"someform\" action=\"https://example.com/processform\"></form</html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -111,6 +118,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
         HttpMessage msg = createMessage();
         msg.setResponseBody(
                 "<html><form name=\"someform\" action=\"http://example.com/processform\"></form</html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRuleUnitTest.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -54,6 +56,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setSecure(false);
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -65,6 +68,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+        given(passiveScanData.isPage200(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -76,6 +80,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -87,6 +92,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -99,6 +105,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
         HttpMessage msg = createMessage();
         msg.setResponseBody(
                 "<html><form name=\"someform\" action=\"https://example.com/processform\"></form</html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -111,6 +118,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
         HttpMessage msg = createMessage();
         msg.setResponseBody(
                 "<html><form name=\"someform\" action=\"http://example.com/processform\"></form</html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRuleUnitTest.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -60,6 +62,7 @@ public class UserControlledCharsetScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+        given(passiveScanData.isPage200(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -70,6 +73,7 @@ public class UserControlledCharsetScanRuleUnitTest
     public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
         // Given
         HttpMessage msg = createMessage();
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // WHen
         scanHttpResponseReceive(msg);
         // Then
@@ -81,6 +85,7 @@ public class UserControlledCharsetScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -92,6 +97,7 @@ public class UserControlledCharsetScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -104,6 +110,7 @@ public class UserControlledCharsetScanRuleUnitTest
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html; charset=");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -117,6 +124,7 @@ public class UserControlledCharsetScanRuleUnitTest
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
         msg.getResponseHeader()
                 .setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html; charset=utf-8");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -131,6 +139,7 @@ public class UserControlledCharsetScanRuleUnitTest
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
         msg.setResponseBody(
                 "<html><META http-equiv=\"Content-Type\" content=\"text/html; charset=\"></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -143,6 +152,7 @@ public class UserControlledCharsetScanRuleUnitTest
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
         msg.setResponseBody("<html><META http-equiv=\"info\" content=\"Someinfo\"></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -156,6 +166,7 @@ public class UserControlledCharsetScanRuleUnitTest
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
         msg.setResponseBody(
                 "<html><META http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\"></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -170,6 +181,7 @@ public class UserControlledCharsetScanRuleUnitTest
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/xml");
         msg.setResponseBody("<?xml version='1.0' encoding=?>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -183,6 +195,7 @@ public class UserControlledCharsetScanRuleUnitTest
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/xml");
         msg.setResponseBody("<?xml version='1.0' encoding='utf-8'?>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRuleUnitTest.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -60,6 +62,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+        given(passiveScanData.isPage200(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -71,6 +74,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -83,6 +87,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         HttpMessage msg = createMessage();
         msg.setResponseHeader(new HttpResponseHeader());
         msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -93,6 +98,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
         // Given
         HttpMessage msg = createMessage();
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // WHen
         scanHttpResponseReceive(msg);
         // Then
@@ -104,6 +110,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -117,6 +124,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         msg.getRequestHeader()
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody("<html><H1>Title</H1></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -130,6 +138,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         msg.getRequestHeader()
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody("<html><img src=\"x.jpg\" alt=\"Some image (x)\")></img></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -144,6 +153,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody(
                 "<html><meta name=\"description\" content=\"UnitTest Content\"></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -157,6 +167,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         msg.getRequestHeader()
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody("<html><meta name=\"description\" content=\"fred\"></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -172,6 +183,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody(
                 "<html><meta http-equiv=\"refresh\" content=\"0; url=http://example.com/\"></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -186,6 +198,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
                 .setURI(new URI("http://example.com/i.php?place=http://example.com/", false));
         msg.setResponseBody(
                 "<html><meta http-equiv=\"refresh\" content=\"0; url=http://example.com/\"></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -204,6 +217,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
                                 false));
         msg.setResponseBody(
                 "<html><meta http-equiv=\"refresh\" content=\"0; url=http://example.com/\"><img src=\"x.jpg\" alt=fred></img></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -219,6 +233,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
         msg.getRequestHeader()
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody("<html><img src=\"x.jpg\" alt=\"fred, here\")></img></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRuleUnitTest.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
@@ -59,6 +61,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
+        given(passiveScanData.isPage200(any())).willReturn(false);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -70,6 +73,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -82,6 +86,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
         HttpMessage msg = createMessage();
         msg.getResponseHeader()
                 .setHeader(HttpHeader.CONTENT_TYPE, ""); // Removed when value set empty
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -92,6 +97,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
         // Given
         HttpMessage msg = createMessage();
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // WHen
         scanHttpResponseReceive(msg);
         // Then
@@ -103,6 +109,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -116,6 +123,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
         msg.getRequestHeader()
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody("<html><img src=\"x.jpg\" onerror=alert(\"Error\")></img></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -129,6 +137,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
         msg.getRequestHeader()
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody("<html><img src=\"x.jpg\" onblah=fred></img></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
@@ -142,6 +151,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
         msg.getRequestHeader()
                 .setURI(new URI("http://example.com/i.php?place=here&name=fred", false));
         msg.setResponseBody("<html><img src=\"x.jpg\" onerror=fred></img></html>");
+        given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then


### PR DESCRIPTION
- Update scan rules to leverage new Custom Pages functionality.
- Update scan rule unit tests to account for the changes.
- Update build file to target ZAP 2.10 and leverage the core snapshot library.
- Update CHANGELOG with a change note about the updates.

Part of zaproxy/zaproxy#9

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>