### PR TITLE
importUrls: Use Log4j 2.x

### DIFF
--- a/addOns/importurls/CHANGELOG.md
+++ b/addOns/importurls/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ## [7] - 2020-01-17
 ### Added

--- a/addOns/importurls/importurls.gradle.kts
+++ b/addOns/importurls/importurls.gradle.kts
@@ -6,7 +6,7 @@ description = "Adds an option to import a file of URLs. The file must be plain t
 zapAddOn {
     addOnName.set("Import files containing URLs")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
+++ b/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ExtensionImportUrls.java
@@ -27,7 +27,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import javax.swing.JFileChooser;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -51,7 +52,7 @@ public class ExtensionImportUrls extends ExtensionAdaptor {
 
     private ImportUrlsAPI api;
 
-    private static Logger log = Logger.getLogger(ExtensionImportUrls.class);
+    private static Logger log = LogManager.getLogger(ExtensionImportUrls.class);
 
     public ExtensionImportUrls() {
         super(NAME);

--- a/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
+++ b/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.importurls;
 
 import java.io.File;
 import net.sf.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiException.Type;
@@ -33,7 +34,7 @@ import org.zaproxy.zap.utils.ApiUtils;
 /** The API for importing URLs from a file. */
 public class ImportUrlsAPI extends ApiImplementor {
 
-    private static final Logger LOG = Logger.getLogger(ImportUrlsAPI.class);
+    private static final Logger LOG = LogManager.getLogger(ImportUrlsAPI.class);
 
     private static final String PREFIX = "importurls";
 
@@ -61,7 +62,7 @@ public class ImportUrlsAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
-        LOG.debug("handleApiAction " + name + " " + params.toString());
+        LOG.debug("handleApiAction {} {}", name, params.toString());
 
         switch (name) {
             case ACTION_IMPORTURLS:


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>