### PR TITLE
pscanrulesBeta: Use Log4j 2.x

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now using 2.10 logging infrastructure (Log4j 2.x).
 
 ## [24] - 2020-12-15
 ### Changed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
@@ -19,9 +19,9 @@
  */
 package org.zaproxy.zap.extension.pscanrulesBeta;
 
-import java.text.MessageFormat;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -40,7 +40,7 @@ public class BigRedirectsScanRule extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX = "pscanbeta.bigredirects.";
     private static final int PLUGIN_ID = 10044;
 
-    private static final Logger logger = Logger.getLogger(BigRedirectsScanRule.class);
+    private static final Logger logger = LogManager.getLogger(BigRedirectsScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -67,9 +67,8 @@ public class BigRedirectsScanRule extends PluginPassiveScanner {
                 responseLocationHeaderURILength = locationHeaderValue.length();
             } else { // No location header found
                 logger.debug(
-                        MessageFormat.format(
-                                "Though the response had a redirect status code it did not have a Location header.\nRequested URL: {0}",
-                                msg.getRequestHeader().getURI().toString()));
+                        "Though the response had a redirect status code it did not have a Location header.\nRequested URL: {}",
+                        msg.getRequestHeader().getURI().toString());
             }
 
             if (responseLocationHeaderURILength > 0) {
@@ -98,14 +97,7 @@ public class BigRedirectsScanRule extends PluginPassiveScanner {
                 }
             }
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        logger.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
     }
 
     /**
@@ -117,10 +109,8 @@ public class BigRedirectsScanRule extends PluginPassiveScanner {
      */
     private int getPredictedResponseSize(int redirectURILength) {
         int predictedResponseSize = redirectURILength + 300;
-        if (logger.isDebugEnabled()) {
-            logger.debug("Original Response Location Header URI Length: " + redirectURILength);
-            logger.debug("Predicted Response Size: " + predictedResponseSize);
-        }
+        logger.debug("Original Response Location Header URI Length: {}", redirectURILength);
+        logger.debug("Predicted Response Size: {}", predictedResponseSize);
         return predictedResponseSize;
     }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import java.util.List;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -42,7 +43,7 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
     private static final int PLUGIN_ID = 10038;
 
     private static final Logger logger =
-            Logger.getLogger(ContentSecurityPolicyMissingScanRule.class);
+            LogManager.getLogger(ContentSecurityPolicyMissingScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -141,14 +142,7 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
                     .raise();
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        logger.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
     }
 
     @Override

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
@@ -25,7 +25,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -150,7 +151,7 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
         // being retrieved from a database??? => Dangerous.
     }
 
-    private static Logger log = Logger.getLogger(HashDisclosureScanRule.class);
+    private static Logger log = LogManager.getLogger(HashDisclosureScanRule.class);
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanbeta.hashdisclosure.";
@@ -169,7 +170,7 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
     @Override
     public void scanHttpRequestSend(HttpMessage msg, int id) {
 
-        if (log.isDebugEnabled()) log.debug("Checking request of message " + msg + " for Hashes");
+        log.debug("Checking request of message {} for Hashes", msg);
 
         // get the request contents as an array of Strings, so we can match against them
         String requestheader = msg.getRequestHeader().getHeadersAsString();
@@ -189,7 +190,7 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
-        if (log.isDebugEnabled()) log.debug("Checking response of message " + msg + " for Hashes");
+        log.debug("Checking response of message {} for Hashes", msg);
 
         // get the response contents as an array of Strings, so we can match against them
         String responseheader = msg.getResponseHeader().getHeadersAsString();
@@ -228,14 +229,12 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
                 continue;
             }
             hashType = hashalert.getDescription();
-            if (log.isDebugEnabled())
-                log.debug("Trying Hash Pattern: " + hashPattern + " for hash type " + hashType);
+            log.debug("Trying Hash Pattern: {} for hash type {}", hashPattern, hashType);
             for (String haystack : haystacks) {
                 Matcher matcher = hashPattern.matcher(haystack);
                 while (matcher.find()) {
                     String evidence = matcher.group();
-                    if (log.isDebugEnabled())
-                        log.debug("Found a match for hash type " + hashType + ":" + evidence);
+                    log.debug("Found a match for hash type {} : {}", hashType, evidence);
                     if (evidence != null && evidence.length() > 0) {
                         // we found something
                         newAlert()

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
@@ -26,7 +26,8 @@ import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
@@ -54,7 +55,7 @@ public class LinkTargetScanRule extends PluginPassiveScanner {
 
     private Model model = null;
 
-    private static final Logger LOG = Logger.getLogger(PluginPassiveScanner.class);
+    private static final Logger LOG = LogManager.getLogger(PluginPassiveScanner.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -119,7 +120,7 @@ public class LinkTargetScanRule extends PluginPassiveScanner {
                         return false;
                     }
                 } catch (Exception e) {
-                    LOG.warn("Invalid regex in rule " + TRUSTED_DOMAINS_PROPERTY + ": " + regex, e);
+                    LOG.warn("Invalid regex in rule {} : {}", TRUSTED_DOMAINS_PROPERTY, regex, e);
                 }
             }
         }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import java.util.List;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -38,7 +39,7 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX = "pscanbeta.retrievedfromcache.";
     private static final int PLUGIN_ID = 10050;
 
-    private static final Logger logger = Logger.getLogger(RetrievedFromCacheScanRule.class);
+    private static final Logger logger = LogManager.getLogger(RetrievedFromCacheScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -54,11 +55,9 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         try {
-            if (logger.isDebugEnabled())
-                logger.debug(
-                        "Checking URL "
-                                + msg.getRequestHeader().getURI().getURI()
-                                + " to see if was served from a shared cache");
+            logger.debug(
+                    "Checking URL {} to see if was served from a shared cache",
+                    msg.getRequestHeader().getURI().getURI());
 
             // X-Cache: HIT
             // X-Cache: HIT from cache.kolich.local					<-- was the data actually served from the
@@ -91,10 +90,9 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
                             if (hitormiss.equals("HIT")) {
                                 // the response was served from cache, so raise it..
                                 String evidence = proxyServerDetails;
-                                if (logger.isDebugEnabled())
-                                    logger.debug(
-                                            msg.getRequestHeader().getURI().getURI()
-                                                    + " was served from a cache, due to presence of a 'HIT' in the 'X-Cache' response header");
+                                logger.debug(
+                                        "{} was served from a cache, due to presence of a 'HIT' in the 'X-Cache' response header",
+                                        msg.getRequestHeader().getURI().getURI());
                                 // could be from HTTP/1.0 or HTTP/1.1. We don't know which.
                                 newAlert()
                                         .setRisk(Alert.RISK_INFO)
@@ -131,10 +129,9 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
                     Long ageAsLong = Long.parseLong(ageHeader);
                     if (ageAsLong != null && ageAsLong >= 0) {
                         String evidence = "Age: " + ageHeader;
-                        if (logger.isDebugEnabled())
-                            logger.debug(
-                                    msg.getRequestHeader().getURI().getURI()
-                                            + " was served from a HTTP/1.1 cache, due to presence of a valid (non-negative decimal integer) 'Age' response header value");
+                        logger.debug(
+                                "{} was served from a HTTP/1.1 cache, due to presence of a valid (non-negative decimal integer) 'Age' response header value",
+                                msg.getRequestHeader().getURI().getURI());
                         newAlert()
                                 .setRisk(Alert.RISK_INFO)
                                 .setConfidence(Alert.CONFIDENCE_MEDIUM)

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 import java.util.List;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
@@ -40,7 +41,7 @@ public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner {
 
     private static final int PLUGIN_ID = 10036;
 
-    private static final Logger logger = Logger.getLogger(ServerHeaderInfoLeakScanRule.class);
+    private static final Logger logger = LogManager.getLogger(ServerHeaderInfoLeakScanRule.class);
 
     private static final Pattern VERSION_PATTERN = Pattern.compile(".*\\d.*");
 
@@ -93,14 +94,7 @@ public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner {
                 }
             }
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        logger.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
     }
 
     @Override

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
@@ -24,7 +24,8 @@ import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -44,7 +45,8 @@ public class ServletParameterPollutionScanRule extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX = "pscanbeta.servletparameterpollution.";
     private static final int PLUGIN_ID = 10026;
 
-    private static final Logger logger = Logger.getLogger(ServletParameterPollutionScanRule.class);
+    private static final Logger logger =
+            LogManager.getLogger(ServletParameterPollutionScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -72,7 +74,7 @@ public class ServletParameterPollutionScanRule extends PluginPassiveScanner {
 
         if (formElements != null && formElements.size() > 0) {
             // Loop through all of the FORM tags
-            logger.debug("Found " + formElements.size() + " forms");
+            logger.debug("Found {} forms", formElements.size());
 
             // check for 'target' param
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
@@ -26,7 +26,8 @@ import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -78,7 +79,8 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner {
         HSTS_MALFORMED_CONTENT
     }
 
-    private static final Logger logger = Logger.getLogger(StrictTransportSecurityScanRule.class);
+    private static final Logger logger =
+            LogManager.getLogger(StrictTransportSecurityScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -169,14 +171,7 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner {
             raiseAlert(VulnType.HSTS_META, metaHSTS, msg, id);
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        logger.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
     }
 
     @Override

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
@@ -25,7 +25,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HtmlParameter;
@@ -41,7 +42,8 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  */
 public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner {
 
-    private static final Logger LOGGER = Logger.getLogger(UserControlledOpenRedirectScanRule.class);
+    private static final Logger LOGGER =
+            LogManager.getLogger(UserControlledOpenRedirectScanRule.class);
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanbeta.usercontrolledopenredirect.";
@@ -86,9 +88,8 @@ public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner {
             requestDomain = msg.getRequestHeader().getURI().getAuthority();
         } catch (URIException ex) {
             LOGGER.warn(
-                    "Unable to get authority from URI :"
-                            + msg.getRequestHeader().getURI()
-                            + ". Ignoring and moving ahead with the scanning OpenRedirect",
+                    "Unable to get authority from URI : {}. Ignoring and moving ahead with the scanning OpenRedirect",
+                    msg.getRequestHeader().getURI().toString(),
                     ex);
         }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 
 import java.util.List;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -40,7 +41,7 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner 
     private static final int PLUGIN_ID = 10039;
 
     private static final Logger logger =
-            Logger.getLogger(XBackendServerInformationLeakScanRule.class);
+            LogManager.getLogger(XBackendServerInformationLeakScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -73,14 +74,7 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner 
                         .raise();
             }
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        logger.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
     }
 
     @Override

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
@@ -24,7 +24,8 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -41,7 +42,8 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX = "pscanbeta.xchromeloggerdata.";
     private static final int PLUGIN_ID = 10052;
 
-    private static final Logger logger = Logger.getLogger(XChromeLoggerDataInfoLeakScanRule.class);
+    private static final Logger logger =
+            LogManager.getLogger(XChromeLoggerDataInfoLeakScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -86,14 +88,7 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner {
                         .raise();
             }
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        logger.debug("\tScan of record {} took {}ms", id, System.currentTimeMillis() - start);
     }
 
     @Override


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.
- Remove use of 2.10 snapshot in build file.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>