### PR TITLE
jython: Use Log4j 2.x

### DIFF
--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update links to zaproxy repo.
+- Maintenance changes.
 
 ## [11] - 2020-12-15
 ### Added

--- a/addOns/jython/jython.gradle.kts
+++ b/addOns/jython/jython.gradle.kts
@@ -6,12 +6,11 @@ description = "Allows Python to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Python Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/python-scripting/")
-        notBeforeVersion.set("2.10.0")
     }
 }
 

--- a/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/JythonOptionsParam.java
+++ b/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/JythonOptionsParam.java
@@ -20,12 +20,13 @@
 package org.zaproxy.zap.extension.jython;
 
 import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 
 public class JythonOptionsParam extends VersionedAbstractParam {
 
-    private static final Logger logger = Logger.getLogger(JythonOptionsParam.class);
+    private static final Logger logger = LogManager.getLogger(JythonOptionsParam.class);
 
     /**
      * The version of the configurations. Used to keep track of configurations changes between
@@ -57,7 +58,7 @@ public class JythonOptionsParam extends VersionedAbstractParam {
         try {
             this.modulePath = super.getConfig().getString(MODULE_PATH_PROPERTY, "");
         } catch (ConversionException e) {
-            logger.error("Error while loading '" + MODULE_PATH_PROPERTY + "':", e);
+            logger.error("Error while loading '{}': ", MODULE_PATH_PROPERTY, e);
         }
     }
 


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>