### PR TITLE
PscanrulesBeta: PII Scan Rule ignore CSS and Styles

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Update RE2/J library to latest version (1.6).
+- PII Scan Rule will now ignore CSS and style information (Issue 6288).
 
 ## [24] - 2020-12-15
 ### Changed


### PR DESCRIPTION
- PiiScanRule > Use core isCss() utility methods, return early if either is true. Added a utility method that removes STYLE elements and attributes prior to the scan rule looking for Pii.
- PiiScanRuleUnitTest > Add tests to assert the updated behavior.
- CHANGELOG > Add change note.

Fixes zaproxy/zaproxy#6288

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>