### PR TITLE
bruteforce: use User-Agent defined in ZAP

### DIFF
--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Send HTTP messages with the user-agent defined in ZAP (Issue 173).
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Manager.java
@@ -186,6 +186,8 @@ public class Manager implements ProcessChecker.ProcessUpdate {
     /* Logger object for the class */
     private static final Logger LOG = LogManager.getLogger(Manager.class);
 
+    private String userAgent;
+
     // ZAP: Changed to public to allow it to be extended
     public Manager() {
         elementsToParse.addElement(new HTMLelementToParse("a", "href"));
@@ -206,6 +208,10 @@ public class Manager implements ProcessChecker.ProcessUpdate {
          * create the httpclient
          */
         createHttpClient();
+    }
+
+    public void setUserAgent(String userAgent) {
+        this.userAgent = userAgent;
     }
 
     // set up dictionay based attack with normal start
@@ -432,7 +438,10 @@ public class Manager implements ProcessChecker.ProcessUpdate {
                     .getParams()
                     .setConnectionTimeout(Config.connectionTimeout * 1000);
             httpclient.setState(initialState);
-            httpclient.getParams().setParameter("http.useragent", Config.userAgent);
+            httpclient
+                    .getParams()
+                    .setParameter(
+                            "http.useragent", userAgent != null ? userAgent : Config.userAgent);
 
             /*
              * Code to deal with http auth

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForce.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForce.java
@@ -87,6 +87,8 @@ public class BruteForce extends Thread implements BruteForceListenner {
 
         ConnectionParam conParam = Model.getSingleton().getOptionsParam().getConnectionParam();
 
+        manager.setUserAgent(conParam.getDefaultUserAgent());
+
         // Set up proxy?
         if (conParam.isUseProxy(target.getHost())) {
             manager.setProxyRealm(


### PR DESCRIPTION
Change `Manager` to allow to set a custom user-agent.
Change `BruteForce` to set the user-agent defined in ZAP.

Part of zaproxy/zaproxy#173.