### PR TITLE
pscanrulesBeta: Hash Disclosure Skip JS unless Threshold Low

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Insecure Form Load
   - Insecure Form Post
   - Strict-Transport-Security
+- Hash Disclosure scan rule will now only evaluate JavaScript responses at Low threshold (Issue 6071).
 
 ## [24] - 2020-12-15
 ### Changed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -189,7 +190,10 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
      */
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-
+        if (msg.getResponseHeader().isJavaScript()
+                && !AlertThreshold.LOW.equals(this.getAlertThreshold())) {
+            return;
+        }
         log.debug("Checking response of message {} for Hashes", msg);
 
         // get the response contents as an array of Strings, so we can match against them

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -40,7 +40,9 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 
 <H2>Hash Disclosure</H2>
 Passively scans for password hashes disclosed by the web server. <br>
-Various formats are including, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes. 
+Various formats are including, including some formats such as MD4, MD5, and SHA*, which are sometimes used for purposes other than to contain password hashes.
+<br>
+<strong>Note:</strong> This scan rule will only analyze JavaScript responses on LOW Threshold. 
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java">HashDisclosureScanRule.java</a>
 


### PR DESCRIPTION
- CHANGELOG > Added change note.
- HashDisclosureScanRule > Add necessary logic.
- HashDisclosureScanRuleUnitTest > Add tests to assert the new behavior.
- pscanbeta.html > Add note to help.

Fixes zaproxy/zaproxy#6071

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>