### PR TITLE
savexmlmessage: update ZAP to 2.10.0

### DIFF
--- a/addOns/savexmlmessage/CHANGELOG.md
+++ b/addOns/savexmlmessage/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ## [0.1.0] - 2020-01-17
 ### Added

--- a/addOns/savexmlmessage/savexmlmessage.gradle.kts
+++ b/addOns/savexmlmessage/savexmlmessage.gradle.kts
@@ -3,7 +3,7 @@ description = "Allows to save content of HTTP messages as XML"
 
 zapAddOn {
     addOnName.set("Save XML Message")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("thatsn0tmysite")

--- a/addOns/savexmlmessage/src/main/java/org/zaproxy/zap/extension/savexmlmessage/PopupMenuSaveXMLMessage.java
+++ b/addOns/savexmlmessage/src/main/java/org/zaproxy/zap/extension/savexmlmessage/PopupMenuSaveXMLMessage.java
@@ -32,7 +32,8 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
@@ -47,7 +48,7 @@ class PopupMenuSaveXMLMessage extends PopupMenuHttpMessageContainer {
 
     private static final long serialVersionUID = -7217818541206464572L;
 
-    private static final Logger log = Logger.getLogger(PopupMenuSaveXMLMessage.class);
+    private static final Logger log = LogManager.getLogger(PopupMenuSaveXMLMessage.class);
 
     private static final String POPUP_MENU_LABEL =
             Constant.messages.getString("savexml.popup.option");


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.