### PR TITLE
Update ZAP to 2.10.0 on remaining add-ons

### DIFF
--- a/addOns/coreLang/CHANGELOG.md
+++ b/addOns/coreLang/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.10.0.
 - Added more people to the credits.
 
 ## 13 - 2018-01-15

--- a/addOns/coreLang/coreLang.gradle.kts
+++ b/addOns/coreLang/coreLang.gradle.kts
@@ -6,7 +6,7 @@ description = "Translations of the core language files"
 zapAddOn {
     addOnName.set("Core Language Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - encode-decode Default and rot13 templates.
 
 ### Changed
+- Update minimum ZAP version to 2.10.0.
 - Update links to zaproxy repo.
 
 ## [0.1.0] - 2020-11-17

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -6,7 +6,7 @@ description = "Provides the GraalVM JavaScript engine for ZAP scripting."
 zapAddOn {
     addOnName.set("GraalVM JavaScript")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/groovy/groovy.gradle.kts
+++ b/addOns/groovy/groovy.gradle.kts
@@ -6,12 +6,11 @@ description = "Adds Groovy support to ZAP"
 zapAddOn {
     addOnName.set("Groovy Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/groovy-support/")
-        notBeforeVersion.set("2.10.0")
     }
 }
 

--- a/addOns/highlighter/CHANGELOG.md
+++ b/addOns/highlighter/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ## 7 - 2018-05-30
 

--- a/addOns/highlighter/highlighter.gradle.kts
+++ b/addOns/highlighter/highlighter.gradle.kts
@@ -3,7 +3,7 @@ description = "Allows you to highlight strings in the request and response tabs.
 
 zapAddOn {
     addOnName.set("Highlighter")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jruby/jruby.gradle.kts
+++ b/addOns/jruby/jruby.gradle.kts
@@ -6,12 +6,11 @@ description = "Allows Ruby to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Ruby Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/ruby-scripting/")
-        notBeforeVersion.set("2.10.0")
     }
 }
 

--- a/addOns/jsonview/CHANGELOG.md
+++ b/addOns/jsonview/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ## 1 - 2018-02-08
 

--- a/addOns/jsonview/jsonview.gradle.kts
+++ b/addOns/jsonview/jsonview.gradle.kts
@@ -3,7 +3,7 @@ description = "Adds a view that shows JSON messages nicely formatted"
 
 zapAddOn {
     addOnName.set("JSON View")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("Juha Kivekäs")

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.10.0.
 
 ## [1.0.0] - 2020-09-14
 

--- a/addOns/kotlin/kotlin.gradle.kts
+++ b/addOns/kotlin/kotlin.gradle.kts
@@ -6,7 +6,7 @@ description = "Allows Kotlin to be used for ZAP scripting"
 zapAddOn {
     addOnName.set("Kotlin Support")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("StackHawk Engineering")

--- a/addOns/onlineMenu/CHANGELOG.md
+++ b/addOns/onlineMenu/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [8] - 2020-12-15
 ### Added

--- a/addOns/onlineMenu/onlineMenu.gradle.kts
+++ b/addOns/onlineMenu/onlineMenu.gradle.kts
@@ -6,11 +6,10 @@ description = "ZAP Online menu items"
 zapAddOn {
     addOnName.set("Online menus")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/online-menu/")
-        notBeforeVersion.set("2.10.0")
     }
 }

--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ### Fixed
  - Close dialogues when the add-on is uninstalled.

--- a/addOns/regextester/regextester.gradle.kts
+++ b/addOns/regextester/regextester.gradle.kts
@@ -3,7 +3,7 @@ description = "Allows to test Regular Expressions"
 
 zapAddOn {
     addOnName.set("Regular Expression Tester")
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 - Update docker refs to use zaproxy.org instead of GitHub wiki.
 
 ## [7] - 2020-01-17

--- a/addOns/tips/tips.gradle.kts
+++ b/addOns/tips/tips.gradle.kts
@@ -6,7 +6,7 @@ description = "Display ZAP Tips and Tricks"
 zapAddOn {
     addOnName.set("Tips and Tricks")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/treetools/CHANGELOG.md
+++ b/addOns/treetools/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.9.0.
+- Update minimum ZAP version to 2.10.0.
 
 ## 7 - 2017-11-27
 

--- a/addOns/treetools/treetools.gradle.kts
+++ b/addOns/treetools/treetools.gradle.kts
@@ -6,7 +6,7 @@ description = "Tools to add functionality to the tree view."
 zapAddOn {
     addOnName.set("TreeTools")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.9.0")
+    zapVersion.set("2.10.0")
 
     manifest {
         author.set("Carl Sampson")


### PR DESCRIPTION
Update ZAP to 2.10.0.
Update changelogs where needed.