### PR TITLE
selenium: update ZAP to 2.10.0

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Now using 2.10 logging infrastructure (Log4j 2.x).
 - Update links to zaproxy repo.
 - Maintenance changes.
 

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -6,12 +6,11 @@ description = "WebDriver provider and includes HtmlUnit browser"
 zapAddOn {
     addOnName.set("Selenium")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/selenium/")
-        notBeforeVersion.set("2.10.0")
     }
 
     apiClientGen {

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
@@ -29,7 +29,8 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 import org.apache.commons.lang.Validate;
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 
 /** Defines the browsers supported by the add-on. */
@@ -56,7 +57,7 @@ public enum Browser {
 
     private static final String WEB_DRIVERS_DIR_NAME = "webdriver";
 
-    private static final Logger logger = Logger.getLogger(Browser.class);
+    private static final Logger logger = LogManager.getLogger(Browser.class);
 
     private static Path zapHomeDir;
 
@@ -158,7 +159,7 @@ public enum Browser {
         try {
             return Paths.get(path).startsWith(getWebDriversDir());
         } catch (InvalidPathException e) {
-            logger.warn("Failed to create path for " + path, e);
+            logger.warn("Failed to create path for {}", path, e);
             return false;
         }
     }

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuItemOpenInBrowser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuItemOpenInBrowser.java
@@ -19,7 +19,8 @@
  */
 package org.zaproxy.zap.extension.selenium;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
@@ -28,7 +29,7 @@ public class PopupMenuItemOpenInBrowser extends PopupMenuItemHttpMessageContaine
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOGGER = Logger.getLogger(PopupMenuItemOpenInBrowser.class);
+    private static final Logger LOGGER = LogManager.getLogger(PopupMenuItemOpenInBrowser.class);
     private ExtensionSelenium ext;
     private ProvidedBrowser browser;
 


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.