### PR TITLE
Update ascanrulesBeta to take advantage of 2.10 core

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now targeting ZAP 2.10.
+- The following scan rules now support Custom Page definitions:
+  - Hidden Files
+  - HTTPS as HTTP
+  - Insecure HTTP Methods
+  - Integer Overflow
+  - Padding Oracle
+  - Remove Code Execution CVE-2012-1823
+  - Session Fixation
+  - Source Code Disclosure CVE-2012-1823
+  - Source Code Disclosure Git
+  - Source Code Disclosure SVN
 
 ## [32] - 2020-11-26
 ### Changed

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -6,11 +6,12 @@ description = "The beta quality Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/active-scan-rules-beta/")
+        notBeforeVersion.set("2.10.0")
 
         dependencies {
             addOns {
@@ -35,7 +36,15 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
+
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
@@ -108,7 +108,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
                 continue;
             }
             int statusCode = testMsg.getResponseHeader().getStatusCode();
-            if (statusCode == HttpStatusCode.OK) {
+            if (isPage200(testMsg)) {
                 String responseBody = testMsg.getResponseBody().toString();
                 // If all the content checks matched then confidence is high
                 boolean matches =

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
@@ -101,12 +101,14 @@ public class HttpsAsHttpScanRule extends AbstractAppPlugin {
         }
 
         int originalStatusCode = getBaseMsg().getResponseHeader().getStatusCode();
-        if (originalStatusCode == HttpStatusCode.NOT_FOUND || originalStatusCode == 0) {
+        boolean was404 = isPage404(getBaseMsg());
+        if (was404) {
             if (log.isDebugEnabled()) {
                 log.debug(
                         "The original request was not successfuly completed (status = "
                                 + originalStatusCode
                                 + "), so there is not much point in looking further.");
+                log.debug("isPage404 returned: " + was404);
             }
             return;
         }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -567,7 +567,7 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
             log.debug("Response Code: " + responseCode);
         }
 
-        if (responseCode == HttpStatusCode.OK || responseCode == HttpStatusCode.CREATED) {
+        if (isPage200(msg) || responseCode == HttpStatusCode.CREATED) {
             evidence =
                     Constant.messages.getString(
                             "ascanbeta.insecurehttpmethod.insecure", responseCode);

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRule.java
@@ -29,7 +29,6 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -90,9 +89,7 @@ public class IntegerOverflowScanRule extends AbstractAppParamPlugin {
         if (checkStop() == true) {
             return;
         }
-        if (getBaseMsg().getResponseHeader().getStatusCode()
-                == HttpStatusCode
-                        .INTERNAL_SERVER_ERROR) // Check to see if the page closed initially
+        if (isPage500(getBaseMsg())) // Check to see if the page was initially a 500
         {
             return; // Stop
         }
@@ -194,7 +191,7 @@ public class IntegerOverflowScanRule extends AbstractAppParamPlugin {
         setParameter(msg, param, returnAttack);
         try {
             sendAndReceive(msg);
-            if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR) {
+            if (isPage500(msg)) {
                 log.debug("Found Header");
                 newAlert()
                         .setConfidence(Alert.CONFIDENCE_MEDIUM)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java
@@ -30,7 +30,6 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 
 /** @author yhawke (2014) */
 public class PaddingOracleScanRule extends AbstractAppParamPlugin {
@@ -136,7 +135,7 @@ public class PaddingOracleScanRule extends AbstractAppParamPlugin {
                 sendAndReceive(msg);
 
                 // If the control test returned an error, then keep going
-                if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK) {
+                if (isPage200(msg)) {
 
                     // Response without any modification
                     String controlResponse = msg.getResponseBody().toString();
@@ -149,8 +148,7 @@ public class PaddingOracleScanRule extends AbstractAppParamPlugin {
 
                     // First check if an Internal Server Error ws launched
                     // in this case we found (very) likely Padding Oracle vulnerability
-                    if (msg.getResponseHeader().getStatusCode()
-                            == HttpStatusCode.INTERNAL_SERVER_ERROR) {
+                    if (isPage500(msg)) {
                         // We Found IT!
                         // First do logging
                         if (log.isDebugEnabled()) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRule.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
-import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.RandomStringUtils;
@@ -41,7 +40,7 @@ import org.zaproxy.zap.model.Vulnerability;
  *
  * @author 70pointer
  */
-public class RemoteCodeExecutionCve0121823ScanRule extends AbstractAppPlugin {
+public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin {
 
     /**
      * details of the vulnerability which we are attempting to find WASC 20 = Improper Input
@@ -50,7 +49,8 @@ public class RemoteCodeExecutionCve0121823ScanRule extends AbstractAppPlugin {
     private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_20");
 
     /** the logger object */
-    private static final Logger log = Logger.getLogger(RemoteCodeExecutionCve0121823ScanRule.class);
+    private static final Logger log =
+            Logger.getLogger(RemoteCodeExecutionCve20121823ScanRule.class);
 
     /** a random string (which remains constant across multiple runs, as long as Zap is not */
     static final String RANDOM_STRING =
@@ -161,7 +161,7 @@ public class RemoteCodeExecutionCve0121823ScanRule extends AbstractAppPlugin {
             // if the command was not recognised (by the host OS), we get a response size of 0 on
             // PHP, but not on Tomcat
             // to be sure it's not a false positive, we look for a string to be echoed
-            if (attackmsg.getResponseHeader().getStatusCode() == HttpStatus.SC_OK
+            if (isPage200(attackmsg)
                     && attackResponseBody.length >= RANDOM_STRING.length()
                     && responseBody.startsWith(RANDOM_STRING)) {
                 if (log.isDebugEnabled()) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
@@ -378,16 +378,15 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
 
                     // if non-200 on the final response for message 1, no point in continuing. Bale
                     // out.
-                    if (msg1Final.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
-                        if (this.debugEnabled)
+                    if (!isPage200(msg1Final)) {
+                        if (this.debugEnabled) {
                             log.debug(
-                                    "Got a non-200 response code ["
-                                            + msg1Final.getResponseHeader().getStatusCode()
-                                            + "] when sending ["
+                                    "Got a non-200 response when sending ["
                                             + msg1Initial.getRequestHeader().getURI()
                                             + "] with param ["
                                             + currentHtmlParameter.getName()
                                             + "] = NULL (possibly somewhere in the redirects)");
+                        }
                         continue;
                     }
 
@@ -899,12 +898,10 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     if (this.debugEnabled) log.debug("Done following redirects");
 
                     // final result was non-200, no point in continuing. Bale out.
-                    if (msg2Final.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+                    if (!isPage200(msg2Final)) {
                         if (this.debugEnabled)
                             log.debug(
-                                    "Got a non-200 response code ["
-                                            + msg2Final.getResponseHeader().getStatusCode()
-                                            + "] when sending ["
+                                    "Got a non-200 response when sending ["
                                             + msg2Initial.getRequestHeader().getURI()
                                             + "] with a borrowed cookie (or by following a redirect) for param ["
                                             + currentHtmlParameter.getName()
@@ -1019,12 +1016,10 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     sendAndReceive(msg1Initial);
 
                     // if non-200 on the response for message 1, no point in continuing. Bale out.
-                    if (msg1Initial.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+                    if (!isPage200(msg1Initial)) {
                         if (this.debugEnabled)
                             log.debug(
-                                    "Got a non-200 response code ["
-                                            + msg1Initial.getResponseHeader().getStatusCode()
-                                            + "] when sending ["
+                                    "Got a non-200 response when sending ["
                                             + msg1Initial.getRequestHeader().getURI()
                                             + "] with param ["
                                             + currentHtmlParameter.getName()
@@ -1278,12 +1273,10 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     sendAndReceive(msg2Initial);
 
                     // final result was non-200, no point in continuing. Bale out.
-                    if (msg2Initial.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+                    if (!isPage200(msg2Initial)) {
                         if (this.debugEnabled)
                             log.debug(
-                                    "Got a non-200 response code ["
-                                            + msg2Initial.getResponseHeader().getStatusCode()
-                                            + "] when sending ["
+                                    "Got a non-200 response when sending ["
                                             + msg2Initial.getRequestHeader().getURI()
                                             + "] with a borrowed session (or by following a redirect) for param ["
                                             + currentHtmlParameter.getName()

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.log4j.Logger;
@@ -41,7 +40,7 @@ import org.zaproxy.zap.model.Vulnerability;
  *
  * @author 70pointer
  */
-public class SourceCodeDisclosureCve0121823ScanRule extends AbstractAppPlugin {
+public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
 
     /** match on PHP tags in the response */
     private static final Pattern PHP_PATTERN1 =
@@ -61,7 +60,7 @@ public class SourceCodeDisclosureCve0121823ScanRule extends AbstractAppPlugin {
     private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_20");
 
     private static final Logger log =
-            Logger.getLogger(SourceCodeDisclosureCve0121823ScanRule.class);
+            Logger.getLogger(SourceCodeDisclosureCve20121823ScanRule.class);
 
     @Override
     public int getId() {
@@ -131,8 +130,7 @@ public class SourceCodeDisclosureCve0121823ScanRule extends AbstractAppPlugin {
             // at Low or Medium strength, do not attack URLs which returned "Not Found"
             AttackStrength attackStrength = getAttackStrength();
             if ((attackStrength == AttackStrength.LOW || attackStrength == AttackStrength.MEDIUM)
-                    && (getBaseMsg().getResponseHeader().getStatusCode()
-                            == HttpStatus.SC_NOT_FOUND)) return;
+                    && (isPage404(getBaseMsg()))) return;
 
             URI originalURI = getBaseMsg().getRequestHeader().getURI();
 
@@ -147,7 +145,7 @@ public class SourceCodeDisclosureCve0121823ScanRule extends AbstractAppPlugin {
             HttpMessage attackmsg = new HttpMessage(attackURI);
             sendAndReceive(attackmsg, false); // do not follow redirects
 
-            if (attackmsg.getResponseHeader().getStatusCode() == HttpStatus.SC_OK) {
+            if (isPage200(attackmsg)) {
                 // double-check: does the response contain HTML encoded PHP?
                 // Ignore the case where it contains encoded HTML for now, since thats not a source
                 // code disclosure anyway

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.URI;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -119,8 +118,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
         // at Low or Medium strength, do not attack URLs which returned "Not Found"
         AttackStrength attackStrength = getAttackStrength();
         if ((attackStrength == AttackStrength.LOW || attackStrength == AttackStrength.MEDIUM)
-                && (getBaseMsg().getResponseHeader().getStatusCode() == HttpStatus.SC_NOT_FOUND))
-            return;
+                && (isPage404(getBaseMsg()))) return;
 
         // scan the node itself (ie, at URL level, rather than at parameter level)
         if (log.isDebugEnabled()) {

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRuleUnitTest.java
@@ -34,13 +34,13 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-/** Unit test for {@link RemoteCodeExecutionCve0121823ScanRule}. */
+/** Unit test for {@link RemoteCodeExecutionCve20121823ScanRule}. */
 public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
-        extends ActiveScannerTest<RemoteCodeExecutionCve0121823ScanRule> {
+        extends ActiveScannerTest<RemoteCodeExecutionCve20121823ScanRule> {
 
     @Override
-    protected RemoteCodeExecutionCve0121823ScanRule createScanner() {
-        return new RemoteCodeExecutionCve0121823ScanRule();
+    protected RemoteCodeExecutionCve20121823ScanRule createScanner() {
+        return new RemoteCodeExecutionCve20121823ScanRule();
     }
 
     @Test
@@ -159,7 +159,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     public void shouldAlertIfWindowsAttackWasSuccessful() throws Exception {
         // Given
         final String body =
-                RemoteCodeExecutionCve0121823ScanRule.RANDOM_STRING
+                RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
                         + "<html><body>X Y Z</body></html>";
         String test = "/shouldAlertIfWindowsAttackWasSuccessful/";
         nano.addHandler(new WinResponse(test, body));
@@ -176,7 +176,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
                 is(
                         equalTo(
                                 "<?php exec('cmd.exe /C echo "
-                                        + RemoteCodeExecutionCve0121823ScanRule.RANDOM_STRING
+                                        + RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
                                         + "',$colm);echo join(\"\n\",$colm);die();?>")));
         assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
@@ -187,7 +187,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     public void shouldNotDoWinAttackIfWinTechIsNotIncluded() throws Exception {
         // Given
         final String body =
-                RemoteCodeExecutionCve0121823ScanRule.RANDOM_STRING
+                RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
                         + "<html><body>X Y Z</body></html>";
         String test = "/shouldNotDoWinAttackIfWinTechIsNotIncluded/";
         nano.addHandler(new WinResponse(test, body));
@@ -205,7 +205,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     public void shouldAlertIfNixAttackWasSuccessful() throws Exception {
         // Given
         final String body =
-                RemoteCodeExecutionCve0121823ScanRule.RANDOM_STRING
+                RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
                         + "<html><body>X Y Z</body></html>";
         String test = "/shouldAlertIfNixAttackWasSuccessful/";
         nano.addHandler(new NixResponse(test, body));
@@ -222,7 +222,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
                 is(
                         equalTo(
                                 "<?php exec('echo "
-                                        + RemoteCodeExecutionCve0121823ScanRule.RANDOM_STRING
+                                        + RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
                                         + "',$colm);echo join(\"\n\",$colm);die();?>")));
         assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_HIGH)));
         assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
@@ -236,7 +236,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
         nano.addHandler(
                 new NixResponse(
                         test,
-                        RemoteCodeExecutionCve0121823ScanRule.RANDOM_STRING
+                        RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
                                 + "<html><body>X Y Z</body></html>"));
         HttpMessage message = getHttpMessage(test);
         rule.init(message, parent);

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRuleUnitTest.java
@@ -39,9 +39,9 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-/** Unit test for {@link SourceCodeDisclosureCve0121823ScanRule}. */
+/** Unit test for {@link SourceCodeDisclosureCve20121823ScanRule}. */
 public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
-        extends ActiveScannerTest<SourceCodeDisclosureCve0121823ScanRule> {
+        extends ActiveScannerTest<SourceCodeDisclosureCve20121823ScanRule> {
 
     private static final String RESPONSE_HEADER_404_NOT_FOUND =
             "HTTP/1.1 404 Not Found\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n";
@@ -49,8 +49,9 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     private static final String PHP_SOURCE_ECHO_TAG = "<?= '<h1>Welcome!</h1>' ?>";
 
     @Override
-    protected SourceCodeDisclosureCve0121823ScanRule createScanner() {
-        SourceCodeDisclosureCve0121823ScanRule rule = new SourceCodeDisclosureCve0121823ScanRule();
+    protected SourceCodeDisclosureCve20121823ScanRule createScanner() {
+        SourceCodeDisclosureCve20121823ScanRule rule =
+                new SourceCodeDisclosureCve20121823ScanRule();
         rule.setConfig(new ZapXmlConfiguration());
         return rule;
     }


### PR DESCRIPTION
- Update scan rules to leverage new Custom Pages functionality.
- Update build file to target ZAP 2.10 and leverage the core snapshot library.
- Update CHANGELOG with a change note about the updates.
- Fix naming mistake on RCE and Source Code Disclosure CVE-2012-1823 scan rules (the leading 2 on the year had been dropped).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>