### PR TITLE
Implement initial sanity check before running the jobs

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
@@ -67,22 +67,39 @@ public class SpiderJob extends AutomationJob {
         return extSpider;
     }
 
-    public boolean applyCustomParameter(String name, String value) {
+    private boolean verifyOrApplyCustomParameter(
+            String name, String value, AutomationProgress progress) {
         switch (name) {
             case PARAM_CONTEXT:
-                contextName = value;
+                if (progress == null) {
+                    contextName = value;
+                }
                 return true;
             case PARAM_URL:
-                url = value;
+                if (progress == null) {
+                    url = value;
+                }
                 return true;
             case PARAM_FAIL_IF_LESS_URLS:
-                failIfFoundUrlsLessThan = Integer.parseInt(value);
+                if (progress != null) {
+                    verifyIntValue(name, value, progress);
+                } else {
+                    failIfFoundUrlsLessThan = Integer.parseInt(value);
+                }
                 return true;
             case PARAM_WARN_IF_LESS_URLS:
-                warnIfFoundUrlsLessThan = Integer.parseInt(value);
+                if (progress != null) {
+                    verifyIntValue(name, value, progress);
+                } else {
+                    warnIfFoundUrlsLessThan = Integer.parseInt(value);
+                }
                 return true;
             case PARAM_MAX_DURATION:
-                maxDuration = Integer.parseInt(value);
+                if (progress != null) {
+                    verifyIntValue(name, value, progress);
+                } else {
+                    maxDuration = Integer.parseInt(value);
+                }
                 // Don't consume this as we still want it to be applied to the spider params
                 return false;
             default:
@@ -90,6 +107,26 @@ public class SpiderJob extends AutomationJob {
                 break;
         }
         return false;
+    }
+
+    private void verifyIntValue(String name, String value, AutomationProgress progress) {
+        try {
+            Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            progress.error(
+                    Constant.messages.getString(
+                            "automation.error.options.badint", this.getName(), name, value));
+        }
+    }
+
+    @Override
+    public boolean applyCustomParameter(String name, String value) {
+        return this.verifyOrApplyCustomParameter(name, value, null);
+    }
+
+    @Override
+    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {
+        this.verifyOrApplyCustomParameter(name, value, progress);
     }
 
     @Override

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
@@ -376,7 +376,7 @@ class AutomationJobUnitTest {
         Map map = new HashMap();
         LinkedHashMap<?, ?> params = new LinkedHashMap(map);
         // When
-        job.applyParameters(tpc, "getBadTestParam", params, progress);
+        job.verifyOrApplyParameters(tpc, "getBadTestParam", params, progress, false);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(true)));

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -319,7 +319,7 @@ class ExtentionAutomationUnitTest extends TestUtils {
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(true)));
-        assertThat(job1.wasRun(), is(equalTo(true)));
+        assertThat(job1.wasRun(), is(equalTo(false)));
         assertThat(job3.wasRun(), is(equalTo(false)));
     }
 

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -365,10 +365,9 @@ class ActiveScanJobUnitTest {
         data.put("policyDefinition", "Incorrect");
 
         // When
-        ScanPolicy policy = job.getScanPolicy(data, progress);
+        job.verifyJobSpecificData(data, progress);
 
         // Then
-        assertThat(policy, is(nullValue()));
         assertThat(progress.hasWarnings(), is(equalTo(true)));
         assertThat(
                 progress.getWarnings().get(0), is(equalTo("!automation.error.options.badlist!")));
@@ -530,7 +529,7 @@ class ActiveScanJobUnitTest {
         data.put("policyDefinition", policyDefn);
 
         // When
-        job.getScanPolicy(data, progress);
+        job.verifyJobSpecificData(data, progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(true)));
@@ -560,7 +559,7 @@ class ActiveScanJobUnitTest {
         data.put("policyDefinition", policyDefn);
 
         // When
-        job.getScanPolicy(data, progress);
+        job.verifyJobSpecificData(data, progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(true)));
@@ -588,7 +587,7 @@ class ActiveScanJobUnitTest {
         data.put("policyDefinition", policyDefn);
 
         // When
-        job.getScanPolicy(data, progress);
+        job.verifyJobSpecificData(data, progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(true)));
@@ -616,7 +615,7 @@ class ActiveScanJobUnitTest {
         data.put("policyDefinition", policyDefn);
 
         // When
-        job.getScanPolicy(data, progress);
+        job.verifyJobSpecificData(data, progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(true)));
@@ -645,7 +644,7 @@ class ActiveScanJobUnitTest {
         data.put("policyDefinition", policyDefn);
 
         // When
-        job.getScanPolicy(data, progress);
+        job.verifyJobSpecificData(data, progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(true)));

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/AddOnJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/AddOnJobUnitTest.java
@@ -147,6 +147,49 @@ class AddOnJobUnitTest {
     }
 
     @Test
+    void shouldErrorOnUnkownInstallDataFormat() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        AddOnJob job = new AddOnJob();
+        String contextStr = "parameters: \n  updateAddOns: false\n" + "install: addonOne, addonTwo";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> jobData =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+
+        // When
+        job.verifyJobSpecificData(jobData, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(
+                progress.getErrors().get(0), is(equalTo("!automation.error.addons.addon.data!")));
+    }
+
+    @Test
+    void shouldErrorOnUnkownUninstallDataFormat() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        AddOnJob job = new AddOnJob();
+        String contextStr =
+                "parameters: \n  updateAddOns: false\n" + "uninstall: addonOne, addonTwo";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> jobData =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+
+        // When
+        job.verifyJobSpecificData(jobData, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(
+                progress.getErrors().get(0), is(equalTo("!automation.error.addons.addon.data!")));
+    }
+
+    @Test
     void shouldReturnFileConfigData() {
         // Given
         AddOnJob job = new AddOnJob();

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
@@ -245,7 +245,7 @@ class PassiveScanConfigJobUnitTest {
         PassiveScanConfigJob job = new PassiveScanConfigJob();
 
         // When
-        job.runJob(null, data, progress);
+        job.verifyJobSpecificData(data, progress);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(false)));
@@ -254,8 +254,6 @@ class PassiveScanConfigJobUnitTest {
         assertThat(
                 progress.getWarnings().get(0),
                 is(equalTo("!automation.error.pscan.rule.unknown!")));
-        assertThat(rule2.getAlertThreshold(), is(equalTo(AlertThreshold.MEDIUM)));
-        assertThat(rule3.getAlertThreshold(), is(equalTo(AlertThreshold.HIGH)));
     }
 
     private class TestPluginScanner extends PluginPassiveScanner {


### PR DESCRIPTION
The type and value of all paramters of all the jobs specified in the config is now verified before execution, thus ensuring that  if any job has a misconfigured param, then no job would be executed.

A test was also tweaked according to these changes.

Part of zaproxy/zaproxy#6461