### PR TITLE
soap: tweak name/help and prepare release

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -3,12 +3,12 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [4] - 2020-12-16
 ### Changed
 - Internationalise file filter description.
 - Dynamically unload the add-on.
 - Change default accelerator for "Import a WSDL file from local file system".
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Add import menus to (new) top level Import menu instead of Tools menu.
 - Add support for SOAP version 1.2 to the Action Spoofing Scan Rule.
 - Distinguish alerts by adding the SOAP version to the "Other Info" section.
@@ -32,3 +32,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First version
 
+[4]: https://github.com/zaproxy/zap-extensions/releases/soap-v4

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -2,11 +2,12 @@ version = "4"
 description = "Imports and scans WSDL files containing SOAP endpoints."
 
 zapAddOn {
-    addOnName.set("SOAP Scanner")
+    addOnName.set("SOAP Support")
     zapVersion.set("2.9.0")
 
     manifest {
         author.set("Alberto (albertov91) + ZAP Dev Team")
+        notBeforeVersion.set("2.10.0")
     }
 
     apiClientGen {

--- a/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
+++ b/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/contents/soap.html
@@ -3,11 +3,11 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-SOAP Add-on
+SOAP Support
 </TITLE>
 </HEAD>
 <BODY>
-<H1>SOAP Add-on</H1>
+<H1>SOAP Support</H1>
 This add-on imports and scans WSDL files containing SOAP endpoints.
 <h2>Importing</H2>
 The add-on will automatically detect any SOAP definitions and spider them as long as they are in scope.

--- a/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/helpset.hs
+++ b/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/helpset.hs
@@ -3,10 +3,10 @@
   PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
          "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
 <helpset version="2.0" xml:lang="en-GB">
-  <title>SOAP Scanner | ZAP Extension</title>
+  <title>SOAP Support Add-on</title>
 
   <maps>
-     <homeID>top</homeID>
+     <homeID>soap</homeID>
      <mapref location="map.jhm"/>
   </maps>
 

--- a/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/toc.xml
+++ b/addOns/soap/src/main/javahelp/org/zaproxy/zap/extension/soap/resources/help/toc.xml
@@ -6,7 +6,7 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="SOAP Scanner" image="soap-icon" target="soap"/>
+			<tocitem text="SOAP Support" image="soap-icon" target="soap"/>
 		</tocitem>
 	</tocitem>
 </toc>


### PR DESCRIPTION
Rename the add-on to "SOAP Support", it's not just a scanner, it allows
to import and spider.
Update the help accordingly.
Update minimum ZAP version to 2.10.0.
Add release date and link to tag.