### PR TITLE
Sort form input names scanner 10202

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Added Express error string pattern (Issue 6412).
+- Added sort to form field names that are displayed in Anti-CSRF alert other info field, duplicate names (arrays) are combined and not repeated.
 
 
 ## [32] - 2021-01-20

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -21,6 +21,8 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
@@ -135,6 +137,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                                 + formElement.getParentElement()
                                 + "]");
                 StringBuilder sbForm = new StringBuilder();
+                SortedSet<String> elementNames = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
                 ++numberOfFormsPassed;
                 // if the form has no parent, it is pretty likely invalid HTML (or Javascript!!!),
                 // so we will not report
@@ -160,7 +163,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                 }
 
                 List<Element> inputElements = formElement.getAllElements(HTMLElementName.INPUT);
-                sbForm.append("[Form " + numberOfFormsPassed + ": ");
+                sbForm.append("[Form " + numberOfFormsPassed + ": \"");
                 boolean foundCsrfToken = false;
 
                 if (inputElements != null && inputElements.size() > 0) {
@@ -169,7 +172,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                     for (Element inputElement : inputElements) {
                         String attId = inputElement.getAttributeValue("ID");
                         if (attId != null) {
-                            sbForm.append("\"" + attId + "\" ");
+                            elementNames.add(attId);
                             for (String tokenName : tokenNames) {
                                 if (tokenName.equalsIgnoreCase(attId)) {
                                     foundCsrfToken = true;
@@ -181,7 +184,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                         if (name != null) {
                             if (attId == null) {
                                 // Dont bother recording both
-                                sbForm.append("\"" + name + "\" ");
+                                elementNames.add(name);
                             }
                             for (String tokenName : tokenNames) {
                                 if (tokenName.equalsIgnoreCase(name)) {
@@ -199,7 +202,9 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                 String evidence = "";
                 evidence = formElement.getFirstElement().getStartTag().toString();
 
-                sbForm.append(']');
+                // Append the form names with double quotes
+                sbForm.append(String.join("\" \"", elementNames));
+                sbForm.append("\" ]");
 
                 String formDetails = sbForm.toString();
                 String tokenNamesFlattened = tokenNames.toString();

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -116,6 +116,7 @@ Post 2.5.0 you can specify a comma separated list of identifiers in the
 <code>rules.csrf.ignorelist</code> parameter via the Options 'Rule configuration' panel.
 Any FORMs with a name or ID that matches one of these identifiers will be ignored when scanning for missing Anti-CSRF tokens.
 Only use this feature to ignore FORMs that you know are safe, for example search forms.
+Form element names are sorted and de-duplicated when they are printed in the Zap Report.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java">CsrfCountermeasuresScanRule.java</a>
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.pscanrules;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
@@ -113,6 +114,57 @@ public class CsrfCountermeasuresScanRuleUnitTest
         assertEquals(alertsRaised.size(), 1);
         assertEquals(alertsRaised.get(0).getWascId(), 9);
         assertEquals(alertsRaised.get(0).getEvidence(), "<form id=\"no_csrf_token\">");
+    }
+
+    @Test
+    public void shouldRaiseAlertWithSortedFormFieldsInOtherInfoIfThereIsNoCSRFTokenFound() {
+        // Given
+        msg.setResponseBody(
+                "<html><head></head><body>"
+                        + "<form id=\"no_csrf_token\">"
+                        + "    <input type=\"text\" id=\"Cat\"/>"
+                        + "    <input type=\"text\" id=\"car\"/>"
+                        + "    <input type=\"text\" id=\"Bat\"/>"
+                        + "    <input type=\"text\" id=\"bar\"/>"
+                        + "    <input type=\"text\" id=\"art\"/>"
+                        + "    <input type=\"submit\"/>"
+                        + "</form></body></html>");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(alertsRaised.size(), 1);
+        assertTrue(
+                alertsRaised
+                        .get(0)
+                        .getOtherInfo()
+                        .contains("\"art\" \"bar\" \"Bat\" \"car\" \"Cat\""));
+    }
+
+    @Test
+    public void shouldRaiseAlertWithSortedUniqueFormFieldsInOtherInfoIfThereIsNoCSRFTokenFound() {
+        // Given
+        msg.setResponseBody(
+                "<html><head></head><body>"
+                        + "<form id=\"no_csrf_token\">"
+                        + "    <input type=\"text\" id=\"Id\"/>"
+                        + "    <input type=\"text\" id=\"username\"/>"
+                        + "    <input type=\"text\" id=\"Key\"/>"
+                        + "    <input type=\"text\" id=\"group\"/>"
+                        + "    <input type=\"text\" id=\"group\"/>"
+                        + "    <input type=\"text\" id=\"group\"/>"
+                        + "    <input type=\"text\" id=\"group\"/>"
+                        + "    <input type=\"text\" id=\"group\"/>"
+                        + "    <input type=\"submit\"/>"
+                        + "</form></body></html>");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(alertsRaised.size(), 1);
+        assertTrue(
+                alertsRaised
+                        .get(0)
+                        .getOtherInfo()
+                        .contains("\"group\" \"Id\" \"Key\" \"username\""));
     }
 
     @Test


### PR DESCRIPTION
In the report after a spider attack, the Anti-CSRF scanner 10202 prints the standard Anti-CSRF tokens and the scanned form's fields in the Other information section when no anti-CSRF token is found. The output can look like this:

No known Anti-CSRF token [anticsrf, CSRFToken, __RequestVerificationToken, csrfmiddlewaretoken, authenticity_token, OWASP_CSRFTOKEN, anoncsrf, csrf_token, _csrf, _csrfSecret] was found in the following HTML form: [Form 1: "tenant-status" "toggle-tenant-status" "woEnabled" "toggle-woEnabled" "campManagerEnabled" "toggle-campManagerEnabled" "conSpeechEnabled" "toggle-conSpeechEnabled" "webCallBackEnabled" "toggle-webCallBackEnabled" "cccEnabled" "toggle-cccEnabled" "sbrEnabled" "toggle-sbrEnabled" "multiMediaEnabled" "toggle-multiMediaEnabled" "voiceCallBackEnabled" "toggle-voiceCallBackEnabled" "jukeboxEnabled" "toggle-jukeboxEnabled" "pruningStrategy" "seatMapEnabled" "toggle-seatMapEnabled" "analyticsEnabled" "toggle-analyticsEnabled" "permitAlert" "toggle-permitAlert" "firstAgentRouting" "toggle-firstAgentRouting" "armRecordingEnabled" "toggle-armRecordingEnabled" "siteLevelEnabled" "toggle-siteLevelEnabled" "multipleTimeZoneEnabled" "toggle-multipleTimeZoneEnabled" "cfbEnabled" "toggle-cfbEnabled" "allowUserThresholds" "toggle-allowUserThresholds" "pauseResumeEnabled" "toggle-pauseResumeEnabled" "checkAgentAvailability" "toggle-checkAgentAvailability" "recordAllCalls" "toggle-recordAllCalls" "serviceManagementUrl" "toggle-ManagementUrl" ].

For this target, the Anti-CSRF token is xcsrf_token. Having the fields sorted makes it easier to confirm the field really isn’t present (and not just misspelled). 
