### PR TITLE
scripts: improve: Copy as curl Command extender JavaScript script

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Update links to zaproxy repo.
 - Maintenance Changes.
+- 'Copy as curl command menu.js' is now preceded by a separator, and the Title Caps of the menu item were fixed (Issue 2000).
 
 ## [28] - 2020-12-18
 

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
@@ -5,9 +5,12 @@
 
 // Script variable to use when uninstalling
 var popupmenuitemtype = Java.type("org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer");
-var curlmenuitem = new popupmenuitemtype("Copy as curl command") {
+var curlmenuitem = new popupmenuitemtype("Copy as curl Command") {
 	performAction: function(href) {
 		invokeWith(href.getHttpMessage());
+	},
+	precedeWithSeparator: function() {
+		return true;
 	}
 }
 


### PR DESCRIPTION
- Menu item is now preceded by a separator.
- Tweaked the capitalization of the menu item (title caps, curl was purposefully left lowercase and that's how it's usually presented,
despite being a name).

![image](https://user-images.githubusercontent.com/7570458/116332285-7769e780-a79f-11eb-83bf-e2dabb8cf50b.png)

<sub>Ignore the XML/HAR part, an old build of exim was installed.</sub>

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>