### PR TITLE
commonlib: Add AbstractHostFilePlugin

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
+- Maintenance changes.
 
 ## [38] - 2020-12-15
 ### Changed

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -14,7 +14,9 @@ zapAddOn {
 
         dependencies {
             addOns {
-                register("commonlib")
+                register("commonlib") {
+                    version.set(">= 1.3.0 & < 2.0.0")
+                }
             }
         }
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
@@ -19,19 +19,8 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
-import java.io.IOException;
-import org.apache.commons.httpclient.URI;
-import org.apache.commons.httpclient.URIException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
-import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.core.scanner.Category;
-import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpRequestHeader;
-import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.addon.commonlib.AbstractHostFilePlugin;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -41,40 +30,13 @@ import org.zaproxy.zap.model.TechSet;
  *
  * @author kingthorin+owaspzap@gmail.com
  */
-public class ElmahScanRule extends AbstractHostPlugin {
+public class ElmahScanRule extends AbstractHostFilePlugin {
 
     private static final String MESSAGE_PREFIX = "ascanrules.elmah.";
     private static final int PLUGIN_ID = 40028;
 
-    private static final Logger LOG = LogManager.getLogger(ElmahScanRule.class);
-
-    @Override
-    public int getId() {
-        return PLUGIN_ID;
-    }
-
-    @Override
-    public String getName() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "name");
-    }
-
-    @Override
-    public String getDescription() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
-    }
-
-    @Override
-    public String getSolution() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
-    }
-
-    @Override
-    public String getReference() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
-    }
-
-    private String getOtherInfo() {
-        return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo");
+    public ElmahScanRule() {
+        super("/elmah.axd", MESSAGE_PREFIX);
     }
 
     @Override
@@ -86,103 +48,12 @@ public class ElmahScanRule extends AbstractHostPlugin {
     }
 
     @Override
-    public int getCategory() {
-        return Category.INFO_GATHER;
+    public boolean hasContent(HttpMessage msg) {
+        return msg.getResponseBody().toString().contains("Error Log for");
     }
 
     @Override
-    public int getRisk() {
-        return Alert.RISK_MEDIUM;
-    }
-
-    @Override
-    public int getCweId() {
-        return 215; // CWE-215: Information Exposure Through Debug Information
-    }
-
-    @Override
-    public int getWascId() {
-        return 13; // WASC-13: Information Leakage
-    }
-
-    @Override
-    public void scan() {
-
-        // Check if the user stopped things. One request per URL so check before
-        // sending the request
-        if (isStop()) {
-            LOG.debug("Scan rule {} Stopping.", getName());
-            return;
-        }
-
-        HttpMessage newRequest = getNewMsg();
-        newRequest.getRequestHeader().setMethod(HttpRequestHeader.GET);
-        newRequest.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
-        newRequest.setRequestBody("");
-        URI baseUri = getBaseMsg().getRequestHeader().getURI();
-        URI elmahUri = null;
-        try {
-            elmahUri =
-                    new URI(
-                            baseUri.getScheme(),
-                            null,
-                            baseUri.getHost(),
-                            baseUri.getPort(),
-                            "/elmah.axd");
-        } catch (URIException uEx) {
-            LOG.debug(
-                    "An error occurred creating a URI for the: {} rule. {}",
-                    getName(),
-                    uEx.getMessage(),
-                    uEx);
-            return;
-        }
-        try {
-            newRequest.getRequestHeader().setURI(elmahUri);
-        } catch (URIException uEx) {
-            LOG.debug(
-                    "An error occurred setting the URI for a new request used by: {} rule. {}",
-                    getName(),
-                    uEx.getMessage(),
-                    uEx);
-            return;
-        }
-        try {
-            sendAndReceive(newRequest, false);
-        } catch (IOException e) {
-            LOG.warn(
-                    "An error occurred while checking [{}] [{}] for {} Caught {} {}",
-                    newRequest.getRequestHeader().getMethod(),
-                    newRequest.getRequestHeader().getURI(),
-                    getName(),
-                    e.getClass().getName(),
-                    e.getMessage());
-            return;
-        }
-        int statusCode = newRequest.getResponseHeader().getStatusCode();
-        if (statusCode == HttpStatusCode.OK) {
-            boolean hasContent = newRequest.getResponseBody().toString().contains("Error Log for");
-            if (this.getAlertThreshold().equals(AlertThreshold.LOW) || hasContent) {
-                raiseAlert(
-                        newRequest,
-                        getRisk(),
-                        hasContent ? Alert.CONFIDENCE_HIGH : Alert.CONFIDENCE_LOW,
-                        "");
-            }
-        } else if (this.getAlertThreshold().equals(AlertThreshold.LOW)
-                && (statusCode == HttpStatusCode.UNAUTHORIZED
-                        || statusCode == HttpStatusCode.FORBIDDEN)) {
-            raiseAlert(newRequest, Alert.RISK_INFO, Alert.CONFIDENCE_LOW, getOtherInfo());
-        }
-    }
-
-    private void raiseAlert(HttpMessage msg, int risk, int confidence, String otherInfo) {
-        newAlert()
-                .setRisk(risk)
-                .setConfidence(confidence)
-                .setOtherInfo(otherInfo)
-                .setEvidence(msg.getResponseHeader().getPrimeHeader())
-                .setMessage(msg)
-                .raise();
+    public int getId() {
+        return PLUGIN_ID;
     }
 }

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- Added AbstractHostFilePlugin for use with ElmahScanRule and other future Host level file scan rules (Issue 6133).
+- Maintenance changes (Issue 6376).
 
 ## [1.2.0] - 2020-12-15
 ### Changed

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractHostFilePlugin.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractHostFilePlugin.java
@@ -1,0 +1,212 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import java.io.IOException;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+
+/**
+ * An {@code AbstractAppPlugin} that checks for the presence of a file.
+ *
+ * @since 1.3.0
+ */
+public abstract class AbstractHostFilePlugin extends AbstractHostPlugin {
+
+    private static final Logger LOG = LogManager.getLogger(AbstractHostFilePlugin.class);
+    private final String filename;
+    private final String messagePrefix;
+
+    /**
+     * Constructs an {@code AbstractHostFilePlugin} with the given file name and messages prefix.
+     *
+     * <p>The message prefix is used to load the messages for the alert and scan rule, from the main
+     * resource bundle ({@link Constant#messages}).
+     *
+     * @param filename the name of the file to check if it's present.
+     * @param messagePrefix the messages prefix (including the trailing period).
+     */
+    protected AbstractHostFilePlugin(String filename, String messagePrefix) {
+        this.filename = filename;
+        this.messagePrefix = messagePrefix;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(messagePrefix + "name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(messagePrefix + "desc");
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(messagePrefix + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(messagePrefix + "refs");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INFO_GATHER;
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_MEDIUM;
+    }
+
+    @Override
+    public int getCweId() {
+        return 215; // CWE-215: Information Exposure Through Debug Information
+    }
+
+    @Override
+    public int getWascId() {
+        return 13; // WASC-13: Information Leakage
+    }
+
+    private String getOtherInfo() {
+        return Constant.messages.getString(messagePrefix + "otherinfo");
+    }
+
+    /**
+     * Always returns true - override to add functionality to match specific content
+     *
+     * @param msg the message being scanned (after being sent).
+     * @return true if the content matches
+     */
+    public boolean hasContent(HttpMessage msg) {
+        return true;
+    }
+
+    /**
+     * Always returns false - override to add functionality to detect FPs
+     *
+     * @param msg the message being scanned (after being sent).
+     * @return true if its a false positive
+     */
+    public boolean isFalsePositive(HttpMessage msg) {
+        return false;
+    }
+
+    @Override
+    public void scan() {
+
+        // Check if the user stopped things. One request per URL so check before
+        // sending the request
+        if (isStop()) {
+            LOG.debug("Scan rule {} Stopping.", getName());
+            return;
+        }
+
+        HttpMessage newRequest = getNewMsg();
+        newRequest.getRequestHeader().setMethod(HttpRequestHeader.GET);
+        newRequest.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+        newRequest.setRequestBody("");
+        URI baseUri = getBaseMsg().getRequestHeader().getURI();
+        URI fileUri = null;
+        try {
+            fileUri =
+                    new URI(
+                            baseUri.getScheme(),
+                            null,
+                            baseUri.getHost(),
+                            baseUri.getPort(),
+                            getFilename());
+        } catch (URIException uEx) {
+            LOG.debug(
+                    "An error occurred creating a URI for the: {} rule. {}",
+                    getName(),
+                    uEx.getMessage(),
+                    uEx);
+            return;
+        }
+        try {
+            newRequest.getRequestHeader().setURI(fileUri);
+        } catch (URIException uEx) {
+            LOG.debug(
+                    "An error occurred setting the URI for a new request used by: {} rule. {}",
+                    getName(),
+                    uEx.getMessage(),
+                    uEx);
+            return;
+        }
+        try {
+            sendAndReceive(newRequest, false);
+        } catch (IOException e) {
+            LOG.warn(
+                    "An error occurred while checking [{}] [{}] for {} Caught {} {}",
+                    newRequest.getRequestHeader().getMethod(),
+                    newRequest.getRequestHeader().getURI(),
+                    getName(),
+                    e.getClass().getName(),
+                    e.getMessage());
+            return;
+        }
+        if (isFalsePositive(newRequest)) {
+            return;
+        }
+        int statusCode = newRequest.getResponseHeader().getStatusCode();
+        if (isSuccess(newRequest)) {
+            boolean hasContent = hasContent(newRequest);
+            if (this.getAlertThreshold().equals(AlertThreshold.LOW) || hasContent) {
+                raiseAlert(
+                        newRequest,
+                        getRisk(),
+                        hasContent ? Alert.CONFIDENCE_HIGH : Alert.CONFIDENCE_LOW,
+                        "");
+            }
+        } else if (this.getAlertThreshold().equals(AlertThreshold.LOW)
+                && (statusCode == HttpStatusCode.UNAUTHORIZED
+                        || statusCode == HttpStatusCode.FORBIDDEN)) {
+            raiseAlert(newRequest, Alert.RISK_INFO, Alert.CONFIDENCE_LOW, getOtherInfo());
+        }
+    }
+
+    private void raiseAlert(HttpMessage msg, int risk, int confidence, String otherInfo) {
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setOtherInfo(otherInfo)
+                .setEvidence(msg.getResponseHeader().getPrimeHeader())
+                .setMessage(msg)
+                .raise();
+    }
+
+    public String getFilename() {
+        return filename;
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/AbstractHostFilePluginUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/AbstractHostFilePluginUnitTest.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Unit test for {@link AbstractHostFilePlugin}. */
+public abstract class AbstractHostFilePluginUnitTest<T extends AbstractHostFilePlugin>
+        extends ActiveScannerTestUtils<AbstractHostFilePlugin> {
+
+    private String body;
+
+    public AbstractHostFilePluginUnitTest() {
+        this.body = "<html><head></head><H>Awesome Content</H1>Some text...<html>";
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    @Test
+    public void shouldCleanupOriginalRequestWhenMakingHostFileRequest()
+            throws HttpMalformedHeaderException {
+        // Given
+        String path = "/";
+        nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(Response.Status.OK, NanoHTTPD.MIME_HTML, body)));
+        HttpMessage message = getHttpMessage(path);
+        message.getRequestHeader().setMethod("POST");
+        message.getRequestBody().setBody("foo=bar");
+        message.getRequestHeader()
+                .addHeader(HttpHeader.CONTENT_TYPE, "application/x-www-form-urlencoded");
+        rule.init(message, parent);
+        // When
+        rule.scan();
+        // Then
+        HttpMessage sentMessage = httpMessagesSent.get(0);
+        assertThat(sentMessage.getRequestHeader().getMethod(), is(equalTo("GET")));
+        assertThat(
+                sentMessage.getRequestHeader().getHeaderValues(HttpHeader.CONTENT_TYPE),
+                is(equalTo(Collections.emptyList())));
+        assertThat(sentMessage.getRequestBody().length(), is(equalTo(0)));
+    }
+
+    private static NanoServerHandler createHandler(String path, Response response) {
+        return new NanoServerHandler(path) {
+            @Override
+            protected Response serve(IHTTPSession session) {
+                return response;
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Updated commonlib to target 2.10 more specifically (now that 2.10 has been released).
- Added AbstractHostFilePlugin and UnitTest.
- Updated other commonlib classes to use Log4j 2.x infrastructure.
- Updated ElmanScanRule to leverage AbstractHostFilePlugin.

Fixes zaproxy/zaproxy#6133

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>