### PR TITLE
Use core helper methods to read properties

### DIFF
--- a/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/BrowserViewParam.java
+++ b/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/BrowserViewParam.java
@@ -82,17 +82,10 @@ public class BrowserViewParam extends AbstractParam {
     protected void parse() {
         updateConfigFile();
 
-        try {
-            warnOnJavaFXInitError =
-                    getConfig()
-                            .getBoolean(
-                                    PARAM_WARN_ON_JAVA_FX_INIT_ERROR,
-                                    PARAM_WARN_ON_JAVA_FX_INIT_ERROR_DEFAULT_VALUE);
-        } catch (ConversionException e) {
-            LOGGER.error(
-                    "Error while loading the '{}' option: ", PARAM_WARN_ON_JAVA_FX_INIT_ERROR, e);
-            warnOnJavaFXInitError = PARAM_WARN_ON_JAVA_FX_INIT_ERROR_DEFAULT_VALUE;
-        }
+        warnOnJavaFXInitError =
+                getBoolean(
+                        PARAM_WARN_ON_JAVA_FX_INIT_ERROR,
+                        PARAM_WARN_ON_JAVA_FX_INIT_ERROR_DEFAULT_VALUE);
     }
 
     /**

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [10] - 2020-12-15
 

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForceParam.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForceParam.java
@@ -27,13 +27,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 
 public class BruteForceParam extends AbstractParam {
-
-    private static final Logger logger = Logger.getLogger(BruteForceParam.class);
 
     private static final String THREAD_PER_SCAN = "bruteforce.threadPerHost";
     private static final String DEFAULT_FILE = "bruteforce.defaultFile";
@@ -84,16 +80,10 @@ public class BruteForceParam extends AbstractParam {
         } catch (Exception e) {
         }
 
-        try {
-            String path = getConfig().getString(DEFAULT_FILE, "");
-            if (!"".equals(path)) {
-                this.defaultFile = new ForcedBrowseFile(new File(path));
-            } else {
-                this.defaultFile = null;
-            }
-        } catch (ConversionException e) {
-            logger.error(
-                    "Error while loading the forced browse default file: " + e.getMessage(), e);
+        String path = getString(DEFAULT_FILE, "");
+        if (!"".equals(path)) {
+            this.defaultFile = new ForcedBrowseFile(new File(path));
+        } else {
             this.defaultFile = null;
         }
     }

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerParam.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerParam.java
@@ -99,12 +99,7 @@ public class FormHandlerParam extends AbstractParam {
             }
         }
 
-        try {
-            this.confirmRemoveField = getConfig().getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
-        } catch (ConversionException e) {
-            logger.error(
-                    "Error while loading the confirm remove field option: {}", e.getMessage(), e);
-        }
+        this.confirmRemoveField = getBoolean(CONFIRM_REMOVE_TOKEN_KEY, true);
     }
 
     @ZapApiIgnore

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Maintenance changes.
+
 ### Fixed
 - Update results panels when Look and Feel changes (Issue 6479).
 

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptions.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptions.java
@@ -22,15 +22,11 @@ package org.zaproxy.zap.extension.fuzz;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 import org.zaproxy.zap.extension.fuzz.messagelocations.MessageLocationsReplacementStrategy;
 
 public class FuzzOptions extends VersionedAbstractParam {
-
-    private static final Logger LOGGER = Logger.getLogger(FuzzOptions.class);
 
     public static final int MAX_THREADS_PER_FUZZER = Constant.MAX_THREADS_PER_SCAN;
 
@@ -101,84 +97,27 @@ public class FuzzOptions extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
-        try {
-            customCategory = getConfig().getBoolean(IS_CUSTOM_DEFAULT_CATEGORY_KEY, false);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + IS_CUSTOM_DEFAULT_CATEGORY_KEY + "':", e);
-        }
-
-        try {
-            defaultCategoryName = getConfig().getString(DEFAULT_CATEGORY_NAME_KEY, "");
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + DEFAULT_CATEGORY_NAME_KEY + "':", e);
-        }
-
-        try {
-            customFuzzerLastSelectedDirectory =
-                    Paths.get(getConfig().getString(CUSTOM_FUZZER_LAST_SELECTED_DIRECTORY_KEY, ""));
-        } catch (ConversionException e) {
-            LOGGER.error(
-                    "Error while loading '" + CUSTOM_FUZZER_LAST_SELECTED_DIRECTORY_KEY + "':", e);
-        }
-
-        try {
-            maxFinishedFuzzersInUI =
-                    getConfig().getInt(MAX_FINISHED_FUZZERS_IN_UI_KEY, DEFAULT_MAX_FUZZERS_IN_UI);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + MAX_FINISHED_FUZZERS_IN_UI_KEY + "':", e);
-        }
-
-        try {
-            promptToClearFinishedFuzzers =
-                    getConfig()
-                            .getBoolean(
-                                    PROMPT_TO_CLEAR_FINISHED_FUZZERS_KEY,
-                                    DEFAULT_PROMPT_TO_CLEAR_FINISHED_SCANS);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + PROMPT_TO_CLEAR_FINISHED_FUZZERS_KEY + "':", e);
-        }
-
-        try {
-            defaultRetriesOnIOError =
-                    getConfig()
-                            .getInt(DEFAULT_RETRIES_ON_IO_ERROR_KEY, DEFAULT_RETRIES_ON_IO_ERROR);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + DEFAULT_RETRIES_ON_IO_ERROR_KEY + "':", e);
-        }
-
-        try {
-            defaultMaxErrorsAllowed =
-                    getConfig().getInt(DEFAULT_MAX_ERRORS_ALLOWED_KEY, DEFAULT_MAX_ERRORS_ALLOWED);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + DEFAULT_MAX_ERRORS_ALLOWED_KEY + "':", e);
-        }
-
-        try {
-            defaultPayloadReplacementStrategy =
-                    MessageLocationsReplacementStrategy.getValue(
-                            getConfig()
-                                    .getString(
-                                            DEFAULT_PAYLOAD_REPLACEMENT_STRATEGY_KEY,
-                                            MessageLocationsReplacementStrategy.DEPTH_FIRST
-                                                    .getConfigId()));
-        } catch (ConversionException e) {
-            LOGGER.error(
-                    "Error while loading '" + DEFAULT_PAYLOAD_REPLACEMENT_STRATEGY_KEY + "':", e);
-        }
-
-        try {
-            defaultThreadsPerFuzzer =
-                    getConfig().getInt(DEFAULT_THREADS_PER_FUZZER_KEY, DEFAULT_THREADS_PER_FUZZER);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + DEFAULT_THREADS_PER_FUZZER_KEY + "':", e);
-        }
-
-        try {
-            defaultFuzzDelayInMs =
-                    getConfig().getInt(DEFAULT_FUZZ_DELAY_IN_MS_KEY, DEFAULT_FUZZ_DELAY_IN_MS);
-        } catch (ConversionException e) {
-            LOGGER.error("Error while loading '" + DEFAULT_FUZZ_DELAY_IN_MS_KEY + "':", e);
-        }
+        customCategory = getBoolean(IS_CUSTOM_DEFAULT_CATEGORY_KEY, false);
+        defaultCategoryName = getString(DEFAULT_CATEGORY_NAME_KEY, "");
+        customFuzzerLastSelectedDirectory =
+                Paths.get(getString(CUSTOM_FUZZER_LAST_SELECTED_DIRECTORY_KEY, ""));
+        maxFinishedFuzzersInUI = getInt(MAX_FINISHED_FUZZERS_IN_UI_KEY, DEFAULT_MAX_FUZZERS_IN_UI);
+        promptToClearFinishedFuzzers =
+                getBoolean(
+                        PROMPT_TO_CLEAR_FINISHED_FUZZERS_KEY,
+                        DEFAULT_PROMPT_TO_CLEAR_FINISHED_SCANS);
+        defaultRetriesOnIOError =
+                getInt(DEFAULT_RETRIES_ON_IO_ERROR_KEY, DEFAULT_RETRIES_ON_IO_ERROR);
+        defaultMaxErrorsAllowed =
+                getInt(DEFAULT_MAX_ERRORS_ALLOWED_KEY, DEFAULT_MAX_ERRORS_ALLOWED);
+        defaultPayloadReplacementStrategy =
+                MessageLocationsReplacementStrategy.getValue(
+                        getString(
+                                DEFAULT_PAYLOAD_REPLACEMENT_STRATEGY_KEY,
+                                MessageLocationsReplacementStrategy.DEPTH_FIRST.getConfigId()));
+        defaultThreadsPerFuzzer =
+                getInt(DEFAULT_THREADS_PER_FUZZER_KEY, DEFAULT_THREADS_PER_FUZZER);
+        defaultFuzzDelayInMs = getInt(DEFAULT_FUZZ_DELAY_IN_MS_KEY, DEFAULT_FUZZ_DELAY_IN_MS);
     }
 
     @Override
@@ -187,60 +126,27 @@ public class FuzzOptions extends VersionedAbstractParam {
             case NO_CONFIG_VERSION:
                 // Previously in core. Normalise the name of old options.
                 String threadPerScanKey = "fuzzer.threadPerScan";
-                try {
-                    int oldThreadPerScan =
-                            getConfig().getInt(threadPerScanKey, DEFAULT_THREADS_PER_FUZZER);
-                    getConfig()
-                            .setProperty(
-                                    DEFAULT_THREADS_PER_FUZZER_KEY,
-                                    Integer.valueOf(oldThreadPerScan));
-                } catch (ConversionException e) {
-                    LOGGER.warn(
-                            "Failed to read (old) configuration '"
-                                    + threadPerScanKey
-                                    + "', no update will be made.");
-                }
+                int oldThreadPerScan = getInt(threadPerScanKey, DEFAULT_THREADS_PER_FUZZER);
+                getConfig()
+                        .setProperty(
+                                DEFAULT_THREADS_PER_FUZZER_KEY, Integer.valueOf(oldThreadPerScan));
                 getConfig().clearProperty(threadPerScanKey);
 
                 String defaultCategoryKey = "fuzzer.defaultCategory";
-                try {
-                    String defaultCategory = getConfig().getString(defaultCategoryKey, "");
-                    getConfig().setProperty(DEFAULT_CATEGORY_NAME_KEY, defaultCategory);
-                } catch (ConversionException e) {
-                    LOGGER.warn(
-                            "Failed to read (old) configuration '"
-                                    + defaultCategoryKey
-                                    + "', no update will be made.");
-                }
+                String defaultCategory = getString(defaultCategoryKey, "");
+                getConfig().setProperty(DEFAULT_CATEGORY_NAME_KEY, defaultCategory);
                 getConfig().clearProperty(defaultCategoryKey);
 
                 String dealyInMsKey = "fuzzer.delayInMs";
-                try {
-                    int delayInMs = getConfig().getInt(dealyInMsKey, DEFAULT_FUZZ_DELAY_IN_MS);
-                    getConfig()
-                            .setProperty(DEFAULT_FUZZ_DELAY_IN_MS_KEY, Integer.valueOf(delayInMs));
-                } catch (ConversionException e) {
-                    LOGGER.warn(
-                            "Failed to read (old) configuration '"
-                                    + dealyInMsKey
-                                    + "', no update will be made.");
-                }
+                int delayInMs = getInt(dealyInMsKey, DEFAULT_FUZZ_DELAY_IN_MS);
+                getConfig().setProperty(DEFAULT_FUZZ_DELAY_IN_MS_KEY, Integer.valueOf(delayInMs));
                 getConfig().clearProperty(dealyInMsKey);
 
                 String lastSelectedDirectoryKey = "fuzzer.lastSelectedDirectoryAddCustomFile";
-                try {
-                    String lastSelectedDirectory =
-                            getConfig().getString(lastSelectedDirectoryKey, "");
-                    getConfig()
-                            .setProperty(
-                                    CUSTOM_FUZZER_LAST_SELECTED_DIRECTORY_KEY,
-                                    lastSelectedDirectory);
-                } catch (ConversionException e) {
-                    LOGGER.warn(
-                            "Failed to read (old) configuration '"
-                                    + lastSelectedDirectoryKey
-                                    + "', no update will be made.");
-                }
+                String lastSelectedDirectory = getString(lastSelectedDirectoryKey, "");
+                getConfig()
+                        .setProperty(
+                                CUSTOM_FUZZER_LAST_SELECTED_DIRECTORY_KEY, lastSelectedDirectory);
                 getConfig().clearProperty(lastSelectedDirectoryKey);
         }
     }

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/InvokeParam.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/InvokeParam.java
@@ -98,11 +98,7 @@ public class InvokeParam extends AbstractParam {
             logger.error("Error while loading invoke applications: {}", e.getMessage(), e);
         }
 
-        try {
-            this.confirmRemoveApp = getConfig().getBoolean(CONFIRM_REMOVE_APP_KEY, true);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the confirm remove option: {}", e.getMessage(), e);
-        }
+        this.confirmRemoveApp = getBoolean(CONFIRM_REMOVE_APP_KEY, true);
     }
 
     public List<InvokableApp> getListInvoke() {

--- a/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/JythonOptionsParam.java
+++ b/addOns/jython/src/main/java/org/zaproxy/zap/extension/jython/JythonOptionsParam.java
@@ -19,14 +19,9 @@
  */
 package org.zaproxy.zap.extension.jython;
 
-import org.apache.commons.configuration.ConversionException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 
 public class JythonOptionsParam extends VersionedAbstractParam {
-
-    private static final Logger logger = LogManager.getLogger(JythonOptionsParam.class);
 
     /**
      * The version of the configurations. Used to keep track of configurations changes between
@@ -55,11 +50,7 @@ public class JythonOptionsParam extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
-        try {
-            this.modulePath = super.getConfig().getString(MODULE_PATH_PROPERTY, "");
-        } catch (ConversionException e) {
-            logger.error("Error while loading '{}': ", MODULE_PATH_PROPERTY, e);
-        }
+        this.modulePath = getString(MODULE_PATH_PROPERTY, "");
     }
 
     @Override

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
@@ -159,12 +159,7 @@ public class ReplacerParam extends AbstractParam {
             }
         }
 
-        try {
-            this.confirmRemoveToken = getConfig().getBoolean(CONFIRM_REMOVE_RULE_KEY, true);
-        } catch (ConversionException e) {
-            logger.error(
-                    "Error while loading the confirm remove rule option: " + e.getMessage(), e);
-        }
+        this.confirmRemoveToken = getBoolean(CONFIRM_REMOVE_RULE_KEY, true);
     }
 
     public List<ReplacerParamRule> getRules() {

--- a/addOns/reveal/src/main/java/org/zaproxy/zap/extension/reveal/RevealParam.java
+++ b/addOns/reveal/src/main/java/org/zaproxy/zap/extension/reveal/RevealParam.java
@@ -19,13 +19,9 @@
  */
 package org.zaproxy.zap.extension.reveal;
 
-import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 
 public class RevealParam extends VersionedAbstractParam {
-
-    private static final Logger logger = Logger.getLogger(RevealParam.class);
 
     /**
      * The version of the configurations. Used to keep track of configurations changes between
@@ -57,30 +53,18 @@ public class RevealParam extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
-        try {
-            reveal = getConfig().getBoolean(PARAM_REVEAL_STATE, PARAM_REVEAL_STATE_DEFAULT_VALUE);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the reveal state: " + e.getMessage(), e);
-        }
+        reveal = getBoolean(PARAM_REVEAL_STATE, PARAM_REVEAL_STATE_DEFAULT_VALUE);
     }
 
     @Override
     protected void updateConfigsImpl(int fileVersion) {
         // When in ZAP "core"
         if (fileVersion == NO_CONFIG_VERSION) {
-            try {
-                final String oldKey = "view.reveal";
-                boolean oldValue = getConfig().getBoolean(oldKey, false);
-                getConfig().clearProperty(oldKey);
+            final String oldKey = "view.reveal";
+            boolean oldValue = getBoolean(oldKey, false);
+            getConfig().clearProperty(oldKey);
 
-                getConfig().setProperty(PARAM_REVEAL_STATE, Boolean.valueOf(oldValue));
-            } catch (ConversionException e) {
-                logger.error(
-                        "Error while updating the reveal state from old version ["
-                                + fileVersion
-                                + "]",
-                        e);
-            }
+            getConfig().setProperty(PARAM_REVEAL_STATE, Boolean.valueOf(oldValue));
         }
     }
 

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update links to zaproxy repo.
+- Maintenance changes.
 
 ## [15.3.0] - 2020-12-15
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
@@ -22,9 +22,7 @@ package org.zaproxy.zap.extension.selenium;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.lang.Validate;
-import org.apache.log4j.Logger;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.ie.InternetExplorerDriverService;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
@@ -44,8 +42,6 @@ import org.zaproxy.zap.extension.api.ZapApiIgnore;
  * </ul>
  */
 public class SeleniumOptions extends VersionedAbstractParam {
-
-    private static final Logger LOGGER = Logger.getLogger(SeleniumOptions.class);
 
     public static final String CHROME_DRIVER_SYSTEM_PROPERTY =
             ChromeDriverService.CHROME_DRIVER_EXE_PROPERTY;
@@ -180,14 +176,9 @@ public class SeleniumOptions extends VersionedAbstractParam {
     private String readSystemPropertyWithOptionFallback(String systemProperty, String optionKey) {
         String value = System.getProperty(systemProperty);
         if (value == null) {
-            try {
-                value = getConfig().getString(optionKey, "");
-                if (!value.isEmpty()) {
-                    System.setProperty(systemProperty, value);
-                }
-            } catch (ConversionException e) {
-                LOGGER.error("Failed to read '" + optionKey + "'", e);
-                value = "";
+            value = getString(optionKey, "");
+            if (!value.isEmpty()) {
+                System.setProperty(systemProperty, value);
             }
         } else {
             getConfig().setProperty(optionKey, value);

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [23.3.0] - 2021-03-09
 ### Added

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -210,49 +210,15 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
-        try {
-            this.numberOfBrowsers =
-                    getConfig().getInt(NUMBER_OF_BROWSERS_KEY, DEFAULT_NUMBER_OF_BROWSERS);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the number of browsers: " + e.getMessage(), e);
-        }
+        this.numberOfBrowsers = getInt(NUMBER_OF_BROWSERS_KEY, DEFAULT_NUMBER_OF_BROWSERS);
+        this.maxCrawlDepth = getInt(MAX_CRAWL_DEPTH_KEY, DEFAULT_MAX_CRAWL_DEPTH);
+        this.maxCrawlStates = getInt(MAX_CRAWL_STATES_KEY, DEFAULT_CRAWL_STATES);
+        this.maxDuration = getInt(MAX_DURATION_KEY, DEFAULT_MAX_DURATION);
+        this.eventWait = getInt(EVENT_WAIT_TIME_KEY, DEFAULT_EVENT_WAIT_TIME);
+        this.reloadWait = getInt(RELOAD_WAIT_TIME_KEY, DEFAULT_RELOAD_WAIT_TIME);
 
-        try {
-            this.maxCrawlDepth = getConfig().getInt(MAX_CRAWL_DEPTH_KEY, DEFAULT_MAX_CRAWL_DEPTH);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the max crawl depth: " + e.getMessage(), e);
-        }
+        browserId = getString(BROWSER_ID_KEY, DEFAULT_BROWSER_ID);
 
-        try {
-            this.maxCrawlStates = getConfig().getInt(MAX_CRAWL_STATES_KEY, DEFAULT_CRAWL_STATES);
-        } catch (ConversionException e) {
-            logger.error("Error while loading max crawl states: " + e.getMessage(), e);
-        }
-
-        try {
-            this.maxDuration = getConfig().getInt(MAX_DURATION_KEY, DEFAULT_MAX_DURATION);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the crawl duration: " + e.getMessage(), e);
-        }
-
-        try {
-            this.eventWait = getConfig().getInt(EVENT_WAIT_TIME_KEY, DEFAULT_EVENT_WAIT_TIME);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the event wait time: " + e.getMessage(), e);
-        }
-
-        try {
-            this.reloadWait = getConfig().getInt(RELOAD_WAIT_TIME_KEY, DEFAULT_RELOAD_WAIT_TIME);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the reload wait time: " + e.getMessage(), e);
-        }
-
-        try {
-            browserId = getConfig().getString(BROWSER_ID_KEY, DEFAULT_BROWSER_ID);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the browser id: " + e.getMessage(), e);
-            browserId = DEFAULT_BROWSER_ID;
-        }
         try {
             Browser.getBrowserWithId(browserId);
         } catch (IllegalArgumentException e) {
@@ -266,31 +232,10 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
             browserId = DEFAULT_BROWSER_ID;
         }
 
-        try {
-            this.clickDefaultElems =
-                    getConfig().getBoolean(CLICK_DEFAULT_ELEMS_KEY, DEFAULT_CLICK_DEFAULT_ELEMS);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the click default option: " + e.getMessage(), e);
-        }
-
-        try {
-            this.clickElemsOnce =
-                    getConfig().getBoolean(CLICK_ELEMS_ONCE_KEY, DEFAULT_CLICK_ELEMS_ONCE);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the click once option: " + e.getMessage(), e);
-        }
-
-        try {
-            this.randomInputs = getConfig().getBoolean(RANDOM_INPUTS_KEY, DEFAULT_RANDOM_INPUTS);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the random inputs option: " + e.getMessage(), e);
-        }
-
-        try {
-            this.showAdvancedDialog = getConfig().getBoolean(SHOW_ADV_OPTIONS_KEY, false);
-        } catch (ConversionException e) {
-            logger.error("Error while loading the show advanced option: " + e.getMessage(), e);
-        }
+        this.clickDefaultElems = getBoolean(CLICK_DEFAULT_ELEMS_KEY, DEFAULT_CLICK_DEFAULT_ELEMS);
+        this.clickElemsOnce = getBoolean(CLICK_ELEMS_ONCE_KEY, DEFAULT_CLICK_ELEMS_ONCE);
+        this.randomInputs = getBoolean(RANDOM_INPUTS_KEY, DEFAULT_RANDOM_INPUTS);
+        this.showAdvancedDialog = getBoolean(SHOW_ADV_OPTIONS_KEY, false);
 
         try {
             List<HierarchicalConfiguration> fields =
@@ -322,12 +267,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
             }
         }
 
-        try {
-            this.confirmRemoveElem = getConfig().getBoolean(CONFIRM_REMOVE_ELEM_KEY, true);
-        } catch (ConversionException e) {
-            logger.error(
-                    "Error while loading the confirm remove element option: " + e.getMessage(), e);
-        }
+        this.confirmRemoveElem = getBoolean(CONFIRM_REMOVE_ELEM_KEY, true);
 
         try {
             List<HierarchicalConfiguration> fields =
@@ -362,16 +302,8 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
                 break;
             case 1:
                 String crawlInDepthKey = AJAX_SPIDER_BASE_KEY + ".crawlInDepth";
-                try {
-                    boolean crawlInDepth = getConfig().getBoolean(crawlInDepthKey, false);
-                    getConfig()
-                            .setProperty(CLICK_DEFAULT_ELEMS_KEY, Boolean.valueOf(!crawlInDepth));
-                } catch (ConversionException e) {
-                    logger.warn(
-                            "Failed to read (old) configuration '"
-                                    + crawlInDepthKey
-                                    + "', no update will be made.");
-                }
+                boolean crawlInDepth = getBoolean(crawlInDepthKey, false);
+                getConfig().setProperty(CLICK_DEFAULT_ELEMS_KEY, Boolean.valueOf(!crawlInDepth));
                 getConfig().clearProperty(crawlInDepthKey);
                 // $FALL-THROUGH$
             case 2:

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Clear Zest Results Panel when new script is added.
+- Maintenance changes.
 
 ## [33] - 2020-11-27
 ### Added

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
@@ -99,9 +99,8 @@ public class ZestParam extends AbstractParam {
 
     @Override
     protected void parse() {
-        // Parse the params
+        this.includeResponses = getBoolean(INCLUDE_RESPONSES_KEY, true);
         try {
-            this.includeResponses = getConfig().getBoolean(INCLUDE_RESPONSES_KEY, true);
 
             this.allHeaders.clear();
             for (String header : ALL_HEADERS) {


### PR DESCRIPTION
Use the core methods that already handle conversion exceptions when
reading the properties.
Update changelogs where needed.