### PR TITLE
scripts: do not show hidden script engines

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Do not show `Null` script engine in Edit Script dialogue.
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Update links to zaproxy repo.
 - Maintenance Changes.

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/EditScriptDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/EditScriptDialog.java
@@ -52,7 +52,9 @@ public class EditScriptDialog extends StandardFieldsDialog {
         if (script != null) {
             this.removeAllFields();
             this.addTextField(FIELD_NAME, script.getName());
-            this.addTextFieldReadOnly(FIELD_ENGINE, getScriptEngineName());
+            if (script.getEngine() == null || script.getEngine().isVisible()) {
+                this.addTextFieldReadOnly(FIELD_ENGINE, getScriptEngineName());
+            }
             this.addTextFieldReadOnly(FIELD_FILE, "");
             this.addMultilineField(FIELD_DESC, script.getDescription());
             this.addCheckBoxField(FIELD_LOAD, script.isLoadOnStart());


### PR DESCRIPTION
Change Edit Script dialogue to not show hidden engines, which are not
actual script engines (e.g. avoid showing " : Null").