### PR TITLE
automation: Stop plan when applyParameters fails

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added support for enum parameters.
 - Added a new parameter "handleParameters" for the *spider* job.
 
+### Fixed
+- A bug where the plan did not stop when it encountered an error or warning and env:parameters:failOnError or env:parameters:failOnWarning was set to true.
+
 ## [0.0.1] - 2021-03-09
 
 - First version.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -208,6 +208,11 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
                 }
                 job.applyParameters((LinkedHashMap<?, ?>) paramsObj, progress);
 
+                // In case errors or warnings are encountered in the applyParameters() call above
+                if (env.isTimeToQuit()) {
+                    break;
+                }
+
                 progress.info(
                         Constant.messages.getString("automation.info.jobstart", job.getType()));
                 job.runJob(env, jobData, progress);

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -408,6 +408,111 @@ public class ExtentionAutomationUnitTest extends TestUtils {
         assertThat(job3.wasRun(), is(equalTo(true)));
     }
 
+    @Test
+    public void shouldFailPlanOnErrorApplyingParameters() {
+        // Given
+        AutomationJobImpl job =
+                new AutomationJobImpl() {
+                    @Override
+                    public String getType() {
+                        return "job";
+                    }
+
+                    @Override
+                    public Order getOrder() {
+                        return Order.EXPLORE;
+                    }
+
+                    @Override
+                    public Object getParamMethodObject() {
+                        return new TestParamContainer();
+                    }
+
+                    @Override
+                    public String getParamMethodName() {
+                        return "getTestParam";
+                    }
+                };
+        ExtensionAutomation extAuto = new ExtensionAutomation();
+        Path filePath = getResourcePath("resources/testPlan-failOnErrorApplyingParameters.yaml");
+
+        // When
+        extAuto.registerAutomationJob(job);
+        AutomationProgress progress =
+                extAuto.runAutomationFile(filePath.toAbsolutePath().toString());
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!automation.error.options.badbool!")));
+        assertThat(job.wasRun(), is(equalTo(false)));
+    }
+
+    @Test
+    public void shouldFailPlanOnWarningApplyingParameters() {
+        // Given
+        AutomationJobImpl job =
+                new AutomationJobImpl() {
+                    @Override
+                    public String getType() {
+                        return "job";
+                    }
+
+                    @Override
+                    public Order getOrder() {
+                        return Order.EXPLORE;
+                    }
+
+                    @Override
+                    public Object getParamMethodObject() {
+                        return new TestParamContainer();
+                    }
+
+                    @Override
+                    public String getParamMethodName() {
+                        return "getTestParam";
+                    }
+                };
+        ExtensionAutomation extAuto = new ExtensionAutomation();
+        Path filePath = getResourcePath("resources/testPlan-failOnWarningApplyingParameters.yaml");
+
+        // When
+        extAuto.registerAutomationJob(job);
+        AutomationProgress progress =
+                extAuto.runAutomationFile(filePath.toAbsolutePath().toString());
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(progress.getWarnings().size(), is(equalTo(1)));
+        assertThat(
+                progress.getWarnings().get(0), is(equalTo("!automation.error.options.unknown!")));
+        assertThat(job.wasRun(), is(equalTo(false)));
+    }
+
+    // Methods are accessed via reflection
+    @SuppressWarnings("unused")
+    private static class TestParamContainer {
+
+        private TestParam testParam = new TestParam();
+
+        public TestParam getTestParam() {
+            return testParam;
+        }
+    }
+
+    // Methods are accessed via reflection
+    @SuppressWarnings("unused")
+    private static class TestParam {
+
+        private boolean boolParam;
+
+        public void setBoolParam(boolean boolParam) {
+            this.boolParam = boolParam;
+        }
+    }
+
     private static class AutomationJobImpl extends AutomationJob {
 
         private boolean wasRun = false;

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnErrorApplyingParameters.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnErrorApplyingParameters.yaml
@@ -1,0 +1,13 @@
+env:
+  contexts:
+    - name: example
+      url: https://www.example.com/
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+
+jobs:
+  - type: job
+    parameters:
+      boolParam: invalid                   # We want an error when setting this boolean variable, which is why this is not "true" or "false".

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnWarningApplyingParameters.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnWarningApplyingParameters.yaml
@@ -1,0 +1,13 @@
+env:
+  contexts:
+    - name: example
+      url: https://www.example.com/
+  parameters:
+    failOnError: false
+    failOnWarning: true
+    progressToStdout: true
+
+jobs:
+  - type: job
+    parameters:
+      invalidParam: true                   # Supply an invalid parameter to trigger a warning in the call to AutomationJob#applyParameters.


### PR DESCRIPTION
- Stop running when applyParameters encounters an error or warning and env:parameters:failOnError or env:parameters:failOnWarning is true.

Signed-off-by: ricekot <ricekot@gmail.com>