### PR TITLE
ImageLocationScanner: Use core 2.10

### DIFF
--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Minimum ZAP version is now 2.10.
 
 ## [2] - 2020-07-03
 ### Added

--- a/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
+++ b/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
@@ -6,7 +6,7 @@ description = "Image Location and Privacy Passive Scanner"
 zapAddOn {
     addOnName.set("Image Location and Privacy Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("Jay Ball (veggiespam) and the ZAP Dev Team")

--- a/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
+++ b/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
@@ -25,7 +25,8 @@ import net.htmlparser.jericho.Source;
 
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
@@ -49,16 +50,14 @@ import com.veggiespam.imagelocationscanner.ILS;
  * @see https://www.veggiespam.com/ils/
  */
 public class ImageLocationScanRule extends PluginPassiveScanner {
-	private PassiveScanThread parent = null;
-	private static final Logger logger = Logger.getLogger(ImageLocationScanRule.class);
+	private static final Logger logger = LogManager.getLogger(ImageLocationScanRule.class);
 	private static final String MESSAGE_PREFIX = "imagelocationscanner.";
 	public static final int PLUGIN_ID = 10103;
 	
-	
-	@Override
-	public void setParent (PassiveScanThread parent) {
-		this.parent = parent;
-	}
+    @Override
+    public void setParent(PassiveScanThread parent) {
+        // Nothing to do.
+    }
 
 	@Override
 	public void scanHttpRequestSend(HttpMessage msg, int id) {
@@ -105,7 +104,7 @@ public class ImageLocationScanRule extends PluginPassiveScanner {
         }
 
         if (logger.isDebugEnabled()) {
-		    logger.debug("\tCT: " + CT + " url: " + url + " fileName: " + fileName + " ext: " + extension);
+            logger.debug("\tCT: {} url: {} fileName: {} ext: {}", CT, url, fileName, extension);
         }
         
         // everything is already lowercase
@@ -118,26 +117,22 @@ public class ImageLocationScanRule extends PluginPassiveScanner {
 			String hasGPS = ILS.scanForLocationInImage(msg.getResponseBody().getBytes(), false);
 			
 			if (! hasGPS.isEmpty()) {
-				Alert alert = new Alert(getPluginId(), Alert.RISK_INFO, Alert.CONFIDENCE_MEDIUM, getAlertTitle());
-				alert.setDetail(
-			    		getDescription(), 
-			    		url,
-			    		"",	// Param
-			    		"", // Attack
-			    		"", // Other info
-			    		getSolution(), 
-			            getReference(), 
-                        getAlertDetailPrefix()  + "\n" + hasGPS,	// Evidence
-			            200, // CWE-200: Information Exposure
-			            13,	// WASC-13: Information Leakage
-			            msg);
-				
-		    	parent.raiseAlert(id, alert);
+			    newAlert()
+			    .setName(getAlertTitle())
+			    .setRisk(Alert.RISK_INFO)
+			    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+			    .setDescription(getDescription())
+			    .setSolution(getSolution())
+			    .setReference(getReference())
+			    .setEvidence(getAlertDetailPrefix()  + "\n" + hasGPS)
+			    .setCweId(200) // CWE-200: Information Exposure
+			    .setWascId(13) // WASC-13: Information Leakage
+			    .raise();
 			}
 			
 		}
 		if (logger.isDebugEnabled()) {
-			logger.debug("\tScan of record " + id + " took " + (System.currentTimeMillis() - start) + " ms");
+		    logger.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
 		}
 	}
 

--- a/addOns/imagelocationscanner/src/test/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRuleUnitTest.java
+++ b/addOns/imagelocationscanner/src/test/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRuleUnitTest.java
@@ -56,7 +56,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
 
         // When
         msg = createHttpMessageFromFilename(fname);
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
 
         // Then
         assertEquals(alertsRaised.size(), 1);
@@ -74,7 +74,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
 
         // When
         msg = createHttpMessageFromFilename(fname);
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
 
         // Then
         assertEquals(alertsRaised.size(), 0);
@@ -85,7 +85,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
 
         // When
         msg = createHttpMessageFromFilename(fname);
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
 
         // Then
         assertEquals(alertsRaised.size(), 0);
@@ -101,7 +101,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
 
         // When
         msg = createHttpMessageFromFilename(fname);
-        rule.scanHttpResponseReceive(msg, -1, createSource(msg));
+        scanHttpResponseReceive(msg);
 
         // Then
         assertEquals(alertsRaised.size(), 1);


### PR DESCRIPTION
- Update build file, and CHANGELOG.
- ImageLocationScanRule > Upgrade to more recent Alert and parent handling, and leverage newer logging infrastructure.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>