### PR TITLE
encoder: help tweak

### DIFF
--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Remove "Advanced" in help page.
 
 ## [0.4.0] - 2020-12-15
 

--- a/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
+++ b/addOns/encoder/src/main/javahelp/org/zaproxy/addon/encoder/resources/help/contents/encoder.html
@@ -3,11 +3,11 @@
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
 <TITLE>
-Advanced Encode / Decode / Hash dialog
+Encode / Decode / Hash dialog
 </TITLE>
 </HEAD>
 <BODY>
-<H1>Advanced Encode / Decode / Hash dialog</H1>
+<H1>Encode / Decode / Hash dialog</H1>
 
 <p>
 This allows you to encode, decode or hash text.
@@ -173,9 +173,9 @@ Custom "Encode/Decode" scripts can be created/added to the Scripts Tree and used
 <H2>Accessed via</H2>
 <table>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Tools menu 'Advanced Encode/Decode/Hash...' item</td></tr>
+Tools menu 'Encode/Decode/Hash...' item</td></tr>
 <tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td>
-Many text areas such as the Output tab, Scripts console, Request and Response panels via 'Advanced Encode/Decode/Hash...' 
+Many text areas such as the Output tab, Scripts console, Request and Response panels via 'Encode/Decode/Hash...' 
 right click menu item</td></tr>
 </table>
 


### PR DESCRIPTION
Remove "Advanced" in help page, no longer needed.