### PR TITLE
Wappalyzer: Use Log4j 2.x

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -6,8 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
-
-
+- Now using 2.10 logging infrastructure (Log4j 2.x).
 
 ## [21.0.0] - 2020-12-15
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/ExtensionWappalyzer.java
@@ -33,7 +33,8 @@ import javax.swing.ImageIcon;
 import javax.swing.tree.TreeNode;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
@@ -73,7 +74,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
     private boolean enabled;
     private WappalyzerParam wappalyzerParam;
 
-    private static final Logger logger = Logger.getLogger(ExtensionWappalyzer.class);
+    private static final Logger logger = LogManager.getLogger(ExtensionWappalyzer.class);
 
     /** The dependencies of the extension. */
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
@@ -263,9 +264,7 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
         try {
             return lead + uri.getAuthority();
         } catch (URIException e) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Unable to get authority from: " + uri.toString(), e);
-            }
+            logger.debug("Unable to get authority from: {}", uri.toString(), e);
             // Shouldn't happen, but sure fallback
             return ScanPanel.cleanSiteName(uri.toString(), true);
         }
@@ -276,10 +275,8 @@ public class ExtensionWappalyzer extends ExtensionAdaptor
             site = normalizeSite(new URI(site == null ? "" : site, false));
         } catch (URIException ue) {
             // Shouldn't happen, but sure fallback
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "Falling back to 'CleanSiteName'. Failed to create URI from: " + site, ue);
-            }
+            logger.debug(
+                    "Falling back to 'CleanSiteName'. Failed to create URI from: {}", site, ue);
             site = ScanPanel.cleanSiteName(site, true);
         }
         return site;

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -45,7 +45,8 @@ import org.apache.batik.bridge.UserAgentAdapter;
 import org.apache.batik.ext.awt.RenderingHintsKeyExt;
 import org.apache.batik.gvt.GraphicsNode;
 import org.apache.batik.util.XMLResourceDescriptor;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.svg.SVGDocument;
 
 public class WappalyzerJsonParser {
@@ -54,13 +55,13 @@ public class WappalyzerJsonParser {
     private static final String FIELD_VERSION = "version:";
     private static final int SIZE = 16;
 
-    private static final Logger logger = Logger.getLogger(WappalyzerJsonParser.class);
+    private static final Logger logger = LogManager.getLogger(WappalyzerJsonParser.class);
     private final PatternErrorHandler patternErrorHandler;
     private final ParsingExceptionHandler parsingExceptionHandler;
 
     public WappalyzerJsonParser() {
         this(
-                (pattern, e) -> logger.error("Invalid pattern syntax " + pattern, e),
+                (pattern, e) -> logger.error("Invalid pattern syntax {}", pattern, e),
                 e -> logger.error(e.getMessage(), e));
     }
 
@@ -77,7 +78,7 @@ public class WappalyzerJsonParser {
         try {
             return parseJson(getStringResource(path));
         } catch (IOException e) {
-            logger.warn("An error occurred reading the file: " + path);
+            logger.warn("An error occurred reading the file: {}", path);
         }
         return null;
     }
@@ -211,7 +212,7 @@ public class WappalyzerJsonParser {
         try {
             svgIcon = builder.build(new BridgeContext(userAgent, loader), doc);
         } catch (BridgeException | StringIndexOutOfBoundsException ex) {
-            logger.debug("Failed to parse SVG. " + ex.getMessage());
+            logger.debug("Failed to parse SVG. {}", ex.getMessage());
             return null;
         }
 
@@ -244,7 +245,7 @@ public class WappalyzerJsonParser {
                 if (category != null) {
                     list.add(category);
                 } else {
-                    logger.error("Failed to find category for " + obj.toString());
+                    logger.error("Failed to find category for {}", obj.toString());
                 }
             }
         }
@@ -265,17 +266,16 @@ public class WappalyzerJsonParser {
                     list.add(map);
                 } catch (NumberFormatException e) {
                     logger.error(
-                            "Invalid field syntax " + entry.getKey() + " : " + entry.getValue(), e);
+                            "Invalid field syntax {} : {}", entry.getKey(), entry.getValue(), e);
                 } catch (PatternSyntaxException e) {
                     patternErrorHandler.handleError(entry.getValue(), e);
                 }
             }
         } else if (json != null) {
             logger.error(
-                    "Unexpected header type for "
-                            + json.toString()
-                            + " "
-                            + json.getClass().getCanonicalName());
+                    "Unexpected header type for {} {}",
+                    json.toString(),
+                    json.getClass().getCanonicalName());
         }
         return list;
     }
@@ -323,17 +323,17 @@ public class WappalyzerJsonParser {
                 } else if (values[i].startsWith(FIELD_VERSION)) {
                     ap.setVersion(values[i].substring(FIELD_VERSION.length()));
                 } else {
-                    logger.error("Unexpected field: " + values[i]);
+                    logger.error("Unexpected field: {}", values[i]);
                 }
             } catch (Exception e) {
-                logger.error("Invalid field syntax " + values[i], e);
+                logger.error("Invalid field syntax {}", values[i], e);
             }
         }
         if (pattern.indexOf(FIELD_CONFIDENCE) > 0) {
-            logger.warn("Confidence field in pattern?: " + pattern);
+            logger.warn("Confidence field in pattern?: {}", pattern);
         }
         if (pattern.indexOf(FIELD_VERSION) > 0) {
-            logger.warn("Version field in pattern?: " + pattern);
+            logger.warn("Version field in pattern?: {}", pattern);
         }
         ap.setPattern(pattern);
         return ap;

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -26,7 +26,8 @@ import java.util.Set;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
@@ -37,7 +38,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 public class WappalyzerPassiveScanner implements PassiveScanner {
 
-    private static final Logger LOGGER = Logger.getLogger(WappalyzerPassiveScanner.class);
+    private static final Logger LOGGER = LogManager.getLogger(WappalyzerPassiveScanner.class);
     private WappalyzerApplicationHolder applicationHolder;
     private Set<String> visitedSiteIdentifiers = new HashSet<>();
     private ApplicationMatch appMatch;
@@ -73,18 +74,14 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
             checkAppMatches(msg, source);
             if (appMatch != null) {
                 String site = ExtensionWappalyzer.normalizeSite(msg.getRequestHeader().getURI());
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Adding " + app.getName() + " to " + site);
-                }
+                LOGGER.debug("Adding {} to {}", app.getName(), site);
                 addApplicationsToSite(site, appMatch);
                 this.appMatch = null;
             }
             this.currentApp = null;
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Analyse took " + (System.currentTimeMillis() - startTime) + "ms");
-        }
+        LOGGER.debug("Analysis took {} ms", System.currentTimeMillis() - startTime);
     }
 
     private String getSiteIdentifier(HttpMessage msg) {
@@ -198,10 +195,8 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
             // TODO may need to account for the wappalyzer spec in dealing with version info:
             // https://www.wappalyzer.com/docs/specification
             results.forEach(appMatch::addVersion);
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(
-                        appPattern.getType() + " matched " + appMatch.getApplication().getName());
-            }
+            LOGGER.debug(
+                    "{} matched {}", appPattern.getType(), appMatch.getApplication().getName());
         }
     }
 

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -10,7 +10,6 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
-        notBeforeVersion.set("2.10.0")
         url.set("https://www.zaproxy.org/docs/desktop/addons/technology-detection/")
     }
 
@@ -20,15 +19,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
-
     implementation("com.google.re2j:re2j:1.5")
 
     val batikVersion = "1.13"


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.
- Remove use of 2.10 snapshot in build file.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>