### PR TITLE
httpsinfo: Use Log4j 2.x

### DIFF
--- a/addOns/httpsInfo/CHANGELOG.md
+++ b/addOns/httpsInfo/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Updated owasp.org references (Issue 5962).
 
 ## [12] - 2019-04-26

--- a/addOns/httpsInfo/httpsInfo.gradle.kts
+++ b/addOns/httpsInfo/httpsInfo.gradle.kts
@@ -3,7 +3,7 @@ description = "Displays HTTPS configuration information."
 
 zapAddOn {
     addOnName.set("HttpsInfo")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
@@ -13,8 +13,8 @@ zapAddOn {
 
 dependencies {
     implementation("com.github.spoofzu:DeepViolet:5.1.16")
-    implementation("org.slf4j:slf4j-log4j12:1.7.6") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1") {
         // Provided by ZAP.
-        exclude(group = "log4j")
+        exclude(group = "org.apache.logging.log4j")
     }
 }

--- a/addOns/httpsInfo/src/main/java/org/zaproxy/zap/extension/httpsinfo/HttpsInfoOutputPanel.java
+++ b/addOns/httpsInfo/src/main/java/org/zaproxy/zap/extension/httpsinfo/HttpsInfoOutputPanel.java
@@ -28,7 +28,8 @@ import com.mps.deepviolet.api.IDVX509Certificate;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
@@ -44,7 +45,7 @@ public class HttpsInfoOutputPanel extends OutputPanel {
 
     private static final String NEWLINE = System.lineSeparator();
 
-    private static final Logger LOGGER = Logger.getLogger(HttpsInfoOutputPanel.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpsInfoOutputPanel.class);
 
     private static final int BEAST_PLUGIN_ID = 10200;
     private static final int CRIME_PLUGIN_ID = 10201;


### PR DESCRIPTION
- Update build file, CHANGELOG, and change code to use updated logging infrastructure.
    - Set minimum ZAP version to 2.10.
    - Change from slf4j12 v1.7.6 (which was behind as a dependency) to up-to-date log4j-slf4j-impl v2.14.1
    - Update CHANGELOG entry.

Part of: zaproxy/zaproxy#6376

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>