### PR TITLE
beanshell: Use Log4j 2.x

### DIFF
--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Improve permissions and space handling when saving.
 
 ## 6 - 2017-11-27

--- a/addOns/beanshell/beanshell.gradle.kts
+++ b/addOns/beanshell/beanshell.gradle.kts
@@ -6,7 +6,7 @@ description = "Provides a BeanShell Console"
 zapAddOn {
     addOnName.set("BeanShell Console")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
+++ b/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
@@ -38,7 +38,8 @@ import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ViewDelegate;
@@ -66,7 +67,7 @@ public class BeanShellConsoleFrame extends AbstractFrame {
 
     private JPanel jPanel = null;
 
-    private static final Logger log = Logger.getLogger(BeanShellConsoleFrame.class);
+    private static final Logger log = LogManager.getLogger(BeanShellConsoleFrame.class);
 
     /** @throws HeadlessException */
     public BeanShellConsoleFrame() throws HeadlessException {
@@ -155,9 +156,7 @@ public class BeanShellConsoleFrame extends AbstractFrame {
                     input.close();
                 }
             } catch (IOException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug(e.getMessage(), e);
-                }
+                log.debug(e.getMessage(), e);
             }
         }
 
@@ -176,9 +175,7 @@ public class BeanShellConsoleFrame extends AbstractFrame {
                     output.close();
                 }
             } catch (IOException e) {
-                if (log.isDebugEnabled()) {
-                    log.debug(e.getMessage(), e);
-                }
+                log.debug(e.getMessage(), e);
             }
         }
     }
@@ -309,10 +306,6 @@ public class BeanShellConsoleFrame extends AbstractFrame {
 
     public void setExtension(Extension extension) {
         this.extension = extension;
-    }
-
-    private Extension getExtension() {
-        return extension;
     }
 
     @Override


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.
- As a clean code activity remove unused private method `BeanShellConsoleFrame.getExtension()`.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>