### PR TITLE
pscanrules: Don't look for timestamps in fonts

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cache-control scan rule no longer checks if Pragma is set or not.
 - Maintenance changes.
 - The Timestamp Disclosure scan rule now excludes values in "Report-To" or "NEL" headers (Issue 6493).
+- The Timestamp Disclosure scan rule no longer considers font type requests or responses when looking for possible timestamps (Issue 6274).
 
 ## [33] - 2021-01-29
 ### Added


### PR DESCRIPTION
- TimestampDisclosureScanRule > Now checks if the request/response is related to fonts and skips if so.
- TimestampDisclosureScanRuleUnitTest > Added new tests to assert the new behavior.
- CHANGELOG > Added change note.

Fixes zaproxy/zaproxy#6274

Reference resources:
- https://www.w3schools.com/css/css3_fonts.asp
- https://en.wikipedia.org/wiki/Web_Open_Font_Format
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>