### PR TITLE
importLogFiles: Use Log4j 2.x

### DIFF
--- a/addOns/importLogFiles/CHANGELOG.md
+++ b/addOns/importLogFiles/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Internationalise some strings.
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Add import menu to (new) top level Import menu instead of Analyse menu.
 - Change info URL to link to the site.
 

--- a/addOns/importLogFiles/importLogFiles.gradle.kts
+++ b/addOns/importLogFiles/importLogFiles.gradle.kts
@@ -3,7 +3,7 @@ description = "Allows you to import log files from ModSecurity and files previou
 
 zapAddOn {
     addOnName.set("Log File Importer")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("Joseph Kirwin, ZAP Dev Team")

--- a/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
+++ b/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
@@ -39,7 +39,8 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jwall.web.audit.AuditEvent;
 import org.jwall.web.audit.io.ModSecurity2AuditReader;
 import org.parosproxy.paros.Constant;
@@ -80,7 +81,7 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
 
     private ZapMenuItem menuExample = null;
 
-    private static Logger log = Logger.getLogger(ExtensionImportLogFiles.class);
+    private static Logger log = LogManager.getLogger(ExtensionImportLogFiles.class);
 
     private ImportLogAPI importLogAPI;
 

--- a/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
+++ b/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
@@ -28,7 +28,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import net.sf.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.api.ApiAction;
@@ -42,7 +43,7 @@ import org.zaproxy.zap.extension.importLogFiles.ExtensionImportLogFiles.LogType;
 /// This class extends the ImportLog functionality to the ZAP REST API
 public class ImportLogAPI extends ApiImplementor {
 
-    private static Logger log = Logger.getLogger(ImportLogAPI.class);
+    private static Logger log = LogManager.getLogger(ImportLogAPI.class);
 
     // API method names
     private static final String PREFIX = "importLogFiles";


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>