### PR TITLE
testutils: sync ping in WebSocket test server

### DIFF
--- a/testutils/src/main/java/org/zaproxy/zap/testutils/websocket/server/NanoWebSocketConnection.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/websocket/server/NanoWebSocketConnection.java
@@ -71,7 +71,7 @@ public class NanoWebSocketConnection extends NanoWSD.WebSocket {
      * Sends a ping message to the client. Ping payload defined by {@link
      * NanoWebSocketConnection#setPingMessage(byte[])}
      */
-    protected boolean ping() {
+    protected synchronized boolean ping() {
         try {
             if (isPongReceived()) {
                 super.ping(pingPayload);


### PR DESCRIPTION
Sync ping to make sure the internal state is consistent when checking
if expected pong was received.
Addresses intermittent failure in WebSocket ping/pong test.