### PR TITLE
zest: update ZAP to 2.10.0

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Clear Zest Results Panel when new script is added.
-- Maintenance changes.
+- Update minimum ZAP version to 2.10.0.
 
 ## [33] - 2020-11-27
 ### Added

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -44,7 +44,8 @@ import javax.swing.JToolBar;
 import net.htmlparser.jericho.Source;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
@@ -116,7 +117,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     public static final String HTTP_HEADER_X_SECURITY_PROXY = "X-Security-Proxy";
     public static final String VALUE_RECORD = "record";
 
-    private static final Logger logger = Logger.getLogger(ExtensionZest.class);
+    private static final Logger logger = LogManager.getLogger(ExtensionZest.class);
 
     private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
 
@@ -536,7 +537,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     }
 
     public ScriptNode add(ZestScriptWrapper script, boolean display) {
-        logger.debug("add script " + script.getName());
+        logger.debug("add script {}", script.getName());
         ScriptNode node = this.getExtScript().addScript(script, display);
         this.display(script, node, true);
         if (script.isRecording()) {
@@ -559,7 +560,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
         if (node == null) {
             return;
         }
-        logger.debug("Display node=" + node.getNodeName() + " expand=" + expand);
+        logger.debug("Display node={} expand={}", node.getNodeName(), expand);
         if (View.isInitialised() && this.getExtScript().getScriptUI() != null) {
             this.getExtScript()
                     .getScriptUI()
@@ -572,7 +573,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
         if (node == null) {
             return;
         }
-        logger.debug("Updated node=" + node.getNodeName());
+        logger.debug("Updated node={}", node.getNodeName());
         this.getZestTreeModel().update(node);
         ZestScriptWrapper sw = this.getZestTreeModel().getScriptWrapper(node);
         sw.setChanged(true);
@@ -641,17 +642,16 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     public void addToParent(ScriptNode parent, HttpMessage msg, String prefix) {
         if (parent == null) {
             // They're gone for the 'new script' option...
-            logger.debug("addToParent parent=null msg=" + msg.getRequestHeader().getURI());
+            logger.debug("addToParent parent=null msg={}", msg.getRequestHeader().getURI());
             this.dialogManager.showZestEditScriptDialog(null, null, prefix, true);
             if (msg != null) {
                 this.dialogManager.addDeferedMessage(msg);
             }
         } else {
             logger.debug(
-                    "addToParent parent="
-                            + parent.getNodeName()
-                            + " msg="
-                            + msg.getRequestHeader().getURI());
+                    "addToParent parent={} msg={}",
+                    parent.getNodeName(),
+                    msg.getRequestHeader().getURI());
 
             try {
                 ZestRequest req = ZestZapUtils.toZestRequest(msg, false, this.getParam());
@@ -700,10 +700,9 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
                         String var = acsrfTokenToVar.get(acsrf.getValue());
                         if (var != null) {
                             logger.debug(
-                                    "Replacing ACSRF value "
-                                            + acsrf.getValue()
-                                            + " with variable "
-                                            + var);
+                                    "Replacing ACSRF value {} with variable {}",
+                                    acsrf.getValue(),
+                                    var);
                             this.replaceInRequest(
                                     req,
                                     acsrf.getValue(),
@@ -735,10 +734,9 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
                         // Record mapping of value to variable name for later
                         // replacement
                         logger.debug(
-                                "Recording ACSRF value "
-                                        + acsrf.getValue()
-                                        + " against variable "
-                                        + zafv.getVariableName());
+                                "Recording ACSRF value {} against variable {}",
+                                acsrf.getValue(),
+                                zafv.getVariableName());
                         acsrfTokenToVar.put(acsrf.getValue(), zafv.getVariableName());
                         zafv.setFieldDefinition(fd);
                         this.addToParent(parent, zafv);
@@ -810,7 +808,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     }
 
     public final ScriptNode addToParent(ScriptNode parent, ZestExpression newExp) {
-        logger.debug("addToParent parent=" + parent.getNodeName() + " new=" + newExp.toString());
+        logger.debug("addToParent parent={} new={}", parent.getNodeName(), newExp.toString());
         ScriptNode node;
         ZestElement parentZe = ZestZapUtils.getElement(parent);
         if (parentZe instanceof ZestConditional) {
@@ -846,7 +844,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     public final ScriptNode addToParent(
             ScriptNode parent, ZestStatement newChild, boolean display) {
         logger.debug(
-                "addToParent parent=" + parent.getNodeName() + " new=" + newChild.getElementType());
+                "addToParent parent={} new={}", parent.getNodeName(), newChild.getElementType());
         ScriptNode node;
         ZestElement parentElement = ZestZapUtils.getElement(parent);
         if (parentElement instanceof ZestScript) {
@@ -888,12 +886,10 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             ZestStatement existingChild,
             ZestStatement newChild) {
         logger.debug(
-                "addAfterRequest parent="
-                        + parent.getNodeName()
-                        + " existing="
-                        + existingChild.getElementType()
-                        + " new="
-                        + newChild.getElementType());
+                "addAfterRequest parent={} existing={} new={}",
+                parent.getNodeName(),
+                existingChild.getElementType(),
+                newChild.getElementType());
 
         if (ZestZapUtils.getElement(parent) instanceof ZestScript) {
             return this.addAfterRequest(
@@ -941,12 +937,10 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             ZestStatement existingChild,
             ZestStatement newChild) {
         logger.debug(
-                "addAfterRequest parent="
-                        + parent.getNodeName()
-                        + " existing="
-                        + existingChild.getElementType()
-                        + " new="
-                        + newChild.getElementType());
+                "addAfterRequest parent={} existing={} new={}",
+                parent.getNodeName(),
+                existingChild.getElementType(),
+                newChild.getElementType());
 
         if (ZestZapUtils.getElement(parent) instanceof ZestScript) {
             return this.addBeforeRequest(
@@ -1058,7 +1052,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             next = (ScriptNode) next.getNextSibling();
         }
         if (next == null) {
-            logger.error("Cant move node down " + node.getNodeName());
+            logger.error("Cant move node down {}", node.getNodeName());
             return;
         }
         if (ZestZapUtils.getElement(node) instanceof ZestScript) {
@@ -1289,16 +1283,12 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             ScriptNode afterChild) {
         if (cnpNodes != null && cnpNodes.size() > 0) {
             logger.debug(
-                    "pasteToNode parent="
-                            + parent.getNodeName()
-                            + " num children="
-                            + cnpNodes.size()
-                            + " cut="
-                            + cutNodes
-                            + " before="
-                            + beforeChild
-                            + " after = "
-                            + afterChild);
+                    "pasteToNode parent={} num children={} cut={} before={} after = {}",
+                    parent.getNodeName(),
+                    cnpNodes.size(),
+                    cutNodes,
+                    beforeChild,
+                    afterChild);
             if (ZestZapUtils.getElement(cnpNodes.get(0)) instanceof ZestExpression) {
                 pasteExpressionsToNode(parent);
             } else {
@@ -1582,7 +1572,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
 
                 if (key.length() > 1) {
                     // Ignore all 'control' keys, at least initially
-                    logger.debug("Client recording, ignoring " + key);
+                    logger.debug("Client recording, ignoring {}", key);
                 } else {
                     if (getRecordingNode().getChildCount() > 0) {
                         // We get key presses one at a time - try to combine them up where possible
@@ -1666,7 +1656,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             ScriptNode typeNode =
                     this.getExtScript().getTreeModel().getTypeNode(script.getTypeName());
             if (typeNode == null) {
-                logger.error("Failed to find type node: " + script.getTypeName());
+                logger.error("Failed to find type node: {}", script.getTypeName());
 
                 typeNode =
                         this.getExtScript()
@@ -1730,7 +1720,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
          *
          * ScriptNode typeNode = this.getExtScript().getTreeModel()
          * .getTypeNode(script.getTypeName()); if (typeNode == null) {
-         * logger.error("Failed to find type node: " + script.getTypeName());
+         * logger.error("Failed to find type node: {}", script.getTypeName());
          *
          * typeNode = this.getExtScript().getTreeModel()
          * .getTypeNode(ExtensionScript.TYPE_STANDALONE); }
@@ -1816,8 +1806,8 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
                 }
             } catch (Exception e) {
                 logger.debug(
-                        "Exception occurred while fetching HttpMessages from sequence script: "
-                                + e.getMessage());
+                        "Exception occurred while fetching HttpMessages from sequence script: {}",
+                        e.getMessage());
             }
         }
         return requests;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/FileFuzzer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/FileFuzzer.java
@@ -28,7 +28,8 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class FileFuzzer {
 
@@ -36,7 +37,7 @@ public class FileFuzzer {
     private int length = -1;
     private List<String> fuzzStrs = new ArrayList<>();
     private Iterator<String> iter = null;
-    private static Logger log = Logger.getLogger(FileFuzzer.class);
+    private static Logger log = LogManager.getLogger(FileFuzzer.class);
 
     protected FileFuzzer(File file) {
         this.file = file;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.zest;
 
 import java.io.IOException;
 import javax.script.ScriptException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ascan.ActiveScript;
@@ -37,7 +38,7 @@ public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
     private String param = null;
     private ExtensionZest extension = null;
 
-    private static Logger logger = Logger.getLogger(ZestActiveRunner.class);
+    private static Logger logger = LogManager.getLogger(ZestActiveRunner.class);
 
     public ZestActiveRunner(ExtensionZest extension, ZestScriptWrapper script) {
         super(extension, script);
@@ -48,7 +49,7 @@ public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
     @Override
     public void scan(ScriptsActiveScanner sas, HttpMessage msg, String param, String value)
             throws ScriptException {
-        logger.debug("Zest ActiveScan script: " + this.script.getName());
+        logger.debug("Zest ActiveScan script: {}", this.script.getName());
         this.sas = sas;
         this.msg = msg;
         this.param = param;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestFuzzerDelegate.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestFuzzerDelegate.java
@@ -31,7 +31,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.owasp.jbrofuzz.core.Database;
 import org.owasp.jbrofuzz.core.Fuzzer;
 import org.owasp.jbrofuzz.core.NoSuchFuzzerException;
@@ -47,7 +48,7 @@ public class ZestFuzzerDelegate {
 
     public static final String JBROFUZZ_CATEGORY_PREFIX = "jbrofuzz / ";
 
-    private static final Logger logger = Logger.getLogger(ZestFuzzerDelegate.class);
+    private static final Logger logger = LogManager.getLogger(ZestFuzzerDelegate.class);
 
     public ZestFuzzerDelegate() {
         this.loadFiles();

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestHttpSenderRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestHttpSenderRunner.java
@@ -23,7 +23,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import javax.script.ScriptException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
@@ -42,7 +43,7 @@ public class ZestHttpSenderRunner extends ZestZapRunner implements HttpSenderScr
     private ExtensionZest extension = null;
     private HttpSenderScriptHelper helper = null;
 
-    private Logger logger = Logger.getLogger(ZestHttpSenderRunner.class);
+    private Logger logger = LogManager.getLogger(ZestHttpSenderRunner.class);
 
     public ZestHttpSenderRunner(ExtensionZest extension, ZestScriptWrapper script) {
         super(extension, script);
@@ -53,7 +54,7 @@ public class ZestHttpSenderRunner extends ZestZapRunner implements HttpSenderScr
     @Override
     public void sendingRequest(HttpMessage msg, int initiator, HttpSenderScriptHelper helper)
             throws ScriptException {
-        logger.debug("Zest sendingRequest script: " + this.script.getName());
+        logger.debug("Zest sendingRequest script: {}", this.script.getName());
         this.helper = helper;
         this.msg = msg;
         try {
@@ -89,7 +90,7 @@ public class ZestHttpSenderRunner extends ZestZapRunner implements HttpSenderScr
     @Override
     public void responseReceived(HttpMessage msg, int initiator, HttpSenderScriptHelper helper)
             throws ScriptException {
-        logger.debug("Zest responseReceived script: " + this.script.getName());
+        logger.debug("Zest responseReceived script: {}", this.script.getName());
         this.msg = msg;
         try {
             // Create the previous request so the script has something to run against

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
@@ -23,7 +23,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.configuration.ConversionException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.common.AbstractParam;
 import org.parosproxy.paros.network.HttpHeader;
 import org.zaproxy.zap.extension.httpsessions.ExtensionHttpSessions;
@@ -84,7 +85,7 @@ public class ZestParam extends AbstractParam {
     private static final String INCLUDE_RESPONSES_KEY = DEFAULT_ZEST_KEY + ".incResponses";
 
     /** The Constant log. */
-    private static final Logger log = Logger.getLogger(ZestParam.class);
+    private static final Logger log = LogManager.getLogger(ZestParam.class);
 
     /** The full list of headers that can be ignored. */
     private List<String> allHeaders = new ArrayList<String>();
@@ -121,7 +122,7 @@ public class ZestParam extends AbstractParam {
             }
 
         } catch (ConversionException e) {
-            log.error("Error while parsing config file: " + e.getMessage(), e);
+            log.error("Error while parsing config file: {}", e.getMessage(), e);
             // Use the defaults
             for (String header : DEFAULT_IGNORED_HEADERS) {
                 this.ignoredHeaders.add(header);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.zest;
 
 import javax.script.ScriptException;
 import net.htmlparser.jericho.Source;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScript;
@@ -35,7 +36,7 @@ public class ZestPassiveRunner extends ZestZapRunner implements PassiveScript {
     private HttpMessage msg = null;
     private ExtensionZest extension = null;
 
-    private Logger logger = Logger.getLogger(ZestPassiveRunner.class);
+    private Logger logger = LogManager.getLogger(ZestPassiveRunner.class);
 
     public ZestPassiveRunner(ExtensionZest extension, ZestScriptWrapper script) {
         super(extension, script);
@@ -47,7 +48,7 @@ public class ZestPassiveRunner extends ZestZapRunner implements PassiveScript {
     @Override
     public void scan(ScriptsPassiveScanner scriptsPassiveScanner, HttpMessage msg, Source source)
             throws ScriptException {
-        logger.debug("Zest PassiveScan script: " + this.script.getName());
+        logger.debug("Zest PassiveScan script: {}", this.script.getName());
         this.sps = scriptsPassiveScanner;
         this.msg = msg;
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestProxyRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestProxyRunner.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.zest;
 import java.util.HashMap;
 import java.util.Map;
 import javax.script.ScriptException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
@@ -38,7 +39,7 @@ public class ZestProxyRunner extends ZestZapRunner implements ProxyScript {
     private HttpMessage msg = null;
     private ExtensionZest extension = null;
 
-    private Logger logger = Logger.getLogger(ZestProxyRunner.class);
+    private Logger logger = LogManager.getLogger(ZestProxyRunner.class);
 
     public ZestProxyRunner(ExtensionZest extension, ZestScriptWrapper script) {
         super(extension, script);
@@ -48,7 +49,7 @@ public class ZestProxyRunner extends ZestZapRunner implements ProxyScript {
 
     @Override
     public boolean proxyRequest(HttpMessage msg) throws ScriptException {
-        logger.debug("Zest proxyRequest script: " + this.script.getName());
+        logger.debug("Zest proxyRequest script: {}", this.script.getName());
         this.msg = msg;
         try {
             // Create the previous request so the script has something to run against
@@ -105,7 +106,7 @@ public class ZestProxyRunner extends ZestZapRunner implements ProxyScript {
 
     @Override
     public boolean proxyResponse(HttpMessage msg) {
-        logger.debug("Zest proxyResponse script: " + this.script.getName());
+        logger.debug("Zest proxyResponse script: {}", this.script.getName());
         this.msg = msg;
         try {
             // Create the previous request so the script has something to run against

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
@@ -28,7 +28,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
@@ -55,7 +56,7 @@ import org.zaproxy.zest.core.v1.ZestStatement;
 public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript {
 
     private ZestScriptWrapper script = null;
-    private static final Logger logger = Logger.getLogger(ZestSequenceRunner.class);
+    private static final Logger logger = LogManager.getLogger(ZestSequenceRunner.class);
 
     private static final int SEQUENCE_HISTORY_TYPE = HistoryReference.TYPE_SEQUENCE_TEMPORARY;
 
@@ -90,8 +91,8 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
                 }
             } catch (Exception e) {
                 logger.debug(
-                        "Exception occurred while fetching HttpMessages from sequence script: "
-                                + e.getMessage());
+                        "Exception occurred while fetching HttpMessages from sequence script: {}",
+                        e.getMessage());
             }
         }
         return requests;
@@ -120,8 +121,8 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
             msgOriginal.getRequestHeader().setContentLength(msgOriginal.getRequestBody().length());
         } catch (Exception e) {
             logger.debug(
-                    "Error running Sequence script in 'runSequenceBefore' method : "
-                            + e.getMessage());
+                    "Error running Sequence script in 'runSequenceBefore' method : {}",
+                    e.getMessage());
         }
         return msgOriginal;
     }
@@ -179,8 +180,8 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
 
         } catch (Exception e) {
             logger.debug(
-                    "Error running Sequence script in 'runSequenceAfter' method : "
-                            + e.getMessage());
+                    "Error running Sequence script in 'runSequenceAfter' method : {}",
+                    e.getMessage());
         }
     }
 
@@ -237,7 +238,7 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
                 }
             }
         } catch (Exception e) {
-            logger.debug("Exception in ZestSequenceRunner isSameRequest:" + e.getMessage());
+            logger.debug("Exception in ZestSequenceRunner isSameRequest: {}", e.getMessage());
         }
         return false;
     }
@@ -251,7 +252,7 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
                 }
             }
         } catch (Exception e) {
-            logger.debug("Exception in getMatchingMessageFromScript: " + e.getMessage());
+            logger.debug("Exception in getMatchingMessageFromScript: {}", e.getMessage());
         }
         return null;
     }
@@ -309,7 +310,8 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
                 }
             } catch (Exception e) {
                 logger.error(
-                        "An exception occurred while scanning sequence directly: " + e.getMessage(),
+                        "An exception occurred while scanning sequence directly: {}",
+                        e.getMessage(),
                         e);
             }
         }
@@ -339,8 +341,8 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
             temp.setHistoryReference(ref);
         } catch (Exception e) {
             logger.error(
-                    "An exception occurred while converting a HttpMessage to SiteNode: "
-                            + e.getMessage(),
+                    "An exception occurred while converting a HttpMessage to SiteNode: {}",
+                    e.getMessage(),
                     e);
         }
         return temp;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeCellRenderer.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeCellRenderer.java
@@ -24,7 +24,8 @@ import javax.swing.ImageIcon;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultTreeCellRenderer;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.utils.DisplayUtils;
@@ -258,7 +259,7 @@ public class ZestTreeCellRenderer extends DefaultTreeCellRenderer {
 
     private static final long serialVersionUID = -4278691012245035225L;
 
-    private static final Logger logger = Logger.getLogger(ZestTreeCellRenderer.class);
+    private static final Logger logger = LogManager.getLogger(ZestTreeCellRenderer.class);
 
     public ZestTreeCellRenderer() {}
 
@@ -400,8 +401,8 @@ public class ZestTreeCellRenderer extends DefaultTreeCellRenderer {
                         setIcon(CLIENT_WINDOW_OPEN_URL_ICON);
                     } else {
                         logger.error(
-                                "Unrecognised element element class="
-                                        + zew.getElement().getClass().getCanonicalName());
+                                "Unrecognised element element class={}",
+                                zew.getElement().getClass().getCanonicalName());
                     }
                 }
             }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeModel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeModel.java
@@ -19,7 +19,8 @@
  */
 package org.zaproxy.zap.extension.zest;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptTreeModel;
 import org.zaproxy.zest.core.v1.ZestAction;
@@ -40,7 +41,7 @@ import org.zaproxy.zest.core.v1.ZestStructuredExpression;
  */
 public class ZestTreeModel {
 
-    private static final Logger logger = Logger.getLogger(ZestTreeModel.class);
+    private static final Logger logger = LogManager.getLogger(ZestTreeModel.class);
 
     private ScriptTreeModel model;
 
@@ -49,7 +50,7 @@ public class ZestTreeModel {
     }
 
     public void addScript(ScriptNode parent, ZestScriptWrapper script) {
-        logger.debug("addScript " + script.getName());
+        logger.debug("addScript {}", script.getName());
         if (script.getZestScript().getStatements() != null) {
             for (ZestStatement stmt : script.getZestScript().getStatements()) {
                 this.addToNode(parent, stmt);
@@ -70,7 +71,7 @@ public class ZestTreeModel {
     }
 
     public ScriptNode addToNode(ScriptNode parent, ZestElement za) {
-        logger.debug("addToNode " + parent.getNodeName() + " " + za.getElementType());
+        logger.debug("addToNode {} {}", parent.getNodeName(), za.getElementType());
         ScriptNode zestNode = this.getZestNode(za);
         ZestElement parentZe = ZestZapUtils.getElement(parent);
 
@@ -123,7 +124,7 @@ public class ZestTreeModel {
                 }
             }
         } else {
-            logger.debug("added a non container element " + za.getElementType());
+            logger.debug("added a non container element {}", za.getElementType());
             parent.add(zestNode);
         }
         model.nodeStructureChanged(parent);
@@ -131,8 +132,7 @@ public class ZestTreeModel {
     }
 
     public ScriptNode addToNodeAt(ScriptNode parent, ZestElement za, int index) {
-        logger.debug(
-                "addToNode " + parent.getNodeName() + " " + za.getElementType() + " at " + index);
+        logger.debug("addToNode {} {} at {}", parent.getNodeName(), za.getElementType(), index);
         ScriptNode zestNode = this.getZestNode(za);
         ZestElement parentZe = ZestZapUtils.getElement(parent);
 
@@ -199,14 +199,14 @@ public class ZestTreeModel {
     }
 
     public ScriptNode addAfterNode(ScriptNode parent, ScriptNode existingNode, ZestStatement stmt) {
-        logger.debug("addAfterNode " + existingNode.getNodeName() + " " + stmt.getElementType());
+        logger.debug("addAfterNode {} {}", existingNode.getNodeName(), stmt.getElementType());
 
         return this.addToNodeAt(parent, stmt, parent.getIndex(existingNode) + 1);
     }
 
     public ScriptNode addBeforeNode(
             ScriptNode parent, ScriptNode existingNode, ZestStatement stmt) {
-        logger.debug("addBeforeNode " + existingNode.getNodeName() + " " + stmt.getElementType());
+        logger.debug("addBeforeNode {} {}", existingNode.getNodeName(), stmt.getElementType());
 
         return this.addToNodeAt(parent, stmt, parent.getIndex(existingNode));
     }
@@ -223,11 +223,11 @@ public class ZestTreeModel {
         ZestElement childZe = ZestZapUtils.getElement(node);
 
         if (parentZe == null) {
-            logger.error("delete: Parent user object null: " + node.toString());
+            logger.error("delete: Parent user object null: {}", node.toString());
             return;
         }
         if (childZe == null) {
-            logger.error("delete: Child user object null: " + node.toString());
+            logger.error("delete: Child user object null: {}", node.toString());
             return;
         }
         if (ZestZapUtils.getElement(node) instanceof ZestConditional) {
@@ -246,16 +246,16 @@ public class ZestTreeModel {
         if (parent.getParent().isRoot()) {
             if ((childZe instanceof ZestScript)) {
                 logger.error(
-                        "delete: unexpected child of root node: "
-                                + childZe.getClass().getCanonicalName());
+                        "delete: unexpected child of root node: {}",
+                        childZe.getClass().getCanonicalName());
             }
         } else if (parentZe instanceof ZestScript) {
             if (childZe instanceof ZestStatement) {
                 ((ZestScript) parentZe).remove((ZestStatement) childZe);
             } else {
                 logger.error(
-                        "delete: unexpected child of script node: "
-                                + childZe.getClass().getCanonicalName());
+                        "delete: unexpected child of script node: {}",
+                        childZe.getClass().getCanonicalName());
             }
         } else if (parentZe instanceof ZestConditional) {
             ZestConditional zc = (ZestConditional) parentZe;
@@ -277,17 +277,17 @@ public class ZestTreeModel {
                 ((ZestRequest) parentZe).removeAssertion((ZestAssertion) childZe);
             } else {
                 logger.error(
-                        "delete: unexpected child of request node: "
-                                + childZe.getClass().getCanonicalName());
+                        "delete: unexpected child of request node: {}",
+                        childZe.getClass().getCanonicalName());
             }
         } else if (parentZe instanceof ZestAction) {
             logger.error(
-                    "delete: unexpected child of request node: "
-                            + childZe.getClass().getCanonicalName());
+                    "delete: unexpected child of request node: {}",
+                    childZe.getClass().getCanonicalName());
         } else {
-            logger.error("delete: unknown nodes: " + node.toString() + " " + parent.toString());
-            logger.error("Parent user object: " + parentZe.getClass().getCanonicalName());
-            logger.error("Child user object: " + childZe.getClass().getCanonicalName());
+            logger.error("delete: unknown nodes: {} {}", node.toString(), parent.toString());
+            logger.error("Parent user object: {}", parentZe.getClass().getCanonicalName());
+            logger.error("Child user object: {}", childZe.getClass().getCanonicalName());
         }
 
         model.nodeStructureChanged(parent);
@@ -314,7 +314,7 @@ public class ZestTreeModel {
     }
 
     public void update(ScriptNode node) {
-        logger.debug("Update node=" + node.getNodeName());
+        logger.debug("Update node={}", node.getNodeName());
         ZestElement ze = ZestZapUtils.getElement(node);
         node.setNodeName(ZestZapUtils.toUiString(ze, true, ZestZapUtils.getShadowLevel(node)));
         model.nodeChanged(node);
@@ -334,10 +334,7 @@ public class ZestTreeModel {
     public void switchNodes(ScriptNode node1, ScriptNode node2) {
         if (!node1.getParent().equals(node2.getParent())) {
             logger.error(
-                    "Nodes have different parents "
-                            + node1.getNodeName()
-                            + " "
-                            + node2.getNodeName());
+                    "Nodes have different parents {} {}", node1.getNodeName(), node2.getNodeName());
         } else {
             ScriptNode parent = node1.getParent();
             int i1 = parent.getIndex(node1);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
@@ -26,7 +26,8 @@ import javax.swing.JTree;
 import javax.swing.TransferHandler;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zest.core.v1.ZestConditional;
@@ -37,7 +38,7 @@ import org.zaproxy.zest.core.v1.ZestStatement;
 public class ZestTreeTransferHandler extends TransferHandler {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = Logger.getLogger(ZestTreeTransferHandler.class);
+    private static final Logger logger = LogManager.getLogger(ZestTreeTransferHandler.class);
     private ExtensionZest extension;
 
     public ZestTreeTransferHandler(ExtensionZest ext) {
@@ -48,7 +49,7 @@ public class ZestTreeTransferHandler extends TransferHandler {
     public boolean canImport(TransferHandler.TransferSupport support) {
         // Debug logging commented out as it produces loads of messages. Useful if debugging DnD
         // issues of course ;)
-        // logger.debug("canImport " + support.getComponent().getClass().getCanonicalName());
+        // logger.debug("canImport {}", support.getComponent().getClass().getCanonicalName());
 
         support.setShowDropLocation(true);
 
@@ -69,7 +70,7 @@ public class ZestTreeTransferHandler extends TransferHandler {
             return false;
         } else if (!(dragZew.getElement() instanceof ZestStatement)) {
             // Dont support other elements yet
-            // logger.debug("canImport cant drag to a non ZestStatement " +
+            // logger.debug("canImport cant drag to a non ZestStatement {}",
             // dragZew.getElement().getClass().getCanonicalName());
             return false;
         } else if (dragZew.getShadowLevel() > 0) {
@@ -83,19 +84,19 @@ public class ZestTreeTransferHandler extends TransferHandler {
         TreePath dest = dl.getPath();
         ScriptNode parent = (ScriptNode) dest.getLastPathComponent();
         if (parent.getUserObject() == null) {
-            // logger.debug("canImport cant paste to a null user object " + parent.toString());
+            // logger.debug("canImport cant paste to a null user object {}", parent.toString());
             return false;
         } else if (parent.getUserObject() instanceof ZestScriptWrapper) {
             // Can always paste into scripts, more checks later
         } else if (!(parent.getUserObject() instanceof ZestElementWrapper)) {
-            // logger.debug("canImport cant paste to a node of class " +
+            // logger.debug("canImport cant paste to a node of class {}",
             // parent.getUserObject().getClass().getCanonicalName());
             return false;
         } else {
             ZestElementWrapper dropZew = (ZestElementWrapper) parent.getUserObject();
             if (dropZew == null || !(dropZew.getElement() instanceof ZestContainer)) {
                 // Dont support other elements yet
-                // logger.debug("canImport cant paste to a non ZestContainer " +
+                // logger.debug("canImport cant paste to a non ZestContainer {}",
                 // dropZew.getElement().getClass().getCanonicalName());
                 return false;
             } else if (dropZew.getElement() instanceof ZestConditional
@@ -120,7 +121,7 @@ public class ZestTreeTransferHandler extends TransferHandler {
             // prevent drop between shadow nodes
             ScriptNode nextSibling = (ScriptNode) parent.getChildAt(childIndex);
             if (nextSibling != null) {
-                // logger.debug("canImport nextSibling is " + nextSibling.getNodeName());
+                // logger.debug("canImport nextSibling is {}", nextSibling.getNodeName());
                 ZestElementWrapper sibZew = (ZestElementWrapper) nextSibling.getUserObject();
                 if (sibZew.getShadowLevel() > 0) {
                     // logger.debug("canImport cant paste before shadow node");
@@ -153,13 +154,13 @@ public class ZestTreeTransferHandler extends TransferHandler {
 
     @Override
     public int getSourceActions(JComponent c) {
-        logger.debug("getSourceActions " + c.getClass().getCanonicalName());
+        logger.debug("getSourceActions {}", c.getClass().getCanonicalName());
         return TransferHandler.COPY_OR_MOVE;
     }
 
     @Override
     public boolean importData(TransferHandler.TransferSupport support) {
-        logger.debug("importData " + support.getComponent().getClass().getCanonicalName());
+        logger.debug("importData {}", support.getComponent().getClass().getCanonicalName());
 
         if (!support.isDrop()) {
             return false;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -24,7 +24,8 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.HostProcess;
@@ -63,7 +64,7 @@ import org.zaproxy.zest.impl.ZestBasicRunner;
 
 public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 
-    private static final Logger log = Logger.getLogger(ZestZapRunner.class);
+    private static final Logger log = LogManager.getLogger(ZestZapRunner.class);
 
     private static final int ZEST_HISTORY_REFERENCE_TYPE = HistoryReference.TYPE_ZEST_SCRIPT;
     private static final int FAIL_ACTION_PLUGIN_ID = 50004;
@@ -108,7 +109,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
             throws ZestAssertFailException, ZestActionFailException, IOException,
                     ZestInvalidCommonTestException, ZestAssignFailException,
                     ZestClientFailException {
-        log.debug("Run script " + script.getTitle());
+        log.debug("Run script {}", script.getTitle());
         // Check for any missing parameters
         boolean missingParams = false;
         for (String[] vars : script.getParameters().getVariables()) {
@@ -150,7 +151,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
             throws ZestAssertFailException, ZestActionFailException, IOException,
                     ZestInvalidCommonTestException, ZestAssignFailException,
                     ZestClientFailException {
-        log.debug("Run script " + script.getTitle());
+        log.debug("Run script {}", script.getTitle());
         if (wrapper.getWriter() != null) {
             super.setOutputWriter(wrapper.getWriter());
         } else if (scriptUI != null && !hasOutputWriter()) {
@@ -261,7 +262,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
             ZestScript script, ZestStatement stmt, ZestResponse lastResponse)
             throws ZestAssertFailException, ZestActionFailException, ZestInvalidCommonTestException,
                     IOException, ZestAssignFailException, ZestClientFailException {
-        log.debug("runStatement " + stmt.getElementType());
+        log.debug("runStatement {}", stmt.getElementType());
         while (this.isPaused() && !this.isStop) {
             try {
                 Thread.sleep(200);
@@ -278,7 +279,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     @Override
     public String handleAction(ZestScript script, ZestAction action, ZestResponse lastResponse)
             throws ZestActionFailException {
-        log.debug("handleAction " + action.getElementType());
+        log.debug("handleAction {}", action.getElementType());
         if (action instanceof ZestActionScan) {
             this.invokeScan(script, (ZestActionScan) action);
         } else if (action instanceof ZestActionIntercept) {
@@ -301,7 +302,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     public String handleAssignment(
             ZestScript script, ZestAssignment assign, ZestResponse lastResponse)
             throws ZestAssignFailException {
-        log.debug("handleAssignment " + assign.getElementType());
+        log.debug("handleAssignment {}", assign.getElementType());
         try {
             return super.handleAssignment(script, assign, lastResponse);
         } catch (ZestAssignFailException e) {
@@ -313,7 +314,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     @Override
     public void handleResponse(ZestRequest request, ZestResponse response)
             throws ZestAssertFailException {
-        log.debug("handleResponse " + request.getElementType());
+        log.debug("handleResponse {}", request.getElementType());
         try {
             HttpMessage msg = ZestZapUtils.toHttpMessage(request, response);
 
@@ -371,7 +372,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     }
 
     private void invokeScan(ZestScript script, ZestActionScan scan) throws ZestActionFailException {
-        log.debug("invokeScan " + scan.getElementType());
+        log.debug("invokeScan {}", scan.getElementType());
         this.alerts = new ArrayList<Alert>();
 
         ScannerParam scannerParam = new ScannerParam();
@@ -502,7 +503,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
                     val = val.substring(0, 100) + "...";
                 }
             }
-            log.debug("getVariable " + name + " : " + val);
+            log.debug("getVariable {} : {}", name, val);
 
             return value;
         } else {
@@ -520,7 +521,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
                     val = val.substring(0, 100) + "...";
                 }
             }
-            log.debug("setVariable " + name + " = " + val);
+            log.debug("setVariable {} = {}", name, val);
             super.setVariable(name, value);
         } else {
             super.setVariable(name, value);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapUtils.java
@@ -33,7 +33,8 @@ import java.util.Map;
 import javax.swing.JPopupMenu;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -102,7 +103,7 @@ public class ZestZapUtils {
 
     private static final String ZEST_VAR_VALID_CHRS = "-:.";
 
-    private static final Logger log = Logger.getLogger(ZestZapUtils.class);
+    private static final Logger log = LogManager.getLogger(ZestZapUtils.class);
 
     /**
      * A map to convert labels to calc operations.
@@ -869,7 +870,7 @@ public class ZestZapUtils {
         try {
             file = Paths.get(filePath);
         } catch (InvalidPathException e) {
-            log.warn("Failed to parse the file path: " + filePath, e);
+            log.warn("Failed to parse the file path: {}", filePath, e);
             return "";
         }
 
@@ -1102,10 +1103,9 @@ public class ZestZapUtils {
             return ((ZestElementWrapper) node.getUserObject()).getElement();
         }
         log.debug(
-                "getElement "
-                        + node.getNodeName()
-                        + " Unrecognised class: "
-                        + node.getUserObject().getClass().getCanonicalName());
+                "getElement {} Unrecognised class: {}",
+                node.getNodeName(),
+                node.getUserObject().getClass().getCanonicalName());
         return null;
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
@@ -27,7 +27,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import javax.swing.event.TreeSelectionListener;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.model.SiteNode;
@@ -73,7 +74,7 @@ import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 public class ZestDialogManager extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = Logger.getLogger(ZestDialogManager.class);
+    private static final Logger logger = LogManager.getLogger(ZestDialogManager.class);
 
     private ExtensionZest extension = null;
     private ScriptUI scriptUI = null;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
@@ -30,7 +30,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import javax.swing.JFileChooser;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
@@ -78,7 +79,7 @@ public class ZestLoopDialog extends StandardFieldsDialog implements ZestDialog {
     private static final String FIELD_EXACT = "zest.dialog.loop.regex.exact";
     private static final String FIELD_GROUP = "zest.dialog.loop.regex.group";
 
-    private static final Logger logger = Logger.getLogger(ZestLoopDialog.class);
+    private static final Logger logger = LogManager.getLogger(ZestLoopDialog.class);
 
     public ZestLoopDialog(ExtensionZest extension, Frame owner, Dimension dim) {
         super(owner, "zest.dialog.loop.add.title", dim);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -29,7 +29,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
@@ -58,7 +59,7 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
     private static final String FIELD_LOAD = "zest.dialog.script.label.load";
     private static final String FIELD_CLIENT_NODE = "zest.dialog.script.label.clientnode";
 
-    private static final Logger logger = Logger.getLogger(ZestRecordScriptDialog.class);
+    private static final Logger logger = LogManager.getLogger(ZestRecordScriptDialog.class);
 
     private static final long serialVersionUID = 1L;
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRunScriptWithParamsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRunScriptWithParamsDialog.java
@@ -26,7 +26,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import javax.swing.JTable;
 import javax.swing.SwingUtilities;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
@@ -46,7 +47,7 @@ public class ZestRunScriptWithParamsDialog extends StandardFieldsDialog implemen
     private JTable paramsTable = null;
     private ScriptTokensTableModel paramsModel = null;
 
-    private static final Logger logger = Logger.getLogger(ZestRunScriptWithParamsDialog.class);
+    private static final Logger logger = LogManager.getLogger(ZestRunScriptWithParamsDialog.class);
 
     public ZestRunScriptWithParamsDialog(ExtensionZest ext, Frame owner, Dimension dim) {
         super(owner, "zest.dialog.run.title", dim);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
@@ -36,7 +36,8 @@ import javax.swing.JOptionPane;
 import javax.swing.JTable;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
@@ -72,7 +73,7 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
     private static final String FIELD_LOAD = "zest.dialog.script.label.load";
     private static final String FIELD_DEBUG = "zest.dialog.script.label.debug";
 
-    private static final Logger logger = Logger.getLogger(ZestScriptsDialog.class);
+    private static final Logger logger = LogManager.getLogger(ZestScriptsDialog.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -413,8 +414,7 @@ public class ZestScriptsDialog extends StandardFieldsDialog {
             scriptNode = extension.add(scriptWrapper, false);
             // Add any defered messages
             for (HttpMessage msg : deferedMessages) {
-                logger.debug(
-                        "Adding defered message: " + msg.getRequestHeader().getURI().toString());
+                logger.debug("Adding defered message: {}", msg.getRequestHeader().getURI());
                 extension.addToParent(scriptNode, msg, null);
             }
             deferedMessages.clear();

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddConditionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddConditionPopupMenu.java
@@ -62,7 +62,7 @@ public class ZestAddConditionPopupMenu extends ExtensionPopupMenuItem {
     private ExtensionZest extension;
 
     // private static final Logger logger =
-    // Logger.getLogger(ZestAddConditionPopupMenu.class);
+    // LogManager.getLogger(ZestAddConditionPopupMenu.class);
 
     /** This method initializes */
     public ZestAddConditionPopupMenu(ExtensionZest extension) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddLoopPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddLoopPopupMenu.java
@@ -25,7 +25,8 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.view.View;
@@ -49,7 +50,7 @@ public class ZestAddLoopPopupMenu extends ExtensionPopupMenuItem {
 
     private ExtensionZest extension;
 
-    private static final Logger logger = Logger.getLogger(ZestAddConditionPopupMenu.class);
+    private static final Logger logger = LogManager.getLogger(ZestAddConditionPopupMenu.class);
 
     /** This method initializes */
     public ZestAddLoopPopupMenu(ExtensionZest extension) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestCompareReqRespPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestCompareReqRespPopupMenu.java
@@ -20,7 +20,8 @@
 package org.zaproxy.zap.extension.zest.menu;
 
 import java.lang.reflect.Method;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
@@ -40,7 +41,7 @@ public class ZestCompareReqRespPopupMenu extends PopupMenuItemHistoryReferenceCo
 
     private static final long serialVersionUID = 2282358266003940700L;
 
-    private static final Logger LOGGER = Logger.getLogger(ZestCompareReqRespPopupMenu.class);
+    private static final Logger LOGGER = LogManager.getLogger(ZestCompareReqRespPopupMenu.class);
 
     private ExtensionZest extension;
     private boolean request = false;
@@ -106,7 +107,7 @@ public class ZestCompareReqRespPopupMenu extends PopupMenuItemHistoryReferenceCo
                                     this.request);
                         }
                     } catch (Exception e) {
-                        LOGGER.error("Failed to show diff dialogue: " + e.getMessage(), e);
+                        LOGGER.error("Failed to show diff dialogue: {}", e.getMessage(), e);
                     }
                 }
             }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestGenerateScriptFromAlertMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestGenerateScriptFromAlertMenu.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.zest.menu;
 import java.util.regex.Pattern;
 import javax.swing.JTree;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
@@ -47,7 +48,8 @@ public class ZestGenerateScriptFromAlertMenu extends PopupMenuItemHttpMessageCon
 
     private static final long serialVersionUID = 2282358266003940700L;
 
-    private static final Logger LOGGER = Logger.getLogger(ZestGenerateScriptFromAlertMenu.class);
+    private static final Logger LOGGER =
+            LogManager.getLogger(ZestGenerateScriptFromAlertMenu.class);
 
     private ExtensionZest extension;
 
@@ -74,7 +76,7 @@ public class ZestGenerateScriptFromAlertMenu extends PopupMenuItemHttpMessageCon
         try {
             performActionImpl(msg);
         } catch (Exception e) {
-            LOGGER.error("Failer to generate script from alert menu: " + e.getMessage(), e);
+            LOGGER.error("Failer to generate script from alert menu: {}", e.getMessage(), e);
         }
     }
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupCommentOnOff.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupCommentOnOff.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.zest.menu;
 
 import java.awt.Component;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
@@ -35,7 +36,7 @@ public class ZestPopupCommentOnOff extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = Logger.getLogger(ZestPopupCommentOnOff.class);
+    private static final Logger logger = LogManager.getLogger(ZestPopupCommentOnOff.class);
 
     private ExtensionZest extension = null;
     private boolean comment = false;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodeCopyOrCut.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodeCopyOrCut.java
@@ -22,7 +22,8 @@ package org.zaproxy.zap.extension.zest.menu;
 import java.awt.Component;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
@@ -36,7 +37,7 @@ public class ZestPopupNodeCopyOrCut extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = Logger.getLogger(ZestPopupNodeCopyOrCut.class);
+    private static final Logger logger = LogManager.getLogger(ZestPopupNodeCopyOrCut.class);
 
     private ExtensionZest extension = null;
     private boolean cut;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodePaste.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodePaste.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.zest.menu;
 
 import java.awt.Component;
 import javax.swing.JTree;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
@@ -36,7 +37,7 @@ public class ZestPopupNodePaste extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = Logger.getLogger(ZestPopupNodePaste.class);
+    private static final Logger logger = LogManager.getLogger(ZestPopupNodePaste.class);
 
     private ExtensionZest extension = null;
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestDelete.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestDelete.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.zest.menu;
 
 import java.awt.Component;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
@@ -34,7 +35,7 @@ public class ZestPopupZestDelete extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = Logger.getLogger(ZestPopupZestDelete.class);
+    private static final Logger logger = LogManager.getLogger(ZestPopupZestDelete.class);
 
     private ExtensionZest extension = null;
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestMove.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestMove.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.zest.menu;
 
 import java.awt.Component;
 import javax.swing.JTree;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
@@ -36,7 +37,7 @@ public class ZestPopupZestMove extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = Logger.getLogger(ZestPopupZestMove.class);
+    private static final Logger logger = LogManager.getLogger(ZestPopupZestMove.class);
 
     private ExtensionZest extension = null;
     private boolean up;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
@@ -21,7 +21,8 @@ package org.zaproxy.zap.extension.zest.menu;
 
 import java.awt.Component;
 import javax.swing.JTree;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
@@ -34,7 +35,7 @@ public class ZestRecordOnOffPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = Logger.getLogger(ZestRecordOnOffPopupMenu.class);
+    private static final Logger logger = LogManager.getLogger(ZestRecordOnOffPopupMenu.class);
 
     private ExtensionZest extension = null;
     private boolean record;

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -17,7 +17,7 @@ description = "A graphical security scripting language, ZAPs macro language on s
 zapAddOn {
     addOnName.set("Zest - Graphical Security Scripting Language")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.