### PR TITLE
authstats: Use Log4j 2.x

### DIFF
--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Dynamically unload the add-on.
 - Change info URL to link to the site.
 

--- a/addOns/authstats/authstats.gradle.kts
+++ b/addOns/authstats/authstats.gradle.kts
@@ -3,7 +3,7 @@ description = "Records logged in/out statistics for all contexts in scope."
 
 zapAddOn {
     addOnName.set("Authentication Statistics")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/authstats/src/main/java/org/zaproxy/zap/extension/authstats/ExtensionAuthStats.java
+++ b/addOns/authstats/src/main/java/org/zaproxy/zap/extension/authstats/ExtensionAuthStats.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.authstats;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -44,7 +45,7 @@ import org.zaproxy.zap.utils.Stats;
  */
 public class ExtensionAuthStats extends ExtensionAdaptor implements HttpSenderListener {
 
-    private static final Logger log = Logger.getLogger(ExtensionAuthStats.class);
+    private static final Logger log = LogManager.getLogger(ExtensionAuthStats.class);
 
     @Override
     public void hook(ExtensionHook extensionHook) {


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>