### PR TITLE
ascanrules: Path Traversal Check 5 and Other Info adjustments

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
+- The Path Traversal scan rule should now be less False Positive prone, one of it's checks will now only run at Low Threshold (Issues: 4209, 6030, 6219, 6372, and 6380).
+  - The Other info field of Alerts will now include a reference indicating which check the triggered alert is caused by, in order to assist in future user inquiries.
 
 ## [38] - 2020-12-15
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -223,6 +223,10 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
         return "Failed to load vulnerability reference from file";
     }
 
+    /**
+     * <strong>NOTE:</strong> If the checks are re-ordered please do not change the "check #"
+     * identifiers. These help with troubleshooting and are included in alert Other Info.
+     */
     @Override
     public void scan(HttpMessage msg, String param, String value) {
 
@@ -298,7 +302,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
                     // Check if a there was a finding or the scan has been stopped
                     // if yes dispose resources and exit
-                    if (sendAndCheckPayload(param, WIN_LOCAL_FILE_TARGETS[h], WIN_PATTERN)
+                    if (sendAndCheckPayload(param, WIN_LOCAL_FILE_TARGETS[h], WIN_PATTERN, 1)
                             || isStop()) {
                         // Dispose all resources
                         // Exit the scan rule
@@ -310,7 +314,8 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                         if (sendAndCheckPayload(
                                         param,
                                         WIN_LOCAL_FILE_TARGETS[h] + NULL_BYTE_CHARACTER,
-                                        WIN_PATTERN)
+                                        WIN_PATTERN,
+                                        1)
                                 || isStop()) {
                             return;
                         }
@@ -320,7 +325,8 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                                             WIN_LOCAL_FILE_TARGETS[h]
                                                     + NULL_BYTE_CHARACTER
                                                     + extension,
-                                            WIN_PATTERN)
+                                            WIN_PATTERN,
+                                            1)
                                     || isStop()) {
                                 return;
                             }
@@ -338,7 +344,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
                     // Check if a there was a finding or the scan has been stopped
                     // if yes dispose resources and exit
-                    if (sendAndCheckPayload(param, NIX_LOCAL_FILE_TARGETS[h], NIX_PATTERN)
+                    if (sendAndCheckPayload(param, NIX_LOCAL_FILE_TARGETS[h], NIX_PATTERN, 2)
                             || isStop()) {
                         // Dispose all resources
                         // Exit the scan rule
@@ -350,7 +356,8 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                         if (sendAndCheckPayload(
                                         param,
                                         NIX_LOCAL_FILE_TARGETS[h] + NULL_BYTE_CHARACTER,
-                                        NIX_PATTERN)
+                                        NIX_PATTERN,
+                                        2)
                                 || isStop()) {
                             return;
                         }
@@ -361,7 +368,8 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                                             NIX_LOCAL_FILE_TARGETS[h]
                                                     + NULL_BYTE_CHARACTER
                                                     + extension,
-                                            NIX_PATTERN)
+                                            NIX_PATTERN,
+                                            2)
                                     || isStop()) {
                                 return;
                             }
@@ -378,7 +386,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
                 // Check if a there was a finding or the scan has been stopped
                 // if yes dispose resources and exit
-                if (sendAndCheckPayload(param, LOCAL_DIR_TARGETS[h], DIR_PATTERN) || isStop()) {
+                if (sendAndCheckPayload(param, LOCAL_DIR_TARGETS[h], DIR_PATTERN, 3) || isStop()) {
                     // Dispose all resources
                     // Exit the scan rule
                     return;
@@ -406,10 +414,10 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
                     // Check if a there was a finding or the scan has been stopped
                     // if yes dispose resources and exit
-                    if (sendAndCheckPayload(param, sslashPattern, WAR_PATTERN)
-                            || sendAndCheckPayload(param, bslashPattern, WAR_PATTERN)
-                            || sendAndCheckPayload(param, '/' + sslashPattern, WAR_PATTERN)
-                            || sendAndCheckPayload(param, '\\' + bslashPattern, WAR_PATTERN)
+                    if (sendAndCheckPayload(param, sslashPattern, WAR_PATTERN, 4)
+                            || sendAndCheckPayload(param, bslashPattern, WAR_PATTERN, 4)
+                            || sendAndCheckPayload(param, '/' + sslashPattern, WAR_PATTERN, 4)
+                            || sendAndCheckPayload(param, '\\' + bslashPattern, WAR_PATTERN, 4)
                             || isStop()) {
 
                         // Dispose all resources
@@ -422,107 +430,112 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                 }
             }
 
-            // Check 5: try a local file Path Traversal on the file name of the URL (which obviously
-            // will not be in the target list above).
-            // first send a query for a random parameter value, and see if we get a 200 back
-            // if 200 is returned, abort this check (on the url filename itself), because it would
-            // be unreliable.
-            // if we know that a random query returns <> 200, then a 200 response likely means
-            // something!
-            // this logic is all about avoiding false positives, while still attempting to match on
-            // actual vulnerabilities
-            msg = getNewMsg();
-            setParameter(msg, param, NON_EXISTANT_FILENAME);
+            if (getAlertThreshold().equals(AlertThreshold.LOW)) {
+                // Check 5: try a local file Path Traversal on the file name of the URL (which
+                // obviously will not be in the target list above).
+                // first send a query for a random parameter value, and see if we get a 200 back
+                // if 200 is returned, abort this check (on the url filename itself), because it
+                // would be unreliable.
+                // if we know that a random query returns <> 200, then a 200 response likely means
+                // something!
+                // this logic is all about avoiding false positives, while still attempting to match
+                // on actual vulnerabilities
+                msg = getNewMsg();
+                setParameter(msg, param, NON_EXISTANT_FILENAME);
 
-            // send the modified message (with a hopefully non-existent filename), and see what we
-            // get back
-            try {
-                sendAndReceive(msg);
+                // send the modified message (with a hopefully non-existent filename), and see what
+                // we get back
+                try {
+                    sendAndReceive(msg);
 
-            } catch (SocketException
-                    | IllegalStateException
-                    | UnknownHostException
-                    | IllegalArgumentException
-                    | InvalidRedirectLocationException
-                    | URIException ex) {
-                log.debug(
-                        "Caught {} {} when accessing: {}",
-                        ex.getClass().getName(),
-                        ex.getMessage(),
-                        msg.getRequestHeader().getURI().toString());
+                } catch (SocketException
+                        | IllegalStateException
+                        | UnknownHostException
+                        | IllegalArgumentException
+                        | InvalidRedirectLocationException
+                        | URIException ex) {
+                    log.debug(
+                            "Caught {} {} when accessing: {}",
+                            ex.getClass().getName(),
+                            ex.getMessage(),
+                            msg.getRequestHeader().getURI().toString());
 
-                return; // Something went wrong, no point continuing
-            }
+                    return; // Something went wrong, no point continuing
+                }
 
-            // do some pattern matching on the results.
-            Pattern errorPattern = Pattern.compile("Exception|Error");
-            Matcher errorMatcher = errorPattern.matcher(msg.getResponseBody().toString());
+                // do some pattern matching on the results.
+                Pattern errorPattern = Pattern.compile("Exception|Error");
+                Matcher errorMatcher = errorPattern.matcher(msg.getResponseBody().toString());
 
-            String urlfilename = msg.getRequestHeader().getURI().getName();
+                String urlfilename = msg.getRequestHeader().getURI().getName();
 
-            // url file name may be empty, i.e. there is no file name for next check
-            if (!StringUtils.isEmpty(urlfilename) && (!isPage200(msg) || errorMatcher.find())) {
+                // url file name may be empty, i.e. there is no file name for next check
+                if (!StringUtils.isEmpty(urlfilename) && (!isPage200(msg) || errorMatcher.find())) {
 
-                log.debug(
-                        "It is possible to check for local file Path Traversal on the url filename on [{}] [{}], [{}]",
-                        msg.getRequestHeader().getMethod(),
-                        msg.getRequestHeader().getURI().toString(),
-                        param);
+                    log.debug(
+                            "It is possible to check for local file Path Traversal on the url filename on [{}] [{}], [{}]",
+                            msg.getRequestHeader().getMethod(),
+                            msg.getRequestHeader().getURI().toString(),
+                            param);
 
-                String prefixedUrlfilename;
+                    String prefixedUrlfilename;
 
-                // for the url filename, try each of the prefixes in turn
-                for (String prefix : LOCAL_FILE_RELATIVE_PREFIXES) {
+                    // for the url filename, try each of the prefixes in turn
+                    for (String prefix : LOCAL_FILE_RELATIVE_PREFIXES) {
 
-                    prefixedUrlfilename = prefix + urlfilename;
-                    msg = getNewMsg();
-                    setParameter(msg, param, prefixedUrlfilename);
+                        prefixedUrlfilename = prefix + urlfilename;
+                        msg = getNewMsg();
+                        setParameter(msg, param, prefixedUrlfilename);
 
-                    // send the modified message (with the url filename), and see what we get back
-                    try {
-                        sendAndReceive(msg);
+                        // send the modified message (with the url filename), and see what we get
+                        // back
+                        try {
+                            sendAndReceive(msg);
 
-                    } catch (SocketException
-                            | IllegalStateException
-                            | UnknownHostException
-                            | IllegalArgumentException
-                            | InvalidRedirectLocationException
-                            | URIException ex) {
-                        log.debug(
-                                "Caught {} {} when accessing: {}",
-                                ex.getClass().getName(),
-                                ex.getMessage(),
-                                msg.getRequestHeader().getURI().toString());
+                        } catch (SocketException
+                                | IllegalStateException
+                                | UnknownHostException
+                                | IllegalArgumentException
+                                | InvalidRedirectLocationException
+                                | URIException ex) {
+                            log.debug(
+                                    "Caught {} {} when accessing: {}",
+                                    ex.getClass().getName(),
+                                    ex.getMessage(),
+                                    msg.getRequestHeader().getURI().toString());
 
-                        continue; // Something went wrong, move to the next prefix in the loop
-                    }
+                            continue; // Something went wrong, move to the next prefix in the loop
+                        }
 
-                    // did we get an Exception or an Error?
-                    errorMatcher = errorPattern.matcher(msg.getResponseBody().toString());
-                    if (isPage200(msg) && (!errorMatcher.find())) {
+                        // did we get an Exception or an Error?
+                        errorMatcher = errorPattern.matcher(msg.getResponseBody().toString());
+                        if (isPage200(msg) && (!errorMatcher.find())) {
 
-                        // if it returns OK, and the random string above did NOT return ok, then
-                        // raise an alert
-                        // since the filename has likely been picked up and used as a file name from
-                        // the parameter
-                        newAlert()
-                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                .setParam(param)
-                                .setAttack(prefixedUrlfilename)
-                                .setMessage(msg)
-                                .raise();
+                            // if it returns OK, and the random string above did NOT return ok, then
+                            // raise an alert since the filename has likely been picked up and used
+                            // as a file name from the parameter
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_LOW)
+                                    .setParam(param)
+                                    .setAttack(prefixedUrlfilename)
+                                    .setOtherInfo(
+                                            Constant.messages.getString(
+                                                    "ascanrules.pathtraversal.other", 5))
+                                    .setMessage(msg)
+                                    .raise();
 
-                        // All done. No need to look for vulnerabilities on subsequent parameters
-                        // on the same request (to reduce performance impact)
-                        return;
-                    }
+                            // All done. No need to look for vulnerabilities on subsequent
+                            // parameters on the same request (to reduce performance impact)
+                            return;
+                        }
 
-                    // Check if the scan has been stopped
-                    // if yes dispose resources and exit
-                    if (isStop()) {
-                        // Dispose all resources
-                        // Exit the scan rule
-                        return;
+                        // Check if the scan has been stopped
+                        // if yes dispose resources and exit
+                        if (isStop()) {
+                            // Dispose all resources
+                            // Exit the scan rule
+                            return;
+                        }
                     }
                 }
             }
@@ -564,7 +577,8 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
     }
 
     private boolean sendAndCheckPayload(
-            String param, String newValue, ContentsMatcher contentsMatcher) throws IOException {
+            String param, String newValue, ContentsMatcher contentsMatcher, int check)
+            throws IOException {
         if (contentsMatcher.match(getContentsToMatch(getBaseMsg())) != null) {
             // Evidence already present, no point sending the payload/attack.
             return false;
@@ -611,6 +625,8 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                     .setParam(param)
                     .setAttack(newValue)
                     .setEvidence(match)
+                    .setOtherInfo(
+                            Constant.messages.getString("ascanrules.pathtraversal.other", check))
                     .setMessage(msg)
                     .raise();
 

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -125,6 +125,8 @@ current target file an alert is raised and the scanner returns immediately. If n
 attempted using the filename in the URL. As long as submitting an arbitrary filename does not return an OK status code but the real filename does, an alert is raised
 and the scanner returns immediately.
 <p>
+Note: This scan rule has one check that is only executed at Low Alert Threshold.
+<p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java">PathTraversalScanRule.java</a>
 
 <H2>Remote File Include</H2>

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -109,6 +109,7 @@ ascanrules.parametertamper.desc=Parameter manipulation caused an error page or J
 ascanrules.parametertamper.soln=Identify the cause of the error and fix it.  Do not trust client side input and enforce a tight check in the server side.  Besides, catch the exception properly.  Use a generic 500 error page for internal server error.
 
 ascanrules.pathtraversal.name=Path Traversal
+ascanrules.pathtraversal.other=Check {0}
 
 ascanrules.remotefileinclude.name=Remote File Inclusion
 


### PR DESCRIPTION
- PathTraversalScanRule > Only do "check 5" at Low Threshold, add "Check #" reference to Other info field (to facilitate future user inquiries).
- PathTraversalScanRuleUnitTests > Add assertions for Other info field.
- Messages.properties > Add Other info pair.
- CHANGELOG > Add change notes.

* Fixes zaproxy/zaproxy#4209
* Fixes zaproxy/zaproxy#6030
* Fixes zaproxy/zaproxy#6219
* Fixes zaproxy/zaproxy#6372
* Fixes zaproxy/zaproxy#6380

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>