### PR TITLE
Improved the XXE Scan Rule to detect a possible XXE Local File Reflection Attack when XML is validated

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - The .env file scan rule now performs a simple content check to reduce false positives (Issue 6099).
 - The trace.axd file scan rule now performs a content check to reduce false positives (Issue 6517).
+- XML External Entity Attack scan rule changed to detect a possible XML File Reflection Attack when XML validation is present. (Issue 6204)
 
 ## [33] - 2020-12-15
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -341,7 +341,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 This component attempts to identify applications which are subject to XML eXternal Entity (XXE) attacks.
 Applications which parse XML input may be subject to XXE when weakly or poorly configured parsers 
 handle XML input containing reference to an external entity such as a local file, HTTP requests to 
-internal or tertiary systems, etc.<br>
+internal or tertiary systems, etc. The number of tags which are tested individually depends on the strength of the rule.<br>
 <br>
 It requires the Callback extension, so will not work if this extension is disabled or removed. 
 It is also recommended that you test that the Callback extension is correctly configured for your target site.

--- a/addOns/ascanrulesBeta/src/test/resources/org/zaproxy/zap/extension/ascanrulesBeta/xxescanrule/SampleXml.txt
+++ b/addOns/ascanrulesBeta/src/test/resources/org/zaproxy/zap/extension/ascanrulesBeta/xxescanrule/SampleXml.txt
@@ -1,0 +1,18 @@
+<comments>
+    <comment>
+    <text>testOne
+    </text>
+    </comment>
+
+    <comment>
+    <text>  testTwo  </text>
+    </comment>
+    <comment>
+
+<otherValue>A</otherValue>
+<otherValue>testThree</otherValue>
+<otherValue>C</otherValue>
+
+<otherValue>D</otherValue>
+    </comment>
+</comments>


### PR DESCRIPTION
Introduced functions to create payloads where only a certain specified tag value is changed. Depending on the attack strength, a number of such payloads are sent and their response is matched against local file patterns, which if matches raises an alert.Fixes zaproxy/zaproxy#6204