### PR TITLE
pscanrules all: Discontinue use of CWE-16

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,6 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The Timestamp Disclosure scan rule now excludes values in "Report-To" or "NEL" headers (Issue 6493).
 - The Timestamp Disclosure scan rule no longer considers font type requests or responses when looking for possible timestamps (Issue 6274).
 - X-Frame-Options scan rule CWE ID changed from 16 to 1021.
+- Discontinued use of CWE-16 and switched to more specific weaknesses in the following scan rules:
+  - Character Set Mismatch
+  - Content Security Policy
+  - Cookie HttpOnly
+  - Cookie SameSite
+  - JSF ViewState
+  - MS ViewState
+  - X-Content-Type-Options
 
 ## [33] - 2021-01-29
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
@@ -270,7 +270,7 @@ public class CharsetMismatchScanRule extends PluginPassiveScanner {
                 .setOtherInfo(getExtraInfo(firstCharset, secondCharset, currentMismatch))
                 .setSolution(getSolutionMessage())
                 .setReference(getReferenceMessage())
-                .setCweId(16) // CWE-16: Configuration
+                .setCweId(436) // CWE-436: Interpretation Conflict
                 .setWascId(15) // WASC-15: Application Misconfiguration
                 .raise();
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -416,7 +416,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence)
-                .setCweId(16) // CWE-16: Configuration
+                .setCweId(693) // CWE-693: Protection Mechanism Failure
                 .setWascId(15) // WASC-15: Application Misconfiguration)
                 .raise();
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -95,7 +95,7 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), headerValue))
-                .setCweId(16) // CWE-16: Configuration
+                .setCweId(1004) // CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag
                 .setWascId(13); // WASC-13: Info leakage
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
@@ -98,7 +98,7 @@ public class CookieSameSiteScanRule extends PluginPassiveScanner {
                 .setEvidence(
                         CookieUtils.getSetCookiePlusName(
                                 msg.getResponseHeader().toString(), cookieHeaderValue))
-                .setCweId(16) // CWE Id 16 - Configuration
+                .setCweId(1275) // CWE-1275: Sensitive Cookie with Improper SameSite Attribute
                 .setWascId(13) // WASC Id - Info leakage
                 .raise();
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
@@ -214,7 +214,7 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner {
                 .setOtherInfo(Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", viewState))
                 .setSolution(getSolution())
                 .setReference(getReference())
-                .setCweId(16) // CWE Id 16 - Configuration
+                .setCweId(642) // CWE-642: External Control of Critical State Data
                 .setWascId(14) // WASC Id - Server Misconfiguration
                 .raise();
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
@@ -85,7 +85,7 @@ public class ViewstateScanRule extends PluginPassiveScanner {
                 .setDescription(var.pattern.getAlertDescription())
                 .setOtherInfo(var.getResultExtract().toString())
                 .setSolution(getSolution())
-                .setCweId(16) // CWE Id 16 - Configuration
+                .setCweId(642) // CWE-642: External Control of Critical State Data
                 .setWascId(14); // WASC Id - Server Misconfiguration
     }
 
@@ -96,7 +96,7 @@ public class ViewstateScanRule extends PluginPassiveScanner {
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "oldver.desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "oldver.soln"))
-                .setCweId(16) // CWE Id 16 - Configuration
+                .setCweId(642) // CWE-642: External Control of Critical State Data
                 .setWascId(14); // WASC Id - Server Misconfiguration
     }
 
@@ -133,7 +133,7 @@ public class ViewstateScanRule extends PluginPassiveScanner {
                 .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "split.desc"))
                 .setSolution(Constant.messages.getString(MESSAGE_PREFIX + "split.soln"))
-                .setCweId(16) // CWE Id 16 - Configuration
+                .setCweId(642) // CWE-642: External Control of Critical State Data
                 .setWascId(14); // WASC Id - Server Misconfiguration
     }
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
@@ -88,7 +88,7 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner {
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(xContentTypeOption)
-                .setCweId(16) // CWE-16: Configuration
+                .setCweId(693) // CWE-693: Protection Mechanism Failure
                 .setWascId(15) // WASC15: Application Misconfiguration
                 .raise();
     }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRuleUnitTest.java
@@ -148,7 +148,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
         assertThat(alertsRaised.get(0), containsNameLoadedWithKey(HEADER_METACHARSET_MISMATCH));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
 
         assertThat(
@@ -156,7 +156,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
                 containsNameLoadedWithKey(NO_MISMATCH_METACONTENTTYPE_MISSING));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(1).getWascId(), equalTo(15));
     }
 
@@ -182,7 +182,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
                 containsNameLoadedWithKey(NO_MISMATCH_METACONTENTTYPE_MISSING));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
     }
 
@@ -210,7 +210,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
         assertThat(alertsRaised.get(0), containsNameLoadedWithKey(HEADER_METACONTENTYPE_MISMATCH));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
     }
 
@@ -239,7 +239,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
         assertThat(alertsRaised.get(0), containsNameLoadedWithKey(HEADER_METACHARSET_MISMATCH));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
 
         assertThat(
@@ -247,7 +247,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
                 containsNameLoadedWithKey(NO_MISMATCH_METACONTENTTYPE_MISSING));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(1).getWascId(), equalTo(15));
     }
 
@@ -278,13 +278,13 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
                 containsNameLoadedWithKey(METACONTENTTYPE_METACHARSET_MISMATCH));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
 
         assertThat(alertsRaised.get(1), containsNameLoadedWithKey(HEADER_METACHARSET_MISMATCH));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(1).getWascId(), equalTo(15));
     }
 
@@ -326,7 +326,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
                 containsOtherInfoLoadedWithKey(XML_MISMATCH, "UTF-8", "ISO-123"));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(436));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(15));
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
@@ -140,7 +140,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
         assertThat(alertsRaised.get(0), containsNameLoadedWithKey(INSECURE_JSF));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
     }
 
@@ -167,7 +167,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
         assertThat(alertsRaised.get(0), containsNameLoadedWithKey(INSECURE_JSF));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
     }
 
@@ -194,7 +194,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
         assertThat(alertsRaised.get(0), containsNameLoadedWithKey(INSECURE_JSF));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
     }
 
@@ -225,7 +225,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
         assertThat(alertsRaised.get(0), containsNameLoadedWithKey(INSECURE_JSF));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_LOW));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
     }
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
@@ -120,7 +120,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_LOW));
         assertThat(alertsRaised.get(1).getName(), equalTo("Old Asp.Net Version in Use"));
         assertThat(alertsRaised.get(1).getWascId(), equalTo(14));
-        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(642));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
         assertSame(msg, alertsRaised.get(1).getMessage());
     }
@@ -148,7 +148,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
         assertThat(alertsRaised.get(0).getName(), equalTo("Emails Found in the Viewstate"));
         assertThat(alertsRaised.get(0).getOtherInfo(), equalTo("[Itest@test.com]"));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
         assertSame(msg, alertsRaised.get(0).getMessage());
     }
 
@@ -171,7 +171,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
                         "The following potential IP addresses were found being serialized in the viewstate field:"));
         assertThat(alertsRaised.get(0).getOtherInfo(), equalTo("[127.0.0.1]"));
         assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
-        assertThat(alertsRaised.get(0).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
         assertSame(msg, alertsRaised.get(0).getMessage());
     }
 
@@ -189,7 +189,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
         assertThat(alertsRaised.get(1).getName(), equalTo("Split Viewstate in Use"));
         assertThat(alertsRaised.get(1).getWascId(), equalTo(14));
-        assertThat(alertsRaised.get(1).getCweId(), equalTo(16));
+        assertThat(alertsRaised.get(1).getCweId(), equalTo(642));
         assertSame(msg, alertsRaised.get(0).getMessage());
     }
 

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
+- Discontinued use of CWE-16 and switched to more specific weaknesses in the following scan rules:
+  - Feature Policy
+  - Site Isolation
+  - Sub Resource Integrity
 
 ## [30] - 2021-02-08
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java
@@ -70,7 +70,7 @@ public class FeaturePolicyScanRule extends PluginPassiveScanner {
                     .setDescription(getAlertAttribute("desc"))
                     .setSolution(getAlertAttribute("soln"))
                     .setReference(getAlertAttribute("refs"))
-                    .setCweId(16) // CWE-16: Configuration
+                    .setCweId(693) // CWE-693: Protection Mechanism Failure
                     .setWascId(15) // WASC-15: Application Misconfiguration
                     .raise();
         }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
@@ -137,7 +137,7 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
                     .setDescription(getString("desc"))
                     .setSolution(getString("soln"))
                     .setReference(getString("refs"))
-                    .setCweId(16) // CWE-16: Configuration
+                    .setCweId(693) // CWE-693: Protection Mechanism Failure
                     .setWascId(14) // WASC-14: Server Misconfiguration
                     .setEvidence(evidence);
         }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
@@ -110,7 +110,8 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner 
                                     .setSolution(getString("soln"))
                                     .setReference(getString("refs"))
                                     .setEvidence(element.toString())
-                                    .setCweId(16) // CWE CATEGORY: Configuration
+                                    .setCweId(345) // CWE-345: Insufficient Verification of Data
+                                    // Authenticity
                                     .setWascId(15) // Application Misconfiguration
                                     .raise();
                         });

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Update RE2/J library to latest version (1.6).
 - PII Scan Rule will now ignore CSS and style information (Issue 6288).
+- Discontinued use of CWE-16 and switched to more specific weaknesses in the following scan rules:
+  - CSP Missing
+  - Insecure Form Load
+  - Insecure Form Post
+  - Strict-Transport-Security
 
 ## [24] - 2020-12-15
 ### Changed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
@@ -124,7 +124,7 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
                     .setDescription(getAlertAttribute("desc"))
                     .setSolution(getAlertAttribute("soln"))
                     .setReference(getAlertAttribute("refs"))
-                    .setCweId(16) // CWE-16: Configuration
+                    .setCweId(693) // CWE-693: Protection Mechanism Failure
                     .setWascId(15) // WASC-15: Application Misconfiguration
                     .raise();
         }
@@ -137,7 +137,7 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
                     .setDescription(getAlertAttribute("ro.desc"))
                     .setSolution(getAlertAttribute("soln"))
                     .setReference(getAlertAttribute("ro.refs"))
-                    .setCweId(16) // CWE-16: Configuration
+                    .setCweId(693) // CWE-693: Protection Mechanism Failure
                     .setWascId(15) // WASC-15: Application Misconfiguration
                     .raise();
         }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
@@ -98,7 +98,7 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner {
                 .setOtherInfo(getExtraInfoMessage(msg, formElement))
                 .setSolution(getSolutionMessage())
                 .setReference(getReferenceMessage())
-                .setCweId(16) // CWE-16: Configuration
+                .setCweId(319) // CWE-319: Cleartext Transmission of Sensitive Information
                 .setWascId(15) // WASC-15: Application Misconfiguration
                 .raise();
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
@@ -98,7 +98,7 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner {
                 .setOtherInfo(getExtraInfoMessage(msg, formElement))
                 .setSolution(getSolutionMessage())
                 .setReference(getReferenceMessage())
-                .setCweId(16) // CWE-16: Configuration
+                .setCweId(319) // CWE-319: Cleartext Transmission of Sensitive Information
                 .setWascId(15) // WASC-15: Application Misconfiguration
                 .raise();
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
@@ -101,7 +101,7 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner {
                 .setSolution(getAlertElement(currentVT, "soln"))
                 .setReference(getAlertElement(currentVT, "refs"))
                 .setEvidence(evidence)
-                .setCweId(16) // CWE-16: Configuration
+                .setCweId(319) // CWE-319: Cleartext Transmission of Sensitive Information
                 .setWascId(15) // WASC-15: Application Misconfiguration
                 .raise();
     }

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRuleUnitTest.java
@@ -233,7 +233,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
         assertThat(alert.getReference(), is(getLocalisedString(key + "refs")));
         assertThat(alert.getSolution(), is(getLocalisedString("soln")));
         assertThat(alert.getConfidence(), is(Alert.CONFIDENCE_HIGH));
-        assertThat(alert.getCweId(), is(16));
+        assertThat(alert.getCweId(), is(693));
         assertThat(alert.getWascId(), is(15));
         assertThat(alert.getUri(), is(URI));
     }


### PR DESCRIPTION
In all three pscanrules add-ons replace use of CWE-16 which is a category and shouldn't be referenced directly (per Mitre's guidance/documentation). [Update unit tests where necessary.]

In cases where a more specific CWE couldn't be identified, CWE-693 is now used (https://cwe.mitre.org/data/definitions/693.html):
```console
This weakness covers three distinct situations. A "missing" protection
mechanism occurs when the application does not define any mechanism against a certain
class of attack. An "insufficient" protection mechanism might provide some defenses
- for example, against the most common attacks - but it does not protect against
everything that is intended. Finally, an "ignored" mechanism occurs when a mechanism is
available and in active use within the product, but the developer has not applied it in
some code path. 

```

Fixes zaproxy/zaproxy#6533

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>