### PR TITLE
graphql: Use Log4j 2.x

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Update minimum ZAP version to 2.10.0.
 - Add two new options that allow enforcing maximum query depth leniently for fields with no leaf types.
+- Maintenance changes.
 
 ### Fixed
 - Fix invalid query generation when query depth was reached and the deepest fields had no leaf types (Issue 6316).

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -26,7 +26,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -53,7 +54,7 @@ public class ExtensionGraphQl extends ExtensionAdaptor
         implements CommandLineListener, SessionChangedListener {
 
     public static final String NAME = "ExtensionGraphQl";
-    private static final Logger LOG = Logger.getLogger(ExtensionGraphQl.class);
+    private static final Logger LOG = LogManager.getLogger(ExtensionGraphQl.class);
 
     private ZapMenuItem menuImportLocalGraphQl = null;
     private ZapMenuItem menuImportUrlGraphQl = null;
@@ -173,7 +174,7 @@ public class ExtensionGraphQl extends ExtensionAdaptor
         synchronized (parserThreads) {
             for (ParserThread thread : parserThreads) {
                 if (thread.isRunning()) {
-                    LOG.debug("Stopping Thread " + thread.getName());
+                    LOG.debug("Stopping Thread {}", thread.getName());
                     thread.stopParser();
                 }
             }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlApi.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlApi.java
@@ -23,7 +23,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
@@ -39,8 +38,6 @@ public class GraphQlApi extends ApiImplementor {
     private static final String PARAM_FILE = "file";
     private static final String PARAM_URL = "url";
     private static final String PARAM_ENDPOINT = "endurl";
-
-    private static final Logger LOG = Logger.getLogger(GraphQlApi.class);
 
     public GraphQlApi() {
         this.addApiAction(

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlGenerator.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlGenerator.java
@@ -42,7 +42,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.zaproxy.addon.graphql.GraphQlParam.RequestMethodOption;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
@@ -50,7 +51,7 @@ import org.zaproxy.zap.model.ValueGenerator;
 
 public class GraphQlGenerator {
 
-    private static final Logger LOG = Logger.getLogger(GraphQlGenerator.class);
+    private static final Logger LOG = LogManager.getLogger(GraphQlGenerator.class);
     private final Requestor requestor;
     private final GraphQlParam param;
     private GraphQLSchema schema;

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParam.java
@@ -20,7 +20,8 @@
 package org.zaproxy.addon.graphql;
 
 import java.util.Locale;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 import org.zaproxy.zap.extension.api.ApiException;
@@ -47,7 +48,7 @@ public class GraphQlParam extends VersionedAbstractParam {
      */
     private static final int PARAM_CURRENT_VERSION = 2;
 
-    private static final Logger LOG = Logger.getLogger(GraphQlParam.class);
+    private static final Logger LOG = LogManager.getLogger(GraphQlParam.class);
 
     public GraphQlParam() {}
 
@@ -205,7 +206,7 @@ public class GraphQlParam extends VersionedAbstractParam {
         try {
             setArgsType(ArgsTypeOption.valueOf(argsType.toUpperCase(Locale.ROOT)));
         } catch (IllegalArgumentException e) {
-            LOG.debug('"' + argsType + "\" is not a valid Arguments Specification Type.");
+            LOG.debug("'{}' is not a valid Arguments Specification Type.", argsType);
             throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage());
         }
     }
@@ -224,7 +225,7 @@ public class GraphQlParam extends VersionedAbstractParam {
         try {
             setQuerySplitType(QuerySplitOption.valueOf(querySplitType.toUpperCase(Locale.ROOT)));
         } catch (IllegalArgumentException e) {
-            LOG.debug('"' + querySplitType + "\" is not a valid Query Split Type.");
+            LOG.debug("'{}' is not a valid Query Split Type.", querySplitType);
             throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage());
         }
     }
@@ -243,7 +244,7 @@ public class GraphQlParam extends VersionedAbstractParam {
         try {
             setRequestMethod(RequestMethodOption.valueOf(requestMethod.toUpperCase(Locale.ROOT)));
         } catch (IllegalArgumentException e) {
-            LOG.debug('"' + requestMethod + "\" is not a valid Request Method Option.");
+            LOG.debug("'{}' is not a valid Request Method Option.", requestMethod);
             throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, e.getMessage());
         }
     }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -35,7 +35,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.network.HttpMessage;
@@ -43,7 +44,7 @@ import org.parosproxy.paros.network.HttpSender;
 
 public class GraphQlParser {
 
-    private static final Logger LOG = Logger.getLogger(GraphQlParser.class);
+    private static final Logger LOG = LogManager.getLogger(GraphQlParser.class);
     private static final String THREAD_PREFIX = "ZAP-GraphQL-Parser";
     private static AtomicInteger threadId = new AtomicInteger();
 

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlSpider.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlSpider.java
@@ -20,14 +20,15 @@
 package org.zaproxy.addon.graphql;
 
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 
 public class GraphQlSpider extends SpiderParser {
 
-    private static final Logger LOG = Logger.getLogger(GraphQlSpider.class);
+    private static final Logger LOG = LogManager.getLogger(GraphQlSpider.class);
 
     @Override
     public boolean parseResource(HttpMessage message, Source source, int depth) {
@@ -51,10 +52,10 @@ public class GraphQlSpider extends SpiderParser {
         String uri = message.getRequestHeader().getURI().toString();
         switch (MessageValidator.validate(message)) {
             case VALID_ENDPOINT:
-                LOG.debug("Found GraphQl endpoint at: " + uri);
+                LOG.debug("Found GraphQl endpoint at: {}", uri);
                 return true;
             case VALID_SCHEMA:
-                LOG.debug("Found GraphQL schema at: " + uri);
+                LOG.debug("Found GraphQL schema at: {}", uri);
                 break;
         }
         return false;

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/HistoryPersister.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/HistoryPersister.java
@@ -19,7 +19,8 @@
  */
 package org.zaproxy.addon.graphql;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
@@ -30,7 +31,7 @@ import org.zaproxy.zap.utils.ThreadUtils;
 
 public class HistoryPersister implements RequesterListener {
 
-    private static final Logger LOG = Logger.getLogger(ExtensionGraphQl.class);
+    private static final Logger LOG = LogManager.getLogger(ExtensionGraphQl.class);
 
     @Override
     public void handleMessage(final HttpMessage message, int initiator) {

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/Requestor.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/Requestor.java
@@ -26,7 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
@@ -43,7 +44,7 @@ public class Requestor {
     private List<RequesterListener> listeners = new ArrayList<RequesterListener>();
     private HttpSender sender;
     private final HttpRequestConfig requestConfig;
-    private static final Logger LOG = Logger.getLogger(Requestor.class);
+    private static final Logger LOG = LogManager.getLogger(Requestor.class);
     private static final String GRAPHQL_CONTENT_TYPE = "application/graphql";
 
     public Requestor(URI endpointUrl, int initiator) {


### PR DESCRIPTION
- Update CHANGELOG, and change code to use updated logging infrastructure.
- GraphQlApi > Removed un-used logger instantiation.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>