### PR TITLE
Update ascanrules to take advantage of 2.10 core

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now targeting ZAP 2.10.
+- The following scan rules now support Custom Page definitions:
+  - Buffer Overflow
+  - Directory Browsing
+  - Format String
+  - Parameter Tamper
+  - Path Traversal
+  - Remote File Include
+  - Source Code Disclosure WEB-INF
 
 ## [37] - 2020-11-26
 ### Changed

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -6,11 +6,12 @@ description = "The release quality Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/active-scan-rules/")
+        notBeforeVersion.set("2.10.0")
 
         dependencies {
             addOns {
@@ -20,7 +21,15 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
+
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     implementation("org.bitbucket.mstrobel:procyon-compilertools:0.5.36")

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
@@ -32,7 +32,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -96,9 +95,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
             }
             return; // Stop!
         }
-        if (getBaseMsg().getResponseHeader().getStatusCode()
-                == HttpStatusCode
-                        .INTERNAL_SERVER_ERROR) // Check to see if the page closed initially
+        if (isPage500(getBaseMsg())) // Check to see if the page closed initially
         {
             return; // Stop
         }
@@ -129,8 +126,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
             // response
             String chkerrorheader = requestReturn.getHeadersAsString();
             log.debug("Header: " + chkerrorheader);
-            if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.INTERNAL_SERVER_ERROR
-                    && chkerrorheader.contains(checkStringHeader1)) {
+            if (isPage500(msg) && chkerrorheader.contains(checkStringHeader1)) {
                 log.debug("Found Header");
                 newAlert()
                         .setConfidence(Alert.CONFIDENCE_MEDIUM)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java
@@ -117,12 +117,6 @@ public class CrlfInjectionScanRule extends AbstractAppParamPlugin {
     }
 
     private boolean checkResult(HttpMessage msg, String param, String attack) {
-        // no need to bother if response OK or not.
-        //      if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK
-        //          && !HttpStatusCode.isServerError(msg.getResponseHeader().getStatusCode())) {
-        //          return false;
-        //      }
-
         Matcher matcher = patternCookieTamper.matcher(msg.getResponseHeader().toString());
         if (matcher.find()) {
             newAlert()

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
@@ -37,7 +37,6 @@ import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.Tech;
 
 public class DirectoryBrowsingScanRule extends AbstractAppPlugin {
@@ -111,7 +110,7 @@ public class DirectoryBrowsingScanRule extends AbstractAppPlugin {
             writeProgress(msg.getRequestHeader().getURI().toString());
             sendAndReceive(msg);
 
-            if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+            if (!isPage200(msg)) {
                 return;
             }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
@@ -49,7 +49,6 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.network.HttpResponseBody;
@@ -115,9 +114,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             return; // Stop!
         }
 
-        if (getBaseMsg().getResponseHeader().getStatusCode()
-                == HttpStatusCode
-                        .INTERNAL_SERVER_ERROR) // Check to see if the page closed initially
+        if (isPage500(getBaseMsg())) // Check to see if the page closed initially
         {
             return; // Stop
         }
@@ -154,8 +151,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                 return; // Something went wrong, no point continuing
             }
 
-            if (HttpStatusCode.INTERNAL_SERVER_ERROR
-                    == testMsg.getResponseHeader().getStatusCode()) {
+            if (isPage500(testMsg)) {
                 return; // Initial message returned error, subsequent requests are likely to as well
             }
 
@@ -194,8 +190,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                                     + "\n The target may have replied with a poorly formed redirect due to our input.");
                 return; // Something went wrong, no point continuing
             }
-            if (intialAttackMsg.getResponseHeader().getStatusCode()
-                    == HttpStatusCode.INTERNAL_SERVER_ERROR) {
+            if (isPage500(intialAttackMsg)) {
                 StringBuilder sb1 = new StringBuilder();
                 sb1.append(initialMessage);
                 for (i = 0; i < 10; i++) {
@@ -222,8 +217,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                 }
                 HttpResponseBody secondAttackResponseBody = verificationMsg.getResponseBody();
                 if (secondAttackResponseBody.length() > initialResponseLength + 20
-                        && verificationMsg.getResponseHeader().getStatusCode()
-                                == HttpStatusCode.OK) {
+                        && isPage200(verificationMsg)) {
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
                             .setParam(param)
@@ -282,8 +276,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                                     + "\n The target may have replied with a poorly formed redirect due to our input.");
                 return; // Something went wrong, no point continuing
             }
-            if (microsoftTestMsg.getResponseHeader().getStatusCode()
-                    == HttpStatusCode.INTERNAL_SERVER_ERROR) {
+            if (isPage500(microsoftTestMsg)) {
                 newAlert()
                         .setConfidence(Alert.CONFIDENCE_MEDIUM)
                         .setParam(param)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
@@ -43,7 +43,6 @@ import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 
 public class ParameterTamperScanRule extends AbstractAppParamPlugin {
 
@@ -139,7 +138,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
             return;
         }
 
-        if (normalMsg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+        if (!isPage200(normalMsg)) {
             return;
         }
 
@@ -186,8 +185,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
     private boolean checkResult(
             HttpMessage msg, String param, String attack, String normalHTTPResponse) {
 
-        if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK
-                && !HttpStatusCode.isServerError(msg.getResponseHeader().getStatusCode())) {
+        if (!isPage200(msg) && !isPage500(msg)) {
             return false;
         }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -38,7 +38,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
@@ -470,9 +469,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
             String urlfilename = msg.getRequestHeader().getURI().getName();
 
             // url file name may be empty, i.e. there is no file name for next check
-            if (!StringUtils.isEmpty(urlfilename)
-                    && (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK
-                            || errorMatcher.find())) {
+            if (!StringUtils.isEmpty(urlfilename) && (!isPage200(msg) || errorMatcher.find())) {
 
                 if (log.isDebugEnabled()) {
                     log.debug(
@@ -519,8 +516,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
                     // did we get an Exception or an Error?
                     errorMatcher = errorPattern.matcher(msg.getResponseBody().toString());
-                    if ((msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK)
-                            && (!errorMatcher.find())) {
+                    if (isPage200(msg) && (!errorMatcher.find())) {
 
                         // if it returns OK, and the random string above did NOT return ok, then
                         // raise an alert
@@ -647,7 +643,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
         String match = contentsMatcher.match(getContentsToMatch(msg));
 
         // if the output matches, and we get a 200
-        if ((msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK) && match != null) {
+        if (isPage200(msg) && match != null) {
             newAlert()
                     .setConfidence(Alert.CONFIDENCE_MEDIUM)
                     .setParam(param)

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
@@ -30,7 +30,6 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
 
@@ -223,8 +222,7 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
                             msg.getResponseHeader().toString() + msg.getResponseBody().toString();
                     matcher = REMOTE_FILE_PATTERNS[i].matcher(response);
                     // if the output matches, and we get a 200
-                    if (matcher.find()
-                            && msg.getResponseHeader().getStatusCode() == HttpStatusCode.OK) {
+                    if (matcher.find() && isPage200(msg)) {
                         // And check that this isnt exactly the same as the original response
                         origMatcher = REMOTE_FILE_PATTERNS[i].matcher(origResponse);
                         if (origMatcher.find() && origMatcher.group().equals(matcher.group())) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -30,7 +30,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.SystemUtils;
@@ -190,7 +189,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
 
                 HttpMessage classfilemsg = new HttpMessage(classURI);
                 sendAndReceive(classfilemsg, false); // do not follow redirects
-                if (classfilemsg.getResponseHeader().getStatusCode() == HttpStatus.SC_OK) {
+                if (isPage200(classfilemsg)) {
                     // to decompile the class file, we need to write it to disk..
                     // under the current version of the library, at least
                     File classFile = null;
@@ -266,8 +265,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
                             URI propsFileURI = getPropsFileURI(originalURI, propsFilename);
                             HttpMessage propsfilemsg = new HttpMessage(propsFileURI);
                             sendAndReceive(propsfilemsg, false); // do not follow redirects
-                            if (propsfilemsg.getResponseHeader().getStatusCode()
-                                    == HttpStatus.SC_OK) {
+                            if (isPage200(propsfilemsg)) {
                                 // Holy sheet.. we found a properties file
                                 newAlert()
                                         .setConfidence(Alert.CONFIDENCE_MEDIUM)


### PR DESCRIPTION
- Update scan rules to leverage new Custom Pages functionality.
- Update build file to target ZAP 2.10 and leverage the core snapshot library.
- Update CHANGELOG with a change note about the updates.

* CrlfInjectionScanRule > Remove un-necessary commented code block.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>