### PR TITLE
ascanrules: Path Traveral rule further tweaks

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
-- The Path Traversal scan rule should now be less False Positive prone, one of it's checks will now only run at Low Threshold (Issues: 4209, 6030, 6219, 6372, and 6380).
+- The Path Traversal scan rule should now be less False Positive prone at High Threshold, one of it's checks will now be excluded at High Threshold (Issues: 4209, 6030, 6219, 6372, and 6380).
   - The Other info field of Alerts will now include a reference indicating which check the triggered alert is caused by, in order to assist in future user inquiries.
 
 ## [38] - 2020-12-15

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -430,7 +430,8 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                 }
             }
 
-            if (getAlertThreshold().equals(AlertThreshold.LOW)) {
+            if (getAlertThreshold().equals(AlertThreshold.LOW)
+                    || getAlertThreshold().equals(AlertThreshold.MEDIUM)) {
                 // Check 5: try a local file Path Traversal on the file name of the URL (which
                 // obviously will not be in the target list above).
                 // first send a query for a random parameter value, and see if we get a 200 back

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -125,7 +125,7 @@ current target file an alert is raised and the scanner returns immediately. If n
 attempted using the filename in the URL. As long as submitting an arbitrary filename does not return an OK status code but the real filename does, an alert is raised
 and the scanner returns immediately.
 <p>
-Note: This scan rule has one check that is only executed at Low Alert Threshold.
+Note: This scan rule has one check that is excluded at High Alert Threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java">PathTraversalScanRule.java</a>
 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRuleUnitTest.java
@@ -192,15 +192,18 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
         assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("Check 1")));
     }
 
-    @Test
-    public void shouldAlertOnCheckFiveAtLowThresholdUnderValidConditions()
-            throws HttpMalformedHeaderException {
+    @ParameterizedTest
+    @EnumSource(
+            value = Plugin.AlertThreshold.class,
+            names = {"LOW", "MEDIUM"})
+    public void shouldAlertOnCheckFiveBelowHighThresholdUnderValidConditions(
+            AlertThreshold alertThreshold) throws HttpMalformedHeaderException {
         // Given
         String path = "/file.ext";
         HttpMessage msg = getHttpMessage(path + "?p=a");
         rule.init(msg, parent);
         nano.addHandler(new Check5Handler(path, "p", Check5Handler.GENERIC_CONTENT, true));
-        rule.setAlertThreshold(AlertThreshold.LOW);
+        rule.setAlertThreshold(alertThreshold);
         // When
         rule.scan();
         // Then
@@ -209,18 +212,15 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
         assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("Check 5")));
     }
 
-    @ParameterizedTest
-    @EnumSource(
-            value = Plugin.AlertThreshold.class,
-            names = {"MEDIUM", "HIGH"})
-    public void shouldNotAlertOnCheckFiveAboveLowThresholdUnderValidConditions(
-            AlertThreshold alertThreshold) throws HttpMalformedHeaderException {
+    @Test
+    public void shouldNotAlertOnCheckFiveAtHighThresholdUnderValidConditions()
+            throws HttpMalformedHeaderException {
         // Given
         String path = "/file.ext";
         HttpMessage msg = getHttpMessage(path + "?p=a");
         rule.init(msg, parent);
         nano.addHandler(new Check5Handler(path, "p", Check5Handler.GENERIC_CONTENT, true));
-        rule.setAlertThreshold(alertThreshold);
+        rule.setAlertThreshold(AlertThreshold.HIGH);
         // When
         rule.scan();
         // Then


### PR DESCRIPTION
As discussed via email, and in follow-up to recent wavsep runs.

- PathTraversalScanRule > Do check 5 at both LOW and MEDIUM threshold. (Which gives the user the option of setting Threshold HIGH to exclude it.)
- PathTraversalScanRuleUnitTest > Revised to accomodate modified logic.
- ascanrules.html > Updated threshold note.
- CHANGELOG > Updated change note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>