### PR TITLE
reports: add logging bridge

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Correct logging of dependency.
 
 ## [0.2.0] - 2021-04-12
 

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -38,6 +38,11 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.0")
     implementation("org.snakeyaml:snakeyaml-engine:2.2.1")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1") {
+        // Provided by ZAP.
+        exclude(group = "org.apache.logging.log4j")
+    }
+
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
Add bridge for slf4j, used by a dependency.

Reported in zaproxy/zaproxy#6524.