### PR TITLE
Improved XXE rule to consider the case when the XML is part of a multipart request

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Added evidence
 - The Source Code Disclosure - File Inclusion scan rule was modified to make use of the Dice algorithm for calculating the match percentage, thus improving its performance.
 - Maintenance changes.
+- XML External Entity Attack scan rule extended to detect XXE attacks when the XML is part of a multipart request.
 
 ### Fixed
 - Add missing file, used by Hidden File Finder scan rule.

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -341,7 +341,8 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 This component attempts to identify applications which are subject to XML eXternal Entity (XXE) attacks.
 Applications which parse XML input may be subject to XXE when weakly or poorly configured parsers 
 handle XML input containing reference to an external entity such as a local file, HTTP requests to 
-internal or tertiary systems, etc. The number of tags which are tested individually depends on the strength of the rule.<br>
+internal or tertiary systems, etc. It tests the request in both cases, whether the XML is directly POSTed 
+to the server or is part of a multipart request. The number of tags which are tested individually depends on the strength of the rule.<br>
 <br>
 It requires the Callback extension, so will not work if this extension is disabled or removed. 
 It is also recommended that you test that the Callback extension is correctly configured for your target site.


### PR DESCRIPTION
The XXE scan rule was extended to cover the possibility of a XML file being uploaded as part of a multipart/form-data request, rather than being simply POSTed to an endpoint.

Fixes zaproxy/zaproxy#1190