### PR TITLE
Rename reliability to confidence

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
@@ -102,7 +102,7 @@ public class DirectoryBrowsingScanRule extends AbstractAppPlugin {
 
         boolean result = false;
         HttpMessage msg = getNewMsg();
-        int reliability = Alert.CONFIDENCE_MEDIUM;
+        int confidence = Alert.CONFIDENCE_MEDIUM;
         StringBuilder evidence = new StringBuilder();
 
         try {
@@ -121,13 +121,13 @@ public class DirectoryBrowsingScanRule extends AbstractAppPlugin {
                 result = true;
             } else if (matchBodyPattern(msg, patternGeneralParent, evidence)) {
                 result = true;
-                reliability = Alert.CONFIDENCE_LOW;
+                confidence = Alert.CONFIDENCE_LOW;
             } else if (matchBodyPattern(msg, patternGeneralDir1, evidence)) {
                 // Dont append the second matching pattern to the evidence as they will be in
                 // different places
                 if (matchBodyPattern(msg, patternGeneralDir2, null)) {
                     result = true;
-                    reliability = Alert.CONFIDENCE_LOW;
+                    confidence = Alert.CONFIDENCE_LOW;
                 }
             }
 
@@ -136,7 +136,7 @@ public class DirectoryBrowsingScanRule extends AbstractAppPlugin {
 
         if (result) {
             newAlert()
-                    .setConfidence(reliability)
+                    .setConfidence(confidence)
                     .setAttack(evidence.toString())
                     .setMessage(msg)
                     .raise();

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update links to zaproxy repo.
+- Rename reliability to confidence in active/passive templates.
 
 ## [7] - 2020-12-15
 ### Added

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/active/Active default template.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/active/Active default template.rb
@@ -33,11 +33,11 @@ class JRubyActiveScript
     # Test the response here, and make other requests as required
     if (true)
   	  # Change to a test which detects the vulnerability
-      # raiseAlert(risk, int reliability, String name, String description, String uri, 
+      # raiseAlert(risk, int confidence, String name, String description, String uri, 
       #		String param, String attack, String otherInfo, String solution, String evidence, 
       #		int cweId, int wascId, HttpMessage msg)
       # risk: 0: info, 1: low, 2: medium, 3: high
-      # reliability: 0: falsePassitive, 1: suspicious, 2: warning
+      # confidence: 0: false positive, 1: low, 2: medium, 3: high
       sas.raiseAlert(1, 1, 'Active Vulnerability title', 'Full description', 
       msg.getRequestHeader().getURI().toString(), 
         param, 'Your attack', 'Any other info', 'The solution ', '', 0, 0, msg);

--- a/addOns/jruby/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.rb
+++ b/addOns/jruby/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.rb
@@ -24,11 +24,11 @@ class JRubyPassiveScript
       'scan called for url=' + msg.getRequestHeader().getURI().toString());
     if (true)
       # Change to a test which detects the vulnerability
-      # raiseAlert(risk, int reliability, String name, String description, String uri, 
+      # raiseAlert(risk, int confidence, String name, String description, String uri, 
       # String param, String attack, String otherInfo, String solution, String evidence, 
       # int cweId, int wascId, HttpMessage msg)
       # risk: 0: info, 1: low, 2: medium, 3: high
-      # reliability: 0: falsePositive, 1: suspicious, 2: warning
+      # confidence: 0: false positive, 1: low, 2: medium, 3: high
       ps.raiseAlert(1, 1, 'Passive Vulnerability title', 'Full description', 
         msg.getRequestHeader().getURI().toString(), 
         'The param', 'Your attack', 'Any other info', 'The solution', '', 0, 0, msg);

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update links to zaproxy repo.
+- Rename reliability to confidence in active/passive templates.
 - Maintenance changes.
 
 ## [11] - 2020-12-15

--- a/addOns/jython/src/main/zapHomeFiles/scripts/templates/active/Active default template.py
+++ b/addOns/jython/src/main/zapHomeFiles/scripts/templates/active/Active default template.py
@@ -35,11 +35,11 @@ def scan(sas, msg, param, value):
   # Test the response here, and make other requests as required
   if (True):
   	# Change to a test which detects the vulnerability
-    # raiseAlert(risk, int reliability, String name, String description, String uri, 
+    # raiseAlert(risk, int confidence, String name, String description, String uri, 
     #		String param, String attack, String otherInfo, String solution, String evidence, 
     #		int cweId, int wascId, HttpMessage msg)
     # risk: 0: info, 1: low, 2: medium, 3: high
-    # reliability: 0: falsePassitive, 1: suspicious, 2: warning
+    # confidence: 0: false positive, 1: low, 2: medium, 3: high
     sas.raiseAlert(1, 1, 'Active Vulnerability title', 'Full description', 
     msg.getRequestHeader().getURI().toString(), 
       param, 'Your attack', 'Any other info', 'The solution ', '', 0, 0, msg);

--- a/addOns/jython/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.py
+++ b/addOns/jython/src/main/zapHomeFiles/scripts/templates/passive/Passive default template.py
@@ -33,11 +33,11 @@ def scan(ps, msg, src):
   # Test the request and/or response here
   if (True):
     # Change to a test which detects the vulnerability
-    # raiseAlert(risk, int reliability, String name, String description, String uri, 
+    # raiseAlert(risk, int confidence, String name, String description, String uri, 
     # String param, String attack, String otherInfo, String solution, String evidence, 
     # int cweId, int wascId, HttpMessage msg)
     # risk: 0: info, 1: low, 2: medium, 3: high
-    # reliability: 0: falsePositive, 1: suspicious, 2: warning
+    # confidence: 0: false positive, 1: low, 2: medium, 3: high
     ps.raiseAlert(1, 1, 'Passive Vulnerability title', 'Full description', 
       msg.getRequestHeader().getURI().toString(), 
       'The param', 'Your attack', 'Any other info', 'The solution', '', 0, 0, msg);

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -208,7 +208,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Tweaked "Source Code Disclosure" scanner to reduce false positives
 - Added "Insecure Component" scanner
-- Addressed issue 1262 (Risk & Reliability for 'User controllable HTML element attribute (potential XSS)' and 'Timestamp Disclosure')
+- Addressed issue 1262 (Risk & Confidence for 'User controllable HTML element attribute (potential XSS)' and 'Timestamp Disclosure')
 - Add Big Redirect scanner (Issue 1257)
 - Fixed an issue in detecting SHA-512 Crypt hashes, and other hashes beginning with "$"
 - Detect Node.js source code


### PR DESCRIPTION
Update code, changelog, and script templates to use confidence instead
of reliability.
Update/add confidence values in script templates.