### PR TITLE
pscanrules: Added Express Error Pattern

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Added Express error string pattern (Issue 6412).
 
 
 ## [32] - 2021-01-20

--- a/addOns/pscanrules/src/main/zapHomeFiles/xml/application_errors.xml
+++ b/addOns/pscanrules/src/main/zapHomeFiles/xml/application_errors.xml
@@ -94,6 +94,7 @@ Elaborated by yhawke 2013
   <Pattern type="string">mySQL error with query</Pattern>
   <Pattern type="string">on MySQL result index</Pattern>
   <Pattern type="string">server object error</Pattern>
+  <Pattern type="string">SyntaxError: Unexpected token</Pattern>
   <Pattern type="regex">(?i)Line\s\d+:\sIncorrect\ssyntax\snear\s'[^']*'</Pattern>
   <Pattern type="regex">(?i)pg_query\(\)[:]*\squery\sfailed:\serror:\s</Pattern>
   <Pattern type="regex">(?i)'[^']*'\sis\snull\sor\snot\san\sobject</Pattern>

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleBundledStringsUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleBundledStringsUnitTest.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.pscanrules;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpStatusCode;
+
+public class ApplicationErrorScanRuleBundledStringsUnitTest
+        extends PassiveScannerTest<ApplicationErrorScanRule> {
+
+    private static final String URI = "https://www.example.com/test/";
+    private static final String REQUEST_HEADER = format("GET %s HTTP/1.1", URI);
+
+    @Override
+    protected ApplicationErrorScanRule createScanner() {
+        return new ApplicationErrorScanRule();
+    }
+
+    @Test
+    public void shouldRaiseAlertForResponseCodeOkAndExpressPayloadDetected()
+            throws HttpMalformedHeaderException {
+        // Given
+        String expectedEvidence = "SyntaxError: Unexpected token";
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(REQUEST_HEADER);
+        msg.setResponseHeader(createResponseHeader(HttpStatusCode.OK));
+        given(passiveScanData.isPage500(any())).willReturn(false);
+        given(passiveScanData.isPage404(any())).willReturn(false);
+        msg.setResponseBody(
+                "<!DOCTYPE html>\n"
+                        + "<html lang=\"en\">\n"
+                        + "<head>\n"
+                        + "<meta charset=\"utf-8\">\n"
+                        + "<title>Error</title>\n"
+                        + "</head>\n"
+                        + "<body>\n"
+                        + "<pre>SyntaxError: Unexpected token <br> in JSON at position 98<br> &nbsp; \n"
+                        + "...\n"
+                        + "</pre>\n"
+                        + "</body>\n"
+                        + "</html>");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+        Alert result = alertsRaised.get(0);
+        assertThat(result.getEvidence(), equalTo(expectedEvidence));
+        validateAlert(result);
+    }
+
+    private static void validateAlert(Alert alert) {
+        assertThat(alert.getPluginId(), equalTo(90022));
+        assertThat(alert.getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(alert.getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alert.getUri(), equalTo(URI));
+    }
+
+    private static String createResponseHeader(int code) {
+        return format("HTTP/1.1 %d\r\n", code);
+    }
+}


### PR DESCRIPTION
- application_errors.xml > Added Express error string pattern.
- CHANGELOG > Added change note.
- ApplicationErrorScanRuleBundledStringsUnitTest > Add Unit Test which uses string patterns from the bundled file.

Fixes zaproxy/zaproxy#6412

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>