### PR TITLE
Suspicious Comments rule alert tweaks + release

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -3,13 +3,14 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [33] - 2021-01-29
 ### Added
 - Added Express error string pattern (Issue 6412).
 
 ### Changed
 - X-Frame-Options (XFO) scan rule no longer suggests the use of "ALLOW-FROM", and also includes CSP "frame-ancestors" as an alternative.
   - XFO headers implementing "ALLOW-FROM" will now be considered malformed.
+- The Suspicious Comments scan rule will raise one alert per pattern per page and use more suitable evidence.
 
 ## [32] - 2021-01-20
 ### Changed
@@ -220,6 +221,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 
+[33]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v33
 [32]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v32
 [31]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v31
 [30]: https://github.com/zaproxy/zap-extensions/releases/pscanrules-v30

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -24,7 +24,11 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
@@ -44,6 +48,8 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
             "pscanrules.informationdisclosuresuspiciouscomments.";
     private static final int PLUGIN_ID = 10027;
 
+    private static final int MAX_ELEMENT_CHRS_TO_REPORT = 128;
+
     public static final String suspiciousCommentsListDir = "xml";
     public static final String suspiciousCommentsListFile = "suspicious-comments.txt";
     private static final Logger logger =
@@ -58,7 +64,7 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         List<Pattern> patterns = getPatterns();
-        int confidence = Alert.CONFIDENCE_MEDIUM;
+        Map<String, List<AlertSummary>> alertMap = new HashMap<>();
 
         if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isText()) {
 
@@ -67,12 +73,15 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
                 String[] lines = msg.getResponseBody().toString().split("\n");
                 for (String line : lines) {
                     for (Pattern pattern : patterns) {
-                        if (pattern.matcher(line).find()) {
-                            String other =
-                                    Constant.messages.getString(
-                                            MESSAGE_PREFIX + "otherinfo", pattern);
-                            confidence = Alert.CONFIDENCE_LOW;
-                            this.raiseAlert(msg, id, other, confidence, line);
+                        Matcher m = pattern.matcher(line);
+                        if (m.find()) {
+                            recordAlertSummary(
+                                    alertMap,
+                                    new AlertSummary(
+                                            pattern.toString(),
+                                            line,
+                                            Alert.CONFIDENCE_LOW,
+                                            m.group()));
                             break; // Only need to record this line once
                         }
                     }
@@ -85,11 +94,15 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
                 for (Tag tag : tags) {
                     String tagStr = tag.toString();
                     for (Pattern pattern : patterns) {
-                        if (pattern.matcher(tagStr).find()) {
-                            String other =
-                                    Constant.messages.getString(
-                                            MESSAGE_PREFIX + "otherinfo", pattern);
-                            this.raiseAlert(msg, id, other, confidence, tagStr);
+                        Matcher m = pattern.matcher(tagStr);
+                        if (m.find()) {
+                            recordAlertSummary(
+                                    alertMap,
+                                    new AlertSummary(
+                                            pattern.toString(),
+                                            tagStr,
+                                            Alert.CONFIDENCE_MEDIUM,
+                                            m.group()));
                             break; // Only need to record this comment once
                         }
                     }
@@ -98,14 +111,17 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
                 Element el;
                 int offset = 0;
                 while ((el = source.getNextElement(offset, HTMLElementName.SCRIPT)) != null) {
-                    String elStr = el.toString();
                     for (Pattern pattern : patterns) {
-                        if (pattern.matcher(elStr).find()) {
-                            String other =
-                                    Constant.messages.getString(
-                                            MESSAGE_PREFIX + "otherinfo", pattern);
-                            confidence = Alert.CONFIDENCE_LOW;
-                            this.raiseAlert(msg, id, other, confidence, elStr);
+                        String elStr = el.toString();
+                        Matcher m = pattern.matcher(elStr);
+                        if (m.find()) {
+                            recordAlertSummary(
+                                    alertMap,
+                                    new AlertSummary(
+                                            pattern.toString(),
+                                            elStr,
+                                            Alert.CONFIDENCE_LOW,
+                                            m.group()));
                             break; // Only need to record this script once
                         }
                     }
@@ -113,6 +129,40 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
                 }
             }
         }
+
+        // Only raise one alert for each pattern detected, giving a total count if > 1 instance
+        for (Entry<String, List<AlertSummary>> entry : alertMap.entrySet()) {
+            String other;
+            AlertSummary firstSummary = entry.getValue().get(0);
+            if (entry.getValue().size() == 1) {
+                other =
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "otherinfo",
+                                firstSummary.getPattern(),
+                                truncateString(firstSummary.getDetail()));
+            } else {
+                other =
+                        Constant.messages.getString(
+                                MESSAGE_PREFIX + "otherinfo2",
+                                firstSummary.getPattern(),
+                                truncateString(firstSummary.getDetail()),
+                                entry.getValue().size());
+            }
+            this.raiseAlert(
+                    msg, id, other, firstSummary.getConfidence(), firstSummary.getEvidence());
+        }
+    }
+
+    private static void recordAlertSummary(
+            Map<String, List<AlertSummary>> alertMap, AlertSummary summary) {
+        alertMap.computeIfAbsent(summary.getPattern(), k -> new ArrayList<>()).add(summary);
+    }
+
+    private String truncateString(String str) {
+        if (str.length() > MAX_ELEMENT_CHRS_TO_REPORT) {
+            return str.substring(0, MAX_ELEMENT_CHRS_TO_REPORT);
+        }
+        return str;
     }
 
     private void raiseAlert(
@@ -190,5 +240,36 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
     @Override
     public int getPluginId() {
         return PLUGIN_ID;
+    }
+
+    private static class AlertSummary {
+        private final String pattern;
+        private final String detail;
+        private final int confidence;
+        private final String evidence;
+
+        public AlertSummary(String pattern, String detail, int confidence, String evidence) {
+            super();
+            this.pattern = pattern;
+            this.detail = detail;
+            this.confidence = confidence;
+            this.evidence = evidence;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public String getDetail() {
+            return detail;
+        }
+
+        public int getConfidence() {
+            return confidence;
+        }
+
+        public String getEvidence() {
+            return evidence;
+        }
     }
 }

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -73,7 +73,8 @@ pscanrules.informationdisclosurereferrer.issuer.field=Issuer:
 
 pscanrules.informationdisclosuresuspiciouscomments.name=Information Disclosure - Suspicious Comments
 pscanrules.informationdisclosuresuspiciouscomments.desc=The response appears to contain suspicious comments which may help an attacker. Note: Matches made within script blocks or files are against the entire content not only comments.
-pscanrules.informationdisclosuresuspiciouscomments.otherinfo=The following pattern was used: {0}, see evidence field for the suspicious comment/snippet.
+pscanrules.informationdisclosuresuspiciouscomments.otherinfo=The following pattern was used: {0} and was detected in the element starting with: "{1}", see evidence field for the suspicious comment/snippet.
+pscanrules.informationdisclosuresuspiciouscomments.otherinfo2=The following pattern was used: {0} and was detected {2} times, the first in the element starting with: "{1}", see evidence field for the suspicious comment/snippet.
 pscanrules.informationdisclosuresuspiciouscomments.soln=Remove all comments that return information that may help an attacker and fix any underlying problems they refer to.
 
 pscanrules.insecureauthentication.name=Weak Authentication Method


### PR DESCRIPTION
The last set of changes to this rule exposed a core bug:
https://github.com/zaproxy/zaproxy/issues/6421

Examining the alerts raised in that case showed that the info included
was actually not that useful.
An issue would be raise for every instance of a suspicious string in a
page, and the evidence was the relevant page element, which for scripts
could be very large. And scripts could trigger the bug above ;)

This PR changes the rule to only raise one alert per suspicious string
instance per page - if there are more than one instance then it gives
the count. The evidence is just the string matched while the 'other'
field now contains the first 128 bytes of the first relevant element.
Screen shots to be included...

Also prepare add-on for release so that we're less likely to hit the
core bug...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>