### PR TITLE
zest: depend on scritps add-on

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Depend on Script Console add-on, it's required to work with Zest scripts (Issue 2656).
 - Clear Zest Results Panel when new script is added.
 - Update minimum ZAP version to 2.10.0.
 

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -27,6 +27,7 @@ zapAddOn {
                 register("selenium") {
                     version.set("15.*")
                 }
+                register("scripts")
             }
         }
     }


### PR DESCRIPTION
The add-on is required to work with Zest scripts.

Fix zaproxy/zaproxy#2656.