### PR TITLE
webdrivermacos: bundle correct geckodriver

### DIFF
--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
-
+## [28] - 2021-04-23
+### Fixed
+ - Bundle geckodriver with the correct architecture (Issue 6543).
 
 ## [27] - 2021-04-15
 ### Changed
@@ -131,6 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - First release: Firefox v0.13.0 Chrome v2.27
 
+[28]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v28
 [27]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v27
 [26]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v26
 [25]: https://github.com/zaproxy/zap-extensions/releases/webdrivermacos-v25

--- a/buildSrc/src/main/java/org/zaproxy/gradle/tasks/DownloadWebDriver.java
+++ b/buildSrc/src/main/java/org/zaproxy/gradle/tasks/DownloadWebDriver.java
@@ -27,9 +27,11 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -157,6 +159,13 @@ public abstract class DownloadWebDriver extends DefaultTask {
 
             FirefoxDriverManagerCustom() {
                 instanceMap.put(DriverManagerType.FIREFOX, this);
+            }
+
+            @Override
+            protected List<URL> getDrivers() throws IOException {
+                List<URL> urls = super.getDrivers();
+                urls.removeIf(url -> url.toString().contains("aarch64"));
+                return urls;
             }
 
             @Override


### PR DESCRIPTION
Exclude aarch64 when obtaining the download URLs of geckodriver to
bundle the one with the correct architecture.
Prepare release of the add-on.

Fix zaproxy/zaproxy#6543.