### PR TITLE
Correct detection of WSDL files

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fix detection of WSDL files (Issue 6440).
 
 ## [5] - 2021-01-04
 ### Changed

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
@@ -57,9 +57,7 @@ public class WSDLFilePassiveScanRule extends PluginPassiveScanner {
             HttpResponseHeader header = msg.getResponseHeader();
             String baseURL = msg.getRequestHeader().getURI().toString().trim();
             String contentType = header.getHeader(HttpHeader.CONTENT_TYPE).trim();
-            return baseURL.endsWith(".wsdl")
-                    || contentType.equals("text/xml")
-                    || contentType.equals("application/wsdl+xml");
+            return baseURL.endsWith(".wsdl") || contentType.equals("application/wsdl+xml");
         }
         return false;
     }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
@@ -22,13 +22,19 @@ package org.zaproxy.zap.extension.soap;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
 public class WSDLFilePassiveScanRuleTestCase {
     private HttpMessage wsdlMsg = new HttpMessage();
+
+    private static void setContentType(HttpMessage msg, String contentType) {
+        msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
+    }
 
     @BeforeEach
     public void setUp() {
@@ -57,5 +63,38 @@ public class WSDLFilePassiveScanRuleTestCase {
 
         result = scanner.isWsdl(new HttpMessage()); /* Empty response. */
         assertFalse(result);
+    }
+
+    @Test
+    public void shouldNotAlertWhenWsdlFileNotFound() throws IOException {
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
+        setContentType(wsdlMsg, "text/xml");
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
+        boolean result = scanner.isWsdl(wsdlMsg);
+        assertFalse(result);
+    }
+
+    @Test
+    public void shouldAlertWhenWsdlFileFound() throws IOException {
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
+        setContentType(wsdlMsg, "text/xml");
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
+        boolean result = scanner.isWsdl(wsdlMsg);
+        assertTrue(result);
+    }
+
+    @Test
+    public void shouldAlertWhenWsdlXmlContentTypeFound() throws IOException {
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
+        setContentType(wsdlMsg, "application/wsdl+xml");
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
+        boolean result = scanner.isWsdl(wsdlMsg);
+        assertTrue(result);
     }
 }


### PR DESCRIPTION
As @kingthorin told.

```
Should be as simple as:

- return baseURL.endsWith(".wsdl")
-                    || contentType.equals("text/xml")
-                    || contentType.equals("application/wsdl+xml");
+ return (baseURL.endsWith(".wsdl")
+                    && contentType.equals("text/xml"))
+                    || contentType.equals("application/wsdl+xml");
Or

- return baseURL.endsWith(".wsdl")
-                    || contentType.equals("text/xml")
-                    || contentType.equals("application/wsdl+xml");
+ return baseURL.endsWith(".wsdl")
+                    && (contentType.equals("text/xml")
+                    || contentType.equals("application/wsdl+xml"));
```

 I made changes.

Fixes zaproxy/zaproxy/issues/6440

Signed-off-by: Aman Rawat <rawataman6525@gmail.com>