### PR TITLE
improvement: various add-ons - stop using printStackTrace

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Don't set the font color for inherited entries (Issue 6397).
-- Upate minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.10.0.
+- Maintenance changes.
 
 ## [6] - 2020-10-06
 

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
@@ -88,7 +88,7 @@ public class AccessControlAlertsProcessor {
         try {
             msg = result.getHistoryReference().getHttpMessage();
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            e.printStackTrace();
+            log.debug(e);
         }
         // @formatter:off
         alert.setDetail(
@@ -120,7 +120,7 @@ public class AccessControlAlertsProcessor {
         try {
             msg = result.getHistoryReference().getHttpMessage();
         } catch (HttpMalformedHeaderException | DatabaseException e) {
-            e.printStackTrace();
+            log.debug(e);
         }
         // @formatter:off
         alert.setDetail(

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [10] - 2020-12-15
 ### Added

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -223,7 +223,7 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
                                 // target before sending
                                 sendAndReceive(msg);
                             } catch (IOException e) {
-                                e.printStackTrace();
+                                log.debug(e);
                             }
                             return true;
                         }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -259,7 +259,6 @@ public class Base64Disclosure extends PluginPassiveScanner {
                         } catch (Exception e) {
                             // no need to do anything here.. just don't set "validviewstate" to true
                             // :)
-                            // e.printStackTrace();
                             log.debug(
                                     "The Base64 value [{}] has a valid ViewState pre-amble, but is not a valid viewstate. It may be an EVENTVALIDATION value, is not yet decodable.",
                                     base64evidence);

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupUseScriptAsAuthenticationScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupUseScriptAsAuthenticationScript.java
@@ -286,7 +286,7 @@ public class PopupUseScriptAsAuthenticationScript extends ExtensionPopupMenuItem
                         && script.getTypeName()
                                 .equals(ScriptBasedAuthenticationMethodType.SCRIPT_TYPE_AUTH);
             } catch (Exception e) {
-                e.printStackTrace();
+                log.debug(e);
             }
         }
         return false;

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [34] - 2021-04-22
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -260,7 +260,7 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
 
             } catch (Exception e) {
                 // Its an older version, so just dont try to use it
-                e.printStackTrace();
+                logger.debug(e);
             }
         }
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -244,7 +244,7 @@ public class ZestRecordScriptDialog extends StandardFieldsDialog {
 
                 } catch (Exception e) {
                     // Its an older version, so just dont try to use it
-                    e.printStackTrace();
+                    logger.debug(e);
                 }
             }
         }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestSurroundWithPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestSurroundWithPopupMenu.java
@@ -24,6 +24,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.parosproxy.paros.view.View;
@@ -50,6 +52,7 @@ import org.zaproxy.zest.core.v1.ZestStructuredExpression;
 
 public class ZestSurroundWithPopupMenu extends ExtensionPopupMenuItem {
     private static final long serialVersionUID = -5847208243296422433L;
+    private static final Logger LOGGER = LogManager.getLogger(ZestSurroundWithPopupMenu.class);
     private ExtensionZest extension;
 
     /** This method initializes */
@@ -132,7 +135,7 @@ public class ZestSurroundWithPopupMenu extends ExtensionPopupMenuItem {
             try {
                 createPopupAddActionMenu(parent, children, new ZestLoopFile());
             } catch (IOException e) {
-                e.printStackTrace();
+                LOGGER.debug(e);
             }
             createPopupAddActionMenu(parent, children, new ZestLoopInteger());
             createPopupAddActionMenu(parent, children, new ZestConditional(new ZestExpressionOr()));


### PR DESCRIPTION
- accessControl > Replaced two prints with debug logging. Fixed a typo in the CHANGELOG and added maintenance entry.
- domxss > Replaced one print with debug logging. CHANGELOG added maintenance entry.
- pscanrulesAlpha > Removed one commented print.
- scripts > Replaced one print with debug logging. (Unreleased section already has maint note.)
- zest > Replaced three prints with debug logging. CHANGELOG added maintenance entry.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>