### PR TITLE
spiderAjax: use Log4j 2 APIs

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
 
 ## [23.3.0] - 2021-03-09

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -32,7 +32,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import net.sf.json.JSON;
 import net.sf.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.model.HistoryReference;
@@ -58,7 +59,7 @@ import org.zaproxy.zap.utils.ApiUtils;
 
 public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
 
-    private static final Logger logger = Logger.getLogger(AjaxSpiderAPI.class);
+    private static final Logger logger = LogManager.getLogger(AjaxSpiderAPI.class);
 
     private static final String PREFIX = "ajaxSpider";
 

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
@@ -29,7 +29,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.Model;
@@ -67,7 +68,7 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
     private static final String FIELD_EVENT_WAIT = "spiderajax.options.label.eventwait";
     private static final String FIELD_RELOAD_WAIT = "spiderajax.options.label.reloadwait";
 
-    private static final Logger logger = Logger.getLogger(AjaxSpiderDialog.class);
+    private static final Logger logger = LogManager.getLogger(AjaxSpiderDialog.class);
     private static final long serialVersionUID = 1L;
 
     private ExtensionAjax extension = null;
@@ -108,7 +109,7 @@ public class AjaxSpiderDialog extends StandardFieldsDialog {
             this.target = target;
         }
 
-        logger.debug("init " + this.target);
+        logger.debug("init {}", this.target);
         if (params == null) {
             params = this.extension.getAjaxSpiderParam();
         }

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -26,14 +26,15 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.commons.configuration.ConversionException;
 import org.apache.commons.configuration.HierarchicalConfiguration;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 import org.zaproxy.zap.extension.api.ZapApiIgnore;
 import org.zaproxy.zap.extension.selenium.Browser;
 
 public class AjaxSpiderParam extends VersionedAbstractParam {
 
-    private static final Logger logger = Logger.getLogger(AjaxSpiderParam.class);
+    private static final Logger logger = LogManager.getLogger(AjaxSpiderParam.class);
 
     /**
      * The current version of the configurations. Used to keep track of configuration changes
@@ -223,12 +224,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
             Browser.getBrowserWithId(browserId);
         } catch (IllegalArgumentException e) {
             logger.warn(
-                    "Unknow browser ["
-                            + browserId
-                            + "] using default ["
-                            + DEFAULT_BROWSER_ID
-                            + "].",
-                    e);
+                    "Unknow browser [{}] using default [{}].", browserId, DEFAULT_BROWSER_ID, e);
             browserId = DEFAULT_BROWSER_ID;
         }
 
@@ -255,7 +251,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading clickable elements: " + e.getMessage(), e);
+            logger.error("Error while loading clickable elements: {}", e.getMessage(), e);
             this.elems = new ArrayList<>(DEFAULT_ELEMS_NAMES.length);
             this.enabledElemsNames = new ArrayList<>(DEFAULT_ELEMS_NAMES.length);
         }
@@ -286,7 +282,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
                 }
             }
         } catch (ConversionException e) {
-            logger.error("Error while loading allowed resources: " + e.getMessage(), e);
+            logger.error("Error while loading allowed resources: {}", e.getMessage(), e);
             this.allowedResources = new ArrayList<>(DEFAULT_ALLOWED_RESOURCES);
         }
         confirmRemoveAllowedResource = getBoolean(CONFIRM_REMOVE_ALLOWED_RESOURCE, true);

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderTarget.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderTarget.java
@@ -20,7 +20,8 @@
 package org.zaproxy.zap.extension.spiderAjax;
 
 import java.net.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.model.Context;
@@ -31,7 +32,7 @@ import org.zaproxy.zap.users.User;
 /** A target of AJAX spider scans. */
 public final class AjaxSpiderTarget {
 
-    private static final Logger LOGGER = Logger.getLogger(AjaxSpiderTarget.class);
+    private static final Logger LOGGER = LogManager.getLogger(AjaxSpiderTarget.class);
 
     private final URI startUri;
     private final boolean inScopeOnly;
@@ -122,7 +123,7 @@ public final class AjaxSpiderTarget {
                             "GET",
                             ""));
         } catch (Exception e) {
-            LOGGER.error("Failed to convert target URL " + this.getStartUri().toString(), e);
+            LOGGER.error("Failed to convert target URL {}", this.getStartUri(), e);
         }
         target.setContext(getContext());
         target.setInScopeOnly(this.isInScopeOnly());

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -28,7 +28,6 @@ import java.util.List;
 import javax.swing.ImageIcon;
 import javax.swing.tree.TreeNode;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
@@ -56,7 +55,6 @@ import org.zaproxy.zap.view.ZapMenuItem;
  */
 public class ExtensionAjax extends ExtensionAdaptor {
 
-    private static final Logger logger = Logger.getLogger(ExtensionAjax.class);
     public static final int PROXY_LISTENER_ORDER = ProxyListenerLog.PROXY_LISTENER_ORDER + 1;
     public static final String NAME = "ExtensionSpiderAjax";
 

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/HttpPrefixUriValidator.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/HttpPrefixUriValidator.java
@@ -23,7 +23,8 @@ import java.util.Arrays;
 import java.util.Locale;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A {@code URI} validator based on a HTTP or HTTPS {@code URI}.
@@ -35,7 +36,7 @@ import org.apache.log4j.Logger;
  */
 class HttpPrefixUriValidator {
 
-    private static final Logger LOGGER = Logger.getLogger(HttpPrefixUriValidator.class);
+    private static final Logger LOGGER = LogManager.getLogger(HttpPrefixUriValidator.class);
 
     /** The normalised form of HTTP scheme, that is, all letters lowercase. */
     private static final String HTTP_SCHEME = "http";
@@ -299,7 +300,7 @@ class HttpPrefixUriValidator {
         try {
             return host.equals(normalisedHost(uri));
         } catch (URIException e) {
-            LOGGER.warn("Failed to normalise host: " + Arrays.toString(uri.getRawHost()), e);
+            LOGGER.warn("Failed to normalise host: {}", Arrays.toString(uri.getRawHost()), e);
         }
         return false;
     }

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.spiderAjax;
 
 import javax.swing.ImageIcon;
-import org.apache.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.model.SiteNode;
@@ -31,7 +30,6 @@ public class PopupMenuAjaxSite extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;
     private ExtensionAjax extension = null;
-    private static Logger logger = Logger.getLogger(PopupMenuAjaxSite.class);
 
     /** @param label */
     public PopupMenuAjaxSite(String label, ExtensionAjax extension) {

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -32,7 +32,8 @@ import java.util.TreeSet;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
@@ -52,7 +53,7 @@ import org.zaproxy.zap.view.table.HistoryReferencesTable;
  */
 public class SpiderPanel extends AbstractPanel implements SpiderListener {
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = Logger.getLogger(SpiderPanel.class);
+    private static final Logger logger = LogManager.getLogger(SpiderPanel.class);
 
     private javax.swing.JScrollPane scrollLog = null;
     private javax.swing.JPanel AJAXSpiderPanel = null;


### PR DESCRIPTION
Use Log4j 2 APIs.
Remove unused loggers.

Part of zaproxy/zaproxy#6376.