### PR TITLE
reveal: update ZAP to 2.10.0

### DIFF
--- a/addOns/reveal/CHANGELOG.md
+++ b/addOns/reveal/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ## [3] - 2020-01-17
 ### Added

--- a/addOns/reveal/reveal.gradle.kts
+++ b/addOns/reveal/reveal.gradle.kts
@@ -6,7 +6,7 @@ description = "Show hidden fields and enable disabled fields"
 zapAddOn {
     addOnName.set("Reveal")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/reveal/src/main/java/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
+++ b/addOns/reveal/src/main/java/org/zaproxy/zap/extension/reveal/ExtensionReveal.java
@@ -33,7 +33,8 @@ import net.htmlparser.jericho.HTMLElementName;
 import net.htmlparser.jericho.OutputDocument;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.proxy.ProxyListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -44,7 +45,7 @@ import org.zaproxy.zap.view.ZapToggleButton;
 
 public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
 
-    private static final Logger logger = Logger.getLogger(ExtensionReveal.class);
+    private static final Logger logger = LogManager.getLogger(ExtensionReveal.class);
 
     public static final String NAME = "ExtensionReveal";
     public static final int PROXY_LISTENER_ORDER = 10;
@@ -189,14 +190,14 @@ public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
 
         if (formElements != null && formElements.size() > 0) {
             // Loop through all of the FORM tags
-            logger.debug("Found " + formElements.size() + " forms");
+            logger.debug("Found {} forms", formElements.size());
 
             for (Element formElement : formElements) {
                 List<Element> elements = formElement.getAllElements();
 
                 if (elements != null && elements.size() > 0) {
                     // Loop through all of the elements
-                    logger.debug("Found " + elements.size() + " inputs");
+                    logger.debug("Found {} inputs", elements.size());
                     for (Element element : elements) {
                         Attributes atts = element.getAttributes();
 
@@ -209,11 +210,9 @@ public class ExtensionReveal extends ExtensionAdaptor implements ProxyListener {
                                         || (ATT_TYPE.equalsIgnoreCase(att.getName())
                                                 && TYPE_HIDDEN.equalsIgnoreCase(att.getValue()))) {
                                     logger.debug(
-                                            "Removing "
-                                                    + att.getName()
-                                                    + ": "
-                                                    + response.substring(
-                                                            att.getBegin(), att.getEnd()));
+                                            "Removing {}: {}",
+                                            att.getName(),
+                                            response.substring(att.getBegin(), att.getEnd()));
                                     outputDocument.remove(att);
                                     changed = true;
                                 }


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.