### PR TITLE
accessControl: Fix font color handling in non-default LaFs

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Don't set the font color for inherited entries (Issue 6397).
 
 ## [6] - 2020-10-06
 

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
@@ -287,10 +287,8 @@ public class ContextAccessControlPanel extends AbstractContextPropertiesPanel {
 
     private static final Color COLOR_DENIED = Color.RED;
     private static final Color COLOR_ALLOWED = new Color(31, 131, 31);
-    private static final Color COLOR_UNKNOWN = new Color(76, 76, 76);
     private static final Color COLOR_DENIED_FOCUS = new Color(255, 195, 195);
     private static final Color COLOR_ALLOWED_FOCUS = new Color(195, 255, 195);
-    private static final Color COLOR_UNKNOWN_FOCUS = new Color(220, 220, 220);
 
     /**
      * A custom cell renderer used for the tree of access rules that sets custom colors and icons
@@ -360,13 +358,6 @@ public class ContextAccessControlPanel extends AbstractContextPropertiesPanel {
                             }
                             break;
                         default:
-                            // Text color
-                            if (selected) {
-                                this.setForeground(COLOR_UNKNOWN_FOCUS);
-                            } else {
-                                this.setForeground(COLOR_UNKNOWN);
-                            }
-
                             // Icon
                             if (isLeaf) {
                                 setIcon(LEAF_ICON);


### PR DESCRIPTION
- CHANGELOG > Add change entry.
- ContextAccessControlPanel > Don't set font color "default" (inherited) entries.

Fixes zaproxy/zaproxy#6397

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>