### PR TITLE
birtreports: Use Log4j 2.x

### DIFF
--- a/addOns/birtreports/CHANGELOG.md
+++ b/addOns/birtreports/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ### Fixed
 - Restore generation of reports.

--- a/addOns/birtreports/birtreports.gradle.kts
+++ b/addOns/birtreports/birtreports.gradle.kts
@@ -3,7 +3,7 @@ description = "Alert reports using BIRT report API"
 
 zapAddOn {
     addOnName.set("BIRT Reports")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("Johanna Curiel And Rauf Butt")

--- a/addOns/birtreports/src/main/java/org/zaproxy/zap/extension/birtreports/ExtensionBirtReports.java
+++ b/addOns/birtreports/src/main/java/org/zaproxy/zap/extension/birtreports/ExtensionBirtReports.java
@@ -19,7 +19,8 @@
  */
 package org.zaproxy.zap.extension.birtreports;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.core.framework.Platform;
 import org.parosproxy.paros.Constant;
@@ -31,7 +32,7 @@ import org.zaproxy.zap.view.ZapMenuItem;
 /** The extension responsible to setup the BIRT reports. */
 public class ExtensionBirtReports extends ExtensionAdaptor {
 
-    private static final Logger LOGGER = Logger.getLogger(ExtensionBirtReports.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionBirtReports.class);
 
     private ZapMenuItem menuGeneratePdfReport;
     private ZapMenuItem menuGenerateScriptedPdfReport;

--- a/addOns/birtreports/src/main/java/org/zaproxy/zap/extension/birtreports/ReportLastScan.java
+++ b/addOns/birtreports/src/main/java/org/zaproxy/zap/extension/birtreports/ReportLastScan.java
@@ -46,7 +46,8 @@ import javax.imageio.ImageIO;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 import javax.xml.transform.stream.StreamSource;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.birt.core.exception.BirtException;
 import org.eclipse.birt.core.framework.Platform;
 import org.eclipse.birt.report.engine.api.EngineConfig;
@@ -91,7 +92,7 @@ public class ReportLastScan {
     private static final Path XML_REPORT =
             REPORT_DESIGN_FILES_DIR.resolve("xmloutput/xmloutputzap.xml");
 
-    private Logger logger = Logger.getLogger(ReportLastScan.class);
+    private Logger logger = LogManager.getLogger(ReportLastScan.class);
     private ResourceBundle messages = null;
     private StringBuilder sbXML;
     private int totalCount = 0;


### PR DESCRIPTION
Update build file, CHANGELOG, and change code to use updated logging infrastructure.
Part of: zaproxy/zaproxy#6376
