### PR TITLE
openapi: Updates

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
+- Automation parameters are now in camelCase. This is a breaking change, and older automation configurations containing all-lowercase openapi parameters will stop working.
 
 ## [18] - 2021-03-09
 ### Added

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now using 2.10 logging infrastructure (Log4j 2.x).
 
 ## [18] - 2021-03-09
 ### Added

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -6,12 +6,11 @@ description = "Imports and spiders OpenAPI definitions."
 zapAddOn {
     addOnName.set("OpenAPI Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak, Marcin Spiewak, and SDA SE Open Industry Solutions")
         url.set("https://www.zaproxy.org/docs/desktop/addons/openapi-support/")
-        notBeforeVersion.set("2.10.0")
         extensions {
             register("org.zaproxy.zap.extension.openapi.automation.ExtensionOpenApiAutomation") {
                 classnames {
@@ -50,10 +49,11 @@ dependencies {
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    implementation("org.slf4j:slf4j-log4j12:1.7.30") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.0") {
         // Provided by ZAP.
-        exclude(group = "log4j")
+        exclude(group = "org.apache.logging.log4j")
     }
 
+    testImplementation("org.apache.logging.log4j:log4j-core:2.14.0")
     testImplementation(project(":testutils"))
 }

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -55,5 +55,6 @@ dependencies {
     }
 
     testImplementation("org.apache.logging.log4j:log4j-core:2.14.0")
+    testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -67,7 +68,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     private static final int ARG_IMPORT_URL_IDX = 1;
     private static final int ARG_TARGET_URL_IDX = 2;
 
-    private static final Logger LOG = Logger.getLogger(ExtensionOpenApi.class);
+    private static final Logger LOG = LogManager.getLogger(ExtensionOpenApi.class);
 
     public ExtensionOpenApi() {
         super(NAME);

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -19,14 +19,10 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -55,8 +51,6 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     public static final String URL_ADDED_STATS = "openapi.urls.added";
 
     private static final String THREAD_PREFIX = "ZAP-Import-OpenAPI-";
-
-    private static final String RESOURCES_DIR = "/org/zaproxy/zap/extension/openapi/resources/";
 
     private ZapMenuItem menuImportLocalOpenApi = null;
     private ZapMenuItem menuImportUrlOpenApi = null;
@@ -461,19 +455,5 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     public boolean handleFile(File file) {
         // Not supported
         return false;
-    }
-
-    public static String getResourceAsString(String name) {
-        try (InputStream in = ExtensionOpenApi.class.getResourceAsStream(RESOURCES_DIR + name)) {
-            return new BufferedReader(new InputStreamReader(in))
-                            .lines()
-                            .collect(Collectors.joining("\n"))
-                    + "\n";
-        } catch (Exception e) {
-            CommandLine.error(
-                    Constant.messages.getString(
-                            "openapi.automation.error.nofile", RESOURCES_DIR + name));
-        }
-        return "";
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/HistoryPersister.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/HistoryPersister.java
@@ -19,7 +19,8 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
@@ -32,7 +33,7 @@ import org.zaproxy.zap.utils.ThreadUtils;
 
 public class HistoryPersister implements RequesterListener {
 
-    private static final Logger LOG = Logger.getLogger(HistoryPersister.class);
+    private static final Logger LOG = LogManager.getLogger(HistoryPersister.class);
 
     private final ExtensionHistory extHistory;
 
@@ -66,7 +67,7 @@ public class HistoryPersister implements RequesterListener {
             }
             Stats.incCounter(ExtensionOpenApi.URL_ADDED_STATS);
         } catch (Exception e) {
-            LOG.warn("Failed to persist the message: " + e.getMessage(), e);
+            LOG.warn("Failed to persist the message: {}", e.getMessage(), e);
             return;
         }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiSpider.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.openapi;
 import java.util.Locale;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
@@ -36,7 +37,7 @@ import org.zaproxy.zap.spider.parser.SpiderParser;
 
 public class OpenApiSpider extends SpiderParser {
 
-    private static final Logger log = Logger.getLogger(OpenApiSpider.class);
+    private static final Logger log = LogManager.getLogger(OpenApiSpider.class);
     private Requestor requestor;
     private ValueGenerator valGen = null;
 
@@ -83,7 +84,7 @@ public class OpenApiSpider extends SpiderParser {
         } catch (Exception e) {
             return false;
         }
-        log.debug("Cant parse " + message.getRequestHeader().getURI());
+        log.debug("Can't parse {}", message.getRequestHeader().getURI());
         return false;
     }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/ExtensionOpenApiAutomation.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/ExtensionOpenApiAutomation.java
@@ -41,6 +41,7 @@ public class ExtensionOpenApiAutomation extends ExtensionAdaptor {
     static {
         List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
         dependencies.add(ExtensionOpenApi.class);
+        dependencies.add(ExtensionAutomation.class);
         DEPENDENCIES = Collections.unmodifiableList(dependencies);
     }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
@@ -20,10 +20,14 @@
 package org.zaproxy.zap.extension.openapi.automation;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.io.IOUtils;
+import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.zaproxy.addon.automation.AutomationEnvironment;
@@ -35,10 +39,11 @@ import org.zaproxy.zap.extension.openapi.OpenApiResults;
 public class OpenApiJob extends AutomationJob {
 
     private static final String JOB_NAME = "openapi";
+    private static final String RESOURCES_DIR = "/org/zaproxy/zap/extension/openapi/resources/";
 
-    private static final String PARAM_API_URL = "apiurl";
-    private static final String PARAM_API_FILE = "apifile";
-    private static final String PARAM_TARGET_URL = "targeturl";
+    private static final String PARAM_API_URL = "apiUrl";
+    private static final String PARAM_API_FILE = "apiFile";
+    private static final String PARAM_TARGET_URL = "targetUrl";
 
     private ExtensionOpenApi extOpenApi;
 
@@ -140,11 +145,39 @@ public class OpenApiJob extends AutomationJob {
     }
 
     public String getTemplateDataMin() {
-        return ExtensionOpenApi.getResourceAsString(this.getType() + "-min.yaml");
+        return getResourceAsString(this.getType() + "-min.yaml");
     }
 
     public String getTemplateDataMax() {
-        return ExtensionOpenApi.getResourceAsString(this.getType() + "-max.yaml");
+        return getResourceAsString(this.getType() + "-max.yaml");
+    }
+
+    private static String getResourceAsString(String name) {
+        try {
+            return IOUtils.toString(
+                    OpenApiJob.class.getResourceAsStream(RESOURCES_DIR + name),
+                    StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            CommandLine.error(
+                    Constant.messages.getString(
+                            "openapi.automation.error.nofile", RESOURCES_DIR + name));
+        }
+        return "";
+    }
+
+    // For Unit Tests
+    protected String getApiFile() {
+        return apiFile;
+    }
+
+    // For Unit Tests
+    protected String getApiUrl() {
+        return apiUrl;
+    }
+
+    // For Unit Tests
+    protected String getTargetUrl() {
+        return targetUrl;
     }
 
     @Override

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/OperationHelper.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/OperationHelper.java
@@ -22,12 +22,13 @@ package org.zaproxy.zap.extension.openapi.converter.swagger;
 import io.swagger.v3.oas.models.PathItem;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.extension.openapi.network.RequestMethod;
 
 public class OperationHelper {
 
-    private static final Logger log = Logger.getLogger(OperationHelper.class);
+    private static final Logger log = LogManager.getLogger(OperationHelper.class);
 
     public List<OperationModel> getAllOperations(PathItem path, String url) {
         List<OperationModel> operations = new LinkedList<OperationModel>();
@@ -54,7 +55,7 @@ public class OperationHelper {
             operations.add(new OperationModel(url, path.getPatch(), RequestMethod.PATCH));
         }
         if (operations.isEmpty()) {
-            log.debug("Failed to find any operations for url=" + url + " path=" + path);
+            log.debug("Failed to find any operations for url={} path={}", url, path);
         }
 
         return operations;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -43,7 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.openapi.converter.Converter;
 import org.zaproxy.zap.extension.openapi.generators.Generators;
@@ -55,7 +56,7 @@ public class SwaggerConverter implements Converter {
     /** The base key for internationalised messages. */
     private static final String BASE_KEY_I18N = "openapi.swaggerconverter.";
 
-    private static Logger LOG = Logger.getLogger(SwaggerConverter.class);
+    private static Logger LOG = LogManager.getLogger(SwaggerConverter.class);
     private final UriBuilder targetUriBuilder;
     private final UriBuilder definitionUriBuilder;
     private String defn;
@@ -340,13 +341,10 @@ public class SwaggerConverter implements Converter {
             try {
                 UriBuilder uriBuilder = UriBuilder.parse(url);
                 if (!hasSupportedScheme(uriBuilder)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Ignoring server URL "
-                                        + url
-                                        + " because of unsupported scheme: "
-                                        + uriBuilder.getScheme());
-                    }
+                    LOG.debug(
+                            "Ignoring server URL {} because of unsupported scheme: {}",
+                            url,
+                            uriBuilder.getScheme());
                     continue;
                 }
                 if (!uriBuilder.isEmpty()) {
@@ -355,7 +353,7 @@ public class SwaggerConverter implements Converter {
 
                 urls.add(uriBuilder.merge(definitionUriBuilder));
             } catch (IllegalArgumentException e) {
-                LOG.warn("Failed to create server URL from: " + url, e);
+                LOG.warn("Failed to create server URL from: {}", url, e);
             }
         }
         return urls;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
@@ -30,13 +30,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class BodyGenerator {
 
     private Generators generators;
     private DataGenerator dataGenerator;
-    private static final Logger LOG = Logger.getLogger(BodyGenerator.class);
+    private static final Logger LOG = LogManager.getLogger(BodyGenerator.class);
 
     public BodyGenerator(Generators generators) {
         this.generators = generators;
@@ -74,9 +75,7 @@ public class BodyGenerator {
         }
 
         boolean isArray = schema instanceof ArraySchema;
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Generate body for object " + schema.getName());
-        }
+        LOG.debug("Generate body for object {}", schema.getName());
 
         if (isArray) {
             return generateFromArraySchema((ArraySchema) schema);
@@ -177,7 +176,7 @@ public class BodyGenerator {
             return schema.getAnyOf().get(0);
         }
         // Should not be reached, allOf schema is resolved by the parser
-        LOG.error("Unknown composed schema type: " + schema);
+        LOG.error("Unknown composed schema type: {}", schema);
         return null;
     }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/ValueGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/ValueGenerator.java
@@ -21,14 +21,15 @@ package org.zaproxy.zap.extension.openapi.generators;
 
 import java.util.Collections;
 import java.util.HashMap;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /** A wrapper around the core ValueGenerator class */
 public class ValueGenerator {
 
     private org.zaproxy.zap.model.ValueGenerator coreValGen;
 
-    private static final Logger LOG = Logger.getLogger(ValueGenerator.class);
+    private static final Logger LOG = LogManager.getLogger(ValueGenerator.class);
 
     public ValueGenerator(org.zaproxy.zap.model.ValueGenerator coreValGen) {
         this.coreValGen = coreValGen;
@@ -39,16 +40,11 @@ public class ValueGenerator {
             defaultValue = "";
         }
         if (coreValGen == null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug(
-                        "Name : "
-                                + name
-                                + " Type : "
-                                + type
-                                + " Default : "
-                                + defaultValue
-                                + " Returning default value");
-            }
+            LOG.debug(
+                    "Name : {} Type : {} Default : {} Returning default value",
+                    name,
+                    type,
+                    defaultValue);
             return defaultValue;
         }
 
@@ -64,17 +60,8 @@ public class ValueGenerator {
                         Collections.<String, String>emptyMap(),
                         fieldAtts);
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "Name : "
-                            + name
-                            + " Type : "
-                            + type
-                            + " Default : "
-                            + defaultValue
-                            + " Returning : "
-                            + value);
-        }
+        LOG.debug(
+                "Name : {} Type : {} Default : {} Returning : {}", name, type, defaultValue, value);
 
         return value;
     }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/network/Requestor.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/network/Requestor.java
@@ -23,7 +23,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpHeaderField;
@@ -38,7 +39,7 @@ public class Requestor {
     private List<RequesterListener> listeners = new ArrayList<RequesterListener>();
     private HttpSender sender;
     private final HttpRequestConfig requestConfig;
-    private static final Logger LOG = Logger.getLogger(Requestor.class);
+    private static final Logger LOG = LogManager.getLogger(Requestor.class);
 
     public Requestor(int initiator) {
         this.initiator = initiator;

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
@@ -12,23 +12,17 @@ This add-on supports the Automation Framework.
 <br><br>
 The add-on will add OpenAPI definitions if they are found while spidering but adding them explicitly via a URL or local file is recommended if they are available.
 <br><br>
-The targeturl parameter works in the same way per <a href="openapi.html">'Target URL Format'</a>.
+The targetUrl parameter works in the same way per <a href="openapi.html">'Target URL Format'</a>.
 
 <H2>Job: openapi</H2>
 The openapi job allows you to import OpenAPI definitions via a URL or file.
 <pre>
   - type: openapi                      # OpenAPI definition import
     parameters:
-      apifile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
-      apiurl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      targeturl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden
+      apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
+      apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
+      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden
 </pre>
-
-<H2>Statistics</H2>
-The add-on maintains the following statistics:
-<ul>
-<li>openapi.urls.added : The total number of URLs added when importing OpenAPI definitions</li>
-</ul>
 
 </BODY>
 </HTML>

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -60,5 +60,11 @@ These can be overridden using the Form Handler add-on which allows you to specif
 In most cases these will be simple values (like strings and integers) but in some cases you may need to specify structured values, 
 e.g. <pre>{ "id": 0, "name": "Freda" }</pre>
 
+<H2>Statistics</H2>
+The add-on maintains the following statistics:
+<ul>
+    <li>openapi.urls.added : The total number of URLs added when importing OpenAPI definitions</li>
+</ul>
+
 </BODY>
 </HTML>

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/index.xml
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/index.xml
@@ -5,5 +5,5 @@
 
 <index version="2.0">
 	<indexitem text="openapi" target="openapi" />
-	<indexitem text="openapi.automation" target="openapi.automation" />
+	<indexitem text="openapi automation" target="openapi.automation" />
 </index>

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
@@ -1,5 +1,5 @@
   - type: openapi                      # OpenAPI definition import
     parameters:
-      apifile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
-      apiurl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      targeturl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden
+      apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
+      apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
+      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-min.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-min.yaml
@@ -1,5 +1,5 @@
   - type: openapi                      # OpenAPI definition import
     parameters:
-      apifile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
-      apiurl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      targeturl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden
+      apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
+      apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
+      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -1,0 +1,142 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.automation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Locale;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+import org.zaproxy.zap.utils.I18N;
+
+public class OpenApiJobUnitTest {
+
+    private ExtensionOpenApi extOpenApi;
+
+    @BeforeEach
+    public void setUp() {
+        Constant.messages = new I18N(Locale.ENGLISH);
+
+        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        Model.setSingletonForTesting(model);
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        extOpenApi = mock(ExtensionOpenApi.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionOpenApi.class)).willReturn(extOpenApi);
+
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+    }
+
+    @Test
+    public void shouldReturnDefaultFields() {
+        // Given / When
+        OpenApiJob job = new OpenApiJob();
+
+        // Then
+        assertThat(job.getType(), is(equalTo("openapi")));
+        assertThat(job.getName(), is(equalTo("openapi")));
+        assertThat(job.getOrder(), is(equalTo(AutomationJob.Order.EXPLORE)));
+        assertThat(job.getParamMethodObject(), is(nullValue()));
+        assertThat(job.getParamMethodName(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnCustomConfigParams() {
+        // Given
+        OpenApiJob job = new OpenApiJob();
+
+        // When
+        Map<String, String> params = job.getCustomConfigParameters();
+
+        // Then
+        assertThat(params.size(), is(equalTo(3)));
+        assertThat(params.get("apiFile"), is(equalTo("")));
+        assertThat(params.get("apiUrl"), is(equalTo("")));
+        assertThat(params.get("targetUrl"), is(equalTo("")));
+    }
+
+    @Test
+    public void shouldApplyCustomConfigParams() {
+        // Given
+        OpenApiJob job = new OpenApiJob();
+        String apiFile = "C:\\Users\\ZAPBot\\Documents\\test file.json";
+        String apiUrl = "https://example.com/test%20file.json";
+        String targetUrl = "https://example.com/endpoint/";
+
+        // When
+        job.applyCustomParameter("apiFile", apiFile);
+        job.applyCustomParameter("apiUrl", apiUrl);
+        job.applyCustomParameter("targetUrl", targetUrl);
+
+        // Then
+        assertThat(job.getApiFile(), is(equalTo(apiFile)));
+        assertThat(job.getApiUrl(), is(equalTo(apiUrl)));
+        assertThat(job.getTargetUrl(), is(equalTo(targetUrl)));
+    }
+
+    @Test
+    public void shouldFailIfInvalidUrl() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+
+        // When
+        OpenApiJob job = new OpenApiJob();
+        job.applyCustomParameter("apiUrl", "Invalid URL.");
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!openapi.automation.error.url!")));
+    }
+
+    @Test
+    public void shouldFailIfInvalidFile() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+
+        // When
+        OpenApiJob job = new OpenApiJob();
+        job.applyCustomParameter("apiFile", "Invalid file path.");
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!openapi.automation.error.file!")));
+    }
+}

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -25,10 +25,10 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.OpenAPIV3Parser;
 import io.swagger.v3.parser.core.models.ParseOptions;
-import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.openapi.converter.swagger.OperationModel;
@@ -394,8 +394,8 @@ public class BodyGeneratorUnitTest {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);
         String defn =
-                FileUtils.readFileToString(
-                        new File(this.getClass().getResource(fileName).getFile()), "UTF-8");
+                IOUtils.toString(
+                        this.getClass().getResourceAsStream(fileName), StandardCharsets.UTF_8);
         return new OpenAPIV3Parser().readContents(defn, new ArrayList<>(), options).getOpenAPI();
     }
 }


### PR DESCRIPTION
- Use Log4j 2.x (part of zaproxy/zaproxy#6376).
- Automation Framework Support Updates
  - Add unit tests.
  - Change params to camelCase.
  - Other minor changes.