### PR TITLE
wappalyzer: Add support for Dom inspection/patterns

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated with upstream Wappalyzer icon and pattern changes.
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 
+### Added
+- Support for DOM patterns, aligning with the upstream project (Issue 6180).
+
 ## [21.0.0] - 2020-12-15
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
@@ -36,6 +36,7 @@ public class Application {
     private List<AppPattern> url = new ArrayList<AppPattern>();
     private List<AppPattern> html = new ArrayList<AppPattern>();
     private List<Map<String, AppPattern>> metas;
+    private List<Map<String, Map<String, Map<String, AppPattern>>>> dom;
     private List<AppPattern> css = new ArrayList<AppPattern>();
     private List<AppPattern> script = new ArrayList<AppPattern>();
 
@@ -101,6 +102,10 @@ public class Application {
         this.metas = metas;
     }
 
+    public void setDom(List<Map<String, Map<String, Map<String, AppPattern>>>> dom) {
+        this.dom = dom;
+    }
+
     public void setScript(List<AppPattern> script) {
         this.script = script;
     }
@@ -143,6 +148,10 @@ public class Application {
 
     public void addMetas(Map<String, AppPattern> meta) {
         this.metas.add(meta);
+    }
+
+    public List<Map<String, Map<String, Map<String, AppPattern>>>> getDom() {
+        return dom;
     }
 
     public List<AppPattern> getCss() {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
@@ -75,6 +75,43 @@ public class PopupMenuEvidence extends ExtensionPopupMenu {
                         addMenuItem(p, ExtensionSearch.Type.Response);
                     }
                 }
+                for (Map<String, Map<String, Map<String, AppPattern>>> map : app.getDom()) {
+                    for (Map.Entry<String, Map<String, Map<String, AppPattern>>> domSelectorObject :
+                            map.entrySet()) {
+                        for (Map.Entry<String, Map<String, AppPattern>> nodeSelectorObject :
+                                domSelectorObject.getValue().entrySet()) {
+                            for (Map.Entry<String, AppPattern> objvalue :
+                                    nodeSelectorObject.getValue().entrySet()) {
+                                if (nodeSelectorObject.getKey() == "text") {
+                                    Pattern pat =
+                                            Pattern.compile(
+                                                    domSelectorObject.getKey()
+                                                            + ".*"
+                                                            + objvalue.getKey()
+                                                            + ".*"
+                                                            + objvalue.getValue()
+                                                                    .getJavaPattern()
+                                                                    .pattern());
+                                    addMenuItem(pat, ExtensionSearch.Type.Response);
+                                } else {
+                                    Pattern pat =
+                                            Pattern.compile(
+                                                    domSelectorObject.getKey()
+                                                            + ".*"
+                                                            + nodeSelectorObject.getKey()
+                                                            + ".*"
+                                                            + objvalue.getKey()
+                                                            + ".*"
+                                                            + objvalue.getValue()
+                                                                    .getJavaPattern()
+                                                                    .pattern());
+                                    addMenuItem(pat, ExtensionSearch.Type.Response);
+                                }
+                            }
+                        }
+                    }
+                }
+
                 for (AppPattern p : app.getScript()) {
                     addMenuItem(p.getJavaPattern(), ExtensionSearch.Type.Response);
                 }

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -12,6 +12,7 @@ It works in a very similar way to the Wappalyzer browser add-ons with the follow
 <ul>
 <li>It does not use the 'Global JavaScript variables' as these are difficult to test without a 'full' browser</li>
 <li>It does not not show the confidence - this is still todo</li>
+<li>It does not match technologies on the basis of DOM properties as some properties are set by JavaScript in the browser after the response has passed through ZAP</li>
 <li>It allows you to see the 'evidence' used to detect the technologies</li>
 </ul>
 <H2>The Technology Tab</H2>

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
@@ -50,6 +50,7 @@ public class WappalyzerJsonParserUnitTest {
         assertEquals(2, app.getScript().size());
         assertEquals(0, app.getMetas().size());
         assertEquals(0, app.getImplies().size());
+        assertEquals(2, app.getDom().size());
         assertTrue(app.getCpe().equals(""));
         // Ignore Icon
     }

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -90,10 +90,8 @@ public class WappalyzerPassiveScannerUnitTest
                         + "<script type='text/javascript' src='libs/modernizr.min.js?ver=4.1.1'>"
                         + "</script>"
                         + "</html>");
-
         // When
         scan(msg);
-
         // Then
         assertFoundAppCount("https://www.example.com", 1);
         assertFoundApp("https://www.example.com", "Modernizr");
@@ -105,10 +103,67 @@ public class WappalyzerPassiveScannerUnitTest
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody("<html><body>libs/modernizr.min.js?ver=4.1.1</body></html>");
-
         // When
         scan(msg);
+        // Then
+        assertNull(getDefaultHolder().getAppsForSite("https://www.example.com"));
+    }
 
+    @Test
+    public void shouldMatchDomElementWithTextAndAttribute() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = makeHttpMessage();
+        msg.setResponseBody(
+                "<html><body>"
+                        + "<a href=\"https://www.example.com\" title=\"version 1\" style=\"border: 5px groove rgb(244, 250, 88);\">Example</a>"
+                        + "</body></html>");
+        // When
+        scan(msg);
+        // Then
+        assertFoundAppCount("https://www.example.com", 1);
+        assertFoundApp("https://www.example.com", "Test Entry");
+    }
+
+    @Test
+    public void shouldMatchDomElementWithOnlyText() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = makeHttpMessage();
+        msg.setResponseBody(
+                "<html><body>"
+                        + "<a href=\"https://www.modern.com\"  style=\"border: 5px groove rgb(244, 250, 88);\">Modern</a>"
+                        + "</body></html>");
+        // When
+        scan(msg);
+        // Then
+        assertFoundAppCount("https://www.example.com", 1);
+        assertFoundApp("https://www.example.com", "Modernizr");
+    }
+
+    @Test
+    public void shouldMatchDomElementWithOnlyAttribute() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = makeHttpMessage();
+        msg.setResponseBody(
+                "<html><body>"
+                        + "<a href=\"https://www.apache.com\" title=\"version 1\" style=\"border: 5px groove rgb(244, 250, 88);\">Example</a>"
+                        + "</body></html>");
+        // When
+        scan(msg);
+        // Then
+        assertFoundAppCount("https://www.example.com", 1);
+        assertFoundApp("https://www.example.com", "Apache");
+    }
+
+    @Test
+    public void shouldNotMatchDomElementIfNoContentMatches() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = makeHttpMessage();
+        msg.setResponseBody(
+                "<html><body>"
+                        + "<a href=\"https://www.pinter.com\" title=\"version\" style=\"border: 5px groove rgb(244, 250, 88);\">Pinterest</a>"
+                        + "</body></html>");
+        // When
+        scan(msg);
         // Then
         assertNull(getDefaultHolder().getAppsForSite("https://www.example.com"));
     }

--- a/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
+++ b/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
@@ -18,6 +18,18 @@
         "Test_Entry_": "",
         "__test_entry_urls": ""
       },
+      "dom": {
+        "a[href='https://www.example.com'][title*='version']": {
+          "attributes": {
+            "title": "^version ([0-9.]+)$\\;version:\\1"
+          },
+          "text":
+            "Example",
+          "properties": {
+            "data-value": "1"
+          }
+        }
+      },
       "scripts": [
         "testentry\\.com/",
         "ad\\.ca\\.testentry\\.net"
@@ -49,6 +61,13 @@
       "headers": {
         "Server": "(?:Apache(?:$|/([\\d.]+)|[^/-])|(?:^|\\b)HTTPD)\\;version:\\1"
       },
+      "dom": {
+        "a[href='https://www.apache.com'][title*='version']": {
+          "attributes": {
+            "title": "^version ([0-9.]+)$\\;version:\\1"
+          }
+       }
+      },
       "icon": "Apache.svg",
       "website": "http://apache.org"
     },
@@ -59,6 +78,12 @@
       "icon": "Modernizr.svg",
       "js": {
         "Modernizr._version": "^(.+)$\\;version:\\1"
+      },
+      "dom": {
+        "a[href='https://www.modern.com']": {
+          "text":
+            "Modern"
+        }
       },
       "scripts": [
         "([\\d.]+)?/modernizr(?:\\.([\\d.]+))?.*\\.js\\;version:\\1?\\1:\\2"

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -29,5 +29,7 @@ dependencies {
     implementation("org.apache.xmlgraphics:batik-gvt:$batikVersion")
     implementation("org.apache.xmlgraphics:batik-util:$batikVersion")
 
+    implementation("org.jsoup:jsoup:1.13.1")
+
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
- Added necessary code.
- Added unit tests.
- Added CHANGELOG notes.
- Used Jsoup as dom selector as Jericho lacks jquery-like selector capabilities.

Fixes zaproxy/zaproxy#6180

Signed-off-by: bettercalln1ck bettercallnck6303@gmail.com