### PR TITLE
Various Add-ons: Tweak previously added toString() in logger usage

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
@@ -112,7 +112,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
                         "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        msg.getRequestHeader().getURI().toString());
+                        msg.getRequestHeader().getURI());
                 return; // Something went wrong no point continuing
             }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
@@ -190,7 +190,7 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {}{} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg.getRequestHeader().getURI().toString());
+                            msg.getRequestHeader().getURI());
                     continue; // Advance in the PHP payload loop, no point continuing on this
                     // payload
                 }
@@ -265,7 +265,7 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg.getRequestHeader().getURI().toString());
+                            msg.getRequestHeader().getURI());
                     continue; // Advance in the ASP payload loop, no point continuing on this
                     // payload
                 }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -517,7 +517,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg.getRequestHeader().getURI().toString());
+                            msg.getRequestHeader().getURI());
                     continue; // Something went wrong, move to next payload iteration
                 }
                 elapsedTime = msg.getTimeElapsedMillis();
@@ -603,7 +603,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg.getRequestHeader().getURI().toString());
+                            msg.getRequestHeader().getURI());
                     continue; // Something went wrong, move to next blind iteration
                 }
                 elapsedTime = msg.getTimeElapsedMillis();

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
@@ -142,7 +142,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                         "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        testMsg.getRequestHeader().getURI().toString());
+                        testMsg.getRequestHeader().getURI());
                 return; // Something went wrong, no point continuing
             }
 
@@ -178,7 +178,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                         "Caught {} {} when accessing: {}.\nThe target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        intialAttackMsg.getRequestHeader().getURI().toString());
+                        intialAttackMsg.getRequestHeader().getURI());
                 return; // Something went wrong, no point continuing
             }
             if (isPage500(intialAttackMsg)) {
@@ -199,7 +199,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            verificationMsg.getRequestHeader().getURI().toString());
+                            verificationMsg.getRequestHeader().getURI());
                     return; // Something went wrong, no point continuing
                 }
                 HttpResponseBody secondAttackResponseBody = verificationMsg.getResponseBody();
@@ -254,7 +254,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                         "Caught {} {} when accessing: {}. \nThe target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        microsoftTestMsg.getRequestHeader().getURI().toString());
+                        microsoftTestMsg.getRequestHeader().getURI());
                 return; // Something went wrong, no point continuing
             }
             if (isPage500(microsoftTestMsg)) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
@@ -127,7 +127,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
                     "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                     ex.getClass().getName(),
                     ex.getMessage(),
-                    normalMsg.getRequestHeader().getURI().toString());
+                    normalMsg.getRequestHeader().getURI());
             return; // Something went wrong, no point continuing
         } catch (Exception e) {
             // ZAP: Log exceptions
@@ -162,7 +162,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            testMsg.getRequestHeader().getURI().toString());
+                            testMsg.getRequestHeader().getURI());
                     continue; // Something went wrong, move on to the next item in the PARAM_LIST
                 }
                 if (checkResult(testMsg, param, attack, normalMsg.getResponseBody().toString())) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -459,7 +459,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg.getRequestHeader().getURI().toString());
+                            msg.getRequestHeader().getURI());
 
                     return; // Something went wrong, no point continuing
                 }
@@ -476,7 +476,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "It is possible to check for local file Path Traversal on the url filename on [{}] [{}], [{}]",
                             msg.getRequestHeader().getMethod(),
-                            msg.getRequestHeader().getURI().toString(),
+                            msg.getRequestHeader().getURI(),
                             param);
 
                     String prefixedUrlfilename;
@@ -503,7 +503,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                                     "Caught {} {} when accessing: {}",
                                     ex.getClass().getName(),
                                     ex.getMessage(),
-                                    msg.getRequestHeader().getURI().toString());
+                                    msg.getRequestHeader().getURI());
 
                             continue; // Something went wrong, move to the next prefix in the loop
                         }
@@ -611,7 +611,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                     "Caught {} {} when accessing: {}",
                     ex.getClass().getName(),
                     ex.getMessage(),
-                    msg.getRequestHeader().getURI().toString());
+                    msg.getRequestHeader().getURI());
 
             return false; // Something went wrong, no point continuing
         }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
@@ -205,7 +205,7 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
                                 "Caught {} {} when accessing: {}",
                                 ex.getClass().getName(),
                                 ex.getMessage(),
-                                msg.getRequestHeader().getURI().toString());
+                                msg.getRequestHeader().getURI());
                         continue; // Something went wrong, continue to the next target in the loop
                     }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -663,7 +663,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                 "Caught {} {} when accessing: {}",
                                 ex.getClass().getName(),
                                 ex.getMessage(),
-                                msg1.getRequestHeader().getURI().toString());
+                                msg1.getRequestHeader().getURI());
                         continue; // Something went wrong, continue to the next prefixString in the
                         // loop
                     }
@@ -768,7 +768,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         "Caught {} {} when accessing: {}",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        refreshedmessage.getRequestHeader().getURI().toString());
+                        refreshedmessage.getRequestHeader().getURI());
                 return; // Something went wrong, no point continuing
             }
 
@@ -914,7 +914,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         "Caught {} {} when accessing: {}",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        refreshedmessage.getRequestHeader().getURI().toString());
+                        refreshedmessage.getRequestHeader().getURI());
                 return; // Something went wrong, no point continuing
             }
 
@@ -950,7 +950,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg2.getRequestHeader().getURI().toString());
+                            msg2.getRequestHeader().getURI());
                     continue; // Something went wrong, continue to the next item in the loop
                 }
                 countBooleanBasedRequests++;
@@ -995,7 +995,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                     "Caught {} {} when accessing: {}",
                                     ex.getClass().getName(),
                                     ex.getMessage(),
-                                    msg2_and_false.getRequestHeader().getURI().toString());
+                                    msg2_and_false.getRequestHeader().getURI());
                             continue; // Something went wrong, continue on to the next item in the
                             // loop
                         }
@@ -1107,7 +1107,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                         "Caught {} {} when accessing: {}",
                                         ex.getClass().getName(),
                                         ex.getMessage(),
-                                        msg2_or_true.getRequestHeader().getURI().toString());
+                                        msg2_or_true.getRequestHeader().getURI());
                                 continue; // Something went wrong, continue on to the next item in
                                 // the loop
                             }
@@ -1275,7 +1275,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg2.getRequestHeader().getURI().toString());
+                            msg2.getRequestHeader().getURI());
                     continue; // Something went wrong, continue on to the next item in the loop
                 }
                 countBooleanBasedRequests++;
@@ -1301,7 +1301,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                 "Caught {} {} when accessing: {}",
                                 ex.getClass().getName(),
                                 ex.getMessage(),
-                                msg2_and_false.getRequestHeader().getURI().toString());
+                                msg2_and_false.getRequestHeader().getURI());
                         continue; // Something went wrong, continue on to the next item in the loop
                     }
                     countBooleanBasedRequests++;
@@ -1388,7 +1388,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg3.getRequestHeader().getURI().toString());
+                            msg3.getRequestHeader().getURI());
                     continue; // Something went wrong, continue on to the next item in the loop
                 }
                 countUnionBasedRequests++;
@@ -1456,7 +1456,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         "Caught {} {} when accessing: {}",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        refreshedmessage.getRequestHeader().getURI().toString());
+                        refreshedmessage.getRequestHeader().getURI());
                 return; // Something went wrong, no point continuing
             }
 
@@ -1481,7 +1481,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg5.getRequestHeader().getURI().toString());
+                            msg5.getRequestHeader().getURI());
                     return; // Something went wrong, no point continuing
                 }
                 countOrderByBasedRequests++;
@@ -1534,7 +1534,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                     "Caught {} {} when accessing: {}",
                                     ex.getClass().getName(),
                                     ex.getMessage(),
-                                    msg5Confirm.getRequestHeader().getURI().toString());
+                                    msg5Confirm.getRequestHeader().getURI());
                             continue; // Something went wrong, continue on to the next item in the
                             // loop
                         }
@@ -1796,7 +1796,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     "Caught {} {} when accessing: {}",
                     ex.getClass().getName(),
                     ex.getMessage(),
-                    msg.getRequestHeader().getURI().toString());
+                    msg.getRequestHeader().getURI());
             return; // Something went wrong, no point continuing
         }
         countExpressionBasedRequests++;
@@ -1815,7 +1815,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 log.debug(
                         "Check 4, STRIPPED html output for modified expression parameter [{}] matched (refreshed) original results for {}",
                         modifiedParamValue,
-                        refreshedmessage.getRequestHeader().getURI().toString());
+                        refreshedmessage.getRequestHeader().getURI());
                 // confirm that a different parameter value generates different output, to minimise
                 // false positives
                 // this time param value will be different to original value and mismatch is
@@ -1832,7 +1832,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msgConfirm.getRequestHeader().getURI().toString());
+                            msgConfirm.getRequestHeader().getURI());
                     return; // Something went wrong
                 }
                 countExpressionBasedRequests++;

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -202,7 +202,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             log.debug(
                     "Scanning URL [{}] [{}], [{}] with value [{}] for LDAP Injection",
                     originalmsg.getRequestHeader().getMethod(),
-                    originalmsg.getRequestHeader().getURI().toString(),
+                    originalmsg.getRequestHeader().getURI(),
                     paramname,
                     paramvalue);
 
@@ -532,7 +532,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                                 + "on parameter [{2}], using [{3}] to simulate a logically "
                                 + "equivalent condition, and using [{4}] to simulate a FALSE condition.",
                         msg.getRequestHeader().getMethod(),
-                        msg.getRequestHeader().getURI().toString(),
+                        msg.getRequestHeader().getURI(),
                         parameterName,
                         attack,
                         falseAttack);

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ApacheRangeHeaderDosScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ApacheRangeHeaderDosScanRule.java
@@ -118,7 +118,7 @@ public class ApacheRangeHeaderDosScanRule extends AbstractAppPlugin {
                 LOG.warn(
                         "An error occurred while checking [{}] [{}] for Apache Range Header DoS (CVE-2011-3192). Caught {} {}",
                         newRequest.getRequestHeader().getMethod(),
-                        newRequest.getRequestHeader().getURI().toString(),
+                        newRequest.getRequestHeader().getURI(),
                         e.getClass().getName(),
                         e.getMessage());
                 return;
@@ -144,7 +144,7 @@ public class ApacheRangeHeaderDosScanRule extends AbstractAppPlugin {
             LOG.warn(
                     "An error occurred while validating [{}] [{}] for Apache Range Header DoS (CVE-2011-3192) applicability. Caught {} {}",
                     chkRequest.getRequestHeader().getMethod(),
-                    chkRequest.getRequestHeader().getURI().toString(),
+                    chkRequest.getRequestHeader().getURI(),
                     e.getClass().getName(),
                     e.getMessage());
             return false;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
@@ -357,7 +357,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
         log.debug(
                 "Checking [{}] [{}], for Backup File Disclosure",
                 getBaseMsg().getRequestHeader().getMethod(),
-                getBaseMsg().getRequestHeader().getURI().toString());
+                getBaseMsg().getRequestHeader().getURI());
 
         try {
             URI uri = this.getBaseMsg().getRequestHeader().getURI();
@@ -454,12 +454,12 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                 gives404s = false;
                 log.debug(
                         "The server does not return a 404 status for a non-existent path: {}",
-                        nonexistfilemsg.getRequestHeader().getURI().toString());
+                        nonexistfilemsg.getRequestHeader().getURI());
             } else {
                 gives404s = true;
                 log.debug(
                         "The server gives a 404 status for a non-existent path: {}",
-                        nonexistfilemsg.getRequestHeader().getURI().toString());
+                        nonexistfilemsg.getRequestHeader().getURI());
             }
 
             // now request a different (and non-existent) parent directory,
@@ -502,12 +502,12 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                     parentgives404s = false;
                     log.debug(
                             "The server does not return a 404 status for a non-existent parent path: {}",
-                            nonexistparentmsg.getRequestHeader().getURI().toString());
+                            nonexistparentmsg.getRequestHeader().getURI());
                 } else {
                     parentgives404s = true;
                     log.debug(
                             "The server gives a 404 status for a non-existent parent path: {}",
-                            nonexistparentmsg.getRequestHeader().getURI().toString());
+                            nonexistparentmsg.getRequestHeader().getURI());
                 }
             }
 
@@ -800,7 +800,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
         } catch (Exception e) {
             log.error(
                     "Some error occurred when looking for a backup file for '{}'",
-                    originalMessage.getRequestHeader().getURI().toString(),
+                    originalMessage.getRequestHeader().getURI(),
                     e);
             return;
         }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
@@ -123,7 +123,7 @@ public class CloudMetadataScanRule extends AbstractHostPlugin {
                 this.raiseAlert(newRequest);
             }
         } catch (Exception e) {
-            LOG.error("Error sending URL {}", newRequest.getRequestHeader().getURI().toString(), e);
+            LOG.error("Error sending URL {}", newRequest.getRequestHeader().getURI(), e);
             return;
         }
     }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
@@ -146,7 +146,7 @@ public class ExpressionLanguageInjectionScanRule extends AbstractAppParamPlugin 
                         "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        msg.getRequestHeader().getURI().toString());
+                        msg.getRequestHeader().getURI());
                 return;
             }
             // Check if the resulting content contains the executed addition

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GetForPostScanRule.java
@@ -103,7 +103,7 @@ public class GetForPostScanRule extends AbstractAppPlugin {
             LOG.warn(
                     "An error occurred while checking [{}] [{}] for {} Caught {} {}",
                     newRequest.getRequestHeader().getMethod(),
-                    newRequest.getRequestHeader().getURI().toString(),
+                    newRequest.getRequestHeader().getURI(),
                     getName(),
                     e.getClass().getName(),
                     e.getMessage());

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
@@ -171,7 +171,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
             LOG.warn(
                     "An error occurred while checking [{}] [{}] for {} Caught {} {}",
                     testMsg.getRequestHeader().getMethod(),
-                    testMsg.getRequestHeader().getURI().toString(),
+                    testMsg.getRequestHeader().getURI(),
                     getName(),
                     e.getClass().getName(),
                     e.getMessage());

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpParameterPollutionScanRule.java
@@ -109,7 +109,7 @@ public class HttpParameterPollutionScanRule extends AbstractAppPlugin {
                                 "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                                 ex.getClass().getName(),
                                 ex.getMessage(),
-                                newMsg.getRequestHeader().getURI().toString());
+                                newMsg.getRequestHeader().getURI());
                         return;
                     }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HttpsAsHttpScanRule.java
@@ -110,8 +110,7 @@ public class HttpsAsHttpScanRule extends AbstractAppPlugin {
         }
 
         log.debug(
-                "Checking if {} is available via HTTP.",
-                getBaseMsg().getRequestHeader().getURI().toString());
+                "Checking if {} is available via HTTP.", getBaseMsg().getRequestHeader().getURI());
 
         HttpMessage newRequest = getNewMsg();
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
@@ -643,7 +643,7 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
                 log.warn(
                         "A timeout occurred while checking [{}] [{}] for Proxy Disclosure.\nThe currently configured timeout is: {}",
                         trackmsg.getRequestHeader().getMethod(),
-                        trackmsg.getRequestHeader().getURI().toString(),
+                        trackmsg.getRequestHeader().getURI(),
                         Integer.toString(
                                 Model.getSingleton()
                                         .getOptionsParam()

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -207,7 +207,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin {
         log.debug(
                 "Checking [{}] [{}], for Relative Path Confusion issues",
                 originalMsg.getRequestHeader().getMethod(),
-                originalMsg.getRequestHeader().getURI().toString());
+                originalMsg.getRequestHeader().getURI());
 
         try {
             URI baseUri = originalMsg.getRequestHeader().getURI();
@@ -223,7 +223,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin {
             // Confusion
             // (based on the instances of this that I've in seen in the wild, at least)
             if (fileext != null && fileext.length() > 0) {
-                log.debug("The file extension of {} is {}", baseUri.getURI().toString(), fileext);
+                log.debug("The file extension of {} is {}", baseUri, fileext);
 
                 // 1: First manipulate the URL, using a URL which is ambiguous..
                 URI originalURI = originalMsg.getRequestHeader().getURI();
@@ -622,7 +622,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin {
 
                 log.debug(
                         "A Relative Path Confusion issue exists on {}",
-                        getBaseMsg().getRequestHeader().getURI().toString());
+                        getBaseMsg().getRequestHeader().getURI());
                 return;
 
             } else {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
@@ -227,7 +227,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                 log.debug(
                         "Scanning URL [{}] [{}], [{}] field [{}] with value [{}] for Session Fixation",
                         msg1Initial.getRequestHeader().getMethod(),
-                        msg1Initial.getRequestHeader().getURI().toString(),
+                        msg1Initial.getRequestHeader().getURI(),
                         currentHtmlParameter.getType(),
                         currentHtmlParameter.getName(),
                         currentHtmlParameter.getValue());
@@ -355,7 +355,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     if (!isPage200(msg1Final)) {
                         log.debug(
                                 "Got a non-200 response when sending [{}] with param [{}] = NULL (possibly somewhere in the redirects)",
-                                msg1Initial.getRequestHeader().getURI().toString(),
+                                msg1Initial.getRequestHeader().getURI(),
                                 currentHtmlParameter.getName());
                         continue;
                     }
@@ -507,7 +507,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                         log.debug(
                                 "A session identifier in [{}] URL [{}] {} field: [{}] may be accessible to JavaScript",
                                 getBaseMsg().getRequestHeader().getMethod(),
-                                getBaseMsg().getRequestHeader().getURI().getURI().toString(),
+                                getBaseMsg().getRequestHeader().getURI().getURI(),
                                 currentHtmlParameter.getType(),
                                 currentHtmlParameter.getName());
                         // Note: do NOT continue to the next field at this point..
@@ -836,7 +836,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     if (!isPage200(msg2Final)) {
                         log.debug(
                                 "Got a non-200 response when sending [{}] with a borrowed cookie (or by following a redirect) for param [{}]",
-                                msg2Initial.getRequestHeader().getURI().toString(),
+                                msg2Initial.getRequestHeader().getURI(),
                                 currentHtmlParameter.getName());
                         continue; // to next parameter
                     }
@@ -948,7 +948,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     if (!isPage200(msg1Initial)) {
                         log.debug(
                                 "Got a non-200 response when sending [{}] with param [{}] = NULL (possibly somewhere in the redirects)",
-                                msg1Initial.getRequestHeader().getURI().toString(),
+                                msg1Initial.getRequestHeader().getURI(),
                                 currentHtmlParameter.getName());
                         continue;
                     }
@@ -1178,7 +1178,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                     if (!isPage200(msg2Initial)) {
                         log.debug(
                                 "Got a non-200 response when sending [{}] with a borrowed session (or by following a redirect) for param [{}]",
-                                msg2Initial.getRequestHeader().getURI().toString(),
+                                msg2Initial.getRequestHeader().getURI(),
                                 currentHtmlParameter.getName());
                         continue; // next field!
                     }
@@ -1271,7 +1271,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                                 isPseudoUrlParameter ? "pseudo/URL rewritten" : "",
                                 currentHtmlParameter.getName(),
                                 getBaseMsg().getRequestHeader().getMethod(),
-                                getBaseMsg().getRequestHeader().getURI().toString());
+                                getBaseMsg().getRequestHeader().getURI());
                     }
 
                     continue; // onto the next parameter

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
@@ -160,9 +160,7 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
                 boolean match2 = matcher2.matches();
 
                 if ((!responseBody.equals(responseBodyDecoded)) && (match1 || match2)) {
-                    log.debug(
-                            "Source Code Disclosure alert for: {}",
-                            originalURI.getURI().toString());
+                    log.debug("Source Code Disclosure alert for: {}", originalURI.getURI());
 
                     String sourceCode = null;
                     if (match1) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -231,7 +231,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
             log.debug(
                     "Checking [{}] [{}], parameter [{}], with original value [{}] for Source Code Disclosure",
                     getBaseMsg().getRequestHeader().getMethod(),
-                    getBaseMsg().getRequestHeader().getURI().toString(),
+                    getBaseMsg().getRequestHeader().getURI(),
                     paramname,
                     paramvalue);
             // the response of the original message is not populated! so populate it.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
@@ -126,7 +126,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
         log.debug(
                 "Checking [{}] [{}], for Source Code Disclosure using Git meta-data",
                 getBaseMsg().getRequestHeader().getMethod(),
-                getBaseMsg().getRequestHeader().getURI().toString());
+                getBaseMsg().getRequestHeader().getURI());
 
         try {
             URI uri = this.getBaseMsg().getRequestHeader().getURI();
@@ -260,7 +260,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
                                 null,
                                 null);
                 try {
-                    log.debug("Trying for a Git index file {}", gitindexuri.getURI().toString());
+                    log.debug("Trying for a Git index file {}", gitindexuri.getURI());
 
                     if (!gitindexentrycache.isIndexCached(gitindexuri)) {
                         // The Git index is not cached, so parse it and cache it.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
@@ -147,7 +147,7 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
         log.debug(
                 "Checking [{}] [{}], for Source Code Disclosure using SVN meta-data",
                 getBaseMsg().getRequestHeader().getMethod(),
-                getBaseMsg().getRequestHeader().getURI().toString());
+                getBaseMsg().getRequestHeader().getURI());
 
         try {
             URI uri = this.getBaseMsg().getRequestHeader().getURI();

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
@@ -273,13 +273,13 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
                 log.debug(
                         "The Base Time Check timed out on [{}] URL [{}]",
                         msgTimeBaseline.getRequestHeader().getMethod(),
-                        msgTimeBaseline.getRequestHeader().getURI().toString());
+                        msgTimeBaseline.getRequestHeader().getURI());
             } catch (SocketException ex) {
                 log.debug(
                         "Caught {} {} when accessing: {} for Base Time Check",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        msgTimeBaseline.getRequestHeader().getURI().toString());
+                        msgTimeBaseline.getRequestHeader().getURI());
                 return; // No need to keep going
             }
             long originalTimeUsed = msgTimeBaseline.getTimeElapsedMillis();
@@ -291,7 +291,7 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
             log.debug(
                     "Scanning URL [{}] [{}], field [{}] with value [{}] for SQL Injection",
                     getBaseMsg().getRequestHeader().getMethod(),
-                    getBaseMsg().getRequestHeader().getURI().toString(),
+                    getBaseMsg().getRequestHeader().getURI(),
                     paramName,
                     paramValue);
 
@@ -319,14 +319,14 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "The time check query timed out on [{}] URL [{}] on field: [{}]",
                             msgTimeBaseline.getRequestHeader().getMethod(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString(),
+                            msgTimeBaseline.getRequestHeader().getURI(),
                             paramName);
                 } catch (SocketException ex) {
                     log.debug(
                             "Caught {} {} when accessing: {} for time check query",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString());
+                            msgTimeBaseline.getRequestHeader().getURI());
                     return; // No need to keep going
                 }
                 long modifiedTimeUsed = msgAttack.getTimeElapsedMillis();
@@ -383,7 +383,7 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "A likely Time Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}]",
                             msgAttack.getRequestHeader().getMethod(),
-                            msgAttack.getRequestHeader().getURI().getURI().toString(),
+                            msgAttack.getRequestHeader().getURI().getURI(),
                             paramName);
                     return;
                 } // query took longer than the amount of time we attempted to retard it by

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java
@@ -179,7 +179,7 @@ public class SqlInjectionMsSqlScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "Both base time checks 1 and 2 for [{}] URL [{}] are way too slow to be usable for the purposes of checking for time based SQL Injection checking.  We are aborting the check on this particular url.",
                             msgTimeBaseline.getRequestHeader().getMethod(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString());
+                            msgTimeBaseline.getRequestHeader().getURI());
                     return;
                 }
                 // the second time came in within the limits. use the later timing details as the
@@ -190,7 +190,7 @@ public class SqlInjectionMsSqlScanRule extends AbstractAppParamPlugin {
             log.debug(
                     "Scanning URL [{}] [{}], field [{}] with value [{}] for MsSQL Injection",
                     getBaseMsg().getRequestHeader().getMethod(),
-                    getBaseMsg().getRequestHeader().getURI().toString(),
+                    getBaseMsg().getRequestHeader().getURI(),
                     paramName,
                     paramValue);
 
@@ -283,7 +283,7 @@ public class SqlInjectionMsSqlScanRule extends AbstractAppParamPlugin {
             log.debug(
                     "The Base Time Check timed out on [{}] URL [{}]",
                     msg.getRequestHeader().getMethod(),
-                    msg.getRequestHeader().getURI().toString());
+                    msg.getRequestHeader().getURI());
         }
         countTimeBasedRequests++;
         return msg.getTimeElapsedMillis();

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java
@@ -275,13 +275,13 @@ public class SqlInjectionMyqlScanRule extends AbstractAppParamPlugin {
                 log.debug(
                         "The Base Time Check timed out on [{}] URL [{}]",
                         msgTimeBaseline.getRequestHeader().getMethod(),
-                        msgTimeBaseline.getRequestHeader().getURI().toString());
+                        msgTimeBaseline.getRequestHeader().getURI());
             } catch (SocketException ex) {
                 log.debug(
                         "Caught {} {} when accessing: {}",
                         ex.getClass().getName(),
                         ex.getMessage(),
-                        msgTimeBaseline.getRequestHeader().getURI().toString());
+                        msgTimeBaseline.getRequestHeader().getURI());
                 return; // No need to keep going
             }
             long originalTimeUsed = msgTimeBaseline.getTimeElapsedMillis();
@@ -302,13 +302,13 @@ public class SqlInjectionMyqlScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "Base Time Check 2 timed out on [{}] URL [{}]",
                             msgTimeBaseline.getRequestHeader().getMethod(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString());
+                            msgTimeBaseline.getRequestHeader().getURI());
                 } catch (SocketException ex) {
                     log.debug(
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString());
+                            msgTimeBaseline.getRequestHeader().getURI());
                     return; // No need to keep going
                 }
                 long originalTimeUsed2 = msgTimeBaseline.getTimeElapsedMillis();
@@ -317,7 +317,7 @@ public class SqlInjectionMyqlScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "Both base time checks 1 and 2 for [{}] URL [{}] are way too slow to be usable for the purposes of checking for time based SQL Injection checking.  We are aborting the check on this particular url.",
                             msgTimeBaseline.getRequestHeader().getMethod(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString());
+                            msgTimeBaseline.getRequestHeader().getURI());
                     return;
                 } else {
                     // phew.  the second time came in within the limits. use the later timing
@@ -332,7 +332,7 @@ public class SqlInjectionMyqlScanRule extends AbstractAppParamPlugin {
             log.debug(
                     "Scanning URL [{}] [{}], [{}] with value [{}] for SQL Injection",
                     getBaseMsg().getRequestHeader().getMethod(),
-                    getBaseMsg().getRequestHeader().getURI().toString(),
+                    getBaseMsg().getRequestHeader().getURI(),
                     paramName,
                     originalParamValue);
 
@@ -359,14 +359,14 @@ public class SqlInjectionMyqlScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "The time check query timed out on [{}] URL [{}] on field: [{}]",
                             msg3.getRequestHeader().getMethod(),
-                            msg3.getRequestHeader().getURI().toString(),
+                            msg3.getRequestHeader().getURI(),
                             paramName);
                 } catch (SocketException ex) {
                     log.debug(
                             "Caught {} {} when accessing: {}",
                             ex.getClass().getName(),
                             ex.getMessage(),
-                            msg3.getRequestHeader().getURI().toString());
+                            msg3.getRequestHeader().getURI());
                     return; // No need to keep going
                 }
                 long modifiedTimeUsed = msg3.getTimeElapsedMillis();
@@ -421,7 +421,7 @@ public class SqlInjectionMyqlScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "A likely Time Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}]",
                             msg3.getRequestHeader().getMethod(),
-                            msg3.getRequestHeader().getURI().toString(),
+                            msg3.getRequestHeader().getURI(),
                             paramName);
 
                     return;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
@@ -227,7 +227,7 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                 log.debug(
                         "The Base Time Check timed out on [{}] URL [{}]",
                         msgTimeBaseline.getRequestHeader().getMethod(),
-                        msgTimeBaseline.getRequestHeader().getURI().toString());
+                        msgTimeBaseline.getRequestHeader().getURI());
             }
             long originalTimeUsed = msgTimeBaseline.getTimeElapsedMillis();
             // end of timing baseline check
@@ -238,7 +238,7 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
             log.debug(
                     "Scanning URL [{}] [{}], field [{}] with value [{}] for Oracle SQL Injection",
                     getBaseMsg().getRequestHeader().getMethod(),
-                    getBaseMsg().getRequestHeader().getURI().toString(),
+                    getBaseMsg().getRequestHeader().getURI(),
                     paramName,
                     paramValue);
 
@@ -263,7 +263,7 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "The time check query timed out on [{}] URL [{}] on field: [{}]",
                             msgTimeBaseline.getRequestHeader().getMethod(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString(),
+                            msgTimeBaseline.getRequestHeader().getURI(),
                             paramName);
                 }
                 long modifiedTimeUsed = msgAttack.getTimeElapsedMillis();
@@ -318,7 +318,7 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "A likely Time Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}]",
                             msgAttack.getRequestHeader().getMethod(),
-                            msgAttack.getRequestHeader().getURI().toString(),
+                            msgAttack.getRequestHeader().getURI(),
                             paramName);
                     return;
                 } // query took longer than the amount of time we attempted to retard it by

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
@@ -316,7 +316,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                 log.debug(
                         "The Base Time Check timed out on [{}] URL [{}]",
                         msgTimeBaseline.getRequestHeader().getMethod(),
-                        msgTimeBaseline.getRequestHeader().getURI().toString());
+                        msgTimeBaseline.getRequestHeader().getURI());
             }
             long originalTimeUsed = msgTimeBaseline.getTimeElapsedMillis();
             // if the time was very slow (because JSP was being compiled on first call, for
@@ -336,7 +336,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "Base Time Check 2 timed out on [{}] URL [{}]",
                             msgTimeBaseline.getRequestHeader().getMethod(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString());
+                            msgTimeBaseline.getRequestHeader().getURI());
                 }
                 long originalTimeUsed2 = msgTimeBaseline.getTimeElapsedMillis();
                 if (originalTimeUsed2 > expectedDelayInMs) {
@@ -344,7 +344,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "Both base time checks 1 and 2 for [{}] URL [{}] are way too slow to be usable for the purposes of checking for time based SQL Injection checking.  We are aborting the check on this particular url.",
                             msgTimeBaseline.getRequestHeader().getMethod(),
-                            msgTimeBaseline.getRequestHeader().getURI().toString());
+                            msgTimeBaseline.getRequestHeader().getURI());
                     return;
                 } else {
                     // phew.  the second time came in within the limits. use the later timing
@@ -358,7 +358,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
             log.debug(
                     "Scanning URL [{}] [{}], [{}] with value [{}] for SQL Injection",
                     getBaseMsg().getRequestHeader().getMethod(),
-                    getBaseMsg().getRequestHeader().getURI().toString(),
+                    getBaseMsg().getRequestHeader().getURI(),
                     paramName,
                     originalParamValue);
 
@@ -415,7 +415,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                         log.debug(
                                 "The time check query timed out on [{}] URL [{}] on field: [{}]",
                                 msgTimeBaseline.getRequestHeader().getMethod(),
-                                msgTimeBaseline.getRequestHeader().getURI().toString(),
+                                msgTimeBaseline.getRequestHeader().getURI(),
                                 paramName);
                     }
                     long modifiedTimeUsed = msgDelay.getTimeElapsedMillis();
@@ -446,7 +446,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                             log.debug(
                                     "A likely Error Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}], by matching for pattern [{}]",
                                     msgDelay.getRequestHeader().getMethod(),
-                                    msgDelay.getRequestHeader().getURI().toString(),
+                                    msgDelay.getRequestHeader().getURI(),
                                     paramName,
                                     errorMessagePattern.toString());
                             foundTimeBased =
@@ -588,7 +588,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                         log.debug(
                                 "A likely Time Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}]",
                                 detectableDelayMessage.getRequestHeader().getMethod(),
-                                detectableDelayMessage.getRequestHeader().getURI().toString(),
+                                detectableDelayMessage.getRequestHeader().getURI(),
                                 paramName);
 
                     // outta the time based loop..

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -314,7 +314,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
                 if (!HttpStatusCode.isSuccess(msgCpy.getResponseHeader().getStatusCode())) {
                     log.warn(
                             "The original URL [{}] returned a non-OK HTTP status {} (after {} of {} steps). Could be indicative of SQL Injection, or some other error. The URL is not stable enough to look at Username Enumeration",
-                            getBaseMsg().getRequestHeader().getURI().toString(),
+                            getBaseMsg().getRequestHeader().getURI(),
                             msgCpy.getResponseHeader().getStatusCode(),
                             i,
                             numberOfRequests);
@@ -350,7 +350,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
                     // a CAPTCHA has fired, or a WAF has kicked in.  Let's abort now so.
                     log.warn(
                             "The original URL [{}] does not produce stable output (at {} of {} steps).  There is no static element in the output that can be used as a basis of comparison for the result of requesting URLs with the parameter values modified. Perhaps a CAPTCHA or WAF has kicked in!!",
-                            getBaseMsg().getRequestHeader().getURI().toString(),
+                            getBaseMsg().getRequestHeader().getURI(),
                             i + 1,
                             numberOfRequests);
                     return; // we have not even got as far as looking at the parameters, so just
@@ -555,7 +555,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
                     if (!HttpStatusCode.isSuccess(msgCpy.getResponseHeader().getStatusCode())) {
                         log.warn(
                                 "The modified URL [{}] returned a non-OK HTTP status {} (after {} of {} steps for [{}] parameter {}). Could be indicative of SQL Injection, or some other error. The URL is not stable enough to look at Username Enumeration",
-                                msgModifiedParam.getRequestHeader().getURI().toString(),
+                                msgModifiedParam.getRequestHeader().getURI(),
                                 msgCpy.getResponseHeader().getStatusCode(),
                                 i + 1,
                                 numberOfRequests,
@@ -594,7 +594,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
                         // Perhaps a CAPTCHA has fired, or a WAF has kicked in.  Let's abort now so.
                         log.warn(
                                 "The modified URL [{}] (for [{}] parameter {}) does not produce stable output (after {} of {} steps). There is no static element in the output that can be used as a basis of comparison with the static output of the original questy. Perhaps a CAPTCHA or WAF has kicked in!!",
-                                msgModifiedParam.getRequestHeader().getURI().toString(),
+                                msgModifiedParam.getRequestHeader().getURI(),
                                 currentHtmlParameter.getType(),
                                 currentHtmlParameter.getName(),
                                 i + 1,

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XpathInjectionScanRule.java
@@ -167,7 +167,7 @@ public class XpathInjectionScanRule extends AbstractAppParamPlugin {
         log.debug(
                 "Checking [{}] [{}], parameter [{}] for XPath Injection vulnerabilities.",
                 msg.getRequestHeader().getMethod(),
-                msg.getRequestHeader().getURI().toString(),
+                msg.getRequestHeader().getURI(),
                 paramName);
 
         // Start launching evil payloads

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XsltInjectionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/XsltInjectionScanRule.java
@@ -161,7 +161,7 @@ public class XsltInjectionScanRule extends AbstractAppParamPlugin {
                 LOG.warn(
                         "An error occurred while checking [{}] [{}] for {}. Caught {} {}",
                         getBaseMsg().getRequestHeader().getMethod(),
-                        getBaseMsg().getRequestHeader().getURI().toString(),
+                        getBaseMsg().getRequestHeader().getURI(),
                         getName(),
                         e.getClass().getName(),
                         e.getMessage());
@@ -188,7 +188,7 @@ public class XsltInjectionScanRule extends AbstractAppParamPlugin {
         } catch (URIException e) {
             LOG.warn(
                     "An error occurred while getting Host for {}. Caught {} {}",
-                    msg.getRequestHeader().getURI().toString(),
+                    msg.getRequestHeader().getURI(),
                     e.getClass().getName(),
                     e.getMessage());
             return "";

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -90,7 +90,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
         boolean cspHeaderFound = false;
         int noticesRisk = Alert.RISK_INFO;
 
-        LOGGER.debug("Start {} : {}", id, msg.getRequestHeader().getURI().toString());
+        LOGGER.debug("Start {} : {}", id, msg.getRequestHeader().getURI());
 
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
@@ -78,7 +78,7 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner {
         try {
             log.debug(
                     "Checking message {} for Cross-Domain misconfigurations",
-                    msg.getRequestHeader().getURI().toString());
+                    msg.getRequestHeader().getURI());
 
             String corsAllowOriginValue =
                     msg.getResponseHeader().getHeader(HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -104,7 +104,7 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
      */
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        log.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI().toString());
+        log.debug("Checking message {} for timestamps", msg.getRequestHeader().getURI());
 
         List<HttpHeaderField> responseheaders = msg.getResponseHeader().getHeaders();
         StringBuffer filteredResponseheaders = new StringBuffer();

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
@@ -68,7 +68,7 @@ public class BigRedirectsScanRule extends PluginPassiveScanner {
             } else { // No location header found
                 logger.debug(
                         "Though the response had a redirect status code it did not have a Location header.\nRequested URL: {}",
-                        msg.getRequestHeader().getURI().toString());
+                        msg.getRequestHeader().getURI());
             }
 
             if (responseLocationHeaderURILength > 0) {

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
@@ -89,7 +89,7 @@ public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner {
         } catch (URIException ex) {
             LOGGER.warn(
                     "Unable to get authority from URI : {}. Ignoring and moving ahead with the scanning OpenRedirect",
-                    msg.getRequestHeader().getURI().toString(),
+                    msg.getRequestHeader().getURI(),
                     ex);
         }
 


### PR DESCRIPTION
Related to zaproxy/zaproxy#6376

I believe all impacted add-ons (with the exception of pascanrulesAlpha) had either a logging or maintenance changes not already (in the unreleased section).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>