### PR TITLE
webdrivers: update geckodriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [27] - 2021-04-09
 ### Changed
+- Update geckodriver to 0.29.1.
 - Update minimum ZAP version to 2.10.0.
 
 ## [26] - 2021-03-25
@@ -127,6 +128,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[27]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v24

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -10,7 +10,7 @@
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
     <li>Chrome - ChromeDriver 89.0.4389.23</li>
-    <li>Firefox - geckodriver 0.29.0</li>
+    <li>Firefox - geckodriver 0.29.1</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [26] - 2021-04-09
 ### Changed
+- Update geckodriver to 0.29.1.
 - Update minimum ZAP version to 2.10.0.
 
 ## [25] - 2021-03-25
@@ -123,6 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[26]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v24
 [23]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v23

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -10,7 +10,7 @@
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
     <li>Chrome - ChromeDriver 89.0.4389.23</li>
-    <li>Firefox - geckodriver 0.29.0</li>
+    <li>Firefox - geckodriver 0.29.1</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -4,7 +4,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 
 description = "Common configuration of the WebDriver add-ons."
 
-val geckodriverVersion = "0.29.0"
+val geckodriverVersion = "0.29.1"
 val chromeDriverVersion = "89.0.4389.23"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [27] - 2021-04-09
 ### Changed
+- Update geckodriver to 0.29.1.
 - Update minimum ZAP version to 2.10.0.
 
 ## [26] - 2021-03-25
@@ -130,6 +131,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[27]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v24

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -10,7 +10,7 @@
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
     <li>Chrome - ChromeDriver 89.0.4389.23</li>
-    <li>Firefox - geckodriver 0.29.0</li>
+    <li>Firefox - geckodriver 0.29.1</li>
 </ul>
 
 <H2>See also</H2>


### PR DESCRIPTION
Update geckodriver to 0.29.1.
Add release dates and links to tags.