### PR TITLE
webdrivers: update geckodriver, prepare releases

### DIFF
--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -38,6 +38,6 @@ dependencies {
 tasks.withType<Test>().configureEach {
     systemProperties.putAll(mapOf(
             "wdm.chromeDriverVersion" to "83.0.4103.39",
-            "wdm.geckoDriverVersion" to "0.26.0",
+            "wdm.geckoDriverVersion" to "0.29.0",
             "wdm.forceCache" to "true"))
 }

--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [24] - 2021-01-14
+### Changed
+- Update geckodriver to 0.29.0.
 
 ## [23] - 2020-11-18
 ### Changed
@@ -114,6 +115,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[24]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v24
 [23]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v23
 [22]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v22
 [21]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v21

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -10,7 +10,7 @@
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
     <li>Chrome - ChromeDriver 87.0.4280.20</li>
-    <li>Firefox - geckodriver 0.28.0</li>
+    <li>Firefox - geckodriver 0.29.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [23] - 2021-01-14
+### Changed
+- Update geckodriver to 0.29.0.
 
 ## [22] - 2020-11-18
 ### Changed
@@ -110,6 +111,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[23]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v23
 [22]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v22
 [21]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v21
 [20]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v20

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -10,7 +10,7 @@
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
     <li>Chrome - ChromeDriver 87.0.4280.20</li>
-    <li>Firefox - geckodriver 0.28.0</li>
+    <li>Firefox - geckodriver 0.29.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -4,7 +4,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 
 description = "Common configuration of the WebDriver add-ons."
 
-val geckodriverVersion = "0.28.0"
+val geckodriverVersion = "0.29.0"
 val chromeDriverVersion = "87.0.4280.20"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [24] - 2021-01-14
+### Changed
+- Update geckodriver to 0.29.0.
 
 ## [23] - 2020-11-18
 ### Changed
@@ -117,6 +118,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[24]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v24
 [23]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v23
 [22]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v22
 [21]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v21

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -10,7 +10,7 @@
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
     <li>Chrome - ChromeDriver 87.0.4280.20</li>
-    <li>Firefox - geckodriver 0.28.0</li>
+    <li>Firefox - geckodriver 0.29.0</li>
 </ul>
 
 <H2>See also</H2>


### PR DESCRIPTION
Update geckodriver to 0.29.0.
Add release dates and links to tags.
Update the geckodriver version used for domxss tests.