### PR TITLE
openapi: always use enum values when defined

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Always use enum values when defined (Issue 6489).
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Automation parameters are now in camelCase. This is a breaking change, and older automation configurations containing all-lowercase openapi parameters will stop working.
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -88,11 +88,10 @@ public class DataGenerator {
                 return strValue;
             }
         }
-        if (schema instanceof StringSchema) {
-            List<String> enumValues = ((StringSchema) schema).getEnum();
-            if (enumValues != null && !enumValues.isEmpty()) {
-                return enumValues.get(0);
-            }
+
+        List<?> enumValues = schema.getEnum();
+        if (enumValues != null && !enumValues.isEmpty()) {
+            return String.valueOf(enumValues.get(0));
         }
         return null;
     }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiEnumsUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiEnumsUnitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.v3;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.extension.openapi.AbstractServerTest;
+import org.zaproxy.zap.extension.openapi.converter.Converter;
+import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerConverter;
+import org.zaproxy.zap.extension.openapi.network.RequesterListener;
+import org.zaproxy.zap.extension.openapi.network.Requestor;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Test that enum values are used. */
+class OpenApiEnumsUnitTest extends AbstractServerTest {
+
+    @Test
+    void shouldUseEnumValues() throws Exception {
+        // Given
+        this.nano.addHandler(new PlainResponseServerHandler());
+
+        Converter converter =
+                new SwaggerConverter(
+                        getHtml(
+                                "openapi_enum_values.yaml",
+                                new String[][] {{"PORT", String.valueOf(nano.getListeningPort())}}),
+                        null);
+        List<HttpMessage> accessedMessages = new ArrayList<>();
+        RequesterListener listener = (message, initiator) -> accessedMessages.add(message);
+
+        Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        requestor.addListener(listener);
+        // When
+        requestor.run(converter.getRequestModels());
+        // Then
+        HttpMessage message = accessedMessages.get(0);
+        assertThat(message.getRequestHeader().getURI().getEscapedQuery(), is(equalTo("Name=123")));
+
+        message = accessedMessages.get(1);
+        assertThat(message.getRequestHeader().getURI().getEscapedQuery(), is(equalTo("Name=12.3")));
+
+        message = accessedMessages.get(2);
+        assertThat(message.getRequestHeader().getURI().getEscapedQuery(), is(equalTo("Name=123")));
+    }
+
+    private static class PlainResponseServerHandler extends NanoServerHandler {
+
+        public PlainResponseServerHandler() {
+            super("");
+        }
+
+        @Override
+        protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
+            consumeBody(session);
+            return newFixedLengthResponse(Status.OK, NanoHTTPD.MIME_PLAINTEXT, "");
+        }
+    }
+}

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_enum_values.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_enum_values.yaml
@@ -1,0 +1,49 @@
+openapi: 3.0.0
+servers:
+  - url: http://localhost:@@@PORT@@@/
+paths:
+  /parameters/integer:
+    get:
+      operationId: parameters/integer
+      parameters:
+      - in: query
+        name: Name
+        schema:
+          type: integer
+          enum:
+            - 123
+            - 456
+      responses:
+        default:
+          content:
+            text/plain: {}
+  /parameters/number:
+    get:
+      operationId: parameters/number
+      parameters:
+      - in: query
+        name: Name
+        schema:
+          type: number
+          enum:
+            - 12.3
+            - 45.6
+      responses:
+        default:
+          content:
+            text/plain: {}
+  /parameters/string:
+    get:
+      operationId: parameters/string
+      parameters:
+      - in: query
+        name: Name
+        schema:
+          type: string
+          enum:
+            - "123"
+            - "456"
+      responses:
+        default:
+          content:
+            text/plain: {}


### PR DESCRIPTION
Don't explicitly check the type of the schema when checking if it has
enum values, just use them when defined.

Fix zaproxy/zaproxy#6489.