### PR TITLE
pscanrules: Timestamp Disclosure ignore further headers

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Cache-control scan rule no longer checks if Pragma is set or not.
 - Maintenance changes.
+- The Timestamp Disclosure scan rule now excludes values in "Report-To" or "NEL" headers (Issue 6493).
 
 ## [33] - 2021-01-29
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -70,8 +70,14 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
      * ignore the following response headers for the purposes of the comparison, since they cause
      * false positives
      */
-    private static final String[] RESPONSE_HEADERS_TO_IGNORE = {
-        HttpHeader._KEEP_ALIVE, HttpHeader.CACHE_CONTROL, "ETag", "Age", "Strict-Transport-Security"
+    public static final String[] RESPONSE_HEADERS_TO_IGNORE = {
+        HttpHeader._KEEP_ALIVE,
+        HttpHeader.CACHE_CONTROL,
+        "ETag",
+        "Age",
+        "Strict-Transport-Security",
+        "Report-To",
+        "NEL"
     };
 
     /**

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,17 @@ public class TimestampDisclosureScanRuleUnitTest
     @Override
     protected TimestampDisclosureScanRule createScanner() {
         return new TimestampDisclosureScanRule();
+    }
+
+    @Test
+    public void verifyExcludedHeadersListAsExpected() {
+        // Given / When
+        List<String> ignoreList =
+                Arrays.asList(TimestampDisclosureScanRule.RESPONSE_HEADERS_TO_IGNORE);
+        // Then
+        assertEquals(7, ignoreList.size());
+        assertTrue(ignoreList.contains("NEL"));
+        assertTrue(ignoreList.contains("Report-To"));
     }
 
     @Test


### PR DESCRIPTION
- CHANGELOG > Added change note
- TimestampDisclosureScanRule > Added "Report-To" and "NEL" as headers to ignore.
- TimestampDisclosureScanRuleUnitTest > Add test for number of excluded headers, and that the array contains the newly added headers.

Fixes zaproxy/zaproxy#6493

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>