### PR TITLE
fix: SAST Items

### DIFF
--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveXmlMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveXmlMessage.java
@@ -22,7 +22,6 @@ package org.zaproxy.addon.exim;
 import java.io.File;
 import java.util.Base64;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
@@ -35,6 +34,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.zaproxy.zap.utils.XmlUtils;
 
 public class PopupMenuSaveXmlMessage extends AbstractPopupMenuSaveMessage {
 
@@ -87,8 +87,8 @@ public class PopupMenuSaveXmlMessage extends AbstractPopupMenuSaveMessage {
     private static void writeToFile(File file, byte[] headersContent, byte[] bodyContent) {
         try {
 
-            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+            DocumentBuilder docBuilder =
+                    XmlUtils.newXxeDisabledDocumentBuilderFactory().newDocumentBuilder();
 
             Document doc = docBuilder.newDocument();
             Element rootElement = doc.createElement("Message");

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -81,8 +81,8 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
         "NEL"
     };
 
-    private static final Pattern PATTERN_FONT_EXTENSIONS =
-            Pattern.compile("\\.ttf|\\.woff|\\.woff2|\\.otf\\z", Pattern.CASE_INSENSITIVE);
+    static final Pattern PATTERN_FONT_EXTENSIONS =
+            Pattern.compile("(?:\\.ttf|\\.woff|\\.woff2|\\.otf)\\z", Pattern.CASE_INSENSITIVE);
 
     /**
      * gets the name of the scanner

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -340,6 +340,15 @@ public class TimestampDisclosureScanRuleUnitTest
         assertEquals(0, alertsRaised.size());
     }
 
+    @Test
+    public void patternFontExtensionShouldNotFindSubString() {
+        // Given / When
+        boolean result =
+                TimestampDisclosureScanRule.PATTERN_FONT_EXTENSIONS.matcher("/font.woffL").find();
+        // Then
+        assertEquals(false, result);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"font/ttf", "font/otf", "font/woff", "font/woff2"})
     public void shouldNotRaiseAlertOnValidTimeStampWhenInFontResponse(String type)


### PR DESCRIPTION
- PopupMenuSaveXmlMessage > Use a doc builder with XXE disabled.
- TimestampDisclosureScanRule > Use a non-capturing group to ensure operator precedence (\z should apply to all, not only .otf). Add a Unit Test to check the pattern behavior.
- XxeScanRule > Don't bother passing `payload` to `localFileReflectionAttack(HttpMessage)` which is simply overwritten.

CHANGELOGs weren't updated as none of the related changes have been released.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>