### PR TITLE
exim: De-duplicate first two components

### DIFF
--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -9,7 +9,7 @@ zapAddOn {
     zapVersion.set("2.10.0")
 
     manifest {
-        author.set("ZAP Dev Team")
+        author.set("ZAP Dev Team & thatsn0tmysite")
         url.set("https://www.zaproxy.org/docs/desktop/addons/import-export/")
 
         helpSet {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
@@ -1,0 +1,259 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.JMenu;
+import javax.swing.filechooser.FileFilter;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
+import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
+
+abstract class AbstractPopupMenuSaveMessage extends PopupMenuHttpMessageContainer {
+
+    private static final long serialVersionUID = 8080417865825721164L;
+
+    public static enum MessageComponent {
+        REQUEST,
+        REQUEST_HEADER,
+        REQUEST_BODY,
+        RESPONSE,
+        RESPONSE_HEADER,
+        RESPONSE_BODY
+    }
+
+    protected AbstractPopupMenuSaveMessage(
+            String messagePrefix, String fileExtension, ContentWriter writer) {
+        super(Constant.messages.getString(messagePrefix + "popup.option"));
+
+        String popupMenuAll = Constant.messages.getString("exim.popup.option.all");
+        String popupMenuBody = Constant.messages.getString("exim.popup.option.body");
+        String popupMenuHeader = Constant.messages.getString("exim.popup.option.header");
+        String popupMenuRequest = Constant.messages.getString("exim.popup.option.request");
+        String popupMenuResponse = Constant.messages.getString("exim.popup.option.response");
+
+        setButtonStateOverriddenByChildren(false);
+
+        JMenu request = new SaveMessagePopupMenu(popupMenuRequest, MessageComponent.REQUEST);
+        SaveMessagePopupMenuItem requestHeader =
+                new SaveMessagePopupMenuItem(
+                        popupMenuHeader, MessageComponent.REQUEST_HEADER, fileExtension, writer);
+
+        request.add(requestHeader);
+        SaveMessagePopupMenuItem requestBody =
+                new SaveMessagePopupMenuItem(
+                        popupMenuBody, MessageComponent.REQUEST_BODY, fileExtension, writer);
+        request.add(requestBody);
+        request.addSeparator();
+        SaveMessagePopupMenuItem requestAll =
+                new SaveMessagePopupMenuItem(
+                        popupMenuAll, MessageComponent.REQUEST, fileExtension, writer);
+        request.add(requestAll);
+        add(request);
+
+        JMenu response = new SaveMessagePopupMenu(popupMenuResponse, MessageComponent.RESPONSE);
+        SaveMessagePopupMenuItem responseHeader =
+                new SaveMessagePopupMenuItem(
+                        popupMenuHeader, MessageComponent.RESPONSE_HEADER, fileExtension, writer);
+        response.add(responseHeader);
+        SaveMessagePopupMenuItem responseBody =
+                new SaveMessagePopupMenuItem(
+                        popupMenuBody, MessageComponent.RESPONSE_BODY, fileExtension, writer);
+        response.add(responseBody);
+        response.addSeparator();
+        SaveMessagePopupMenuItem responseAll =
+                new SaveMessagePopupMenuItem(
+                        popupMenuAll, MessageComponent.RESPONSE, fileExtension, writer);
+        response.add(responseAll);
+        add(response);
+    }
+
+    @Override
+    public boolean precedeWithSeparator() {
+        return true;
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+
+    private static class SaveMessagePopupMenu extends PopupMenuHttpMessageContainer {
+
+        private static final long serialVersionUID = -6742362073862968150L;
+
+        private final MessageComponent messageComponent;
+
+        public SaveMessagePopupMenu(String label, MessageComponent messageComponent) {
+            super(label);
+
+            setButtonStateOverriddenByChildren(false);
+
+            if (!(messageComponent == MessageComponent.REQUEST
+                    || messageComponent == MessageComponent.RESPONSE)) {
+                throw new IllegalArgumentException("Parameter messageComponent is not supported.");
+            }
+
+            this.messageComponent = messageComponent;
+        }
+
+        @Override
+        protected boolean isButtonEnabledForSelectedHttpMessage(HttpMessage httpMessage) {
+            boolean enabled = false;
+            if (MessageComponent.REQUEST == messageComponent) {
+                enabled = !httpMessage.getRequestHeader().isEmpty();
+            } else if (MessageComponent.RESPONSE == messageComponent) {
+                enabled = !httpMessage.getResponseHeader().isEmpty();
+            }
+
+            return enabled;
+        }
+
+        @Override
+        public boolean isSafe() {
+            return true;
+        }
+    }
+
+    private static class SaveMessagePopupMenuItem extends PopupMenuItemHttpMessageContainer {
+
+        private static final long serialVersionUID = -4108212857830575776L;
+
+        private final MessageComponent messageComponent;
+
+        private final String fileExtension;
+        private final String fileDescription;
+        private final ContentWriter writer;
+
+        public SaveMessagePopupMenuItem(
+                String label,
+                MessageComponent messageComponent,
+                String fileExtension,
+                ContentWriter writer) {
+            super(label);
+
+            this.messageComponent = messageComponent;
+            this.fileExtension = fileExtension;
+            this.fileDescription = fileExtension;
+            this.writer = writer;
+        }
+
+        @Override
+        public boolean isButtonEnabledForSelectedHttpMessage(HttpMessage httpMessage) {
+            boolean enabled = false;
+            switch (messageComponent) {
+                case REQUEST_HEADER:
+                    enabled = !httpMessage.getRequestHeader().isEmpty();
+                    break;
+                case REQUEST_BODY:
+                case REQUEST:
+                    enabled = (httpMessage.getRequestBody().length() != 0);
+                    break;
+                case RESPONSE_HEADER:
+                    enabled = !httpMessage.getResponseHeader().isEmpty();
+                    break;
+                case RESPONSE_BODY:
+                case RESPONSE:
+                    enabled = (httpMessage.getResponseBody().length() != 0);
+                    break;
+                default:
+                    enabled = false;
+            }
+
+            return enabled;
+        }
+
+        @Override
+        public void performAction(HttpMessage httpMessage) {
+            File file = getOutputFile();
+            if (file == null) {
+                return;
+            }
+
+            writer.writeOutput(messageComponent, httpMessage, file);
+        }
+
+        @Override
+        public boolean isSafe() {
+            return true;
+        }
+
+        private File getOutputFile() {
+            SaveFileChooser fileChooser = new SaveFileChooser();
+            int rc = fileChooser.showSaveDialog(View.getSingleton().getMainFrame());
+            if (rc == JFileChooser.APPROVE_OPTION) {
+                return fileChooser.getSelectedFile();
+            }
+            return null;
+        }
+
+        private class SaveFileChooser extends WritableFileChooser {
+
+            private static final long serialVersionUID = -5743352709683023906L;
+
+            public SaveFileChooser() {
+                super(Model.getSingleton().getOptionsParam().getUserDirectory());
+                setFileFilter(new SpecificFileFilter());
+            }
+
+            @Override
+            public void approveSelection() {
+                File file = getSelectedFile();
+                if (file != null) {
+                    String fileName = file.getAbsolutePath();
+                    if (!fileName.endsWith(fileExtension)) {
+                        fileName += fileExtension;
+                        setSelectedFile(new File(fileName));
+                    }
+                }
+
+                super.approveSelection();
+            }
+        }
+
+        private class SpecificFileFilter extends FileFilter {
+
+            @Override
+            public boolean accept(File file) {
+                if (file.isDirectory()) {
+                    return true;
+                } else if (file.isFile() && file.getName().endsWith(fileExtension)) {
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public String getDescription() {
+                return fileDescription;
+            }
+        }
+    }
+
+    public interface ContentWriter {
+
+        void writeOutput(MessageComponent messageComponent, HttpMessage httpMessage, File file);
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveRawMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveRawMessage.java
@@ -24,220 +24,59 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.text.MessageFormat;
-import javax.swing.JFileChooser;
-import javax.swing.JMenu;
-import javax.swing.filechooser.FileFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
-import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
-import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
-import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
-class PopupMenuSaveRawMessage extends PopupMenuHttpMessageContainer {
-
+public class PopupMenuSaveRawMessage extends AbstractPopupMenuSaveMessage {
     private static final long serialVersionUID = -7217818541206464572L;
+    private static final Logger LOG = LogManager.getLogger(PopupMenuSaveRawMessage.class);
 
-    private static final Logger log = LogManager.getLogger(PopupMenuSaveRawMessage.class);
-
-    private static final String POPUP_MENU_LABEL =
-            Constant.messages.getString("exim.saveraw.popup.option");
-    private static final String POPUP_MENU_ALL =
-            Constant.messages.getString("exim.saveraw.popup.option.all");
-    private static final String POPUP_MENU_BODY =
-            Constant.messages.getString("exim.saveraw.popup.option.body");
-    private static final String POPUP_MENU_HEADER =
-            Constant.messages.getString("exim.saveraw.popup.option.header");
-    private static final String POPUP_MENU_REQUEST =
-            Constant.messages.getString("exim.saveraw.popup.option.request");
-    private static final String POPUP_MENU_RESPONSE =
-            Constant.messages.getString("exim.saveraw.popup.option.response");
-
-    private static final String FILE_DESCRIPTION =
-            Constant.messages.getString("exim.saveraw.file.description");
-    private static final String ERROR_SAVE =
-            Constant.messages.getString("exim.saveraw.file.save.error");
-
+    private static final String MESSAGE_PREFIX = "exim.saveraw.";
     private static final String RAW_FILE_EXTENSION = ".raw";
 
-    private static enum MessageComponent {
-        REQUEST,
-        REQUEST_HEADER,
-        REQUEST_BODY,
-        RESPONSE,
-        RESPONSE_HEADER,
-        RESPONSE_BODY
-    }
-
     public PopupMenuSaveRawMessage() {
-        super(POPUP_MENU_LABEL);
-
-        setButtonStateOverriddenByChildren(false);
-
-        JMenu request = new SaveMessagePopupMenu(POPUP_MENU_REQUEST, MessageComponent.REQUEST);
-        SaveMessagePopupMenuItem requestHeader =
-                new SaveMessagePopupMenuItem(POPUP_MENU_HEADER, MessageComponent.REQUEST_HEADER);
-
-        request.add(requestHeader);
-        SaveMessagePopupMenuItem requestBody =
-                new SaveMessagePopupMenuItem(POPUP_MENU_BODY, MessageComponent.REQUEST_BODY);
-        request.add(requestBody);
-        request.addSeparator();
-        SaveMessagePopupMenuItem requestAll =
-                new SaveMessagePopupMenuItem(POPUP_MENU_ALL, MessageComponent.REQUEST);
-        request.add(requestAll);
-        add(request);
-
-        JMenu response = new SaveMessagePopupMenu(POPUP_MENU_RESPONSE, MessageComponent.RESPONSE);
-        SaveMessagePopupMenuItem responseHeader =
-                new SaveMessagePopupMenuItem(POPUP_MENU_HEADER, MessageComponent.RESPONSE_HEADER);
-        response.add(responseHeader);
-        SaveMessagePopupMenuItem responseBody =
-                new SaveMessagePopupMenuItem(POPUP_MENU_BODY, MessageComponent.RESPONSE_BODY);
-        response.add(responseBody);
-        response.addSeparator();
-        SaveMessagePopupMenuItem responseAll =
-                new SaveMessagePopupMenuItem(POPUP_MENU_ALL, MessageComponent.RESPONSE);
-        response.add(responseAll);
-        add(response);
+        super(MESSAGE_PREFIX, RAW_FILE_EXTENSION, PopupMenuSaveRawMessage::writeOutput);
     }
 
-    @Override
-    public boolean precedeWithSeparator() {
-        return true;
-    }
+    private static void writeOutput(
+            MessageComponent messageComponent, HttpMessage httpMessage, File file) {
+        byte[] bytes = new byte[0];
 
-    @Override
-    public boolean isSafe() {
-        return true;
-    }
+        byte[] bytesHeader;
+        byte[] bytesBody;
 
-    private static class SaveMessagePopupMenu extends PopupMenuHttpMessageContainer {
-
-        private static final long serialVersionUID = -6742362073862968150L;
-
-        private final MessageComponent messageComponent;
-
-        public SaveMessagePopupMenu(String label, MessageComponent messageComponent) {
-            super(label);
-
-            setButtonStateOverriddenByChildren(false);
-
-            if (!(messageComponent == MessageComponent.REQUEST
-                    || messageComponent == MessageComponent.RESPONSE)) {
-                throw new IllegalArgumentException("Parameter messageComponent is not supported.");
-            }
-
-            this.messageComponent = messageComponent;
+        switch (messageComponent) {
+            case REQUEST_HEADER:
+                bytes = httpMessage.getRequestHeader().toString().getBytes();
+                break;
+            case REQUEST_BODY:
+                bytes = httpMessage.getRequestBody().getBytes();
+                break;
+            case REQUEST:
+                bytesHeader = httpMessage.getRequestHeader().toString().getBytes();
+                bytesBody = httpMessage.getRequestBody().getBytes();
+                bytes = new byte[bytesHeader.length + bytesBody.length];
+                System.arraycopy(bytesHeader, 0, bytes, 0, bytesHeader.length);
+                System.arraycopy(bytesBody, 0, bytes, bytesHeader.length, bytesBody.length);
+                break;
+            case RESPONSE_HEADER:
+                bytes = httpMessage.getResponseHeader().toString().getBytes();
+                break;
+            case RESPONSE_BODY:
+                bytes = httpMessage.getResponseBody().getBytes();
+                break;
+            case RESPONSE:
+                bytesHeader = httpMessage.getResponseHeader().toString().getBytes();
+                bytesBody = httpMessage.getResponseBody().getBytes();
+                bytes = new byte[bytesHeader.length + bytesBody.length];
+                System.arraycopy(bytesHeader, 0, bytes, 0, bytesHeader.length);
+                System.arraycopy(bytesBody, 0, bytes, bytesHeader.length, bytesBody.length);
+                break;
         }
-
-        @Override
-        protected boolean isButtonEnabledForSelectedHttpMessage(HttpMessage httpMessage) {
-            boolean enabled = false;
-            if (MessageComponent.REQUEST == messageComponent) {
-                enabled = !httpMessage.getRequestHeader().isEmpty();
-            } else if (MessageComponent.RESPONSE == messageComponent) {
-                enabled = !httpMessage.getResponseHeader().isEmpty();
-            }
-
-            return enabled;
-        }
-
-        @Override
-        public boolean isSafe() {
-            return true;
-        }
-    }
-
-    private static class SaveMessagePopupMenuItem extends PopupMenuItemHttpMessageContainer {
-
-        private static final long serialVersionUID = -4108212857830575776L;
-
-        private final MessageComponent messageComponent;
-
-        public SaveMessagePopupMenuItem(String label, MessageComponent messageComponent) {
-            super(label);
-
-            this.messageComponent = messageComponent;
-        }
-
-        @Override
-        public boolean isButtonEnabledForSelectedHttpMessage(HttpMessage httpMessage) {
-            boolean enabled = false;
-            switch (messageComponent) {
-                case REQUEST_HEADER:
-                    enabled = !httpMessage.getRequestHeader().isEmpty();
-                    break;
-                case REQUEST_BODY:
-                case REQUEST:
-                    enabled = (httpMessage.getRequestBody().length() != 0);
-                    break;
-                case RESPONSE_HEADER:
-                    enabled = !httpMessage.getResponseHeader().isEmpty();
-                    break;
-                case RESPONSE_BODY:
-                case RESPONSE:
-                    enabled = (httpMessage.getResponseBody().length() != 0);
-                    break;
-                default:
-                    enabled = false;
-            }
-
-            return enabled;
-        }
-
-        @Override
-        public void performAction(HttpMessage httpMessage) {
-            File file = getOutputFile();
-            if (file == null) {
-                return;
-            }
-
-            byte[] bytes = new byte[0];
-
-            byte[] bytesHeader;
-            byte[] bytesBody;
-
-            switch (messageComponent) {
-                case REQUEST_HEADER:
-                    bytes = httpMessage.getRequestHeader().toString().getBytes();
-                    break;
-                case REQUEST_BODY:
-                    bytes = httpMessage.getRequestBody().getBytes();
-                    break;
-                case REQUEST:
-                    bytesHeader = httpMessage.getRequestHeader().toString().getBytes();
-                    bytesBody = httpMessage.getRequestBody().getBytes();
-                    bytes = new byte[bytesHeader.length + bytesBody.length];
-                    System.arraycopy(bytesHeader, 0, bytes, 0, bytesHeader.length);
-                    System.arraycopy(bytesBody, 0, bytes, bytesHeader.length, bytesBody.length);
-                    break;
-                case RESPONSE_HEADER:
-                    bytes = httpMessage.getResponseHeader().toString().getBytes();
-                    break;
-                case RESPONSE_BODY:
-                    bytes = httpMessage.getResponseBody().getBytes();
-                    break;
-                case RESPONSE:
-                    bytesHeader = httpMessage.getResponseHeader().toString().getBytes();
-                    bytesBody = httpMessage.getResponseBody().getBytes();
-                    bytes = new byte[bytesHeader.length + bytesBody.length];
-                    System.arraycopy(bytesHeader, 0, bytes, 0, bytesHeader.length);
-                    System.arraycopy(bytesBody, 0, bytes, bytesHeader.length, bytesBody.length);
-                    break;
-            }
-
-            writeToFile(file, bytes);
-        }
-
-        @Override
-        public boolean isSafe() {
-            return true;
-        }
+        writeToFile(file, bytes);
     }
 
     private static void writeToFile(File file, byte[] bytes) {
@@ -245,59 +84,10 @@ class PopupMenuSaveRawMessage extends PopupMenuHttpMessageContainer {
             fw.write(bytes);
         } catch (IOException e) {
             View.getSingleton()
-                    .showWarningDialog(MessageFormat.format(ERROR_SAVE, file.getAbsolutePath()));
-            log.error(e.getMessage(), e);
-        }
-    }
-
-    private static File getOutputFile() {
-        SaveRawFileChooser fileChooser = new SaveRawFileChooser();
-        int rc = fileChooser.showSaveDialog(View.getSingleton().getMainFrame());
-        if (rc == JFileChooser.APPROVE_OPTION) {
-            return fileChooser.getSelectedFile();
-        }
-        return null;
-    }
-
-    private static class SaveRawFileChooser extends WritableFileChooser {
-
-        private static final long serialVersionUID = -5743352709683023906L;
-
-        public SaveRawFileChooser() {
-            super(Model.getSingleton().getOptionsParam().getUserDirectory());
-            setFileFilter(new RawFileFilter());
-        }
-
-        @Override
-        public void approveSelection() {
-            File file = getSelectedFile();
-            if (file != null) {
-                String fileName = file.getAbsolutePath();
-                if (!fileName.endsWith(RAW_FILE_EXTENSION)) {
-                    fileName += RAW_FILE_EXTENSION;
-                    setSelectedFile(new File(fileName));
-                }
-            }
-
-            super.approveSelection();
-        }
-    }
-
-    private static final class RawFileFilter extends FileFilter {
-
-        @Override
-        public boolean accept(File file) {
-            if (file.isDirectory()) {
-                return true;
-            } else if (file.isFile() && file.getName().endsWith(RAW_FILE_EXTENSION)) {
-                return true;
-            }
-            return false;
-        }
-
-        @Override
-        public String getDescription() {
-            return FILE_DESCRIPTION;
+                    .showWarningDialog(
+                            Constant.messages.getString(
+                                    "exim.file.save.error", file.getAbsolutePath()));
+            LOG.error(e.getMessage(), e);
         }
     }
 }

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -1,17 +1,13 @@
-exim.saveraw.file.description = Raw
-exim.saveraw.file.save.error = Error saving file to {0}.
-exim.saveraw.popup.option = Save Raw
-exim.saveraw.popup.option.all = All
-exim.saveraw.popup.option.body = Body
-exim.saveraw.popup.option.header = Header
-exim.saveraw.popup.option.request = Request
-exim.saveraw.popup.option.response = Response
+exim.file.save.error = Error saving file to {0}.
 
-exim.savexml.file.description  = XML
+exim.popup.option.all = All
+exim.popup.option.body = Body
+exim.popup.option.header = Header
+exim.popup.option.request = Request
+exim.popup.option.response = Response
+
+exim.saveraw.file.extension = Raw
+exim.saveraw.popup.option = Save Raw
+
+exim.savexml.file.extension  = XML
 exim.savexml.popup.option = Save XML
-exim.savexml.popup.option.all = All
-exim.savexml.popup.option.body = Body
-exim.savexml.file.save.error = Error saving file to {0}.
-exim.savexml.popup.option.header = Header
-exim.savexml.popup.option.request = Request
-exim.savexml.popup.option.response = Response


### PR DESCRIPTION
Reduce duplication for the original saverawmessage and savexmlmessage components now that they're in a single add-on. This creates an abstract class for the popup menus, and an output interface for processing content and actually writing to the file.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>