### PR TITLE
sqliplugin: remove usage of redirect exception

### DIFF
--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
@@ -27,8 +27,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.RedirectException;
-import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1148,7 +1147,7 @@ public class SQLInjectionScanRule extends AbstractAppParamPlugin {
                 lastErrorPageUID = lastRequestUID;
             }
 
-        } catch (RedirectException | URIException e) {
+        } catch (HttpException e) {
             log.debug(
                     "SQL Injection vulnerability check failed for parameter [{}] and payload [{}] due to: {}",
                     paramName,


### PR DESCRIPTION
Catch HTTP exception instead (base class of redirect exception and URI
exception) to remove the usage of redirect exception class.
While other exceptions might be caught where previously wouldn't they
are caused by malformed response (like with the redirection).