### PR TITLE
ascanrulesBeta: trace.axd rule FP fix

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - The .env file scan rule now performs a simple content check to reduce false positives (Issue 6099).
+- The trace.axd file scan rule now performs a content check to reduce false positives (Issue 6517).
 
 ## [33] - 2020-12-15
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRule.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.ascanrulesBeta;
 
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.AbstractAppFilePlugin;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
@@ -41,6 +42,14 @@ public class TraceAxdScanRule extends AbstractAppFilePlugin {
     @Override
     public int getId() {
         return PLUGIN_ID;
+    }
+
+    @Override
+    public boolean isFalsePositive(HttpMessage msg) {
+        String body = msg.getResponseBody().toString();
+        return !body.contains("Application Trace")
+                && !body.contains("Request Details")
+                && !body.contains("Trace Information");
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRuleUnitTest.java
@@ -1,0 +1,114 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesBeta;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.AbstractAppFilePluginUnitTest;
+
+/** Unit test for {@link TraceAxdScanRule}. */
+public class TraceAxdScanRuleUnitTest extends AbstractAppFilePluginUnitTest<TraceAxdScanRule> {
+
+    private static final String RELEVANT_BODY = "<html><H1>Application Trace</H1></html>";
+    private static final String IRRELEVANT_BODY = "<html><title>Some Page</title></html>";
+
+    @Override
+    protected TraceAxdScanRule createScanner() {
+        return new TraceAxdScanRule();
+    }
+
+    @Override
+    protected void setUpMessages() {
+        mockMessages(new ExtensionAscanRulesBeta());
+    }
+
+    @Override
+    @Test
+    public void shouldAlertWhenRequestIsSuccessful() throws Exception {
+        // Given
+        String path = "/trace.axd";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, RELEVANT_BODY)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(1, httpMessagesSent.size());
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_MEDIUM, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_MEDIUM, alert.getConfidence());
+    }
+
+    @Override
+    @Test
+    public void shouldAlertWhenRequestIsUnauthorizedAtLowThreshold() throws Exception {
+        // Given
+        String path = "/trace.axd";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.UNAUTHORIZED,
+                                NanoHTTPD.MIME_HTML,
+                                IRRELEVANT_BODY)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertEquals(1, httpMessagesSent.size());
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_INFO, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_LOW, alert.getConfidence());
+    }
+
+    @Test
+    public void shouldNotAlertWhenRequestIsSuccessfulButContentNotRelevant() throws Exception {
+        // Given
+        String path = "/trace.axd";
+        this.nano.addHandler(
+                createHandler(
+                        path,
+                        newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, IRRELEVANT_BODY)));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+    }
+}


### PR DESCRIPTION
- TraceAxdScanRule > Add overridden `isFalsePositive(HttpMessage)` method that performs a simple content check.
- TraceAxdScanRuleUnitTest > Add unit test to assert the new behavior.
- CHANGELOG  > Add change note.

Content strings are based on screenshots:
https://docs.microsoft.com/en-us/previous-versions/aspnet/bb386420(v=vs.100)

Fixes zaproxy/zaproxy#6517

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>