### PR TITLE
zest: track changes done to scripts

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Clear Zest Results Panel when new script is added.
 - Update minimum ZAP version to 2.10.0.
 
+### Fixed
+- Track modifications done to the scripts to refresh the cached ones (Issue 6558).
+
 ## [33] - 2020-11-27
 ### Added
 - Allow to create a screenshot from the browser, using the context menu `Add Zest Client` > `Screenshot`.

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -576,6 +576,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
         logger.debug("Updated node={}", node.getNodeName());
         this.getZestTreeModel().update(node);
         ZestScriptWrapper sw = this.getZestTreeModel().getScriptWrapper(node);
+        sw.incModCount();
         sw.setChanged(true);
 
         if (this.getExtScript().getScriptUI() != null

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -44,6 +44,7 @@ public class ZestScriptWrapper extends ScriptWrapper {
     private ScriptWrapper original = null;
     private boolean debug = false;
     private boolean recording = false;
+    private int zestModCount;
 
     public ZestScriptWrapper(ScriptWrapper script) {
         this.original = script;
@@ -170,7 +171,16 @@ public class ZestScriptWrapper extends ScriptWrapper {
 
     @Override
     public void setContents(String script) {
-        // Do nothing - its all handled elsewhere
+        incModCount();
+    }
+
+    void incModCount() {
+        zestModCount++;
+    }
+
+    @Override
+    public int getModCount() {
+        return zestModCount;
     }
 
     @Override


### PR DESCRIPTION
Keep mod count in `ZestScriptWrapper` to properly report changes done to
the scripts (to refresh cached ones).
Change `ExtensionZest` to update the mod count of the scripts when
changed.

Fix zaproxy/zaproxy#6558.