### PR TITLE
Introduce DiceMatcher to replace HirshbergMatcher in scan rules

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update links to zaproxy repo.
 - Target 2.10 core and use new logging infrastructure (Log4j 2.x).
+- The LDAP Injection scan rule was modified to make use of the Dice algorithm for calculating the match percentage, thus improving its performance.
 
 ### Added
 - CORS active scan rule.

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -11,7 +11,9 @@ zapAddOn {
 
         dependencies {
             addOns {
-                register("commonlib")
+                register("commonlib") {
+                    version.set(">= 1.3.0 & < 2.0.0")
+                }
             }
         }
     }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -37,7 +37,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.core.scanner.NameValuePair;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.utils.HirshbergMatcher;
+import org.zaproxy.addon.commonlib.DiceMatcher;
 
 /**
  * The LdapInjectionScanRule scan rule identifies LDAP injection vulnerabilities with LDAP based
@@ -100,9 +100,6 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             }
         }
     }
-
-    // use Hirshberg to calculate longest common substring between two strings.
-    private static final HirshbergMatcher hirshberg = new HirshbergMatcher();
 
     @Override
     public int getId() {
@@ -243,7 +240,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             HttpMessage repeatMsg = getNewMsg();
             sendAndReceive(repeatMsg);
             int repeatMatch =
-                    this.calcMatchPercentage(
+                    DiceMatcher.getMatchPercentage(
                             originalmsg.getResponseBody().toString(),
                             repeatMsg.getResponseBody().toString());
             log.debug("Got percentage for repeat: {}", repeatMatch);
@@ -283,7 +280,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             sendAndReceive(randomParamMsg2);
 
             int randomVersusRandomMatch =
-                    this.calcMatchPercentage(
+                    DiceMatcher.getMatchPercentage(
                             randomParamMsg1.getResponseBody().toString(),
                             randomParamMsg2.getResponseBody().toString());
             log.debug(
@@ -299,7 +296,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
 
             // now check the random against the original, to make sure the output is different
             int randomVersusOriginalMatch =
-                    this.calcMatchPercentage(
+                    DiceMatcher.getMatchPercentage(
                             randomParamMsg1.getResponseBody().toString(),
                             originalmsg.getResponseBody().toString());
             log.debug(
@@ -343,7 +340,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                 sendAndReceive(appendTrueMsg);
 
                 int appendTrueVersusOriginalMatch =
-                        this.calcMatchPercentage(
+                        DiceMatcher.getMatchPercentage(
                                 appendTrueMsg.getResponseBody().toString(),
                                 originalmsg.getResponseBody().toString());
                 log.debug(
@@ -443,7 +440,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                 sendAndReceive(hopefullyTrueMsg);
 
                 int hopefullyTrueVersusOriginalMatch =
-                        this.calcMatchPercentage(
+                        DiceMatcher.getMatchPercentage(
                                 hopefullyTrueMsg.getResponseBody().toString(),
                                 originalmsg.getResponseBody().toString());
                 log.debug(
@@ -537,25 +534,6 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                         attack,
                         falseAttack);
         log.debug(logMessage);
-    }
-
-    /**
-     * calculate the percentage length of similarity between 2 strings.
-     *
-     * @param a
-     * @param b
-     * @return
-     */
-    private int calcMatchPercentage(String a, String b) {
-        // log.debug("About to get LCS for [{}] and [{}]", a, b);
-        if (a == null && b == null) return 100;
-        if (a == null || b == null) return 0;
-        if (a.length() == 0 && b.length() == 0) return 100;
-        if (a.length() == 0 || b.length() == 0) return 0;
-        String lcs = hirshberg.getLCS(a, b);
-        // log.debug("Got LCS: {}", lcs);
-        // get the percentage match against the longer of the 2 strings
-        return (int) ((((double) lcs.length()) / Math.max(a.length(), b.length())) * 100);
     }
 
     /**

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Evidence is now the string that was matched in the response
   - XPath Injection
     - Added evidence
+- The Source Code Disclosure - File Inclusion scan rule was modified to make use of the Dice algorithm for calculating the match percentage, thus improving its performance.
 
 ## [33] - 2020-12-15
 ### Changed

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -14,7 +14,9 @@ zapAddOn {
 
         dependencies {
             addOns {
-                register("commonlib")
+                register("commonlib") {
+                    version.set(">= 1.3.0 & < 2.0.0")
+                }
             }
         }
 

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added AbstractHostFilePlugin for use with ElmahScanRule and other future Host level file scan rules (Issue 6133).
 - Maintenance changes (Issue 6376 & Issue 6099).
+- Added DiceMatcher, which implements the Dice algorithm to calculate the percentage similarity between two strings.
 
 ## [1.2.0] - 2020-12-15
 ### Changed

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/DiceMatcher.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/DiceMatcher.java
@@ -1,0 +1,92 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import java.util.Arrays;
+
+/**
+ * A {@code DiceMatcher} that implements the Dice algorithm to measure the similarity between two
+ * strings
+ *
+ * @since 1.3.0
+ */
+public final class DiceMatcher {
+
+    private DiceMatcher() {}
+
+    /**
+     * @param a The first string to be compared
+     * @param b The second string to be compared
+     * @return The match percentage of the two strings, rounded off to the nearest integer
+     */
+
+    /*
+     * Source : https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Dice%27s_coefficient
+     * License :  https://creativecommons.org/licenses/by-sa/3.0/
+     * Author : Jelle Fresen
+     * Changes : Fixed indexing to prevent out of array access
+     * Released under CC-BY-SA.
+     */
+
+    public static int getMatchPercentage(String a, String b) {
+
+        String s = a.replaceAll("\\s+", " ");
+        String t = b.replaceAll("\\s+", " ");
+
+        // Verifying the input:
+        if (s == null || t == null) return 0;
+        // Quick check to catch identical objects:
+        if (s == t) return 1;
+        // avoid exception for single character searches
+        if (s.length() < 2 || t.length() < 2) return 0;
+
+        // Create the bigrams for string s:
+        final int n = s.length() - 1;
+        final int[] sPairs = new int[n];
+        for (int i = 0; i < n; i++)
+            if (i == 0) sPairs[i] = s.charAt(i) << 16;
+            else if (i == n - 1) sPairs[i - 1] |= s.charAt(i);
+            else sPairs[i] = (sPairs[i - 1] |= s.charAt(i)) << 16;
+
+        // Create the bigrams for string t:
+        final int m = t.length() - 1;
+        final int[] tPairs = new int[m];
+        for (int i = 0; i < m; i++)
+            if (i == 0) tPairs[i] = t.charAt(i) << 16;
+            else if (i == m - 1) tPairs[i - 1] |= t.charAt(i);
+            else tPairs[i] = (tPairs[i - 1] |= t.charAt(i)) << 16;
+
+        // Sort the bigram lists:
+        Arrays.sort(sPairs);
+        Arrays.sort(tPairs);
+
+        // Count the matches:
+        int matches = 0, i = 0, j = 0;
+        while (i < n && j < m) {
+            if (sPairs[i] == tPairs[j]) {
+                matches += 2;
+                i++;
+                j++;
+            } else if (sPairs[i] < tPairs[j]) i++;
+            else j++;
+        }
+        return (int) Math.floor((double) matches * 100 / (n + m));
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/DiceMatcherUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/DiceMatcherUnitTest.java
@@ -1,0 +1,135 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+class DiceMatcherUnitTest {
+
+    private static final String ORIGINAL_STRING =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus"
+                    + "eget sapien sit amet tortor finibus feugiat sit amet eu tellus. Duis orci"
+                    + "ligula, tempor eget ultrices ac, mattis vitae leo. Nam eget neque et quam"
+                    + "rutrum feugiat eget eget felis. Mauris ipsum urna, fringilla ut volutpat"
+                    + "vitae, fringilla a elit. Aenean quis feugiat quam. Fusce suscipit est"
+                    + "sapien, sed ornare elit auctor et. Duis in porttitor eros. Praesent vel"
+                    + "imperdiet libero. Etiam eu nulla metus. Etiam ultrices risus eget tellus"
+                    + "luctus, ac accumsan purus sollicitudin. Sed lacinia est ornare ex accumsan,"
+                    + "nec auctor enim porttitor. Praesent ut nibh eleifend massa consequat"
+                    + "fringilla non at tellus. Aenean placerat sit amet dui sed fringilla. Ut"
+                    + "iaculis fermentum iaculis.Quisque eu fermentum neque. In imperdiet, massa et"
+                    + "accumsan pulvinar, nisl dolor aliquam nunc, a tincidunt augue risus id diam."
+                    + "Donec sit amet nulla maximus, blandit nisi nec, lobortis arcu. Sed"
+                    + "hendrerit risus non massa gravida, a gravida lectus bibendum. Phasellus quis"
+                    + "dictum elit, ut gravida sapien. In quis porta orci. Nunc quis convallis"
+                    + "ligula. Nullam quis tincidunt ante. Nullam elementum auctor risus mattis"
+                    + "aliquam. Sed sit amet volutpat dolor, eu consectetur nulla. Aenean sapien"
+                    + "diam, egestas sit amet feugiat bibendum, molestie ac massa. Donec quis"
+                    + "feugiat dolor, quis hendrerit nunc. Pellentesque sit amet velit non quam"
+                    + "euismod tincidunt quis vitae lectus. Vestibulum finibus egestas tincidunt."
+                    + "Sed eget felis sit amet massa luctus malesuada. Aenean non lacus mattis,"
+                    + "tempor ex at, pulvinar risus.";
+
+    private static final String SIMILAR_STRING =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phaselluseget"
+                    + "sapien sit amet tortor finibus feugiat sit amet eu tellus. Duis orciligula,"
+                    + "tempor eget ultrices ac, mattis vitae leo. Nam eget neque et quamrutrum feugiat"
+                    + "eget eget felis. Mauris ipsum urna, fringilla ut volutpatvitae, fringilla a"
+                    + "elit. Aenean quis feugiat quam. Fusce suscipit estsapien, sed ornare elit"
+                    + "auctor et. Duis in porttitor eros. Praesent velimperdiet libero. Etiam eu nulla"
+                    + "metus. Etiam ultrices risus eget tellusluctus, ac accumsan purus sollicitudin."
+                    + "Sed lacinia est ornare ex accumsan,nec auctor enim porttitor. Praesent ut"
+                    + "nibh eleifend massa consequatfringilla non at tellus. Aenean placerat sit amet"
+                    + "dui sed fringilla. Utiaculis fermentum iaculis.Quisque eu fermentum neque. In"
+                    + "imperdiet, massa etaccumsan pulvinar, nisl dolor aliquam nunc, a tincidunt augue"
+                    + "risus id diam.Donec sit amet nulla maximus, blandit nisi nec, lobortis arcu."
+                    + "Sedhendrerit risus non massa gravida, a gravida lectus bibendum. Phasellus quisdictum"
+                    + "elit, ut gravida sapien. In quis porta orci. Nunc quis convallisligula. Nullam"
+                    + "quis tincidunt ante. Nullam elementum auctor ;{Ta$i2,V- BPN~_2J^B$ h%e.a_9zRt"
+                    + "pv4]r[.Ury 6i%F^SZS0c wIFTzTZ<TI uWr?8<j-(2 yba3iJ9_D ?YOo*>i'MW ;ERtYa}V;"
+                    + "@R4toBiB9, lX3&kOs_Z% 9bBobiqiG{ |p@.lV<1g  (8e/b.[WZd (IC.PM$3w] B{} %GQT}m"
+                    + "Oq{=~!H_,m 3d<k{zqW SsQ*j.,XQW wa.Vi:)VW^ 2t:NGi'YIo BlRB%7(^Ca JHf#@G6H)0"
+                    + "4)fofbSAiS fF+oqc#eWa |+ wCxptXM JW}v~x}hhy -<^IgTMmwH k'sP)&x^! 4~AnehXsH"
+                    + "9z:q{Q^TM9  D)4q8vKe m^z9A4Zxo Gbo9-,-Wjh <~Nx{r)jXb dShM_~$icx 9f8dIN;CHw"
+                    + "yDitJ,d0-/ 8]15T9yfj] (MTLf)Uh Rb?FKVNQ/Z 3e/il;;W_( Yf*|J@uqPT *lOW(W$:I`"
+                    + "k|CIH&}fhu ?XI]n-G? #n9&R:%if Kj+>p@#rJ^ 1!6Sp])y x?zn]AK=$ x;?@&r=$/"
+                    + "FSy(U*V}ll :sM{H^# )U";
+
+    private static final String DIFFERENT_STRING =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phaselluseget"
+                    + "sapien sit amet tortor finibus feugiat sit amet eu tellus. Duis orciligula,"
+                    + "tempor eget ultrices ac, mattis vitae leo. Nam eget neque et quamrutrum feugiat"
+                    + "eget eget felis. Mauris ipsum urna, fringilla ut volutpatvitae, fringilla a"
+                    + "elit. Aenean quis feugiat quam. Fusce suscipit estsapien, sed 7aDw,|*(.]"
+                    + "5mgdeqCoLW G5?7T*:yyp {<V`;S2wmd lX4a\5OC:B Bmc CwzQ ]lau[j3B4 nyIXz-m_z."
+                    + ",/ozmjqFRD aM.q|eP{o_ H/CO@Ogelq jWWrZ[`cgj j)IpP*[#q+ %Z)R:+Ihdg HM7z@R)wq-"
+                    + "-g)=;z^t+^ jsgIx<1a>/ _y0 kb@ED[ `K>4qKSJIu K,!_kqyr,G GkBoB'(4za @nz1Hy>ABp"
+                    + ";C)rsS&d ,5lkPRd;cr nlEUj-}7~ >4z:-DQEP- EO0z<bcrjg ANPf1>Sc.  l|U:Z;{=H"
+                    + "O.9fPZ?!G0 rs$UE]+)b g:oZM<PmCy :.c!P,rzS v?wEQ5s`N1 j_5LTOx$  |SuF<.a)P="
+                    + "lK~J`c`8t< mu/-l,X#/* SajXg?bk<f YprGm|u];  #HW'(*o41~ 28F!XHQ,_H 5m10JL`.x?"
+                    + "X+\5(fSSa~ s>#oW .mc %`(^D1#i`* /aN=^o.fK0 6+C24dr($ ,:}JZgOL+A =;~`;xGY?C"
+                    + "^sL2dvJ-74 %m.5PG)&xd !S%EUe,@0: 8@?;.=q&D* }3YKmOTr}@ kP`J{p2D'O nph4t9T2gp"
+                    + "{?dl)yeOa6 o<5WO1(X@D p4r-[*So? OO[vt$-UX >}JZCP} sK ?#%+v%Mm@- [`sQ)6Q'<n"
+                    + "Q[R<QL^A awkg>4Qr+( cju.nq'[i' =;Uv@Y=7JX TezMX*mB+s (Rf(W-[<| `<u:u}KdV"
+                    + "#{6AX8b(H] s'Yf6LnS SZF3LeQu# q.11 .1EZ rx.Ezj)T{H YP6KwbrVN3 pXP`zI[;|u NN"
+                    + "T}yt{'? /=N%y@|-jH ?{#I8-.n(* GPxQ#0QXXx &1C},73Sfw <[Tkq0aZbV 1 oI4+J  p"
+                    + "(uXq4oEWaQ UCet45;xp xP  XIH~7F |i@0-%Rn&< (T1YULn ( WoPzyr0!&< 35 LpE0lN9"
+                    + "lv..p)>zwU +bj#*;zjyO 84Dq-qMP -:@!pW7+I4 3c+_}1J/ (M!CbXWZkO gIbD3<%YZ5"
+                    + "znws3K($+. U+I`i0eI z}Re7Ky@UY m<6?tpgMb; Ckm09Fu#@0 _%jE0[@ :. 2E8]p<E3]@"
+                    + "58#VT=t4a% .3y5ixV;L #q21SkpR! 3i*9ZuDCNU 6}%3~bf/EE P$sVa7|G;R p@A/=St,Z&"
+                    + "Y/YH.i^UdD e73KVGbXz& P|^lw^YE&] swmU(XZ,R% kaEgMN-Dqg ;.:?>7wj$x bn2',Vn%X7"
+                    + "x9Rqs|X<ag r,Y{so,;w n. >f(TdB  eW}pD)FFO4 (9T)3_$@Qu !|%OO'zAJ_ Dj,x,!h9u"
+                    + "z#bk]QDaU U 5yWjpM} q=|y(p(] v=.,E3v:vH q3i|Az:iuS %?}NJqGu&k :R(i{6[3$c"
+                    + "XP*])<ux3d 89cZ7rt;Xr L>zyDrY>V' |DQv'A_&9h _{V^3XZPZ  2>a(QIA$mq K*dU6|wZ'["
+                    + ";6#Ht/[)do dI31R z6x0 V+O;FIOT I{A96t7v@S !yZz=vydv xMB(#[5qQm O.cK9-3Lf "
+                    + "%Ydy[(k8 xyJKwGw,y6 >#]A-=Rx#e ]x.#]2-Ds [r#y;#Ea^Ra)AzHYa%,i z ctr<qUtQ"
+                    + "=O.QHn_s5/ p__C0v':a: -O~I,6CRm! Gc_>81{|^* =D.A)umZz` By_;]+<x+| 0K;9*[ln0l";
+
+    @Test
+    void shouldGiveCorrectPercentageForSameString() {
+        // Given / When
+        int sim = DiceMatcher.getMatchPercentage(ORIGINAL_STRING, ORIGINAL_STRING);
+
+        // Then
+        assertThat(sim, is(equalTo(100)));
+    }
+
+    @Test
+    void shouldGiveCorrectPercentageForSimilarString() {
+        // Given / When
+        int sim = DiceMatcher.getMatchPercentage(ORIGINAL_STRING, SIMILAR_STRING);
+
+        // Then
+        assertThat(sim, is(equalTo(70)));
+    }
+
+    @Test
+    void shouldGiveCorrectPercentageForDifferentString() {
+        // Given / When
+        int sim = DiceMatcher.getMatchPercentage(ORIGINAL_STRING, DIFFERENT_STRING);
+
+        // Then
+        assertThat(sim, is(equalTo(25)));
+    }
+}


### PR DESCRIPTION
The LdapInjectionScanRule and SourceCodeDisclosureFileInclusionScanRule
were modified to make use of the new DiceMatcher to calculate match
percentage between two strings. Added test and update the Changelogs.

Takes care of two out of the three rules reported as having poor performance in zaproxy/zaproxy#6515