### PR TITLE
reports: do not rely on default encoding

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Correct logging of dependency.
 
+### Fixed
+- Do not rely on default encoding when creating the reports, use UTF-8 always (Issue 6561).
+
 ## [0.2.0] - 2021-04-12
 
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -23,10 +23,12 @@ import com.lowagie.text.DocumentException;
 import java.awt.Desktop;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Writer;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -316,9 +318,9 @@ public class ExtensionReports extends ExtensionAdaptor {
         }
 
         File file = new File(reportFilename);
-        try (FileWriter fileWriter = new FileWriter(file)) {
+        try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
             templateEngine.process(
-                    template.getReportTemplateFile().getAbsolutePath(), context, fileWriter);
+                    template.getReportTemplateFile().getAbsolutePath(), context, writer);
         }
 
         if ("PDF".equals(template.getFormat())) {


### PR DESCRIPTION
Use UTF-8 to write the reports, to prevent encoding issues.

Fix zaproxy/zaproxy#6561.