### PR TITLE
ascanrulesBeta: Add simple .env file scan rule content check

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
+- The .env file scan rule now performs a simple content check to reduce false positives (Issue 6099).
 
 ## [33] - 2020-12-15
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRule.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.AbstractAppFilePlugin;
 
 public class EnvFileScanRule extends AbstractAppFilePlugin {
@@ -33,5 +34,12 @@ public class EnvFileScanRule extends AbstractAppFilePlugin {
     @Override
     public int getId() {
         return PLUGIN_ID;
+    }
+
+    @Override
+    public boolean isFalsePositive(HttpMessage msg) {
+        String responseBody = msg.getResponseBody().toString();
+        // It likely is a FP if the response contains neither a comment nor assignment
+        return !responseBody.contains("#") && !responseBody.contains("=");
     }
 }

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Added AbstractHostFilePlugin for use with ElmahScanRule and other future Host level file scan rules (Issue 6133).
-- Maintenance changes (Issue 6376).
+- Maintenance changes (Issue 6376 & Issue 6099).
 
 ## [1.2.0] - 2020-12-15
 ### Changed

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/AbstractAppFilePlugin.java
@@ -165,11 +165,11 @@ public abstract class AbstractAppFilePlugin extends AbstractAppPlugin {
                     e.getMessage());
             return;
         }
-        if (isFalsePositive(newRequest)) {
-            return;
-        }
         int statusCode = newRequest.getResponseHeader().getStatusCode();
         if (statusCode == HttpStatusCode.OK) {
+            if (isFalsePositive(newRequest)) {
+                return;
+            }
             raiseAlert(newRequest, getRisk(), Alert.CONFIDENCE_MEDIUM, "");
         } else if (this.getAlertThreshold().equals(AlertThreshold.LOW)
                 && (statusCode == HttpStatusCode.UNAUTHORIZED

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/AbstractAppFilePluginUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/AbstractAppFilePluginUnitTest.java
@@ -286,7 +286,7 @@ public abstract class AbstractAppFilePluginUnitTest<T extends AbstractAppFilePlu
         assertEquals(Alert.CONFIDENCE_LOW, alert.getConfidence());
     }
 
-    private static NanoServerHandler createHandler(String path, Response response) {
+    protected static NanoServerHandler createHandler(String path, Response response) {
         return new NanoServerHandler(path) {
             @Override
             protected Response serve(IHTTPSession session) {


### PR DESCRIPTION
- ascanrulesBeta/EnvFileScanRule > Added overridden isFalsePositive method that does a simple content check.
- ascanrulesBeta/EnvFileScanRuleUnitTest > Added overridden test methods to assert the rule specific behavior.
- ascanrulesBeta/CHANGELOG > Added change note.

* commonlib/AbstractAppFilePlugin > Relocate "isFalsePositive" check to be in the valid (200'ish) response block (obviously content or FP checks are unlikely to be successful in Unauthorized or Forbidden responses).
* commonlib/AbstractAppFilePluginUnitTest > Change visibility of "createHandler" to protected (from private).
* commoblib/CHANGELOG > Added change reference.

Note I locally ran other uses of AbstractAppFilePluginUnitTest to ensure the changes didn't negatively impact other scan rules.

Fixes zaproxy/zaproxy#6099

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>