### PR TITLE
tlsdebug: update ZAP to 2.10.0

### DIFF
--- a/addOns/tlsdebug/CHANGELOG.md
+++ b/addOns/tlsdebug/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Now using 2.10 logging infrastructure (Log4j 2.x).
 
 ## [4] - 2020-12-15
 ### Added

--- a/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/HttpsCallerLauncher.java
+++ b/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/HttpsCallerLauncher.java
@@ -26,13 +26,14 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 
 public class HttpsCallerLauncher {
 
     private static String SEP = System.getProperty("path.separator");
-    private static final Logger logger = Logger.getLogger(HttpsCallerLauncher.class);
+    private static final Logger logger = LogManager.getLogger(HttpsCallerLauncher.class);
 
     private ExtensionTlsDebug extension;
 

--- a/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
+++ b/addOns/tlsdebug/src/main/java/org/zaproxy/zap/extension/tlsdebug/TlsDebugPanel.java
@@ -41,7 +41,8 @@ import javax.swing.JTextArea;
 import javax.swing.UIManager;
 import javax.swing.border.EtchedBorder;
 import org.apache.commons.httpclient.URI;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractPanel;
 import org.parosproxy.paros.model.Model;
@@ -56,7 +57,7 @@ import org.zaproxy.zap.view.NodeSelectDialog;
 public class TlsDebugPanel extends AbstractPanel implements Tab {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger logger = Logger.getLogger(TlsDebugPanel.class);
+    private static final Logger logger = LogManager.getLogger(TlsDebugPanel.class);
 
     private static final String RESOURCES = "/org/zaproxy/zap/extension/tlsdebug/resources";
     private static final ImageIcon TLSDEBUG_ICON =

--- a/addOns/tlsdebug/tlsdebug.gradle.kts
+++ b/addOns/tlsdebug/tlsdebug.gradle.kts
@@ -3,11 +3,10 @@ description = "Provides a tab which allows to quickly debug a TLS/SSL connection
 
 zapAddOn {
     addOnName.set("TLS Debug")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("P.M.J. Roth")
         url.set("https://www.zaproxy.org/docs/desktop/addons/tls-debug/")
-        notBeforeVersion.set("2.10.0")
     }
 }


### PR DESCRIPTION
Update ZAP to 2.10.0.
Use Log4j 2 APIs.

Part of zaproxy/zaproxy#6376.