### PR TITLE
chore: added evidence to suspicious comment scan rule

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Handle an IllegalArgumentException that could occur in the CSP scan rule if multiple CSP headers were present and one (or more) had a report-uri directive when trying to merge them.
 - Allow to ignore cookies in same site and loosely scoped scan rules.
 - The Application Error scan rule will not alert on web assembly responses.
+- The Suspicious Comments scan rule will include the offending line as evidence.
+- The Suspicious Comments scan rule will raise one alert per finding, instead of one aggeregated alert per HTTP message.
 
 ## [29] - 2020-06-01
 ### Changed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -73,7 +73,7 @@ pscanrules.informationdisclosurereferrer.issuer.field=Issuer:
 
 pscanrules.informationdisclosuresuspiciouscomments.name=Information Disclosure - Suspicious Comments
 pscanrules.informationdisclosuresuspiciouscomments.desc=The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.
-pscanrules.informationdisclosuresuspiciouscomments.otherinfo=The following comment/snippet was identified via the pattern: {0}\n{1}
+pscanrules.informationdisclosuresuspiciouscomments.otherinfo=The following pattern was used: {0}, see evidence field for the suspicious comment/snippet.
 pscanrules.informationdisclosuresuspiciouscomments.soln=Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.
 
 pscanrules.insecureauthentication.name=Weak Authentication Method

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
@@ -99,6 +99,9 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
         // Then
         assertEquals(1, alertsRaised.size());
         assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
+        assertEquals(
+                "Some text <script>Some Script Element FIXME: DO something </script>",
+                alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -118,6 +121,30 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
 
         // Then
         assertEquals(0, alertsRaised.size());
+    }
+
+    @Test
+    public void shouldCreateOneAlertPerSuspiciousComment()
+            throws HttpMalformedHeaderException, URIException {
+
+        // Given
+        String body =
+                "Some text <script>Some Script Element FIXME: DO something\nFIXME: DO something else </script>\nLine 2\n";
+        HttpMessage msg = createHttpMessageWithRespBody(body, "text/javascript;charset=ISO-8859-1");
+
+        assertTrue(msg.getResponseHeader().isText());
+        assertTrue(msg.getResponseHeader().isJavaScript());
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertEquals(2, alertsRaised.size());
+        assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
+        assertEquals(
+                "Some text <script>Some Script Element FIXME: DO something",
+                alertsRaised.get(0).getEvidence());
+        assertEquals("FIXME: DO something else </script>", alertsRaised.get(1).getEvidence());
     }
 
     @Test


### PR DESCRIPTION
The alert did not added the offending line as evidence, changed the code to add each offending line as a single alert