### PR TITLE
BeanShell Addon - Tweaks

### DIFF
--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.10.0.
+- Maintenance changes.
 - Improve permissions and space handling when saving.
 
 ## 6 - 2017-11-27

--- a/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
+++ b/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.beanshell;
 import bsh.EvalError;
 import bsh.Interpreter;
 import java.awt.FlowLayout;
-import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.HeadlessException;
@@ -41,7 +40,6 @@ import javax.swing.JPanel;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ViewDelegate;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpSender;
@@ -59,7 +57,6 @@ public class BeanShellConsoleFrame extends AbstractFrame {
     private JButton btnLoad = null;
     private JButton btnSave = null;
     private JButton btnSaveAs = null;
-    private Extension extension = null;
     private Interpreter interpreter = null;
     private String scriptsDir = System.getProperty("user.dir") + "/scripts/";
     private File currentScriptFile = null;
@@ -72,20 +69,6 @@ public class BeanShellConsoleFrame extends AbstractFrame {
     /** @throws HeadlessException */
     public BeanShellConsoleFrame() throws HeadlessException {
         super();
-        initialize();
-    }
-
-    /**
-     * @param parent
-     * @param modal
-     * @param extension
-     * @throws HeadlessException
-     */
-    public BeanShellConsoleFrame(Frame parent, boolean modal, Extension extension)
-            throws HeadlessException {
-        // super(parent, modal);
-        super();
-        this.extension = extension;
         initialize();
     }
 
@@ -302,10 +285,6 @@ public class BeanShellConsoleFrame extends AbstractFrame {
                     });
         }
         return btnSaveAs;
-    }
-
-    public void setExtension(Extension extension) {
-        this.extension = extension;
     }
 
     @Override

--- a/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/ExtensionBeanShell.java
+++ b/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/ExtensionBeanShell.java
@@ -87,8 +87,7 @@ public class ExtensionBeanShell extends ExtensionAdaptor {
 
     BeanShellConsoleFrame getBeanShellConsoleDialog() {
         if (beanShellConsoleDialog == null) {
-            beanShellConsoleDialog =
-                    new BeanShellConsoleFrame(getView().getMainFrame(), false, this);
+            beanShellConsoleDialog = new BeanShellConsoleFrame();
             beanShellConsoleDialog.setView(getView());
             beanShellConsoleDialog.setPreferredSize(new Dimension(600, 600));
             beanShellConsoleDialog.setTitle(Constant.messages.getString("beanshell.title"));


### PR DESCRIPTION
BeanShellConsoleFrame & ExtensionBeanShell > Stop handling unused `Extension` variable, remove unnecessary constructor. 
ExtensionBeanShell > Use no-arg constructor.
CHANGELOG > Added maintenance note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>