### PR TITLE
simpleexample: update ZAP to 2.10.0

### DIFF
--- a/addOns/simpleexample/simpleexample.gradle.kts
+++ b/addOns/simpleexample/simpleexample.gradle.kts
@@ -3,7 +3,7 @@ description = "A simple extension example."
 
 zapAddOn {
     addOnName.set("Simple Example")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/simpleexample/src/main/java/org/zaproxy/zap/extension/simpleexample/ExtensionSimpleExample.java
+++ b/addOns/simpleexample/src/main/java/org/zaproxy/zap/extension/simpleexample/ExtensionSimpleExample.java
@@ -25,7 +25,8 @@ import java.io.File;
 import java.nio.file.Files;
 import javax.swing.ImageIcon;
 import javax.swing.JTextPane;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
@@ -69,7 +70,7 @@ public class ExtensionSimpleExample extends ExtensionAdaptor {
 
     private SimpleExampleAPI api;
 
-    private static final Logger LOGGER = Logger.getLogger(ExtensionSimpleExample.class);
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionSimpleExample.class);
 
     public ExtensionSimpleExample() {
         super(NAME);

--- a/addOns/simpleexample/src/main/java/org/zaproxy/zap/extension/simpleexample/SimpleExampleAPI.java
+++ b/addOns/simpleexample/src/main/java/org/zaproxy/zap/extension/simpleexample/SimpleExampleAPI.java
@@ -20,7 +20,8 @@
 package org.zaproxy.zap.extension.simpleexample;
 
 import net.sf.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
@@ -34,7 +35,7 @@ public class SimpleExampleAPI extends ApiImplementor {
 
     private static final String ACTION_HELLO_WORLD = "helloWorld";
 
-    private static final Logger LOGGER = Logger.getLogger(SimpleExampleAPI.class);
+    private static final Logger LOGGER = LogManager.getLogger(SimpleExampleAPI.class);
 
     public SimpleExampleAPI(ExtensionSimpleExample extension) {
         this.extension = extension;


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.