### PR TITLE
sequence: update ZAP to 2.10.0

### DIFF
--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Issue 2000 - Updated strings shown in active scan dialog with title caps.
 
 ## 5 - 2017-11-28

--- a/addOns/sequence/sequence.gradle.kts
+++ b/addOns/sequence/sequence.gradle.kts
@@ -3,7 +3,7 @@ description = "Gives the possibility of defining a sequence of requests to be sc
 
 zapAddOn {
     addOnName.set("Sequence")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/ExtensionSequence.java
@@ -25,7 +25,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.swing.ImageIcon;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.parosproxy.paros.core.scanner.Scanner;
@@ -48,7 +49,7 @@ public class ExtensionSequence extends ExtensionAdaptor implements ScannerHook {
 
     private ExtensionScript extScript;
     private ExtensionActiveScan extActiveScan;
-    public static final Logger logger = Logger.getLogger(ExtensionSequence.class);
+    public static final Logger logger = LogManager.getLogger(ExtensionSequence.class);
     public static final ImageIcon ICON =
             new ImageIcon(
                     ExtensionSequence.class.getResource(
@@ -189,8 +190,8 @@ public class ExtensionSequence extends ExtensionAdaptor implements ScannerHook {
                     }
                 } catch (Exception e) {
                     logger.debug(
-                            "Exception occurred, while trying to fetch Included Sequence Script: "
-                                    + e.getMessage());
+                            "Exception occurred, while trying to fetch Included Sequence Script: {}",
+                            e.getMessage());
                 }
             }
         }

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequenceAscanPanel.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequenceAscanPanel.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.sequence;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.model.HistoryReference;
@@ -41,7 +42,7 @@ import org.zaproxy.zap.model.Target;
 public class SequenceAscanPanel implements CustomScanPanel {
 
     private SequencePanel sequencePanel = null;
-    public static final Logger logger = Logger.getLogger(SequenceAscanPanel.class);
+    public static final Logger logger = LogManager.getLogger(SequenceAscanPanel.class);
 
     private final ExtensionScript extensionScript;
 

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequencePopupMenuItem.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequencePopupMenuItem.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.sequence;
 import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.text.MessageFormat;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -36,7 +37,7 @@ public class SequencePopupMenuItem extends ExtensionPopupMenuItem {
     private static final long serialVersionUID = 1L;
 
     private final ExtensionScript extScript;
-    public static final Logger logger = Logger.getLogger(SequencePopupMenuItem.class);
+    public static final Logger logger = LogManager.getLogger(SequencePopupMenuItem.class);
     private ExtensionSequence extension = null;
 
     public SequencePopupMenuItem(ExtensionSequence extension, ExtensionScript extensionScript) {


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.