### PR TITLE
testutils: Upgrade test libraries to address UnitTest failures

### DIFF
--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -10,7 +10,7 @@ java {
 }
 
 val nanohttpdVersion = "2.3.1"
-val jupiterVersion = "5.6.0"
+val jupiterVersion = "5.7.0"
 
 dependencies {
     compileOnly("org.zaproxy:zap:2.9.0")
@@ -19,7 +19,7 @@ dependencies {
     api("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
     api("org.junit.jupiter:junit-jupiter-params:$jupiterVersion")
     runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
-    api("org.mockito:mockito-junit-jupiter:3.1.0")
+    api("org.mockito:mockito-junit-jupiter:3.6.28")
 
     api("org.nanohttpd:nanohttpd-webserver:$nanohttpdVersion")
     api("org.nanohttpd:nanohttpd-websocket:$nanohttpdVersion")


### PR DESCRIPTION
Addresses UnitTest failures with Eclipse 2020-12.

Upgrade testutils to use jupiterVersion 5.7.0, and org.mockito:mockito-junit-jupiter 3.6.28. (JUnit 5.7.0 to address a 0local test failure issue in Eclipse 2020-12, and mockito just as a dependency maintenance activity.)

```console
java.lang.NoClassDefFoundError:
org/junit/platform/commons/util/ClassNamePatternFilterUtils
	at org.junit.platform.launcher.core.LauncherFactory.loadAndFilterTestExecutionListeners(LauncherFactory.java:122)
	at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:108)
	at org.junit.platform.launcher.core.LauncherFactory.create(LauncherFactory.java:75)
	at org.eclipse.jdt.internal.junit5.runner.JUnit5TestLoader.<init>(JUnit5TestLoader.java:34)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native
Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at java.base/java.lang.Class.newInstance(Class.java:584)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.createRawTestLoader(RemoteTestRunner.java:371)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.createLoader(RemoteTestRunner.java:366)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.defaultInit(RemoteTestRunner.java:310)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.init(RemoteTestRunner.java:225)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)
Caused by: java.lang.ClassNotFoundException:
org.junit.platform.commons.util.ClassNamePatternFilterUtils
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 14 more
```

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>