### PR TITLE
ascanrules: Use Log4j 2.x

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now using 2.10 logging infrastructure (Log4j 2.x).
 
 ## [38] - 2020-12-15
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
@@ -25,7 +25,8 @@ package org.zaproxy.zap.extension.ascanrules;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -41,7 +42,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
     private static final String MESSAGE_PREFIX = "ascanrules.bufferoverflow.";
 
     private static final int PLUGIN_ID = 30001;
-    private static Logger log = Logger.getLogger(BufferOverflowScanRule.class);
+    private static Logger log = LogManager.getLogger(BufferOverflowScanRule.class);
 
     @Override
     public int getId() {
@@ -90,9 +91,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
     public void scan(HttpMessage msg, String param, String value) {
 
         if (this.isStop()) { // Check if the user stopped things
-            if (log.isDebugEnabled()) {
-                log.debug("Scanner " + this.getName() + " Stopping.");
-            }
+            log.debug("Scanner {} Stopping.", this.getName());
             return; // Stop!
         }
         if (isPage500(getBaseMsg())) // Check to see if the page closed initially
@@ -109,15 +108,11 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(msg);
             } catch (UnknownHostException ex) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + msg.getRequestHeader().getURI().toString()
-                                    + "\n The target may have replied with a poorly formed redirect due to our input.");
+                log.debug(
+                        "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        msg.getRequestHeader().getURI().toString());
                 return; // Something went wrong no point continuing
             }
 
@@ -125,7 +120,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
             // This is where BASE baseResponseBody was you detect potential vulnerabilities in the
             // response
             String chkerrorheader = requestReturn.getHeadersAsString();
-            log.debug("Header: " + chkerrorheader);
+            log.debug("Header: {}", chkerrorheader);
             if (isPage500(msg) && chkerrorheader.contains(checkStringHeader1)) {
                 log.debug("Found Header");
                 newAlert()
@@ -141,9 +136,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
 
             return;
         } catch (URIException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Failed to send HTTP message, cause: " + e.getMessage());
-            }
+            log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -33,7 +33,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -267,7 +268,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
     }
 
     // Logger instance
-    private static final Logger log = Logger.getLogger(CommandInjectionScanRule.class);
+    private static final Logger log = LogManager.getLogger(CommandInjectionScanRule.class);
 
     // Get WASC Vulnerability description
     private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_31");
@@ -340,14 +341,11 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
             timeSleepSeconds = this.getConfig().getInt(RULE_SLEEP_TIME, DEFAULT_TIME_SLEEP_SEC);
         } catch (ConversionException e) {
             log.debug(
-                    "Invalid value for '"
-                            + RULE_SLEEP_TIME
-                            + "': "
-                            + this.getConfig().getString(RULE_SLEEP_TIME));
+                    "Invalid value for '{}': {}",
+                    RULE_SLEEP_TIME,
+                    this.getConfig().getString(RULE_SLEEP_TIME));
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Sleep set to " + timeSleepSeconds + " seconds");
-        }
+        log.debug("Sleep set to {} seconds", timeSleepSeconds);
     }
 
     /**
@@ -372,16 +370,11 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
     public void scan(HttpMessage msg, String paramName, String value) {
 
         // Begin scan rule execution
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "Checking ["
-                            + msg.getRequestHeader().getMethod()
-                            + "]["
-                            + msg.getRequestHeader().getURI()
-                            + "], parameter ["
-                            + paramName
-                            + "] for OS Command Injection vulnerabilites");
-        }
+        log.debug(
+                "Checking [{}][{}], parameter [{}] for OS Command Injection vulnerabilites",
+                msg.getRequestHeader().getMethod(),
+                msg.getRequestHeader().getURI(),
+                paramName);
 
         // Number of targets to try
         int targetCount = 0;
@@ -513,24 +506,18 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
             paramValue = value + payload;
             setParameter(msg, paramName, paramValue);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Testing [" + paramName + "] = [" + paramValue + "]");
-            }
+            log.debug("Testing [{}] = [{}]", paramName, paramValue);
 
             try {
                 // Send the request and retrieve the response
                 try {
                     sendAndReceive(msg, false);
                 } catch (SocketException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + msg.getRequestHeader().getURI().toString()
-                                        + "\n The target may have replied with a poorly formed redirect due to our input.");
+                    log.debug(
+                            "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg.getRequestHeader().getURI().toString());
                     continue; // Something went wrong, move to next payload iteration
                 }
                 elapsedTime = msg.getTimeElapsedMillis();
@@ -542,14 +529,10 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
                 if (matcher.find()) {
                     // We Found IT!
                     // First do logging
-                    if (log.isDebugEnabled()) {
-                        log.debug(
-                                "[OS Command Injection Found] on parameter ["
-                                        + paramName
-                                        + "] with value ["
-                                        + paramValue
-                                        + "]");
-                    }
+                    log.debug(
+                            "[OS Command Injection Found] on parameter [{}] with value [{}]",
+                            paramName,
+                            paramValue);
 
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -568,11 +551,9 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
                 // Do not try to internationalise this.. we need an error message in any event..
                 // if it's in English, it's still better than not having it at all.
                 log.warn(
-                        "Command Injection vulnerability check failed for parameter ["
-                                + paramName
-                                + "] and payload ["
-                                + payload
-                                + "] due to an I/O error",
+                        "Command Injection vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                        paramName,
+                        payload,
                         ex);
             }
 
@@ -611,24 +592,18 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
             paramValue = value + payload.replace("{0}", timeSleepSecondsStr);
             setParameter(msg, paramName, paramValue);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Testing [" + paramName + "] = [" + paramValue + "]");
-            }
+            log.debug("Testing [{}] = [{}]", paramName, paramValue);
 
             try {
                 // Send the request and retrieve the response
                 try {
                     sendAndReceive(msg, false);
                 } catch (SocketException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + msg.getRequestHeader().getURI().toString()
-                                        + "\n The target may have replied with a poorly formed redirect due to our input.");
+                    log.debug(
+                            "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg.getRequestHeader().getURI().toString());
                     continue; // Something went wrong, move to next blind iteration
                 }
                 elapsedTime = msg.getTimeElapsedMillis();
@@ -641,14 +616,10 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
 
                     // We Found IT!
                     // First do logging
-                    if (log.isDebugEnabled()) {
-                        log.debug(
-                                "[Blind OS Command Injection Found] on parameter ["
-                                        + paramName
-                                        + "] with value ["
-                                        + paramValue
-                                        + "]");
-                    }
+                    log.debug(
+                            "[Blind OS Command Injection Found] on parameter [{}] with value [{}]",
+                            paramName,
+                            paramValue);
 
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -666,11 +637,9 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
                 // Do not try to internationalise this.. we need an error message in any event..
                 // if it's in English, it's still better than not having it at all.
                 log.warn(
-                        "Blind Command Injection vulnerability check failed for parameter ["
-                                + paramName
-                                + "] and payload ["
-                                + payload
-                                + "] due to an I/O error",
+                        "Blind Command Injection vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                        paramName,
+                        payload,
                         ex);
             }
 
@@ -709,12 +678,9 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
         // Check if there is too much deviation
         if (result > WARN_TIME_STDEV) {
             log.warn(
-                    "There is considerable lagging "
-                            + "in connection response(s) which gives a standard deviation of "
-                            + result
-                            + "ms on the sample set which is more than "
-                            + WARN_TIME_STDEV
-                            + "ms");
+                    "There is considerable lagging in connection response(s) which gives a standard deviation of {}ms on the sample set which is more than {}ms",
+                    result,
+                    WARN_TIME_STDEV);
         }
 
         return result;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -27,7 +27,8 @@ import java.util.List;
 import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -62,7 +63,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
     private static final List<Integer> GET_POST_TYPES =
             Arrays.asList(NameValuePair.TYPE_QUERY_STRING, NameValuePair.TYPE_POST_DATA);
     private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_8");
-    private static Logger log = Logger.getLogger(CrossSiteScriptingScanRule.class);
+    private static Logger log = LogManager.getLogger(CrossSiteScriptingScanRule.class);
     private int currentParamType;
 
     @Override
@@ -153,9 +154,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         try {
             sendAndReceive(msg2);
         } catch (URIException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Failed to send HTTP message, cause: " + e.getMessage());
-            }
+            log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
             return null;
         } catch (InvalidRedirectLocationException | UnknownHostException e) {
             // Not an error, just means we probably attacked the redirect
@@ -202,9 +201,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(msg2);
             } catch (URIException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Failed to send HTTP message, cause: " + e.getMessage());
-                }
+                log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
                 return;
             } catch (InvalidRedirectLocationException | UnknownHostException e) {
                 // Not an error, just means we probably attacked the redirect
@@ -234,9 +231,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 try {
                     sendAndReceive(msg2);
                 } catch (URIException e) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Failed to send HTTP message, cause: " + e.getMessage());
-                    }
+                    log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
                     return;
                 } catch (InvalidRedirectLocationException | UnknownHostException e) {
                     // Second eyecatcher failed for some reason, no need to
@@ -307,8 +302,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         }
                         if (!attackWorked) {
                             log.debug(
-                                    "Failed to find vuln in script attribute on "
-                                            + msg.getRequestHeader().getURI());
+                                    "Failed to find vuln in script attribute on {}",
+                                    msg.getRequestHeader().getURI());
                         }
 
                     } else if (context.isInUrlAttribute()) {
@@ -335,8 +330,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         }
                         if (!attackWorked) {
                             log.debug(
-                                    "Failed to find vuln in url attribute on "
-                                            + msg.getRequestHeader().getURI());
+                                    "Failed to find vuln in url attribute on {}",
+                                    msg.getRequestHeader().getURI());
                         }
                     }
                     if (!attackWorked && context.isInTagWithSrc()) {
@@ -365,8 +360,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         }
                         if (!attackWorked) {
                             log.debug(
-                                    "Failed to find vuln in tag with src attribute on "
-                                            + msg.getRequestHeader().getURI());
+                                    "Failed to find vuln in tag with src attribute on {}",
+                                    msg.getRequestHeader().getURI());
                         }
                     }
 
@@ -396,8 +391,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                             }
                             if (!attackWorked) {
                                 log.debug(
-                                        "Failed to find vuln with simple script attack "
-                                                + msg.getRequestHeader().getURI());
+                                        "Failed to find vuln with simple script attack {}",
+                                        msg.getRequestHeader().getURI());
                             }
 
                             if (attackWorked || isStop()) {
@@ -433,8 +428,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         }
                         if (!attackWorked) {
                             log.debug(
-                                    "Failed to find vuln in with simple onmounseover "
-                                            + msg.getRequestHeader().getURI());
+                                    "Failed to find vuln in with simple onmounseover {}",
+                                    msg.getRequestHeader().getURI());
                         }
                     }
                 } else if (context.isHtmlComment()) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.ascanrules;
 import java.io.IOException;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -45,7 +46,7 @@ public class ElmahScanRule extends AbstractHostPlugin {
     private static final String MESSAGE_PREFIX = "ascanrules.elmah.";
     private static final int PLUGIN_ID = 40028;
 
-    private static final Logger LOG = Logger.getLogger(ElmahScanRule.class);
+    private static final Logger LOG = LogManager.getLogger(ElmahScanRule.class);
 
     @Override
     public int getId() {
@@ -110,9 +111,7 @@ public class ElmahScanRule extends AbstractHostPlugin {
         // Check if the user stopped things. One request per URL so check before
         // sending the request
         if (isStop()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Scan rule " + getName() + " Stopping.");
-            }
+            LOG.debug("Scan rule {} Stopping.", getName());
             return;
         }
 
@@ -131,43 +130,33 @@ public class ElmahScanRule extends AbstractHostPlugin {
                             baseUri.getPort(),
                             "/elmah.axd");
         } catch (URIException uEx) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "An error occurred creating a URI for the: "
-                                + getName()
-                                + " rule. "
-                                + uEx.getMessage(),
-                        uEx);
-            }
+            LOG.debug(
+                    "An error occurred creating a URI for the: {} rule. {}",
+                    getName(),
+                    uEx.getMessage(),
+                    uEx);
             return;
         }
         try {
             newRequest.getRequestHeader().setURI(elmahUri);
         } catch (URIException uEx) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "An error occurred setting the URI for a new request used by: "
-                                + getName()
-                                + " rule. "
-                                + uEx.getMessage(),
-                        uEx);
-            }
+            LOG.debug(
+                    "An error occurred setting the URI for a new request used by: {} rule. {}",
+                    getName(),
+                    uEx.getMessage(),
+                    uEx);
             return;
         }
         try {
             sendAndReceive(newRequest, false);
         } catch (IOException e) {
             LOG.warn(
-                    "An error occurred while checking ["
-                            + newRequest.getRequestHeader().getMethod()
-                            + "] ["
-                            + newRequest.getRequestHeader().getURI()
-                            + "] for "
-                            + getName()
-                            + " Caught "
-                            + e.getClass().getName()
-                            + " "
-                            + e.getMessage());
+                    "An error occurred while checking [{}] [{}] for {} Caught {} {}",
+                    newRequest.getRequestHeader().getMethod(),
+                    newRequest.getRequestHeader().getURI(),
+                    getName(),
+                    e.getClass().getName(),
+                    e.getMessage());
             return;
         }
         int statusCode = newRequest.getResponseHeader().getStatusCode();

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
@@ -28,7 +28,8 @@ import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -100,7 +101,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
     // Get WASC Vulnerability description
     private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_38");
 
-    private static final Logger logger = Logger.getLogger(ExternalRedirectScanRule.class);
+    private static final Logger logger = LogManager.getLogger(ExternalRedirectScanRule.class);
 
     @Override
     public int getId() {
@@ -165,9 +166,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
         int targetCount = 0;
 
         // Debug only
-        if (logger.isDebugEnabled()) {
-            logger.debug("Attacking at Attack Strength: " + this.getAttackStrength());
-        }
+        logger.debug("Attacking at Attack Strength: ", this.getAttackStrength());
 
         // Figure out how aggressively we should test
         switch (this.getAttackStrength()) {
@@ -195,16 +194,11 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
                 break;
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "Checking ["
-                            + getBaseMsg().getRequestHeader().getMethod()
-                            + "]["
-                            + getBaseMsg().getRequestHeader().getURI()
-                            + "], parameter ["
-                            + param
-                            + "] for Open Redirect Vulnerabilities");
-        }
+        logger.debug(
+                "Checking [{}][{}], parameter [{}] for Open Redirect Vulnerabilities",
+                getBaseMsg().getRequestHeader().getMethod(),
+                getBaseMsg().getRequestHeader().getURI(),
+                param);
 
         // For each target in turn
         // note that depending on the AttackLevel,
@@ -220,9 +214,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
             HttpMessage testMsg = getNewMsg();
             setParameter(testMsg, param, payload);
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Testing [" + param + "] = [" + payload + "]");
-            }
+            logger.debug("Testing [{}] = [{}]", param, payload);
 
             try {
                 // Send the request and retrieve the response
@@ -241,14 +233,10 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
                 if (redirectType != NO_REDIRECT) {
                     // We Found IT!
                     // First do logging
-                    if (logger.isDebugEnabled()) {
-                        logger.debug(
-                                "[External Redirection Found] on parameter ["
-                                        + param
-                                        + "] with payload ["
-                                        + payload
-                                        + "]");
-                    }
+                    logger.debug(
+                            "[External Redirection Found] on parameter [{}] with payload [{}]",
+                            param,
+                            payload);
 
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -274,11 +262,9 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
                 // Do not try to internationalize this.. we need an error message in any event..
                 // if it's in English, it's still better than not having it at all.
                 logger.warn(
-                        "External Redirect vulnerability check failed for parameter ["
-                                + param
-                                + "] and payload ["
-                                + payload
-                                + "] due to an I/O error",
+                        "External Redirect vulnerability check failed for parameter [{}] and payload [{}] due to an I/O error",
+                        param,
+                        payload,
                         ex);
             }
         }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
@@ -43,7 +43,8 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -59,7 +60,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
     private static final String MESSAGE_PREFIX = "ascanrules.formatstring.";
 
     private static final int PLUGIN_ID = 30002;
-    private static Logger log = Logger.getLogger(FormatStringScanRule.class);
+    private static Logger log = LogManager.getLogger(FormatStringScanRule.class);
 
     @Override
     public int getId() {
@@ -108,9 +109,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
     public void scan(HttpMessage msg, String param, String value) {
 
         if (this.isStop()) { // Check if the user stopped things
-            if (log.isDebugEnabled()) {
-                log.debug("Scanner " + getName() + " Stopping.");
-            }
+            log.debug("Scanner {} Stopping.", getName());
             return; // Stop!
         }
 
@@ -139,15 +138,11 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(testMsg);
             } catch (InvalidRedirectLocationException | UnknownHostException ex) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + testMsg.getRequestHeader().getURI().toString()
-                                    + "\n The target may have replied with a poorly formed redirect due to our input.");
+                log.debug(
+                        "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        testMsg.getRequestHeader().getURI().toString());
                 return; // Something went wrong, no point continuing
             }
 
@@ -179,15 +174,11 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(intialAttackMsg);
             } catch (InvalidRedirectLocationException | UnknownHostException ex) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + intialAttackMsg.getRequestHeader().getURI().toString()
-                                    + "\n The target may have replied with a poorly formed redirect due to our input.");
+                log.debug(
+                        "Caught {} {} when accessing: {}.\nThe target may have replied with a poorly formed redirect due to our input.",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        intialAttackMsg.getRequestHeader().getURI().toString());
                 return; // Something went wrong, no point continuing
             }
             if (isPage500(intialAttackMsg)) {
@@ -204,15 +195,11 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                 try {
                     sendAndReceive(verificationMsg);
                 } catch (InvalidRedirectLocationException | UnknownHostException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + verificationMsg.getRequestHeader().getURI().toString()
-                                        + "\n The target may have replied with a poorly formed redirect due to our input.");
+                    log.debug(
+                            "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            verificationMsg.getRequestHeader().getURI().toString());
                     return; // Something went wrong, no point continuing
                 }
                 HttpResponseBody secondAttackResponseBody = verificationMsg.getResponseBody();
@@ -240,9 +227,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             // errors.  It is only
             //  used if the GNU and generic C compiler check fails to find a vulnerability.
             if (this.isStop()) { // Check if the user stopped things
-                if (log.isDebugEnabled()) {
-                    log.debug("Scanner " + getName() + " Stopping.");
-                }
+                log.debug("Scanner {} Stopping.", getName());
                 return; // Stop!
             }
             StringBuilder sb2 = new StringBuilder();
@@ -265,15 +250,11 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(microsoftTestMsg);
             } catch (InvalidRedirectLocationException | UnknownHostException ex) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + microsoftTestMsg.getRequestHeader().getURI().toString()
-                                    + "\n The target may have replied with a poorly formed redirect due to our input.");
+                log.debug(
+                        "Caught {} {} when accessing: {}. \nThe target may have replied with a poorly formed redirect due to our input.",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        microsoftTestMsg.getRequestHeader().getURI().toString());
                 return; // Something went wrong, no point continuing
             }
             if (isPage500(microsoftTestMsg)) {
@@ -288,9 +269,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             return;
 
         } catch (URIException e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Failed to send HTTP message, cause: " + e.getMessage());
-            }
+            log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
@@ -36,7 +36,8 @@ import java.net.UnknownHostException;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
@@ -74,7 +75,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
                     "(Apache Tomcat).*(Caused by:|HTTP Status 500 - Internal Server Error)",
                     PATTERN_PARAM);
     // ZAP: Added logger
-    private static Logger log = Logger.getLogger(ParameterTamperScanRule.class);
+    private static Logger log = LogManager.getLogger(ParameterTamperScanRule.class);
 
     @Override
     public int getId() {
@@ -122,15 +123,11 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
                 | IllegalArgumentException
                 | URIException
                 | UnknownHostException ex) {
-            if (log.isDebugEnabled())
-                log.debug(
-                        "Caught "
-                                + ex.getClass().getName()
-                                + " "
-                                + ex.getMessage()
-                                + " when accessing: "
-                                + normalMsg.getRequestHeader().getURI().toString()
-                                + "\n The target may have replied with a poorly formed redirect due to our input.");
+            log.debug(
+                    "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                    ex.getClass().getName(),
+                    ex.getMessage(),
+                    normalMsg.getRequestHeader().getURI().toString());
             return; // Something went wrong, no point continuing
         } catch (Exception e) {
             // ZAP: Log exceptions
@@ -161,15 +158,11 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
                         | IllegalArgumentException
                         | URIException
                         | UnknownHostException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + testMsg.getRequestHeader().getURI().toString()
-                                        + "\n The target may have replied with a poorly formed redirect due to our input.");
+                    log.debug(
+                            "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            testMsg.getRequestHeader().getURI().toString());
                     continue; // Something went wrong, move on to the next item in the PARAM_LIST
                 }
                 if (checkResult(testMsg, param, attack, normalMsg.getResponseBody().toString())) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -31,7 +31,8 @@ import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -173,7 +174,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
      */
     private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_33");
 
-    private static final Logger log = Logger.getLogger(PathTraversalScanRule.class);
+    private static final Logger log = LogManager.getLogger(PathTraversalScanRule.class);
 
     @Override
     public int getId() {
@@ -235,7 +236,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
             boolean includeNullByteInjectionPayload = false;
             // DEBUG only
             if (log.isDebugEnabled()) {
-                log.debug("Attacking at Attack Strength: " + this.getAttackStrength());
+                log.debug("Attacking at Attack Strength: {}", this.getAttackStrength());
             }
 
             switch (this.getAttackStrength()) {
@@ -282,16 +283,11 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                     // Default to off
             }
 
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Checking ["
-                                + getBaseMsg().getRequestHeader().getMethod()
-                                + "] ["
-                                + getBaseMsg().getRequestHeader().getURI()
-                                + "], parameter ["
-                                + param
-                                + "] for Path Traversal to local files");
-            }
+            log.debug(
+                    "Checking [{}] [{}], parameter [{}] for Path Traversal to local files",
+                    getBaseMsg().getRequestHeader().getMethod(),
+                    getBaseMsg().getRequestHeader().getURI(),
+                    param);
 
             // Check 1: Start detection for Windows patterns
             // note that depending on the AttackLevel, the number of prefixes that we will try
@@ -449,15 +445,11 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                     | IllegalArgumentException
                     | InvalidRedirectLocationException
                     | URIException ex) {
-                if (log.isDebugEnabled()) {
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + msg.getRequestHeader().getURI().toString());
-                }
+                log.debug(
+                        "Caught {} {} when accessing: {}",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        msg.getRequestHeader().getURI().toString());
 
                 return; // Something went wrong, no point continuing
             }
@@ -471,16 +463,11 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
             // url file name may be empty, i.e. there is no file name for next check
             if (!StringUtils.isEmpty(urlfilename) && (!isPage200(msg) || errorMatcher.find())) {
 
-                if (log.isDebugEnabled()) {
-                    log.debug(
-                            "It is possible to check for local file Path Traversal on the url filename on ["
-                                    + msg.getRequestHeader().getMethod()
-                                    + "] ["
-                                    + msg.getRequestHeader().getURI()
-                                    + "], ["
-                                    + param
-                                    + "]");
-                }
+                log.debug(
+                        "It is possible to check for local file Path Traversal on the url filename on [{}] [{}], [{}]",
+                        msg.getRequestHeader().getMethod(),
+                        msg.getRequestHeader().getURI().toString(),
+                        param);
 
                 String prefixedUrlfilename;
 
@@ -501,15 +488,11 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                             | IllegalArgumentException
                             | InvalidRedirectLocationException
                             | URIException ex) {
-                        if (log.isDebugEnabled()) {
-                            log.debug(
-                                    "Caught "
-                                            + ex.getClass().getName()
-                                            + " "
-                                            + ex.getMessage()
-                                            + " when accessing: "
-                                            + msg.getRequestHeader().getURI().toString());
-                        }
+                        log.debug(
+                                "Caught {} {} when accessing: {}",
+                                ex.getClass().getName(),
+                                ex.getMessage(),
+                                msg.getRequestHeader().getURI().toString());
 
                         continue; // Something went wrong, move to the next prefix in the loop
                     }
@@ -557,37 +540,26 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
         } catch (SocketTimeoutException ste) {
             log.warn(
-                    "A timeout occurred while checking ["
-                            + msg.getRequestHeader().getMethod()
-                            + "] ["
-                            + msg.getRequestHeader().getURI()
-                            + "], parameter ["
-                            + param
-                            + "] for Path Traversal. "
-                            + "The currently configured timeout is: "
-                            + Integer.toString(
-                                    Model.getSingleton()
-                                            .getOptionsParam()
-                                            .getConnectionParam()
-                                            .getTimeoutInSecs()));
+                    "A timeout occurred while checking [{}] [{}], parameter [{}] for Path Traversal. The currently configured timeout is: {}",
+                    msg.getRequestHeader().getMethod(),
+                    msg.getRequestHeader().getURI(),
+                    param,
+                    Integer.toString(
+                            Model.getSingleton()
+                                    .getOptionsParam()
+                                    .getConnectionParam()
+                                    .getTimeoutInSecs()));
 
-            if (log.isDebugEnabled()) {
-                log.debug("Caught " + ste.getClass().getName() + " " + ste.getMessage());
-            }
+            log.debug("Caught {} {}", ste.getClass().getName(), ste.getMessage());
 
         } catch (IOException e) {
             log.warn(
-                    "An error occurred while checking ["
-                            + msg.getRequestHeader().getMethod()
-                            + "] ["
-                            + msg.getRequestHeader().getURI()
-                            + "], parameter ["
-                            + param
-                            + "] for Path Traversal."
-                            + "Caught "
-                            + e.getClass().getName()
-                            + " "
-                            + e.getMessage());
+                    "An error occurred while checking [{}] [{}], parameter [{}] for Path Traversal.Caught {} {}",
+                    msg.getRequestHeader().getMethod(),
+                    msg.getRequestHeader().getURI(),
+                    param,
+                    e.getClass().getName(),
+                    e.getMessage());
         }
     }
 
@@ -603,18 +575,12 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
         HttpMessage msg = getNewMsg();
         setParameter(msg, param, newValue);
 
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "Checking ["
-                            + msg.getRequestHeader().getMethod()
-                            + "] ["
-                            + msg.getRequestHeader().getURI()
-                            + "], parameter ["
-                            + param
-                            + "] for Windows Path Traversal (local file) with value ["
-                            + newValue
-                            + "]");
-        }
+        log.debug(
+                "Checking [{}] [{}], parameter [{}] for Windows Path Traversal (local file) with value [{}]",
+                msg.getRequestHeader().getMethod(),
+                msg.getRequestHeader().getURI(),
+                param,
+                newValue);
 
         // send the modified request, and see what we get back
         try {
@@ -626,15 +592,11 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                 | IllegalArgumentException
                 | InvalidRedirectLocationException
                 | URIException ex) {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Caught "
-                                + ex.getClass().getName()
-                                + " "
-                                + ex.getMessage()
-                                + " when accessing: "
-                                + msg.getRequestHeader().getURI().toString());
-            }
+            log.debug(
+                    "Caught {} {} when accessing: {}",
+                    ex.getClass().getName(),
+                    ex.getMessage(),
+                    msg.getRequestHeader().getURI().toString());
 
             return false; // Something went wrong, no point continuing
         }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
@@ -19,7 +19,8 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -31,7 +32,7 @@ public class PersistentXssPrimeScanRule extends AbstractAppParamPlugin {
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanrules.persistentxssprime.";
 
-    private static Logger log = Logger.getLogger(PersistentXssPrimeScanRule.class);
+    private static Logger log = LogManager.getLogger(PersistentXssPrimeScanRule.class);
 
     @Override
     public int getId() {
@@ -68,9 +69,7 @@ public class PersistentXssPrimeScanRule extends AbstractAppParamPlugin {
         try {
             HttpMessage msg1 = msg.cloneRequest();
             this.setParameter(msg1, param, PersistentXssUtils.getUniqueValue(msg1, param));
-            if (log.isDebugEnabled()) {
-                log.debug("Prime msg=" + msg1.getRequestHeader().getURI() + " param=" + param);
-            }
+            log.debug("Prime msg={} param={}", msg1.getRequestHeader().getURI(), param);
             sendAndReceive(msg1, false);
         } catch (Exception e) {
             log.error(e.getMessage(), e);

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
@@ -23,7 +23,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -48,7 +49,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
             Arrays.asList(NameValuePair.TYPE_QUERY_STRING, NameValuePair.TYPE_POST_DATA);
 
     private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_8");
-    private static Logger log = Logger.getLogger(PersistentXssScanRule.class);
+    private static Logger log = LogManager.getLogger(PersistentXssScanRule.class);
     private int currentParamType;
 
     @Override
@@ -239,8 +240,8 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                                 }
                                 if (!attackWorked) {
                                     log.debug(
-                                            "Failed to find vuln in script attribute on "
-                                                    + sourceMsg.getRequestHeader().getURI());
+                                            "Failed to find vuln in script attribute on {}",
+                                            sourceMsg.getRequestHeader().getURI());
                                 }
 
                             } else if (context.isInUrlAttribute()) {
@@ -273,8 +274,8 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                                 }
                                 if (!attackWorked) {
                                     log.debug(
-                                            "Failed to find vuln in url attribute on "
-                                                    + sourceMsg.getRequestHeader().getURI());
+                                            "Failed to find vuln in url attribute on {}",
+                                            sourceMsg.getRequestHeader().getURI());
                                 }
                             }
                             if (!attackWorked && context.isInTagWithSrc()) {
@@ -304,8 +305,8 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                                 }
                                 if (!attackWorked) {
                                     log.debug(
-                                            "Failed to find vuln in tag with src attribute on "
-                                                    + sourceMsg.getRequestHeader().getURI());
+                                            "Failed to find vuln in tag with src attribute on {}",
+                                            sourceMsg.getRequestHeader().getURI());
                                 }
                             }
 
@@ -338,8 +339,8 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                                 }
                                 if (!attackWorked) {
                                     log.debug(
-                                            "Failed to find vuln with simple script attack "
-                                                    + sourceMsg.getRequestHeader().getURI());
+                                            "Failed to find vuln with simple script attack {}",
+                                            sourceMsg.getRequestHeader().getURI());
                                 }
                             }
                             if (!attackWorked) {
@@ -372,8 +373,8 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                                 }
                                 if (!attackWorked) {
                                     log.debug(
-                                            "Failed to find vuln in with simple onmounseover "
-                                                    + sourceMsg.getRequestHeader().getURI());
+                                            "Failed to find vuln in with simple onmounseover {}",
+                                            sourceMsg.getRequestHeader().getURI());
                                 }
                             }
                         } else if (context.isHtmlComment()) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
@@ -19,7 +19,8 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -31,7 +32,7 @@ public class PersistentXssSpiderScanRule extends AbstractAppPlugin {
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanrules.persistentxssspider.";
 
-    private static Logger log = Logger.getLogger(PersistentXssSpiderScanRule.class);
+    private static Logger log = LogManager.getLogger(PersistentXssSpiderScanRule.class);
 
     @Override
     public int getId() {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssUtils.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssUtils.java
@@ -25,7 +25,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.collections.map.ReferenceMap;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
@@ -64,7 +65,7 @@ public class PersistentXssUtils {
      */
     private static Map<String, String> cachedParams;
 
-    private static Logger log = Logger.getLogger(PersistentXssUtils.class);
+    private static Logger log = LogManager.getLogger(PersistentXssUtils.class);
 
     static {
         reset();
@@ -99,15 +100,12 @@ public class PersistentXssUtils {
     }
 
     private static void setSinkForSource(UserDataSource source, HttpMessage sinkMsg) {
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "setSinkForSource src="
-                            + source.getUri()
-                            + " param="
-                            + source.getParam()
-                            + " sink="
-                            + sinkMsg.getRequestHeader().getURI());
-        }
+        log.debug(
+                "setSinkForSource src={} param={} sink={}",
+                source.getUri(),
+                source.getParam(),
+                sinkMsg.getRequestHeader().getURI());
+
         HashSet<Integer> sinks = sourceToSinks.get(source.toString());
         if (sinks == null) {
             sinks = new HashSet<>();
@@ -136,15 +134,12 @@ public class PersistentXssUtils {
      */
     public static Set<Integer> getSinksIdsForSource(HttpMessage sourceMsg, String param) {
         UserDataSource source = new UserDataSource(sourceMsg, param);
-        if (log.isDebugEnabled()) {
-            log.debug(
-                    "getSinksIdsForSource src="
-                            + source.getUri()
-                            + " param="
-                            + param
-                            + " sinks="
-                            + sourceToSinks.get(source.toString()));
-        }
+        log.debug(
+                "getSinksIdsForSource src={} param={} sinks={}",
+                source.getUri(),
+                param,
+                sourceToSinks.get(source.toString()));
+
         return sourceToSinks.get(source.toString());
     }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
@@ -24,7 +24,8 @@ import static org.zaproxy.zap.extension.ascanrules.utils.Constants.NULL_BYTE_CHA
 import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -87,7 +88,7 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
     /** details of the vulnerability which we are attempting to find */
     private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_5");
     /** the logger object */
-    private static Logger log = Logger.getLogger(RemoteFileIncludeScanRule.class);
+    private static Logger log = LogManager.getLogger(RemoteFileIncludeScanRule.class);
 
     @Override
     public int getId() {
@@ -146,9 +147,8 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
             // DEBUG only
             // this.setAttackStrength(AttackStrength.INSANE);
 
-            if (log.isDebugEnabled()) {
-                log.debug("Attacking at Attack Strength: " + this.getAttackStrength());
-            }
+            log.debug("Attacking at Attack Strength: {}", this.getAttackStrength());
+
             String origResponse =
                     msg.getResponseHeader().toString() + msg.getResponseBody().toString();
 
@@ -178,16 +178,11 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
             Matcher matcher;
             Matcher origMatcher;
 
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Checking ["
-                                + getBaseMsg().getRequestHeader().getMethod()
-                                + "] ["
-                                + getBaseMsg().getRequestHeader().getURI()
-                                + "], parameter ["
-                                + param
-                                + "] for Path Traversal to remote files");
-            }
+            log.debug(
+                    "Checking [{}] [{}], parameter [{}] for Path Traversal to remote files",
+                    getBaseMsg().getRequestHeader().getMethod(),
+                    getBaseMsg().getRequestHeader().getURI(),
+                    param);
 
             // for each prefix in turn
             for (int h = 0; h < prefixCountRFI; h++) {
@@ -206,14 +201,11 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
                     try {
                         sendAndReceive(msg);
                     } catch (IllegalStateException | UnknownHostException ex) {
-                        if (log.isDebugEnabled())
-                            log.debug(
-                                    "Caught "
-                                            + ex.getClass().getName()
-                                            + " "
-                                            + ex.getMessage()
-                                            + " when accessing: "
-                                            + msg.getRequestHeader().getURI().toString());
+                        log.debug(
+                                "Caught {} {} when accessing: {}",
+                                ex.getClass().getName(),
+                                ex.getMessage(),
+                                msg.getRequestHeader().getURI().toString());
                         continue; // Something went wrong, continue to the next target in the loop
                     }
 
@@ -228,8 +220,8 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
                         if (origMatcher.find() && origMatcher.group().equals(matcher.group())) {
                             // Its the same as before
                             log.debug(
-                                    "Not reporting alert - same title as original: "
-                                            + matcher.group());
+                                    "Not reporting alert - same title as original: {}",
+                                    matcher.group());
                         } else {
                             newAlert()
                                     .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -255,17 +247,12 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
             }
 
         } catch (Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "Error checking ["
-                                + getBaseMsg().getRequestHeader().getMethod()
-                                + "] ["
-                                + getBaseMsg().getRequestHeader().getURI()
-                                + "], parameter ["
-                                + param
-                                + "] for Remote File Include. "
-                                + e.getMessage());
-            }
+            log.debug(
+                    "Error checking [{}] [{}], parameter [{}] for Remote File Include. {}",
+                    getBaseMsg().getRequestHeader().getMethod(),
+                    getBaseMsg().getRequestHeader().getURI(),
+                    param,
+                    e.getMessage());
         }
     }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
@@ -31,7 +31,8 @@ package org.zaproxy.zap.extension.ascanrules;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -42,7 +43,7 @@ import org.zaproxy.zap.model.TechSet;
 
 public class ServerSideIncludeScanRule extends AbstractAppParamPlugin {
 
-    private static final Logger LOGGER = Logger.getLogger(ServerSideIncludeScanRule.class);
+    private static final Logger LOGGER = LogManager.getLogger(ServerSideIncludeScanRule.class);
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanrules.serversideinclude.";
@@ -161,17 +162,15 @@ public class ServerSideIncludeScanRule extends AbstractAppParamPlugin {
                 return true;
             }
         } catch (IOException e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
-                        "IO exception while sending a message [URI="
-                                + getBaseMsg().getRequestHeader().getURI()
-                                + ", parameter="
-                                + parameter
-                                + ", value="
-                                + value
-                                + "]:",
-                        e);
-            }
+            LOGGER.debug(
+                    "IO exception while sending a message [URI={}"
+                            + ", parameter={}"
+                            + ", value={}"
+                            + "]:",
+                    getBaseMsg().getRequestHeader().getURI(),
+                    parameter,
+                    value,
+                    e);
         }
         return false;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -33,7 +33,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.SystemUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -83,7 +84,8 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
      */
     private static final Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_34");
 
-    private static final Logger log = Logger.getLogger(SourceCodeDisclosureWebInfScanRule.class);
+    private static final Logger log =
+            LogManager.getLogger(SourceCodeDisclosureWebInfScanRule.class);
 
     @Override
     public int getId() {
@@ -185,7 +187,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
             while (javaClassesFound.size() > 0) {
                 String classname = javaClassesFound.get(0);
                 URI classURI = getClassURI(originalURI, classname);
-                if (log.isDebugEnabled()) log.debug("Looking for Class file: " + classURI.getURI());
+                log.debug("Looking for Class file: {}", classURI.getURI());
 
                 HttpMessage classfilemsg = new HttpMessage(classURI);
                 sendAndReceive(classfilemsg, false); // do not follow redirects
@@ -220,9 +222,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
                             continue;
                         }
 
-                        if (log.isDebugEnabled()) {
-                            log.debug("Source Code Disclosure alert for: " + classname);
-                        }
+                        log.debug("Source Code Disclosure alert for: {}", classname);
 
                         newAlert()
                                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -259,8 +259,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
                         Matcher propsFileMatcher = PROPERTIES_FILE_PATTERN.matcher(javaSourceCode);
                         while (propsFileMatcher.find()) {
                             String propsFilename = propsFileMatcher.group(1);
-                            if (log.isDebugEnabled())
-                                log.debug("Found props file: " + propsFilename);
+                            log.debug("Found props file: {}", propsFilename);
 
                             URI propsFileURI = getPropsFileURI(originalURI, propsFilename);
                             HttpMessage propsfilemsg = new HttpMessage(propsFileURI);
@@ -301,8 +300,8 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
             }
         } catch (Exception e) {
             log.error(
-                    "Error scanning a Host for Source Code Disclosure via the WEB-INF folder: "
-                            + e.getMessage(),
+                    "Error scanning a Host for Source Code Disclosure via the WEB-INF folder: {}",
+                    e.getMessage(),
                     e);
         }
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -35,7 +35,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
@@ -444,7 +445,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
     };
 
     /** for logging. */
-    private static Logger log = Logger.getLogger(SqlInjectionScanRule.class);
+    private static Logger log = LogManager.getLogger(SqlInjectionScanRule.class);
     /** determines if we should output Debug level logging */
     private boolean debugEnabled = log.isDebugEnabled();
 
@@ -497,9 +498,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
      */
     @Override
     public void init() {
-        if (this.debugEnabled) {
-            log.debug("Initialising");
-        }
+        log.debug("Initialising");
 
         // DEBUG only
         // this.debugEnabled=true;
@@ -576,10 +575,8 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
             doSpecificErrorBased = true;
             doGenericErrorBased = false;
         } else if (this.getAlertThreshold() == AlertThreshold.HIGH) {
-            if (this.debugEnabled) {
-                log.debug(
-                        "Disabling the Error Based checking, since the Alert Threshold is set to High or Medium, and this type of check is notably prone to false positives");
-            }
+            log.debug(
+                    "Disabling the Error Based checking, since the Alert Threshold is set to High or Medium, and this type of check is notably prone to false positives");
             doSpecificErrorBased = false;
             doGenericErrorBased = false;
             doErrorMaxRequests = 0;
@@ -588,19 +585,17 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
         // Only check for generic errors if not targeting a specific DB
         doGenericErrorBased &= getTechSet().includes(Tech.Db);
 
-        if (this.debugEnabled) {
-            log.debug("Doing RDBMS specific error based? " + doSpecificErrorBased);
-            log.debug("Doing generic RDBMS error based? " + doGenericErrorBased);
-            log.debug("Using a max of " + doErrorMaxRequests + " requests");
-            log.debug("Doing expession based? " + doExpressionBased);
-            log.debug("Using a max of " + doExpressionMaxRequests + " requests");
-            log.debug("Using boolean based? " + doBooleanBased);
-            log.debug("Using a max of " + doBooleanMaxRequests + " requests");
-            log.debug("Doing UNION based? " + doUnionBased);
-            log.debug("Using a max of " + doUnionMaxRequests + " requests");
-            log.debug("Doing ORDER BY based? " + doOrderByBased);
-            log.debug("Using a max of " + doOrderByMaxRequests + " requests");
-        }
+        log.debug("Doing RDBMS specific error based? {}", doSpecificErrorBased);
+        log.debug("Doing generic RDBMS error based? {}", doGenericErrorBased);
+        log.debug("Using a max of {} requests", doErrorMaxRequests);
+        log.debug("Doing expession based? {}", doExpressionBased);
+        log.debug("Using a max of {} requests", doExpressionMaxRequests);
+        log.debug("Using boolean based? {}", doBooleanBased);
+        log.debug("Using a max of {} requests", doBooleanMaxRequests);
+        log.debug("Doing UNION based? {}", doUnionBased);
+        log.debug("Using a max of {} requests", doUnionMaxRequests);
+        log.debug("Doing ORDER BY based? {}", doOrderByBased);
+        log.debug("Using a max of {} requests", doOrderByMaxRequests);
     }
 
     /** scans for SQL Injection vulnerabilities */
@@ -664,14 +659,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     try {
                         sendAndReceive(msg1, false); // do not follow redirects
                     } catch (SocketException ex) {
-                        if (log.isDebugEnabled())
-                            log.debug(
-                                    "Caught "
-                                            + ex.getClass().getName()
-                                            + " "
-                                            + ex.getMessage()
-                                            + " when accessing: "
-                                            + msg1.getRequestHeader().getURI().toString());
+                        log.debug(
+                                "Caught {} {} when accessing: {}",
+                                ex.getClass().getName(),
+                                ex.getMessage(),
+                                msg1.getRequestHeader().getURI().toString());
                         continue; // Something went wrong, continue to the next prefixString in the
                         // loop
                     }
@@ -772,14 +764,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(refreshedmessage, false); // do not follow redirects
             } catch (SocketException ex) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + refreshedmessage.getRequestHeader().getURI().toString());
+                log.debug(
+                        "Caught {} {} when accessing: {}",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        refreshedmessage.getRequestHeader().getURI().toString());
                 return; // Something went wrong, no point continuing
             }
 
@@ -799,10 +788,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     // Integer.parseInt(SqlInjectionScanRule.getURLDecode(origParamValue));
                     int paramAsInt = Integer.parseInt(origParamValue);
 
-                    if (this.debugEnabled) {
-                        log.debug(
-                                "The parameter value [" + origParamValue + "] is of type Integer");
-                    }
+                    log.debug("The parameter value [{}] is of type Integer", origParamValue);
                     // This check is implemented using two variant PLUS(+) and MULT(*)
                     try {
                         // PLUS variant check the param value "3-2" gives same result as original
@@ -855,24 +841,14 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             }
                         }
                     } catch (ArithmeticException ex) {
-                        if (this.debugEnabled) {
-                            log.debug(
-                                    "Caught "
-                                            + ex.getClass().getName()
-                                            + " "
-                                            + ex.getMessage()
-                                            + "When performing integer math with the parameter value ["
-                                            + origParamValue
-                                            + "]");
-                        }
+                        log.debug(
+                                "Caught {} {}. When performing integer math with the parameter value [{}]",
+                                ex.getClass().getName(),
+                                ex.getMessage(),
+                                origParamValue);
                     }
                 } catch (Exception e) {
-                    if (this.debugEnabled) {
-                        log.debug(
-                                "The parameter value ["
-                                        + origParamValue
-                                        + "] is NOT of type Integer");
-                    }
+                    log.debug("The parameter value [{}] is NOT of type Integer", origParamValue);
                     // TODO: implement a similar check for string types?  This probably needs to be
                     // RDBMS specific (ie, it should not live in this scanner)
                 }
@@ -920,11 +896,9 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
             //            and we will simply hope that the *last* constraint in the SQL query is
             // constructed from a HTTP parameter under our control.
 
-            if (this.debugEnabled) {
-                log.debug(
-                        "Doing Check 2, since check 1 did not match for "
-                                + getBaseMsg().getRequestHeader().getURI());
-            }
+            log.debug(
+                    "Doing Check 2, since check 1 did not match for {}",
+                    getBaseMsg().getRequestHeader().getURI());
 
             // Since the previous checks are attempting SQL injection, and may have actually
             // succeeded in modifying the database (ask me how I know?!)
@@ -936,14 +910,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(refreshedmessage, false); // do not follow redirects
             } catch (SocketException ex) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + refreshedmessage.getRequestHeader().getURI().toString());
+                log.debug(
+                        "Caught {} {} when accessing: {}",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        refreshedmessage.getRequestHeader().getURI().toString());
                 return; // Something went wrong, no point continuing
             }
 
@@ -975,14 +946,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 try {
                     sendAndReceive(msg2, false); // do not follow redirects
                 } catch (SocketException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + msg2.getRequestHeader().getURI().toString());
+                    log.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg2.getRequestHeader().getURI().toString());
                     continue; // Something went wrong, continue to the next item in the loop
                 }
                 countBooleanBasedRequests++;
@@ -1007,17 +975,13 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     if (andTrueBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
                                     normalBodyOutput[booleanStrippedUnstrippedIndex])
                             == 0) {
-                        if (this.debugEnabled) {
-                            log.debug(
-                                    "Check 2, "
-                                            + (strippedOutput[booleanStrippedUnstrippedIndex]
-                                                    ? "STRIPPED"
-                                                    : "UNSTRIPPED")
-                                            + " html output for AND TRUE condition ["
-                                            + sqlBooleanAndTrueValue
-                                            + "] matched (refreshed) original results for "
-                                            + refreshedmessage.getRequestHeader().getURI());
-                        }
+                        log.debug(
+                                "Check 2, {} html output for AND TRUE condition [{}] matched (refreshed) original results for {}",
+                                (strippedOutput[booleanStrippedUnstrippedIndex]
+                                        ? "STRIPPED"
+                                        : "UNSTRIPPED"),
+                                sqlBooleanAndTrueValue,
+                                refreshedmessage.getRequestHeader().getURI());
                         // so they match. Was it a fluke? See if we get the same result by tacking
                         // on "AND 1 = 2" to the original
                         HttpMessage msg2_and_false = getNewMsg();
@@ -1027,17 +991,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         try {
                             sendAndReceive(msg2_and_false, false); // do not follow redirects
                         } catch (SocketException ex) {
-                            if (log.isDebugEnabled())
-                                log.debug(
-                                        "Caught "
-                                                + ex.getClass().getName()
-                                                + " "
-                                                + ex.getMessage()
-                                                + " when accessing: "
-                                                + msg2_and_false
-                                                        .getRequestHeader()
-                                                        .getURI()
-                                                        .toString());
+                            log.debug(
+                                    "Caught {} {} when accessing: {}",
+                                    ex.getClass().getName(),
+                                    ex.getMessage(),
+                                    msg2_and_false.getRequestHeader().getURI().toString());
                             continue; // Something went wrong, continue on to the next item in the
                             // loop
                         }
@@ -1068,17 +1026,13 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         if (andFalseBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
                                         normalBodyOutput[booleanStrippedUnstrippedIndex])
                                 != 0) {
-                            if (this.debugEnabled) {
-                                log.debug(
-                                        "Check 2, "
-                                                + (strippedOutput[booleanStrippedUnstrippedIndex]
-                                                        ? "STRIPPED"
-                                                        : "UNSTRIPPED")
-                                                + " html output for AND FALSE condition ["
-                                                + sqlBooleanAndFalseValue
-                                                + "] differed from (refreshed) original results for "
-                                                + refreshedmessage.getRequestHeader().getURI());
-                            }
+                            log.debug(
+                                    "Check 2, {} html output for AND FALSE condition [{}] differed from (refreshed) original results for {}",
+                                    (strippedOutput[booleanStrippedUnstrippedIndex]
+                                            ? "STRIPPED"
+                                            : "UNSTRIPPED"),
+                                    sqlBooleanAndFalseValue,
+                                    refreshedmessage.getRequestHeader().getURI());
 
                             // it's different (suggesting that the "AND 1 = 2" appended on gave
                             // different results because it restricted the data set to nothing
@@ -1137,34 +1091,23 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             // condition becomes one that is effectively always true, returning ALL
                             // data (or as much as possible), allowing us to pinpoint the SQL
                             // Injection
-                            if (this.debugEnabled) {
-                                log.debug(
-                                        "Check 2 , "
-                                                + (strippedOutput[booleanStrippedUnstrippedIndex]
-                                                        ? "STRIPPED"
-                                                        : "UNSTRIPPED")
-                                                + " html output for AND FALSE condition ["
-                                                + sqlBooleanAndFalseValue
-                                                + "] SAME as (refreshed) original results for "
-                                                + refreshedmessage.getRequestHeader().getURI()
-                                                + " ### (forcing OR TRUE check) ");
-                            }
+                            log.debug(
+                                    "Check 2 , {} html output for AND FALSE condition [{}] SAME as (refreshed) original results for {} ### (forcing OR TRUE check) {}",
+                                    (strippedOutput[booleanStrippedUnstrippedIndex]
+                                            ? "STRIPPED"
+                                            : "UNSTRIPPED"),
+                                    sqlBooleanAndFalseValue,
+                                    refreshedmessage.getRequestHeader().getURI());
                             HttpMessage msg2_or_true = getNewMsg();
                             setParameter(msg2_or_true, param, orValue);
                             try {
                                 sendAndReceive(msg2_or_true, false); // do not follow redirects
                             } catch (SocketException ex) {
-                                if (log.isDebugEnabled())
-                                    log.debug(
-                                            "Caught "
-                                                    + ex.getClass().getName()
-                                                    + " "
-                                                    + ex.getMessage()
-                                                    + " when accessing: "
-                                                    + msg2_or_true
-                                                            .getRequestHeader()
-                                                            .getURI()
-                                                            .toString());
+                                log.debug(
+                                        "Caught {} {} when accessing: {}",
+                                        ex.getClass().getName(),
+                                        ex.getMessage(),
+                                        msg2_or_true.getRequestHeader().getURI().toString());
                                 continue; // Something went wrong, continue on to the next item in
                                 // the loop
                             }
@@ -1187,19 +1130,13 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                     orTrueBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
                                             normalBodyOutput[booleanStrippedUnstrippedIndex]);
                             if (compareOrToOriginal != 0) {
-
-                                if (this.debugEnabled) {
-                                    log.debug(
-                                            "Check 2, "
-                                                    + (strippedOutput[
-                                                                    booleanStrippedUnstrippedIndex]
-                                                            ? "STRIPPED"
-                                                            : "UNSTRIPPED")
-                                                    + " html output for OR TRUE condition ["
-                                                    + orValue
-                                                    + "] different to (refreshed) original results for "
-                                                    + refreshedmessage.getRequestHeader().getURI());
-                                }
+                                log.debug(
+                                        "Check 2, {} html output for OR TRUE condition [{}] different to (refreshed) original results for {}",
+                                        (strippedOutput[booleanStrippedUnstrippedIndex]
+                                                ? "STRIPPED"
+                                                : "UNSTRIPPED"),
+                                        orValue,
+                                        refreshedmessage.getRequestHeader().getURI());
 
                                 // it's different (suggesting that the "OR 1 = 1" appended on gave
                                 // different results because it broadened the data set from nothing
@@ -1256,14 +1193,12 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         // whatever reason (no sql injection, or the web page is not stable)
                         if (this.debugEnabled) {
                             log.debug(
-                                    "Check 2, "
-                                            + (strippedOutput[booleanStrippedUnstrippedIndex]
-                                                    ? "STRIPPED"
-                                                    : "UNSTRIPPED")
-                                            + " html output for AND condition ["
-                                            + sqlBooleanAndTrueValue
-                                            + "] does NOT match the (refreshed) original results for "
-                                            + refreshedmessage.getRequestHeader().getURI());
+                                    "Check 2, {} html output for AND condition [{}] does NOT match the (refreshed) original results for {}",
+                                    (strippedOutput[booleanStrippedUnstrippedIndex]
+                                            ? "STRIPPED"
+                                            : "UNSTRIPPED"),
+                                    sqlBooleanAndTrueValue,
+                                    refreshedmessage.getRequestHeader().getURI());
                             Patch<String> diffpatch =
                                     DiffUtils.diff(
                                             new LinkedList<String>(
@@ -1303,7 +1238,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                                 + delta.getRevised()
                                                 + "\n");
                             }
-                            log.debug("DIFFS: " + tempDiff);
+                            log.debug("DIFFS: {}", tempDiff);
                         }
                     }
                     // bale out if we were asked nicely
@@ -1336,14 +1271,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 try {
                     sendAndReceive(msg2, false); // do not follow redirects
                 } catch (SocketException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + msg2.getRequestHeader().getURI().toString());
+                    log.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg2.getRequestHeader().getURI().toString());
                     continue; // Something went wrong, continue on to the next item in the loop
                 }
                 countBooleanBasedRequests++;
@@ -1355,12 +1287,9 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 // TODO: change the percentage difference threshold based on the alert threshold
                 if ((resBodyORTrueUnstripped.length()
                         > (mResBodyNormalUnstripped.length() * 1.2))) {
-                    if (this.debugEnabled) {
-                        log.debug(
-                                "Check 2a, unstripped html output for OR TRUE condition ["
-                                        + sqlBooleanOrTrueValue
-                                        + "] produced sufficiently larger results than the original message");
-                    }
+                    log.debug(
+                            "Check 2a, unstripped html output for OR TRUE condition [{}] produced sufficiently larger results than the original message",
+                            sqlBooleanOrTrueValue);
                     // if we can also restrict it back to the original results by appending a " and
                     // 1=2", then "Winner Winner, Chicken Dinner".
                     HttpMessage msg2_and_false = getNewMsg();
@@ -1368,17 +1297,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     try {
                         sendAndReceive(msg2_and_false, false); // do not follow redirects
                     } catch (SocketException ex) {
-                        if (log.isDebugEnabled())
-                            log.debug(
-                                    "Caught "
-                                            + ex.getClass().getName()
-                                            + " "
-                                            + ex.getMessage()
-                                            + " when accessing: "
-                                            + msg2_and_false
-                                                    .getRequestHeader()
-                                                    .getURI()
-                                                    .toString());
+                        log.debug(
+                                "Caught {} {} when accessing: {}",
+                                ex.getClass().getName(),
+                                ex.getMessage(),
+                                msg2_and_false.getRequestHeader().getURI().toString());
                         continue; // Something went wrong, continue on to the next item in the loop
                     }
                     countBooleanBasedRequests++;
@@ -1397,16 +1320,10 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     boolean verificationUsingStripped =
                             resBodyANDFalseStripped.compareTo(mResBodyNormalStripped) == 0;
                     if (verificationUsingUnstripped || verificationUsingStripped) {
-                        if (this.debugEnabled) {
-                            log.debug(
-                                    "Check 2, "
-                                            + (verificationUsingStripped
-                                                    ? "STRIPPED"
-                                                    : "UNSTRIPPED")
-                                            + " html output for AND FALSE condition ["
-                                            + sqlBooleanAndFalseValue
-                                            + "] matches the (refreshed) original results");
-                        }
+                        log.debug(
+                                "Check 2, {} html output for AND FALSE condition [{}] matches the (refreshed) original results",
+                                (verificationUsingStripped ? "STRIPPED" : "UNSTRIPPED"),
+                                sqlBooleanAndFalseValue);
                         // Likely a SQL Injection. Raise it
                         String extraInfo = null;
                         if (verificationUsingStripped) {
@@ -1467,14 +1384,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 try {
                     sendAndReceive(msg3, false); // do not follow redirects
                 } catch (SocketException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + msg3.getRequestHeader().getURI().toString());
+                    log.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg3.getRequestHeader().getURI().toString());
                     continue; // Something went wrong, continue on to the next item in the loop
                 }
                 countUnionBasedRequests++;
@@ -1538,14 +1452,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
             try {
                 sendAndReceive(refreshedmessage, false); // do not follow redirects
             } catch (SocketException ex) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Caught "
-                                    + ex.getClass().getName()
-                                    + " "
-                                    + ex.getMessage()
-                                    + " when accessing: "
-                                    + refreshedmessage.getRequestHeader().getURI().toString());
+                log.debug(
+                        "Caught {} {} when accessing: {}",
+                        ex.getClass().getName(),
+                        ex.getMessage(),
+                        refreshedmessage.getRequestHeader().getURI().toString());
                 return; // Something went wrong, no point continuing
             }
 
@@ -1566,14 +1477,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 try {
                     sendAndReceive(msg5, false); // do not follow redirects
                 } catch (SocketException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + msg5.getRequestHeader().getURI().toString());
+                    log.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg5.getRequestHeader().getURI().toString());
                     return; // Something went wrong, no point continuing
                 }
                 countOrderByBasedRequests++;
@@ -1601,17 +1509,13 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     if (ascendingBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
                                     normalBodyOutput[booleanStrippedUnstrippedIndex])
                             == 0) {
-                        if (this.debugEnabled) {
-                            log.debug(
-                                    "Check X, "
-                                            + (strippedOutput[booleanStrippedUnstrippedIndex]
-                                                    ? "STRIPPED"
-                                                    : "UNSTRIPPED")
-                                            + " html output for modified Order By parameter ["
-                                            + modifiedParamValue
-                                            + "] matched (refreshed) original results for "
-                                            + refreshedmessage.getRequestHeader().getURI());
-                        }
+                        log.debug(
+                                "Check X, {} html output for modified Order By parameter [{}] matched (refreshed) original results for {}",
+                                (strippedOutput[booleanStrippedUnstrippedIndex]
+                                        ? "STRIPPED"
+                                        : "UNSTRIPPED"),
+                                modifiedParamValue,
+                                refreshedmessage.getRequestHeader().getURI());
                         // confirm that a different parameter value generates different output, to
                         // minimise false positives
 
@@ -1626,17 +1530,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         try {
                             sendAndReceive(msg5Confirm, false); // do not follow redirects
                         } catch (SocketException ex) {
-                            if (log.isDebugEnabled())
-                                log.debug(
-                                        "Caught "
-                                                + ex.getClass().getName()
-                                                + " "
-                                                + ex.getMessage()
-                                                + " when accessing: "
-                                                + msg5Confirm
-                                                        .getRequestHeader()
-                                                        .getURI()
-                                                        .toString());
+                            log.debug(
+                                    "Caught {} {} when accessing: {}",
+                                    ex.getClass().getName(),
+                                    ex.getMessage(),
+                                    msg5Confirm.getRequestHeader().getURI().toString());
                             continue; // Something went wrong, continue on to the next item in the
                             // loop
                         }
@@ -1894,14 +1792,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
         try {
             sendAndReceive(msg, false); // do not follow redirects
         } catch (SocketException ex) {
-            if (log.isDebugEnabled())
-                log.debug(
-                        "Caught "
-                                + ex.getClass().getName()
-                                + " "
-                                + ex.getMessage()
-                                + " when accessing: "
-                                + msg.getRequestHeader().getURI().toString());
+            log.debug(
+                    "Caught {} {} when accessing: {}",
+                    ex.getClass().getName(),
+                    ex.getMessage(),
+                    msg.getRequestHeader().getURI().toString());
             return; // Something went wrong, no point continuing
         }
         countExpressionBasedRequests++;
@@ -1917,13 +1812,10 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
             // something.
 
             if (modifiedExpressionOutputStripped.compareTo(normalBodyOutputStripped) == 0) {
-                if (this.debugEnabled) {
-                    log.debug(
-                            "Check 4, STRIPPED html output for modified expression parameter ["
-                                    + modifiedParamValue
-                                    + "] matched (refreshed) original results for "
-                                    + refreshedmessage.getRequestHeader().getURI().toString());
-                }
+                log.debug(
+                        "Check 4, STRIPPED html output for modified expression parameter [{}] matched (refreshed) original results for {}",
+                        modifiedParamValue,
+                        refreshedmessage.getRequestHeader().getURI().toString());
                 // confirm that a different parameter value generates different output, to minimise
                 // false positives
                 // this time param value will be different to original value and mismatch is
@@ -1936,14 +1828,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 try {
                     sendAndReceive(msgConfirm, false); // do not follow redirects
                 } catch (SocketException ex) {
-                    if (log.isDebugEnabled())
-                        log.debug(
-                                "Caught "
-                                        + ex.getClass().getName()
-                                        + " "
-                                        + ex.getMessage()
-                                        + " when accessing: "
-                                        + msgConfirm.getRequestHeader().getURI().toString());
+                    log.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msgConfirm.getRequestHeader().getURI().toString());
                     return; // Something went wrong
                 }
                 countExpressionBasedRequests++;


### PR DESCRIPTION
- Update build file, CHANGELOGS, and change code to use updated logging infrastructure.
- Remove use of 2.10 snapshot in build files where it is no longer necessary.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>