### PR TITLE
directorylists, fuzzdb, svndigger: update ZAP

### DIFF
--- a/addOns/directorylistv1/CHANGELOG.md
+++ b/addOns/directorylistv1/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ## [4] - 2020-01-17
 ### Added

--- a/addOns/directorylistv1/directorylistv1.gradle.kts
+++ b/addOns/directorylistv1/directorylistv1.gradle.kts
@@ -6,7 +6,7 @@ description = "List of directory names to be used with Forced Browse or Fuzzer a
 zapAddOn {
     addOnName.set("Directory List v1.0")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3/CHANGELOG.md
+++ b/addOns/directorylistv2_3/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Change info URL to link to the site.
 
 ## 3 - 2015-12-04

--- a/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
+++ b/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
@@ -6,7 +6,7 @@ description = "Lists of directory names to be used with Forced Browse or Fuzzer 
 zapAddOn {
     addOnName.set("Directory List v2.3")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3_lc/CHANGELOG.md
+++ b/addOns/directorylistv2_3_lc/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Change info URL to link to the site.
 
 ## 3 - 2015-12-04

--- a/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
+++ b/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
@@ -6,7 +6,7 @@ description = "Lists of lower case directory names to be used with Forced Browse
 zapAddOn {
     addOnName.set("Directory List v2.3 LC")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/fuzzdb/CHANGELOG.md
+++ b/addOns/fuzzdb/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.10.0.
+
 ### Fixed
  - Terminology
 

--- a/addOns/fuzzdb/fuzzdb.gradle.kts
+++ b/addOns/fuzzdb/fuzzdb.gradle.kts
@@ -17,7 +17,7 @@ description = "FuzzDB files which can be used with the ZAP fuzzer"
 zapAddOn {
     addOnName.set("FuzzDB Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/svndigger/CHANGELOG.md
+++ b/addOns/svndigger/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Promote to release status.
 - Change info URL to link to the site.
 

--- a/addOns/svndigger/svndigger.gradle.kts
+++ b/addOns/svndigger/svndigger.gradle.kts
@@ -12,7 +12,7 @@ val processFiles by tasks.registering(ProcessSvnDiggerFiles::class) {
 zapAddOn {
     addOnName.set("SVN Digger Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")


### PR DESCRIPTION
Update add-ons to ZAP 2.10.0.