### PR TITLE
graphql, soap: cope with missing Nashorn engine

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 - Fix invalid query generation when query depth was reached and the deepest fields had no leaf types (Issue 6316).
+- Cope with missing Nashorn engine (Issue 6501).
 
 ## [0.2.0] - 2020-11-18
 ### Changed

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.graphql;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -189,7 +190,7 @@ public class ExtensionGraphQl extends ExtensionAdaptor
         if (extScript != null && extScript.getScript(scriptName) == null) {
             ScriptType variantType =
                     extScript.getScriptType(ExtensionActiveScan.SCRIPT_TYPE_VARIANT);
-            ScriptEngineWrapper engine = extScript.getEngineWrapper("Oracle Nashorn");
+            ScriptEngineWrapper engine = getEngine(extScript, "Oracle Nashorn");
             if (variantType != null && engine != null) {
                 File scriptPath =
                         Paths.get(
@@ -212,6 +213,15 @@ public class ExtensionGraphQl extends ExtensionAdaptor
                 extScript.addScript(script, false);
             }
         }
+    }
+
+    private static ScriptEngineWrapper getEngine(ExtensionScript ext, String engineName) {
+        try {
+            return ext.getEngineWrapper(engineName);
+        } catch (InvalidParameterException e) {
+            LOG.warn("The {} engine was not found, script variant will not be added.", engineName);
+        }
+        return null;
     }
 
     @Override

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix detection of WSDL files (Issue 6440).
+- Cope with missing Nashorn engine (Issue 6500).
 
 ## [5] - 2021-01-04
 ### Changed

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDL.java
@@ -23,6 +23,7 @@ import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.security.InvalidParameterException;
 import javax.swing.JFileChooser;
 import javax.swing.SwingUtilities;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -191,7 +192,7 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
         if (extScript != null && extScript.getScript(scriptName) == null) {
             ScriptType variantType =
                     extScript.getScriptType(ExtensionActiveScan.SCRIPT_TYPE_VARIANT);
-            ScriptEngineWrapper engine = extScript.getEngineWrapper("Oracle Nashorn");
+            ScriptEngineWrapper engine = getEngine(extScript, "Oracle Nashorn");
             if (variantType != null && engine != null) {
                 File scriptPath =
                         Paths.get(
@@ -214,6 +215,18 @@ public class ExtensionImportWSDL extends ExtensionAdaptor {
                 extScript.addScript(script, false);
             }
         }
+    }
+
+    private static ScriptEngineWrapper getEngine(ExtensionScript ext, String engineName) {
+        try {
+            return ext.getEngineWrapper(engineName);
+        } catch (InvalidParameterException e) {
+            LOG.warn(
+                    "The "
+                            + engineName
+                            + " engine was not found, script variant will not be added.");
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Catch the exception thrown when the engine is missing, preventing the
failure during initialisation.

Part of zaproxy/zaproxy#6500 and zaproxy/zaproxy#6501.