### PR TITLE
replacer: update ZAP to 2.10.0

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Update links to zaproxy repo.
 - Maintenance changes.
 

--- a/addOns/replacer/replacer.gradle.kts
+++ b/addOns/replacer/replacer.gradle.kts
@@ -6,7 +6,7 @@ description = "Easy way to replace strings in requests and responses."
 zapAddOn {
     addOnName.set("Replacer")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ExtensionReplacer.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.replacer;
 
 import java.awt.event.KeyEvent;
 import java.util.regex.Pattern;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -50,7 +51,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
     private OptionsReplacerPanel optionsReplacerPanel;
     private ReplacerParam params;
     private ZapMenuItem replacerMenuItem;
-    private static final Logger LOGGER = Logger.getLogger(ExtensionReplacer.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionReplacer.class);
 
     public ExtensionReplacer() {
         super(NAME);
@@ -151,10 +152,9 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                 switch (rule.getMatchType()) {
                     case REQ_HEADER:
                         LOGGER.debug(
-                                "Add in request header: "
-                                        + rule.getMatchString()
-                                        + " : "
-                                        + rule.getReplacement());
+                                "Add in request header: {} : {}",
+                                rule.getMatchString(),
+                                rule.getReplacement());
                         if (rule.getReplacement().length() == 0) {
                             // Remove the header
                             msg.getRequestHeader().setHeader(rule.getMatchString(), null);
@@ -165,10 +165,9 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                         break;
                     case REQ_HEADER_STR:
                         LOGGER.debug(
-                                "Replace in request header: "
-                                        + rule.getMatchString()
-                                        + " with "
-                                        + rule.getReplacement());
+                                "Replace in request header: {} with {}",
+                                rule.getMatchString(),
+                                rule.getReplacement());
                         String header = msg.getRequestHeader().toString();
                         if (contains(header, rule.getMatchString(), p)) {
                             header =
@@ -186,10 +185,9 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                         break;
                     case REQ_BODY_STR:
                         LOGGER.debug(
-                                "Add in request body: "
-                                        + rule.getMatchString()
-                                        + " : "
-                                        + rule.getReplacement());
+                                "Add in request body: {} : {}",
+                                rule.getMatchString(),
+                                rule.getReplacement());
                         String body = msg.getRequestBody().toString();
                         if (contains(body, rule.getMatchString(), p)) {
                             body =
@@ -206,7 +204,7 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                     case RESP_HEADER_STR:
                     case RESP_BODY_STR:
                         // Ignore response rules here
-                        LOGGER.debug("Ignore response rule " + rule.getDescription());
+                        LOGGER.debug("Ignore response rule {}", rule.getDescription());
                         break;
                 }
             }
@@ -226,14 +224,13 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                     case REQ_HEADER_STR:
                     case REQ_BODY_STR:
                         // Ignore request rules here
-                        LOGGER.debug("Ignore request rule " + rule.getDescription());
+                        LOGGER.debug("Ignore request rule {}", rule.getDescription());
                         break;
                     case RESP_HEADER:
                         LOGGER.debug(
-                                "Add in response header: "
-                                        + rule.getMatchString()
-                                        + " : "
-                                        + rule.getReplacement());
+                                "Add in response header: {} : {}",
+                                rule.getMatchString(),
+                                rule.getReplacement());
                         if (rule.getReplacement().length() == 0) {
                             // Remove the header
                             msg.getResponseHeader().setHeader(rule.getMatchString(), null);
@@ -244,10 +241,9 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                         break;
                     case RESP_HEADER_STR:
                         LOGGER.debug(
-                                "Replace in response header: "
-                                        + rule.getMatchString()
-                                        + " with "
-                                        + rule.getReplacement());
+                                "Replace in response header: {} with {}",
+                                rule.getMatchString(),
+                                rule.getReplacement());
                         String header = msg.getResponseHeader().toString();
                         if (contains(header, rule.getMatchString(), p)) {
                             header =
@@ -265,10 +261,9 @@ public class ExtensionReplacer extends ExtensionAdaptor implements HttpSenderLis
                         break;
                     case RESP_BODY_STR:
                         LOGGER.debug(
-                                "Replace in response body: "
-                                        + rule.getMatchString()
-                                        + " with "
-                                        + rule.getReplacement());
+                                "Replace in response body: {} with {}",
+                                rule.getMatchString(),
+                                rule.getReplacement());
                         String body = msg.getResponseBody().toString();
                         if (contains(body, rule.getMatchString(), p)) {
                             body =

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
@@ -24,14 +24,15 @@ import java.util.List;
 import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
 import org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType;
 
 public class ReplacerParam extends AbstractParam {
 
-    private static final Logger logger = Logger.getLogger(ReplacerParam.class);
+    private static final Logger logger = LogManager.getLogger(ReplacerParam.class);
 
     private static final String REPLACER_BASE_KEY = "replacer";
 
@@ -136,8 +137,8 @@ public class ReplacerParam extends AbstractParam {
                                 initList.add(Integer.parseInt(str.trim()));
                             } catch (NumberFormatException e) {
                                 logger.error(
-                                        "Error while loading global repacement rule: "
-                                                + e.getMessage(),
+                                        "Error while loading global repacement rule: {}",
+                                        e.getMessage(),
                                         e);
                             }
                         }
@@ -149,7 +150,7 @@ public class ReplacerParam extends AbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading global repacement rules: " + e.getMessage(), e);
+            logger.error("Error while loading global repacement rules: {}", e.getMessage(), e);
             this.rules = new ArrayList<>(defaultList.size());
         }
 


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.