### PR TITLE
pscanrules: Use Log4j 2.x

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Cache-control scan rule no longer checks if Pragma is set or not.
+- Maintenance changes.
 
 ## [33] - 2021-01-29
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -29,7 +29,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -50,7 +51,7 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.applicationerrors.";
 
-    private static final Logger LOGGER = Logger.getLogger(ApplicationErrorScanRule.class);
+    private static final Logger LOGGER = LogManager.getLogger(ApplicationErrorScanRule.class);
 
     // Name of the file related to pattern's definition list
     private String APP_ERRORS_FILE =
@@ -76,11 +77,9 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
                 matcher = ContentMatcher.getInstance(is);
             } catch (IOException | IllegalArgumentException e) {
                 LOGGER.warn(
-                        "Unable to read "
-                                + getName()
-                                + " input file: "
-                                + APP_ERRORS_FILE
-                                + ". Falling back to ZAP archive.");
+                        "Unable to read {} input file: {}. Falling back to ZAP archive.",
+                        getName(),
+                        APP_ERRORS_FILE);
                 matcher =
                         ContentMatcher.getInstance(
                                 ApplicationErrorScanRule.class.getResourceAsStream(

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -33,7 +33,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -54,7 +55,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
 
     private static final String MESSAGE_PREFIX = "pscanrules.csp.";
     private static final int PLUGIN_ID = 10055;
-    private static final Logger LOGGER = Logger.getLogger(ContentSecurityPolicyScanRule.class);
+    private static final Logger LOGGER = LogManager.getLogger(ContentSecurityPolicyScanRule.class);
 
     private static final String HTTP_HEADER_CSP = "Content-Security-Policy";
     private static final String HTTP_HEADER_XCSP = "X-Content-Security-Policy";
@@ -88,11 +89,8 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         boolean cspHeaderFound = false;
         int noticesRisk = Alert.RISK_INFO;
-        // LOGGER.setLevel(Level.DEBUG); //Enable for debugging
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Start " + id + " : " + msg.getRequestHeader().getURI().toString());
-        }
+        LOGGER.debug("Start {} : {}", id, msg.getRequestHeader().getURI().toString());
 
         long start = System.currentTimeMillis();
 
@@ -244,14 +242,10 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
             }
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                    "\tScan of record "
-                            + String.valueOf(id)
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        LOGGER.debug(
+                "\tScan of record {} took {} ms",
+                String.valueOf(id),
+                System.currentTimeMillis() - start);
     }
 
     private static boolean hasReportUri(List<String> cspOptions) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.pscanrules;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
@@ -40,7 +41,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner {
 
     /** the logger. it logs stuff. */
-    private static Logger log = Logger.getLogger(CrossDomainMisconfigurationScanRule.class);
+    private static Logger log = LogManager.getLogger(CrossDomainMisconfigurationScanRule.class);
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.crossdomain.";
@@ -75,11 +76,9 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         try {
-            if (log.isDebugEnabled())
-                log.debug(
-                        "Checking message "
-                                + msg.getRequestHeader().getURI().getURI()
-                                + " for Cross-Domain misconfigurations");
+            log.debug(
+                    "Checking message {} for Cross-Domain misconfigurations",
+                    msg.getRequestHeader().getURI().toString());
 
             String corsAllowOriginValue =
                     msg.getResponseHeader().getHeader(HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN);
@@ -91,12 +90,10 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner {
             // msg.getResponseHeader().getHeader(HttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS);
 
             if (corsAllowOriginValue != null && corsAllowOriginValue.equals("*")) {
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Raising a Medium risk Cross Domain alert on "
-                                    + HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN
-                                    + ": "
-                                    + corsAllowOriginValue);
+                log.debug(
+                        "Raising a Medium risk Cross Domain alert on {}: {}",
+                        HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN,
+                        corsAllowOriginValue);
                 // Its a Medium, rather than a High (as originally thought), for the following
                 // reasons:
                 // Assumption: if an API is accessible in an unauthenticated manner, it doesn't need

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
@@ -25,7 +25,8 @@ import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
@@ -42,7 +43,8 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
 
     private static final int PLUGIN_ID = 10017;
 
-    private static final Logger logger = Logger.getLogger(CrossDomainScriptInclusionScanRule.class);
+    private static final Logger logger =
+            LogManager.getLogger(CrossDomainScriptInclusionScanRule.class);
     private Model model = null;
 
     @Override
@@ -155,7 +157,7 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
                 }
             }
         } catch (URIException e) {
-            logger.debug("Error: " + e.getMessage());
+            logger.debug("Error: {}", e.getMessage());
         }
         return otherDomain;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -28,7 +28,8 @@ import net.htmlparser.jericho.Element;
 import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -59,7 +60,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
     private String csrfValIgnoreList;
 
     /** the logger */
-    private static Logger logger = Logger.getLogger(CsrfCountermeasuresScanRule.class);
+    private static Logger logger = LogManager.getLogger(CsrfCountermeasuresScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -111,14 +112,14 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
             boolean hasSecurityAnnotation = false;
 
             // Loop through all of the FORM tags
-            logger.debug("Found " + formElements.size() + " forms");
+            logger.debug("Found {} forms", formElements.size());
 
             int numberOfFormsPassed = 0;
 
             List<String> ignoreList = new ArrayList<String>();
             String ignoreConf = getCSRFIgnoreList();
             if (ignoreConf != null && ignoreConf.length() > 0) {
-                logger.debug("Using ignore list: " + ignoreConf);
+                logger.debug("Using ignore list: {}", ignoreConf);
                 for (String str : ignoreConf.split(",")) {
                     String strTrim = str.trim();
                     if (strTrim.length() > 0) {
@@ -131,11 +132,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
 
             for (Element formElement : formElements) {
                 logger.debug(
-                        "FORM ["
-                                + formElement
-                                + "] has parent ["
-                                + formElement.getParentElement()
-                                + "]");
+                        "FORM [{}] has parent [{}]", formElement, formElement.getParentElement());
                 StringBuilder sbForm = new StringBuilder();
                 SortedSet<String> elementNames = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
                 ++numberOfFormsPassed;
@@ -168,7 +165,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
 
                 if (inputElements != null && inputElements.size() > 0) {
                     // Loop through all of the INPUT elements
-                    logger.debug("Found " + inputElements.size() + " inputs");
+                    logger.debug("Found {} inputs", inputElements.size());
                     for (Element inputElement : inputElements) {
                         String attId = inputElement.getAttributeValue("ID");
                         if (attId != null) {
@@ -236,14 +233,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                         .raise();
             }
         }
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        logger.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
     }
 
     private boolean formOnIgnoreList(Element formElement, List<String> ignoreList) {
@@ -251,14 +241,10 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
         String name = formElement.getAttributeValue("name");
         for (String ignore : ignoreList) {
             if (ignore.equals(id)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Ignoring form with id = " + id);
-                }
+                logger.debug("Ignoring form with id = {}", id);
                 return true;
             } else if (ignore.equals(name)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Ignoring form with name = " + name);
-                }
+                logger.debug("Ignoring form with name = {}", name);
                 return true;
             }
         }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
@@ -28,7 +28,8 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -44,7 +45,7 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
 
     private static final String debugErrorFile = "xml/debug-error-messages.txt";
     private static final Logger logger =
-            Logger.getLogger(InformationDisclosureDebugErrorsScanRule.class);
+            LogManager.getLogger(InformationDisclosureDebugErrorsScanRule.class);
     private List<String> errors = null;
 
     @Override
@@ -98,7 +99,7 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
         BufferedReader reader = null;
         File f = path.toFile();
         if (!f.exists()) {
-            logger.error("No such file: " + f.getAbsolutePath());
+            logger.error("No such file: {}", f.getAbsolutePath());
             return strings;
         }
         try {
@@ -110,13 +111,13 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
                 }
             }
         } catch (IOException e) {
-            logger.debug("Error on opening/reading debug error file. Error: " + e.getMessage(), e);
+            logger.debug("Error on opening/reading debug error file. Error: {}", e.getMessage(), e);
         } finally {
             if (reader != null) {
                 try {
                     reader.close();
                 } catch (IOException e) {
-                    logger.debug("Error on closing the file reader. Error: " + e.getMessage(), e);
+                    logger.debug("Error on closing the file reader. Error: {}", e.getMessage(), e);
                 }
             }
         }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
@@ -29,7 +29,8 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HtmlParameter;
@@ -45,7 +46,8 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner {
     public static final String URL_SENSITIVE_INFORMATION_DIR = "xml";
     public static final String URL_SENSITIVE_INFORMATION_FILE =
             "URL-information-disclosure-messages.txt";
-    private static final Logger logger = Logger.getLogger(InformationDisclosureInUrlScanRule.class);
+    private static final Logger logger =
+            LogManager.getLogger(InformationDisclosureInUrlScanRule.class);
     private static List<String> messages = null;
     static Pattern emailAddressPattern =
             Pattern.compile("\\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}\\b");
@@ -120,7 +122,7 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner {
         List<String> strings = new ArrayList<String>();
         File f = new File(Constant.getZapHome() + File.separator + file);
         if (!f.exists()) {
-            logger.error("No such file: " + f.getAbsolutePath());
+            logger.error("No such file: {}", f.getAbsolutePath());
             return strings;
         }
 
@@ -132,7 +134,7 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner {
                 }
             }
         } catch (IOException e) {
-            logger.debug("Error on opening/reading debug error file. Error: " + e.getMessage(), e);
+            logger.debug("Error on opening/reading debug error file. Error: {}", e.getMessage(), e);
         }
 
         return strings;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
@@ -30,7 +30,8 @@ import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
@@ -50,7 +51,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner 
     public static final String URL_SENSITIVE_INFORMATION_FILE =
             "URL-information-disclosure-messages.txt";
     private static final Logger logger =
-            Logger.getLogger(InformationDisclosureReferrerScanRule.class);
+            LogManager.getLogger(InformationDisclosureReferrerScanRule.class);
     private List<String> messages = null;
     static Pattern emailAddressPattern =
             Pattern.compile("\\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,4}\\b");
@@ -110,7 +111,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner 
                     result = true;
                 }
             } catch (URIException e) {
-                logger.debug("Error: " + e.getMessage());
+                logger.debug("Error: {}", e.getMessage());
             }
         }
         return result;
@@ -173,7 +174,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner 
         List<String> strings = new ArrayList<String>();
         File f = new File(Constant.getZapHome() + File.separator + file);
         if (!f.exists()) {
-            logger.error("No such file: " + f.getAbsolutePath());
+            logger.error("No such file: {}", f.getAbsolutePath());
             return strings;
         }
 
@@ -185,7 +186,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner 
                 }
             }
         } catch (IOException e) {
-            logger.debug("Error on opening/reading debug error file. Error: " + e.getMessage(), e);
+            logger.debug("Error on opening/reading debug error file. Error: {}", e.getMessage(), e);
         }
 
         return strings;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -35,7 +35,8 @@ import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTagType;
 import net.htmlparser.jericho.Tag;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -53,7 +54,7 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
     public static final String suspiciousCommentsListDir = "xml";
     public static final String suspiciousCommentsListFile = "suspicious-comments.txt";
     private static final Logger logger =
-            Logger.getLogger(InformationDisclosureSuspiciousCommentsScanRule.class);
+            LogManager.getLogger(InformationDisclosureSuspiciousCommentsScanRule.class);
 
     private static List<Pattern> patterns = null;
 
@@ -207,13 +208,12 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
                 }
             } catch (IOException e) {
                 logger.error(
-                        "Error on opening/reading suspicious comments file: "
-                                + File.separator
-                                + suspiciousCommentsListDir
-                                + File.separator
-                                + suspiciousCommentsListFile
-                                + " Error: "
-                                + e.getMessage());
+                        "Error on opening/reading suspicious comments file: {}{}{}{} Error: {}",
+                        File.separator,
+                        suspiciousCommentsListDir,
+                        File.separator,
+                        suspiciousCommentsListFile,
+                        e.getMessage());
             }
         }
         return patterns;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -30,8 +30,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -61,7 +61,7 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
                 Pattern.compile("\\b[0-9]{8,10}\\b", Pattern.CASE_INSENSITIVE), "Unix");
     }
 
-    private static Logger log = Logger.getLogger(TimestampDisclosureScanRule.class);
+    private static Logger log = LogManager.getLogger(TimestampDisclosureScanRule.class);
 
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "pscanrules.timestampdisclosure.";
@@ -104,99 +104,81 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
      */
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        try {
-            if (log.isDebugEnabled())
-                log.debug(
-                        "Checking message "
-                                + msg.getRequestHeader().getURI().getURI()
-                                + " for timestamps");
+        log.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI().toString());
 
-            List<HttpHeaderField> responseheaders = msg.getResponseHeader().getHeaders();
-            StringBuffer filteredResponseheaders = new StringBuffer();
-            for (HttpHeaderField responseheader : responseheaders) {
-                boolean ignoreHeader = false;
-                for (String headerToIgnore : RESPONSE_HEADERS_TO_IGNORE) {
-                    if (responseheader.getName().equalsIgnoreCase(headerToIgnore)) {
-                        if (log.isDebugEnabled())
-                            log.debug("Ignoring header " + responseheader.getName());
-                        ignoreHeader = true;
-                        break; // out of inner loop
-                    }
-                }
-                if (!ignoreHeader) {
-                    filteredResponseheaders.append("\n");
-                    filteredResponseheaders.append(
-                            responseheader.getName() + ": " + responseheader.getValue());
+        List<HttpHeaderField> responseheaders = msg.getResponseHeader().getHeaders();
+        StringBuffer filteredResponseheaders = new StringBuffer();
+        for (HttpHeaderField responseheader : responseheaders) {
+            boolean ignoreHeader = false;
+            for (String headerToIgnore : RESPONSE_HEADERS_TO_IGNORE) {
+                if (responseheader.getName().equalsIgnoreCase(headerToIgnore)) {
+                    log.debug("Ignoring header {}", responseheader.getName());
+                    ignoreHeader = true;
+                    break; // out of inner loop
                 }
             }
+            if (!ignoreHeader) {
+                filteredResponseheaders.append("\n");
+                filteredResponseheaders.append(
+                        responseheader.getName() + ": " + responseheader.getValue());
+            }
+        }
 
-            String responsebody = msg.getResponseBody().toString();
-            String[] responseparts = {filteredResponseheaders.toString(), responsebody};
+        String responsebody = msg.getResponseBody().toString();
+        String[] responseparts = {filteredResponseheaders.toString(), responsebody};
 
-            // try each of the patterns in turn against the response.
-            String timestampType = null;
-            Iterator<Pattern> patternIterator = timestampPatterns.keySet().iterator();
+        // try each of the patterns in turn against the response.
+        String timestampType = null;
+        Iterator<Pattern> patternIterator = timestampPatterns.keySet().iterator();
 
-            while (patternIterator.hasNext()) {
-                Pattern timestampPattern = patternIterator.next();
-                timestampType = timestampPatterns.get(timestampPattern);
-                if (log.isDebugEnabled())
-                    log.debug(
-                            "Trying Timestamp Pattern: "
-                                    + timestampPattern
-                                    + " for timestamp type "
-                                    + timestampType);
-                for (String haystack : responseparts) {
-                    Matcher matcher = timestampPattern.matcher(haystack);
-                    while (matcher.find()) {
-                        String evidence = matcher.group();
-                        java.util.Date timestamp = null;
-                        try {
-                            // parse the number as a Unix timestamp
-                            timestamp =
-                                    new java.util.Date((long) Integer.parseInt(evidence) * 1000);
-                        } catch (NumberFormatException nfe) {
-                            // the number is not formatted correctly to be a timestamp. Skip it.
-                            continue;
-                        }
-                        if (log.isDebugEnabled())
-                            log.debug(
-                                    "Found a match for timestamp type "
-                                            + timestampType
-                                            + ":"
-                                            + evidence);
+        while (patternIterator.hasNext()) {
+            Pattern timestampPattern = patternIterator.next();
+            timestampType = timestampPatterns.get(timestampPattern);
+            log.debug(
+                    "Trying Timestamp Pattern: {} for timestamp type {}",
+                    timestampPattern,
+                    timestampType);
+            for (String haystack : responseparts) {
+                Matcher matcher = timestampPattern.matcher(haystack);
+                while (matcher.find()) {
+                    String evidence = matcher.group();
+                    java.util.Date timestamp = null;
+                    try {
+                        // parse the number as a Unix timestamp
+                        timestamp = new java.util.Date((long) Integer.parseInt(evidence) * 1000);
+                    } catch (NumberFormatException nfe) {
+                        // the number is not formatted correctly to be a timestamp. Skip it.
+                        continue;
+                    }
+                    log.debug("Found a match for timestamp type {}:{}", timestampType, evidence);
 
-                        if (evidence != null && evidence.length() > 0) {
-                            // we found something.. potentially
-                            if (AlertThreshold.HIGH.equals(this.getAlertThreshold())) {
-                                Instant foundInstant =
-                                        Instant.ofEpochSecond(Long.parseLong(evidence));
-                                ZonedDateTime now = ZonedDateTime.now();
-                                if (!(foundInstant.isAfter(now.minusYears(1).toInstant())
-                                        && foundInstant.isBefore(now.plusYears(1).toInstant()))) {
-                                    continue;
-                                }
+                    if (evidence != null && evidence.length() > 0) {
+                        // we found something.. potentially
+                        if (AlertThreshold.HIGH.equals(this.getAlertThreshold())) {
+                            Instant foundInstant = Instant.ofEpochSecond(Long.parseLong(evidence));
+                            ZonedDateTime now = ZonedDateTime.now();
+                            if (!(foundInstant.isAfter(now.minusYears(1).toInstant())
+                                    && foundInstant.isBefore(now.plusYears(1).toInstant()))) {
+                                continue;
                             }
-                            newAlert()
-                                    .setName(getName() + " - " + timestampType)
-                                    .setRisk(Alert.RISK_INFO)
-                                    .setConfidence(Alert.CONFIDENCE_LOW)
-                                    .setDescription(getDescription() + " - " + timestampType)
-                                    .setOtherInfo(getExtraInfo(msg, evidence, timestamp))
-                                    .setSolution(getSolution())
-                                    .setReference(getReference())
-                                    .setEvidence(evidence)
-                                    .setCweId(200) // Information Exposure,
-                                    .setWascId(13) // Information Leakage
-                                    .raise();
-                            // do NOT break at this point.. we need to find *all* the potential
-                            // timestamps in the response..
                         }
+                        newAlert()
+                                .setName(getName() + " - " + timestampType)
+                                .setRisk(Alert.RISK_INFO)
+                                .setConfidence(Alert.CONFIDENCE_LOW)
+                                .setDescription(getDescription() + " - " + timestampType)
+                                .setOtherInfo(getExtraInfo(msg, evidence, timestamp))
+                                .setSolution(getSolution())
+                                .setReference(getReference())
+                                .setEvidence(evidence)
+                                .setCweId(200) // Information Exposure,
+                                .setWascId(13) // Information Leakage
+                                .raise();
+                        // do NOT break at this point.. we need to find *all* the potential
+                        // timestamps in the response..
                     }
                 }
             }
-        } catch (URIException e) {
-            log.error("An exception occurrred passively scanning for timestamps");
         }
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
@@ -29,7 +29,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -42,7 +43,7 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX = "pscanrules.usernameidor.";
     private static final int PLUGIN_ID = 10057;
 
-    private static final Logger LOGGER = Logger.getLogger(UsernameIdorScanRule.class);
+    private static final Logger LOGGER = LogManager.getLogger(UsernameIdorScanRule.class);
 
     private static final String ADMIN = "Admin";
     private static final String ADMIN_2 = "admin";
@@ -79,9 +80,7 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         List<User> scanUsers = getUsers();
         if (scanUsers.isEmpty()) { // Should continue if not empty
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("There does not appear to be any contexts with configured users.");
-            }
+            LOGGER.debug("There does not appear to be any contexts with configured users.");
             return;
         }
 
@@ -107,14 +106,7 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
                 }
             }
         }
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        LOGGER.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
     }
 
     private void raiseAlert(

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
@@ -24,7 +24,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -41,7 +42,7 @@ public class XDebugTokenScanRule extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX = "pscanrules.xdebugtoken.";
     private static final int PLUGIN_ID = 10056;
 
-    private static final Logger LOGGER = Logger.getLogger(XDebugTokenScanRule.class);
+    private static final Logger LOGGER = LogManager.getLogger(XDebugTokenScanRule.class);
 
     private static final String X_DEBUG_TOKEN_HEADER = "X-Debug-Token";
     private static final String X_DEBUG_TOKEN_LINK_HEADER = "X-Debug-Token-Link";
@@ -71,14 +72,7 @@ public class XDebugTokenScanRule extends PluginPassiveScanner {
             return;
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                    "\tScan of record "
-                            + id
-                            + " took "
-                            + (System.currentTimeMillis() - start)
-                            + " ms");
-        }
+        LOGGER.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
     }
 
     private void raiseAlert(HttpMessage msg, String evidence) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
@@ -24,7 +24,8 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -42,7 +43,8 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner {
     private static final String HEADER_NAME = "X-Powered-By";
     private static final int PLUGIN_ID = 10037;
 
-    private static final Logger logger = Logger.getLogger(XPoweredByHeaderInfoLeakScanRule.class);
+    private static final Logger logger =
+            LogManager.getLogger(XPoweredByHeaderInfoLeakScanRule.class);
 
     @Override
     public void setParent(PassiveScanThread parent) {
@@ -61,14 +63,7 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner {
         if (isXPoweredByHeaderExist(msg)) {
             List<String> xpbHeaders = getXPoweredByHeaders(msg);
             raiseAlert(msg, id, xpbHeaders);
-            if (logger.isDebugEnabled()) {
-                logger.debug(
-                        "\tScan of record "
-                                + id
-                                + " took "
-                                + (System.currentTimeMillis() - start)
-                                + " ms");
-            }
+            logger.debug("\tScan of record {} took {} ms", id, System.currentTimeMillis() - start);
         }
     }
 


### PR DESCRIPTION
- Update CHANGELOG, and change code to use updated logging infrastructure.
- TimestampDisclosureScanRule shows a significant change because a try/catch was removed which was never/no-longer needed.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>