### PR TITLE
webdrivers: update ChromeDriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [26] - 2021-03-25
+### Changed
+- Update ChromeDriver to 89.0.4389.23.
 
 ## [25] - 2021-01-27
 ### Changed
@@ -122,6 +123,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[26]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v24
 [23]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v23

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,7 +9,7 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 88.0.4324.96</li>
+    <li>Chrome - ChromeDriver 89.0.4389.23</li>
     <li>Firefox - geckodriver 0.29.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [25] - 2021-03-25
+### Changed
+- Update ChromeDriver to 89.0.4389.23.
 
 ## [24] - 2021-01-27
 ### Changed
@@ -118,6 +119,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[25]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v24
 [23]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v23
 [22]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v22

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,7 +9,7 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 88.0.4324.96</li>
+    <li>Chrome - ChromeDriver 89.0.4389.23</li>
     <li>Firefox - geckodriver 0.29.0</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.29.0"
-val chromeDriverVersion = "88.0.4324.96"
+val chromeDriverVersion = "89.0.4389.23"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [26] - 2021-03-25
+### Changed
+- Update ChromeDriver to 89.0.4389.23.
 
 ## [25] - 2021-01-27
 ### Changed
@@ -125,6 +126,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[26]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v24
 [23]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v23

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,7 +9,7 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 88.0.4324.96</li>
+    <li>Chrome - ChromeDriver 89.0.4389.23</li>
     <li>Firefox - geckodriver 0.29.0</li>
 </ul>
 


### PR DESCRIPTION
Update ChromeDriver to 89.0.4389.23.
Add release dates and links to tags.