### PR TITLE
wappalyzer: Add support for CSS inspection/patterns

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
+- Now targeting ZAP 2.10.
 - Add-on promoted to Release.
 - Dependency updates.
+
+### Added
+- Added support for CSS patterns, aligning with upstream project.
 
 ## [20.3.0] - 2020-09-30
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
@@ -36,6 +36,7 @@ public class Application {
     private List<AppPattern> url = new ArrayList<AppPattern>();
     private List<AppPattern> html = new ArrayList<AppPattern>();
     private List<Map<String, AppPattern>> metas;
+    private List<AppPattern> css = new ArrayList<AppPattern>();
     private List<AppPattern> script = new ArrayList<AppPattern>();
 
     private List<String> implies = new ArrayList<String>();
@@ -92,6 +93,10 @@ public class Application {
         this.html = html;
     }
 
+    public void setCss(List<AppPattern> css) {
+        this.css = css;
+    }
+
     public void setMetas(List<Map<String, AppPattern>> metas) {
         this.metas = metas;
     }
@@ -138,6 +143,14 @@ public class Application {
 
     public void addMetas(Map<String, AppPattern> meta) {
         this.metas.add(meta);
+    }
+
+    public List<AppPattern> getCss() {
+        return css;
+    }
+
+    public void addMCss(AppPattern css) {
+        this.css.add(css);
     }
 
     public List<AppPattern> getScript() {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
@@ -78,6 +78,9 @@ public class PopupMenuEvidence extends ExtensionPopupMenu {
                 for (AppPattern p : app.getScript()) {
                     addMenuItem(p.getJavaPattern(), ExtensionSearch.Type.Response);
                 }
+                for (AppPattern p : app.getCss()) {
+                    addMenuItem(p.getJavaPattern(), ExtensionSearch.Type.Response);
+                }
             }
             return getMenuComponentCount() != 0;
         }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -137,6 +137,7 @@ public class WappalyzerJsonParser {
                 app.setHtml(this.jsonToPatternList("HTML", appData.get("html")));
                 app.setScript(this.jsonToPatternList("SCRIPT", appData.get("scripts")));
                 app.setMetas(this.jsonToAppPatternMapList("META", appData.get("meta")));
+                app.setCss(this.jsonToPatternList("CSS", appData.get("css")));
                 app.setImplies(this.jsonToStringList(appData.get("implies")));
                 app.setCpe(appData.optString("cpe"));
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -123,6 +123,19 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
         checkBodyMatches(msg);
         checkMetaElementsMatches(source);
         checkScriptElementsMatches(source);
+        checkCssElementsMatches(msg, source);
+    }
+
+    private void checkCssElementsMatches(HttpMessage msg, Source source) {
+        for (AppPattern appPattern : currentApp.getCss()) {
+            if (msg.getRequestHeader().isCss() || msg.getResponseHeader().isCss()) {
+                addIfMatches(appPattern, msg.getResponseBody().toString());
+            } else {
+                for (Element styleElement : source.getAllElements(HTMLElementName.STYLE)) {
+                    addIfMatches(appPattern, styleElement.getSource().toString());
+                }
+            }
+        }
     }
 
     private void checkScriptElementsMatches(Source source) {

--- a/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
+++ b/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
@@ -1,10 +1,11 @@
 {
   "$schema": "../schema.json",
   "technologies": {
-	"Test Entry": {
+    "Test Entry": {
       "cats": [
         36
       ],
+      "css": "\\.example",
       "html": [
         "example\\.com/test\\.html[^>]+></iframe>",
         "<!-- (?:End )?Test Entry -->"

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -1,15 +1,16 @@
 import org.zaproxy.gradle.addon.AddOnStatus
 
-version = "20.4.0"
+version = "21.0.0"
 description = "Technology detection using Wappalyzer: wappalyzer.com"
 
 zapAddOn {
     addOnName.set("Wappalyzer - Technology Detection")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
+        notBeforeVersion.set("2.10.0")
         url.set("https://www.zaproxy.org/docs/desktop/addons/technology-detection/")
     }
 
@@ -19,7 +20,15 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
+
     implementation("com.google.re2j:re2j:1.5")
 
     val batikVersion = "1.13"


### PR DESCRIPTION
Part of zaproxy/zaproxy#6180

- Added necessary infrastructure/code.
- Added unit tests.
- Add CHANGELOG notes.
- Rolled version identifier to 21.0.0 (since now targeting ZAP 2.10,
which is somewhat breaking).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>