### PR TITLE
websocket: fix NPE when handling breakpoints

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.10.0.
+
 ### Fixed
+ - Fix exception when handling breakpoints with ZAP 2.10.0.
  - Terminology
 
 ## [22] - 2020-08-17

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -369,6 +369,7 @@ public class ExtensionWebSocket extends ExtensionAdaptor
                         new WebSocketBreakpointMessageHandler(
                                 extBreak.getBreakpointManagementInterface(), config);
                 wsBrkMessageHandler.setEnabledBreakpoints(extBreak.getBreakpointsEnabledList());
+                wsBrkMessageHandler.setEnabledIgnoreRules(Collections.emptyList());
 
                 // listen on new messages such that breakpoints can apply
                 addAllChannelObserver(new WebSocketProxyListenerBreak(this, wsBrkMessageHandler));

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/WebSocketPanelSender.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/WebSocketPanelSender.java
@@ -200,7 +200,7 @@ public class WebSocketPanelSender implements MessageSender, WebSocketObserver {
                 extHistory.addHistory(ref);
             }
 
-            SessionStructure.addPath(Model.getSingleton().getSession(), ref, httpMessage);
+            SessionStructure.addPath(Model.getSingleton(), ref, httpMessage);
 
         } catch (HttpMalformedHeaderException | DatabaseException e) {
             logger.warn("Failed to persist message sent:", e);

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/utility/WebSocketUtils.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/utility/WebSocketUtils.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.websocket.utility;
 
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.LinkedHashMap;
@@ -26,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.apache.log4j.Logger;
-import org.parosproxy.paros.extension.encoder.Encoder;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.websocket.WebSocketProtocol;
 
@@ -35,14 +35,14 @@ public final class WebSocketUtils {
 
     public static final String WEB_SOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-    private static Encoder encoder = new Encoder();
-
     /** Given a Sec-WebSocket-Key, Generate response key Sec-WebSocket-Accept */
     public static String encodeWebSocketKey(String key) {
         String toEncode = key + WEB_SOCKET_GUID;
 
         try {
-            return Base64.getEncoder().encodeToString(encoder.getHashSHA1(toEncode.getBytes()));
+            MessageDigest sha = MessageDigest.getInstance("SHA-1");
+            sha.update(toEncode.getBytes());
+            return Base64.getEncoder().encodeToString(sha.digest());
         } catch (NoSuchAlgorithmException e) {
             // Should never happen
             return null;

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/pscan/WebSocketPassiveScannerManagerUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/pscan/WebSocketPassiveScannerManagerUnitTest.java
@@ -37,7 +37,6 @@ public class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
     @BeforeEach
     public void setUp() {
         wsPscanManager = new WebSocketPassiveScannerManager(mock(AlertManager.class));
-        super.setUpLog();
     }
 
     @Test

--- a/addOns/websocket/websocket.gradle.kts
+++ b/addOns/websocket/websocket.gradle.kts
@@ -6,7 +6,7 @@ description = "Allows you to inspect WebSocket communication."
 zapAddOn {
     addOnName.set("WebSockets")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")


### PR DESCRIPTION
Set empty list for ignore rules to avoid NPE when handling the
breakpoints.

Update ZAP to 2.10.0, required to call the setter.
Address deprecations in ZAP 2.10.0:
 - Remove usage of `Encoder`;
 - Call `SessionStructure#addPath` with the `model`.

Remove log set up in the tests, calling method that does not exist (per
Log4j major update in core).