### PR TITLE
Include button elements in DOM XSS Scan Rule

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.9.0.
 - Maintenance changes.
 - Promote to beta
+- Now clicking on different buttons throughout the page to see if it triggers XSS.
 
 ## [9] - 2019-06-12
 ### Fixed

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -452,20 +452,21 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
             throw new DomAlertException(url, attackVector);
         }
 
-        List<WebElement> inputElements;
+        List<WebElement> possibleDomXSSTriggers;
 
         try {
-            inputElements = findHelper(driver, By.tagName("input"));
+            possibleDomXSSTriggers = findHelper(driver, By.tagName("input"));
+            possibleDomXSSTriggers.addAll(findHelper(driver, By.tagName("button")));
         } catch (UnhandledAlertException uae) {
             Stats.incCounter("domxss.vulns.input1");
             throw new DomAlertException(url, attackVector);
         }
 
-        for (int i = 0; i < inputElements.size(); i++) {
+        for (int i = 0; i < possibleDomXSSTriggers.size(); i++) {
             if (this.isStop()) {
                 return;
             }
-            WebElement element = inputElements.get(i);
+            WebElement element = possibleDomXSSTriggers.get(i);
             String tagName = null;
             String attributeId = null;
             String attributeName = null;
@@ -476,10 +477,14 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
                 attributeId = element.getAttribute("id");
                 attributeName = element.getAttribute("name");
 
-                element.sendKeys(attackVector);
+                if (tagName.equals("input")) {
+                    element.sendKeys(attackVector);
+                }
+
                 element.click();
+
             } catch (UnhandledAlertException uae) {
-                Stats.incCounter("domxss.vulns.input2");
+                Stats.incCounter("domxss.vulns.possibleDomXSSTriggers2");
                 throw new DomAlertException(url, attackVector, tagName, attributeId, attributeName);
             } catch (WebDriverException wde) {
                 log.debug(wde);
@@ -491,9 +496,10 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
                 throw new DomAlertException(url, attackVector, tagName, attributeId, attributeName);
             }
             try {
-                inputElements = findHelper(driver, By.tagName("input"));
+                possibleDomXSSTriggers = findHelper(driver, By.tagName("input"));
+                possibleDomXSSTriggers.addAll(findHelper(driver, By.tagName("button")));
             } catch (UnhandledAlertException uae) {
-                Stats.incCounter("domxss.vulns.input3");
+                Stats.incCounter("domxss.vulns.possibleDomXSSTriggers3");
                 throw new DomAlertException(url, attackVector, tagName, attributeId, attributeName);
             }
         }

--- a/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
+++ b/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
@@ -201,6 +201,28 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
         assertAlertsRaised();
     }
 
+    /** Test to trigger XSS after cancel button is clicked */
+    @ParameterizedTest
+    @MethodSource("testBrowsers")
+    public void shouldReportXssWhenCancelButtonIsClicked(String browser)
+            throws NullPointerException, IOException {
+        // Given
+        String test = "/shouldReportXssWhenCancelButtonIsClicked/";
+
+        this.nano.addHandler(new TestNanoServerHandler(test, "CancelButton.html"));
+
+        HttpMessage msg = this.getHttpMessage(test + "?returnUrl=javascript:alert()");
+        this.rule.getConfig().setProperty("rules.domxss.browserid", browser);
+
+        this.rule.init(msg, this.parent);
+
+        // When
+        this.rule.scan();
+
+        // Then
+        assertAlertsRaised();
+    }
+
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/function */
     @ParameterizedTest
     @MethodSource("testBrowsers")

--- a/addOns/domxss/src/test/resources/org/zaproxy/zap/extension/domxss/CancelButton.html
+++ b/addOns/domxss/src/test/resources/org/zaproxy/zap/extension/domxss/CancelButton.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DOM XSS Button Click Test Page</title>
+
+</head>
+<body>
+    <button onclick="myFunction()">Cancel</button>
+
+    <script>
+        const queryString = window.location.search;
+        const urlParams = new URLSearchParams(queryString);
+        const returnUrl = urlParams.get('returnUrl')
+
+        function myFunction() {
+            window.location = returnUrl;
+        }
+    </script>
+
+</body>
+</html>


### PR DESCRIPTION
The goal of this MR is to have the DomXSS Plugin click on additional buttons within the DOM to see if XSS can be triggered.

The script is hitting buttons like this: `<button onclick="onCancelClicked()">Click me</button>` , but doesn't test buttons formatted like this: but not like this `<button type="button">Cancel</button>`

Tested against an internal site, screenshot here: 
![image](https://user-images.githubusercontent.com/3794761/100753797-41733380-33b8-11eb-9754-f91dcfa1f1c2.png)
