### PR TITLE
frontendscanner: Use Log4j 2.x

### DIFF
--- a/addOns/frontendscanner/frontendscanner.gradle.kts
+++ b/addOns/frontendscanner/frontendscanner.gradle.kts
@@ -3,7 +3,7 @@ description = "Scan modern web applications relying heavily on Javascript."
 
 zapAddOn {
     addOnName.set("Front-end Scanner")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/ExtensionFrontEndScanner.java
@@ -32,7 +32,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.swing.ImageIcon;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
@@ -74,7 +75,7 @@ public class ExtensionFrontEndScanner extends ExtensionAdaptor {
     private FrontEndScannerOptions options;
     private FrontEndScannerProxyListener proxyListener;
 
-    private static final Logger LOGGER = Logger.getLogger(ExtensionFrontEndScanner.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionFrontEndScanner.class);
 
     private static final List<Class<? extends Extension>> DEPENDENCIES;
 

--- a/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
+++ b/addOns/frontendscanner/src/main/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListener.java
@@ -23,7 +23,8 @@ import java.util.List;
 import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.OutputDocument;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.extension.history.ProxyListenerLog;
 import org.parosproxy.paros.network.HttpMessage;
@@ -31,7 +32,7 @@ import org.zaproxy.zap.extension.api.API;
 
 /** The {@link ProxyListener} the {@link ExtensionFrontEndScanner} relies on. */
 public class FrontEndScannerProxyListener implements ProxyListener {
-    private static final Logger LOGGER = Logger.getLogger(FrontEndScannerProxyListener.class);
+    private static final Logger LOGGER = LogManager.getLogger(FrontEndScannerProxyListener.class);
 
     private final FrontEndScannerAPI api;
     private final FrontEndScannerOptions options;


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.
- Address deprecation of ParameterParser.getParams, with the upgrade to target 2.10.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>