### PR TITLE
Compile add-ons with main ZAP release

### DIFF
--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -11,7 +11,6 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/active-scan-rules/")
-        notBeforeVersion.set("2.10.0")
 
         dependencies {
             addOns {
@@ -21,15 +20,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
-
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
     implementation("org.bitbucket.mstrobel:procyon-compilertools:0.5.36")

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -2068,6 +2068,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
         if (techSet != null) {
             return techSet;
         }
-        return TechSet.AllTech;
+        return TechSet.getAllTech();
     }
 }

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -11,7 +11,6 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/active-scan-rules-beta/")
-        notBeforeVersion.set("2.10.0")
 
         dependencies {
             addOns {
@@ -36,15 +35,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
-
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.10.0.
 
 ## [0.2.0] - 2020-11-18
 ### Changed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -3,7 +3,7 @@ description = "Inspect and attack GraphQL endpoints."
 
 zapAddOn {
     addOnName.set("GraphQL Support")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
@@ -18,16 +18,8 @@ zapAddOn {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.10.0-SNAPSHOT")
-
     implementation("com.google.code.gson:gson:2.8.6")
     implementation("com.graphql-java:graphql-java:15.0")
 
     testImplementation(project(":testutils"))
-}
-
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
 }

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -11,7 +11,6 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules/")
-        notBeforeVersion.set("2.10.0")
 
         dependencies {
             addOns {
@@ -36,14 +35,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
     implementation("com.shapesecurity:salvation:2.7.2")
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -7,7 +7,6 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
-        notBeforeVersion.set("2.10.0")
         extensions {
             register("org.zaproxy.zap.extension.pscanrulesAlpha.payloader.ExtensionPayloader") {
                 classnames {
@@ -26,15 +25,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
-
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
     testImplementation(parent!!.childProjects.get("custompayloads")!!)

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -10,7 +10,6 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
-        notBeforeVersion.set("2.10.0")
         url.set("https://www.zaproxy.org/docs/desktop/addons/passive-scan-rules-beta/")
 
         dependencies {
@@ -21,15 +20,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
-
     implementation("com.google.re2j:re2j:1.5")
 
     compileOnly(parent!!.childProjects.get("commonlib")!!)

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRuleUnitTest.java
@@ -45,7 +45,7 @@ public class ServletParameterPollutionScanRuleUnitTest
     @BeforeEach
     public void before() {
         rule.setAlertThreshold(AlertThreshold.LOW);
-        when(passiveScanData.getTechSet()).thenReturn(TechSet.AllTech);
+        when(passiveScanData.getTechSet()).thenReturn(TechSet.getAllTech());
     }
 
     @Test

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -6,11 +6,11 @@ description = "Retire.js"
 zapAddOn {
     addOnName.set("Retire.js")
     addOnStatus.set(AddOnStatus.RELEASE)
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("Nikita Mundhada and the ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/retire.js/")
-        zapVersion.set("2.10.0")
         bundle {
             baseName.set("org.zaproxy.addon.retire.resources.Messages")
             prefix.set("retire")
@@ -22,15 +22,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.10.0-20201111.162919-2")
-
         implementation("com.google.code.gson:gson:2.8.6")
 
         testImplementation(project(":testutils"))

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.10.0.
 
 ## [23.2.0] - 2020-11-09
 ### Added

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -3,11 +3,7 @@ import org.zaproxy.gradle.addon.AddOnStatus
 version = "23.3.0"
 description = "Allows you to spider sites that make heavy use of JavaScript using Crawljax"
 
-repositories {
-    maven(url = uri("https://oss.sonatype.org/content/repositories/snapshots/"))
-}
-
-val minimumZapVersion = "2.9.0"
+val minimumZapVersion = "2.10.0"
 
 zapAddOn {
     addOnName.set("Ajax Spider")

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderTarget.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderTarget.java
@@ -116,7 +116,7 @@ public final class AjaxSpiderTarget {
         try {
             target.setStartNode(
                     SessionStructure.find(
-                            Model.getSingleton().getSession().getSessionId(),
+                            Model.getSingleton(),
                             new org.apache.commons.httpclient.URI(
                                     this.getStartUri().toString(), false),
                             "GET",


### PR DESCRIPTION
Use main version instead of snapshots, no longer available.
Update changelogs where needed.