### PR TITLE
webdrivers: update ChromeDriver, prepare releases

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [28] - 2021-04-15
+### Changed
+- Update ChromeDriver to 90.0.4430.24.
 
 ## [27] - 2021-04-09
 ### Changed
@@ -131,6 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[28]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v28
 [27]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdriverlinux-v25

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,7 +9,7 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 89.0.4389.23</li>
+    <li>Chrome - ChromeDriver 90.0.4430.24</li>
     <li>Firefox - geckodriver 0.29.1</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [27] - 2021-04-15
+### Changed
+- Update ChromeDriver to 90.0.4430.24.
 
 ## [26] - 2021-04-09
 ### Changed
@@ -127,6 +128,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[27]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v25
 [24]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v24

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,7 +9,7 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 89.0.4389.23</li>
+    <li>Chrome - ChromeDriver 90.0.4430.24</li>
     <li>Firefox - geckodriver 0.29.1</li>
 </ul>
 

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,7 +5,7 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 description = "Common configuration of the WebDriver add-ons."
 
 val geckodriverVersion = "0.29.1"
-val chromeDriverVersion = "89.0.4389.23"
+val chromeDriverVersion = "90.0.4430.24"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [28] - 2021-04-15
+### Changed
+- Update ChromeDriver to 90.0.4430.24.
 
 ## [27] - 2021-04-09
 ### Changed
@@ -134,6 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27 IE 3.0.0
 
+[28]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v28
 [27]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdriverwindows-v25

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,7 +9,7 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 89.0.4389.23</li>
+    <li>Chrome - ChromeDriver 90.0.4430.24</li>
     <li>Firefox - geckodriver 0.29.1</li>
 </ul>
 


### PR DESCRIPTION
Update ChromeDriver to 90.0.4430.24.
Add release dates and links to tags.