### PR TITLE
BrowserView reduce missing JavaFX logging in regular use

### DIFF
--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 - Maintenance changes.
+- Make missing JavaFX logging less verbose in regular use.
 
 ## 5 - 2017-07-21
 

--- a/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/ExtensionHttpPanelBrowserView.java
+++ b/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/ExtensionHttpPanelBrowserView.java
@@ -95,7 +95,8 @@ public class ExtensionHttpPanelBrowserView extends ExtensionAdaptor {
             javafx.embed.swing.JFXPanel unused = new javafx.embed.swing.JFXPanel();
             return true;
         } catch (Throwable e) {
-            LOGGER.warn("Unable to use JavaFX:", e);
+            LOGGER.warn("Unable to use JavaFX: " + e.getMessage());
+            LOGGER.debug(e);
             System.setProperty(ZAP_JAVAFX_INIT_FAILED_SYSTEM_PROPERTY, "true");
         }
         return false;


### PR DESCRIPTION
- ExtensionHttpPanelBroswerView > In regular use just log the exception's `getMessage()` value. If debug is enabled log the whole stack trace as well.
- CHANGELOG > Added change note.

Related to zaproxy/zaproxy#6339

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>