### PR TITLE
Reporting: Support job specific data

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
@@ -22,9 +22,12 @@ package org.zaproxy.addon.automation;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.model.Context;
@@ -39,6 +42,7 @@ public class AutomationEnvironment {
     private List<Context> contexts = new ArrayList<Context>();;
     private boolean failOnError = true;
     private boolean failOnWarning = false;
+    private Map<String, Object> jobData = new HashMap<>();
 
     public AutomationEnvironment(
             LinkedHashMap<?, ?> envData, AutomationProgress progress, Session session) {
@@ -178,6 +182,18 @@ public class AutomationEnvironment {
 
     public Context getDefaultContext() {
         return contexts.get(0);
+    }
+
+    public void addJobData(String key, Object data) {
+        this.jobData.put(key, data);
+    }
+
+    public Object getJobData(String key) {
+        return this.jobData.get(key);
+    }
+
+    public Set<String> getJobDataKeys() {
+        return this.jobData.keySet();
     }
 
     public boolean isFailOnError() {

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-addons.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-addons.html
@@ -13,6 +13,8 @@ This job allows you to manage the ZAP add-ons.
 The add-on identifiers to use in the 'install' and 'uninstall' lists are shown in the ZAP Desktop 'Manage Add-ons' dialog or 
 can be found in the <a href="https://www.zaproxy.org/download/#latest-versions">XML files</a> which define the ZAP releases.
 
+<H2>YAML</H2>
+
 <pre>
   - type: addOns                       # Add-on management
     parameters:

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
@@ -13,6 +13,8 @@ This job runs the active scanner. This actively attacks your applications and sh
 <p>
 By default this job will actively scan the first context defined in the <a href="environment.html">environment</a> and so none of the parameters are mandatory.
 
+<H2>YAML</H2>
+
 <pre>
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
@@ -36,6 +38,14 @@ By default this job will actively scan the first context defined in the <a href=
         strength:                      # String: The Attack Strength for this rule, one of Low, Medium, High, Insane, default: Medium
         threshold:                     # String: The Alert Threshold for this rule, one of Off, Low, Medium, High, default: Medium
 </pre>
+
+<H2>Job Data</H2>
+The following class will be made available to add-ons that provide access to the Job Data such as the Reporting add-on.
+Note that in this case the data is from the last Active Scan, regardless of whether it was started by the Automation Framework, the UI, or the API.
+<ul>
+<li>Key: <code>activeScanData</code>
+<li>Class: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJobResultData.java">ActiveScanJobResultData</a>
+</ul>
 
 </BODY>
 </HTML>

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-pscanconf.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-pscanconf.html
@@ -14,6 +14,8 @@ The passive scanner runs against all requests and responses that are generated b
 If you want to configure the passive scan configuration then you should typically do so before running any other jobs.
 However you can run this job later, or multiple times, if you want different jobs to use different passive scan configurations.
 
+<H2>YAML</H2>
+
 <pre>
   - type: passiveScan-config           # Passive scan configuration
     parameters:

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-pscanwait.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-pscanwait.html
@@ -13,11 +13,21 @@ You should typically run this job after the jobs that explore you application, s
 If any more requests are sent by ZAP or proxied through ZAP after this job has run then they will be processed by the passive scanner.
 You can run this job as many times as you need to.
 
+<H2>YAML</H2>
+
 <pre>
   - type: passiveScan-wait             # Passive scan wait for the passive scanner to finish
     parameters:
       maxDuration: 5                   # Int: The max time to wait for the passive scanner, default: 0 unlimited
 </pre>
+
+<H2>Job Data</H2>
+The following class will be made available to add-ons that provide access to the Job Data such as the Reporting add-on.
+Note that in this case the data is from the currently enabled Passive Scan rules, regardless of whether they have been used as a result of the Automation Framework, the UI, or the API.
+<ul>
+<li>Key: <code>passiveScanData</code>
+<li>Class: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanJobResultData.java">PassiveScanJobResultData</a>
+</ul>
 
 </BODY>
 </HTML>

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-spider.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-spider.html
@@ -12,6 +12,8 @@ This job runs the traditional spider. This is fast but does not handle modern ap
 <p>
 By default this job will spider the first context defined in the <a href="environment.html">environment</a> and so none of the parameters are mandatory.
 
+<H2>YAML</H2>
+
 <pre>
   - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
     parameters:

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Support for template sections
 - Automation job: support risk, confidence and section configuration
+- Passing rules to traditional plus HTML report
 
 ### Changed
 - Format HTML and XML templates as part of the build

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -22,7 +22,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set("0.*")
+                            version.set(">=0.2.0")
                         }
                     }
                 }

--- a/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/create.html
+++ b/addOns/reports/src/main/javahelp/org/zaproxy/addon/reports/resources/help/contents/create.html
@@ -127,9 +127,9 @@ sections:    # An optional list of sections - parts of the report which may be i
 	class that defines the data to be included in the report. This can be
 	used, for example, to tell if there were no level alerts of a specific
 	level or if they were deliberately excluded.
-	<p>The plan is to allow any add-ons to make additional data items
-		available. This help page will be updated when that feature is
-		available.</p>
+	<p>Automation jobs can make additional data available to the
+		reports, in many cases even if the automation framework was not used.
+		See the help pages for the relevant jobs for more details.</p>
 	<H2>Testing Reports</H2>
 	ZAP does not cache the report templates, so it rereads them every time
 	you generate a report. This makes it much easier to test them. Just

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/Messages.properties
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/Messages.properties
@@ -2,5 +2,12 @@
 report.template.chart = Alert Chart
 report.template.section.chart = Chart
 report.template.section.alertcount = Alert Count
-report.template.section.instancecount = Instance Chart
+report.template.section.instancecount = Instance Count
+report.template.section.passingrules = Passing Rules
 report.template.section.alertdetails = Alert Details
+report.template.pass.list = Passing Rules
+report.template.pass.type = Rule Type
+report.template.pass.type.active = Active
+report.template.pass.type.passive = Passive
+report.template.pass.threshold = Threshold
+report.template.pass.strength = Strength

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
@@ -245,6 +245,46 @@ td {
 		<div class="spacer-lg"></div>
 	</th:block>
 
+	<th:block th:if="${reportData.isIncludeSection('passingrules')}">
+		<h3 th:text="#{report.template.pass.list}">Passing Rules</h3>
+		<table class="alerts">
+			<tr>
+				<th th:text="#{report.alerts.list.name}" width="55%" height="24">Name</th>
+				<th th:text="#{report.template.pass.type}" width="15%"
+					align="center">Type</th>
+				<th th:text="#{report.template.pass.threshold}" width="15%"
+					align="center">Threshold</th>
+				<th th:text="#{report.template.pass.strength}" width="15%"
+					align="center">Strength</th>
+			</tr>
+			<th:block
+				th:if="${reportData.reportObjects.get('activeScanData') != null}">
+				<th:block
+					th:each="ascan : ${reportData.reportObjects.get('activeScanData').allRuleData}">
+					<tr th:if="${alertCountsByRule.get(ascan.id) == null}">
+						<td><a th:href="'#' + ${ascan.id}" th:text="${ascan.name}"
+							href="#pluginId">Alert Name</a></td>
+						<td th:text="#{report.template.pass.type.active}" align="center">Active</td>
+						<td align="center" th:text="${ascan.threshold}">Threshold</td>
+						<td align="center" th:text="${ascan.strength}">Strength</td>
+					</tr>
+				</th:block>
+			</th:block>
+			<th:block
+				th:each="pscan : ${reportData.reportObjects.get('passiveScanData').allRuleData}">
+				<tr th:if="${alertCountsByRule.get(pscan.id) == null}">
+					<td><a th:href="'#' + ${pscan.id}" th:text="${pscan.name}"
+						href="#pluginId">Alert Name</a></td>
+					<td th:text="#{report.template.pass.type.passive}" align="center">Passive</td>
+					<td align="center" th:text="${pscan.threshold}">Threshold</td>
+					<td align="center">-</td>
+				</tr>
+			</th:block>
+		</table>
+		<div class="spacer-lg"></div>
+	</th:block>
+
+
 	<th:block th:if="${reportData.isIncludeSection('alertdetails')}">
 		<h3 th:text="#{report.alerts.detail}">Alert Detail</h3>
 		<th:block th:each="alert: ${alertTree.children}">

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/template.yaml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/template.yaml
@@ -6,4 +6,5 @@ sections:
  - chart
  - alertcount
  - instancecount
+ - passingrules
  - alertdetails


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/6483

This adds a new Passing Rules section to the HTML plus report:

![Screenshot_2021-04-06 ZAP Scanning Report](https://user-images.githubusercontent.com/1081115/113742206-49423c00-96fa-11eb-9ed8-175437cd4938.png)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>