### PR TITLE
Fix various issues identified via SAST (Sonar)

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.10.0.
+- Maintenance changes.
 
 ## [10] - 2020-01-17
 ### Added

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
@@ -81,8 +81,8 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
     private boolean canChangeContext;
     private int scopeYOffset;
     private Context workingContext;
+    private AlertFilter oldAlertFilter;
     private AlertFilter alertFilter;
-    private AlertFilter updatedAlertFilter;
     private JButton testButton;
     private JButton applyButton;
     private JLabel testResultsLabel;
@@ -135,23 +135,23 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 
     @Override
     protected void init() {
-        if (this.alertFilter != null) {
-            log.debug("Initializing add alertFilter dialog for: {}", alertFilter);
+        if (this.oldAlertFilter != null) {
+            log.debug("Initializing add alertFilter dialog for: {}", oldAlertFilter);
             getAlertCombo()
                     .setSelectedItem(
-                            ExtensionAlertFilters.getRuleNameForId(alertFilter.getRuleId()));
+                            ExtensionAlertFilters.getRuleNameForId(oldAlertFilter.getRuleId()));
             getNewLevelCombo()
-                    .setSelectedItem(AlertFilter.getNameForRisk(alertFilter.getNewRisk()));
-            getUrlTextField().setText(alertFilter.getUrl());
-            getUrlRegexCheckBox().setSelected(alertFilter.isUrlRegex());
-            getParamTextField().setText(alertFilter.getParameter());
-            getParamRegexCheckBox().setSelected(alertFilter.isParameterRegex());
-            getAttackTextField().setText(alertFilter.getAttack());
-            getAttackRegexCheckBox().setSelected(alertFilter.isAttackRegex());
-            getEvidenceTextField().setText(alertFilter.getEvidence());
-            getEvidenceRegexCheckBox().setSelected(alertFilter.isEvidenceRegex());
+                    .setSelectedItem(AlertFilter.getNameForRisk(oldAlertFilter.getNewRisk()));
+            getUrlTextField().setText(oldAlertFilter.getUrl());
+            getUrlRegexCheckBox().setSelected(oldAlertFilter.isUrlRegex());
+            getParamTextField().setText(oldAlertFilter.getParameter());
+            getParamRegexCheckBox().setSelected(oldAlertFilter.isParameterRegex());
+            getAttackTextField().setText(oldAlertFilter.getAttack());
+            getAttackRegexCheckBox().setSelected(oldAlertFilter.isAttackRegex());
+            getEvidenceTextField().setText(oldAlertFilter.getEvidence());
+            getEvidenceRegexCheckBox().setSelected(oldAlertFilter.isEvidenceRegex());
 
-            getEnabledCheckBox().setSelected(alertFilter.isEnabled());
+            getEnabledCheckBox().setSelected(oldAlertFilter.isEnabled());
             setButtonStates();
         }
         this.setConfirmButtonEnabled(true);
@@ -217,7 +217,7 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 
     @Override
     protected void performAction() {
-        this.updatedAlertFilter = fieldsToFilter();
+        this.alertFilter = fieldsToFilter();
     }
 
     private AlertFilter fieldsToFilter() {
@@ -243,7 +243,7 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 
     @Override
     protected void clearFields() {
-        this.alertFilter = null;
+        this.oldAlertFilter = null;
         this.enabledCheckBox.setSelected(true);
         this.alertCombo.setSelectedIndex(0);
         this.newLevelCombo.setSelectedIndex(0);
@@ -267,18 +267,18 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
     }
 
     public void setAlertFilter(AlertFilter alertFilter) {
-        this.alertFilter = alertFilter;
-        this.updatedAlertFilter = null;
+        this.oldAlertFilter = alertFilter;
+        this.alertFilter = null;
         setButtonStates();
     }
 
     /**
-     * Gets the alertFilter defined in the dialog, will be null if the dialog is cancelled.
+     * Gets the {@code AlertFilter} defined in the dialog, will be null if the dialog is cancelled.
      *
-     * @return the alertFilter, if correctly built or null, otherwise
+     * @return the {@code AlertFilter}, if correctly built or null otherwise
      */
     public AlertFilter getAlertFilter() {
-        return updatedAlertFilter;
+        return alertFilter;
     }
 
     @Override
@@ -399,9 +399,9 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 
                         @Override
                         public void actionPerformed(ActionEvent arg0) {
-                            alertFilter = fieldsToFilter();
+                            oldAlertFilter = fieldsToFilter();
                             if (validateFields()) {
-                                int count = extension.applyAlertFilter(alertFilter, true);
+                                int count = extension.applyAlertFilter(oldAlertFilter, true);
                                 testResultsLabel.setText(
                                         Constant.messages.getString(
                                                 "alertFilters.dialog.filter.state.appliesto",
@@ -429,9 +429,9 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
 
                         @Override
                         public void actionPerformed(ActionEvent arg0) {
-                            alertFilter = fieldsToFilter();
+                            oldAlertFilter = fieldsToFilter();
                             if (validateFields()) {
-                                int count = extension.applyAlertFilter(alertFilter, false);
+                                int count = extension.applyAlertFilter(oldAlertFilter, false);
                                 applyResultsLabel.setText(
                                         Constant.messages.getString(
                                                 "alertFilters.dialog.filter.state.appliedto",

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssUtils.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssUtils.java
@@ -36,8 +36,8 @@ import org.parosproxy.paros.network.HttpMessage;
 public class PersistentXssUtils {
 
     private static int uniqueIndex;
-    public static String PXSS_PREFIX = "zApPX";
-    public static String PXSS_POSTFIX = "sS";
+    public static final String PXSS_PREFIX = "zApPX";
+    public static final String PXSS_POSTFIX = "sS";
     private static Map<String, UserDataSource> map;
     private static Map<String, HashSet<Integer>> sourceToSinks;
     /**

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -290,7 +290,11 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
                     } finally {
                         // delete the temp file.
                         // this will be deleted when the VM is shut down anyway, but just in case!
-                        if (classFile != null) classFile.delete();
+                        if (classFile != null && !classFile.delete()) {
+                            log.debug(
+                                    "The temporary file {} could not be deleted.",
+                                    classFile.getAbsolutePath());
+                        }
                     }
                 }
                 // remove the class from the set to handle, and add it to the list of classes

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
@@ -46,13 +46,19 @@ public class GraphQlParserUnitTest extends TestUtils {
 
     @Test
     public void shouldFailIntrospectionWhenResponseIsEmpty() throws Exception {
+        // Given
         nano.addHandler(new StaticContentServerHandler("/", ""));
-        assertThrows(IOException.class, () -> new GraphQlParser(endpointUrl).introspect());
+        GraphQlParser gqp = new GraphQlParser(endpointUrl);
+        // When/Then
+        assertThrows(IOException.class, () -> gqp.introspect());
     }
 
     @Test
     public void shouldFailIntrospectionWhenResponseIsNotJson() throws Exception {
+        // Given
         nano.addHandler(new StaticContentServerHandler("/", "not json"));
-        assertThrows(IOException.class, () -> new GraphQlParser(endpointUrl).introspect());
+        GraphQlParser gqp = new GraphQlParser(endpointUrl);
+        // When/Then
+        assertThrows(IOException.class, () -> gqp.introspect());
     }
 }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,8 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
     private static final String ADMIN = "Admin";
     private static final String ADMIN_2 = "admin";
 
-    public static final List<String> DEFAULT_USERNAMES = Arrays.asList(ADMIN, ADMIN_2);
+    public static final List<String> DEFAULT_USERNAMES =
+            Collections.unmodifiableList(Arrays.asList(ADMIN, ADMIN_2));
     private static final Supplier<Iterable<String>> DEFAULT_PAYLOAD_PROVIDER =
             () -> DEFAULT_USERNAMES;
     public static final String USERNAME_IDOR_PAYLOAD_CATEGORY = "Username-Idor";

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.9.0.
 - Update links to zaproxy repo.
+- Maintenance changes.
 
 ## [8] - 2020-01-17
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerPanel.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerPanel.java
@@ -43,10 +43,7 @@ public class OptionsReplacerPanel extends AbstractParamPanel {
 
     public OptionsReplacerPanel() {
         super();
-        initialize();
-    }
 
-    private void initialize() {
         this.setName(PANEL_NAME);
         this.setLayout(new GridBagLayout());
 

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -67,7 +67,12 @@ public class RetireScanRule extends PluginPassiveScanner {
         if (!msg.getResponseHeader().isImage()
                 && !msg.getRequestHeader().isCss()
                 && !msg.getResponseHeader().isCss()) {
-            Result result = getRepo().scanJS(msg);
+            Repo repo = getRepo();
+            if (repo == null) {
+                LOGGER.error("\tThe Retire.js repository was null.");
+                return;
+            }
+            Result result = repo.scanJS(msg);
             if (result == null) {
                 LOGGER.debug("\tNo vulnerabilities found in record {} with URL {}", id, uri);
             } else {

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RevisitDialog.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RevisitDialog.java
@@ -78,7 +78,7 @@ public class RevisitDialog extends AbstractDialog {
         super();
         this.extension = extension;
         this.setAlwaysOnTop(true);
-        initialize();
+        init();
     }
 
     /**
@@ -91,11 +91,11 @@ public class RevisitDialog extends AbstractDialog {
         super(arg0, arg1);
         this.extension = extension;
         this.setAlwaysOnTop(true);
-        initialize();
+        init();
     }
 
     /** This method initializes this */
-    private void initialize() {
+    private void init() {
         this.setContentPane(getJPanel());
         this.pack();
 

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update links to zaproxy repo.
+- Maintenance Changes.
 
 ## [28] - 2020-12-18
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -55,11 +55,7 @@ public class CommandPanel extends AbstractPanel {
     public CommandPanel(KeyListener listener) {
         super();
         this.listener = listener;
-        initialize();
-    }
 
-    /** This method initializes this */
-    private void initialize() {
         this.setLayout(new CardLayout());
         this.setName("ConsoleCommandPanel");
 
@@ -99,7 +95,7 @@ public class CommandPanel extends AbstractPanel {
     }
 
     @Override
-    public void addKeyListener(KeyListener l) {
+    public synchronized void addKeyListener(KeyListener l) {
         // Don't do anything, the (only) listener is specified through the constructor.
     }
 

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -93,10 +93,7 @@ public class ConsolePanel extends AbstractPanel implements Tab {
     public ConsolePanel(ExtensionScriptsUI extension) {
         super();
         this.extension = extension;
-        initialize();
-    }
 
-    private void initialize() {
         this.setIcon(
                 new ImageIcon(ZAP.class.getResource("/resource/icon/16/059.png"))); // 'script' icon
         this.setDefaultAccelerator(

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
@@ -73,11 +73,7 @@ public class OutputPanel extends AbstractPanel {
     public OutputPanel(ExtensionScriptsUI extension) {
         super();
         this.extension = extension;
-        initialize();
-    }
 
-    /** This method initializes this */
-    private void initialize() {
         this.setLayout(new BorderLayout());
         this.setName("ConsoleOutputPanel");
         this.add(getMainPanel(), BorderLayout.CENTER);

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -111,10 +111,7 @@ public class ScriptsListPanel extends AbstractPanel {
     public ScriptsListPanel(ExtensionScriptsUI extension) {
         super();
         this.extension = extension;
-        initialize();
-    }
 
-    private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("scripts.list.panel.title"));
         this.setIcon(ExtensionScriptsUI.ICON);

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Accept only encoded URLs.
 - Add support for the Automation Framework.
 - Add support for statistics for the number of added URLs (or SOAP Actions).
+- Maintenance changes.
 
 ### Fixed
 - Fix detection of WSDL files (Issue 6440).

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPMsgConfig.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/SOAPMsgConfig.java
@@ -104,8 +104,17 @@ public class SOAPMsgConfig {
         this.bindOp = bindOp;
     }
 
-    public boolean equals(SOAPMsgConfig other) {
-        return this.getHash() == other.getHash();
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof SOAPMsgConfig)) {
+            return false;
+        }
+        return this.getHash() == ((SOAPMsgConfig) other).getHash();
+    }
+
+    @Override
+    public int hashCode() {
+        return getHash();
     }
 
     private int getHash() {

--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLiPayloadManager.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLiPayloadManager.java
@@ -79,6 +79,7 @@ public class SQLiPayloadManager {
     private static final String PAYLOAD_FILE = "resources/payloads.xml";
     private static final String TAG_BOUNDARY = "boundary";
     private static final String TAG_TEST = "test";
+    private static final Random RAND = new Random();
 
     private static final String PAYLOAD_DELIMITER = "\\x00";
     // Regular expression used for replacing non-alphanum characters
@@ -180,12 +181,11 @@ public class SQLiPayloadManager {
      * @return the integer value
      */
     public static String randomInt(int length) {
-        Random rand = new Random();
         StringBuilder result = new StringBuilder();
-        result.append((char) (rand.nextInt(9) + '1'));
+        result.append((char) (RAND.nextInt(9) + '1'));
 
         for (int i = 1; i < length; i++) {
-            result.append((char) (rand.nextInt(10) + '0'));
+            result.append((char) (RAND.nextInt(10) + '0'));
         }
 
         return result.toString();
@@ -209,7 +209,6 @@ public class SQLiPayloadManager {
      * @return a string element containing exactly "lenght" characters
      */
     public static String randomString(int length, boolean lowerCase, String alphabet) {
-        Random rand = new Random();
         StringBuilder result = new StringBuilder();
 
         if (alphabet == null) {
@@ -220,7 +219,7 @@ public class SQLiPayloadManager {
         }
 
         for (int i = 0; i < length; i++) {
-            result.append(alphabet.charAt(rand.nextInt(alphabet.length())));
+            result.append(alphabet.charAt(RAND.nextInt(alphabet.length())));
         }
 
         return result.toString();

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [23] - 2020-12-18
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/utility/WebSocketUtils.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/utility/WebSocketUtils.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.extension.websocket.WebSocketProtocol;
 
 public final class WebSocketUtils {
     private static final Logger LOGGER = Logger.getLogger(WebSocketUtils.class);
+    private static final Random RAND = new Random();
 
     public static final String WEB_SOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
@@ -56,8 +57,7 @@ public final class WebSocketUtils {
      */
     public static String generateSecWebSocketKey() {
         byte[] random = new byte[16];
-        Random rand = new Random();
-        rand.nextBytes(random);
+        RAND.nextBytes(random);
         return Base64.getEncoder().encodeToString(random);
     }
 


### PR DESCRIPTION
- pscanrules > UsernameIdorScanRule make DEFAULT_USERNAMES unmodifiable. (This addresses "Mutable fields should not be 'public static'")
- ascanrules
    - PersistentXssUtils make prefix and postfix constants final. (This addresses two findings for each const: "'public static' fields should be constant" and "Class variable fields should not have public accessibility")
    - SourceCodeDisclosureWebInfScanRule > When delete() is called log a debug message if not successful. (This addresses "Return values should not be ignored when they contain the operation status code")
- websocket > WebSocketUtils, save and re-use Random.
- sqliplugin > SQLiPayloadManager, save and re-use Random.
- graphql > GraphQlParserUnitTests, instantiate the GraphQlParser before the assertion, so that the assertion is actually testing the intprospect() method for sure (since GraphQlParser constructor can also throw IOException).
- alertFilters > AlertFiltersMultipleOptionsPanel & DialogAddAlertFilter, rename class variables to more closely match their uses and applicable getters.
- replacer > OptionsReplacerPanel, move initialize() actions into constructor so there's no confusion with the private method in the parent class.
- retire > RetireScanRule, handle theoretical NPE.
- revisit > RevisitDialog, move initialize() actions into constructor so there's no confusion with the private method in the parent class.
- scripts
    - CommandPanel, move initialize() actions into constructor so there's no confusion with the private method in the
parent class. Also make addKeyListener synchronized to match parent class's implementation.
    - ConsolePanel, move initialize() actions into constructor so there's no confusion with the private method in the parent class.
    - OutputPanel, move initialize() actions into constructor so there's no confusion with the private method in the parent class.
    - ScriptsListPanel, move initialize() actions into constructor so there's no confusion with the private method in the parent class.
- soap > SOAPMsgConfig, add override notation and accept generic Object in equals method, to prevent any confusion. (Add overridden hashCode method which uses local getHash method.)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>