### PR TITLE
improve: Unit Test related SAST (sonar) findings

### DIFF
--- a/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/AlertFilterTest.java
+++ b/addOns/alertFilters/src/test/java/org/zaproxy/zap/extension/alertFilters/AlertFilterTest.java
@@ -27,12 +27,12 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 
 /** Unit test for {@link AlertFilter}. */
-public class AlertFilterTest {
+class AlertFilterTest {
 
     private Alert alert;
 
     @BeforeEach
-    public void before() throws Exception {
+    void before() throws Exception {
         alert = new Alert(1, Alert.RISK_INFO, Alert.CONFIDENCE_LOW, "Test alert");
         alert.setUri("https://www.example.com");
         alert.setParam("param");
@@ -41,7 +41,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void defaultEnabledFilterMatches() {
+    void defaultEnabledFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -51,7 +51,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void defaultDisabledFilterDoesNotMatch() {
+    void defaultDisabledFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -61,7 +61,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void missingUriFilterMatches() {
+    void missingUriFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -72,7 +72,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void differentUriFilterDoesNotMatch() {
+    void differentUriFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -83,7 +83,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void matchingUriRegexFilterMatches() {
+    void matchingUriRegexFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -95,7 +95,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void notMatchingUriRegexFilterDoesNotMatch() {
+    void notMatchingUriRegexFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -107,7 +107,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void missingParameterFilterMatches() {
+    void missingParameterFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -118,7 +118,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void differentParameterFilterDoesNotMatch() {
+    void differentParameterFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -129,7 +129,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void matchingParameterRegexFilterMatches() {
+    void matchingParameterRegexFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -141,7 +141,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void notMatchingParameterRegexFilterDoesNotMatch() {
+    void notMatchingParameterRegexFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -153,7 +153,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void missingAttackFilterMatches() {
+    void missingAttackFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -164,7 +164,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void differentAttackFilterDoesNotMatch() {
+    void differentAttackFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -175,7 +175,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void matchingAttackRegexFilterMatches() {
+    void matchingAttackRegexFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -187,7 +187,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void notMatchingAttackRegexFilterDoesNotMatch() {
+    void notMatchingAttackRegexFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -199,7 +199,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void missingEvidenceFilterMatches() {
+    void missingEvidenceFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -210,7 +210,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void differentEvidenceFilterDoesNotMatch() {
+    void differentEvidenceFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -221,7 +221,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void matchingEvidenceRegexFilterMatches() {
+    void matchingEvidenceRegexFilterMatches() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When
@@ -233,7 +233,7 @@ public class AlertFilterTest {
     }
 
     @Test
-    public void notMatchingEvidenceRegexFilterDoesNotMatch() {
+    void notMatchingEvidenceRegexFilterDoesNotMatch() {
         // Given
         AlertFilter af = new AlertFilter(-1, alert);
         // When

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ActiveScannerTest.java
@@ -22,8 +22,7 @@ package org.zaproxy.zap.extension.ascanrules;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 
-public abstract class ActiveScannerTest<T extends AbstractPlugin>
-        extends ActiveScannerTestUtils<T> {
+abstract class ActiveScannerTest<T extends AbstractPlugin> extends ActiveScannerTestUtils<T> {
 
     @Override
     protected void setUpMessages() {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link BufferOverflowScanRule}. */
-public class BufferOverflowScanRuleUnitTest extends ActiveScannerTest<BufferOverflowScanRule> {
+class BufferOverflowScanRuleUnitTest extends ActiveScannerTest<BufferOverflowScanRule> {
 
     @Override
     protected BufferOverflowScanRule createScanner() {
@@ -41,7 +41,7 @@ public class BufferOverflowScanRuleUnitTest extends ActiveScannerTest<BufferOver
     }
 
     @Test
-    public void shouldTargetCTech() {
+    void shouldTargetCTech() {
         // Given
         TechSet techSet = techSet(Tech.C);
         // When
@@ -51,7 +51,7 @@ public class BufferOverflowScanRuleUnitTest extends ActiveScannerTest<BufferOver
     }
 
     @Test
-    public void shouldNotTargetNonCTechs() {
+    void shouldNotTargetNonCTechs() {
         // Given
         TechSet techSet = techSetWithout(Tech.C);
         // When
@@ -61,7 +61,7 @@ public class BufferOverflowScanRuleUnitTest extends ActiveScannerTest<BufferOver
     }
 
     @Test
-    public void shouldCreateAlert() throws Exception {
+    void shouldCreateAlert() throws Exception {
         // Given
         String test = "/shouldReportBufferOverflowIssue/";
 

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRuleUnitTest.java
@@ -37,7 +37,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link CodeInjectionScanRule}. */
-public class CodeInjectionScanRuleUnitTest extends ActiveScannerTest<CodeInjectionScanRule> {
+class CodeInjectionScanRuleUnitTest extends ActiveScannerTest<CodeInjectionScanRule> {
 
     @Override
     protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
@@ -61,7 +61,7 @@ public class CodeInjectionScanRuleUnitTest extends ActiveScannerTest<CodeInjecti
     }
 
     @Test
-    public void shouldTargetAspTech() {
+    void shouldTargetAspTech() {
         // Given
         TechSet techSet = techSet(Tech.ASP);
         // When
@@ -71,7 +71,7 @@ public class CodeInjectionScanRuleUnitTest extends ActiveScannerTest<CodeInjecti
     }
 
     @Test
-    public void shouldTargetPhpTech() {
+    void shouldTargetPhpTech() {
         // Given
         TechSet techSet = techSet(Tech.PHP);
         // When
@@ -81,7 +81,7 @@ public class CodeInjectionScanRuleUnitTest extends ActiveScannerTest<CodeInjecti
     }
 
     @Test
-    public void shouldNotTargetNonAspPhpTechs() {
+    void shouldNotTargetNonAspPhpTechs() {
         // Given
         TechSet techSet = techSetWithout(Tech.ASP, Tech.PHP);
         // When
@@ -91,7 +91,7 @@ public class CodeInjectionScanRuleUnitTest extends ActiveScannerTest<CodeInjecti
     }
 
     @Test
-    public void shouldFindPhpInjection() throws Exception {
+    void shouldFindPhpInjection() throws Exception {
         // Given
         String test = "/shouldFindPhpInjection.php";
         String PHP_ENCODED_TOKEN =
@@ -122,7 +122,7 @@ public class CodeInjectionScanRuleUnitTest extends ActiveScannerTest<CodeInjecti
     }
 
     @Test
-    public void shouldFindAspInjection() throws Exception {
+    void shouldFindAspInjection() throws Exception {
         // Given
         String test = "/shouldFindAspInjection";
         List<String> evaluationResults = new ArrayList<>();

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRuleUnitTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
@@ -47,7 +48,7 @@ import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link CommandInjectionScanRule}. */
-public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandInjectionScanRule> {
+class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandInjectionScanRule> {
 
     @Override
     protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
@@ -73,7 +74,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldTargetLinuxTech() {
+    void shouldTargetLinuxTech() {
         // Given
         TechSet techSet = techSet(Tech.Linux);
         // When
@@ -83,7 +84,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldTargetMacOsTech() {
+    void shouldTargetMacOsTech() {
         // Given
         TechSet techSet = techSet(Tech.MacOS);
         // When
@@ -93,7 +94,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldTargetWindowsTech() {
+    void shouldTargetWindowsTech() {
         // Given
         TechSet techSet = techSet(Tech.Windows);
         // When
@@ -103,7 +104,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldNotTargetNonLinuxMacOsWindowsTechs() {
+    void shouldNotTargetNonLinuxMacOsWindowsTechs() {
         // Given
         TechSet techSet = techSetWithout(Tech.Linux, Tech.MacOS, Tech.Windows);
         // When
@@ -113,15 +114,16 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldFailToInitWithoutConfig() throws Exception {
+    void shouldFailToInitWithoutConfig() throws Exception {
         // Given
         CommandInjectionScanRule scanner = new CommandInjectionScanRule();
+        HttpMessage msg = getHttpMessage("");
         // When / Then
-        assertThrows(NullPointerException.class, () -> scanner.init(getHttpMessage(""), parent));
+        assertThrows(NullPointerException.class, () -> scanner.init(msg, parent));
     }
 
     @Test
-    public void shouldInitWithConfig() throws Exception {
+    void shouldInitWithConfig() throws Exception {
         // Given
         CommandInjectionScanRule scanner = new CommandInjectionScanRule();
         scanner.setConfig(new ZapXmlConfiguration());
@@ -130,7 +132,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldUse5SecsByDefaultForTimeBasedAttacks() throws Exception {
+    void shouldUse5SecsByDefaultForTimeBasedAttacks() throws Exception {
         // Given / When
         int time = rule.getTimeSleep();
         // Then
@@ -138,7 +140,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldUseTimeDefinedInConfigForTimeBasedAttacks() throws Exception {
+    void shouldUseTimeDefinedInConfigForTimeBasedAttacks() throws Exception {
         // Given
         rule.setConfig(configWithSleepRule("10"));
         // When
@@ -148,8 +150,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldDefaultTo5SecsIfConfigTimeIsMalformedValueForTimeBasedAttacks()
-            throws Exception {
+    void shouldDefaultTo5SecsIfConfigTimeIsMalformedValueForTimeBasedAttacks() throws Exception {
         // Given
         rule.setConfig(configWithSleepRule("not a valid value"));
         // When
@@ -159,7 +160,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldUseSpecifiedTimeInAllTimeBasedPayloads() throws Exception {
+    void shouldUseSpecifiedTimeInAllTimeBasedPayloads() throws Exception {
         // Given
         String sleepTime = "987";
         PayloadCollectorHandler payloadCollector =
@@ -185,7 +186,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasPasswdFileContentAndPayloadIsNullByteBased()
+    void shouldRaiseAlertIfResponseHasPasswdFileContentAndPayloadIsNullByteBased()
             throws HttpMalformedHeaderException {
         // Given
         NullByteVulnerableServerHandler vulnServerHandler =
@@ -200,7 +201,7 @@ public class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandI
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasSystemINIFileContentAndPayloadIsNullByteBased()
+    void shouldRaiseAlertIfResponseHasSystemINIFileContentAndPayloadIsNullByteBased()
             throws HttpMalformedHeaderException {
         // Given
         NullByteVulnerableServerHandler vulnServerHandler =

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link CrlfInjectionScanRule}. */
-public class CrlfInjectionScanRuleUnitTest extends ActiveScannerTest<CrlfInjectionScanRule> {
+class CrlfInjectionScanRuleUnitTest extends ActiveScannerTest<CrlfInjectionScanRule> {
 
     @Override
     protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
@@ -56,7 +56,7 @@ public class CrlfInjectionScanRuleUnitTest extends ActiveScannerTest<CrlfInjecti
     }
 
     @Test
-    public void shouldFindCrLfInjection() throws Exception {
+    void shouldFindCrLfInjection() throws Exception {
         // Given
         String test = "/shouldFindCrLfInjection.php";
         ArrayList<String> tamperedHeaders = new ArrayList<>();

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
@@ -46,8 +46,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class CrossSiteScriptingScanRuleUnitTest
-        extends ActiveScannerTest<CrossSiteScriptingScanRule> {
+class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScriptingScanRule> {
 
     @Override
     protected CrossSiteScriptingScanRule createScanner() {
@@ -55,7 +54,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInParagraph() throws NullPointerException, IOException {
+    void shouldReportXssInParagraph() throws NullPointerException, IOException {
         String test = "/shouldReportXssInParagraph/";
 
         this.nano.addHandler(
@@ -91,7 +90,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInParagraphForNullBytePayloadInjection()
+    void shouldReportXssInParagraphForNullBytePayloadInjection()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssInParagraphForNullByteInjection/";
         // Given
@@ -135,7 +134,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotReportXssInFilteredParagraph() throws NullPointerException, IOException {
+    void shouldNotReportXssInFilteredParagraph() throws NullPointerException, IOException {
         String test = "/shouldNotReportXssInFilteredParagraph/";
 
         this.nano.addHandler(
@@ -172,7 +171,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInComment() throws NullPointerException, IOException {
+    void shouldReportXssInComment() throws NullPointerException, IOException {
         String test = "/shouldReportXssInComment/";
 
         this.nano.addHandler(
@@ -206,7 +205,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInCommentForNullBytePayloadInjection()
+    void shouldReportXssInCommentForNullBytePayloadInjection()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssInCommentForNullBytePayloadInjection/";
         // Given
@@ -248,8 +247,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInCommentWithFilteredScripts()
-            throws NullPointerException, IOException {
+    void shouldReportXssInCommentWithFilteredScripts() throws NullPointerException, IOException {
         String test = "/shouldReportXssInCommentWithFilteredScripts/";
 
         this.nano.addHandler(
@@ -289,7 +287,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotReportXssInFilteredComment() throws NullPointerException, IOException {
+    void shouldNotReportXssInFilteredComment() throws NullPointerException, IOException {
         String test = "/shouldNotReportXssInFilteredComment/";
 
         this.nano.addHandler(
@@ -324,7 +322,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInBody() throws NullPointerException, IOException {
+    void shouldReportXssInBody() throws NullPointerException, IOException {
         String test = "/shouldReportXssInBody/";
 
         this.nano.addHandler(
@@ -357,7 +355,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInBodyForNullByteBasedInjectionPayload()
+    void shouldReportXssInBodyForNullByteBasedInjectionPayload()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssInBodyForNullByteBasedInjectionPayload/";
         // Given
@@ -397,7 +395,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInSpanContent() throws NullPointerException, IOException {
+    void shouldReportXssInSpanContent() throws NullPointerException, IOException {
         String test = "/shouldReportXssInSpanContent/";
 
         this.nano.addHandler(
@@ -434,7 +432,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInSpanContentForNullByteInjectionPayload()
+    void shouldReportXssInSpanContentForNullByteInjectionPayload()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssInSpanContentForNullByteInjectionPayload/";
         // Given
@@ -473,7 +471,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssOutsideOfTags() throws NullPointerException, IOException {
+    void shouldReportXssOutsideOfTags() throws NullPointerException, IOException {
         String test = "/shouldReportXssOutsideOfTags/";
 
         this.nano.addHandler(
@@ -506,7 +504,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssOutsideOfHtmlTags() throws NullPointerException, IOException {
+    void shouldReportXssOutsideOfHtmlTags() throws NullPointerException, IOException {
         String test = "/shouldReportXssOutsideOfHtmlTags/";
 
         this.nano.addHandler(
@@ -542,7 +540,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssOutsideOfHtmlTagsForNullByteBasedInjection()
+    void shouldReportXssOutsideOfHtmlTagsForNullByteBasedInjection()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssOutsideOfHtmlTagsForNullByteBasedInjection/";
         // Given
@@ -582,7 +580,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInBodyWithFilteredScript() throws NullPointerException, IOException {
+    void shouldReportXssInBodyWithFilteredScript() throws NullPointerException, IOException {
         String test = "/shouldReportXssInBodyWithFilteredScript/";
 
         this.nano.addHandler(
@@ -617,7 +615,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotReportXssInFilteredBody() throws NullPointerException, IOException {
+    void shouldNotReportXssInFilteredBody() throws NullPointerException, IOException {
         String test = "/shouldNotReportXssInFilteredBody/";
 
         this.nano.addHandler(
@@ -651,7 +649,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInAttribute() throws NullPointerException, IOException {
+    void shouldReportXssInAttribute() throws NullPointerException, IOException {
         String test = "/shouldReportXssInAttribute/";
 
         this.nano.addHandler(
@@ -689,7 +687,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotReportXssInFilteredAttribute() throws NullPointerException, IOException {
+    void shouldNotReportXssInFilteredAttribute() throws NullPointerException, IOException {
         String test = "/shouldNotReportXssInFilteredAttribute/";
 
         this.nano.addHandler(
@@ -727,7 +725,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInAttributeScriptTag() throws NullPointerException, IOException {
+    void shouldReportXssInAttributeScriptTag() throws NullPointerException, IOException {
         String test = "/shouldReportXssInAttributeScriptTag/";
 
         this.nano.addHandler(
@@ -765,7 +763,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInFrameSrcTag() throws NullPointerException, IOException {
+    void shouldReportXssInFrameSrcTag() throws NullPointerException, IOException {
         String test = "/shouldReportXssInFrameSrcTag/";
 
         this.nano.addHandler(
@@ -803,7 +801,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInScriptIdTag() throws NullPointerException, IOException {
+    void shouldReportXssInScriptIdTag() throws NullPointerException, IOException {
         String test = "/shouldReportXssInScriptIdTag/";
 
         this.nano.addHandler(
@@ -841,7 +839,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInReflectedUrl() throws NullPointerException, IOException {
+    void shouldReportXssInReflectedUrl() throws NullPointerException, IOException {
         String test = "/shouldReportXssInReflectedUrl";
 
         NanoServerHandler handler =
@@ -886,8 +884,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTestWhenMethodIsPutAndThresholdMedium()
-            throws HttpMalformedHeaderException {
+    void shouldNotTestWhenMethodIsPutAndThresholdMedium() throws HttpMalformedHeaderException {
         // Given
         String test = "/shouldReportXssInReflectedUrl";
 
@@ -929,7 +926,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldTestWhenMethodIsPutAndThresholdLow() throws HttpMalformedHeaderException {
+    void shouldTestWhenMethodIsPutAndThresholdLow() throws HttpMalformedHeaderException {
         // Given
         String test = "/shouldReportXssInReflectedUrl";
 
@@ -971,7 +968,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssWeaknessInJsonResponse() throws NullPointerException, IOException {
+    void shouldReportXssWeaknessInJsonResponse() throws NullPointerException, IOException {
         String test = "/shouldReportXssInJsonReponse/";
 
         this.nano.addHandler(
@@ -1004,8 +1001,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInsideDivWithFilteredScript()
-            throws NullPointerException, IOException {
+    void shouldReportXssInsideDivWithFilteredScript() throws NullPointerException, IOException {
         String test = "/shouldReportXssInBodyWithFilteredScript/";
 
         this.nano.addHandler(
@@ -1042,7 +1038,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInBodyWithDoubleDecodedFilteredInjectionPointViaUrlParam()
+    void shouldReportXssInBodyWithDoubleDecodedFilteredInjectionPointViaUrlParam()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssInBodyWithFilteredScript/";
 
@@ -1088,7 +1084,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertXssInBodyWithDoubleDecodedFilteredInjectionPointViaHeaderParam()
+    void shouldNotAlertXssInBodyWithDoubleDecodedFilteredInjectionPointViaHeaderParam()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssInBodyWithFilteredScript/";
 
@@ -1127,7 +1123,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldReportXssInBodyWithDoubleDecodedFilteredInjectionPointViaPostParam()
+    void shouldReportXssInBodyWithDoubleDecodedFilteredInjectionPointViaPostParam()
             throws NullPointerException, IOException {
         String test = "/shouldReportXssInBodyWithFilteredScript/";
 
@@ -1184,7 +1180,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertXssInJsVariableWithEncoding() throws HttpMalformedHeaderException {
+    void shouldNotAlertXssInJsVariableWithEncoding() throws HttpMalformedHeaderException {
         // Given
         String path = "/user/search";
         this.nano.addHandler(
@@ -1216,7 +1212,7 @@ public class CrossSiteScriptingScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertOnceWithMultipleContexts() throws HttpMalformedHeaderException {
+    void shouldAlertOnceWithMultipleContexts() throws HttpMalformedHeaderException {
         // Given
         String path = "/api/search";
         this.nano.addHandler(

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRuleUnitTest.java
@@ -29,8 +29,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link DirectoryBrowsingScanRule}. */
-public class DirectoryBrowsingScanRuleUnitTest
-        extends ActiveScannerTest<DirectoryBrowsingScanRule> {
+class DirectoryBrowsingScanRuleUnitTest extends ActiveScannerTest<DirectoryBrowsingScanRule> {
     private static final String RESOURCES_FOLDER =
             "/org/zaproxy/zap/extension/ascanrules/directorybrowsingscanrule/";
 
@@ -40,7 +39,7 @@ public class DirectoryBrowsingScanRuleUnitTest
     }
 
     @Test
-    public void shouldFindDirectoryListing() throws Exception {
+    void shouldFindDirectoryListing() throws Exception {
         // Given
         String test = "/";
         this.nano.addHandler(

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRuleUnitTest.java
@@ -38,7 +38,7 @@ import org.zaproxy.addon.commonlib.AbstractHostFilePluginUnitTest;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link ElmahScanRule}. */
-public class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahScanRule> {
+class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahScanRule> {
 
     private static final String URL = "/elmah.axd";
     private static final String RESPONSE_WITHOUT_EVIDENCE =
@@ -70,7 +70,7 @@ public class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahS
 
     @ParameterizedTest
     @ValueSource(ints = {301, 403, 404, 500})
-    public void shouldNotAlertIfNonExistingElmahFileReturnsNon200CodeStdThreshold(int status)
+    void shouldNotAlertIfNonExistingElmahFileReturnsNon200CodeStdThreshold(int status)
             throws Exception {
         // Given
         nano.addHandler(new StatusCodeResponse("/", status));
@@ -83,7 +83,7 @@ public class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahS
     }
 
     @Test
-    public void shouldAlertIfElmahFileFound() throws Exception {
+    void shouldAlertIfElmahFileFound() throws Exception {
         // Given
         nano.addHandler(new OkResponseWithEvidence("/"));
         HttpMessage message = getHttpMessage(URL);
@@ -97,7 +97,7 @@ public class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahS
     }
 
     @Test
-    public void shouldAlertIfElmahFileFoundNonRootInitialUrl() throws Exception {
+    void shouldAlertIfElmahFileFoundNonRootInitialUrl() throws Exception {
         // Given
         String path = "/foo/bar/";
         nano.addHandler(new OkResponseWithoutEvidence(path));
@@ -113,7 +113,7 @@ public class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahS
     }
 
     @Test
-    public void shouldNotAlertIfNonElmahFileFoundStdThreshold() throws Exception {
+    void shouldNotAlertIfNonElmahFileFoundStdThreshold() throws Exception {
         // Given
         nano.addHandler(new OkResponseWithoutEvidence("/"));
         HttpMessage message = getHttpMessage(URL);
@@ -125,7 +125,7 @@ public class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahS
     }
 
     @Test
-    public void shouldAlertIfNonElmahFileFoundLowThreshold() throws Exception {
+    void shouldAlertIfNonElmahFileFoundLowThreshold() throws Exception {
         // Given
         nano.addHandler(new OkResponseWithoutEvidence("/"));
         HttpMessage message = getHttpMessage(URL);
@@ -141,7 +141,7 @@ public class ElmahScanRuleUnitTest extends AbstractHostFilePluginUnitTest<ElmahS
 
     @ParameterizedTest
     @ValueSource(ints = {401, 403})
-    public void shouldAlertIfBehindAuthLowThreshold(int status) throws Exception {
+    void shouldAlertIfBehindAuthLowThreshold(int status) throws Exception {
         // Given
         nano.addHandler(new StatusCodeResponse("/", status));
         HttpMessage message = getHttpMessage(URL);

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRuleUnitTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 
 /** Unit test for {@link ExternalRedirectScanRule}. */
-public class ExternalRedirectScanRuleUnitTest extends ActiveScannerTest<ExternalRedirectScanRule> {
+class ExternalRedirectScanRuleUnitTest extends ActiveScannerTest<ExternalRedirectScanRule> {
 
     @Override
     protected ExternalRedirectScanRule createScanner() {
@@ -35,7 +35,7 @@ public class ExternalRedirectScanRuleUnitTest extends ActiveScannerTest<External
     }
 
     @Test
-    public void shouldHaveHighRisk() {
+    void shouldHaveHighRisk() {
         // Given / When
         int risk = rule.getRisk();
         // Then

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRuleUnitTest.java
@@ -28,7 +28,7 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
 /** Unit test for {@link FormatStringScanRule}. */
-public class FormatStringScanRuleUnitTest extends ActiveScannerTest<FormatStringScanRule> {
+class FormatStringScanRuleUnitTest extends ActiveScannerTest<FormatStringScanRule> {
 
     @Override
     protected FormatStringScanRule createScanner() {
@@ -36,7 +36,7 @@ public class FormatStringScanRuleUnitTest extends ActiveScannerTest<FormatString
     }
 
     @Test
-    public void shouldTargetCTech() {
+    void shouldTargetCTech() {
         // Given
         TechSet techSet = techSet(Tech.C);
         // When
@@ -46,7 +46,7 @@ public class FormatStringScanRuleUnitTest extends ActiveScannerTest<FormatString
     }
 
     @Test
-    public void shouldNotTargetNonCTechs() {
+    void shouldNotTargetNonCTechs() {
         // Given
         TechSet techSet = techSetWithout(Tech.C);
         // When

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HtAccesScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/HtAccesScanRuleUnitTest.java
@@ -35,7 +35,7 @@ import org.zaproxy.addon.commonlib.AbstractAppFilePluginUnitTest;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link HtAccessScanRule}. */
-public class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAccessScanRule> {
+class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAccessScanRule> {
 
     private static final String URL = "/.htaccess";
     private static final String HTACCESS_BODY = "order allow,deny";
@@ -53,7 +53,7 @@ public class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAcc
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.setBody(HTACCESS_BODY);
     }
 
@@ -63,7 +63,7 @@ public class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAcc
     }
 
     @Test
-    public void shouldNotAlertIfNonHtaccessFileFoundStdThreshold() throws Exception {
+    void shouldNotAlertIfNonHtaccessFileFoundStdThreshold() throws Exception {
         // Given
         nano.addHandler(new MiscOkResponse());
         HttpMessage message = getHttpMessage(URL);
@@ -75,7 +75,7 @@ public class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAcc
     }
 
     @Test
-    public void shouldNotAlertIfNonHtaccessFileFoundLowThreshold() throws Exception {
+    void shouldNotAlertIfNonHtaccessFileFoundLowThreshold() throws Exception {
         // Given
         nano.addHandler(new MiscOkResponse());
         HttpMessage message = getHttpMessage(URL);
@@ -89,7 +89,7 @@ public class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAcc
 
     @ParameterizedTest
     @ValueSource(strings = {"application/json", "application/xml"})
-    public void shouldNotAlertIfResponseIsJsonOrXml(String contentType) throws Exception {
+    void shouldNotAlertIfResponseIsJsonOrXml(String contentType) throws Exception {
         // Given
         nano.addHandler(new MiscOkResponse(URL, contentType));
         HttpMessage message = getHttpMessage(URL);
@@ -101,7 +101,7 @@ public class HtAccesScanRuleUnitTest extends AbstractAppFilePluginUnitTest<HtAcc
     }
 
     @Test
-    public void shouldNotAlertIfResponseIsEmpty() throws Exception {
+    void shouldNotAlertIfResponseIsEmpty() throws Exception {
         // Given
         nano.addHandler(new MiscOkResponse(""));
         HttpMessage message = getHttpMessage(URL);

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRuleUnitTest.java
@@ -34,7 +34,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link ParameterTamperScanRule}. */
-public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<ParameterTamperScanRule> {
+class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<ParameterTamperScanRule> {
 
     @Override
     protected ParameterTamperScanRule createScanner() {
@@ -42,7 +42,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldNotContinueScanningIfFirstResponseIsNotOK() throws Exception {
+    void shouldNotContinueScanningIfFirstResponseIsNotOK() throws Exception {
         // Given
         rule.init(getHttpMessage("/?a=b"), parent);
         // When
@@ -53,7 +53,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldContinueScanningIfFirstResponseIsOK() throws Exception {
+    void shouldContinueScanningIfFirstResponseIsOK() throws Exception {
         // Given
         nano.addHandler(
                 new NanoServerHandler("/") {
@@ -72,7 +72,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldNotAlertIfAttackResponseIsAlwaysTheSame() throws Exception {
+    void shouldNotAlertIfAttackResponseIsAlwaysTheSame() throws Exception {
         // Given
         nano.addHandler(
                 new NanoServerHandler("/") {
@@ -92,7 +92,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldNotAlertIfAttackResponseIsNotOkNorServerError() throws Exception {
+    void shouldNotAlertIfAttackResponseIsNotOkNorServerError() throws Exception {
         // Given
         nano.addHandler(
                 new NanoServerHandler("/") {
@@ -119,8 +119,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldNotAlertIfAttackResponseIsServerErrorWithUnknownErrorMessage()
-            throws Exception {
+    void shouldNotAlertIfAttackResponseIsServerErrorWithUnknownErrorMessage() throws Exception {
         // Given
         ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/");
         nano.addHandler(serverErrorOnAttack);
@@ -134,7 +133,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldAlertIfAttackResponseContainsJavaServletError() throws Exception {
+    void shouldAlertIfAttackResponseContainsJavaServletError() throws Exception {
         // Given
         ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/", 2);
         nano.addHandler(serverErrorOnAttack);
@@ -154,7 +153,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldNotAlertIfAttackResponseDoesNotContainsJavaServletError() throws Exception {
+    void shouldNotAlertIfAttackResponseDoesNotContainsJavaServletError() throws Exception {
         // Given
         ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/");
         nano.addHandler(serverErrorOnAttack);
@@ -168,7 +167,7 @@ public class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<Parameter
     }
 
     @Test
-    public void shouldAlertWithLowConfidenceIfAttackResponseContainsOtherKnownServerErrors()
+    void shouldAlertWithLowConfidenceIfAttackResponseContainsOtherKnownServerErrors()
             throws Exception {
         ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/");
         nano.addHandler(serverErrorOnAttack);

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRuleUnitTest.java
@@ -44,7 +44,7 @@ import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link PathTraversalScanRule}. */
-public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTraversalScanRule> {
+class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTraversalScanRule> {
 
     @Override
     protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
@@ -70,7 +70,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldNotAlertIfAttackResponseDoesNotListDirectories() throws Exception {
+    void shouldNotAlertIfAttackResponseDoesNotListDirectories() throws Exception {
         // Given
         rule.init(getHttpMessage("/?p=v"), parent);
         // When
@@ -81,7 +81,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldAlertIfAttackResponseListsWindowsDirectories() throws Exception {
+    void shouldAlertIfAttackResponseListsWindowsDirectories() throws Exception {
         // Given
         nano.addHandler(new ListWinDirsOnAttack("/", "p", "c:/"));
         rule.init(getHttpMessage("/?p=v"), parent);
@@ -99,7 +99,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldAlertIfAttackResponseListsLinuxDirectories() throws Exception {
+    void shouldAlertIfAttackResponseListsLinuxDirectories() throws Exception {
         // Given
         nano.addHandler(new ListLinuxDirsOnAttack("/", "p", "/"));
         rule.init(getHttpMessage("/?p=v"), parent);
@@ -117,7 +117,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldNotAlertIfAttackResponseListsBogusLinuxDirectories() throws Exception {
+    void shouldNotAlertIfAttackResponseListsBogusLinuxDirectories() throws Exception {
         // Given
         nano.addHandler(new ListBogusLinuxDirsOnAttack("/", "p", "/"));
         rule.init(getHttpMessage("/?p=v"), parent);
@@ -128,7 +128,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldNotAlertIfLocalFilePathTraversalDoesNotExist() throws Exception {
+    void shouldNotAlertIfLocalFilePathTraversalDoesNotExist() throws Exception {
         // Given
         nano.addHandler(new LocalFileHandler("/", "p", ""));
         rule.init(getHttpMessage("/?p"), parent);
@@ -140,7 +140,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldNotAlertIfOriginalResponseAlreadyContainsTheEvidence() throws Exception {
+    void shouldNotAlertIfOriginalResponseAlreadyContainsTheEvidence() throws Exception {
         // Given
         String filePath = "/static-file";
         String fileContent = ListWinDirsOnAttack.DIRS_LISTING;
@@ -161,7 +161,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasPasswdFileContentAndPayloadIsNullByteBased()
+    void shouldRaiseAlertIfResponseHasPasswdFileContentAndPayloadIsNullByteBased()
             throws HttpMalformedHeaderException {
         // Given
         NullByteVulnerableServerHandler vulnServerHandler =
@@ -177,7 +177,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasSystemINIFileContentAndPayloadIsNullByteBased()
+    void shouldRaiseAlertIfResponseHasSystemINIFileContentAndPayloadIsNullByteBased()
             throws HttpMalformedHeaderException {
         // Given
         NullByteVulnerableServerHandler vulnServerHandler =
@@ -196,8 +196,8 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     @EnumSource(
             value = Plugin.AlertThreshold.class,
             names = {"LOW", "MEDIUM"})
-    public void shouldAlertOnCheckFiveBelowHighThresholdUnderValidConditions(
-            AlertThreshold alertThreshold) throws HttpMalformedHeaderException {
+    void shouldAlertOnCheckFiveBelowHighThresholdUnderValidConditions(AlertThreshold alertThreshold)
+            throws HttpMalformedHeaderException {
         // Given
         String path = "/file.ext";
         HttpMessage msg = getHttpMessage(path + "?p=a");
@@ -213,7 +213,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldNotAlertOnCheckFiveAtHighThresholdUnderValidConditions()
+    void shouldNotAlertOnCheckFiveAtHighThresholdUnderValidConditions()
             throws HttpMalformedHeaderException {
         // Given
         String path = "/file.ext";
@@ -228,7 +228,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldNotAlertOnCheckFiveAtLowThresholdUnderInvalidInitialConditions()
+    void shouldNotAlertOnCheckFiveAtLowThresholdUnderInvalidInitialConditions()
             throws HttpMalformedHeaderException {
         // Given
         String path = "/file.ext";
@@ -243,7 +243,7 @@ public class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTravers
     }
 
     @Test
-    public void shouldNotAlertOnCheckFiveAtLowThresholdUnderInvalidConditions()
+    void shouldNotAlertOnCheckFiveAtLowThresholdUnderInvalidConditions()
             throws HttpMalformedHeaderException {
         // Given
         String path = "/file.ext";

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRuleUnitTest.java
@@ -20,8 +20,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 /** Unit test for {@link PersistentXssPrimeScanRule}. */
-public class PersistentXssPrimeScanRuleUnitTest
-        extends ActiveScannerTest<PersistentXssPrimeScanRule> {
+class PersistentXssPrimeScanRuleUnitTest extends ActiveScannerTest<PersistentXssPrimeScanRule> {
 
     @Override
     protected PersistentXssPrimeScanRule createScanner() {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRuleUnitTest.java
@@ -20,7 +20,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 /** Unit test for {@link PersistentXssScanRule}. */
-public class PersistentXssScanRuleUnitTest extends ActiveScannerTest<PersistentXssScanRule> {
+class PersistentXssScanRuleUnitTest extends ActiveScannerTest<PersistentXssScanRule> {
 
     @Override
     protected PersistentXssScanRule createScanner() {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRuleUnitTest.java
@@ -20,8 +20,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 /** Unit test for {@link PersistentXssSpiderScanRule}. */
-public class PersistentXssSpiderScanRuleUnitTest
-        extends ActiveScannerTest<PersistentXssSpiderScanRule> {
+class PersistentXssSpiderScanRuleUnitTest extends ActiveScannerTest<PersistentXssSpiderScanRule> {
 
     @Override
     protected PersistentXssSpiderScanRule createScanner() {

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRuleUnitTest.java
@@ -31,8 +31,7 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link RemoteFileIncludeScanRule}. */
-public class RemoteFileIncludeScanRuleUnitTest
-        extends ActiveScannerTest<RemoteFileIncludeScanRule> {
+class RemoteFileIncludeScanRuleUnitTest extends ActiveScannerTest<RemoteFileIncludeScanRule> {
 
     @Override
     protected RemoteFileIncludeScanRule createScanner() {
@@ -42,7 +41,7 @@ public class RemoteFileIncludeScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasRemoteFileContentAndPayloadIsNullByteBased()
+    void shouldRaiseAlertIfResponseHasRemoteFileContentAndPayloadIsNullByteBased()
             throws HttpMalformedHeaderException {
         // Given
         NullByteVulnerableServerHandler vulnServerHandler =

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRuleUnitTest.java
@@ -28,8 +28,7 @@ import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
 /** Unit test for {@link ServerSideIncludeScanRule}. */
-public class ServerSideIncludeScanRuleUnitTest
-        extends ActiveScannerTest<ServerSideIncludeScanRule> {
+class ServerSideIncludeScanRuleUnitTest extends ActiveScannerTest<ServerSideIncludeScanRule> {
 
     @Override
     protected ServerSideIncludeScanRule createScanner() {
@@ -37,7 +36,7 @@ public class ServerSideIncludeScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetLinuxTech() {
+    void shouldTargetLinuxTech() {
         // Given
         TechSet techSet = techSet(Tech.Linux);
         // When
@@ -47,7 +46,7 @@ public class ServerSideIncludeScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetMacOsTech() {
+    void shouldTargetMacOsTech() {
         // Given
         TechSet techSet = techSet(Tech.MacOS);
         // When
@@ -57,7 +56,7 @@ public class ServerSideIncludeScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetWindowsTech() {
+    void shouldTargetWindowsTech() {
         // Given
         TechSet techSet = techSet(Tech.Windows);
         // When
@@ -67,7 +66,7 @@ public class ServerSideIncludeScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonLinuxMacOsWindowsTechs() {
+    void shouldNotTargetNonLinuxMacOsWindowsTechs() {
         // Given
         TechSet techSet = techSetWithout(Tech.Linux, Tech.MacOS, Tech.Windows);
         // When

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebinfScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebinfScanRuleUnitTest.java
@@ -44,7 +44,7 @@ import org.zaproxy.zap.testutils.NanoServerHandler;
 // - https://github.com/zaproxy/zaproxy/issues/4038
 // - https://bitbucket.org/mstrobel/procyon/issues/320/java-9-sunmiscurlclasspath-and
 @EnabledOnJre(JRE.JAVA_8)
-public class SourceCodeDisclosureWebinfScanRuleUnitTest
+class SourceCodeDisclosureWebinfScanRuleUnitTest
         extends ActiveScannerTest<SourceCodeDisclosureWebInfScanRule> {
 
     private static final String JAVA_LIKE_FILE_NAME_PATH = "/WEB-INF/classes/about/html.class";
@@ -55,7 +55,7 @@ public class SourceCodeDisclosureWebinfScanRuleUnitTest
     }
 
     @Test
-    public void shouldTryToObtainWebInfFiles() throws Exception {
+    void shouldTryToObtainWebInfFiles() throws Exception {
         // Given
         rule.init(getHttpMessage("/some/path"), parent);
         // When
@@ -69,8 +69,7 @@ public class SourceCodeDisclosureWebinfScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotContinueScanningIfReturnedContentHasNoJavaLikeFileNames()
-            throws Exception {
+    void shouldNotContinueScanningIfReturnedContentHasNoJavaLikeFileNames() throws Exception {
         // Given
         nano.addHandler(new NotFoundResponse(""));
         rule.init(getHttpMessage(""), parent);
@@ -81,7 +80,7 @@ public class SourceCodeDisclosureWebinfScanRuleUnitTest
     }
 
     @Test
-    public void shouldContinueScanningIfReturnedContentHasJavaLikeFileNamesEvenIfNotWebInfData()
+    void shouldContinueScanningIfReturnedContentHasJavaLikeFileNamesEvenIfNotWebInfData()
             throws Exception {
         // Given
         nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());
@@ -94,7 +93,7 @@ public class SourceCodeDisclosureWebinfScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfJavaLikeFileNameIsNot200Ok() throws Exception {
+    void shouldNotAlertIfJavaLikeFileNameIsNot200Ok() throws Exception {
         // Given
         nano.addHandler(new NotFoundResponse(JAVA_LIKE_FILE_NAME_PATH));
         nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());
@@ -108,7 +107,7 @@ public class SourceCodeDisclosureWebinfScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfJavaLikeFileNameIsNotAJavaClassEvenIfIs200Ok() throws Exception {
+    void shouldNotAlertIfJavaLikeFileNameIsNotAJavaClassEvenIfIs200Ok() throws Exception {
         // Given
         nano.addHandler(new OkResponse(JAVA_LIKE_FILE_NAME_PATH));
         nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());
@@ -122,7 +121,7 @@ public class SourceCodeDisclosureWebinfScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfJavaSourceWasDisclosed() throws Exception {
+    void shouldAlertIfJavaSourceWasDisclosed() throws Exception {
         // Given
         nano.addHandler(new JavaClassResponse(JAVA_LIKE_FILE_NAME_PATH));
         nano.addHandler(new NonWebInfWithJavaLikeFileNameResponse());

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRuleUnitTest.java
@@ -37,7 +37,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SqlInjectionScanRule}. */
-public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjectionScanRule> {
+class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjectionScanRule> {
 
     @Override
     protected int getRecommendMaxNumberMessagesPerParam(AttackStrength strength) {
@@ -61,7 +61,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldTargetDbTech() {
+    void shouldTargetDbTech() {
         // Given
         TechSet techSet = techSet(Tech.Db);
         // When
@@ -71,7 +71,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldTargetDbChildTechs() {
+    void shouldTargetDbChildTechs() {
         // Given
         TechSet techSet = techSet(techsOf(Tech.Db));
         techSet.exclude(Tech.Db);
@@ -82,7 +82,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldTargetDbChildTechsWithNonBuiltInTechInstances() {
+    void shouldTargetDbChildTechsWithNonBuiltInTechInstances() {
         // Given
         TechSet techSet = techSet(new Tech(new Tech("Db"), "SomeDb"));
         // When
@@ -92,7 +92,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldNotTargetNonDbTechs() {
+    void shouldNotTargetNonDbTechs() {
         // Given
         TechSet techSet = techSetWithout(techsOf(Tech.Db));
         // When
@@ -102,7 +102,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldAlertIfSumExpressionsAreSuccessful() throws Exception {
+    void shouldAlertIfSumExpressionsAreSuccessful() throws Exception {
         // Given
         String param = "id";
         nano.addHandler(
@@ -125,7 +125,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldAlertIfSumExpressionsAreSuccessfulAndReflectedInResponse() throws Exception {
+    void shouldAlertIfSumExpressionsAreSuccessfulAndReflectedInResponse() throws Exception {
         // Given
         String param = "id";
         nano.addHandler(
@@ -154,7 +154,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldNotAlertIfSumConfirmationExpressionIsNotSuccessful() throws Exception {
+    void shouldNotAlertIfSumConfirmationExpressionIsNotSuccessful() throws Exception {
         // Given
         String param = "id";
         nano.addHandler(
@@ -171,7 +171,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldNotAlertIfSumConfirmationExpressionIsNotSuccessfulAndIsReflectedInResponse()
+    void shouldNotAlertIfSumConfirmationExpressionIsNotSuccessfulAndIsReflectedInResponse()
             throws Exception {
         // Given
         String param = "id";
@@ -193,7 +193,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldAlertIfMultExpressionsAreSuccessful() throws Exception {
+    void shouldAlertIfMultExpressionsAreSuccessful() throws Exception {
         // Given
         String param = "id";
         nano.addHandler(
@@ -216,7 +216,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldAlertIfMultExpressionsAreSuccessfulAndReflectedInResponse() throws Exception {
+    void shouldAlertIfMultExpressionsAreSuccessfulAndReflectedInResponse() throws Exception {
         // Given
         String param = "id";
         nano.addHandler(
@@ -245,7 +245,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldNotAlertIfMultConfirmationExpressionIsNotSuccessful() throws Exception {
+    void shouldNotAlertIfMultConfirmationExpressionIsNotSuccessful() throws Exception {
         // Given
         String param = "id";
         nano.addHandler(
@@ -262,7 +262,7 @@ public class SqlInjectionScanRuleUnitTest extends ActiveScannerTest<SqlInjection
     }
 
     @Test
-    public void shouldNotAlertIfMultConfirmationExpressionIsNotSuccessfulAndReflectedInResponse()
+    void shouldNotAlertIfMultConfirmationExpressionIsNotSuccessfulAndReflectedInResponse()
             throws Exception {
         // Given
         String param = "id";

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ActiveScannerTest.java
@@ -22,8 +22,7 @@ package org.zaproxy.zap.extension.ascanrulesAlpha;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 
-public abstract class ActiveScannerTest<T extends AbstractPlugin>
-        extends ActiveScannerTestUtils<T> {
+abstract class ActiveScannerTest<T extends AbstractPlugin> extends ActiveScannerTestUtils<T> {
 
     @Override
     protected void setUpMessages() {

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRuleUnitTest.java
@@ -36,7 +36,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link CorsScanRule}. */
-public class CorsScanRuleUnitTest extends ActiveScannerTest<CorsScanRule> {
+class CorsScanRuleUnitTest extends ActiveScannerTest<CorsScanRule> {
     private static final String ACAC = "Access-Control-Allow-Credentials";
     private static final String GENERIC_RESPONSE =
             "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
@@ -48,7 +48,7 @@ public class CorsScanRuleUnitTest extends ActiveScannerTest<CorsScanRule> {
     }
 
     @Test
-    public void shouldNotAlertIfCorsNotSupported() throws Exception {
+    void shouldNotAlertIfCorsNotSupported() throws Exception {
         // Given
         nano.addHandler(new CorsResponse(null, false));
         HttpMessage msg = this.getHttpMessage("/");
@@ -60,7 +60,7 @@ public class CorsScanRuleUnitTest extends ActiveScannerTest<CorsScanRule> {
     }
 
     @Test
-    public void shouldAlertInfoIfAcaoButNotPayloads() throws Exception {
+    void shouldAlertInfoIfAcaoButNotPayloads() throws Exception {
         // Given
         nano.addHandler(new CorsResponse("dummyValue", false));
         HttpMessage msg = this.getHttpMessage("/");
@@ -73,7 +73,7 @@ public class CorsScanRuleUnitTest extends ActiveScannerTest<CorsScanRule> {
 
     @ParameterizedTest
     @ValueSource(strings = {"REFLECT", "*", "null"})
-    public void shouldAlertMediumIfAcaoPayloads(String origin) throws Exception {
+    void shouldAlertMediumIfAcaoPayloads(String origin) throws Exception {
         // Given
         nano.addHandler(new CorsResponse(origin, false));
         HttpMessage msg = this.getHttpMessage("/");
@@ -86,7 +86,7 @@ public class CorsScanRuleUnitTest extends ActiveScannerTest<CorsScanRule> {
 
     @ParameterizedTest
     @ValueSource(strings = {"REFLECT", "null"})
-    public void shouldAlertHighIfAcaoAndAcacPayloads(String origin) throws Exception {
+    void shouldAlertHighIfAcaoAndAcacPayloads(String origin) throws Exception {
         // Given
         nano.addHandler(new CorsResponse(origin, true));
         HttpMessage msg = this.getHttpMessage("/");
@@ -98,7 +98,7 @@ public class CorsScanRuleUnitTest extends ActiveScannerTest<CorsScanRule> {
     }
 
     @Test
-    public void shouldAlertMediumIfAcaoWildcardAndAcac() throws Exception {
+    void shouldAlertMediumIfAcaoWildcardAndAcac() throws Exception {
         // Given
         nano.addHandler(new CorsResponse("*", true));
         HttpMessage msg = this.getHttpMessage("/");

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link ForbiddenBypassScanRule}. */
-public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<ForbiddenBypassScanRule> {
+class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<ForbiddenBypassScanRule> {
 
     private static final String PROTECTED_PATH = "/protected/endpoint";
 
@@ -46,7 +46,7 @@ public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<Forbidden
     }
 
     @Test
-    public void shouldNotAlertIfInitialRequestIsNotForbidden() throws Exception {
+    void shouldNotAlertIfInitialRequestIsNotForbidden() throws Exception {
         // Given
         String path = "/allowed/";
         nano.addHandler(new OkResponse(path));
@@ -60,7 +60,7 @@ public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<Forbidden
     }
 
     @Test
-    public void shouldNotAlertIfAllRequestsAreForbidden() throws Exception {
+    void shouldNotAlertIfAllRequestsAreForbidden() throws Exception {
         // Given
         String path = "/forbidden/";
         nano.addHandler(new ForbiddenResponse(path));
@@ -74,7 +74,7 @@ public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<Forbidden
     }
 
     @Test
-    public void shouldAlertIfOkObtained() throws Exception {
+    void shouldAlertIfOkObtained() throws Exception {
         // Given
         nano.addHandler(new ForbiddenResponse(PROTECTED_PATH));
         nano.addHandler(new OkResponse("/." + PROTECTED_PATH)); // Period is %2e
@@ -90,7 +90,7 @@ public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<Forbidden
     }
 
     @Test
-    public void shouldAlertIfOkWithRewriteUrlHeader() throws Exception {
+    void shouldAlertIfOkWithRewriteUrlHeader() throws Exception {
         // Given
         nano.addHandler(new ForbiddenResponse(PROTECTED_PATH));
         nano.addHandler(new ResponseWithHeaderPayload("/anything", "x-rewrite-url"));
@@ -106,7 +106,7 @@ public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<Forbidden
     }
 
     @Test
-    public void shouldAlertIfOkWithRefererHeader() throws Exception {
+    void shouldAlertIfOkWithRefererHeader() throws Exception {
         // Given
         nano.addHandler(new ForbiddenResponse(PROTECTED_PATH));
         nano.addHandler(new ResponseWithHeaderPayload("/anything", "referer"));
@@ -122,7 +122,7 @@ public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<Forbidden
     }
 
     @Test
-    public void shouldAlertIfOkWithOriginalUrlHeader() throws Exception {
+    void shouldAlertIfOkWithOriginalUrlHeader() throws Exception {
         // Given
         nano.addHandler(new ForbiddenResponse(PROTECTED_PATH));
         nano.addHandler(new ResponseWithHeaderPayload("/", "x-original-url"));
@@ -138,7 +138,7 @@ public class ForbiddenBypassScanRuleUnitTest extends ActiveScannerTest<Forbidden
     }
 
     @Test
-    public void shouldAlertIfOkWithCustomIpAuthorizationHeader() throws Exception {
+    void shouldAlertIfOkWithCustomIpAuthorizationHeader() throws Exception {
         // Given
         nano.addHandler(new ResponseWithHeaderPayload(PROTECTED_PATH, "x-custom-ip-authorization"));
         HttpMessage msg = this.getHttpMessage(PROTECTED_PATH);

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/ActiveScannerTest.java
@@ -22,8 +22,7 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 import org.parosproxy.paros.core.scanner.AbstractPlugin;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 
-public abstract class ActiveScannerTest<T extends AbstractPlugin>
-        extends ActiveScannerTestUtils<T> {
+abstract class ActiveScannerTest<T extends AbstractPlugin> extends ActiveScannerTestUtils<T> {
 
     @Override
     protected void setUpMessages() {

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRuleUnitTest.java
@@ -36,8 +36,7 @@ import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link BackupFileDisclosureScanRule}. */
-public class BackupFileDisclosureScanRuleUnitTest
-        extends ActiveScannerTest<BackupFileDisclosureScanRule> {
+class BackupFileDisclosureScanRuleUnitTest extends ActiveScannerTest<BackupFileDisclosureScanRule> {
 
     private static final String PATH_TOKEN = "@@@PATH@@@";
     private static final String FORBIDDEN_RESPONSE_WITH_REQUESTED_PATH =
@@ -67,7 +66,7 @@ public class BackupFileDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfNonExistingBackupFileReturnsNon404Code() throws Exception {
+    void shouldNotAlertIfNonExistingBackupFileReturnsNon404Code() throws Exception {
         // Given
         String test = "/";
         nano.addHandler(new ForbiddenResponseWithReqPath(test));
@@ -80,7 +79,7 @@ public class BackupFileDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfOriginalFileNorBackupReturnsNon200Code() throws Exception {
+    void shouldNotAlertIfOriginalFileNorBackupReturnsNon200Code() throws Exception {
         // Given
         String test = "/";
         nano.addHandler(new ForbiddenResponseWithReqPath(test));
@@ -94,7 +93,7 @@ public class BackupFileDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfBackupResponseIsNotEmptyAndIsDifferentStatusFromBogusRequest()
+    void shouldAlertIfBackupResponseIsNotEmptyAndIsDifferentStatusFromBogusRequest()
             throws Exception {
         // Given
         String test = "/";
@@ -120,8 +119,7 @@ public class BackupFileDisclosureScanRuleUnitTest
 
     @ParameterizedTest
     @ValueSource(ints = {301, 403, 500})
-    public void shouldNotAlertIfBackupResponseIsNonSuccessStdThreshold(int status)
-            throws Exception {
+    void shouldNotAlertIfBackupResponseIsNonSuccessStdThreshold(int status) throws Exception {
         // Given
         String test = "/";
         nano.addHandler(
@@ -148,7 +146,7 @@ public class BackupFileDisclosureScanRuleUnitTest
 
     @ParameterizedTest
     @ValueSource(ints = {301, 403, 500})
-    public void shouldAlertIfBackupResponseIsNonSuccessLowThreshold(int status) throws Exception {
+    void shouldAlertIfBackupResponseIsNonSuccessLowThreshold(int status) throws Exception {
         // Given
         String test = "/";
         nano.addHandler(
@@ -176,7 +174,7 @@ public class BackupFileDisclosureScanRuleUnitTest
 
     @ParameterizedTest
     @ValueSource(ints = {301, 403, 500})
-    public void shouldAlertIfOldBackupResponseAfterNonSuccess(int status) throws Exception {
+    void shouldAlertIfOldBackupResponseAfterNonSuccess(int status) throws Exception {
         // Given
         String test = "/";
         nano.addHandler(
@@ -206,7 +204,7 @@ public class BackupFileDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfBackupDir() throws Exception {
+    void shouldAlertIfBackupDir() throws Exception {
         // Given
         String test = "/dirbackup/";
         nano.addHandler(
@@ -233,8 +231,7 @@ public class BackupFileDisclosureScanRuleUnitTest
 
     @ParameterizedTest
     @ValueSource(ints = {301, 403, 500})
-    public void shouldNotAlertIfBackupDirResponseIsNonSuccessStdThreshold(int status)
-            throws Exception {
+    void shouldNotAlertIfBackupDirResponseIsNonSuccessStdThreshold(int status) throws Exception {
         // Given
         String test = "/dirbackup/";
         nano.addHandler(
@@ -261,8 +258,7 @@ public class BackupFileDisclosureScanRuleUnitTest
 
     @ParameterizedTest
     @ValueSource(ints = {301, 403, 500})
-    public void shouldAlertIfBackupDirResponseIsNonSuccessLowThreshold(int status)
-            throws Exception {
+    void shouldAlertIfBackupDirResponseIsNonSuccessLowThreshold(int status) throws Exception {
         // Given
         String test = "/dirbackup/";
         nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link CloudMetadataScanRule}. */
-public class CloudMetadataScanRuleUnitTest extends ActiveScannerTest<CloudMetadataScanRule> {
+class CloudMetadataScanRuleUnitTest extends ActiveScannerTest<CloudMetadataScanRule> {
 
     @Override
     protected CloudMetadataScanRule createScanner() {
@@ -41,7 +41,7 @@ public class CloudMetadataScanRuleUnitTest extends ActiveScannerTest<CloudMetada
     }
 
     @Test
-    public void shouldNotAlertIfResponseIsNot200Ok() throws Exception {
+    void shouldNotAlertIfResponseIsNot200Ok() throws Exception {
         // Given
         String path = "/latest/meta-data/";
         String body = "<html><head></head><H>404 - Not Found</H1><html>";
@@ -60,7 +60,7 @@ public class CloudMetadataScanRuleUnitTest extends ActiveScannerTest<CloudMetada
     }
 
     @Test
-    public void shouldAlertIfResponseIs200Ok() throws Exception {
+    void shouldAlertIfResponseIs200Ok() throws Exception {
         // Given
         String path = "/latest/meta-data/";
         // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRuleUnitTest.java
@@ -44,7 +44,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.httpsessions.HttpSessionsParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRule> {
+class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRule> {
 
     @Override
     protected CsrfTokenScanRule createScanner() {
@@ -55,7 +55,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldInitWithConfig() throws Exception {
+    void shouldInitWithConfig() throws Exception {
         // Given
         CsrfTokenScanRule rule = new CsrfTokenScanRule();
         rule.setConfig(new ZapXmlConfiguration());
@@ -64,15 +64,16 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldFailToInitWithoutConfig() throws Exception {
+    void shouldFailToInitWithoutConfig() throws Exception {
         // Given
         CsrfTokenScanRule rule = new CsrfTokenScanRule();
+        HttpMessage msg = getHttpMessage("");
         // When / Then
-        assertThrows(NullPointerException.class, () -> rule.init(getHttpMessage(""), parent));
+        assertThrows(NullPointerException.class, () -> rule.init(msg, parent));
     }
 
     @Test
-    public void shouldHaveSessionIdsInConfig() throws Exception {
+    void shouldHaveSessionIdsInConfig() throws Exception {
         // Given
         OptionsParam options = Model.getSingleton().getOptionsParam();
         HttpSessionsParam sessionOptions = options.getParamSet(HttpSessionsParam.class);
@@ -83,7 +84,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldNotProcessWithoutForm() throws Exception {
+    void shouldNotProcessWithoutForm() throws Exception {
         // Given
         HttpMessage msg =
                 getHttpMessage(
@@ -100,7 +101,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldNotProcessNonHtml() throws Exception {
+    void shouldNotProcessNonHtml() throws Exception {
         // Given
         HttpMessage msg =
                 getHttpMessage(
@@ -121,7 +122,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessWithoutCookie() throws Exception {
+    void shouldProcessWithoutCookie() throws Exception {
         // Given
         HttpMessage msg = getAntiCSRFCompatibleMessage();
         rule.init(msg, parent);
@@ -133,7 +134,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessWithOneSessionCookie() throws Exception {
+    void shouldProcessWithOneSessionCookie() throws Exception {
         // Given
         HttpMessage msg = getAntiCSRFCompatibleMessage();
         TreeSet<HtmlParameter> cookies = new TreeSet<>();
@@ -148,7 +149,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessWithTwoSessionCookies() throws Exception {
+    void shouldProcessWithTwoSessionCookies() throws Exception {
         // Given
         HttpMessage msg = getAntiCSRFCompatibleMessage();
         TreeSet<HtmlParameter> cookies = new TreeSet<>();
@@ -164,7 +165,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessWithOtherCookie() throws Exception {
+    void shouldProcessWithOtherCookie() throws Exception {
         // Given
         HttpMessage msg = getAntiCSRFCompatibleMessage();
         TreeSet<HtmlParameter> cookies = new TreeSet<>();
@@ -179,7 +180,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessWithTwoSessionCookiesAndOtherCookie() throws Exception {
+    void shouldProcessWithTwoSessionCookiesAndOtherCookie() throws Exception {
         // Given
         HttpMessage msg = getAntiCSRFCompatibleMessage();
         TreeSet<HtmlParameter> cookies = new TreeSet<>();
@@ -196,7 +197,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldNotProcessAtHighThresholdAndOutOfScope()
+    void shouldNotProcessAtHighThresholdAndOutOfScope()
             throws HttpMalformedHeaderException, URIException {
         // Given
         HttpMessage msg = createMessage(false);
@@ -211,7 +212,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessAtHighThresholdAndInScope()
+    void shouldProcessAtHighThresholdAndInScope()
             throws HttpMalformedHeaderException, URIException {
         // Given
         HttpMessage msg = createMessage(true);
@@ -226,7 +227,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessAtMediumThresholdAndOutOfScope()
+    void shouldProcessAtMediumThresholdAndOutOfScope()
             throws HttpMalformedHeaderException, URIException {
         // Given
         HttpMessage msg = createMessage(false);
@@ -241,7 +242,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessAtMediumThresholdAndInScope()
+    void shouldProcessAtMediumThresholdAndInScope()
             throws HttpMalformedHeaderException, URIException {
         // Given
         HttpMessage msg = createMessage(true);
@@ -256,7 +257,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessAtLowThresholdAndOutOfScope()
+    void shouldProcessAtLowThresholdAndOutOfScope()
             throws HttpMalformedHeaderException, URIException {
         // Given
         HttpMessage msg = createMessage(false);
@@ -271,8 +272,7 @@ public class CsrfTokenScanRuleUnitTest extends ActiveScannerTest<CsrfTokenScanRu
     }
 
     @Test
-    public void shouldProcessAtLowThresholdAndInScope()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldProcessAtLowThresholdAndInScope() throws HttpMalformedHeaderException, URIException {
         // Given
         HttpMessage msg = createMessage(true);
         rule.setConfig(new ZapXmlConfiguration());

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.AbstractAppFilePluginUnitTest;
 
 /** Unit test for {@link EnvFileScanRule}. */
-public class EnvFileScanRuleUnitTest extends AbstractAppFilePluginUnitTest<EnvFileScanRule> {
+class EnvFileScanRuleUnitTest extends AbstractAppFilePluginUnitTest<EnvFileScanRule> {
 
     private static final String RELEVANT_BODY =
             "DB_CONNECTION=mysql\n"
@@ -102,7 +102,7 @@ public class EnvFileScanRuleUnitTest extends AbstractAppFilePluginUnitTest<EnvFi
     }
 
     @Test
-    public void shouldNotAlertWhenRequestIsSuccessfulButContentNotRelevant() throws Exception {
+    void shouldNotAlertWhenRequestIsSuccessfulButContentNotRelevant() throws Exception {
         // Given
         String path = "/.env";
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
@@ -52,7 +52,7 @@ import org.zaproxy.zap.testutils.StaticContentServerHandler;
  * rule.init()}</br> Note: If using {@code addTestPayload(HiddenFile)} should be called after {@code
  * rule.init()}
  */
-public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule> {
+class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule> {
 
     @Override
     protected HiddenFilesScanRule createScanner() {
@@ -60,12 +60,12 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @AfterEach
-    public void after() {
+    void after() {
         HiddenFilesScanRule.setPayloadProvider(null);
     }
 
     @Test
-    public void shouldScanMessageWithoutPath() throws HttpMalformedHeaderException {
+    void shouldScanMessageWithoutPath() throws HttpMalformedHeaderException {
         // Given
         String path = "";
         HttpMessage msg = getHttpMessage(path);
@@ -85,8 +85,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldSendGetRequestWhenOriginalRequestWasNotGet()
-            throws HttpMalformedHeaderException {
+    void shouldSendGetRequestWhenOriginalRequestWasNotGet() throws HttpMalformedHeaderException {
         // Given
         String path = "";
         HttpMessage msg = getHttpMessage(path);
@@ -114,7 +113,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantContent()
+    void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantContent()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -152,7 +151,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
 
     @ParameterizedTest
     @EnumSource(names = {"LOW", "MEDIUM"})
-    public void shouldNotRaiseAlertIfTestedUrlRespondsForbiddenWhenThresholdNotHigh(
+    void shouldNotRaiseAlertIfTestedUrlRespondsForbiddenWhenThresholdNotHigh(
             AlertThreshold threshold) throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -180,7 +179,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsForbiddenAtHighThreshold()
+    void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsForbiddenAtHighThreshold()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -213,7 +212,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldNotRaiseAlertIfPathIsntServed() throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertIfPathIsntServed() throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldNotAlert";
 
@@ -240,7 +239,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldAlertWithLowConfidenceIfContentStringsDontAllMatchAtHighThreshold()
+    void shouldAlertWithLowConfidenceIfContentStringsDontAllMatchAtHighThreshold()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -275,8 +274,8 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
 
     @ParameterizedTest
     @EnumSource(names = {"LOW", "MEDIUM"})
-    public void shouldNotAlertIfContentStringsDontAllMatchWhenNotHighThreshold(
-            AlertThreshold threshold) throws HttpMalformedHeaderException {
+    void shouldNotAlertIfContentStringsDontAllMatchWhenNotHighThreshold(AlertThreshold threshold)
+            throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
 
@@ -303,7 +302,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertWithHighConfidenceIfContentStringsAllMatch()
+    void shouldRaiseAlertWithHighConfidenceIfContentStringsAllMatch()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -336,7 +335,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkToCustomPayload()
+    void shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkToCustomPayload()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -367,7 +366,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseStatusIsNotOkOrAuthRelated()
+    void shouldNotRaiseAlertIfResponseStatusIsNotOkOrAuthRelated()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldNotAlert";
@@ -395,7 +394,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantContentAndAppropriateNotContent()
+    void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantContentAndAppropriateNotContent()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -430,7 +429,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void
+    void
             shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithRelevantContentButDoesContainNotContentAtHighThreshold()
                     throws HttpMalformedHeaderException {
         // Given
@@ -468,7 +467,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
 
     @ParameterizedTest
     @EnumSource(names = {"LOW", "MEDIUM"})
-    public void
+    void
             shouldNotRaiseAlertIfTestedUrlRespondsOkWithRelevantContentButDoesContainNotContentWhenNotHighThreshold(
                     AlertThreshold threshold) throws HttpMalformedHeaderException {
         // Given
@@ -500,7 +499,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantBinContent()
+    void shouldRaiseAlertIfTestedUrlRespondsOkWithRelevantBinContent()
             throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
@@ -538,7 +537,7 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
     }
 
     @Test
-    public void
+    void
             shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkWithoutRelevantBinContentAtHighThreshold()
                     throws HttpMalformedHeaderException {
         // Given
@@ -581,9 +580,8 @@ public class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesSc
 
     @ParameterizedTest
     @EnumSource(names = {"LOW", "MEDIUM"})
-    public void
-            shouldNotRaiseAlertIfTestedUrlRespondsOkWithoutRelevantBinContentWhenNotHighThreshold(
-                    AlertThreshold threshold) throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertIfTestedUrlRespondsOkWithoutRelevantBinContentWhenNotHighThreshold(
+            AlertThreshold threshold) throws HttpMalformedHeaderException {
         // Given
         String servePath = "/shouldAlert";
 

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/IntegerOverflowScanRuleUnitTest.java
@@ -34,7 +34,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link IntegerOverflowScanRule}. */
-public class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOverflowScanRule> {
+class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOverflowScanRule> {
 
     @Override
     protected IntegerOverflowScanRule createScanner() {
@@ -42,7 +42,7 @@ public class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOv
     }
 
     @Test
-    public void shouldTargetCTech() {
+    void shouldTargetCTech() {
         // Given
         TechSet techSet = techSet(Tech.C);
         // When
@@ -52,7 +52,7 @@ public class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOv
     }
 
     @Test
-    public void shouldNotTargetNonCTechs() {
+    void shouldNotTargetNonCTechs() {
         // Given
         TechSet techSet = techSetWithout(Tech.C);
         // When
@@ -62,7 +62,7 @@ public class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOv
     }
 
     @Test
-    public void shouldSkipScanning500ErrorMessage() throws Exception {
+    void shouldSkipScanning500ErrorMessage() throws Exception {
         // Given
         HttpMessage message = getHttpMessage("?param=value");
         message.setResponseHeader(
@@ -75,7 +75,7 @@ public class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOv
     }
 
     @Test
-    public void shouldScanNon500ErrorMessage() throws Exception {
+    void shouldScanNon500ErrorMessage() throws Exception {
         // Given
         rule.init(getHttpMessage("?param=value"), parent);
         // When
@@ -85,7 +85,7 @@ public class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOv
     }
 
     @Test
-    public void shouldSkipScanIfStopped() throws Exception {
+    void shouldSkipScanIfStopped() throws Exception {
         // Given
         rule.init(getHttpMessage("?param=value"), parent);
         parent.stop();
@@ -96,7 +96,7 @@ public class IntegerOverflowScanRuleUnitTest extends ActiveScannerTest<IntegerOv
     }
 
     @Test
-    public void shouldCreateAlertsWithPrimeHeaderAsEvidence() throws Exception {
+    void shouldCreateAlertsWithPrimeHeaderAsEvidence() throws Exception {
         // Given
         String test = "/shouldReportIntegerOverflowIssue/";
         int INT_MAX = 2147483647; // From c/c++

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRuleUnitTest.java
@@ -35,7 +35,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link RemoteCodeExecutionCve20121823ScanRule}. */
-public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
+class RemoteCodeExecutionCve20121823ScanRuleUnitTest
         extends ActiveScannerTest<RemoteCodeExecutionCve20121823ScanRule> {
 
     @Override
@@ -44,7 +44,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetPhpTech() throws Exception {
+    void shouldTargetPhpTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.PHP);
         // When
@@ -54,7 +54,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonPhpTechs() throws Exception {
+    void shouldNotTargetNonPhpTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.PHP);
         // When
@@ -64,7 +64,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldScanUrlsWithoutPath() throws Exception {
+    void shouldScanUrlsWithoutPath() throws Exception {
         // Given
         HttpMessage message = getHttpMessage("");
         rule.init(message, parent);
@@ -75,7 +75,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldScanUrlsWithEncodedCharsInPath() throws Exception {
+    void shouldScanUrlsWithEncodedCharsInPath() throws Exception {
         // Given
         String test = "/shouldScanUrlsWithEncodedCharsInPath/";
         nano.addHandler(
@@ -96,7 +96,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotScanUrlsIfWinAndNixTechIsNotIncluded() throws Exception {
+    void shouldNotScanUrlsIfWinAndNixTechIsNotIncluded() throws Exception {
         // Given
         String test = "/shouldNotScanUrlsIfWinAndNixTechIsNotIncluded/";
         HttpMessage message = getHttpMessage(test);
@@ -109,7 +109,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfTheAttackIsNotEchoedInTheResponse() throws Exception {
+    void shouldNotAlertIfTheAttackIsNotEchoedInTheResponse() throws Exception {
         // Given
         String test = "/shouldNotAlertIfTheAttackIsNotEchoedInTheResponse/";
         nano.addHandler(
@@ -130,7 +130,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertEvenIfAttackResponseBodyHasBiggerSize() throws Exception {
+    void shouldNotAlertEvenIfAttackResponseBodyHasBiggerSize() throws Exception {
         // Given
         String test = "/shouldNotAlertEvenIfResponseBodyHasBiggerSize/";
         nano.addHandler(
@@ -156,7 +156,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfWindowsAttackWasSuccessful() throws Exception {
+    void shouldAlertIfWindowsAttackWasSuccessful() throws Exception {
         // Given
         final String body =
                 RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
@@ -184,7 +184,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotDoWinAttackIfWinTechIsNotIncluded() throws Exception {
+    void shouldNotDoWinAttackIfWinTechIsNotIncluded() throws Exception {
         // Given
         final String body =
                 RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
@@ -202,7 +202,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfNixAttackWasSuccessful() throws Exception {
+    void shouldAlertIfNixAttackWasSuccessful() throws Exception {
         // Given
         final String body =
                 RemoteCodeExecutionCve20121823ScanRule.RANDOM_STRING
@@ -230,7 +230,7 @@ public class RemoteCodeExecutionCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotDoNixAttackIfNixTechsAreNotIncluded() throws Exception {
+    void shouldNotDoNixAttackIfNixTechsAreNotIncluded() throws Exception {
         // Given
         String test = "/shouldNotDoNixAttackIfNixTechsAreNotIncluded/";
         nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRuleUnitTest.java
@@ -40,7 +40,7 @@ import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link SourceCodeDisclosureCve20121823ScanRule}. */
-public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
+class SourceCodeDisclosureCve20121823ScanRuleUnitTest
         extends ActiveScannerTest<SourceCodeDisclosureCve20121823ScanRule> {
 
     private static final String RESPONSE_HEADER_404_NOT_FOUND =
@@ -57,7 +57,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetPhpTech() throws Exception {
+    void shouldTargetPhpTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.PHP);
         // When
@@ -67,7 +67,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonPhpTechs() throws Exception {
+    void shouldNotTargetNonPhpTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.PHP);
         // When
@@ -77,7 +77,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldIgnoreNonTextResponses() throws Exception {
+    void shouldIgnoreNonTextResponses() throws Exception {
         // Given
         HttpMessage message = getHttpMessage("/");
         message.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "image/jpeg");
@@ -89,7 +89,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldIgnore404NotFoundResponsesOnMediumAttackStrength() throws Exception {
+    void shouldIgnore404NotFoundResponsesOnMediumAttackStrength() throws Exception {
         // Given
         HttpMessage message = httpMessage404NotFound();
         rule.init(message, parent);
@@ -101,7 +101,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldIgnore404NotFoundResponsesOnLowAttackStrength() throws Exception {
+    void shouldIgnore404NotFoundResponsesOnLowAttackStrength() throws Exception {
         // Given
         HttpMessage message = httpMessage404NotFound();
         rule.init(message, parent);
@@ -113,7 +113,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldScan404NotFoundResponsesOnHighAttackStrength() throws Exception {
+    void shouldScan404NotFoundResponsesOnHighAttackStrength() throws Exception {
         // Given
         HttpMessage message = httpMessage404NotFound();
         rule.setAttackStrength(AttackStrength.HIGH);
@@ -125,7 +125,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldScan404NotFoundResponsesOnInsaneAttackStrength() throws Exception {
+    void shouldScan404NotFoundResponsesOnInsaneAttackStrength() throws Exception {
         // Given
         HttpMessage message = httpMessage404NotFound();
         rule.init(message, parent);
@@ -137,7 +137,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldScanUrlsWithoutPath() throws Exception {
+    void shouldScanUrlsWithoutPath() throws Exception {
         // Given
         nano.addHandler(
                 new NanoServerHandler("shouldScanUrlsWithoutPath") {
@@ -156,7 +156,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldScanUrlsWithEncodedCharsInPath() throws Exception {
+    void shouldScanUrlsWithEncodedCharsInPath() throws Exception {
         // Given
         String test = "/shouldScanUrlsWithEncodedCharsInPath/";
         nano.addHandler(
@@ -176,7 +176,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfThereIsNoSourceCodeDisclosure() throws Exception {
+    void shouldNotAlertIfThereIsNoSourceCodeDisclosure() throws Exception {
         // Given
         String test = "/shouldNotAlertIfThereIsNoSourceCodeDisclosure/";
         nano.addHandler(
@@ -196,7 +196,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfPhpSourceTagsWereDisclosedInResponseBody() throws Exception {
+    void shouldAlertIfPhpSourceTagsWereDisclosedInResponseBody() throws Exception {
         // Given
         String test = "/shouldAlertIfPhpSourceTagsWereDisclosedInResponseBody/";
         nano.addHandler(
@@ -224,9 +224,8 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void
-            shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpSourceTagsWereDisclosedInResponseBody()
-                    throws Exception {
+    void shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpSourceTagsWereDisclosedInResponseBody()
+            throws Exception {
         // Given
         String test =
                 "/shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpSourceTagsWereDisclosedInResponseBody/";
@@ -252,7 +251,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfPhpEchoTagsWereDisclosedInResponseBody() throws Exception {
+    void shouldAlertIfPhpEchoTagsWereDisclosedInResponseBody() throws Exception {
         // Given
         String test = "/shouldAlertIfPhpEchoTagsWereDisclosedInResponseBody/";
         nano.addHandler(
@@ -280,9 +279,8 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void
-            shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpEchoTagsWereDisclosedInResponseBody()
-                    throws Exception {
+    void shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpEchoTagsWereDisclosedInResponseBody()
+            throws Exception {
         // Given
         String test =
                 "/shouldNotAlertIfResponseIsNotSuccessfulEvenIfPhpEchoTagsWereDisclosedInResponseBody/";
@@ -308,7 +306,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfJavaScriptFilesAtDefaultThreshold() throws Exception {
+    void shouldNotAlertIfJavaScriptFilesAtDefaultThreshold() throws Exception {
         // Given
         String test = "/shouldNotAlertIfJavaScriptFilesAtDefaultThreshold/";
         nano.addHandler(
@@ -335,7 +333,7 @@ public class SourceCodeDisclosureCve20121823ScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfJavaScriptFilesAtLowThreshold() throws Exception {
+    void shouldAlertIfJavaScriptFilesAtLowThreshold() throws Exception {
         // Given
         String test = "/shouldAlertIfJavaScriptFilesAtLowThreshold/";
         nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRuleUnitTest.java
@@ -34,7 +34,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SqlInjectionHypersonicScanRule}. */
-public class SqlInjectionHypersonicScanRuleUnitTest
+class SqlInjectionHypersonicScanRuleUnitTest
         extends ActiveScannerTest<SqlInjectionHypersonicScanRule> {
 
     @Override
@@ -43,7 +43,7 @@ public class SqlInjectionHypersonicScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetHypersonicSQLTech() throws Exception {
+    void shouldTargetHypersonicSQLTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.HypersonicSQL);
         // When
@@ -53,7 +53,7 @@ public class SqlInjectionHypersonicScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonHypersonicSQLTechs() throws Exception {
+    void shouldNotTargetNonHypersonicSQLTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.HypersonicSQL);
         // When
@@ -63,7 +63,7 @@ public class SqlInjectionHypersonicScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfSleepTimesGetLonger() throws Exception {
+    void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
 
         this.nano.addHandler(
@@ -104,7 +104,7 @@ public class SqlInjectionHypersonicScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
         String test = "/shouldNotReportGeneralTimingIssue/";
 
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRuleUnitTest.java
@@ -34,8 +34,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SqlInjectionMsSqlScanRule}. */
-public class SqlInjectionMsSqlScanRuleUnitTest
-        extends ActiveScannerTest<SqlInjectionMsSqlScanRule> {
+class SqlInjectionMsSqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMsSqlScanRule> {
 
     @Override
     protected SqlInjectionMsSqlScanRule createScanner() {
@@ -43,7 +42,7 @@ public class SqlInjectionMsSqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetMsSQLTech() throws Exception {
+    void shouldTargetMsSQLTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.MsSQL);
         // When
@@ -53,7 +52,7 @@ public class SqlInjectionMsSqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonMsSQLTechs() throws Exception {
+    void shouldNotTargetNonMsSQLTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.MsSQL);
         // When
@@ -63,7 +62,7 @@ public class SqlInjectionMsSqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfSleepTimesGetLonger() throws Exception {
+    void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
 
         this.nano.addHandler(
@@ -101,7 +100,7 @@ public class SqlInjectionMsSqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
         String test = "/shouldNotReportGeneralTimingIssue/";
 
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMySsqlScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMySsqlScanRuleUnitTest.java
@@ -34,8 +34,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SqlInjectionMyqlScanRule}. */
-public class SqlInjectionMySsqlScanRuleUnitTest
-        extends ActiveScannerTest<SqlInjectionMyqlScanRule> {
+class SqlInjectionMySsqlScanRuleUnitTest extends ActiveScannerTest<SqlInjectionMyqlScanRule> {
 
     @Override
     protected SqlInjectionMyqlScanRule createScanner() {
@@ -43,7 +42,7 @@ public class SqlInjectionMySsqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetMySQLTech() throws Exception {
+    void shouldTargetMySQLTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.MySQL);
         // When
@@ -53,7 +52,7 @@ public class SqlInjectionMySsqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonMySQLTechs() throws Exception {
+    void shouldNotTargetNonMySQLTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.MySQL);
         // When
@@ -63,7 +62,7 @@ public class SqlInjectionMySsqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfSleepTimesGetLonger() throws Exception {
+    void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
 
         this.nano.addHandler(
@@ -101,7 +100,7 @@ public class SqlInjectionMySsqlScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
         String test = "/shouldNotReportGeneralTimingIssue/";
 
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRuleUnitTest.java
@@ -34,8 +34,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SqlInjectionOracleScanRule}. */
-public class SqlInjectionOracleScanRuleUnitTest
-        extends ActiveScannerTest<SqlInjectionOracleScanRule> {
+class SqlInjectionOracleScanRuleUnitTest extends ActiveScannerTest<SqlInjectionOracleScanRule> {
 
     @Override
     protected SqlInjectionOracleScanRule createScanner() {
@@ -43,7 +42,7 @@ public class SqlInjectionOracleScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetOracleTech() throws Exception {
+    void shouldTargetOracleTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.Oracle);
         // When
@@ -53,7 +52,7 @@ public class SqlInjectionOracleScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonOracleTechs() throws Exception {
+    void shouldNotTargetNonOracleTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.Oracle);
         // When
@@ -63,7 +62,7 @@ public class SqlInjectionOracleScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfSleepTimesGetLonger() throws Exception {
+    void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
 
         this.nano.addHandler(
@@ -104,7 +103,7 @@ public class SqlInjectionOracleScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
         String test = "/shouldNotReportGeneralTimingIssue/";
 
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRuleUnitTest.java
@@ -34,8 +34,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SqlInjectionPostgreScanRule}. */
-public class SqlInjectionPostgreScanRuleUnitTest
-        extends ActiveScannerTest<SqlInjectionPostgreScanRule> {
+class SqlInjectionPostgreScanRuleUnitTest extends ActiveScannerTest<SqlInjectionPostgreScanRule> {
 
     @Override
     protected SqlInjectionPostgreScanRule createScanner() {
@@ -43,7 +42,7 @@ public class SqlInjectionPostgreScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetPostgreSQLTech() throws Exception {
+    void shouldTargetPostgreSQLTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.PostgreSQL);
         // When
@@ -53,7 +52,7 @@ public class SqlInjectionPostgreScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonPostgreSQLTechs() throws Exception {
+    void shouldNotTargetNonPostgreSQLTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.PostgreSQL);
         // When
@@ -63,7 +62,7 @@ public class SqlInjectionPostgreScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfSleepTimesGetLonger() throws Exception {
+    void shouldAlertIfSleepTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
 
         this.nano.addHandler(
@@ -104,7 +103,7 @@ public class SqlInjectionPostgreScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
         String test = "/shouldNotReportGeneralTimingIssue/";
 
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSQLiteScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSQLiteScanRuleUnitTest.java
@@ -36,8 +36,7 @@ import org.zaproxy.zap.model.TechSet;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SqlInjectionSqLiteScanRule}. */
-public class SqlInjectionSQLiteScanRuleUnitTest
-        extends ActiveScannerTest<SqlInjectionSqLiteScanRule> {
+class SqlInjectionSQLiteScanRuleUnitTest extends ActiveScannerTest<SqlInjectionSqLiteScanRule> {
 
     @Override
     protected SqlInjectionSqLiteScanRule createScanner() {
@@ -61,7 +60,7 @@ public class SqlInjectionSQLiteScanRuleUnitTest
     }
 
     @Test
-    public void shouldTargetSqLiteSQLTech() throws Exception {
+    void shouldTargetSqLiteSQLTech() throws Exception {
         // Given
         TechSet techSet = techSet(Tech.SQLite);
         // When
@@ -71,7 +70,7 @@ public class SqlInjectionSQLiteScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotTargetNonSqLiteSQLTechs() throws Exception {
+    void shouldNotTargetNonSqLiteSQLTechs() throws Exception {
         // Given
         TechSet techSet = techSetWithout(Tech.SQLite);
         // When
@@ -81,7 +80,7 @@ public class SqlInjectionSQLiteScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfSqlErrorReturned() throws Exception {
+    void shouldAlertIfSqlErrorReturned() throws Exception {
         String test = "/shouldReportSqlErrorMessage/";
 
         this.nano.addHandler(
@@ -115,7 +114,7 @@ public class SqlInjectionSQLiteScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfRandomBlobTimesGetLonger() throws Exception {
+    void shouldAlertIfRandomBlobTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
 
         this.nano.addHandler(
@@ -156,7 +155,7 @@ public class SqlInjectionSQLiteScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfAllTimesGetLonger() throws Exception {
+    void shouldNotAlertIfAllTimesGetLonger() throws Exception {
         String test = "/shouldReportSqlTimingIssue/";
 
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/TraceAxdScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.AbstractAppFilePluginUnitTest;
 
 /** Unit test for {@link TraceAxdScanRule}. */
-public class TraceAxdScanRuleUnitTest extends AbstractAppFilePluginUnitTest<TraceAxdScanRule> {
+class TraceAxdScanRuleUnitTest extends AbstractAppFilePluginUnitTest<TraceAxdScanRule> {
 
     private static final String RELEVANT_BODY = "<html><H1>Application Trace</H1></html>";
     private static final String IRRELEVANT_BODY = "<html><title>Some Page</title></html>";
@@ -96,7 +96,7 @@ public class TraceAxdScanRuleUnitTest extends AbstractAppFilePluginUnitTest<Trac
     }
 
     @Test
-    public void shouldNotAlertWhenRequestIsSuccessfulButContentNotRelevant() throws Exception {
+    void shouldNotAlertWhenRequestIsSuccessfulButContentNotRelevant() throws Exception {
         // Given
         String path = "/trace.axd";
         this.nano.addHandler(

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRuleUnitTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
 
 /** Unit test for {@link UserAgentScanRule}. */
-public class UserAgentScanRuleUnitTest extends ActiveScannerTest<UserAgentScanRule> {
+class UserAgentScanRuleUnitTest extends ActiveScannerTest<UserAgentScanRule> {
 
     @Override
     protected UserAgentScanRule createScanner() {
@@ -40,7 +40,7 @@ public class UserAgentScanRuleUnitTest extends ActiveScannerTest<UserAgentScanRu
     }
 
     @Test
-    public void shouldHaveInfoRisk() {
+    void shouldHaveInfoRisk() {
         // Given / When
         int risk = rule.getRisk();
         // Then

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XsltInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XsltInjectionScanRuleUnitTest.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.StaticContentServerHandler;
 
 /** Unit test for {@link XsltInjectionScanRule}. */
-public class XsltInjectionScanRuleUnitTest extends ActiveScannerTest<XsltInjectionScanRule> {
+class XsltInjectionScanRuleUnitTest extends ActiveScannerTest<XsltInjectionScanRule> {
 
     @Override
     protected XsltInjectionScanRule createScanner() {
@@ -38,7 +38,7 @@ public class XsltInjectionScanRuleUnitTest extends ActiveScannerTest<XsltInjecti
     }
 
     @Test
-    public void shouldNotAlertIfResponseDoesNotContainRelevantContent() throws Exception {
+    void shouldNotAlertIfResponseDoesNotContainRelevantContent() throws Exception {
         // Given
         String path = "/shouldNotAlert";
 
@@ -56,7 +56,7 @@ public class XsltInjectionScanRuleUnitTest extends ActiveScannerTest<XsltInjecti
     }
 
     @Test
-    public void shouldAlertIfResponseContainsRelevantErrorString() throws Exception {
+    void shouldAlertIfResponseContainsRelevantErrorString() throws Exception {
         // Given
         String path = "/shouldReportError";
         String errorString = "XSLT compile error";
@@ -77,7 +77,7 @@ public class XsltInjectionScanRuleUnitTest extends ActiveScannerTest<XsltInjecti
     }
 
     @Test
-    public void shouldAlertIfResponseContainsVendorString() throws Exception {
+    void shouldAlertIfResponseContainsVendorString() throws Exception {
         // Given
         String path = "/shouldReportVendor";
         String vendorString = "Saxon-CE 1.1 from Saxonica";

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/XxeScanRuleUnitTest.java
@@ -43,7 +43,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
+class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
 
     @Override
     protected XxeScanRule createScanner() {
@@ -51,7 +51,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     }
 
     @Test
-    public void replaceElementAndRemoveHeader() {
+    void replaceElementAndRemoveHeader() {
         // Given
         String requestBody = "<?xml version=\"1.0\"?><comment><text>\ntest\n</text></comment>";
         // When
@@ -63,7 +63,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     }
 
     @Test
-    public void doNotReplaceAttributes() {
+    void doNotReplaceAttributes() {
         // Given
         String requestBody =
                 "<?xml version=\"1.0\"?><comment><text abc=\"123\">test</text></comment>";
@@ -76,7 +76,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     }
 
     @Test
-    public void replaceMultipleElementsAndRemoveHeader() {
+    void replaceMultipleElementsAndRemoveHeader() {
         // Given
         String sampleXmlMessage = getXmlResource("xxescanrule/SampleXml.txt");
         String requestBody = "\n" + "<?xml version=\"1.0\"?>\n" + sampleXmlMessage;
@@ -108,7 +108,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     }
 
     @Test
-    public void replaceElementsNested() {
+    void replaceElementsNested() {
         // Given
         String sampleXmlMessage = getXmlResource("xxescanrule/SampleXml.txt");
         String requestBody = "\n" + "\n" + sampleXmlMessage;
@@ -142,7 +142,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     }
 
     @Test
-    public void replaceElementsBase() {
+    void replaceElementsBase() {
         // Given
         String sampleXmlMessage = getXmlResource("xxescanrule/SampleXml.txt");
         String requestBody = "\n" + "\n" + sampleXmlMessage;
@@ -177,7 +177,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     }
 
     @Test
-    public void shouldScanOnlyIfRequestContentTypeIsXml() throws HttpMalformedHeaderException {
+    void shouldScanOnlyIfRequestContentTypeIsXml() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = this.getHttpMessage("/test");
         msg.getRequestHeader().setHeader("Content-Type", "application/json");
@@ -198,7 +198,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     @EnumSource(
             value = NanoHTTPD.Response.Status.class,
             names = {"OK", "BAD_REQUEST"})
-    public void shouldAlertWhenLocalFileReflectedInResponse(NanoHTTPD.Response.Status status)
+    void shouldAlertWhenLocalFileReflectedInResponse(NanoHTTPD.Response.Status status)
             throws HttpMalformedHeaderException {
         // Given
         String test = "/test";
@@ -227,7 +227,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     @EnumSource(
             value = NanoHTTPD.Response.Status.class,
             names = {"OK", "BAD_REQUEST"})
-    public void shouldAlertWhenLocalFileIncludedInResponse(NanoHTTPD.Response.Status status)
+    void shouldAlertWhenLocalFileIncludedInResponse(NanoHTTPD.Response.Status status)
             throws HttpMalformedHeaderException {
         // Given
         String test = "/test";
@@ -255,7 +255,7 @@ public class XxeScanRuleUnitTest extends ActiveScannerTest<XxeScanRule> {
     }
 
     @Test
-    public void shouldAlertOnlyIfCertainTagValuesArePresent()
+    void shouldAlertOnlyIfCertainTagValuesArePresent()
             throws HttpMalformedHeaderException, IOException {
         String validatedXmlMessage = getXmlResource("xxescanrule/SampleXml.txt");
         String sampleRequestBody = "\n" + "<?xml version=\"1.0\"?>\n" + validatedXmlMessage;

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
@@ -44,23 +44,23 @@ import org.yaml.snakeyaml.Yaml;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.I18N;
 
-public class AutomationEnvironmentUnitTest {
+class AutomationEnvironmentUnitTest {
 
     private Session session;
     private static MockedStatic<CommandLine> mockedCmdLine;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
         session = mock(Session.class);
         Context context = mock(Context.class);
@@ -68,7 +68,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldFailIfNoData() {
+    void shouldFailIfNoData() {
         // Given
         String contextStr = "env:";
         Yaml yaml = new Yaml();
@@ -86,7 +86,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldFailIfNoContexts() {
+    void shouldFailIfNoContexts() {
         // Given
         String contextStr = "env:\n" + "  contexts:\n";
         Yaml yaml = new Yaml();
@@ -104,7 +104,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldFailIfBadContexts() {
+    void shouldFailIfBadContexts() {
         // Given
         String contextStr = "env:\n" + "  contexts:\n" + "    param1: value 1\n";
         Yaml yaml = new Yaml();
@@ -122,7 +122,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldFailIfNoContextUrl() {
+    void shouldFailIfNoContextUrl() {
         // Given
         String contextStr = "env:\n" + "  contexts:\n" + "    - name: test\n" + "      url: \n";
         Yaml yaml = new Yaml();
@@ -140,7 +140,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldFailIfNoContextName() {
+    void shouldFailIfNoContextName() {
         // Given
         String contextStr =
                 "env:\n"
@@ -162,7 +162,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldFailIfBadContextUrl() {
+    void shouldFailIfBadContextUrl() {
         // Given
         String contextStr =
                 "env:\n" + "  contexts:\n" + "    - name: test\n" + "      url: Not a url\n";
@@ -183,7 +183,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldSucceedWithValidContext() {
+    void shouldSucceedWithValidContext() {
         // Given
         String contextName = "context 1";
         String exampleUrl = "https://www.example.com/";
@@ -218,7 +218,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldSucceedWith2ValidContexts() {
+    void shouldSucceedWith2ValidContexts() {
         // Given
         String contextStr =
                 "env:\n"
@@ -249,7 +249,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldSetValidParams() {
+    void shouldSetValidParams() {
         // Given
         String contextStr =
                 "env:\n"
@@ -280,7 +280,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldWarnOnUnrecognisedEnvParams() {
+    void shouldWarnOnUnrecognisedEnvParams() {
         // Given
         String contextStr =
                 "env:\n"
@@ -311,7 +311,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldWarnOnUnrecognisedContextParams() {
+    void shouldWarnOnUnrecognisedContextParams() {
         // Given
         String contextStr =
                 "env:\n"
@@ -342,7 +342,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldBeTimeToQuitOnErrorIfOptionSet() {
+    void shouldBeTimeToQuitOnErrorIfOptionSet() {
         // Given
         String contextStr =
                 "env:\n"
@@ -366,7 +366,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldNotBeTimeToQuitOnErrorIfOptionNotSet() {
+    void shouldNotBeTimeToQuitOnErrorIfOptionNotSet() {
         // Given
         String contextStr =
                 "env:\n"
@@ -390,7 +390,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldBeTimeToQuitOnWarningIfOptionSet() {
+    void shouldBeTimeToQuitOnWarningIfOptionSet() {
         // Given
         String contextStr =
                 "env:\n"
@@ -414,7 +414,7 @@ public class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldNotBeTimeToQuitOnWarningIfOptionNotSet() {
+    void shouldNotBeTimeToQuitOnWarningIfOptionNotSet() {
         // Given
         String contextStr =
                 "env:\n"

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
@@ -40,27 +40,27 @@ import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.I18N;
 
-public class AutomationJobUnitTest {
+class AutomationJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
     }
 
     @Test
-    public void shouldChangeName() {
+    void shouldChangeName() {
         // Given
         AutomationJob job = new AutomationJobImpl();
         String newName = "new-name";
@@ -80,7 +80,7 @@ public class AutomationJobUnitTest {
     }
 
     @Test
-    public void shouldExtractExpectedParams() {
+    void shouldExtractExpectedParams() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -99,7 +99,7 @@ public class AutomationJobUnitTest {
     }
 
     @Test
-    public void shouldExcludeNamedParams() {
+    void shouldExcludeNamedParams() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job =
@@ -129,7 +129,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldSetParams() {
+    void shouldSetParams() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -165,7 +165,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
-    public void shouldSetCaseInsensitiveEnum() {
+    void shouldSetCaseInsensitiveEnum() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -186,7 +186,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldWarnOnUnknownParam() {
+    void shouldWarnOnUnknownParam() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -208,7 +208,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldIgnoreNullParamValue() {
+    void shouldIgnoreNullParamValue() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -227,7 +227,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldFailOnBadInt() {
+    void shouldFailOnBadInt() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -248,7 +248,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldFailOnBadInteger() {
+    void shouldFailOnBadInteger() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -269,7 +269,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldFailOnBadBool() {
+    void shouldFailOnBadBool() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -290,7 +290,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldFailOnBadEnum() {
+    void shouldFailOnBadEnum() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -310,7 +310,7 @@ public class AutomationJobUnitTest {
     }
 
     @Test
-    public void shouldIgnoreNullParams() {
+    void shouldIgnoreNullParams() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc);
@@ -326,7 +326,7 @@ public class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldFailOnBadOptionsGetterName() {
+    void shouldFailOnBadOptionsGetterName() {
         // Given
         TestParamContainer tpc = new TestParamContainer();
         AutomationJob job = new AutomationJobImpl(tpc, "getBadTestParam");
@@ -345,7 +345,7 @@ public class AutomationJobUnitTest {
     }
 
     @Test
-    public void shouldReturnDefaultConfigFileData() {
+    void shouldReturnDefaultConfigFileData() {
         // Given
         String expectedParams =
                 "  - type: type\n"
@@ -369,7 +369,7 @@ public class AutomationJobUnitTest {
     }
 
     @Test
-    public void shouldReturnSetConfigFileData() {
+    void shouldReturnSetConfigFileData() {
         // Given
         String expectedParams =
                 "  - type: type\n"
@@ -399,7 +399,7 @@ public class AutomationJobUnitTest {
     }
 
     @Test
-    public void shouldCorrectlyOrderJobs() {
+    void shouldCorrectlyOrderJobs() {
         // Given
         AutomationJob lastJob =
                 new AutomationJobImpl() {

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -56,29 +56,29 @@ import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class ExtentionAutomationUnitTest extends TestUtils {
+class ExtentionAutomationUnitTest extends TestUtils {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
     }
 
     @Test
-    public void shouldReturnDefaultData() {
+    void shouldReturnDefaultData() {
         // Given / When
         ExtensionAutomation extAuto = new ExtensionAutomation();
 
@@ -89,7 +89,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldRegisterBuiltInJobs() {
+    void shouldRegisterBuiltInJobs() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
 
@@ -106,7 +106,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldRegisterNewJob() {
+    void shouldRegisterNewJob() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
         String jobName = "testjob";
@@ -134,7 +134,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldUnregisterExistingJob() {
+    void shouldUnregisterExistingJob() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
 
@@ -149,7 +149,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldCreateMinTemplateFile() throws Exception {
+    void shouldCreateMinTemplateFile() throws Exception {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
         Path filePath = getResourcePath("resources/template-min.yaml");
@@ -168,7 +168,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldCreateMaxTemplateFile() throws Exception {
+    void shouldCreateMaxTemplateFile() throws Exception {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
         Path filePath = getResourcePath("resources/template-max.yaml");
@@ -187,7 +187,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldCreateConfigTemplateFile() throws Exception {
+    void shouldCreateConfigTemplateFile() throws Exception {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -217,7 +217,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldRunPlan() {
+    void shouldRunPlan() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
         String job1Name = "job1";
@@ -278,7 +278,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldFailPlanOnError() {
+    void shouldFailPlanOnError() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
         String job1Name = "job1";
@@ -324,7 +324,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldReturnCmdLineArgs() {
+    void shouldReturnCmdLineArgs() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
 
@@ -344,7 +344,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldRunPlanWithWarnings() {
+    void shouldRunPlanWithWarnings() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
         String job1Name = "job1";
@@ -409,7 +409,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldFailPlanOnErrorApplyingParameters() {
+    void shouldFailPlanOnErrorApplyingParameters() {
         // Given
         AutomationJobImpl job =
                 new AutomationJobImpl() {
@@ -450,7 +450,7 @@ public class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldFailPlanOnWarningApplyingParameters() {
+    void shouldFailPlanOnWarningApplyingParameters() {
         // Given
         AutomationJobImpl job =
                 new AutomationJobImpl() {

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobResultsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobResultsUnitTest.java
@@ -37,9 +37,9 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
 
-public class ActiveScanJobResultsUnitTest {
+class ActiveScanJobResultsUnitTest {
     @Test
-    public void shouldReturnJobData() {
+    void shouldReturnJobData() {
         // Given
         ActiveScan activeScan = mock(ActiveScan.class);
         HostProcess hp = mock(HostProcess.class);

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -67,23 +67,23 @@ import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class ActiveScanJobUnitTest {
+class ActiveScanJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
     private ExtensionActiveScan extAScan;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -97,7 +97,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given
 
         // When
@@ -112,7 +112,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         ActiveScanJob job = new ActiveScanJob();
 
@@ -125,7 +125,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldApplyCustomConfigParams() {
+    void shouldApplyCustomConfigParams() {
         // Given
         ActiveScanJob job = new ActiveScanJob();
 
@@ -139,7 +139,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldFailWithUnknownConfigParam() {
+    void shouldFailWithUnknownConfigParam() {
         // Given
         ActiveScanJob job = new ActiveScanJob();
 
@@ -151,7 +151,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldReturnConfigParams() throws MalformedURLException {
+    void shouldReturnConfigParams() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
 
@@ -181,7 +181,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldRunValidJob() throws MalformedURLException {
+    void shouldRunValidJob() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
@@ -215,7 +215,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfUnknownContext() throws MalformedURLException {
+    void shouldFailIfUnknownContext() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
@@ -234,7 +234,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldUseSpecifiedContext() throws MalformedURLException {
+    void shouldUseSpecifiedContext() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
@@ -290,7 +290,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldExitIfActiveScanTakesTooLong() throws MalformedURLException {
+    void shouldExitIfActiveScanTakesTooLong() throws MalformedURLException {
         // Given
         Session session = mock(Session.class);
         Context context = mock(Context.class);
@@ -324,7 +324,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldReturnNullScanPolicyForNullData() throws MalformedURLException {
+    void shouldReturnNullScanPolicyForNullData() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
 
@@ -336,7 +336,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldReturnNullScanPolicyForEmptyData() throws MalformedURLException {
+    void shouldReturnNullScanPolicyForEmptyData() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
 
@@ -348,7 +348,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldReturnWarningForBadScanPolicyData() throws MalformedURLException {
+    void shouldReturnWarningForBadScanPolicyData() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -367,7 +367,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldReturnScanPolicyForDefaultData() throws MalformedURLException {
+    void shouldReturnScanPolicyForDefaultData() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -386,7 +386,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldSetScanPolicyDefaults() throws MalformedURLException {
+    void shouldSetScanPolicyDefaults() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -408,7 +408,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldDisableAllRulesWithString() throws MalformedURLException {
+    void shouldDisableAllRulesWithString() throws MalformedURLException {
         // There is one built in rule, and mocking more is tricky outside of the package :/
 
         // Given
@@ -434,7 +434,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldDisableAllRulesWithBoolean() throws MalformedURLException {
+    void shouldDisableAllRulesWithBoolean() throws MalformedURLException {
         // There is one built in rule, and mocking more is tricky outside of the package :/
 
         // Given
@@ -460,7 +460,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldSetSpecifiedRuleConfigs() throws MalformedURLException {
+    void shouldSetSpecifiedRuleConfigs() throws MalformedURLException {
         // There is one built in rule, and mocking more is tricky outside of the package :/
 
         // Given
@@ -503,7 +503,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldWarnOnUnknownRule() throws MalformedURLException {
+    void shouldWarnOnUnknownRule() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -532,7 +532,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldWarnOnInvalidStringStrength() throws MalformedURLException {
+    void shouldWarnOnInvalidStringStrength() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -560,7 +560,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldWarnOnInvalidIntStrength() throws MalformedURLException {
+    void shouldWarnOnInvalidIntStrength() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -588,7 +588,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldWarnOnInvalidStringThreshold() throws MalformedURLException {
+    void shouldWarnOnInvalidStringThreshold() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();
@@ -617,7 +617,7 @@ public class ActiveScanJobUnitTest {
     }
 
     @Test
-    public void shouldWarnOnInvalidIntThreshold() throws MalformedURLException {
+    void shouldWarnOnInvalidIntThreshold() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();
         AutomationProgress progress = new AutomationProgress();

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/AddOnJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/AddOnJobUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -49,15 +50,15 @@ import org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class AddOnJobUnitTest {
+class AddOnJobUnitTest {
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given / When
         AddOnJob job = new AddOnJob();
 
@@ -70,7 +71,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         AddOnJob job = new AddOnJob();
 
@@ -84,7 +85,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldApplyCustomConfigParams() {
+    void shouldApplyCustomConfigParams() {
         // Given
         AddOnJob job = new AddOnJob();
 
@@ -96,17 +97,17 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldIgnoreUnknownCustomConfigParams() {
+    void shouldIgnoreUnknownCustomConfigParams() {
         // Given
         AddOnJob job = new AddOnJob();
 
         // When / Than
-        job.applyCustomParameter("test", "test");
+        assertFalse(job.applyCustomParameter("test", "test"));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldApplyParams() {
+    void shouldApplyParams() {
         // Given
         AddOnJob job = new AddOnJob();
         AutomationProgress progress = new AutomationProgress();
@@ -125,7 +126,7 @@ public class AddOnJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldWarnOnUnknownParams() {
+    void shouldWarnOnUnknownParams() {
         // Given
         AddOnJob job = new AddOnJob();
         AutomationProgress progress = new AutomationProgress();
@@ -146,7 +147,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldReturnFileConfigData() {
+    void shouldReturnFileConfigData() {
         // Given
         AddOnJob job = new AddOnJob();
 
@@ -158,7 +159,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldCheckForUpdatesByDefault() {
+    void shouldCheckForUpdatesByDefault() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -191,7 +192,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldPassIfNothingToDo() {
+    void shouldPassIfNothingToDo() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -220,7 +221,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldTryToInstallAddOns() {
+    void shouldTryToInstallAddOns() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -250,7 +251,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldReportInstallAddOnsFailure() {
+    void shouldReportInstallAddOnsFailure() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -283,7 +284,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldTryToUninstallAddOns() {
+    void shouldTryToUninstallAddOns() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -313,7 +314,7 @@ public class AddOnJobUnitTest {
     }
 
     @Test
-    public void shouldReportUninstallAddOnsFailure() {
+    void shouldReportUninstallAddOnsFailure() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
@@ -53,7 +53,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class PassiveScanConfigJobUnitTest {
+class PassiveScanConfigJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
 
@@ -61,17 +61,17 @@ public class PassiveScanConfigJobUnitTest {
     private ExtensionPassiveScan extPscan;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -85,7 +85,7 @@ public class PassiveScanConfigJobUnitTest {
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given / When
         PassiveScanConfigJob job = new PassiveScanConfigJob();
 
@@ -98,7 +98,7 @@ public class PassiveScanConfigJobUnitTest {
     }
 
     @Test
-    public void shouldReturnNoCustomConfigParams() {
+    void shouldReturnNoCustomConfigParams() {
         // Given
         PassiveScanConfigJob job = new PassiveScanConfigJob();
 
@@ -110,7 +110,7 @@ public class PassiveScanConfigJobUnitTest {
     }
 
     @Test
-    public void shouldGetOptions() {
+    void shouldGetOptions() {
         // Given
         AutomationProgress progress = new AutomationProgress();
 
@@ -129,7 +129,7 @@ public class PassiveScanConfigJobUnitTest {
     }
 
     @Test
-    public void shouldApplyParameters() {
+    void shouldApplyParameters() {
         // Given
         String yamlStr =
                 "parameters:\n"
@@ -158,7 +158,7 @@ public class PassiveScanConfigJobUnitTest {
     }
 
     @Test
-    public void shouldWarnOnBadParameter() {
+    void shouldWarnOnBadParameter() {
         // Given
         String yamlStr =
                 "parameters:\n"
@@ -190,7 +190,7 @@ public class PassiveScanConfigJobUnitTest {
     }
 
     @Test
-    public void shouldSetRules() {
+    void shouldSetRules() {
         // Given
         String yamlStr =
                 "rules:\n" + "- id: 1\n" + "  threshold: Low\n" + "- id: 3\n" + "  threshold: High";
@@ -223,7 +223,7 @@ public class PassiveScanConfigJobUnitTest {
     }
 
     @Test
-    public void shouldWarnOnUnknownRule() {
+    void shouldWarnOnUnknownRule() {
         // Given
         String yamlStr =
                 "rules:\n" + "- id: 4\n" + "  threshold: Low\n" + "- id: 3\n" + "  threshold: High";

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanJobResultsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanJobResultsUnitTest.java
@@ -50,27 +50,27 @@ import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class PassiveScanJobResultsUnitTest {
+class PassiveScanJobResultsUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
     }
 
     @Test
-    public void shouldReturnJobData() {
+    void shouldReturnJobData() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJobUnitTest.java
@@ -54,27 +54,27 @@ import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class PassiveScanWaitJobUnitTest {
+class PassiveScanWaitJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -97,7 +97,7 @@ public class PassiveScanWaitJobUnitTest {
     }
 
     @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         PassiveScanWaitJob job = new PassiveScanWaitJob();
 
@@ -112,7 +112,7 @@ public class PassiveScanWaitJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldApplyParams() {
+    void shouldApplyParams() {
         // Given
         PassiveScanWaitJob job = new PassiveScanWaitJob();
         AutomationProgress progress = new AutomationProgress();
@@ -132,7 +132,7 @@ public class PassiveScanWaitJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldWarnOnUnknownParams() {
+    void shouldWarnOnUnknownParams() {
         // Given
         AddOnJob job = new AddOnJob();
         AutomationProgress progress = new AutomationProgress();
@@ -152,7 +152,7 @@ public class PassiveScanWaitJobUnitTest {
     }
 
     @Test
-    public void shouldWaitForPassiveScan() {
+    void shouldWaitForPassiveScan() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -190,7 +190,7 @@ public class PassiveScanWaitJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldExitIfPassiveScanTakesLongerThanConfig() {
+    void shouldExitIfPassiveScanTakesLongerThanConfig() {
         // Given
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/SpiderJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/SpiderJobUnitTest.java
@@ -60,23 +60,23 @@ import org.zaproxy.zap.spider.SpiderParam;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class SpiderJobUnitTest {
+class SpiderJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
     private ExtensionSpider extSpider;
 
     @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -90,7 +90,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given
 
         // When
@@ -105,7 +105,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         SpiderJob job = new SpiderJob();
 
@@ -121,7 +121,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldApplyCustomConfigParams() {
+    void shouldApplyCustomConfigParams() {
         // Given
         SpiderJob job = new SpiderJob();
 
@@ -137,7 +137,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldReturnConfigParams() throws MalformedURLException {
+    void shouldReturnConfigParams() throws MalformedURLException {
         // Given
         SpiderJob job = new SpiderJob();
 
@@ -175,7 +175,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldRunValidJob() throws MalformedURLException {
+    void shouldRunValidJob() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
@@ -208,7 +208,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfInvalidUrl() throws MalformedURLException {
+    void shouldFailIfInvalidUrl() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
@@ -227,7 +227,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfUnknownContext() throws MalformedURLException {
+    void shouldFailIfUnknownContext() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
@@ -246,7 +246,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldUseSpecifiedContext() throws MalformedURLException {
+    void shouldUseSpecifiedContext() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
@@ -301,7 +301,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldUseSpecifiedUrl() throws MalformedURLException {
+    void shouldUseSpecifiedUrl() throws MalformedURLException {
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
         Context context = mock(Context.class);
@@ -336,7 +336,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldExitIfSpiderTakesTooLong() throws MalformedURLException {
+    void shouldExitIfSpiderTakesTooLong() throws MalformedURLException {
         // Given
         Session session = mock(Session.class);
         Context context = mock(Context.class);
@@ -370,7 +370,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldWarnIfLessUrlsFoundThanExpected() throws MalformedURLException {
+    void shouldWarnIfLessUrlsFoundThanExpected() throws MalformedURLException {
         // Given
         Session session = mock(Session.class);
         Context context = mock(Context.class);
@@ -404,7 +404,7 @@ public class SpiderJobUnitTest {
     }
 
     @Test
-    public void shouldErrorIfLessUrlsFoundThanExpected() throws MalformedURLException {
+    void shouldErrorIfLessUrlsFoundThanExpected() throws MalformedURLException {
         // Given
         Session session = mock(Session.class);
         Context context = mock(Context.class);

--- a/addOns/bruteforce/src/test/java/com/sittinglittleduck/DirBuster/EasySSLProtocolSocketFactoryUnitTest.java
+++ b/addOns/bruteforce/src/test/java/com/sittinglittleduck/DirBuster/EasySSLProtocolSocketFactoryUnitTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.testutils.HTTPDTestServer;
 
-public class EasySSLProtocolSocketFactoryUnitTest {
+class EasySSLProtocolSocketFactoryUnitTest {
 
     private EasySSLProtocolSocketFactory socketFactory;
 
@@ -46,24 +46,24 @@ public class EasySSLProtocolSocketFactoryUnitTest {
     private static int serverPort;
 
     @BeforeAll
-    public static void startEmbeddedHttpServers() throws Exception {
+    static void startEmbeddedHttpServers() throws Exception {
         testServer = new HTTPDTestServer(0);
         testServer.start();
         serverPort = testServer.getListeningPort();
     }
 
     @AfterAll
-    public static void stopEmbeddedHttpServers() {
+    static void stopEmbeddedHttpServers() {
         testServer.stop();
     }
 
     @BeforeEach
-    public void resetSocketFactory() throws Exception {
+    void resetSocketFactory() throws Exception {
         socketFactory = new EasySSLProtocolSocketFactory();
     }
 
     @Test
-    public void shouldCreateSocketForGivenHostAndPort() throws Exception {
+    void shouldCreateSocketForGivenHostAndPort() throws Exception {
         // Given
         String host = "localhost";
         int port = serverPort;
@@ -77,7 +77,7 @@ public class EasySSLProtocolSocketFactoryUnitTest {
     // Note that on some platforms this gives a ConnectionException while on others it give a
     // UnknownHostException
     @Test
-    public void shouldFailCreatingSocketForUnknownHost() throws Exception {
+    void shouldFailCreatingSocketForUnknownHost() throws Exception {
         // Given
         String unknownHost = "localhorst";
         InetAddress localAddress = InetAddress.getLoopbackAddress();
@@ -93,7 +93,7 @@ public class EasySSLProtocolSocketFactoryUnitTest {
     }
 
     @Test
-    public void shouldFailCreatingSocketForUnknownPort() throws Exception {
+    void shouldFailCreatingSocketForUnknownPort() throws Exception {
         // Given
         int unknownPort = 12345;
         // When / Then
@@ -102,7 +102,7 @@ public class EasySSLProtocolSocketFactoryUnitTest {
     }
 
     @Test
-    public void shouldFailCreatingSocketForMissingParameters() throws Exception {
+    void shouldFailCreatingSocketForMissingParameters() throws Exception {
         // Given
         HttpConnectionParams nullParams = null;
         // When / Then
@@ -118,7 +118,7 @@ public class EasySSLProtocolSocketFactoryUnitTest {
     }
 
     @Test
-    public void shouldCreateSocketWithGivenLocalAddressAndPort() throws Exception {
+    void shouldCreateSocketWithGivenLocalAddressAndPort() throws Exception {
         // Given
         InetAddress localAddress = InetAddress.getLoopbackAddress();
         int localPort = 28080;
@@ -137,7 +137,7 @@ public class EasySSLProtocolSocketFactoryUnitTest {
 
     @Test
     @Disabled(value = "Requires a way to slow down connect process artificially")
-    public void shouldFailCreatingSocketWithInstantTimeout() throws Exception {
+    void shouldFailCreatingSocketWithInstantTimeout() throws Exception {
         // Given
         HttpConnectionParams params = new HttpConnectionParams();
         params.setConnectionTimeout(1);
@@ -154,7 +154,7 @@ public class EasySSLProtocolSocketFactoryUnitTest {
     }
 
     @Test
-    public void shouldSucceedCreatingSocketWithReasonableTimeout() throws Exception {
+    void shouldSucceedCreatingSocketWithReasonableTimeout() throws Exception {
         // Given
         HttpConnectionParams params = new HttpConnectionParams();
         params.setConnectionTimeout(1000);

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CookieUtilsUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CookieUtilsUnitTest.java
@@ -27,13 +27,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link CookieUtils}. */
-public class CookieUtilsUnitTest {
+class CookieUtilsUnitTest {
 
     private static final String EMPTY_HEADER_VALUE = "";
     private static final String EMPTY_ATTRIBUTE_NAME = "";
 
     @Test
-    public void shouldFailToCheckNullHeaderValue() {
+    void shouldFailToCheckNullHeaderValue() {
         // Given
         String headerValue = null;
         // When / Then
@@ -43,7 +43,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldFailToCheckNullAttributeName() {
+    void shouldFailToCheckNullAttributeName() {
         // Given
         String attributeName = null;
         // When / Then
@@ -53,7 +53,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindEmptyAttribute() {
+    void shouldNotFindEmptyAttribute() {
         // Given
         String headerValue = "Name=Value; Attribute1; Attribute2=AV2; ;;";
         // When
@@ -63,7 +63,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindAttributeInEmptyHeader() {
+    void shouldNotFindAttributeInEmptyHeader() {
         // Given
         String attribute = "Attribute1";
         // When
@@ -73,7 +73,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindAttributeIfHeaderHasNoAttributes() {
+    void shouldNotFindAttributeIfHeaderHasNoAttributes() {
         // Given
         String headerValue = "Name=Value";
         String attribute = "Attribute1";
@@ -84,7 +84,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindAttributeInNamelessCookie() {
+    void shouldNotFindAttributeInNamelessCookie() {
         // Given
         String headerValue = "=Value; Attribute1; Attribute2=AV2; ;;";
         String attribute = "Attribute1";
@@ -95,7 +95,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindAttributeIfCookieHasNoNameValueSepartor() {
+    void shouldNotFindAttributeIfCookieHasNoNameValueSepartor() {
         // Given
         String headerValue = "Name; Attribute1; Attribute2=AV2; ;;";
         String attribute = "Attribute1";
@@ -106,7 +106,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindAttributeEvenIfCookieNameIsEqual() {
+    void shouldNotFindAttributeEvenIfCookieNameIsEqual() {
         // Given
         String headerValue = "Attribute1=Value; Attribute2=AV2";
         String attribute = "Attribute1";
@@ -117,7 +117,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindAttributeEvenIfCookieValueIsEqual() {
+    void shouldNotFindAttributeEvenIfCookieValueIsEqual() {
         // Given
         String headerValue = "Name=Attribute1; Attribute2=AV2";
         String attribute = "Attribute1";
@@ -128,7 +128,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindAttributeEvenIfAnAttributeValueIsEqual() {
+    void shouldNotFindAttributeEvenIfAnAttributeValueIsEqual() {
         // Given
         String headerValue = "Name=Value; Attribute2=Attribute1";
         String attribute = "Attribute1";
@@ -139,7 +139,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldFindAttributeInValidCookieHeader() {
+    void shouldFindAttributeInValidCookieHeader() {
         // Given
         String headerValue = "Cookie=Value; Attribute1; Attribute2=AV2";
         String attribute = "Attribute1";
@@ -150,7 +150,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldFindAttributeEvenIfCookieHasNoValue() {
+    void shouldFindAttributeEvenIfCookieHasNoValue() {
         // Given
         String headerValue = "Cookie=; Attribute1; Attribute2=AV2";
         String attribute = "Attribute1";
@@ -161,7 +161,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldFindAttributeEvenIfItHasValue() {
+    void shouldFindAttributeEvenIfItHasValue() {
         // Given
         String headerValue = "Cookie=Value; Attribute1; Attribute2=AV2";
         String attribute = "Attribute2";
@@ -172,7 +172,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldFindAttributeEvenIfItHasSpacesInName() {
+    void shouldFindAttributeEvenIfItHasSpacesInName() {
         // Given
         String headerValue = "Cookie=Value; Attribute1;  Attribute2  =AV2";
         String attribute = "Attribute2";
@@ -183,7 +183,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldFindAttributeEvenIfItHasDifferentCase() {
+    void shouldFindAttributeEvenIfItHasDifferentCase() {
         // Given
         String headerValue = "Cookie=Value; Attribute1; Attribute2=AV2";
         String attribute = "aTtRiBuTe2";
@@ -194,7 +194,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldNotFindCookiePlusNameIfNameIsNull() {
+    void shouldNotFindCookiePlusNameIfNameIsNull() {
         // Given
         String fullHeader = "Set-Cookie: foo; Attribute1";
         String headerValue = "foo; Attribute1";
@@ -205,7 +205,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldKnowThatNameDoesNotIncludeSemiColon() {
+    void shouldKnowThatNameDoesNotIncludeSemiColon() {
         // Given
         String fullHeader = "Set-Cookie: foo; Attribute1; Attribute2=AV2";
         String headerValue = "foo; Attribute1; Attribute2=AV2";
@@ -216,7 +216,7 @@ public class CookieUtilsUnitTest {
     }
 
     @Test
-    public void shouldFindCookiePlusNameIfWellFormed() {
+    void shouldFindCookiePlusNameIfWellFormed() {
         // Given
         String fullHeader = "Set-Cookie: name=value; Attribute1; Attribute2=AV2";
         String headerValue = "name=value; Attribute1; Attribute2=AV2";

--- a/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
+++ b/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
@@ -40,7 +40,7 @@ import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
+class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
 
     @BeforeAll
     static void setup() {
@@ -69,7 +69,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     }
 
     @Test
-    public void shouldUseDefaultWhenUnsupportedBrowser() throws IOException {
+    void shouldUseDefaultWhenUnsupportedBrowser() throws IOException {
         // Given
         HttpMessage msg = this.getHttpMessage("");
         this.rule.getConfig().setProperty("rules.domxss.browserid", "opera");
@@ -80,7 +80,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     }
 
     @Test
-    public void shouldUseDefaultWhenUnknownBrowser() throws IOException {
+    void shouldUseDefaultWhenUnknownBrowser() throws IOException {
         // Given
         HttpMessage msg = this.getHttpMessage("");
         this.rule.getConfig().setProperty("rules.domxss.browserid", "invalid");
@@ -92,7 +92,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
 
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldUseCorrectBrowser(String browser) throws IOException {
+    void shouldUseCorrectBrowser(String browser) throws IOException {
         // Given
         HttpMessage msg = this.getHttpMessage("");
         this.rule.getConfig().setProperty("rules.domxss.browserid", browser);
@@ -105,7 +105,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/assign */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInLocationHashAssign(String browser)
+    void shouldReportXssInLocationHashAssign(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInLocationHashAssign/";
@@ -141,7 +141,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/eval */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInLocationHashEval(String browser)
+    void shouldReportXssInLocationHashEval(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInLocationHashEval/";
@@ -162,7 +162,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/replace */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInLocationHashReplace(String browser)
+    void shouldReportXssInLocationHashReplace(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInLocationHashReplace/";
@@ -183,7 +183,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/setTimeout */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInLocationHashSetTimeout(String browser)
+    void shouldReportXssInLocationHashSetTimeout(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInLocationHashSetTimeout/";
@@ -204,7 +204,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test to trigger XSS after cancel button is clicked */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssWhenCancelButtonIsClicked(String browser)
+    void shouldReportXssWhenCancelButtonIsClicked(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssWhenCancelButtonIsClicked/";
@@ -226,7 +226,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/function */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInLocationHashFunction(String browser)
+    void shouldReportXssInLocationHashFunction(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInLocationHashFunction/";
@@ -247,7 +247,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/jshref */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInLocationHashInlineEvent(String browser)
+    void shouldReportXssInLocationHashInlineEvent(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInLocationHashInlineEvent/";
@@ -268,7 +268,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/formaction */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInLocationHashFormAction(String browser)
+    void shouldReportXssInLocationHashFormAction(String browser)
             throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInLocationHashFormAction/";
@@ -292,7 +292,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
      * Note that this only works in Firefox, not Chrome.
      */
     @Test
-    public void shouldReportXssInEventInnerHtmlFirefox() throws NullPointerException, IOException {
+    void shouldReportXssInEventInnerHtmlFirefox() throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInEventInnerHtml/";
 
@@ -317,8 +317,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
      */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInTypingInnerHtml(String browser)
-            throws NullPointerException, IOException {
+    void shouldReportXssInTypingInnerHtml(String browser) throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInTypingInnerHtml/";
 
@@ -341,8 +340,7 @@ public class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRul
      */
     @ParameterizedTest
     @MethodSource("testBrowsers")
-    public void shouldReportXssInDomPropagation(String browser)
-            throws NullPointerException, IOException {
+    void shouldReportXssInDomPropagation(String browser) throws NullPointerException, IOException {
         // Given
         String test = "/shouldReportXssInDomPropagation/";
 

--- a/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
+++ b/addOns/frontendscanner/src/test/java/org/zaproxy/zap/extension/frontendscanner/FrontEndScannerProxyListenerUnitTest.java
@@ -39,7 +39,7 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link FrontEndScannerProxyListener}. */
-public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
+class FrontEndScannerProxyListenerUnitTest extends TestUtils {
 
     private static final String HOSTNAME = "example.com";
 
@@ -48,7 +48,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     private HttpMessage msg;
 
     @BeforeEach
-    public void setUp() throws URIException, HttpMalformedHeaderException {
+    void setUp() throws URIException, HttpMalformedHeaderException {
         FrontEndScannerAPI api = mock(FrontEndScannerAPI.class);
         options = mock(FrontEndScannerOptions.class);
 
@@ -64,7 +64,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
 
     @ParameterizedTest
     @ValueSource(strings = {"Content-Security-Policy", "X-Content-Security-Policy", "X-WebKit-CSP"})
-    public void testRemovesCSPFromHttpResponsesIfInjecting(String header) {
+    void testRemovesCSPFromHttpResponsesIfInjecting(String header) {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody =
@@ -82,7 +82,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testInjectTheFrontEndTrackerBeforeOtherScriptsInHeadTag() {
+    void testInjectTheFrontEndTrackerBeforeOtherScriptsInHeadTag() {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody =
@@ -103,7 +103,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testInjectAfterMetaTagInHeadTag() {
+    void testInjectAfterMetaTagInHeadTag() {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody = "<!doctype html><html lang='en'><head><meta></head><body></body></html>";
@@ -123,7 +123,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testInjectAfterAllMetaTagsInHeadTag() {
+    void testInjectAfterAllMetaTagsInHeadTag() {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody =
@@ -144,7 +144,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testInjectionShouldBeSuccessfulWithoutHead() {
+    void testInjectionShouldBeSuccessfulWithoutHead() {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody = "<!doctype html><html lang='en'><body></body></head></html>";
@@ -164,7 +164,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testInjectionShouldBeSuccessfulWithEmptyHead() {
+    void testInjectionShouldBeSuccessfulWithEmptyHead() {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody = "<!doctype html><html lang='en'><head></head><body></body></html>";
@@ -184,7 +184,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testInjectionShouldBeSuccessfulWithoutHtmlTag() {
+    void testInjectionShouldBeSuccessfulWithoutHtmlTag() {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody = "<head></head><body></body>";
@@ -204,7 +204,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testInjectionShouldBeSuccessfulWithoutHtmlNorHeadTag() {
+    void testInjectionShouldBeSuccessfulWithoutHtmlNorHeadTag() {
         // Given
         when(options.isEnabled()).thenReturn(true);
         String htmlBody = "<body></body>";
@@ -225,7 +225,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
 
     @ParameterizedTest
     @ValueSource(strings = {"Content-Security-Policy", "X-Content-Security-Policy", "X-WebKit-CSP"})
-    public void testCSPisNotRemovedIfNotEnabledInOptions(String header) {
+    void testCSPisNotRemovedIfNotEnabledInOptions(String header) {
         // Given
         when(options.isEnabled()).thenReturn(false);
         String htmlBody = "<!doctype html><html lang='en'><head></head><body></body></html>";
@@ -242,7 +242,7 @@ public class FrontEndScannerProxyListenerUnitTest extends TestUtils {
     }
 
     @Test
-    public void testNothingIsInjectedIfNotEnabledInOptions() {
+    void testNothingIsInjectedIfNotEnabledInOptions() {
         // Given
         when(options.isEnabled()).thenReturn(false);
         String htmlBody = "<!doctype html><html lang='en'><head></head><body></body></html>";

--- a/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/RequestContentLengthUpdaterProcessorUnitTest.java
+++ b/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/RequestContentLengthUpdaterProcessorUnitTest.java
@@ -40,17 +40,17 @@ import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.utils.I18N;
 
 /** Unit test for {@link RequestContentLengthUpdaterProcessor}. */
-public class RequestContentLengthUpdaterProcessorUnitTest {
+class RequestContentLengthUpdaterProcessorUnitTest {
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         I18N i18n = mock(I18N.class);
         given(i18n.getString(any())).willReturn("");
         Constant.messages = i18n;
     }
 
     @Test
-    public void shouldReturnANonNullInstance() {
+    void shouldReturnANonNullInstance() {
         // Given
         RequestContentLengthUpdaterProcessor processor =
                 RequestContentLengthUpdaterProcessor.getInstance();
@@ -59,7 +59,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldReturnsAlwaysSameInstance() {
+    void shouldReturnsAlwaysSameInstance() {
         // Given
         RequestContentLengthUpdaterProcessor processor =
                 RequestContentLengthUpdaterProcessor.getInstance();
@@ -70,7 +70,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldHaveANonNullName() {
+    void shouldHaveANonNullName() {
         // Given
         RequestContentLengthUpdaterProcessor processor = new RequestContentLengthUpdaterProcessor();
         // When
@@ -80,7 +80,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldCreateProcessorWithUndefinedMethod() {
+    void shouldCreateProcessorWithUndefinedMethod() {
         // Given
         String undefinedMethod = null;
         // When / Then
@@ -88,18 +88,19 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldFailToProcessAnUndefinedMessage() {
+    void shouldFailToProcessAnUndefinedMessage() {
         // Given
         RequestContentLengthUpdaterProcessor processor = new RequestContentLengthUpdaterProcessor();
         HttpMessage undefinedMessage = null;
+        HttpFuzzerTaskProcessorUtils utils = createUtils();
         // When / Then
         assertThrows(
                 NullPointerException.class,
-                () -> processor.processMessage(createUtils(), undefinedMessage));
+                () -> processor.processMessage(utils, undefinedMessage));
     }
 
     @Test
-    public void shouldNotRequireUtilsToProcessMessage() {
+    void shouldNotRequireUtilsToProcessMessage() {
         // Given
         RequestContentLengthUpdaterProcessor processor = new RequestContentLengthUpdaterProcessor();
         // When / Then
@@ -107,7 +108,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldReturnSameMessageWhenProcessing() {
+    void shouldReturnSameMessageWhenProcessing() {
         // Given
         RequestContentLengthUpdaterProcessor processor = new RequestContentLengthUpdaterProcessor();
         HttpMessage message = new HttpMessage();
@@ -118,7 +119,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldNotAddContentLengthIfEmptyBody() {
+    void shouldNotAddContentLengthIfEmptyBody() {
         // Given
         RequestContentLengthUpdaterProcessor processor =
                 new RequestContentLengthUpdaterProcessor("POST");
@@ -132,7 +133,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldAddContentLengthIfNotEmptyBody() {
+    void shouldAddContentLengthIfNotEmptyBody() {
         // Given
         RequestContentLengthUpdaterProcessor processor =
                 new RequestContentLengthUpdaterProcessor("POST");
@@ -146,7 +147,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldUpdateExistingContentLengthIfEmptyBody() {
+    void shouldUpdateExistingContentLengthIfEmptyBody() {
         // Given
         RequestContentLengthUpdaterProcessor processor =
                 new RequestContentLengthUpdaterProcessor("POST");
@@ -160,7 +161,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldUpdateContentLengthForAnyMethodWhenNoMethodIsSpecified() {
+    void shouldUpdateContentLengthForAnyMethodWhenNoMethodIsSpecified() {
         // Given
         RequestContentLengthUpdaterProcessor processor = new RequestContentLengthUpdaterProcessor();
         String body = "RequestBody";
@@ -184,7 +185,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldUpdateContentLengthForAnyMethodWithInstance() {
+    void shouldUpdateContentLengthForAnyMethodWithInstance() {
         // Given
         RequestContentLengthUpdaterProcessor processor =
                 RequestContentLengthUpdaterProcessor.getInstance();
@@ -209,7 +210,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldUpdateContentLengthForSpecifiedMethodOnly() {
+    void shouldUpdateContentLengthForSpecifiedMethodOnly() {
         // Given
         RequestContentLengthUpdaterProcessor processor =
                 new RequestContentLengthUpdaterProcessor("POST");
@@ -234,7 +235,7 @@ public class RequestContentLengthUpdaterProcessorUnitTest {
     }
 
     @Test
-    public void shouldAcceptResultsAlways() {
+    void shouldAcceptResultsAlways() {
         // Given
         RequestContentLengthUpdaterProcessor processor = new RequestContentLengthUpdaterProcessor();
         // When

--- a/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpResponseTagCreatorUnitTest.java
+++ b/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/processors/tagcreator/HttpResponseTagCreatorUnitTest.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class HttpResponseTagCreatorUnitTest {
+class HttpResponseTagCreatorUnitTest {
 
     private static final String NO_RESPONSE_MESSAGE = "";
     private static final String RESPONSE_HEADER =
@@ -41,7 +41,7 @@ public class HttpResponseTagCreatorUnitTest {
     private static final List<String> NO_EXISTING_TAGS = new ArrayList<>();
 
     @Test
-    public void whenMatchHeader_ShouldReturnTag() throws Exception {
+    void whenMatchHeader_ShouldReturnTag() throws Exception {
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("Server: Apache", "apache");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);
@@ -52,7 +52,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenMatchBody_ShouldReturnTag() throws Exception {
+    void whenMatchBody_ShouldReturnTag() throws Exception {
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("Test", "tagTest");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);
@@ -63,7 +63,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenMatchHeaderAndBody_ShouldReturnTag() throws Exception {
+    void whenMatchHeaderAndBody_ShouldReturnTag() throws Exception {
         MatchByRegexTagRule tagRule =
                 new MatchByRegexTagRule("(?s)Server: Apache.*Test", "apacheAndTagTest");
         HttpResponseTagCreator tagCreator =
@@ -75,7 +75,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenMatchAndExistingTags_ShouldReturnAllTags() throws Exception {
+    void whenMatchAndExistingTags_ShouldReturnAllTags() throws Exception {
         List<String> existingTags = Arrays.asList("tagA", "tagB");
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("Server: Apache", "apache");
         HttpResponseTagCreator tagCreator =
@@ -87,7 +87,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenNoRegexExists_ShouldReturnExistingTags() throws Exception {
+    void whenNoRegexExists_ShouldReturnExistingTags() throws Exception {
         List<String> existingTags = Arrays.asList("tagA", "tagB");
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule(NO_MESSAGE_REGEX, "tagC");
         HttpResponseTagCreator tagCreator =
@@ -99,7 +99,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenNotMatch_ShouldReturnExistingTags() throws Exception {
+    void whenNotMatch_ShouldReturnExistingTags() throws Exception {
         List<String> existingTags = Arrays.asList("tagA", "tagB");
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("NotExisting", "tagC");
         HttpResponseTagCreator tagCreator =
@@ -111,7 +111,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenNotMatchDueToMessageEmpty_ShouldReturnExistingTags() throws Exception {
+    void whenNotMatchDueToMessageEmpty_ShouldReturnExistingTags() throws Exception {
         List<String> existingTags = Arrays.asList("tagA", "tagB");
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("NotExisting", "tagC");
         HttpResponseTagCreator tagCreator =
@@ -123,7 +123,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenNotMatchAndNoExistingTags_ShouldReturnEmptyTags() throws Exception {
+    void whenNotMatchAndNoExistingTags_ShouldReturnEmptyTags() throws Exception {
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("NotExisting", "tagC");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);
@@ -134,7 +134,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenMatchHeaderByRegex_ShouldReturnTag() throws Exception {
+    void whenMatchHeaderByRegex_ShouldReturnTag() throws Exception {
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("Se.ver.*ache.*29", "tagC");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);
@@ -145,7 +145,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenMatchBodyByRegex_ShouldReturnTag() throws Exception {
+    void whenMatchBodyByRegex_ShouldReturnTag() throws Exception {
         MatchByRegexTagRule tagRule = new MatchByRegexTagRule("(?s)Test.*MyPage", "tagC");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);
@@ -156,7 +156,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenExtractHeader_ShouldReturnTag() throws Exception {
+    void whenExtractHeader_ShouldReturnTag() throws Exception {
         ExtractByRegexTagRule tagRule = new ExtractByRegexTagRule("Server: (.*?)\\/.*");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);
@@ -167,7 +167,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenExtractWithoutRegex_ShouldReturnEmptyTags() throws Exception {
+    void whenExtractWithoutRegex_ShouldReturnEmptyTags() throws Exception {
         ExtractByRegexTagRule tagRule = new ExtractByRegexTagRule("");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);
@@ -178,7 +178,7 @@ public class HttpResponseTagCreatorUnitTest {
     }
 
     @Test
-    public void whenExtractRegexNothingMatch_ShouldReturnEmptyTags() throws Exception {
+    void whenExtractRegexNothingMatch_ShouldReturnEmptyTags() throws Exception {
         ExtractByRegexTagRule tagRule = new ExtractByRegexTagRule("NotExisting: (.*?)");
         HttpResponseTagCreator tagCreator =
                 new HttpResponseTagCreator(tagRule, RESPONSE_MESSAGE, NO_EXISTING_TAGS);

--- a/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/payloads/generator/JsonPayloadGeneratorUnitTest.java
+++ b/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/payloads/generator/JsonPayloadGeneratorUnitTest.java
@@ -38,29 +38,29 @@ import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.fuzz.payloads.DefaultPayload;
 import org.zaproxy.zap.utils.ResettableAutoCloseableIterator;
 
-public class JsonPayloadGeneratorUnitTest {
+class JsonPayloadGeneratorUnitTest {
 
     @Test
-    public void shouldRejectMissingJsonBase() {
+    void shouldRejectMissingJsonBase() {
         assertThrows(IllegalArgumentException.class, () -> new JsonPayloadGenerator(null, 1));
     }
 
     @Test
-    public void shouldRejectInvalidJsonBase() {
+    void shouldRejectInvalidJsonBase() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> new JsonPayloadGenerator("'an invalid value", 1));
     }
 
     @Test
-    public void shouldHaveAtLeastOnePayload() {
+    void shouldHaveAtLeastOnePayload() {
         String originalJson = "{\"x\": \"hello\"}";
         JsonPayloadGenerator generator = new JsonPayloadGenerator(originalJson, 1);
         assertThat(generator.iterator().hasNext(), is(true));
     }
 
     @Test
-    public void shouldGenerateAtLeastOneFuzzedPayload() {
+    void shouldGenerateAtLeastOneFuzzedPayload() {
         // Given
         String originalJson = "{\"x\": \"hello\"}";
         JsonPayloadGenerator generator = new JsonPayloadGenerator(originalJson, 2);
@@ -75,7 +75,7 @@ public class JsonPayloadGeneratorUnitTest {
     }
 
     @Test
-    public void shouldNotGenerateTooManyPayloads() {
+    void shouldNotGenerateTooManyPayloads() {
         String originalJson = "{\"x\": \"hello\"}";
         JsonPayloadGenerator generator = new JsonPayloadGenerator(originalJson, 1);
         ResettableAutoCloseableIterator<DefaultPayload> iterator = generator.iterator();
@@ -84,7 +84,7 @@ public class JsonPayloadGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateMultipleMutants() {
+    void shouldGenerateMultipleMutants() {
         String originalJson = "{\"x\": \"hello\"}";
         JsonPayloadGenerator generator = new JsonPayloadGenerator(originalJson, 20);
         ResettableAutoCloseableIterator<DefaultPayload> iterator = generator.iterator();

--- a/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/payloads/generator/RegexPayloadGeneratorUnitTest.java
+++ b/addOns/fuzz/src/test/java/org/zaproxy/zap/extension/fuzz/payloads/generator/RegexPayloadGeneratorUnitTest.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link RegexPayloadGenerator}. */
-public class RegexPayloadGeneratorUnitTest {
+class RegexPayloadGeneratorUnitTest {
 
     @Test
     void shouldCalculateNumberOfPayloadsWithNoLimit() {

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
@@ -25,18 +25,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class GraphQlGeneratorUnitTest extends TestUtils {
+class GraphQlGeneratorUnitTest extends TestUtils {
     GraphQlGenerator generator;
     GraphQlParam param;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         setUpZap();
         param = new GraphQlParam(5, true, 5, 5, true, null, null, null);
     }
 
     @Test
-    public void scalarFieldsOnly() throws Exception {
+    void scalarFieldsOnly() throws Exception {
         generator = new GraphQlGenerator(getHtml("scalarFieldsOnly.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { name id age height human } ";
@@ -44,7 +44,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void zeroDepthObjects() throws Exception {
+    void zeroDepthObjects() throws Exception {
         generator = new GraphQlGenerator(getHtml("zeroDepthObjects.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -53,7 +53,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void nestedObjects() throws Exception {
+    void nestedObjects() throws Exception {
         generator = new GraphQlGenerator(getHtml("nestedObjects.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -62,7 +62,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void circularRelationship() throws Exception {
+    void circularRelationship() throws Exception {
         generator = new GraphQlGenerator(getHtml("circularRelationship.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -71,7 +71,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void scalarArguments() throws Exception {
+    void scalarArguments() throws Exception {
         generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { polygon (sides: 1, regular: true) { perimeter area } } ";
@@ -79,7 +79,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void nonNullableScalarArguments() throws Exception {
+    void nonNullableScalarArguments() throws Exception {
         generator =
                 new GraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -88,7 +88,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void enumArgument() throws Exception {
+    void enumArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("enumArgument.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { location (direction: NORTH) } ";
@@ -96,7 +96,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void listAsArgument() throws Exception {
+    void listAsArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("listAsArgument.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -106,7 +106,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void inputObjectArgument() throws Exception {
+    void inputObjectArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("inputObjectArgument.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { plot (point: { x: 3.14, y: 3.14 }) } ";
@@ -114,7 +114,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void listsAndNonNull() throws Exception {
+    void listsAndNonNull() throws Exception {
         generator = new GraphQlGenerator(getHtml("listsAndNonNull.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -123,7 +123,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void nonNullableFields() throws Exception {
+    void nonNullableFields() throws Exception {
         generator = new GraphQlGenerator(getHtml("nonNullableFields.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { name phone child { id name school } } ";
@@ -131,7 +131,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void objectsImplementInterface() throws Exception {
+    void objectsImplementInterface() throws Exception {
         generator = new GraphQlGenerator(getHtml("objectsImplementInterface.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -140,7 +140,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void implementMultipleInterfaces() throws Exception {
+    void implementMultipleInterfaces() throws Exception {
         generator =
                 new GraphQlGenerator(getHtml("implementMultipleInterfaces.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -150,7 +150,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void interfaceImplementsInterface() throws Exception {
+    void interfaceImplementsInterface() throws Exception {
         generator =
                 new GraphQlGenerator(getHtml("interfaceImplementsInterface.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -159,7 +159,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void unionType() throws Exception {
+    void unionType() throws Exception {
         generator = new GraphQlGenerator(getHtml("unionType.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -168,7 +168,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void enumType() throws Exception {
+    void enumType() throws Exception {
         generator = new GraphQlGenerator(getHtml("enumType.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { direction } ";
@@ -176,7 +176,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void mutation() throws Exception {
+    void mutation() throws Exception {
         generator = new GraphQlGenerator(getHtml("mutation.graphql"), null, param);
         String mutation = generator.generate(GraphQlGenerator.RequestType.MUTATION);
         String expectedMutation =
@@ -185,7 +185,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void subscription() throws Exception {
+    void subscription() throws Exception {
         generator = new GraphQlGenerator(getHtml("subscription.graphql"), null, param);
         String subscription = generator.generate(GraphQlGenerator.RequestType.SUBSCRIPTION);
         String expectedSubscription = "subscription { newMessage (roomId: 1) { sender text } } ";
@@ -195,7 +195,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     // Tests for Arguments that use variables (i.e. not inline arguments)
 
     @Test
-    public void separatedScalarArguments() throws Exception {
+    void separatedScalarArguments() throws Exception {
         generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -207,7 +207,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void separatedNonNullableScalarArguments() throws Exception {
+    void separatedNonNullableScalarArguments() throws Exception {
         generator =
                 new GraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"), null, param);
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
@@ -220,7 +220,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void separatedEnumArgumentVariable() throws Exception {
+    void separatedEnumArgumentVariable() throws Exception {
         generator = new GraphQlGenerator(getHtml("enumArgument.graphql"), null, param);
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -231,7 +231,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void separatedListAsArgument() throws Exception {
+    void separatedListAsArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("listAsArgument.graphql"), null, param);
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -246,7 +246,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void separatedInputObjectArgument() throws Exception {
+    void separatedInputObjectArgument() throws Exception {
         generator = new GraphQlGenerator(getHtml("inputObjectArgument.graphql"), null, param);
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query ($plot_point: Point2D) { plot (point: $plot_point) } ";
@@ -256,7 +256,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void variableNamesClash() throws Exception {
+    void variableNamesClash() throws Exception {
         generator = new GraphQlGenerator(getHtml("variableNamesClash.graphql"), null, param);
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
@@ -269,7 +269,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     // Tests for queries that exceed maximum query depth (Lenient Max Query Depth Enabled)
 
     @Test
-    public void lenientDepthDeepNestedLeaf() throws Exception {
+    void lenientDepthDeepNestedLeaf() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("deepNestedLeaf.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -279,7 +279,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void strictDepthScalarArguments() throws Exception {
+    void strictDepthScalarArguments() throws Exception {
         param = new GraphQlParam(1, false, 5, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -288,7 +288,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void lenientDepthScalarArguments() throws Exception {
+    void lenientDepthScalarArguments() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -297,7 +297,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void lenientDepthObjectsImplementInterface() throws Exception {
+    void lenientDepthObjectsImplementInterface() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("objectsImplementInterface.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -306,7 +306,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void lenientDepthUnionType() throws Exception {
+    void lenientDepthUnionType() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("unionType.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -315,7 +315,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void lenientDepthEnumType() throws Exception {
+    void lenientDepthEnumType() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("enumType.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
@@ -324,7 +324,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void lenientDepthScalarArgumentsVariables() throws Exception {
+    void lenientDepthScalarArgumentsVariables() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
@@ -337,7 +337,7 @@ public class GraphQlGeneratorUnitTest extends TestUtils {
     }
 
     @Test
-    public void lenientDepthExceeded() throws Exception {
+    void lenientDepthExceeded() throws Exception {
         param = new GraphQlParam(0, true, 3, 5, true, null, null, null);
         generator = new GraphQlGenerator(getHtml("deepNestedLeaf.graphql"), null, param);
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
@@ -28,24 +28,24 @@ import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.testutils.StaticContentServerHandler;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class GraphQlParserUnitTest extends TestUtils {
+class GraphQlParserUnitTest extends TestUtils {
 
     String endpointUrl;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         setUpZap();
         startServer();
         endpointUrl = "http://localhost:" + nano.getListeningPort();
     }
 
     @AfterEach
-    public void teardown() throws Exception {
+    void teardown() throws Exception {
         stopServer();
     }
 
     @Test
-    public void shouldFailIntrospectionWhenResponseIsEmpty() throws Exception {
+    void shouldFailIntrospectionWhenResponseIsEmpty() throws Exception {
         // Given
         nano.addHandler(new StaticContentServerHandler("/", ""));
         GraphQlParser gqp = new GraphQlParser(endpointUrl);
@@ -54,7 +54,7 @@ public class GraphQlParserUnitTest extends TestUtils {
     }
 
     @Test
-    public void shouldFailIntrospectionWhenResponseIsNotJson() throws Exception {
+    void shouldFailIntrospectionWhenResponseIsNotJson() throws Exception {
         // Given
         nano.addHandler(new StaticContentServerHandler("/", "not json"));
         GraphQlParser gqp = new GraphQlParser(endpointUrl);

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/InlineInjectorUnitTest.java
@@ -20,103 +20,102 @@
 package org.zaproxy.addon.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class InlineInjectorUnitTest extends TestUtils {
+class InlineInjectorUnitTest extends TestUtils {
     InlineInjector injector = new InlineInjector();
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         setUpZap();
     }
 
     // Extraction Tests
 
     @Test
-    public void noArguments() throws Exception {
+    void noArguments() throws Exception {
         String query = "query { name id age height human }";
         HashMap<String, String> arguments = new HashMap<>();
-        assertTrue(arguments.equals(injector.extract(query)));
+        assertEquals(arguments, injector.extract(query));
     }
 
     @Test
-    public void operationName() throws Exception {
+    void operationName() throws Exception {
         String query = "query sample { chemical (name: \"Hydrochloric Acid\") }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("sample.chemical.name", "\"Hydrochloric Acid\"");
-        assertTrue(arguments.equals(injector.extract(query)));
+        assertEquals(arguments, injector.extract(query));
     }
 
     @Test
-    public void scalarArguments() throws Exception {
+    void scalarArguments() throws Exception {
         String query =
                 "query { polygon (sides: 1, regular: true, colour: \"blue\") { perimeter area } }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("polygon.sides", "1");
         arguments.put("polygon.regular", "true");
         arguments.put("polygon.colour", "\"blue\"");
-        assertTrue(arguments.equals(injector.extract(query)));
+        assertEquals(arguments, injector.extract(query));
     }
 
     @Test
-    public void listAsArgument() throws Exception {
+    void listAsArgument() throws Exception {
         String query = "query { sum (numbers: [3.14, 3.14, 3.14]) }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("sum.numbers", "[3.14,3.14,3.14]");
-        assertTrue(arguments.equals(injector.extract(query)));
+        assertEquals(arguments, injector.extract(query));
     }
 
     @Test
-    public void inputObjectArgument() throws Exception {
+    void inputObjectArgument() throws Exception {
         String query = "query { plot (point: { x: 3.14, y: 3.14 }) }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("plot.point", "{x:3.14,y:3.14}");
-        assertTrue(arguments.equals(injector.extract(query)));
+        assertEquals(arguments, injector.extract(query));
     }
 
     @Test
-    public void inlineFragmentArguments() throws Exception {
+    void inlineFragmentArguments() throws Exception {
         String query = "query { ... on field1 { name (id: 1) } }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("field1.name.id", "1");
-        assertTrue(arguments.equals(injector.extract(query)));
+        assertEquals(arguments, injector.extract(query));
     }
 
     @Test
-    public void fragmentSpreadArguments() throws Exception {
+    void fragmentSpreadArguments() throws Exception {
         String query =
                 "query { ...spread }  fragment spread on fragment1 {field1 { name (id: 1) } }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("spread.field1.name.id", "1");
-        assertTrue(arguments.equals(injector.extract(query)));
+        assertEquals(arguments, injector.extract(query));
     }
 
     @Test
-    public void mutationArguments() throws Exception {
+    void mutationArguments() throws Exception {
         String mutation = "mutation { createStudent (id: 1, name: \"ZAP\") }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("createStudent.id", "1");
         arguments.put("createStudent.name", "\"ZAP\"");
-        assertTrue(arguments.equals(injector.extract(mutation)));
+        assertEquals(arguments, injector.extract(mutation));
     }
 
     @Test
-    public void subscriptionArguments() throws Exception {
+    void subscriptionArguments() throws Exception {
         String subscription = "subscription { newMessage (roomId: 1) { sender text } }";
         HashMap<String, String> arguments = new HashMap<>();
         arguments.put("newMessage.roomId", "1");
-        assertTrue(arguments.equals(injector.extract(subscription)));
+        assertEquals(arguments, injector.extract(subscription));
     }
 
     // Injection Tests
 
     @Test
-    public void injectOperationName() throws Exception {
+    void injectOperationName() throws Exception {
         String query = "query sample { chemical (name: \"Hydrochloric Acid\") }";
         String expectedQuery = "query sample {chemical(name:\"Sulphuric Acid\")}";
         assertEquals(
@@ -125,7 +124,7 @@ public class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
-    public void injectScalarArguments() throws Exception {
+    void injectScalarArguments() throws Exception {
         String query =
                 "query { polygon (sides: 1, regular: true, colour: \"blue\") { perimeter area } }";
         String expectedQuery =
@@ -134,28 +133,28 @@ public class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
-    public void injectListAsArgument() throws Exception {
+    void injectListAsArgument() throws Exception {
         String query = "query { sum (numbers: [3.14, 3.14, 3.14]) }";
         String expectedQuery = "query {sum(numbers:[0, 1, 2])}";
         assertEquals(expectedQuery, injector.inject(query, "sum.numbers", "[0, 1, 2]"));
     }
 
     @Test
-    public void injectInputObjectArgument() throws Exception {
+    void injectInputObjectArgument() throws Exception {
         String query = "query { plot (point: { x: 3.14, y: 3.14 }) }";
         String expectedQuery = "query {plot(point:{x: 1.414 , y: 1.732})}";
         assertEquals(expectedQuery, injector.inject(query, "plot.point", "{x: 1.414 , y: 1.732}"));
     }
 
     @Test
-    public void injectInlineFragmentArguments() throws Exception {
+    void injectInlineFragmentArguments() throws Exception {
         String query = "query { ... on field1 { name (id: 1) } }";
         String expectedQuery = "query {... on field1 {name(id:55)}}";
         assertEquals(expectedQuery, injector.inject(query, "field1.name.id", "55"));
     }
 
     @Test
-    public void injectFragmentSpreadArguments() throws Exception {
+    void injectFragmentSpreadArguments() throws Exception {
         String query =
                 "query { ...spread }  fragment spread on fragment1 {field1 { name (id: 1) } }";
         String expectedQuery =
@@ -164,14 +163,14 @@ public class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
-    public void injectMutationArguments() throws Exception {
+    void injectMutationArguments() throws Exception {
         String mutation = "mutation { createStudent (id: 1, name: \"ZAP\") }";
         String expectedMutation = "mutation {createStudent(id:42,name:\"ZAP\")}";
         assertEquals(expectedMutation, injector.inject(mutation, "createStudent.id", "42"));
     }
 
     @Test
-    public void injectSubscriptionArguments() throws Exception {
+    void injectSubscriptionArguments() throws Exception {
         String subscription = "subscription { newMessage (roomId: 1) { sender text } }";
         String expectedSubscription = "subscription {newMessage(roomId:121) {sender text}}";
         assertEquals(
@@ -179,7 +178,7 @@ public class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
-    public void injectReplaceSingleVariable() throws Exception {
+    void injectReplaceSingleVariable() throws Exception {
         String query =
                 "query ($location_direction: Direction) { location (direction: $location_direction) }";
         String expectedQuery = "query {location(direction:WEST)}";
@@ -187,7 +186,7 @@ public class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
-    public void injectReplaceFirstVariable() throws Exception {
+    void injectReplaceFirstVariable() throws Exception {
         String query =
                 "query ($name_height_id: ID, $name_age_id: ID, $name_id: ID) { name (id: $name_id) "
                         + "{ age (id: $name_age_id) height (id: $name_height_id) } }";
@@ -197,7 +196,7 @@ public class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
-    public void injectReplaceMiddleVariable() throws Exception {
+    void injectReplaceMiddleVariable() throws Exception {
         String query =
                 "query ($name_height_id: ID, $name_age_id: ID, $name_id: ID) { name (id: $name_id) "
                         + "{ age (id: $name_age_id) height (id: $name_height_id) } }";
@@ -207,7 +206,7 @@ public class InlineInjectorUnitTest extends TestUtils {
     }
 
     @Test
-    public void injectReplaceLastVariable() throws Exception {
+    void injectReplaceLastVariable() throws Exception {
         String query =
                 "query ($name_height_id: ID, $name_age_id: ID, $name_id: ID) { name (id: $name_id) "
                         + "{ age (id: $name_age_id) height (id: $name_height_id) } }";
@@ -220,42 +219,42 @@ public class InlineInjectorUnitTest extends TestUtils {
     // Query Node Name Tests
 
     @Test
-    public void nodeNameSimpleQuery() throws Exception {
+    void nodeNameSimpleQuery() throws Exception {
         String query = "query { name (id: 1) }";
         String expectedQuery = "(0) query {name}";
         assertEquals(expectedQuery, injector.getNodeName(query));
     }
 
     @Test
-    public void nodeNameNestedFields() throws Exception {
+    void nodeNameNestedFields() throws Exception {
         String query = "query { name (id: 1) { age (id: 1) { height (id: 1) } } }";
         String expectedQuery = "(0) query {name {age {height}}}";
         assertEquals(expectedQuery, injector.getNodeName(query));
     }
 
     @Test
-    public void nodeNameInputObjectArgument() throws Exception {
+    void nodeNameInputObjectArgument() throws Exception {
         String query = "query { plot (point: { x: 3.14, y: 3.14 }) }";
         String expectedQuery = "(0) query {plot}";
         assertEquals(expectedQuery, injector.getNodeName(query));
     }
 
     @Test
-    public void nodeNameMultipleOperations() throws Exception {
+    void nodeNameMultipleOperations() throws Exception {
         String query = "query { name (id: 1) } mutation { change_name (id: 1, name: \"ZAP\") }";
         String expectedQuery = "(00) query {name} mutation {change_name}";
         assertEquals(expectedQuery, injector.getNodeName(query));
     }
 
     @Test
-    public void nodeNameVariables() throws Exception {
+    void nodeNameVariables() throws Exception {
         String query = "mutation ($id: ID!, $name: String) { change_name (id: $id, name: $name) }";
         String expectedQuery = "(1) mutation {change_name}";
         assertEquals(expectedQuery, injector.getNodeName(query));
     }
 
     @Test
-    public void nodeNameMultipleOperationsVariables() throws Exception {
+    void nodeNameMultipleOperationsVariables() throws Exception {
         String query =
                 "query ($id: ID!) { name (id: $id) } mutation ($id: ID!, $name: String) "
                         + "{ change_name (id: $id, name: $name) } subscription { newMessage (roomId: 1) { sender } }";

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/MessageValidatorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/MessageValidatorUnitTest.java
@@ -27,14 +27,14 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class MessageValidatorUnitTest extends TestUtils {
+class MessageValidatorUnitTest extends TestUtils {
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         setUpZap();
     }
 
     @Test
-    public void nonExistentContentTypeHeader() throws Exception {
+    void nonExistentContentTypeHeader() throws Exception {
         HttpMessage message = new HttpMessage(new URI("http://example.com", true));
         assertEquals(MessageValidator.validate(message), MessageValidator.Result.INVALID);
     }

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
@@ -44,12 +44,12 @@ import org.zaproxy.addon.graphql.ExtensionGraphQl;
 import org.zaproxy.addon.graphql.GraphQlParam;
 import org.zaproxy.zap.utils.I18N;
 
-public class GraphQlJobUnitTest {
+class GraphQlJobUnitTest {
 
     private ExtensionGraphQl extGraphQl;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         Constant.messages = new I18N(Locale.ENGLISH);
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
@@ -60,7 +60,7 @@ public class GraphQlJobUnitTest {
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given / When
         GraphQlJob job = new GraphQlJob();
 
@@ -73,7 +73,7 @@ public class GraphQlJobUnitTest {
     }
 
     @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         GraphQlJob job = new GraphQlJob();
 
@@ -88,7 +88,7 @@ public class GraphQlJobUnitTest {
     }
 
     @Test
-    public void shouldApplyCustomConfigParams() {
+    void shouldApplyCustomConfigParams() {
         // Given
         GraphQlJob job = new GraphQlJob();
         String endpoint = "https://example.com/graphql/";
@@ -107,7 +107,7 @@ public class GraphQlJobUnitTest {
     }
 
     @Test
-    public void shouldReturnConfigParams() {
+    void shouldReturnConfigParams() {
         // Given
         GraphQlJob job = new GraphQlJob();
 
@@ -135,7 +135,7 @@ public class GraphQlJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfEmptyEndpoint() {
+    void shouldFailIfEmptyEndpoint() {
         // Given
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
@@ -156,7 +156,7 @@ public class GraphQlJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfInvalidEndpoint() {
+    void shouldFailIfInvalidEndpoint() {
         // Given
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
@@ -175,7 +175,7 @@ public class GraphQlJobUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"", "https://example.com/test file.graphql"})
-    public void shouldFailIfInvalidSchemaUrl(String schemaUrl) {
+    void shouldFailIfInvalidSchemaUrl(String schemaUrl) {
         // Given
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
@@ -194,7 +194,7 @@ public class GraphQlJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfInvalidSchemaFile() {
+    void shouldFailIfInvalidSchemaFile() {
         // Given
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);

--- a/addOns/imagelocationscanner/src/test/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRuleUnitTest.java
+++ b/addOns/imagelocationscanner/src/test/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<ImageLocationScanRule> {
+class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<ImageLocationScanRule> {
     private static final int PLUGIN_ID = ImageLocationScanRule.PLUGIN_ID;
     private static final String URI = "https://www.example.com/";
 
@@ -47,7 +47,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
     }
 
     @Test
-    public void passesIfExifLocationDetected() throws HttpMalformedHeaderException, IOException {
+    void passesIfExifLocationDetected() throws HttpMalformedHeaderException, IOException {
         HttpMessage msg;
         String fname;
 
@@ -65,7 +65,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
     }
 
     @Test
-    public void passesIfNoIssuesDetected() throws HttpMalformedHeaderException, IOException {
+    void passesIfNoIssuesDetected() throws HttpMalformedHeaderException, IOException {
         HttpMessage msg;
         String fname;
 
@@ -92,7 +92,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
     }
 
     @Test
-    public void passesIfPrivacyExposureDetected() throws HttpMalformedHeaderException, IOException {
+    void passesIfPrivacyExposureDetected() throws HttpMalformedHeaderException, IOException {
         HttpMessage msg;
         String fname;
 
@@ -110,7 +110,7 @@ public class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<Image
     }
 
     @Test
-    public void testOfScanHttpRequestSend() throws HttpMalformedHeaderException {
+    void testOfScanHttpRequestSend() throws HttpMalformedHeaderException {
         // the method should do nothing (test just for code coverage)
         rule.scanHttpRequestSend(null, -1);
         assertThat(alertsRaised.size(), equalTo(0));

--- a/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/ClassLoaderTests.java
+++ b/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/ClassLoaderTests.java
@@ -49,7 +49,7 @@ public class ClassLoaderTests {
     }
 
     @Test
-    public void shouldLoadClassesFromProvidedClassLoader() throws Exception {
+    void shouldLoadClassesFromProvidedClassLoader() throws Exception {
 
         ClassLoader currentClassLoader = Thread.currentThread().getContextClassLoader();
 

--- a/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/PrintOutputTests.java
+++ b/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/PrintOutputTests.java
@@ -41,7 +41,7 @@ public class PrintOutputTests {
     }
 
     @Test
-    public void shouldPrintToScriptContextWriter() throws Exception {
+    void shouldPrintToScriptContextWriter() throws Exception {
         String script = getScriptContents("printTest.kts");
 
         ScriptContext sc = se.getContext();

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractOpenApiTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractOpenApiTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractOpenApiTest extends TestUtils {
     }
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         setUpZap();
     }
 }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractServerTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/AbstractServerTest.java
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.BeforeEach;
 public abstract class AbstractServerTest extends AbstractOpenApiTest {
 
     @BeforeEach
-    public void init() throws Exception {
+    void init() throws Exception {
         startServer();
     }
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         stopServer();
     }
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
@@ -42,20 +42,20 @@ import org.zaproxy.zap.model.DefaultNameValuePair;
 import org.zaproxy.zap.model.NameValuePair;
 
 /** Unit test for {@link OpenApiAPI}. */
-public class OpenApiAPIUnitTest extends AbstractServerTest {
+class OpenApiAPIUnitTest extends AbstractServerTest {
 
     private ExtensionOpenApi extension;
 
     private OpenApiAPI openApiAPI;
 
     @BeforeEach
-    public void prepare() {
+    void prepare() {
         extension = mock(ExtensionOpenApi.class);
         openApiAPI = new OpenApiAPI(extension);
     }
 
     @Test
-    public void shouldThrowBadActionIfActionUnknown() {
+    void shouldThrowBadActionIfActionUnknown() {
         // Given
         String actionName = "_NotKnownAction_";
         // When / Then
@@ -71,7 +71,7 @@ public class OpenApiAPIUnitTest extends AbstractServerTest {
         private static final String ACTION = "importUrl";
 
         @Test
-        public void shouldThrowIllegalParameterIfFailedToAccessTarget() {
+        void shouldThrowIllegalParameterIfFailedToAccessTarget() {
             // Given
             JSONObject params = params(param("url", "http://not-reachable.example.com"));
             given(extension.importOpenApiDefinition(any(URI.class), eq(""), eq(false)))

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -42,12 +42,12 @@ import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
 import org.zaproxy.zap.utils.I18N;
 
-public class OpenApiJobUnitTest {
+class OpenApiJobUnitTest {
 
     private ExtensionOpenApi extOpenApi;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         Constant.messages = new I18N(Locale.ENGLISH);
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -60,7 +60,7 @@ public class OpenApiJobUnitTest {
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given / When
         OpenApiJob job = new OpenApiJob();
 
@@ -73,7 +73,7 @@ public class OpenApiJobUnitTest {
     }
 
     @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         OpenApiJob job = new OpenApiJob();
 
@@ -88,7 +88,7 @@ public class OpenApiJobUnitTest {
     }
 
     @Test
-    public void shouldApplyCustomConfigParams() {
+    void shouldApplyCustomConfigParams() {
         // Given
         OpenApiJob job = new OpenApiJob();
         String apiFile = "C:\\Users\\ZAPBot\\Documents\\test file.json";
@@ -107,7 +107,7 @@ public class OpenApiJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfInvalidUrl() {
+    void shouldFailIfInvalidUrl() {
         // Given
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
@@ -124,7 +124,7 @@ public class OpenApiJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfInvalidFile() {
+    void shouldFailIfInvalidFile() {
         // Given
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/InvalidUrlExceptionUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/InvalidUrlExceptionUnitTest.java
@@ -27,10 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link InvalidUrlException}. */
-public class InvalidUrlExceptionUnitTest {
+class InvalidUrlExceptionUnitTest {
 
     @Test
-    public void shouldFailToCreateException2ArgWithNullUrl() {
+    void shouldFailToCreateException2ArgWithNullUrl() {
         // Given
         String url = null;
         // When / Then
@@ -38,7 +38,7 @@ public class InvalidUrlExceptionUnitTest {
     }
 
     @Test
-    public void shouldCreateException2ArgWithNonNullUrl() {
+    void shouldCreateException2ArgWithNonNullUrl() {
         // Given
         String url = "url";
         // When
@@ -48,7 +48,7 @@ public class InvalidUrlExceptionUnitTest {
     }
 
     @Test
-    public void shouldFailToCreateException3ArgWithNullUrl() {
+    void shouldFailToCreateException3ArgWithNullUrl() {
         // Given
         String url = null;
         // When / Then
@@ -56,7 +56,7 @@ public class InvalidUrlExceptionUnitTest {
     }
 
     @Test
-    public void shouldCreateException3ArgWithNonNullUrl() {
+    void shouldCreateException3ArgWithNonNullUrl() {
         // Given
         String url = "url";
         // When

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverterUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverterUnitTest.java
@@ -42,14 +42,14 @@ import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.openapi.AbstractOpenApiTest;
 
 /** Unit test for {@link SwaggerConverter}. */
-public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
+class SwaggerConverterUnitTest extends AbstractOpenApiTest {
 
     private static final String WELLFORMED_URL = "http://example.com";
     private static final String DUMMY_DEFINITION = "{}";
     private static final UriBuilder EMPTY_URI_BUILDER = UriBuilder.parse("");
 
     @Test
-    public void shouldThrowInvalidUrlIfDefinitionUrlHasNoScheme() {
+    void shouldThrowInvalidUrlIfDefinitionUrlHasNoScheme() {
         // Given
         String definitionUrl = "://example.com";
         // When / Then
@@ -59,7 +59,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowInvalidUrlIfDefinitionUrlHasNoAuthority() {
+    void shouldThrowInvalidUrlIfDefinitionUrlHasNoAuthority() {
         // Given
         String definitionUrl = "http://";
         // When / Then
@@ -69,7 +69,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowInvalidUrlIfDefinitionUrlHasMalformedScheme() {
+    void shouldThrowInvalidUrlIfDefinitionUrlHasMalformedScheme() {
         // Given
         String definitionUrl = "notscheme//example.com";
         // When / Then
@@ -79,7 +79,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowInvalidUrlIfDefinitionUrlIsJustPath() {
+    void shouldThrowInvalidUrlIfDefinitionUrlIsJustPath() {
         // Given
         String definitionUrl = "path";
         // When / Then
@@ -89,7 +89,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfDefinitionUrlIsNull() {
+    void shouldNotThrowInvalidUrlIfDefinitionUrlIsNull() {
         // Given
         String definitionUrl = null;
         // When / Then
@@ -98,7 +98,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfDefinitionUrlIsEmpty() {
+    void shouldNotThrowInvalidUrlIfDefinitionUrlIsEmpty() {
         // Given
         String definitionUrl = "";
         // When / Then
@@ -107,7 +107,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfDefinitionUrlHasHttpSchemeAndAuthority() {
+    void shouldNotThrowInvalidUrlIfDefinitionUrlHasHttpSchemeAndAuthority() {
         // Given
         String definitionUrl = "http://example.com";
         // When / Then
@@ -116,7 +116,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfDefinitionUrlHasHttpsSchemeAndAuthority() {
+    void shouldNotThrowInvalidUrlIfDefinitionUrlHasHttpsSchemeAndAuthority() {
         // Given
         String definitionUrl = "https://example.com";
         // When / Then
@@ -125,7 +125,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowInvalidUrlIfDefinitionUrlHasUnsupportedScheme() {
+    void shouldThrowInvalidUrlIfDefinitionUrlHasUnsupportedScheme() {
         // Given
         String definitionUrl = "ws://example.com";
         // When / Then
@@ -135,7 +135,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfDefinitionUrlHasSupportedSchemeAuthorityAndPath() {
+    void shouldNotThrowInvalidUrlIfDefinitionUrlHasSupportedSchemeAuthorityAndPath() {
         // Given
         String definitionUrl = "http://example.com/path";
         // When / Then
@@ -144,7 +144,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowInvalidUrlIfTargetUrlHasNoScheme() {
+    void shouldThrowInvalidUrlIfTargetUrlHasNoScheme() {
         // Given
         String targetUrl = "://example.com";
         // When / Then
@@ -154,7 +154,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetIsJustHttpScheme() {
+    void shouldNotThrowInvalidUrlIfTargetIsJustHttpScheme() {
         // Given
         String targetUrl = "http://";
         // When / Then
@@ -163,7 +163,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetIsJustHttpsScheme() {
+    void shouldNotThrowInvalidUrlIfTargetIsJustHttpsScheme() {
         // Given
         String targetUrl = "https://";
         // When / Then
@@ -172,7 +172,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowInvalidUrlIfTargetUrlHasMalformedScheme() {
+    void shouldThrowInvalidUrlIfTargetUrlHasMalformedScheme() {
         // Given
         String targetUrl = "notscheme//example.com";
         // When / Then
@@ -182,7 +182,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetUrlIsJustAuthority() {
+    void shouldNotThrowInvalidUrlIfTargetUrlIsJustAuthority() {
         // Given
         String targetUrl = "example.com";
         // When / Then
@@ -191,7 +191,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetUrlIsJustAbsolutePath() {
+    void shouldNotThrowInvalidUrlIfTargetUrlIsJustAbsolutePath() {
         // Given
         String targetUrl = "/path";
         // When / Then
@@ -200,7 +200,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetUrlIsNull() {
+    void shouldNotThrowInvalidUrlIfTargetUrlIsNull() {
         // Given
         String targetUrl = null;
         // When / Then
@@ -209,7 +209,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetUrlIsEmpty() {
+    void shouldNotThrowInvalidUrlIfTargetUrlIsEmpty() {
         // Given
         String targetUrl = "";
         // When / Then
@@ -218,7 +218,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetUrlHasHttpSchemeAndAuthority() {
+    void shouldNotThrowInvalidUrlIfTargetUrlHasHttpSchemeAndAuthority() {
         // Given
         String targetUrl = "http://example.com";
         // When / Then
@@ -227,7 +227,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetUrlHasHttpsSchemeAndAuthority() {
+    void shouldNotThrowInvalidUrlIfTargetUrlHasHttpsSchemeAndAuthority() {
         // Given
         String targetUrl = "https://example.com";
         // When / Then
@@ -236,7 +236,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowInvalidUrlIfTargetUrlHasUnsupportedScheme() {
+    void shouldThrowInvalidUrlIfTargetUrlHasUnsupportedScheme() {
         // Given
         String targetUrl = "ws://example.com";
         // When / Then
@@ -246,7 +246,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldNotThrowInvalidUrlIfTargetUrlHasSupportedSchemeAuthorityAndPath() {
+    void shouldNotThrowInvalidUrlIfTargetUrlHasSupportedSchemeAuthorityAndPath() {
         // Given
         String targetUrl = "http://example.com/path";
         // When / Then
@@ -255,7 +255,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowIllegalArgumentWith2ArgIfDefinitionIsNull() {
+    void shouldThrowIllegalArgumentWith2ArgIfDefinitionIsNull() {
         // Given
         String definition = null;
         // When / Then
@@ -263,7 +263,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowIllegalArgumentWith4ArgIfDefinitionIsNull() {
+    void shouldThrowIllegalArgumentWith4ArgIfDefinitionIsNull() {
         // Given
         String definition = null;
         // When / Then
@@ -273,7 +273,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowIllegalArgumentWith2ArgIfDefinitionIsEmpty() {
+    void shouldThrowIllegalArgumentWith2ArgIfDefinitionIsEmpty() {
         // Given
         String definition = "";
         // When / Then
@@ -281,7 +281,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldThrowIllegalArgumentWith4ArgIfDefinitionIsEmpty() {
+    void shouldThrowIllegalArgumentWith4ArgIfDefinitionIsEmpty() {
         // Given
         String definition = "";
         // When / Then
@@ -291,25 +291,23 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateSwaggerConverter2ArgWithDefinitionNotEmpty() {
+    void shouldCreateSwaggerConverter2ArgWithDefinitionNotEmpty() {
         // Given
         String definition = "{}";
-        // When
-        new SwaggerConverter(definition, null);
-        // Then = No Exception
+        // When / Then
+        assertDoesNotThrow(() -> new SwaggerConverter(definition, null));
     }
 
     @Test
-    public void shouldCreateSwaggerConverter4ArgWithDefinitionNotEmpty() {
+    void shouldCreateSwaggerConverter4ArgWithDefinitionNotEmpty() {
         // Given
         String definition = "{}";
-        // When
-        new SwaggerConverter(null, null, definition, null);
-        // Then = No Exception
+        // When / Then
+        assertDoesNotThrow(() -> new SwaggerConverter(null, null, definition, null));
     }
 
     @Test
-    public void shouldThrowNullPointerWhenCreateUriBuildersFromNullServersList() {
+    void shouldThrowNullPointerWhenCreateUriBuildersFromNullServersList() {
         // Given
         List<Server> servers = null;
         // When / Then
@@ -319,7 +317,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateEmptyUriBuilderListFromEmptyServerList() {
+    void shouldCreateEmptyUriBuilderListFromEmptyServerList() {
         // Given
         List<Server> servers = Collections.emptyList();
         // When
@@ -330,7 +328,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithEmptyValue() {
+    void shouldCreateUriBuildersFromServerWithEmptyValue() {
         // Given
         List<Server> servers = asList(server(""));
         // When
@@ -342,7 +340,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithEmptyValueDefaultingToDefinitionUrl() {
+    void shouldCreateUriBuildersFromServerWithEmptyValueDefaultingToDefinitionUrl() {
         // Given
         List<Server> servers = asList(server(""));
         UriBuilder defnUriBuilder = UriBuilder.parse("http://example.com/path");
@@ -354,7 +352,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithJustRelativePath() {
+    void shouldCreateUriBuildersFromServerWithJustRelativePath() {
         // Given
         List<Server> servers = asList(server("relativePath"));
         // When
@@ -366,7 +364,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithJustRelativePathDefaultingToSchemeAndAuthorityOfDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("relativePath"));
@@ -379,7 +377,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithJustRelativePathDefaultingToSchemeAndAuthorityAndMergingPathOfDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("relativePath"));
@@ -392,7 +390,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithAbsolutePath() {
+    void shouldCreateUriBuildersFromServerWithAbsolutePath() {
         // Given
         List<Server> servers = asList(server("/absolutePath"));
         // When
@@ -404,7 +402,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithAbsolutePathDefaultingToSchemeAndAuthorityOfDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("/absolutePath"));
@@ -417,7 +415,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithAuthorityAndNoScheme() {
+    void shouldCreateUriBuildersFromServerWithAuthorityAndNoScheme() {
         // Given
         List<Server> servers = asList(server("//example.com"));
         // When
@@ -429,7 +427,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithAuthorityAndNoSchemeDefaultingToSchemeOfDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("//example.com"));
@@ -442,7 +440,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithEmptyAuthority() {
+    void shouldCreateUriBuildersFromServerWithEmptyAuthority() {
         // Given
         List<Server> servers = asList(server("//"));
         // When
@@ -454,7 +452,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithEmptyAuthorityDefaultingToSchemeAuthorityAndPathOfDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("//"));
@@ -467,7 +465,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithScheme() {
+    void shouldCreateUriBuildersFromServerWithScheme() {
         // Given
         List<Server> servers = asList(server("http://"));
         // When
@@ -479,8 +477,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
-            shouldCreateUriBuildersFromServerWithSchemeDefaultingToAuthorityAndPathOfDefinitionUrl() {
+    void shouldCreateUriBuildersFromServerWithSchemeDefaultingToAuthorityAndPathOfDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("http://"));
         UriBuilder defnUriBuilder = UriBuilder.parse("https://example.com/path");
@@ -492,7 +489,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithSchemeAndAuthority() {
+    void shouldCreateUriBuildersFromServerWithSchemeAndAuthority() {
         // Given
         List<Server> servers = asList(server("http://example.com"));
         // When
@@ -504,7 +501,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithSchemeAndAuthorityDefaultingToAuthorityAndPathOfDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("http://example.com"));
@@ -517,7 +514,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithSchemeAuthorityAndEmptyPath() {
+    void shouldCreateUriBuildersFromServerWithSchemeAuthorityAndEmptyPath() {
         // Given
         List<Server> servers = asList(server("http://example.com/"));
         // When
@@ -529,7 +526,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithSchemeAuthorityAndEmptyPathWithoutDefaultingToDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("http://example.com/"));
@@ -542,7 +539,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithSchemeAuthorityAndNonEmptyPath() {
+    void shouldCreateUriBuildersFromServerWithSchemeAuthorityAndNonEmptyPath() {
         // Given
         List<Server> servers = asList(server("http://example.com/path"));
         // When
@@ -554,7 +551,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void
+    void
             shouldCreateUriBuildersFromServerWithSchemeAuthorityAndNonEmptyPathWithoutDefaultingToDefinitionUrl() {
         // Given
         List<Server> servers = asList(server("http://example.com/path"));
@@ -567,7 +564,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromMultipleServers() {
+    void shouldCreateUriBuildersFromMultipleServers() {
         // Given
         List<Server> servers =
                 asList(server("http://dev.example.com/api/"), server("https://qa.example.com/v2"));
@@ -581,7 +578,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateUriBuildersFromServerWithVariables() {
+    void shouldCreateUriBuildersFromServerWithVariables() {
         // Given
         Server server = server("{scheme}://example.com/");
         ServerVariables variables = new ServerVariables();
@@ -597,7 +594,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldIgnoreServersWithUnsupportedScheme() {
+    void shouldIgnoreServersWithUnsupportedScheme() {
         // Given
         List<Server> servers =
                 asList(server("ws://dev.example.com/api/"), server("wss://qa.example.com/v2"));
@@ -609,7 +606,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldIgnoreServersWithEmptyScheme() {
+    void shouldIgnoreServersWithEmptyScheme() {
         // Given
         List<Server> servers = asList(server("://"));
         // When
@@ -620,7 +617,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldIgnoreServersWithMalformedScheme() {
+    void shouldIgnoreServersWithMalformedScheme() {
         // Given
         List<Server> servers = asList(server("notscheme//"));
         // When
@@ -631,7 +628,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlJustFromServerUrl() throws SwaggerException {
+    void shouldCreateApiUrlJustFromServerUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders =
                 asList(UriBuilder.parse("http://example.com/serverpath"));
@@ -644,7 +641,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlsFromMultipleServerUrls() throws SwaggerException {
+    void shouldCreateApiUrlsFromMultipleServerUrls() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders =
                 asList(
@@ -660,7 +657,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldIgnoreDuplicatedServerUrls() throws SwaggerException {
+    void shouldIgnoreDuplicatedServerUrls() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders =
                 asList(
@@ -675,7 +672,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlIfNoServerUrl() {
+    void shouldFailToCreateApiUrlIfNoServerUrl() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList();
@@ -688,7 +685,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlFromEmptyServerUrl() {
+    void shouldFailToCreateApiUrlFromEmptyServerUrl() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse(""));
@@ -701,7 +698,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlFromJustServerUrlWithoutScheme() {
+    void shouldFailToCreateApiUrlFromJustServerUrlWithoutScheme() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("//example.com"));
@@ -714,7 +711,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlFromJustServerUrlWithoutAuthority() {
+    void shouldFailToCreateApiUrlFromJustServerUrlWithoutAuthority() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://"));
@@ -727,7 +724,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlFromMalformedServerUrl() {
+    void shouldFailToCreateApiUrlFromMalformedServerUrl() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://x%0"));
@@ -740,7 +737,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlFromMalformedServerUrlWithNonEmptyDefinitionUrl() {
+    void shouldFailToCreateApiUrlFromMalformedServerUrlWithNonEmptyDefinitionUrl() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("//x%0"));
@@ -754,7 +751,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlJustFromTargetUrl() throws SwaggerException {
+    void shouldCreateApiUrlJustFromTargetUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders = asList();
         UriBuilder targetUriBuilder = UriBuilder.parseLenient("http://example.com");
@@ -767,7 +764,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlJustFromTargetUrlIfMalformed() {
+    void shouldFailToCreateApiUrlJustFromTargetUrlIfMalformed() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList();
@@ -783,7 +780,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithEmptyServerUrlIfTargetUrlIsMalformed() {
+    void shouldFailToCreateApiUrlWithEmptyServerUrlIfTargetUrlIsMalformed() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse(""));
@@ -799,7 +796,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithServerUrlIfTargetUrlIsMalformed() {
+    void shouldFailToCreateApiUrlWithServerUrlIfTargetUrlIsMalformed() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://example.com"));
@@ -815,7 +812,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithDefinitionUrlIfTargetUrlIsMalformed() {
+    void shouldFailToCreateApiUrlWithDefinitionUrlIfTargetUrlIsMalformed() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList();
@@ -832,7 +829,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithServerUrlDefinitionUrlIfTargetUrlIsMalformed() {
+    void shouldFailToCreateApiUrlWithServerUrlDefinitionUrlIfTargetUrlIsMalformed() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://example.com"));
@@ -849,7 +846,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlWithSchemeFromTargetUrl() throws SwaggerException {
+    void shouldCreateApiUrlWithSchemeFromTargetUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://example.com"));
         UriBuilder targetUriBuilder = UriBuilder.parseLenient("https://example.com");
@@ -862,8 +859,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlWithSchemeFromServerUrlIfNotInTargetUrl()
-            throws SwaggerException {
+    void shouldCreateApiUrlWithSchemeFromServerUrlIfNotInTargetUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("https://example.com"));
         UriBuilder targetUriBuilder = UriBuilder.parseLenient("//example.com");
@@ -876,7 +872,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlJustFromTargetUrlIfHasNoScheme() {
+    void shouldFailToCreateApiUrlJustFromTargetUrlIfHasNoScheme() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList();
@@ -893,7 +889,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithEmptyServerUrlIfTargetUrlHasNoScheme() {
+    void shouldFailToCreateApiUrlWithEmptyServerUrlIfTargetUrlHasNoScheme() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse(""));
@@ -910,7 +906,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithServerUrlIfTargetUrlHasNoScheme() {
+    void shouldFailToCreateApiUrlWithServerUrlIfTargetUrlHasNoScheme() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("//example.com"));
@@ -927,7 +923,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithDefinitionUrlIfTargetUrlHasNoScheme() {
+    void shouldFailToCreateApiUrlWithDefinitionUrlIfTargetUrlHasNoScheme() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList();
@@ -945,7 +941,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithServerUrlDefinitionUrlIfTargetUrlHasNoScheme() {
+    void shouldFailToCreateApiUrlWithServerUrlDefinitionUrlIfTargetUrlHasNoScheme() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("//example.com"));
@@ -963,7 +959,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlWithAuthorityFromTargetUrl() throws SwaggerException {
+    void shouldCreateApiUrlWithAuthorityFromTargetUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://server.example.com"));
         UriBuilder targetUriBuilder = UriBuilder.parseLenient("http://target.example.com");
@@ -976,8 +972,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlWithAuthorityFromServerUrlIfNotInTargetUrl()
-            throws SwaggerException {
+    void shouldCreateApiUrlWithAuthorityFromServerUrlIfNotInTargetUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://server.example.com"));
         UriBuilder targetUriBuilder = UriBuilder.parseLenient("http://");
@@ -990,7 +985,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlJustFromTargetUrlIfHasNoAuthority() {
+    void shouldFailToCreateApiUrlJustFromTargetUrlIfHasNoAuthority() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList();
@@ -1007,7 +1002,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithEmptyServerUrlIfTargetUrlHasNoAuthority() {
+    void shouldFailToCreateApiUrlWithEmptyServerUrlIfTargetUrlHasNoAuthority() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse(""));
@@ -1024,7 +1019,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithServerUrlIfTargetUrlHasNoAuthority() {
+    void shouldFailToCreateApiUrlWithServerUrlIfTargetUrlHasNoAuthority() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://"));
@@ -1041,7 +1036,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithDefinitionUrlIfTargetUrlHasNoAuthority() {
+    void shouldFailToCreateApiUrlWithDefinitionUrlIfTargetUrlHasNoAuthority() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList();
@@ -1059,7 +1054,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldFailToCreateApiUrlWithServerUrlDefinitionUrlIfTargetUrlHasNoAuthority() {
+    void shouldFailToCreateApiUrlWithServerUrlDefinitionUrlIfTargetUrlHasNoAuthority() {
         try {
             // Given
             List<UriBuilder> serverUriBuilders = asList(UriBuilder.parse("http://"));
@@ -1077,7 +1072,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlWithPathFromTargetUrl() throws SwaggerException {
+    void shouldCreateApiUrlWithPathFromTargetUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders =
                 asList(UriBuilder.parse("http://example.com/serverpath/"));
@@ -1091,7 +1086,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlWithPathFromTargetUrlEvenIfEmpty() throws SwaggerException {
+    void shouldCreateApiUrlWithPathFromTargetUrlEvenIfEmpty() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders =
                 asList(UriBuilder.parse("http://example.com/serverpath/"));
@@ -1105,7 +1100,7 @@ public class SwaggerConverterUnitTest extends AbstractOpenApiTest {
     }
 
     @Test
-    public void shouldCreateApiUrlWithPathFromServerUrlIfNotInTargetUrl() throws SwaggerException {
+    void shouldCreateApiUrlWithPathFromServerUrlIfNotInTargetUrl() throws SwaggerException {
         // Given
         List<UriBuilder> serverUriBuilders =
                 asList(UriBuilder.parse("http://example.com/serverpath/"));

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/converter/swagger/UriBuilderUnitTest.java
@@ -35,7 +35,7 @@ import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link UriBuilder}. */
-public class UriBuilderUnitTest {
+class UriBuilderUnitTest {
 
     private static final ParseMethod PARSE = new ParseMethod("parse", UriBuilder::parse);
     private static final ParseMethod PARSE_LENIENT =
@@ -50,7 +50,7 @@ public class UriBuilderUnitTest {
                     Pair.of(PARSE_LENIENT, PARSE));
 
     @Test
-    public void shouldParseWithNullValue() {
+    void shouldParseWithNullValue() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -89,7 +89,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithEmptyValue() {
+    void shouldParseWithEmptyValue() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -103,7 +103,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithJustRelativePath() {
+    void shouldParseWithJustRelativePath() {
         // Given
         ParseMethod method = PARSE;
         String value = "relativePath";
@@ -115,7 +115,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseLenientWithJustAuthority() {
+    void shouldParseLenientWithJustAuthority() {
         // Given
         ParseMethod method = PARSE_LENIENT;
         String value = "authority";
@@ -127,7 +127,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithAbsolutePath() {
+    void shouldParseWithAbsolutePath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -145,7 +145,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithAuthorityAndNoScheme() {
+    void shouldParseWithAuthorityAndNoScheme() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -163,7 +163,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithEmptyAuthority() {
+    void shouldParseWithEmptyAuthority() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -177,7 +177,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithScheme() {
+    void shouldParseWithScheme() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -195,7 +195,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldFailToParseWithEmptyScheme() {
+    void shouldFailToParseWithEmptyScheme() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -212,7 +212,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldFailToParseWithMalformedScheme() {
+    void shouldFailToParseWithMalformedScheme() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -229,7 +229,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithSchemeAndAuthority() {
+    void shouldParseWithSchemeAndAuthority() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -247,7 +247,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithSchemeAuthorityAndEmptyPath() {
+    void shouldParseWithSchemeAuthorityAndEmptyPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -265,7 +265,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldParseWithSchemeAuthorityAndNonEmptyPath() {
+    void shouldParseWithSchemeAuthorityAndNonEmptyPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -283,7 +283,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldThrowNullPointerIfMergingToNull() {
+    void shouldThrowNullPointerIfMergingToNull() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -296,7 +296,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergeSchemeIfNull() {
+    void shouldMergeSchemeIfNull() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -319,7 +319,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldNotMergeSchemeIfNotNull() {
+    void shouldNotMergeSchemeIfNotNull() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -342,7 +342,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergeAuthorityIfNull() {
+    void shouldMergeAuthorityIfNull() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -365,7 +365,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldNotMergeAuthorityIfNotNull() {
+    void shouldNotMergeAuthorityIfNotNull() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -388,7 +388,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergePathIfNull() {
+    void shouldMergePathIfNull() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -411,7 +411,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldNotMergePathIfNotNull() {
+    void shouldNotMergePathIfNotNull() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -434,7 +434,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergeSchemeAuthorityIfJustAbsolutePath() {
+    void shouldMergeSchemeAuthorityIfJustAbsolutePath() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -457,7 +457,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergeRelativePath() {
+    void shouldMergeRelativePath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -477,7 +477,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergeRelativePathWithPathEndedWithSlash() {
+    void shouldMergeRelativePathWithPathEndedWithSlash() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -497,7 +497,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergeRelativePathWithNoPath() {
+    void shouldMergeRelativePathWithNoPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -516,7 +516,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldMergeSchemeAuthorityAndPathIfAllNull() {
+    void shouldMergeSchemeAuthorityAndPathIfAllNull() {
         PARSE_METHODS_MERGE.forEach(
                 pair -> {
                     // Given
@@ -539,7 +539,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldSetDefaulPathIfNotAlreadySet() {
+    void shouldSetDefaulPathIfNotAlreadySet() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -552,7 +552,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldNotSetDefaulPathIfAlreadySet() {
+    void shouldNotSetDefaulPathIfAlreadySet() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -566,7 +566,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBeEmptyWithoutSchemeAuthorityAndPath() {
+    void shouldBeEmptyWithoutSchemeAuthorityAndPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -579,7 +579,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldNotBeEmptyWithScheme() {
+    void shouldNotBeEmptyWithScheme() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -592,7 +592,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldNotBeEmptyWithAuthority() {
+    void shouldNotBeEmptyWithAuthority() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -605,7 +605,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldNotBeEmptyWithPath() {
+    void shouldNotBeEmptyWithPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -618,7 +618,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldCopy() {
+    void shouldCopy() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -640,7 +640,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildWithSchemeAndAuthority() {
+    void shouldBuildWithSchemeAndAuthority() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -653,7 +653,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildWithSchemeAuthorityAndPath() {
+    void shouldBuildWithSchemeAuthorityAndPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -667,7 +667,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildAfterMergeRelativePathWithNoPath() {
+    void shouldBuildAfterMergeRelativePathWithNoPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -684,7 +684,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildAfterMergeRelativePathWithEmptyPath() {
+    void shouldBuildAfterMergeRelativePathWithEmptyPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -701,7 +701,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildAfterMergeAbsolutePathWithNoPath() {
+    void shouldBuildAfterMergeAbsolutePathWithNoPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -718,7 +718,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildAfterMergeAbsolutePathWithEmptyPath() {
+    void shouldBuildAfterMergeAbsolutePathWithEmptyPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -735,7 +735,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildRemovingSlashAtTheEnd() {
+    void shouldBuildRemovingSlashAtTheEnd() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -749,7 +749,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldBuildNormalisingPath() {
+    void shouldBuildNormalisingPath() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -763,7 +763,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldFailToBuildWithNoScheme() {
+    void shouldFailToBuildWithNoScheme() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -776,7 +776,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldFailToBuildWithNoAuthority() {
+    void shouldFailToBuildWithNoAuthority() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given
@@ -790,7 +790,7 @@ public class UriBuilderUnitTest {
     }
 
     @Test
-    public void shouldFailToBuildWithMalformedUri() {
+    void shouldFailToBuildWithMalformedUri() {
         PARSE_METHODS.forEach(
                 method -> {
                     // Given

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/network/RequestorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/network/RequestorUnitTest.java
@@ -39,10 +39,10 @@ import org.zaproxy.zap.extension.openapi.AbstractServerTest;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link Requestor}. */
-public class RequestorUnitTest extends AbstractServerTest {
+class RequestorUnitTest extends AbstractServerTest {
 
     @Test
-    public void shouldNotifyAllRedirectsFollowed() {
+    void shouldNotifyAllRedirectsFollowed() {
         // Given
         String baseUrl = "http://localhost:" + nano.getListeningPort() + "/";
         this.nano.addHandler(

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v1/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v1/OpenApiUnitTest.java
@@ -39,11 +39,10 @@ import org.zaproxy.zap.extension.openapi.network.RequesterListener;
 import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-public class OpenApiUnitTest extends AbstractServerTest {
+class OpenApiUnitTest extends AbstractServerTest {
 
     @Test
-    public void shouldExplorePetStore1_2()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldExplorePetStore1_2() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStore_1_2_defn/";
 
         this.nano.addHandler(

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiPrimitivesInBodyUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiPrimitivesInBodyUnitTest.java
@@ -37,10 +37,10 @@ import org.zaproxy.zap.extension.openapi.network.RequesterListener;
 import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-public class OpenApiPrimitivesInBodyUnitTest extends AbstractServerTest {
+class OpenApiPrimitivesInBodyUnitTest extends AbstractServerTest {
 
     @Test
-    public void shouldExploreBodiesWithPrimitiveValues()
+    void shouldExploreBodiesWithPrimitiveValues()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/OpenApi_defn_body_with_primitives/";
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v2/OpenApiUnitTest.java
@@ -46,11 +46,10 @@ import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-public class OpenApiUnitTest extends AbstractServerTest {
+class OpenApiUnitTest extends AbstractServerTest {
 
     @Test
-    public void shouldExplorePetStoreJson()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldExplorePetStoreJson() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
 
@@ -83,8 +82,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreYaml()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldExplorePetStoreYaml() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreYaml/";
         String defnName = "defn.yaml";
 
@@ -117,7 +115,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreOverridingHost()
+    void shouldExplorePetStoreOverridingHost()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
@@ -153,7 +151,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreWithDefaultHost()
+    void shouldExplorePetStoreWithDefaultHost()
             throws NullPointerException, IOException, SwaggerException {
         // Given
         String test = "/PetStoreJson/";
@@ -191,7 +189,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldFailToExplorePetStoreWithoutHost() throws Exception {
+    void shouldFailToExplorePetStoreWithoutHost() throws Exception {
         // Given
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
@@ -226,7 +224,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreWithDefaultScheme() throws Exception {
+    void shouldExplorePetStoreWithDefaultScheme() throws Exception {
         // Given
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
@@ -264,7 +262,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldFailToExplorePetStoreWithoutScheme() throws Exception {
+    void shouldFailToExplorePetStoreWithoutScheme() throws Exception {
         // Given
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
@@ -286,7 +284,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreYamlLoop()
+    void shouldExplorePetStoreYamlLoop()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreYamlLoop/";
         String defnName = "defn.yaml";
@@ -323,8 +321,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldUseValueGenerator()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldUseValueGenerator() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
         this.nano.addHandler(new DefnServerHandler(test, defnName, "PetStore_defn.json"));
@@ -391,7 +388,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreYamlWithExamples()
+    void shouldExplorePetStoreYamlWithExamples()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreYamlExamples/";
         String defnName = "defn.yaml";

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -35,16 +35,16 @@ import org.zaproxy.zap.extension.openapi.converter.swagger.OperationModel;
 import org.zaproxy.zap.extension.openapi.converter.swagger.RequestModelConverter;
 import org.zaproxy.zap.extension.openapi.generators.Generators;
 
-public class BodyGeneratorUnitTest {
+class BodyGeneratorUnitTest {
     Generators generators;
 
     @BeforeEach
-    public void init() {
+    void init() {
         generators = new Generators(null);
     }
 
     @Test
-    public void shouldGenerateArrayOfStrings() throws IOException {
+    void shouldGenerateArrayOfStrings() throws IOException {
         OpenAPI openAPI = parseResource("PetStore_defn.yaml");
         String jsonArray =
                 generators
@@ -60,7 +60,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateArrayOfEnums() throws IOException {
+    void shouldGenerateArrayOfEnums() throws IOException {
         OpenAPI openAPI = parseResource("PetStore_defn.yaml");
         String jsonArray =
                 generators
@@ -76,7 +76,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateJsonObject() throws IOException {
+    void shouldGenerateJsonObject() throws IOException {
         OpenAPI openAPI = parseResource("PetStore_defn.yaml");
 
         String jsonString =
@@ -90,7 +90,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void objectSchemaWithoutProperties() throws IOException {
+    void objectSchemaWithoutProperties() throws IOException {
         OpenAPI openAPI = parseResource("Object_schema_without_properties.json");
 
         String jsonString =
@@ -102,7 +102,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldHandleRequestBodyRef() throws IOException {
+    void shouldHandleRequestBodyRef() throws IOException {
         OpenAPI openAPI = parseResource("PetStore_defn.yaml");
         String requestBody =
                 new RequestModelConverter()
@@ -117,7 +117,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateFormData() throws IOException {
+    void shouldGenerateFormData() throws IOException {
         OpenAPI openAPI = parseResource("PetStore_defn.yaml");
         String requestBody =
                 new RequestModelConverter()
@@ -132,7 +132,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void complexObjectInFormData() throws IOException {
+    void complexObjectInFormData() throws IOException {
         OpenAPI openAPI = parseResource("Complex_object_in_form_data.yaml");
         String requestBody =
                 new RequestModelConverter()
@@ -147,7 +147,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void arrayInFormData() throws IOException {
+    void arrayInFormData() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_with_array_in_form.yaml");
         String requestBody =
                 new RequestModelConverter()
@@ -160,7 +160,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void testAllOf() throws IOException {
+    void testAllOf() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_allof_schema.yaml");
         String requestBody =
                 new RequestModelConverter()
@@ -175,7 +175,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void testOneOf() throws IOException {
+    void testOneOf() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_oneof_schema.yaml");
         String requestBody =
                 new RequestModelConverter()
@@ -188,7 +188,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void testAnyOf() throws IOException {
+    void testAnyOf() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_anyof_schema.yaml");
         String request =
                 new RequestModelConverter()
@@ -201,7 +201,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void testNot() throws IOException {
+    void testNot() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_not_schema.yaml");
         String requestType =
                 new RequestModelConverter()
@@ -224,7 +224,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldReadAdditionalPropertiesIfNoProperties() throws IOException {
+    void shouldReadAdditionalPropertiesIfNoProperties() throws IOException {
         OpenAPI openAPI = parseResource("Schema_with_additional_properties.yaml");
         String request =
                 new RequestModelConverter()
@@ -241,7 +241,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldReadAdditionalMapString() throws IOException {
+    void shouldReadAdditionalMapString() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_map.yaml");
         String request =
                 new RequestModelConverter()
@@ -256,7 +256,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldReadAdditionalMapNumber() throws IOException {
+    void shouldReadAdditionalMapNumber() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_map.yaml");
         String request =
                 new RequestModelConverter()
@@ -271,7 +271,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldReadAdditionalMapBoolean() throws IOException {
+    void shouldReadAdditionalMapBoolean() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_map.yaml");
         String request =
                 new RequestModelConverter()
@@ -286,7 +286,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldReadAdditionalMapObject() throws IOException {
+    void shouldReadAdditionalMapObject() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_map.yaml");
         String request =
                 new RequestModelConverter()
@@ -303,7 +303,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldUseExample() throws IOException {
+    void shouldUseExample() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
         String request =
                 new RequestModelConverter()
@@ -319,7 +319,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateArraysFromExamples() throws IOException {
+    void shouldGenerateArraysFromExamples() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
         String request =
                 new RequestModelConverter()
@@ -337,7 +337,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateArraysFromFullArrayExampleFormattedAsString() throws IOException {
+    void shouldGenerateArraysFromFullArrayExampleFormattedAsString() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
         String request =
                 new RequestModelConverter()
@@ -356,7 +356,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateArraysFromFullArrayExampleFormattedAsYAML() throws IOException {
+    void shouldGenerateArraysFromFullArrayExampleFormattedAsYAML() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
         String request =
                 new RequestModelConverter()
@@ -375,7 +375,7 @@ public class BodyGeneratorUnitTest {
     }
 
     @Test
-    public void shouldGenerateBodyWithNoSchema() throws IOException {
+    void shouldGenerateBodyWithNoSchema() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_no_schema.yaml");
         String request =
                 new RequestModelConverter()

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiPrimitivesInBodyUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiPrimitivesInBodyUnitTest.java
@@ -37,10 +37,10 @@ import org.zaproxy.zap.extension.openapi.network.RequesterListener;
 import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-public class OpenApiPrimitivesInBodyUnitTest extends AbstractServerTest {
+class OpenApiPrimitivesInBodyUnitTest extends AbstractServerTest {
 
     @Test
-    public void shouldExploreBodiesWithPrimitiveValues()
+    void shouldExploreBodiesWithPrimitiveValues()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/OpenApi_defn_body_with_primitives/";
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -47,11 +47,10 @@ import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-public class OpenApiUnitTest extends AbstractServerTest {
+class OpenApiUnitTest extends AbstractServerTest {
 
     @Test
-    public void shouldExplorePetStoreJson()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldExplorePetStoreJson() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
 
@@ -84,8 +83,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreYaml()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldExplorePetStoreYaml() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreYaml/";
         String defnName = "defn.yaml";
 
@@ -118,7 +116,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreJsonOverrideHost()
+    void shouldExplorePetStoreJsonOverrideHost()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
@@ -154,7 +152,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreYamlWithExamples()
+    void shouldExplorePetStoreYamlWithExamples()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreYamlExamples/";
         String defnName = "defn.yaml";
@@ -201,7 +199,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreWithDefaultUrl()
+    void shouldExplorePetStoreWithDefaultUrl()
             throws NullPointerException, IOException, SwaggerException {
         // Given
         String test = "/PetStoreJson/";
@@ -241,7 +239,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldFailToExplorePetStoreWithoutHost() throws Exception {
+    void shouldFailToExplorePetStoreWithoutHost() throws Exception {
         // Given
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
@@ -262,7 +260,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldFailToExplorePetStoreWithoutFullURL() throws Exception {
+    void shouldFailToExplorePetStoreWithoutFullURL() throws Exception {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
 
@@ -282,7 +280,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldExplorePetStoreYamlLoop()
+    void shouldExplorePetStoreYamlLoop()
             throws NullPointerException, IOException, SwaggerException {
         // loops are not causing any serious issues
         // the result will be a string parameter instead of a ref that is part of a the loop
@@ -321,8 +319,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldUseValueGenerator()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldUseValueGenerator() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
         this.nano.addHandler(new DefnServerHandler(test, defnName, "PetStore_defn.json"));
@@ -389,7 +386,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldInterpretServerVariables()
+    void shouldInterpretServerVariables()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreYaml/";
         String defnName = "defn.yaml";
@@ -420,8 +417,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldGenerateAcceptHeaders()
-            throws NullPointerException, IOException, SwaggerException {
+    void shouldGenerateAcceptHeaders() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";
 
@@ -449,7 +445,7 @@ public class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
-    public void shouldGenerateContentTypeHeaders()
+    void shouldGenerateContentTypeHeaders()
             throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleBundledStringsUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleBundledStringsUnitTest.java
@@ -31,7 +31,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class ApplicationErrorScanRuleBundledStringsUnitTest
+class ApplicationErrorScanRuleBundledStringsUnitTest
         extends PassiveScannerTest<ApplicationErrorScanRule> {
 
     private static final String URI = "https://www.example.com/test/";
@@ -43,7 +43,7 @@ public class ApplicationErrorScanRuleBundledStringsUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertForResponseCodeOkAndExpressPayloadDetected()
+    void shouldRaiseAlertForResponseCodeOkAndExpressPayloadDetected()
             throws HttpMalformedHeaderException {
         // Given
         String expectedEvidence = "SyntaxError: Unexpected token";

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleRegexMatcherUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleRegexMatcherUnitTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.zaproxy.zap.utils.ContentMatcher;
 
-public class ApplicationErrorScanRuleRegexMatcherUnitTest {
+class ApplicationErrorScanRuleRegexMatcherUnitTest {
     private static final String INPUT_PREFIX = "<b>Some text before</b>";
     private static final String INPUT_SUFFIX = "<b>Some text after</b>";
 
@@ -71,7 +71,7 @@ public class ApplicationErrorScanRuleRegexMatcherUnitTest {
                 "<h1>Servlet Error: test</h1>",
                 "Servlet Error</title>"
             })
-    public void shouldRegexMatchErrorMessage(String input) {
+    void shouldRegexMatchErrorMessage(String input) {
         assertNotNull(MATCHER.findInContent(INPUT_PREFIX + input + INPUT_SUFFIX));
     }
 }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
@@ -41,7 +41,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErrorScanRule> {
+class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErrorScanRule> {
     private static final String URI = "https://www.example.com/test/";
     private static final String REQUEST_HEADER = format("GET %s HTTP/1.1", URI);
 
@@ -69,7 +69,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseCodeIsInternalServerErrorLow()
+    void shouldRaiseAlertIfResponseCodeIsInternalServerErrorLow()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -90,7 +90,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseCodeIsInternalServerErrorMed()
+    void shouldRaiseAlertIfResponseCodeIsInternalServerErrorMed()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -111,7 +111,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseCodeIsInternalServerErrorHigh()
+    void shouldNotRaiseAlertIfResponseCodeIsInternalServerErrorHigh()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -126,7 +126,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseCodeIsNotFound() throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertIfResponseCodeIsNotFound() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader(REQUEST_HEADER);
@@ -140,8 +140,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseCodeOkAndEmptyBody()
-            throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertIfResponseCodeOkAndEmptyBody() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader(REQUEST_HEADER);
@@ -155,7 +154,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseCodeOkAndNoEvidenceDetected()
+    void shouldNotRaiseAlertIfResponseCodeOkAndNoEvidenceDetected()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -172,7 +171,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldRaiseAlertForResponseCodeOkAndStringEvidenceDetected()
+    void shouldRaiseAlertForResponseCodeOkAndStringEvidenceDetected()
             throws HttpMalformedHeaderException {
         // Given
         String expectedEvidence = "Microsoft OLE DB Provider for ODBC Drivers";
@@ -192,7 +191,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldRaiseAlertForResponseCodeOkAndEvidenceDetectedWithMatcher()
+    void shouldRaiseAlertForResponseCodeOkAndEvidenceDetectedWithMatcher()
             throws HttpMalformedHeaderException {
         // Given
         String expectedEvidence = "Line 1024: Incorrect syntax near 'login'";
@@ -212,7 +211,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldRaiseAlertForResponseCodeOkAndCustomPayloadDetected()
+    void shouldRaiseAlertForResponseCodeOkAndCustomPayloadDetected()
             throws HttpMalformedHeaderException {
         // Given
         String expectedEvidence = "customPayloadString";
@@ -233,7 +232,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldNotRaiseAlertForResponseCodeOkAndCustomPayloadNotDetected()
+    void shouldNotRaiseAlertForResponseCodeOkAndCustomPayloadNotDetected()
             throws HttpMalformedHeaderException {
         // Given
         String expectedEvidence = "customPayloadString";
@@ -251,7 +250,7 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void shouldRaiseAlertForResponseCodeOkAndFilePayloadDetected()
+    void shouldRaiseAlertForResponseCodeOkAndFilePayloadDetected()
             throws HttpMalformedHeaderException {
         // Given
         // String from standard XML file
@@ -273,9 +272,8 @@ public class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<Applica
     }
 
     @Test
-    public void
-            shouldNotRaiseAlertForResponseCodeOkAndContentTypeWebAssemblyWhenFilePayloadPresent()
-                    throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertForResponseCodeOkAndContentTypeWebAssemblyWhenFilePayloadPresent()
+            throws HttpMalformedHeaderException {
         // Given
         // String from standard XML file
         String expectedEvidence = "Microsoft OLE DB Provider for ODBC Drivers";

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRuleUnitTest.java
@@ -31,7 +31,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheControlScanRule> {
+class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheControlScanRule> {
 
     @Override
     protected CacheControlScanRule createScanner() {
@@ -39,7 +39,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpRequest() throws HttpMalformedHeaderException {
+    void httpRequest() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -60,7 +60,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsAllPresentCacheRequest() throws HttpMalformedHeaderException {
+    void httpsAllPresentCacheRequest() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -82,7 +82,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void shouldIgnoreEmptyHttpsResponses() throws HttpMalformedHeaderException {
+    void shouldIgnoreEmptyHttpsResponses() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -102,7 +102,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsMissingNoCacheRequest() throws HttpMalformedHeaderException {
+    void httpsMissingNoCacheRequest() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -126,7 +126,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsMissingNoStoreCacheRequest() throws HttpMalformedHeaderException {
+    void httpsMissingNoStoreCacheRequest() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -150,7 +150,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsMissingMustRevalidateCacheRequest() throws HttpMalformedHeaderException {
+    void httpsMissingMustRevalidateCacheRequest() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -174,7 +174,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsRedirectLowCacheRequest() throws HttpMalformedHeaderException {
+    void httpsRedirectLowCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
         HttpMessage msg = new HttpMessage();
@@ -199,7 +199,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsRedirectMedCacheRequest() throws HttpMalformedHeaderException {
+    void httpsRedirectMedCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
         HttpMessage msg = new HttpMessage();
@@ -222,7 +222,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsRedirectHighCacheRequest() throws HttpMalformedHeaderException {
+    void httpsRedirectHighCacheRequest() throws HttpMalformedHeaderException {
 
         rule.setAlertThreshold(AlertThreshold.HIGH);
 
@@ -244,7 +244,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsErrorLowCacheRequest() throws HttpMalformedHeaderException {
+    void httpsErrorLowCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
         HttpMessage msg = new HttpMessage();
@@ -268,7 +268,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsErrorMedCacheRequest() throws HttpMalformedHeaderException {
+    void httpsErrorMedCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
         HttpMessage msg = new HttpMessage();
@@ -290,7 +290,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsErrorHighCacheRequest() throws HttpMalformedHeaderException {
+    void httpsErrorHighCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.HIGH);
         HttpMessage msg = new HttpMessage();
@@ -312,7 +312,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsJavaScriptLowCacheRequest() throws HttpMalformedHeaderException {
+    void httpsJavaScriptLowCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
         HttpMessage msg = new HttpMessage();
@@ -336,7 +336,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsJavaScriptMedCacheRequest() throws HttpMalformedHeaderException {
+    void httpsJavaScriptMedCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
         HttpMessage msg = new HttpMessage();
@@ -358,7 +358,7 @@ public class CacheControlScanRuleUnitTest extends PassiveScannerTest<CacheContro
     }
 
     @Test
-    public void httpsJavaScriptHighCacheRequest() throws HttpMalformedHeaderException {
+    void httpsJavaScriptHighCacheRequest() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.HIGH);
         HttpMessage msg = new HttpMessage();

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRuleUnitTest.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetMismatchScanRule> {
+class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetMismatchScanRule> {
 
     private static final String BASE_RESOURCE_KEY = "pscanrules.charsetmismatch.";
     private static final String NO_MISMATCH_METACONTENTTYPE_MISSING =
@@ -45,7 +45,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     private HttpMessage msg;
 
     @BeforeEach
-    public void before() throws HttpMalformedHeaderException {
+    void before() throws HttpMalformedHeaderException {
         rule.setAlertThreshold(AlertThreshold.LOW);
 
         msg = new HttpMessage();
@@ -58,7 +58,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldPassWhenZeroContentLength() throws HttpMalformedHeaderException {
+    void shouldPassWhenZeroContentLength() throws HttpMalformedHeaderException {
         // Given
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"
@@ -72,7 +72,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldPassWhenNoHeaderCharset() throws HttpMalformedHeaderException {
+    void shouldPassWhenNoHeaderCharset() throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody("<html></html>");
         msg.setResponseHeader(
@@ -89,7 +89,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldPassWhenNoContentType() throws HttpMalformedHeaderException {
+    void shouldPassWhenNoContentType() throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody("<html></html>");
         msg.setResponseHeader(
@@ -105,8 +105,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldPassWhenTheSameMetaCharsetAndHeaderHtml()
-            throws HttpMalformedHeaderException {
+    void shouldPassWhenTheSameMetaCharsetAndHeaderHtml() throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody(
                 "<html>"
@@ -129,7 +128,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldRaiseAlertWhenDifferentMetaCharsetAndHeaderHtml()
+    void shouldRaiseAlertWhenDifferentMetaCharsetAndHeaderHtml()
             throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody(
@@ -161,7 +160,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldRaiseAlertWhenNoBodyCharsetTheSameMetaAndHeaderHtml()
+    void shouldRaiseAlertWhenNoBodyCharsetTheSameMetaAndHeaderHtml()
             throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody(
@@ -187,7 +186,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldRaiseAlertWhenDifferentBodyCharsetAndHeaderHtml()
+    void shouldRaiseAlertWhenDifferentBodyCharsetAndHeaderHtml()
             throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody(
@@ -215,7 +214,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldRaiseAlertWhenDifferentMetaAndHeaderPlusAdditionalMetaParametersHtml()
+    void shouldRaiseAlertWhenDifferentMetaAndHeaderPlusAdditionalMetaParametersHtml()
             throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody(
@@ -252,7 +251,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldRaiseAlertWhenDifferentMetaCharsetAndContentType()
+    void shouldRaiseAlertWhenDifferentMetaCharsetAndContentType()
             throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody(
@@ -289,7 +288,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldPassWhenTheSameEncodingAndHeaderXml() throws HttpMalformedHeaderException {
+    void shouldPassWhenTheSameEncodingAndHeaderXml() throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody("<?xml version='1.0' encoding='UTF-8'?>" + "<zap></zap>");
         msg.setResponseHeader(
@@ -306,8 +305,7 @@ public class CharsetMismatchScanRuleUnitTest extends PassiveScannerTest<CharsetM
     }
 
     @Test
-    public void shouldRaiseAlertWhenDifferentEncodingAndHeaderXml()
-            throws HttpMalformedHeaderException {
+    void shouldRaiseAlertWhenDifferentEncodingAndHeaderXml() throws HttpMalformedHeaderException {
         // Given
         msg.setResponseBody("<?xml version='1.0' encoding='ISO-123'?>" + "<zap></zap>");
         msg.setResponseHeader(

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -31,7 +31,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class ContentSecurityPolicyScanRuleUnitTest
+class ContentSecurityPolicyScanRuleUnitTest
         extends PassiveScannerTest<ContentSecurityPolicyScanRule> {
 
     private static final String REASONABLE_POLICY =
@@ -47,7 +47,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertOnNonHtmlAtMediumThreshold() {
+    void shouldNotRaiseAlertOnNonHtmlAtMediumThreshold() {
         // Given
         HttpMessage msg = createHttpMessage("report-uri /__cspreport__");
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "image/png");
@@ -59,7 +59,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertOnNonHtmlAtLowThreshold() {
+    void shouldRaiseAlertOnNonHtmlAtLowThreshold() {
         // Given
         HttpMessage msg = createHttpMessage("report-uri /__cspreport__");
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "image/png");
@@ -71,7 +71,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertWhenCspContainsSyntaxIssues() {
+    void shouldAlertWhenCspContainsSyntaxIssues() {
         // Given
         HttpMessage msg = createHttpMessage("default-src: 'none'; report_uri /__cspreport__");
         // When
@@ -111,7 +111,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertWithCspWarningNoticesWhenApplicable() {
+    void shouldAlertWithCspWarningNoticesWhenApplicable() {
         // Given
         HttpMessage msg = createHttpMessage("default-src none; report-to csp-endpoint ");
         // When
@@ -133,7 +133,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertAtInfoRiskWhenOnlyInformationalNotices() {
+    void shouldRaiseAlertAtInfoRiskWhenOnlyInformationalNotices() {
         // Given
         HttpMessage msg = createHttpMessage("report-uri /__cspreport__");
         // When
@@ -146,7 +146,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldIntersectMultipleCspHeaders() throws HttpMalformedHeaderException {
+    void shouldIntersectMultipleCspHeaders() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -190,7 +190,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotIntersectMultipleCspHeadersIfOneHasReportUri()
+    void shouldNotIntersectMultipleCspHeadersIfOneHasReportUri()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -234,7 +234,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertOnWildcardFrameAncestorsDirective() {
+    void shouldAlertOnWildcardFrameAncestorsDirective() {
         // Given
         HttpMessage msg =
                 createHttpMessage("frame-ancestors *; default-src 'self'; form-action 'none'");
@@ -259,7 +259,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertOnReasonableCsp() {
+    void shouldNotAlertOnReasonableCsp() {
         // Given
         HttpMessage msg = createHttpMessageWithReasonableCsp(HTTP_HEADER_CSP);
         // When
@@ -270,7 +270,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
 
     @ParameterizedTest
     @ValueSource(strings = {"X-Content-Security-Policy", "X-WebKit-CSP"})
-    public void shouldRaiseAlertOnLegacyCspHeader(String input) {
+    void shouldRaiseAlertOnLegacyCspHeader(String input) {
         // Given
         HttpMessage msg = createHttpMessageWithReasonableCsp(input);
         // When
@@ -283,7 +283,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenCspIncludesScriptUnsafeInline() {
+    void shouldRaiseAlertWhenCspIncludesScriptUnsafeInline() {
         // Given
         HttpMessage msg = createHttpMessage("script-src 'unsafe-inline'");
         // When
@@ -297,7 +297,7 @@ public class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenCspIncludesStyleUnsafeInline() {
+    void shouldRaiseAlertWhenCspIncludesStyleUnsafeInline() {
         // Given
         HttpMessage msg = createHttpMessage("style-src 'unsafe-inline'");
         // When

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRuleUnitTest.java
@@ -28,8 +28,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 
-public class ContentTypeMissingScanRuleUnitTest
-        extends PassiveScannerTest<ContentTypeMissingScanRule> {
+class ContentTypeMissingScanRuleUnitTest extends PassiveScannerTest<ContentTypeMissingScanRule> {
 
     @Override
     protected ContentTypeMissingScanRule createScanner() {
@@ -54,7 +53,7 @@ public class ContentTypeMissingScanRuleUnitTest
     }
 
     @Test
-    public void shoudNotAlertIfResponseBodyIsEmpty() throws HttpMalformedHeaderException {
+    void shoudNotAlertIfResponseBodyIsEmpty() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "");
@@ -66,7 +65,7 @@ public class ContentTypeMissingScanRuleUnitTest
     }
 
     @Test
-    public void shoudNotAlertIfContentTypePresentInResponse() throws HttpMalformedHeaderException {
+    void shoudNotAlertIfContentTypePresentInResponse() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader()
@@ -78,8 +77,7 @@ public class ContentTypeMissingScanRuleUnitTest
     }
 
     @Test
-    public void shoudAlertIfContentTypePresentButEmptyInResponse()
-            throws HttpMalformedHeaderException {
+    void shoudAlertIfContentTypePresentButEmptyInResponse() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "");
@@ -93,7 +91,7 @@ public class ContentTypeMissingScanRuleUnitTest
     }
 
     @Test
-    public void shoudAlertIfContentTypeNotPresentInResponse() throws HttpMalformedHeaderException {
+    void shoudAlertIfContentTypeNotPresentInResponse() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
         // When

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
@@ -36,7 +36,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHttpOnlyScanRule> {
+class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHttpOnlyScanRule> {
 
     private Model model;
 
@@ -54,7 +54,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void noHttpOnlyAttribute() throws HttpMalformedHeaderException {
+    void noHttpOnlyAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -76,7 +76,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void noCookie() throws HttpMalformedHeaderException {
+    void noCookie() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -95,7 +95,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void httpOnlyAttribute() throws HttpMalformedHeaderException {
+    void httpOnlyAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -115,7 +115,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void secondCookieNoHttpOnlyAttribute() throws HttpMalformedHeaderException {
+    void secondCookieNoHttpOnlyAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -138,7 +138,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void cookieOnIgnoreList() throws HttpMalformedHeaderException {
+    void cookieOnIgnoreList() throws HttpMalformedHeaderException {
 
         model.getOptionsParam()
                 .getConfig()
@@ -162,7 +162,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void cookieNotOnIgnoreList() throws HttpMalformedHeaderException {
+    void cookieNotOnIgnoreList() throws HttpMalformedHeaderException {
 
         model.getOptionsParam()
                 .getConfig()
@@ -188,7 +188,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
+    void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -208,7 +208,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
+    void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -228,7 +228,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
+    void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -259,7 +259,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
+    void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -290,7 +290,7 @@ public class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHtt
     }
 
     @Test
-    public void secondCookieNoHttpOnlyAttributeFirstExpired() throws HttpMalformedHeaderException {
+    void secondCookieNoHttpOnlyAttributeFirstExpired() throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRuleUnitTest.java
@@ -37,8 +37,7 @@ import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** @author Vahid Rafiei (@vahid_r) */
-public class CookieLooselyScopedScanRuleUnitTest
-        extends PassiveScannerTest<CookieLooselyScopedScanRule> {
+class CookieLooselyScopedScanRuleUnitTest extends PassiveScannerTest<CookieLooselyScopedScanRule> {
 
     private Model model;
 
@@ -63,7 +62,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThereIsNoCookieInResponseHeader() throws Exception {
+    void shouldNotRaiseAlertIfThereIsNoCookieInResponseHeader() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET /admin/roles/ HTTP/1.1");
@@ -76,7 +75,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfCookieDomainIsNotSet() throws Exception {
+    void shouldNotRaiseAlertIfCookieDomainIsNotSet() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET /admin/roles/ HTTP/1.1");
@@ -90,8 +89,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfHostDomainStartsWithDotAndCookieDomainIsNotSet()
-            throws Exception {
+    void shouldNotRaiseAlertIfHostDomainStartsWithDotAndCookieDomainIsNotSet() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET .local.test.com HTTP/1.1");
@@ -105,7 +103,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfHostDomainIsDifferentFromCookieDomain() throws Exception {
+    void shouldRaiseAlertIfHostDomainIsDifferentFromCookieDomain() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://dev.test.org HTTP/1.1");
@@ -120,7 +118,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldDomainComparisonBeCaseInsensitive() throws Exception {
+    void shouldDomainComparisonBeCaseInsensitive() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://TesT.org HTTP/1.1");
@@ -134,9 +132,8 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void
-            shouldNotRaiseAlertIfHostDomainAndCookieDomainAreTheSameAndDomainsAreNotSecondLevel()
-                    throws Exception {
+    void shouldNotRaiseAlertIfHostDomainAndCookieDomainAreTheSameAndDomainsAreNotSecondLevel()
+            throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://test.example.com HTTP/1.1");
@@ -151,7 +148,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfHostDomainHasMoreSubDomainsThanCookieDomain() throws Exception {
+    void shouldRaiseAlertIfHostDomainHasMoreSubDomainsThanCookieDomain() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://test.example.com HTTP/1.1");
@@ -165,8 +162,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfHostDomainHasLessSubDomainsThanCookieDomain()
-            throws Exception {
+    void shouldNotRaiseAlertIfHostDomainHasLessSubDomainsThanCookieDomain() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://example.com HTTP/1.1");
@@ -181,7 +177,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRightMostDomainsMatch() throws Exception {
+    void shouldRaiseAlertIfRightMostDomainsMatch() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://test.example.com/admin/roles HTTP/1.1");
@@ -195,7 +191,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldScanCookieDomainWithJustTld() throws Exception {
+    void shouldScanCookieDomainWithJustTld() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://example.com/ HTTP/1.1");
@@ -206,7 +202,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldScanHostWithoutTld() throws Exception {
+    void shouldScanHostWithoutTld() throws Exception {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://intranet/ HTTP/1.1");
@@ -218,7 +214,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWhenCookieOnIgnoreList() throws HttpMalformedHeaderException {
+    void shouldNotAlertWhenCookieOnIgnoreList() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://test.example.com/admin/roles HTTP/1.1");
@@ -236,7 +232,7 @@ public class CookieLooselyScopedScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertWhenCookieNotOnIgnoreList() throws HttpMalformedHeaderException {
+    void shouldAlertWhenCookieNotOnIgnoreList() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createBasicMessage();
         msg.setRequestHeader("GET http://test.example.com/admin/roles HTTP/1.1");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
@@ -36,7 +36,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteScanRule> {
+class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteScanRule> {
 
     private Model model;
 
@@ -54,7 +54,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void noSameSiteAttribute() throws HttpMalformedHeaderException {
+    void noSameSiteAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -76,7 +76,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void noCookie() throws HttpMalformedHeaderException {
+    void noCookie() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -95,7 +95,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void laxSameSiteAttribute() throws HttpMalformedHeaderException {
+    void laxSameSiteAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -115,7 +115,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void strictSameSiteAttribute() throws HttpMalformedHeaderException {
+    void strictSameSiteAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -135,7 +135,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void secondCookieNoSameSiteAttribute() throws HttpMalformedHeaderException {
+    void secondCookieNoSameSiteAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -158,7 +158,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void badValSameSiteAttribute() throws HttpMalformedHeaderException {
+    void badValSameSiteAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -180,7 +180,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void noValSameSiteAttribute() throws HttpMalformedHeaderException {
+    void noValSameSiteAttribute() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -202,7 +202,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
+    void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -222,7 +222,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
+    void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -242,7 +242,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
+    void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -273,7 +273,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
+    void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -304,7 +304,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void secondCookieNoSameSiteAttributeFirstExpired() throws HttpMalformedHeaderException {
+    void secondCookieNoSameSiteAttributeFirstExpired() throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
 
@@ -326,7 +326,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void shouldNotAlertWhenCookieOnIgnoreList() throws HttpMalformedHeaderException {
+    void shouldNotAlertWhenCookieOnIgnoreList() throws HttpMalformedHeaderException {
         // Given
         model.getOptionsParam()
                 .getConfig()
@@ -353,7 +353,7 @@ public class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSam
     }
 
     @Test
-    public void shouldAlertWhenCookieNotOnIgnoreList() throws HttpMalformedHeaderException {
+    void shouldAlertWhenCookieNotOnIgnoreList() throws HttpMalformedHeaderException {
         // Given
         model.getOptionsParam()
                 .getConfig()

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
@@ -36,7 +36,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieSecureFlagScanRule> {
+class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieSecureFlagScanRule> {
 
     private Model model;
 
@@ -54,7 +54,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void httpNoSecureFlag() throws HttpMalformedHeaderException {
+    void httpNoSecureFlag() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -74,7 +74,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void httpsNoSecureFlag() throws HttpMalformedHeaderException {
+    void httpsNoSecureFlag() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -96,7 +96,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void httpsSecureFlag() throws HttpMalformedHeaderException {
+    void httpsSecureFlag() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -116,7 +116,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void secondCookieNoSecureFlag() throws HttpMalformedHeaderException {
+    void secondCookieNoSecureFlag() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -139,7 +139,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void cookieOnIgnoreList() throws HttpMalformedHeaderException {
+    void cookieOnIgnoreList() throws HttpMalformedHeaderException {
         model.getOptionsParam()
                 .getConfig()
                 .setProperty(RuleConfigParam.RULE_COOKIE_IGNORE_LIST, "aaaa,test,bbb");
@@ -162,7 +162,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void cookieNotOnIgnoreList() throws HttpMalformedHeaderException {
+    void cookieNotOnIgnoreList() throws HttpMalformedHeaderException {
         model.getOptionsParam()
                 .getConfig()
                 .setProperty(RuleConfigParam.RULE_COOKIE_IGNORE_LIST, "aaaa,bbb,ccc");
@@ -187,7 +187,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
+    void shouldNotAlertOnDelete() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -207,7 +207,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
+    void shouldNotAlertOnDeleteHyphenatedDate() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -227,7 +227,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
+    void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -258,7 +258,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
+    void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
         // Given - value empty and epoch start date
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -289,7 +289,7 @@ public class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieS
     }
 
     @Test
-    public void secondCookieNoSecureAttributeFirstExpired() throws HttpMalformedHeaderException {
+    void secondCookieNoSecureAttributeFirstExpired() throws HttpMalformedHeaderException {
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRuleUnitTest.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class CrossDomainMisconfigurationScanRuleUnitTest
+class CrossDomainMisconfigurationScanRuleUnitTest
         extends PassiveScannerTest<CrossDomainMisconfigurationScanRule> {
 
     private static final String URI = "http://example.com/";
@@ -41,7 +41,7 @@ public class CrossDomainMisconfigurationScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfCorsAllowOriginHeaderIsMissing() {
+    void shouldNotRaiseAlertIfCorsAllowOriginHeaderIsMissing() {
         // Given
         HttpMessage msg = createResponse(URI, null);
         // When
@@ -51,7 +51,7 @@ public class CrossDomainMisconfigurationScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfCorsAllowOriginHeaderIsEmpty() {
+    void shouldNotRaiseAlertIfCorsAllowOriginHeaderIsEmpty() {
         // Given
         HttpMessage msg = createResponse(URI, "");
         // When
@@ -61,7 +61,7 @@ public class CrossDomainMisconfigurationScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfCorsAllowOriginHeaderContainsUnrecognisedValue() {
+    void shouldNotRaiseAlertIfCorsAllowOriginHeaderContainsUnrecognisedValue() {
         // Given
         HttpMessage msg = createResponse(URI, "UnrecognisedValue");
         // When
@@ -71,7 +71,7 @@ public class CrossDomainMisconfigurationScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfCorsAllowOriginHeaderIsTooPermissive() {
+    void shouldRaiseAlertIfCorsAllowOriginHeaderIsTooPermissive() {
         // Given
         HttpMessage msg = createResponse(URI, "*");
         // When
@@ -87,7 +87,7 @@ public class CrossDomainMisconfigurationScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfCorsAllowOriginHeaderWithDifferentCaseIsTooPermissive() {
+    void shouldRaiseAlertIfCorsAllowOriginHeaderWithDifferentCaseIsTooPermissive() {
         // Given
         HttpMessage msg = createResponse(URI, null);
         msg.getResponseHeader()

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRuleUnitTest.java
@@ -37,7 +37,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.Context;
 
 /** Unit test for {@link CrossDomainScriptInclusionScanRule}. */
-public class CrossDomainScriptInclusionScanRuleUnitTest
+class CrossDomainScriptInclusionScanRuleUnitTest
         extends PassiveScannerTest<CrossDomainScriptInclusionScanRule> {
 
     @Mock(lenient = true)
@@ -47,7 +47,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     Session session;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(session.getContextsForUrl(anyString())).thenReturn(Collections.emptyList());
         when(model.getSession()).thenReturn(session);
         rule.setModel(model);
@@ -59,7 +59,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void noScripts() throws HttpMalformedHeaderException {
+    void noScripts() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -78,7 +78,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void noCrossDomainScripts() throws HttpMalformedHeaderException {
+    void noCrossDomainScripts() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -103,7 +103,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void crossDomainScript() throws HttpMalformedHeaderException {
+    void crossDomainScript() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -132,7 +132,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void crossDomainScriptWithIntegrity() throws HttpMalformedHeaderException {
+    void crossDomainScriptWithIntegrity() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -157,7 +157,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void crossDomainScriptWithNullIntegrity() throws HttpMalformedHeaderException {
+    void crossDomainScriptWithNullIntegrity() throws HttpMalformedHeaderException {
 
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -186,7 +186,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void crossDomainScriptNotInContext() throws HttpMalformedHeaderException {
+    void crossDomainScriptNotInContext() throws HttpMalformedHeaderException {
         // Given
         Context context = new Context(session, -1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
@@ -219,7 +219,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void shouldIgnoreNonHtmlResponses() throws HttpMalformedHeaderException {
+    void shouldIgnoreNonHtmlResponses() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/thing.js HTTP/1.1");
@@ -248,7 +248,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void crossDomainScriptInContextHigh() throws HttpMalformedHeaderException {
+    void crossDomainScriptInContextHigh() throws HttpMalformedHeaderException {
         // Given
         Context context = new Context(session, -1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
@@ -280,7 +280,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void crossDomainScriptInContextMed() throws HttpMalformedHeaderException {
+    void crossDomainScriptInContextMed() throws HttpMalformedHeaderException {
         // Given
         Context context = new Context(session, -1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
@@ -312,7 +312,7 @@ public class CrossDomainScriptInclusionScanRuleUnitTest
     }
 
     @Test
-    public void crossDomainScriptInContextLow() throws HttpMalformedHeaderException {
+    void crossDomainScriptInContextLow() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -37,15 +37,14 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class CsrfCountermeasuresScanRuleUnitTest
-        extends PassiveScannerTest<CsrfCountermeasuresScanRule> {
+class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCountermeasuresScanRule> {
 
     private ExtensionAntiCSRF extensionAntiCSRFMock;
     private List<String> antiCsrfTokenNames;
     private HttpMessage msg;
 
     @BeforeEach
-    public void before() throws URIException {
+    void before() throws URIException {
         antiCsrfTokenNames = new ArrayList<>();
         antiCsrfTokenNames.add("token");
         antiCsrfTokenNames.add("csrfToken");
@@ -73,7 +72,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThereIsNoHTML() {
+    void shouldNotRaiseAlertIfThereIsNoHTML() {
         // Given
         msg.setResponseBody("no html");
         // When
@@ -83,7 +82,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThereIsNoForm() {
+    void shouldNotRaiseAlertIfThereIsNoForm() {
         // Given
         msg.setResponseBody("<html><head></head><body><p>no form</p></body></html>");
         // When
@@ -93,7 +92,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfFormHasNoParent() {
+    void shouldNotRaiseAlertIfFormHasNoParent() {
         // Given
         msg.setResponseBody(
                 "<form id=\"no_csrf_token\"><input type=\"text\"/><input type=\"submit\"/></form>");
@@ -104,7 +103,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfThereIsNoCSRFTokenFound() {
+    void shouldRaiseAlertIfThereIsNoCSRFTokenFound() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body><form id=\"no_csrf_token\"><input type=\"text\"/><input type=\"submit\"/></form></body></html>");
@@ -117,7 +116,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithSortedFormFieldsInOtherInfoIfThereIsNoCSRFTokenFound() {
+    void shouldRaiseAlertWithSortedFormFieldsInOtherInfoIfThereIsNoCSRFTokenFound() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body>"
@@ -141,7 +140,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithSortedUniqueFormFieldsInOtherInfoIfThereIsNoCSRFTokenFound() {
+    void shouldRaiseAlertWithSortedUniqueFormFieldsInOtherInfoIfThereIsNoCSRFTokenFound() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body>"
@@ -168,7 +167,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenThereIsOnlyOneFormWithFirstKnownCSRFTokenUsingName() {
+    void shouldNotRaiseAlertWhenThereIsOnlyOneFormWithFirstKnownCSRFTokenUsingName() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body><form id=\"form_name\"><input type=\"text\" name=\"token\"/><input type=\"submit\"/></form></body></html>");
@@ -179,7 +178,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenThereIsOnlyOneFormWithAKnownCSRFTokenUsingId() {
+    void shouldNotRaiseAlertWhenThereIsOnlyOneFormWithAKnownCSRFTokenUsingId() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body><form id=\"form_name\"><input type=\"text\" id=\"token\"/><input type=\"submit\"/></form></body></html>");
@@ -190,7 +189,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenThereIsOnlyOneFormWithSecondKnownCSRFTokenUsingName() {
+    void shouldNotRaiseAlertWhenThereIsOnlyOneFormWithSecondKnownCSRFTokenUsingName() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body><form id=\"form_name\"><input type=\"text\" name=\"csrfToken\"/><input type=\"submit\"/></form></body></html>");
@@ -201,7 +200,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseOneAlertForOneFormWhenSecondFormHasAKnownCSRFToken() {
+    void shouldRaiseOneAlertForOneFormWhenSecondFormHasAKnownCSRFToken() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body>"
@@ -216,7 +215,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseOneAlertForOneFormWhenFirstFormOfTwoHasAKnownCSRFToken() {
+    void shouldRaiseOneAlertForOneFormWhenFirstFormOfTwoHasAKnownCSRFToken() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body>"
@@ -231,7 +230,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseTwoAlertsForTwoFormsWhenOneOfThreeHasAKnownCSRFToken() {
+    void shouldRaiseTwoAlertsForTwoFormsWhenOneOfThreeHasAKnownCSRFToken() {
         // Given
         msg.setResponseBody(
                 "<html><head></head><body>"
@@ -250,7 +249,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenFormIdIsOnCsrfIgnoreList() {
+    void shouldNotRaiseAlertWhenFormIdIsOnCsrfIgnoreList() {
         // Given
         rule.setCsrfIgnoreList("ignoredName,otherName");
 
@@ -265,7 +264,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenFormNameIsOnCsrfIgnoreList() {
+    void shouldNotRaiseAlertWhenFormNameIsOnCsrfIgnoreList() {
         // Given
         rule.setCsrfIgnoreList("ignoredName,otherName");
 
@@ -280,7 +279,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseInfoAlertWhenFormAttributeIsOnCsrfAttributeIgnoreList() {
+    void shouldRaiseInfoAlertWhenFormAttributeIsOnCsrfAttributeIgnoreList() {
         // Given
         rule.setCSRFIgnoreAttName("data-no-csrf");
 
@@ -296,7 +295,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseInfoAlertWhenFormAttributeAndValueMatchRuleConfig() {
+    void shouldRaiseInfoAlertWhenFormAttributeAndValueMatchRuleConfig() {
         // Given
         rule.setCSRFIgnoreAttName("data-no-csrf");
         rule.setCSRFIgnoreAttValue("data-no-csrf");
@@ -313,7 +312,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseLowAlertWhenFormAttributeAndRuleConfigMismatch() {
+    void shouldRaiseLowAlertWhenFormAttributeAndRuleConfigMismatch() {
         // Given
         rule.setCSRFIgnoreAttName("ignore");
 
@@ -329,7 +328,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenThresholdHighAndMessageOutOfScope() throws URIException {
+    void shouldNotRaiseAlertWhenThresholdHighAndMessageOutOfScope() throws URIException {
         // Given
         rule.setCSRFIgnoreAttName("ignore");
         HttpMessage msg = createScopedMessage(false);
@@ -342,7 +341,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenThresholdHighAndMessageInScope() throws URIException {
+    void shouldRaiseAlertWhenThresholdHighAndMessageInScope() throws URIException {
         // Given
         rule.setCSRFIgnoreAttName("ignore");
         HttpMessage msg = createScopedMessage(true);
@@ -355,7 +354,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenThresholdMediumAndMessageOutOfScope() throws URIException {
+    void shouldRaiseAlertWhenThresholdMediumAndMessageOutOfScope() throws URIException {
         // Given
         rule.setCSRFIgnoreAttName("ignore");
         HttpMessage msg = createScopedMessage(false);
@@ -368,7 +367,7 @@ public class CsrfCountermeasuresScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenThresholdLowAndMessageOutOfScope() throws URIException {
+    void shouldRaiseAlertWhenThresholdLowAndMessageOutOfScope() throws URIException {
         // Given
         rule.setCSRFIgnoreAttName("ignore");
         HttpMessage msg = createScopedMessage(false);

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRuleUnitTest.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class InfoPrivateAddressDisclosureScanRuleUnitTest
+class InfoPrivateAddressDisclosureScanRuleUnitTest
         extends PassiveScannerTest<InfoPrivateAddressDisclosureScanRule> {
     private static final String URI = "https://www.example.com/";
 
@@ -39,7 +39,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void alertsIfPrivateIp() throws HttpMalformedHeaderException {
+    void alertsIfPrivateIp() throws HttpMalformedHeaderException {
         // ip as candidate / evidence
         String[][] data =
                 new String[][] {
@@ -85,7 +85,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldIgnoreRequestedPrivateIpByDefault() throws Exception {
+    void shouldIgnoreRequestedPrivateIpByDefault() throws Exception {
         // Given
         // ip and aws-hostname which get concatenated with the ports as candidates
         String[] ipHost = new String[] {"10.0.2.2", "ip-10-0-2-2"};
@@ -104,8 +104,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertRequestedPrivateIpIfLowAlertThreshold()
-            throws HttpMalformedHeaderException {
+    void shouldAlertRequestedPrivateIpIfLowAlertThreshold() throws HttpMalformedHeaderException {
         // Given
         String privateIp = "192.168.36.127";
         String requestUri = "https://" + privateIp + ":8123/";
@@ -120,7 +119,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void passesIfNonPrivateOrInvalidIp() throws HttpMalformedHeaderException {
+    void passesIfNonPrivateOrInvalidIp() throws HttpMalformedHeaderException {
         String[] candidates =
                 new String[] {
                     // the "borders" of private IP ranges
@@ -164,7 +163,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void alertsIfPrivIpAndAddsPortToEvidence() throws HttpMalformedHeaderException {
+    void alertsIfPrivIpAndAddsPortToEvidence() throws HttpMalformedHeaderException {
         // ip and aws-hostname which get concatenated with the ports as candidates
         String[] ipHost = new String[] {"10.0.0.0", "ip-10-0-0-0"};
         // several ports in the range 0-65535
@@ -193,7 +192,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void alertsIfPrivIpAndDropsPortNoInEvidence() throws HttpMalformedHeaderException {
+    void alertsIfPrivIpAndDropsPortNoInEvidence() throws HttpMalformedHeaderException {
         // ip and aws-hostname which get concatenated with the ports as candidates
         String[] ipHost = new String[] {"10.0.0.0", "ip-10-0-0-0"};
         // several ports to be ignored
@@ -223,7 +222,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void alertsIfPrivateAwsHostname() throws HttpMalformedHeaderException {
+    void alertsIfPrivateAwsHostname() throws HttpMalformedHeaderException {
         // ip as candidate / evidence
         String[][] data =
                 new String[][] {
@@ -263,7 +262,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void passesIfInvalidAwsHostname() throws HttpMalformedHeaderException {
+    void passesIfInvalidAwsHostname() throws HttpMalformedHeaderException {
         String[] candidates =
                 new String[] {
                     // "outside borders" of private-IP-range-patterns
@@ -310,7 +309,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void alertsWithJustTheFirstEvidenceIfPrivIpAndPrivHostname()
+    void alertsWithJustTheFirstEvidenceIfPrivIpAndPrivHostname()
             throws HttpMalformedHeaderException {
         // candidate, evidence, otherInfo
         String[][] data =
@@ -342,7 +341,7 @@ public class InfoPrivateAddressDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void testOfScanHttpRequestSend() throws HttpMalformedHeaderException {
+    void testOfScanHttpRequestSend() throws HttpMalformedHeaderException {
         // the method should do nothing (test just for code coverage)
         scanHttpRequestSend(createHttpMessage("10.0.2.2"));
         assertThat(alertsRaised.size(), equalTo(0));

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRuleUnitTest.java
@@ -37,7 +37,7 @@ import org.zaproxy.zap.extension.httpsessions.HttpSessionToken;
 import org.zaproxy.zap.extension.httpsessions.HttpSessionsParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSessionIdUrlScanRule> {
+class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSessionIdUrlScanRule> {
 
     private HttpMessage msg;
     private static final String BODY = "Some text in the response, doesn't matter.\nLine 2\n";
@@ -70,7 +70,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void noAlertOnIDSmallerThanMinimum() throws HttpMalformedHeaderException, URIException {
+    void noAlertOnIDSmallerThanMinimum() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "http://example.com/foo?jsessionid=1A53063";
@@ -85,8 +85,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void containsSessionIdAsUrlParameter()
-            throws HttpMalformedHeaderException, URIException {
+    void containsSessionIdAsUrlParameter() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "http://example.com/foo?jsessionid=1A530637289A03B07199A44E8D531427";
@@ -101,7 +100,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void containsSessionIdAsUrlParameterInHTTPS()
+    void containsSessionIdAsUrlParameterInHTTPS()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -117,7 +116,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void noSessionIdInURL() throws HttpMalformedHeaderException, URIException {
+    void noSessionIdInURL() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/";
@@ -132,7 +131,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void noSessionIDAsUrlParameter() throws HttpMalformedHeaderException, URIException {
+    void noSessionIDAsUrlParameter() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/session/foo?session=false";
@@ -147,7 +146,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void containsSessionIdAsUrlParameterInHTTPSOnCustomPort()
+    void containsSessionIdAsUrlParameterInHTTPSOnCustomPort()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -164,7 +163,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void containsJsessionIdInUrlPathBeforeParams()
+    void containsJsessionIdInUrlPathBeforeParams()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -180,8 +179,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void alertsWithoutJSessionidInOptions()
-            throws HttpMalformedHeaderException, URIException {
+    void alertsWithoutJSessionidInOptions() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "http://tld.gtld/fred;JSESSIONID=asdfasdfasdf1234?foo=bar";
@@ -202,7 +200,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void containsCFIDAsUrlParameter() throws HttpMalformedHeaderException, URIException {
+    void containsCFIDAsUrlParameter() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "http://example.com/foo?CFiD=1A530637289A03B07199A44E8D531427";
@@ -218,8 +216,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
 
     @Test
     @Disabled(value = "Scanner does not look for session IDs in the response embedded in HREFs")
-    public void containsSessionIdInResponseHREFParams()
-            throws HttpMalformedHeaderException, URIException {
+    void containsSessionIdInResponseHREFParams() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "http://tld.gtld/fred?foo=bar";
@@ -242,7 +239,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     @Disabled(
             value =
                     "Scanner does not look for session IDs in the response embedded in HREFs before the parameters")
-    public void containsCFIDInResponseHREFBeforeParams()
+    void containsCFIDInResponseHREFBeforeParams()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -263,7 +260,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void detectExposureTo3rdPartyInHREF() throws HttpMalformedHeaderException, URIException {
+    void detectExposureTo3rdPartyInHREF() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/foo?jsessionid=1A530637289A03B07199A44E8D531427";
@@ -284,7 +281,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void detectExposureTo3rdPartyInHREFwCustomPort()
+    void detectExposureTo3rdPartyInHREFwCustomPort()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -306,8 +303,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void detectExposureTo3rdPartyUnquotedHREF()
-            throws HttpMalformedHeaderException, URIException {
+    void detectExposureTo3rdPartyUnquotedHREF() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/foo?jsessionid=1A530637289A03B07199A44E8D531427";
@@ -327,7 +323,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void detectExposureTo3rdPartyInSRC() throws HttpMalformedHeaderException, URIException {
+    void detectExposureTo3rdPartyInSRC() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/foo?jsessionid=1A530637289A03B07199A44E8D531427";
@@ -349,7 +345,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void ignoreExposureToSelf() throws HttpMalformedHeaderException, URIException {
+    void ignoreExposureToSelf() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/foo?jsessionid=1A530637289A03B07199A44E8D531427";
@@ -372,8 +368,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void ignoreExposureToSelfRelativeLink()
-            throws HttpMalformedHeaderException, URIException {
+    void ignoreExposureToSelfRelativeLink() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/foo?jsessionid=1A530637289A03B07199A44E8D531427";
@@ -397,7 +392,7 @@ public class InfoSessionIdUrlScanRuleUnitTest extends PassiveScannerTest<InfoSes
     }
 
     @Test
-    public void ignoreExposureToBookmark() throws HttpMalformedHeaderException, URIException {
+    void ignoreExposureToBookmark() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = "https://example.com/foo?jsessionid=1A530637289A03B07199A44E8D531427";

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRuleUnitTest.java
@@ -39,7 +39,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class InformationDisclosureDebugErrorsScanRuleUnitTest
+class InformationDisclosureDebugErrorsScanRuleUnitTest
         extends PassiveScannerTest<InformationDisclosureDebugErrorsScanRule> {
     private static final String URI = "https://www.example.com/";
     private static final String DEFAULT_ERROR_MESSAGE = "Internal Server Error";
@@ -84,7 +84,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void shouldFindDebugErrorsFile() {
+    void shouldFindDebugErrorsFile() {
         // Given
         String debugErrorFilePath = "/xml/debug-error-messages.txt";
         // When
@@ -94,7 +94,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void alertsIfDebugErrorsDisclosed() throws HttpMalformedHeaderException {
+    void alertsIfDebugErrorsDisclosed() throws HttpMalformedHeaderException {
         for (int i = 0; i < DEBUG_ERRORS.size(); i++) {
             String debugError = DEBUG_ERRORS.get(i);
             String responseBody = "<html>" + debugError + "</html>";
@@ -117,7 +117,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void alertsIfMixedCaseDebugErrorsDisclosed() throws HttpMalformedHeaderException {
+    void alertsIfMixedCaseDebugErrorsDisclosed() throws HttpMalformedHeaderException {
         int expectedAlerts = 0;
 
         // Test the normal error message
@@ -163,7 +163,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void passesIfNoDebugErrorsDisclosed() throws HttpMalformedHeaderException {
+    void passesIfNoDebugErrorsDisclosed() throws HttpMalformedHeaderException {
         String[] data =
                 new String[] {
                     "Error Management theory",
@@ -184,7 +184,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void passesIfResponseIsEmpty() throws HttpMalformedHeaderException {
+    void passesIfResponseIsEmpty() throws HttpMalformedHeaderException {
         HttpMessage msg = createHttpMessageWithRespBody("");
 
         scanHttpResponseReceive(msg);
@@ -193,7 +193,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void passesIfResponseIsNotText() throws HttpMalformedHeaderException {
+    void passesIfResponseIsNotText() throws HttpMalformedHeaderException {
         HttpMessage msg = createHttpMessageWithRespBody(DEFAULT_ERROR_MESSAGE);
         msg.getResponseHeader()
                 .setHeader(
@@ -206,7 +206,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfJSResponseContainsErrorStringAtHighThreshold()
+    void shouldNotAlertIfJSResponseContainsErrorStringAtHighThreshold()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createHttpMessageWithRespBody(DEFAULT_ERROR_MESSAGE);
@@ -221,7 +221,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfJSResponseContainsErrorStringAtMediumThreshold()
+    void shouldNotAlertIfJSResponseContainsErrorStringAtMediumThreshold()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createHttpMessageWithRespBody(DEFAULT_ERROR_MESSAGE);
@@ -236,7 +236,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertIfJSResponseContainsErrorStringAtLowThreshold()
+    void shouldAlertIfJSResponseContainsErrorStringAtLowThreshold()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createHttpMessageWithRespBody(DEFAULT_ERROR_MESSAGE);
@@ -254,7 +254,7 @@ public class InformationDisclosureDebugErrorsScanRuleUnitTest
     }
 
     @Test
-    public void changeDebugErrorsFile() throws HttpMalformedHeaderException {
+    void changeDebugErrorsFile() throws HttpMalformedHeaderException {
         int expectedAlerts = 0;
         List<String> alternativeDebugErrors =
                 Arrays.asList(

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
@@ -34,7 +34,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class InformationDisclosureInUrlScanRuleUnitTest
+class InformationDisclosureInUrlScanRuleUnitTest
         extends PassiveScannerTest<InformationDisclosureInUrlScanRule> {
 
     private static final String URI = "http://example.com/";
@@ -79,7 +79,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void sensitiveInfoInURLParamName() throws HttpMalformedHeaderException, URIException {
+    void sensitiveInfoInURLParamName() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String sensitiveParamName = "UserName";
@@ -98,7 +98,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void noSensitiveInfoInURLParamName() throws HttpMalformedHeaderException, URIException {
+    void noSensitiveInfoInURLParamName() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = URI + "?notused=45365";
@@ -112,8 +112,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void creditCardNoDashesInURLParamValue()
-            throws HttpMalformedHeaderException, URIException {
+    void creditCardNoDashesInURLParamValue() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String sensitiveParamName = "docid";
@@ -151,7 +150,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void noCreditCardInURLParamValue() throws HttpMalformedHeaderException, URIException {
+    void noCreditCardInURLParamValue() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = URI + "?docid=123456&hl=en";
@@ -165,7 +164,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void emailAddressInURLParamValue() throws HttpMalformedHeaderException, URIException {
+    void emailAddressInURLParamValue() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String sensitiveParamName = "docid";
@@ -187,7 +186,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void noEmailAddressInURLParamValue() throws HttpMalformedHeaderException, URIException {
+    void noEmailAddressInURLParamValue() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = URI + "?docid=exampleatgmail.com&hl=en";
@@ -201,7 +200,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void SsnDashesInURLParamValue() throws HttpMalformedHeaderException, URIException {
+    void SsnDashesInURLParamValue() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String sensitiveParamName = "docid";
@@ -223,7 +222,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void noSsnInURLParamValue() throws HttpMalformedHeaderException, URIException {
+    void noSsnInURLParamValue() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = URI + "?docid=snn-no-test&hl=en";
@@ -237,7 +236,7 @@ public class InformationDisclosureInUrlScanRuleUnitTest
     }
 
     @Test
-    public void noQueryParams() throws HttpMalformedHeaderException, URIException {
+    void noQueryParams() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = URI;

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class InformationDisclosureReferrerScanRuleUnitTest
+class InformationDisclosureReferrerScanRuleUnitTest
         extends PassiveScannerTest<InformationDisclosureReferrerScanRule> {
 
     private static final String URI = "http://example.com/";
@@ -81,7 +81,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void noAlertOnRefererSelfReferenceWithSensitiveInfo()
+    void noAlertOnRefererSelfReferenceWithSensitiveInfo()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -96,7 +96,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void noAlertOnNoRefererHeaderWithSensitiveInfoInUrl()
+    void noAlertOnNoRefererHeaderWithSensitiveInfoInUrl()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -122,7 +122,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void noAlertWithUrlAbsolutePathInRefererWithSensitiveInfo()
+    void noAlertWithUrlAbsolutePathInRefererWithSensitiveInfo()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -137,7 +137,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void alertWhenMalformedRefererContainsSensitiveInfo()
+    void alertWhenMalformedRefererContainsSensitiveInfo()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -161,7 +161,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void alertWhenNoHostInRefererContainsSensitiveInfo()
+    void alertWhenNoHostInRefererContainsSensitiveInfo()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -185,7 +185,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenSensitiveInfoInReferer()
+    void shouldRaiseAlertWhenSensitiveInfoInReferer()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -207,7 +207,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWithNoSensitiveInfoInReferer()
+    void shouldNotAlertWithNoSensitiveInfoInReferer()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -222,7 +222,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenCreditCardInReferer()
+    void shouldRaiseAlertWhenCreditCardInReferer()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -254,7 +254,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWithNoCreditCardInReferer()
+    void shouldNotAlertWithNoCreditCardInReferer()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -269,7 +269,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenEmailAddressInReferer()
+    void shouldRaiseAlertWhenEmailAddressInReferer()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -292,7 +292,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWithNoEmailAddressInReferer()
+    void shouldNotAlertWithNoEmailAddressInReferer()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -307,8 +307,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWhenSsnInReferer()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldRaiseAlertWhenSsnInReferer() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String sensitiveParamName = "docid";
@@ -330,8 +329,7 @@ public class InformationDisclosureReferrerScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWithNoSsnInReferer()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldNotAlertWithNoSsnInReferer() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testReferer = "http://example.org/?docid=ssn-no-here&hl=en";

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRuleUnitTest.java
@@ -36,7 +36,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
+class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
         extends PassiveScannerTest<InformationDisclosureSuspiciousCommentsScanRule> {
 
     @Override
@@ -82,7 +82,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertOnSuspiciousCommentInJavaScriptResponse()
+    void shouldAlertOnSuspiciousCommentInJavaScriptResponse()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -105,7 +105,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertOnSuspiciousCommentIsPartOfWordInJavaScriptResponse()
+    void shouldNotAlertOnSuspiciousCommentIsPartOfWordInJavaScriptResponse()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -124,7 +124,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldCreateOneAlertforMultipleAndEqualSuspiciousComments()
+    void shouldCreateOneAlertforMultipleAndEqualSuspiciousComments()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -149,7 +149,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWithoutSuspiciousCommentInJavaScriptResponse()
+    void shouldNotAlertWithoutSuspiciousCommentInJavaScriptResponse()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -167,7 +167,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertOnSuspiciousCommentInHtmlScriptElements()
+    void shouldAlertOnSuspiciousCommentInHtmlScriptElements()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -189,7 +189,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWithoutSuspiciousCommentInHtmlScriptElements()
+    void shouldNotAlertWithoutSuspiciousCommentInHtmlScriptElements()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -209,7 +209,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldAlertOnSuspiciousCommentInHtmlComments()
+    void shouldAlertOnSuspiciousCommentInHtmlComments()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -229,7 +229,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertWhenNoSuspiciousCommentInHtmlComments()
+    void shouldNotAlertWhenNoSuspiciousCommentInHtmlComments()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -249,8 +249,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfResponseIsEmpty()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldNotAlertIfResponseIsEmpty() throws HttpMalformedHeaderException, URIException {
 
         // Given
         HttpMessage msg = createHttpMessageWithRespBody("", "text/html;charset=ISO-8859-1");
@@ -263,8 +262,7 @@ public class InformationDisclosureSuspiciousCommentsScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotAlertIfResponseIsNotText()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldNotAlertIfResponseIsNotText() throws HttpMalformedHeaderException, URIException {
 
         // Given
         HttpMessage msg =

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 
-public class InsecureAuthenticationScanRuleUnitTest
+class InsecureAuthenticationScanRuleUnitTest
         extends PassiveScannerTest<InsecureAuthenticationScanRule> {
 
     private static final String BASE_RESOURCE_KEY = "pscanrules.authenticationcredentialscaptured.";
@@ -53,7 +53,7 @@ public class InsecureAuthenticationScanRuleUnitTest
     }
 
     @Test
-    public void shouldBeSecureIfHttpUsedWithSsl() throws HttpMalformedHeaderException {
+    void shouldBeSecureIfHttpUsedWithSsl() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -65,8 +65,7 @@ public class InsecureAuthenticationScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfBasicAuthenticationWithNoSsl()
-            throws NullPointerException, IOException {
+    void shouldRaiseAlertIfBasicAuthenticationWithNoSsl() throws NullPointerException, IOException {
         // Given
         String userAndPass = user + ":" + pass;
         HttpMessage msg = new HttpMessage();
@@ -102,7 +101,7 @@ public class InsecureAuthenticationScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfBasicAuthenticationOnlyUserWithNoSsl()
+    void shouldRaiseAlertIfBasicAuthenticationOnlyUserWithNoSsl()
             throws NullPointerException, IOException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -136,7 +135,7 @@ public class InsecureAuthenticationScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfBasicAuthenticationResponseWithNoSsl()
+    void shouldRaiseAlertIfBasicAuthenticationResponseWithNoSsl()
             throws NullPointerException, IOException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -162,7 +161,7 @@ public class InsecureAuthenticationScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfDigestAuthenticationWithNoSsl()
+    void shouldRaiseAlertIfDigestAuthenticationWithNoSsl()
             throws NullPointerException, IOException {
         // Given
         String digestValue = "username=\"" + user + "\", realm=\"members only\"";

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class InsecureJsfViewStatePassiveScanRuleUnitTest
+class InsecureJsfViewStatePassiveScanRuleUnitTest
         extends PassiveScannerTest<InsecureJsfViewStatePassiveScanRule> {
 
     private static final String BASE_RESOURCE_KEY = "pscanrules.insecurejsfviewstate.";
@@ -45,7 +45,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldPassAsThereIsNoBody() throws HttpMalformedHeaderException {
+    void shouldPassAsThereIsNoBody() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -58,7 +58,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldPassWhenViewStateContainsUnderscore() throws HttpMalformedHeaderException {
+    void shouldPassWhenViewStateContainsUnderscore() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -76,7 +76,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldPassNoJavaWordInViewState() throws IOException {
+    void shouldPassNoJavaWordInViewState() throws IOException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -97,7 +97,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldPassIfViewStateIsStoredOnServer() throws IOException {
+    void shouldPassIfViewStateIsStoredOnServer() throws IOException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -119,7 +119,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfViewStateContainsJavaWord() throws IOException {
+    void shouldRaiseAlertIfViewStateContainsJavaWord() throws IOException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -145,7 +145,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfViewStateContainsJavaWordCompressed() throws IOException {
+    void shouldRaiseAlertIfViewStateContainsJavaWordCompressed() throws IOException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -172,7 +172,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfInsecureValueViewStateIdWithFormId() throws IOException {
+    void shouldRaiseAlertIfInsecureValueViewStateIdWithFormId() throws IOException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -199,7 +199,7 @@ public class InsecureJsfViewStatePassiveScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfInsecureViewStateManyInputs() throws IOException {
+    void shouldRaiseAlertIfInsecureViewStateManyInputs() throws IOException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRuleUnitTest.java
@@ -31,7 +31,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedContentScanRule> {
+class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedContentScanRule> {
 
     @Override
     protected MixedContentScanRule createScanner() {
@@ -39,7 +39,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldNotRaiseAlertIfHttpResource() {
+    void shouldNotRaiseAlertIfHttpResource() {
         // Given
         String uri = "http://example.com/";
         HttpMessage msg =
@@ -51,7 +51,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldNotRaiseAlertIfHttpsResourceContainsNoMixedContent() {
+    void shouldNotRaiseAlertIfHttpsResourceContainsNoMixedContent() {
         // Given
         String uri = "https://example.com/";
         HttpMessage msg =
@@ -63,7 +63,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldNotRaiseAlertIfHttpsResourceIsEmpty() {
+    void shouldNotRaiseAlertIfHttpsResourceIsEmpty() {
         // Given
         String uri = "https://example.com/";
         HttpMessage msg = createHtmlResponse(uri, "");
@@ -74,7 +74,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldNotRaiseAlertForNonHtmlContent() {
+    void shouldNotRaiseAlertForNonHtmlContent() {
         // Given
         String uri = "https://example.com/script.js";
         HttpMessage msg =
@@ -91,7 +91,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldNotRaiseAlertIfHttpsResourceContainsMixedContentInUnknownAttribute() {
+    void shouldNotRaiseAlertIfHttpsResourceContainsMixedContentInUnknownAttribute() {
         // Given
         String attribute = "unknown";
         String uri = "https://example.com/";
@@ -104,7 +104,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldRaiseLowAlertIfHttpsResourceContainsMixedContentInKnownAttributes() {
+    void shouldRaiseLowAlertIfHttpsResourceContainsMixedContentInKnownAttributes() {
         for (String attribute :
                 Arrays.asList(
                         "src",
@@ -136,7 +136,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void
+    void
             shouldNotRaiseAlertIfHttpsResourceContainsMixedContentInActionAndFormActionAttributesWhenInHighAlertTreshold() {
         for (String attribute : Arrays.asList("action", "formaction")) {
             // Given
@@ -153,7 +153,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldRaiseMediumAlertIfHttpsResourceContainsMixedContentInScriptTag() {
+    void shouldRaiseMediumAlertIfHttpsResourceContainsMixedContentInScriptTag() {
         // Given
         String uri = "https://example.com/";
         HttpMessage msg =
@@ -172,7 +172,7 @@ public class MixedContentScanRuleUnitTest extends PassiveScannerTest<MixedConten
     }
 
     @Test
-    public void shouldRaiseOneAlertForMultipleMixedContent() {
+    void shouldRaiseOneAlertForMultipleMixedContent() {
         // Given
         String uri = "https://example.com/";
         HttpMessage msg =

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PassiveScannerTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/PassiveScannerTest.java
@@ -22,7 +22,7 @@ package org.zaproxy.zap.extension.pscanrules;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-public abstract class PassiveScannerTest<T extends PluginPassiveScanner>
+abstract class PassiveScannerTest<T extends PluginPassiveScanner>
         extends PassiveScannerTestUtils<T> {
 
     @Override

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -36,8 +36,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class TimestampDisclosureScanRuleUnitTest
-        extends PassiveScannerTest<TimestampDisclosureScanRule> {
+class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDisclosureScanRule> {
 
     @Override
     protected TimestampDisclosureScanRule createScanner() {
@@ -45,7 +44,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void verifyExcludedHeadersListAsExpected() {
+    void verifyExcludedHeadersListAsExpected() {
         // Given / When
         List<String> ignoreList =
                 Arrays.asList(TimestampDisclosureScanRule.RESPONSE_HEADERS_TO_IGNORE);
@@ -56,7 +55,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertOnSTSHeader() throws Exception {
+    void shouldNotRaiseAlertOnSTSHeader() throws Exception {
         // Given
         HttpMessage msg = createMessage("");
         msg.setResponseHeader(
@@ -70,7 +69,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertOnValidCurrentTimestamp() throws Exception {
+    void shouldRaiseAlertOnValidCurrentTimestamp() throws Exception {
         // Given
         String now =
                 String.valueOf(System.currentTimeMillis()).substring(0, 10); // 10 Digit precision
@@ -79,11 +78,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(now));
+        assertEquals(now, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldRaiseAlertOnValidCurrentTimestampAtHighThreshold() throws Exception {
+    void shouldRaiseAlertOnValidCurrentTimestampAtHighThreshold() throws Exception {
         // Given
         String now =
                 String.valueOf(System.currentTimeMillis()).substring(0, 10); // 10 Digit precision
@@ -93,11 +92,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(now));
+        assertEquals(now, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenWithinPastYear() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenWithinPastYear() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -106,11 +105,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenWithinPastYearAtHighThreshold() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenWithinPastYearAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -120,11 +119,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenWithinNextYear() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenWithinNextYear() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().plusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -133,11 +132,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenWithinNextYearAtHighThreshold() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenWithinNextYearAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().plusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -147,11 +146,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenThreeYearsAgo() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenThreeYearsAgo() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusYears(3).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -160,11 +159,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldNotRaiseAlertOnTimeStampWhenThreeYearsAgoAtHighThreshold() throws Exception {
+    void shouldNotRaiseAlertOnTimeStampWhenThreeYearsAgoAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusYears(3).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -177,7 +176,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenThreeYearsFromNow() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenThreeYearsFromNow() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().plusYears(3).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -186,12 +185,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldNotRaiseAlertOnTimeStampWhenThreeYearsFromNowAtHighThreshold()
-            throws Exception {
+    void shouldNotRaiseAlertOnTimeStampWhenThreeYearsFromNowAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().plusYears(3).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -204,7 +202,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenFarInThePast() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenFarInThePast() throws Exception {
         // Given
         String strTestDate = String.valueOf(33333333);
         HttpMessage msg = createMessage(strTestDate);
@@ -212,11 +210,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldNotRaiseAlertOnTimeStampWhenFarInThePastAtHighThreshold() throws Exception {
+    void shouldNotRaiseAlertOnTimeStampWhenFarInThePastAtHighThreshold() throws Exception {
         // Given
         String strTestDate = String.valueOf(33333333);
         HttpMessage msg = createMessage(strTestDate);
@@ -228,7 +226,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertOnTimeStampWhenFarInTheFuture() throws Exception {
+    void shouldRaiseAlertOnTimeStampWhenFarInTheFuture() throws Exception {
         // Given
         String strTestDate = String.valueOf(2147483647);
         HttpMessage msg = createMessage(strTestDate);
@@ -236,11 +234,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldNotRaiseAlertOnTimeStampWhenFarInTheFutureAtHighThreshold() throws Exception {
+    void shouldNotRaiseAlertOnTimeStampWhenFarInTheFutureAtHighThreshold() throws Exception {
         // Given
         String strTestDate = String.valueOf(2147483647);
         HttpMessage msg = createMessage(strTestDate);
@@ -252,7 +250,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseTwoAlertsWhenOneOfTwoTimeStampWithinNextYear() throws Exception {
+    void shouldRaiseTwoAlertsWhenOneOfTwoTimeStampWithinNextYear() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().plusMonths(6).toInstant();
         Instant testDate2 = ZonedDateTime.now().plusMonths(18).toInstant();
@@ -265,13 +263,12 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(2, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
-        assertTrue(alertsRaised.get(1).getEvidence().equals(strTestDate2));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
+        assertEquals(strTestDate2, alertsRaised.get(1).getEvidence());
     }
 
     @Test
-    public void shouldRaiseOneAlertWhenOneOfTwoTimeStampWithinNextYearAtHighThreshold()
-            throws Exception {
+    void shouldRaiseOneAlertWhenOneOfTwoTimeStampWithinNextYearAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().plusMonths(6).toInstant();
         Instant testDate2 = ZonedDateTime.now().plusMonths(18).toInstant();
@@ -285,11 +282,11 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
     }
 
     @Test
-    public void shouldRaiseTwoAlertsWhenOneOfTwoTimeStampWithinPastYear() throws Exception {
+    void shouldRaiseTwoAlertsWhenOneOfTwoTimeStampWithinPastYear() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(18).toInstant();
         Instant testDate2 = ZonedDateTime.now().minusMonths(6).toInstant();
@@ -302,13 +299,12 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(2, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate));
-        assertTrue(alertsRaised.get(1).getEvidence().equals(strTestDate2));
+        assertEquals(strTestDate, alertsRaised.get(0).getEvidence());
+        assertEquals(strTestDate2, alertsRaised.get(1).getEvidence());
     }
 
     @Test
-    public void shouldRaiseOneAlertWhenOneOfTwoTimeStampWithinPastYearAtHighThreshold()
-            throws Exception {
+    void shouldRaiseOneAlertWhenOneOfTwoTimeStampWithinPastYearAtHighThreshold() throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(18).toInstant();
         Instant testDate2 = ZonedDateTime.now().minusMonths(6).toInstant();
@@ -322,13 +318,12 @@ public class TimestampDisclosureScanRuleUnitTest
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals(strTestDate2));
+        assertEquals(strTestDate2, alertsRaised.get(0).getEvidence());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"font.woff", "font.woff2", "font.ttf", "font.otf"})
-    public void shouldNotRaiseAlertOnValidTimeStampInFontUrlRequest(String fileName)
-            throws Exception {
+    void shouldNotRaiseAlertOnValidTimeStampInFontUrlRequest(String fileName) throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());
@@ -341,7 +336,7 @@ public class TimestampDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void patternFontExtensionShouldNotFindSubString() {
+    void patternFontExtensionShouldNotFindSubString() {
         // Given / When
         boolean result =
                 TimestampDisclosureScanRule.PATTERN_FONT_EXTENSIONS.matcher("/font.woffL").find();
@@ -351,8 +346,7 @@ public class TimestampDisclosureScanRuleUnitTest
 
     @ParameterizedTest
     @ValueSource(strings = {"font/ttf", "font/otf", "font/woff", "font/woff2"})
-    public void shouldNotRaiseAlertOnValidTimeStampWhenInFontResponse(String type)
-            throws Exception {
+    void shouldNotRaiseAlertOnValidTimeStampWhenInFontResponse(String type) throws Exception {
         // Given
         Instant testDate = ZonedDateTime.now().minusMonths(6).toInstant();
         String strTestDate = String.valueOf(testDate.getEpochSecond());

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.users.User;
 
-public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdorScanRule> {
+class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdorScanRule> {
 
     private HttpMessage msg;
 
@@ -46,7 +46,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     private static final String FOOBAR_MD2 = "3af4bb69e03489fc4ceebe50151d3e1a";
 
     @BeforeEach
-    public void before() throws URIException {
+    void before() throws URIException {
 
         when(passiveScanData.getUsers()).thenReturn(Arrays.asList(new User(1, "guest")));
 
@@ -64,7 +64,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasNoRelevantContent() {
+    void shouldNotRaiseAlertIfResponseHasNoRelevantContent() {
         // Given
         msg.setResponseBody("Some text <h1>Some Title Element</h1>");
         // When
@@ -74,7 +74,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseContainsIrrelevantHash() {
+    void shouldNotRaiseAlertIfResponseContainsIrrelevantHash() {
         // Given - "Guest" with a leading cap
         msg.setResponseBody(
                 "Some text <h1>Some Title Element</h1><i>adb831a7fdd83dd1e2a309ce7591dff8</i>");
@@ -85,7 +85,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseContainsRelevantMd5Hash() {
+    void shouldRaiseAlertIfResponseContainsRelevantMd5Hash() {
         // Given - Mixed case hash
         msg.setResponseBody(
                 "Some text <h1>Some Title Element</h1><i>084E0343A0486fF05530DF6C705C8Bb4</i>");
@@ -97,7 +97,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseContainsRelevantSha1Hash() {
+    void shouldRaiseAlertIfResponseContainsRelevantSha1Hash() {
         // Given
         msg.setResponseBody(
                 "Some text <h1>Some Title Element</h1><b>84983c60f7daadc1cb8698621f802c0d9f9a3c3c295c810748fb048115c186ec</b>");
@@ -109,7 +109,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldRaiseMultipleAlertsIfResponseContainsMultipleRelevantHashes() {
+    void shouldRaiseMultipleAlertsIfResponseContainsMultipleRelevantHashes() {
         // Given
         msg.setResponseBody(
                 "Some text <h1>Some Title Element</h1><b>"
@@ -128,7 +128,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseContainsRelevantHashInHeader() {
+    void shouldRaiseAlertIfResponseContainsRelevantHashInHeader() {
         // Given
         msg.getResponseHeader().setHeader("X-Test-Thing", GUEST_MD5);
         msg.setResponseBody(
@@ -144,7 +144,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasHashOfDefaultPayload() {
+    void shouldRaiseAlertIfResponseHasHashOfDefaultPayload() {
         // Given
         msg.getResponseHeader().setHeader("X-Test-Thing", ADMIN_MD5);
         msg.setResponseBody("Some text <h1>Some Title Element</h1>");
@@ -156,7 +156,7 @@ public class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdo
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasHashOfCustomPayload() {
+    void shouldRaiseAlertIfResponseHasHashOfCustomPayload() {
         // Given
         msg.getResponseHeader().setHeader("X-Test-Thing", FOOBAR_MD2);
         msg.setResponseBody("Some text <h1>Some Title Element</h1>");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
@@ -33,13 +33,13 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
+class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
 
     private HttpMessage msg;
     private HttpRequestHeader header;
 
     @BeforeEach
-    public void before() throws URIException {
+    void before() throws URIException {
         msg = new HttpMessage();
         header = new HttpRequestHeader();
 
@@ -53,14 +53,14 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldNotRaiseAlertAsThereIsNoContent() {
+    void shouldNotRaiseAlertAsThereIsNoContent() {
         scanHttpResponseReceive(msg);
 
         assertThat(alertsRaised.size(), equalTo(0));
     }
 
     @Test
-    public void shouldNotRaiseAlertAsThereIsNoValidViewState() {
+    void shouldNotRaiseAlertAsThereIsNoValidViewState() {
         msg.setResponseBody("<input name=\"__specialstate\">");
 
         scanHttpResponseReceive(msg);
@@ -69,7 +69,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldNotRaiseAlertAsThereIsAnUnknowVersionOfASP() {
+    void shouldNotRaiseAlertAsThereIsAnUnknowVersionOfASP() {
         msg.setResponseBody("<input name=\"__specialstate\" value=\"bm90dmFsaWQ=\">");
 
         scanHttpResponseReceive(msg);
@@ -78,7 +78,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldRaiseAlertAsThereIsNoValidMACUnsure() {
+    void shouldRaiseAlertAsThereIsNoValidMACUnsure() {
         msg.setResponseBody(
                 "<input name=\"__VIEWSTATE\" value=\"/wEPDWUKMTkwNjc4NTIwMWRkaKrolbpTKYmPUNsab597kh8iOBU=\">");
 
@@ -94,7 +94,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldRaiseAlertAsThereIsNoValidMACSure() {
+    void shouldRaiseAlertAsThereIsNoValidMACSure() {
         msg.setResponseBody(
                 "<input name=\"__VIEWSTATE\" value=\"/wEPDWUKMTkwNjc4NTIwwEPDWUKMTkwNjc4NTIwMWRkaMWRka\">");
 
@@ -110,7 +110,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldRaiseAlertForOldASPVersion() {
+    void shouldRaiseAlertForOldASPVersion() {
         msg.setResponseBody(
                 "<input name=\"__VIEWSTATE\" value=\"dDPDWUKMTkwNjc4NTIwMWRkaKrolbpTKYmPUNsab597kh8iOBU=\">");
 
@@ -126,7 +126,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldNotRaiseAlertAsTheParametersDoNotHaveEmailsOrIps() {
+    void shouldNotRaiseAlertAsTheParametersDoNotHaveEmailsOrIps() {
         msg.setResponseBody(
                 "<input name=\"__VIEWSTATE\" value=\"/wEPDwUJODczNjQ5OTk0D2QWAgIDD2QWAgIFDw8WAh4EVGV4dAUWSSBMb3ZlIERvdG5ldEN1cnJ5LmNvbWRkZMHbBY9JqBTvB5/6kXnY15AUSAwa\">");
 
@@ -136,7 +136,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldRaiseAlertBecauseTheParametersDoesHaveEmail() {
+    void shouldRaiseAlertBecauseTheParametersDoesHaveEmail() {
         String encodedViewstate = getViewstateWithText("test@test.com");
         msg.setResponseBody("<input name=\"__VIEWSTATE\" value=\"" + encodedViewstate + "\">");
 
@@ -153,7 +153,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldRaiseAlertBecauseTheParametersDoesHaveIP() {
+    void shouldRaiseAlertBecauseTheParametersDoesHaveIP() {
         String encodedViewstate = getViewstateWithText("127.0.0.1");
         msg.setResponseBody("<input name=\"__VIEWSTATE\" value=\"" + encodedViewstate + "\">");
 
@@ -176,7 +176,7 @@ public class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanR
     }
 
     @Test
-    public void shouldRaiseAlertAsViewstateIsSplit() {
+    void shouldRaiseAlertAsViewstateIsSplit() {
         msg.setResponseBody(
                 "<input type=\"hidden\" name=\"__VIEWSTATEFIELDCOUNT\" id=\"__VIEWSTATEFIELDCOUNT\" value=\"3\" />"
                         + "<input type=\"hidden\" name=\"__VIEWSTATE\" id=\"__VIEWSTATE\" value=\"/wEPDwUKLTk2Njk3OTQxNg9kFgICAw9kFgICCQ88\" />"

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRuleUnitTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class XAspNetVersionScanRuleUnitTest extends PassiveScannerTest<XAspNetVersionScanRule> {
+class XAspNetVersionScanRuleUnitTest extends PassiveScannerTest<XAspNetVersionScanRule> {
 
     @Override
     protected XAspNetVersionScanRule createScanner() {
@@ -34,7 +34,7 @@ public class XAspNetVersionScanRuleUnitTest extends PassiveScannerTest<XAspNetVe
     }
 
     @Test
-    public void shouldRaiseAlertWhenResponseContainsXAspNetVersionHeader()
+    void shouldRaiseAlertWhenResponseContainsXAspNetVersionHeader()
             throws HttpMalformedHeaderException {
 
         HttpMessage msg = createMessage("X-AspNet-Version");
@@ -45,7 +45,7 @@ public class XAspNetVersionScanRuleUnitTest extends PassiveScannerTest<XAspNetVe
     }
 
     @Test
-    public void shouldRaiseAlertWhenResponseContainsXAspNetMvcVersionHeader()
+    void shouldRaiseAlertWhenResponseContainsXAspNetMvcVersionHeader()
             throws HttpMalformedHeaderException {
 
         HttpMessage msg = createMessage("X-AspNetMvc-Version");
@@ -56,7 +56,7 @@ public class XAspNetVersionScanRuleUnitTest extends PassiveScannerTest<XAspNetVe
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenResponseDoesNotContainsXAspNetVersionHeader()
+    void shouldNotRaiseAlertWhenResponseDoesNotContainsXAspNetVersionHeader()
             throws HttpMalformedHeaderException {
 
         HttpMessage msg = createMessage("dummy");

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionScanRuleUnitTest.java
@@ -31,8 +31,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class XContentTypeOptionScanRuleUnitTest
-        extends PassiveScannerTest<XContentTypeOptionsScanRule> {
+class XContentTypeOptionScanRuleUnitTest extends PassiveScannerTest<XContentTypeOptionsScanRule> {
 
     @Override
     protected XContentTypeOptionsScanRule createScanner() {
@@ -40,7 +39,7 @@ public class XContentTypeOptionScanRuleUnitTest
     }
 
     @Test
-    public void xContentTypeOptionsPresent() throws HttpMalformedHeaderException {
+    void xContentTypeOptionsPresent() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -62,8 +61,7 @@ public class XContentTypeOptionScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfHeaderValueHasDifferentCase()
-            throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertIfHeaderValueHasDifferentCase() throws HttpMalformedHeaderException {
         Locale defaultLocale = Locale.getDefault();
         try {
             // Given
@@ -90,7 +88,7 @@ public class XContentTypeOptionScanRuleUnitTest
     }
 
     @Test
-    public void xContentTypeOptionsAbsent() throws HttpMalformedHeaderException {
+    void xContentTypeOptionsAbsent() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -113,7 +111,7 @@ public class XContentTypeOptionScanRuleUnitTest
     }
 
     @Test
-    public void xContentTypeOptionsBad() throws HttpMalformedHeaderException {
+    void xContentTypeOptionsBad() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -137,7 +135,7 @@ public class XContentTypeOptionScanRuleUnitTest
     }
 
     @Test
-    public void xContentTypeOptionsAbsentRedirectLow() throws HttpMalformedHeaderException {
+    void xContentTypeOptionsAbsentRedirectLow() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
         HttpMessage msg = new HttpMessage();
@@ -162,7 +160,7 @@ public class XContentTypeOptionScanRuleUnitTest
     }
 
     @Test
-    public void xContentTypeOptionsAbsentRedirectMed() throws HttpMalformedHeaderException {
+    void xContentTypeOptionsAbsentRedirectMed() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
         HttpMessage msg = new HttpMessage();
@@ -185,7 +183,7 @@ public class XContentTypeOptionScanRuleUnitTest
     }
 
     @Test
-    public void xContentTypeOptionsAbsentRedirectHigh() throws HttpMalformedHeaderException {
+    void xContentTypeOptionsAbsentRedirectHigh() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.HIGH);
         HttpMessage msg = new HttpMessage();

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRuleUnitTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenScanRule> {
+class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenScanRule> {
 
     private static final String X_DEBUG_TOKEN_HEADER = "X-Debug-Token";
     private static final String X_DEBUG_TOKEN_LINK_HEADER = "X-Debug-Token-Link";
@@ -45,7 +45,7 @@ public class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenS
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThereIsNoRelevantHeader() throws Exception {
+    void shouldNotRaiseAlertIfThereIsNoRelevantHeader() throws Exception {
         // Given
         HttpMessage msg = createMessage();
 
@@ -57,7 +57,7 @@ public class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenS
     }
 
     @Test
-    public void shouldRaiseAnAlertIfFindsXDebugToken() throws Exception {
+    void shouldRaiseAnAlertIfFindsXDebugToken() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(X_DEBUG_TOKEN_HEADER, "9687e6");
@@ -71,7 +71,7 @@ public class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenS
     }
 
     @Test
-    public void shouldRaiseAnAlertIfFindsXDebugTokenLink() throws Exception {
+    void shouldRaiseAnAlertIfFindsXDebugTokenLink() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(X_DEBUG_TOKEN_LINK_HEADER, "/_profiler/97b958");
@@ -85,7 +85,7 @@ public class XDebugTokenScanRuleUnitTest extends PassiveScannerTest<XDebugTokenS
     }
 
     @Test
-    public void shouldRaiseOnlyOneAlertIfBothHeaderVariantsFound() throws Exception {
+    void shouldRaiseOnlyOneAlertIfBothHeaderVariantsFound() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader()

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionsScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionsScanRuleUnitTest.java
@@ -31,7 +31,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOptionScanRule> {
+class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOptionScanRule> {
 
     private static final String BASE_RESOURCE_KEY = "pscanrules.xframeoptions.";
     private static final String NAME_HEADER_NOT_SET = BASE_RESOURCE_KEY + "missing.name";
@@ -46,7 +46,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void xframeOptionsDeny() throws HttpMalformedHeaderException {
+    void xframeOptionsDeny() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -68,7 +68,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void xframeOptionsDenyLc() throws HttpMalformedHeaderException {
+    void xframeOptionsDenyLc() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -90,7 +90,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void xframeOptionsDenyMc() throws HttpMalformedHeaderException {
+    void xframeOptionsDenyMc() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -112,7 +112,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void xframeOptionsSameOrigin() throws HttpMalformedHeaderException {
+    void xframeOptionsSameOrigin() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -134,7 +134,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void xframeOptionsAllowFrom() throws HttpMalformedHeaderException {
+    void xframeOptionsAllowFrom() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -156,7 +156,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void noXframeOptions() throws HttpMalformedHeaderException {
+    void noXframeOptions() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -181,7 +181,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void noXframeOptionsErrorLow() throws HttpMalformedHeaderException {
+    void noXframeOptionsErrorLow() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
         HttpMessage msg = new HttpMessage();
@@ -207,7 +207,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void noXframeOptionsErrorMed() throws HttpMalformedHeaderException {
+    void noXframeOptionsErrorMed() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
         HttpMessage msg = new HttpMessage();
@@ -229,7 +229,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void noXframeOptionsErrorHigh() throws HttpMalformedHeaderException {
+    void noXframeOptionsErrorHigh() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.HIGH);
         HttpMessage msg = new HttpMessage();
@@ -251,7 +251,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void noXframeOptionsPlainTextLow() throws HttpMalformedHeaderException {
+    void noXframeOptionsPlainTextLow() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
         HttpMessage msg = new HttpMessage();
@@ -277,7 +277,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void noXframeOptionsPlainTextMed() throws HttpMalformedHeaderException {
+    void noXframeOptionsPlainTextMed() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
         HttpMessage msg = new HttpMessage();
@@ -299,7 +299,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void noXframeOptionsPlainTextHigh() throws HttpMalformedHeaderException {
+    void noXframeOptionsPlainTextHigh() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.HIGH);
         HttpMessage msg = new HttpMessage();
@@ -321,7 +321,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void multipleXframeOptions() throws HttpMalformedHeaderException {
+    void multipleXframeOptions() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -348,7 +348,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void xframeOptionsViaMetaTag() throws HttpMalformedHeaderException {
+    void xframeOptionsViaMetaTag() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -380,7 +380,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void xframeOptionsViaMetaTagAndHeader() throws HttpMalformedHeaderException {
+    void xframeOptionsViaMetaTagAndHeader() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -409,7 +409,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void malformedXframeOptions() throws HttpMalformedHeaderException {
+    void malformedXframeOptions() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -435,7 +435,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void cspNoFaNoXframeOptions() throws HttpMalformedHeaderException {
+    void cspNoFaNoXframeOptions() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -461,7 +461,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void cspWithFaNoXframeOptions() throws HttpMalformedHeaderException {
+    void cspWithFaNoXframeOptions() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -483,7 +483,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void cspWithFaWithXframeOptions() throws HttpMalformedHeaderException {
+    void cspWithFaWithXframeOptions() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET http://www.example.com/test/ HTTP/1.1");
@@ -506,7 +506,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void cspWithFaWithBadXframeOptionsLow() throws HttpMalformedHeaderException {
+    void cspWithFaWithBadXframeOptionsLow() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.LOW);
         HttpMessage msg = new HttpMessage();
@@ -534,7 +534,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void cspWithFaWithBadXframeOptionsMedium() throws HttpMalformedHeaderException {
+    void cspWithFaWithBadXframeOptionsMedium() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.MEDIUM);
         HttpMessage msg = new HttpMessage();
@@ -558,7 +558,7 @@ public class XFrameOptionsScanRuleUnitTest extends PassiveScannerTest<XFrameOpti
     }
 
     @Test
-    public void cspWithFaWithBadXframeOptionsHigh() throws HttpMalformedHeaderException {
+    void cspWithFaWithBadXframeOptionsHigh() throws HttpMalformedHeaderException {
         // Given
         rule.setAlertThreshold(AlertThreshold.HIGH);
         HttpMessage msg = new HttpMessage();

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRuleUnitTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
 /** @author Vahid Rafiei (@vahid_r) */
-public class XPoweredByHeaderInfoLeakScanRuleUnitTest
+class XPoweredByHeaderInfoLeakScanRuleUnitTest
         extends PassiveScannerTest<XPoweredByHeaderInfoLeakScanRule> {
 
     @Override
@@ -36,7 +36,7 @@ public class XPoweredByHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThereIsNoXPoweredBy() throws Exception {
+    void shouldNotRaiseAlertIfThereIsNoXPoweredBy() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -50,7 +50,7 @@ public class XPoweredByHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAnAlertIfFindsXPoweredBy() throws Exception {
+    void shouldRaiseAnAlertIfFindsXPoweredBy() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -68,7 +68,7 @@ public class XPoweredByHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseOnlyOneAlertWithOneEvidenceAndOtherInfoIfFindsMultipleXPoweredBy()
+    void shouldRaiseOnlyOneAlertWithOneEvidenceAndOtherInfoIfFindsMultipleXPoweredBy()
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -91,7 +91,7 @@ public class XPoweredByHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldBeCaseSensitiveWhenShowingHeadersInEvidenceAndOtherInfo() throws Exception {
+    void shouldBeCaseSensitiveWhenShowingHeadersInEvidenceAndOtherInfo() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/AlertsCacheableScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/AlertsCacheableScanRuleUnitTest.java
@@ -31,7 +31,7 @@ import org.parosproxy.paros.network.HttpMessage;
 /* All test-cases should raise either non-storeable alerts
  * or storeable and non-cacheable alerts.
  */
-public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
+class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
 
     private void assertNonStoreable(String expectedEvidence) {
         assertThat(alertsRaised.size(), equalTo(1));
@@ -55,8 +55,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWhenHttpMethodInvalid()
-            throws HttpMalformedHeaderException {
+    void shouldRaiseAlertNonStoreableWhenHttpMethodInvalid() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("PUT / HTTP/1.1");
@@ -68,8 +67,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWithHttpStatusCode600()
-            throws HttpMalformedHeaderException {
+    void shouldRaiseAlertNonStoreableWithHttpStatusCode600() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -83,7 +81,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWithCacheControlNoStoreDirectiveInRequestHeader()
+    void shouldRaiseAlertNonStoreableWithCacheControlNoStoreDirectiveInRequestHeader()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -98,7 +96,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWithPragmaNoStoreDirectiveInRequestHeader()
+    void shouldRaiseAlertNonStoreableWithPragmaNoStoreDirectiveInRequestHeader()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -113,7 +111,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWithCacheControlNoStoreDirectiveInResponseHeader()
+    void shouldRaiseAlertNonStoreableWithCacheControlNoStoreDirectiveInResponseHeader()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -128,7 +126,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWithPragmaNoStoreDirectiveInResponseHeader()
+    void shouldRaiseAlertNonStoreableWithPragmaNoStoreDirectiveInResponseHeader()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -143,7 +141,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWhenCacheControlIsPrivate()
+    void shouldRaiseAlertNonStoreableWhenCacheControlIsPrivate()
             throws HttpMalformedHeaderException {
 
         // Given
@@ -159,9 +157,8 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void
-            shouldRaiseAlertNonStoreableWhenAuthorizationHeaderWithWrongCacheControlDirectiveUsed()
-                    throws HttpMalformedHeaderException {
+    void shouldRaiseAlertNonStoreableWhenAuthorizationHeaderWithWrongCacheControlDirectiveUsed()
+            throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1\r\n" + "Authorization: basic\r\n");
@@ -178,7 +175,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertNonStoreableWhenAuthorizationHeaderWithoutCacheControlUsed()
+    void shouldRaiseAlertNonStoreableWhenAuthorizationHeaderWithoutCacheControlUsed()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -193,7 +190,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void
+    void
             shouldRaiseAlertNonStoreableWhenExpiresMaxAgeAndPublicDirectiveMissingAndStatusNonCacheableByDefault()
                     throws HttpMalformedHeaderException {
         // Given
@@ -208,7 +205,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertStoreableNonCacheableWhenNoCacheDirectiveGiven()
+    void shouldRaiseAlertStoreableNonCacheableWhenNoCacheDirectiveGiven()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -225,7 +222,7 @@ public class AlertsCacheableScanRuleUnitTest extends PassiveScannerTest<Cacheabl
     }
 
     @Test
-    public void shouldRaiseAlertStoreableNonCacheableWhenStaleRetrieveProhibited()
+    void shouldRaiseAlertStoreableNonCacheableWhenStaleRetrieveProhibited()
             throws HttpMalformedHeaderException {
         shouldRaiseAlertStoreableNonCacheableWhenStaleRetrieveProhibited("must-revalidate");
         shouldRaiseAlertStoreableNonCacheableWhenStaleRetrieveProhibited("proxy-revalidate");

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
@@ -36,7 +36,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 /* All test-cases should raise storeable and cacheable alerts
  * or should verfiy the absence of exceptions.
  */
-public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
+class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
 
     private HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
@@ -73,7 +73,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void scannerNameShouldMatch() {
+    void scannerNameShouldMatch() {
         // Quick test to verify scan rule name which is used in the policy dialog but not
         // alerts
 
@@ -84,7 +84,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldNotCauseExceptionWhenExpiresHeaderHasZeroValue()
+    void shouldNotCauseExceptionWhenExpiresHeaderHasZeroValue()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -105,7 +105,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndExpiryDateGiven()
+    void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndExpiryDateGiven()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -121,7 +121,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndCacheIsPublic()
+    void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndCacheIsPublic()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -133,7 +133,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndMaxAgeGiven()
+    void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndMaxAgeGiven()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -145,7 +145,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndS_MaxAgeGiven()
+    void shouldRaiseAlertStoreAndCacheableWhenStatusNonCacheableByDefaultAndS_MaxAgeGiven()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -157,7 +157,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault()
+    void shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault()
             throws URIException, HttpMalformedHeaderException {
         shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("200");
         shouldRaiseAlertStoreAndCacheableWhenStatusCacheableByDefault("203");
@@ -187,7 +187,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndCacheMustRevalidated()
+    void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndCacheMustRevalidated()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessageBasicAuthorization();
@@ -199,7 +199,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndCacheIsPublic()
+    void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndCacheIsPublic()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessageBasicAuthorization();
@@ -211,7 +211,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndS_MaxAgeCacheGiven()
+    void shouldRaiseAlertStoreAndCacheableWhenAuthorizationNeededAndS_MaxAgeCacheGiven()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessageBasicAuthorization();
@@ -223,7 +223,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndS_MaxAgeDirectiveIsSet()
+    void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndS_MaxAgeDirectiveIsSet()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -237,7 +237,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndMaxAgeDirectiveIsSet()
+    void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndMaxAgeDirectiveIsSet()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -251,7 +251,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndExpirySpecified()
+    void shouldRaiseAlertStoreAndCacheableWhenCacheIsFreshAndExpirySpecified()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -269,7 +269,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableCacheIsFreshWhenNoLifetimeSpecified()
+    void shouldRaiseAlertStoreAndCacheableCacheIsFreshWhenNoLifetimeSpecified()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();
@@ -288,7 +288,7 @@ public class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanR
     }
 
     @Test
-    public void shouldRaiseAlertStoreAndCacheableWhenStaleRetrieveAllowed()
+    void shouldRaiseAlertStoreAndCacheableWhenStaleRetrieveAllowed()
             throws URIException, HttpMalformedHeaderException {
         // Given
         HttpMessage msg = createMessage();

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRuleUnitTest.java
@@ -30,13 +30,13 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScanRule> {
+class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScanRule> {
 
     private static final String MESSAGE_PREFIX = "pscanalpha.featurepolicymissing.";
     private HttpMessage msg;
 
     @BeforeEach
-    public void before() throws Exception {
+    void before() throws Exception {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI("http://example.com", false));
 
@@ -51,7 +51,7 @@ public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePol
     }
 
     @Test
-    public void shouldRaiseAlertOnMissingFeaturePolicyHTML() throws Exception {
+    void shouldRaiseAlertOnMissingFeaturePolicyHTML() throws Exception {
         // Given
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
         // When
@@ -62,7 +62,7 @@ public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePol
     }
 
     @Test
-    public void shouldRaiseAlertOnMissingFeaturePolicyJavaScript() throws Exception {
+    void shouldRaiseAlertOnMissingFeaturePolicyJavaScript() throws Exception {
         // Given
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/javascript");
         // When
@@ -72,7 +72,7 @@ public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePol
     }
 
     @Test
-    public void shouldNotRaiseAlertOnMissingFeaturePolicyOthers() throws Exception {
+    void shouldNotRaiseAlertOnMissingFeaturePolicyOthers() throws Exception {
         // Given
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "application/json");
         // When
@@ -82,7 +82,7 @@ public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePol
     }
 
     @Test
-    public void shouldNotRaiseAlertOnAvailableFeaturePolicy() throws Exception {
+    void shouldNotRaiseAlertOnAvailableFeaturePolicy() throws Exception {
         // Given
         msg.getResponseHeader().addHeader("Feature-Policy", "vibrate 'none'");
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/HTML");
@@ -93,8 +93,7 @@ public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePol
     }
 
     @Test
-    public void shouldNotRaiseAlertOnMissingFeaturePolicyRedirectMediumThreshold()
-            throws Exception {
+    void shouldNotRaiseAlertOnMissingFeaturePolicyRedirectMediumThreshold() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
         msg.setResponseHeader("HTTP/1.1 301 Moved Permanently\r\n");
@@ -106,7 +105,7 @@ public class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePol
     }
 
     @Test
-    public void shouldRaiseAlertOnMissingFeaturePolicyRedirectLowThreshold() throws Exception {
+    void shouldRaiseAlertOnMissingFeaturePolicyRedirectLowThreshold() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         msg.setResponseHeader("HTTP/1.1 301 Moved Permanently\r\n");

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class InPageBannerInfoLeakScanRuleUnitTest
+class InPageBannerInfoLeakScanRuleUnitTest
         extends PassiveScannerTest<InPageBannerInfoLeakScanRule> {
 
     private HttpMessage createMessage(String banner) throws URIException {
@@ -52,7 +52,7 @@ public class InPageBannerInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsRedirect() throws URIException {
+    void shouldNotRaiseAlertIfResponseIsRedirect() throws URIException {
         // Given
         HttpMessage msg = createMessage("");
         msg.getResponseHeader().setStatusCode(HttpStatusCode.TEMPORARY_REDIRECT);
@@ -66,7 +66,7 @@ public class InPageBannerInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasRelevanContent() throws URIException {
+    void shouldRaiseAlertIfResponseHasRelevanContent() throws URIException {
         // Given
         String squidBanner = "Squid/2.5.STABLE4";
         HttpMessage msg = createMessage(squidBanner);
@@ -81,7 +81,7 @@ public class InPageBannerInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasRelevantContentWithStatusOk() throws URIException {
+    void shouldNotRaiseAlertIfResponseHasRelevantContentWithStatusOk() throws URIException {
         // Given - Default threshold (MEDIUM)
         String apacheBanner = "Apache/2.4.17";
         HttpMessage msg = createMessage(apacheBanner);
@@ -96,8 +96,7 @@ public class InPageBannerInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasRelevantContentWithCustomPage200()
-            throws URIException {
+    void shouldNotRaiseAlertIfResponseHasRelevantContentWithCustomPage200() throws URIException {
         // Given - Default threshold (MEDIUM)
         String apacheBanner = "Apache/2.4.17";
         HttpMessage msg = createMessage(apacheBanner);
@@ -112,7 +111,7 @@ public class InPageBannerInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfThresholdLowResponseHasRelevantContentWithStatusOk()
+    void shouldRaiseAlertIfThresholdLowResponseHasRelevantContentWithStatusOk()
             throws URIException {
         // Given
         String jettyBanner = "Jetty://9.4z-SNAPSHOT";

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
@@ -38,7 +38,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> {
+class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> {
 
     @Override
     protected JsFunctionScanRule createScanner() {
@@ -57,7 +57,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldAlertGivenFunctionInJavaScriptResponse()
+    void shouldAlertGivenFunctionInJavaScriptResponse()
             throws HttpMalformedHeaderException, URIException {
         // Given
         String body = "Some text <script>$eval()</script>\nLine 2\n";
@@ -72,7 +72,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldAlertGivenFunctionInHtmlScriptElements()
+    void shouldAlertGivenFunctionInHtmlScriptElements()
             throws HttpMalformedHeaderException, URIException {
 
         // Given
@@ -90,7 +90,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldNotAlertGivenNoMatch() throws URIException, HttpMalformedHeaderException {
+    void shouldNotAlertGivenNoMatch() throws URIException, HttpMalformedHeaderException {
         // Given
         String body = "Some text <script>innocentFunction()</script>\nLine 2\n";
         HttpMessage msg = createHttpMessageWithRespBody(body, "text/javascript;charset=ISO-8859-1");
@@ -103,7 +103,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldNotAlertGivenEmptyBody() throws HttpMalformedHeaderException, URIException {
+    void shouldNotAlertGivenEmptyBody() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String body = "";
@@ -117,7 +117,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldAlertGivenCustomPayloadFunctionMatch()
+    void shouldAlertGivenCustomPayloadFunctionMatch()
             throws HttpMalformedHeaderException, URIException {
         // Given
         String body = "Some text <script>$badFunction()</script>\nLine 2\n";
@@ -134,8 +134,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldNotAlertGivenMatchOutsideScript()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldNotAlertGivenMatchOutsideScript() throws HttpMalformedHeaderException, URIException {
         // Given
         String body =
                 "<h1>Some text <script>Something innocent happening here</script></h1>\n"
@@ -150,8 +149,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldAlertGivenMatchInSecondScript()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldAlertGivenMatchInSecondScript() throws HttpMalformedHeaderException, URIException {
         // Given
         String body =
                 "<h1>Some text <script>Something innocent happening here</script></h1>\n"
@@ -168,7 +166,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldAlertOnceGivenMultipleMatchesHTML()
+    void shouldAlertOnceGivenMultipleMatchesHTML()
             throws HttpMalformedHeaderException, URIException {
         // Given
         String body =
@@ -186,8 +184,7 @@ public class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionSca
     }
 
     @Test
-    public void shouldAlertOnceGivenMultipleMatchesJS()
-            throws HttpMalformedHeaderException, URIException {
+    void shouldAlertOnceGivenMultipleMatchesJS() throws HttpMalformedHeaderException, URIException {
         // Given
         String body = "Some text <script>eval()</script>\n" + "bypassSecurityTrustHtml()\n";
         HttpMessage msg = createHttpMessageWithRespBody(body, "text/javascript;charset=ISO-8859-1");

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRuleUnitTest.java
@@ -33,11 +33,11 @@ import java.util.Base64;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
+class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
 
     /* Testing JSO in response */
     @Test
-    public void shouldNotRaiseAlertGivenNoJsoHasBeenDetectedInResponse() throws Exception {
+    void shouldNotRaiseAlertGivenNoJsoHasBeenDetectedInResponse() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -52,8 +52,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInHeaderOfResponse()
-            throws Exception {
+    void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInHeaderOfResponse() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -68,8 +67,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInCookieOfResponse()
-            throws Exception {
+    void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInCookieOfResponse() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -84,8 +82,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenRawJsoMagicBytesAreDetectedInRawBodyOfResponse()
-            throws Exception {
+    void shouldRaiseAlertGivenRawJsoMagicBytesAreDetectedInRawBodyOfResponse() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -107,8 +104,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInBodyOfResponse()
-            throws Exception {
+    void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInBodyOfResponse() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -131,7 +127,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
 
     /* Testing JSO in request */
     @Test
-    public void shouldNotRaiseAlertGivenNoJsoHasBeenDetectedInRequest() throws Exception {
+    void shouldNotRaiseAlertGivenNoJsoHasBeenDetectedInRequest() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader(
@@ -145,7 +141,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInRequestParameterOfRequest()
+    void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInRequestParameterOfRequest()
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -159,7 +155,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInRequestParameterOfRequest()
+    void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInRequestParameterOfRequest()
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -174,7 +170,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInHeaderOfRequest()
+    void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInHeaderOfRequest()
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -188,8 +184,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInHeaderOfRequest()
-            throws Exception {
+    void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInHeaderOfRequest() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         String jso = Base64.getEncoder().encodeToString(createJso());
@@ -203,7 +198,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInCookieOfRequest()
+    void shouldRaiseAlertGivenUriEncodedJsoMagicBytesAreDetectedInCookieOfRequest()
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -218,8 +213,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInCookieOfRequest()
-            throws Exception {
+    void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInCookieOfRequest() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         String jso = Base64.getEncoder().encodeToString(createJso());
@@ -233,7 +227,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenRawJsoMagicBytesAreDetectedInBodyOfRequest() throws Exception {
+    void shouldRaiseAlertGivenRawJsoMagicBytesAreDetectedInBodyOfRequest() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         byte[] jso = createJso();
@@ -254,8 +248,7 @@ public class JsoScanRuleUnitTest extends PassiveScannerTest<JsoScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInBodyOfRequest()
-            throws Exception {
+    void shouldRaiseAlertGivenBase64JsoMagicBytesAreDetectedInBodyOfRequest() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         String jso = Base64.getEncoder().encodeToString(createJso());

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PassiveScannerTest.java
@@ -22,8 +22,7 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-public abstract class PassiveScannerTest<T extends PassiveScanner>
-        extends PassiveScannerTestUtils<T> {
+abstract class PassiveScannerTest<T extends PassiveScanner> extends PassiveScannerTestUtils<T> {
 
     @Override
     protected void setUpMessages() {

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRuleTest.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.network.HttpMessage;
 
 class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule> {
     @Test
-    public void shouldNotRaiseAlertGivenSiteIsIsolated() throws Exception {
+    void shouldNotRaiseAlertGivenSiteIsIsolated() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -49,7 +49,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenSiteIsIsolatedWhenSuccessIdentifiedByCustomPage()
+    void shouldNotRaiseAlertGivenSiteIsIsolatedWhenSuccessIdentifiedByCustomPage()
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -69,7 +69,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenSiteIsIsolatedWhenSuccessAndIdentifiedByCustomPage()
+    void shouldNotRaiseAlertGivenSiteIsIsolatedWhenSuccessAndIdentifiedByCustomPage()
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -89,7 +89,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseCorpAlertGivenResponseDoesntSendCorpHeader() throws Exception {
+    void shouldRaiseCorpAlertGivenResponseDoesntSendCorpHeader() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -111,7 +111,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseCorpAlertGivenCorpHeaderIsSetForSameSite() throws Exception {
+    void shouldRaiseCorpAlertGivenCorpHeaderIsSetForSameSite() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -133,7 +133,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseCorpAlertGivenCorpHeaderContentIsUnexpected() throws Exception {
+    void shouldRaiseCorpAlertGivenCorpHeaderContentIsUnexpected() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -156,7 +156,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseCorpAlertCaseInsensitive() throws Exception {
+    void shouldRaiseCorpAlertCaseInsensitive() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -179,7 +179,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldNotRaiseCorpAlertGivenCorpHeaderIsSetForCrossOrigin() throws Exception {
+    void shouldNotRaiseCorpAlertGivenCorpHeaderIsSetForCrossOrigin() throws Exception {
         // We consider that resource has been explicitly set to be shared.
         // Given
         HttpMessage msg = new HttpMessage();
@@ -199,7 +199,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseCorpAlertOnlyForSuccessfulQueries() throws Exception {
+    void shouldRaiseCorpAlertOnlyForSuccessfulQueries() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -214,7 +214,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldNotRaiseCorpAlertGivenCorsHeaderIsSet() throws Exception {
+    void shouldNotRaiseCorpAlertGivenCorsHeaderIsSet() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -233,7 +233,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseAlertGivenCoepHeaderIsMissing() throws Exception {
+    void shouldRaiseAlertGivenCoepHeaderIsMissing() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -255,7 +255,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseAlertGivenCoepHeaderIsNotEqualsToRequireCorp() throws Exception {
+    void shouldRaiseAlertGivenCoepHeaderIsNotEqualsToRequireCorp() throws Exception {
         // Ref: https://html.spec.whatwg.org/multipage/origin.html#the-headers
         // Given
         HttpMessage msg = new HttpMessage();
@@ -280,7 +280,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseAlertGivenCoopHeaderIsMissing() throws Exception {
+    void shouldRaiseAlertGivenCoopHeaderIsMissing() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");
@@ -302,7 +302,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldRaiseAlertGivenCoopHeaderIsNotSameOrigin() throws Exception {
+    void shouldRaiseAlertGivenCoopHeaderIsNotSameOrigin() throws Exception {
         // Ref: https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies
         // Given
         HttpMessage msg = new HttpMessage();
@@ -327,8 +327,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldNotRaiseCoepOrCoopAlertGivenResourceIsNotAnHtmlOrXmlDocument()
-            throws Exception {
+    void shouldNotRaiseCoepOrCoopAlertGivenResourceIsNotAnHtmlOrXmlDocument() throws Exception {
         // Definition of Document: https://dom.spec.whatwg.org/#document
         // Given
         HttpMessage msg = new HttpMessage();
@@ -347,7 +346,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenNoHeaderContentTypeIsPresent() throws Exception {
+    void shouldNotRaiseAlertGivenNoHeaderContentTypeIsPresent() throws Exception {
         // If no header content-type is provided, it is browser-dependent.
         //        It will try to sniff the type.
         // There is a rule ContentTypeMissingScanRule
@@ -366,7 +365,7 @@ class SiteIsolationScanRuleTest extends PassiveScannerTest<SiteIsolationScanRule
     }
 
     @Test
-    public void shouldNotRaiseAlertForReportingAPI() throws Exception {
+    void shouldNotRaiseAlertForReportingAPI() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET / HTTP/1.1");

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class SourceCodeDisclosureScanRuleUnitTest
+class SourceCodeDisclosureScanRuleUnitTest
         extends PassiveScannerTest<SourceCodeDisclosureScanRule> {
 
     private static final String CODE_SQL = "insert into vulnerabilities values(";
@@ -45,20 +45,20 @@ public class SourceCodeDisclosureScanRuleUnitTest
     }
 
     @BeforeEach
-    public void createHttpMessage() throws IOException {
+    void createHttpMessage() throws IOException {
         msg = new HttpMessage();
         msg.setRequestHeader("GET " + URI + " HTTP/1.1");
     }
 
     @Test
-    public void scannerNameShouldMatch() {
+    void scannerNameShouldMatch() {
         // Quick test to verify scan rule name which is used in the policy dialog but not
         // alone in alerts
         assertThat(rule.getName(), is(getLocalisedString("name")));
     }
 
     @Test
-    public void givenJustHtmlBodyThenNoAlertRaised() {
+    void givenJustHtmlBodyThenNoAlertRaised() {
         // Given
         msg.setResponseBody(CODE_HTML);
 
@@ -70,7 +70,7 @@ public class SourceCodeDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void givenPHPCodeThenAlertRaised() {
+    void givenPHPCodeThenAlertRaised() {
         // Given
         msg.setResponseBody(wrapWithHTML(CODE_PHP));
 
@@ -83,7 +83,7 @@ public class SourceCodeDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void givenSQLCodeThenAlertRaised() {
+    void givenSQLCodeThenAlertRaised() {
         // Given
         msg.setResponseBody(wrapWithHTML(CODE_SQL));
 
@@ -96,7 +96,7 @@ public class SourceCodeDisclosureScanRuleUnitTest
     }
 
     @Test
-    public void givenSQLAndPhpCodeThenOnlyOneAlertRaised() {
+    void givenSQLAndPhpCodeThenOnlyOneAlertRaised() {
         // Given
         msg.setResponseBody(wrapWithHTML(CODE_SQL + CODE_PHP));
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
@@ -27,7 +27,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class SubResourceIntegrityAttributeScanRuleUnitTest
+class SubResourceIntegrityAttributeScanRuleUnitTest
         extends PassiveScannerTest<SubResourceIntegrityAttributeScanRule> {
 
     @Override
@@ -38,7 +38,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenIntegrityAttributeIsPresentInLinkElement()
+    void shouldNotRaiseAlertGivenIntegrityAttributeIsPresentInLinkElement()
             throws HttpMalformedHeaderException {
         // Given
         // From https://www.w3.org/TR/SRI/#use-casesexamples
@@ -56,7 +56,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenIntegrityAttributeIsPresentInScriptElement()
+    void shouldNotRaiseAlertGivenIntegrityAttributeIsPresentInScriptElement()
             throws HttpMalformedHeaderException {
         // Given
         // From https://www.w3.org/TR/SRI/#use-casesexamples
@@ -74,7 +74,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertGivenIntegrityAttributeIsMissingForSupportedElement()
+    void shouldRaiseAlertGivenIntegrityAttributeIsMissingForSupportedElement()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
@@ -91,8 +91,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldIndicateElementWithoutIntegrityAttribute()
-            throws HttpMalformedHeaderException {
+    void shouldIndicateElementWithoutIntegrityAttribute() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
                 buildMessage(
@@ -110,7 +109,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenElementIsServedByCurrentDomain()
+    void shouldNotRaiseAlertGivenElementIsServedByCurrentDomain()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
@@ -128,8 +127,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertGivenElementIsServedBySubDomain()
-            throws HttpMalformedHeaderException {
+    void shouldRaiseAlertGivenElementIsServedBySubDomain() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
                 buildMessage(
@@ -145,8 +143,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenElementIsServedRelatively()
-            throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertGivenElementIsServedRelatively() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
                 buildMessage(
@@ -167,7 +164,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenElementIsInline() throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertGivenElementIsInline() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
                 buildMessage(
@@ -193,7 +190,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldIgnoreInvalidFormattedHostname() throws HttpMalformedHeaderException {
+    void shouldIgnoreInvalidFormattedHostname() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
                 buildMessage(
@@ -209,7 +206,7 @@ public class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertGivenHtmlAssetIsInline() throws HttpMalformedHeaderException {
+    void shouldNotRaiseAlertGivenHtmlAssetIsInline() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg =
                 buildMessage(

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRuleUnitTest.java
@@ -33,14 +33,14 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class BigRedirectsScanRuleUnitTest extends PassiveScannerTest<BigRedirectsScanRule> {
+class BigRedirectsScanRuleUnitTest extends PassiveScannerTest<BigRedirectsScanRule> {
     private static final String URI = "http://example.com";
     private static final int ALLOWABLE_BODY_SIZE = URI.length() + 300;
 
     private HttpMessage msg;
 
     @BeforeEach
-    public void createHttpMessage() throws IOException {
+    void createHttpMessage() throws IOException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
         requestHeader.setURI(new URI(URI, false));
 
@@ -54,7 +54,7 @@ public class BigRedirectsScanRuleUnitTest extends PassiveScannerTest<BigRedirect
     }
 
     @Test
-    public void givenRedirectWithSmallBodyThenItRaisesNoAlert() {
+    void givenRedirectWithSmallBodyThenItRaisesNoAlert() {
         // Given
         msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
         msg.getResponseHeader().setHeader(HttpHeader.LOCATION, URI);
@@ -68,7 +68,7 @@ public class BigRedirectsScanRuleUnitTest extends PassiveScannerTest<BigRedirect
     }
 
     @Test
-    public void givenRedirectHeadersWithLargeBodyThenAlertRaised() {
+    void givenRedirectHeadersWithLargeBodyThenAlertRaised() {
         // Given
         msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
         msg.getResponseHeader().setHeader(HttpHeader.LOCATION, URI);
@@ -83,7 +83,7 @@ public class BigRedirectsScanRuleUnitTest extends PassiveScannerTest<BigRedirect
     }
 
     @Test
-    public void givenNotModifiedStatusCodeWithLargeBodyThenNoAlertRaised() {
+    void givenNotModifiedStatusCodeWithLargeBodyThenNoAlertRaised() {
         // Given
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_MODIFIED);
         msg.getResponseHeader().setHeader(HttpHeader.LOCATION, URI);
@@ -97,7 +97,7 @@ public class BigRedirectsScanRuleUnitTest extends PassiveScannerTest<BigRedirect
     }
 
     @Test
-    public void givenNotFoundStatusCodeWithLargeBodyThenNoAlertRaised() {
+    void givenNotFoundStatusCodeWithLargeBodyThenNoAlertRaised() {
         // Given
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_FOUND);
         msg.getResponseHeader().setHeader(HttpHeader.LOCATION, URI);
@@ -111,7 +111,7 @@ public class BigRedirectsScanRuleUnitTest extends PassiveScannerTest<BigRedirect
     }
 
     @Test
-    public void givenRedirectStatusCodeWithoutLocationHeaderThenNoAlertRaised() {
+    void givenRedirectStatusCodeWithoutLocationHeaderThenNoAlertRaised() {
         // Given
         msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
         msg.setResponseBody(new byte[ALLOWABLE_BODY_SIZE + 1]);

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRuleUnitTest.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class ContentSecurityPolicyMissingScanRuleUnitTest
+class ContentSecurityPolicyMissingScanRuleUnitTest
         extends PassiveScannerTest<ContentSecurityPolicyMissingScanRule> {
     private static final String URI = "https://www.example.com";
     private static final String HEADER_HTML = "Content-Type: text/html";
@@ -45,7 +45,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenMissingCspHeaderThenAlertRaised() throws Exception {
+    void givenMissingCspHeaderThenAlertRaised() throws Exception {
         // Given
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML);
 
@@ -57,8 +57,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenMissingCspHeaderInRedirectAtMediumAlertThresholdThenNoAlertRaised()
-            throws Exception {
+    void givenMissingCspHeaderInRedirectAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
         HttpMessage msg = createHttpMessageWithHeaders(301, HEADER_HTML);
@@ -71,8 +70,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenMissingCspHeaderInRedirectAtLowAlertThresholdThenAlertRaised()
-            throws Exception {
+    void givenMissingCspHeaderInRedirectAtLowAlertThresholdThenAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         HttpMessage msg = createHttpMessageWithHeaders(301, HEADER_HTML);
@@ -85,7 +83,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenCspHeaderAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
+    void givenCspHeaderAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP);
@@ -98,7 +96,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenCspHeaderAtLowAlertThresholdThenAlertRaised() throws Exception {
+    void givenCspHeaderAtLowAlertThresholdThenAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP);
@@ -111,7 +109,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenAllCspHeadersButXCspAtLowAlertThresholdThenAlertRaised() throws Exception {
+    void givenAllCspHeadersButXCspAtLowAlertThresholdThenAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP, HEADER_WEBKIT_CSP);
@@ -124,8 +122,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenAllCspHeadersButWebkitCspAtLowAlertThresholdThenAlertRaised()
-            throws Exception {
+    void givenAllCspHeadersButWebkitCspAtLowAlertThresholdThenAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_CSP, HEADER_X_CSP);
@@ -138,7 +135,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenAllCspHeadersAtLowAlertThresholdThenNoAlertRaised() throws Exception {
+    void givenAllCspHeadersAtLowAlertThresholdThenNoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         String[] headers = {HEADER_HTML, HEADER_CSP, HEADER_X_CSP, HEADER_WEBKIT_CSP};
@@ -152,7 +149,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenTextContentTypeAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
+    void givenTextContentTypeAtMediumAlertThresholdThenNoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_TEXT);
@@ -165,7 +162,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenTextContentTypeAtLowAlertThresholdThenAlertRaised() throws Exception {
+    void givenTextContentTypeAtLowAlertThresholdThenAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_TEXT);
@@ -178,8 +175,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenTextContentTypeWithCspHeadersAtLowAlertThresholdThenNoAlertRaised()
-            throws Exception {
+    void givenTextContentTypeWithCspHeadersAtLowAlertThresholdThenNoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         String[] headers = {HEADER_TEXT, HEADER_CSP, HEADER_X_CSP, HEADER_WEBKIT_CSP};
@@ -193,7 +189,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenReportOnlyCspThenInfoAlertRaised() throws Exception {
+    void givenReportOnlyCspThenInfoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_REPORT_ONLY);
@@ -208,7 +204,7 @@ public class ContentSecurityPolicyMissingScanRuleUnitTest
     }
 
     @Test
-    public void givenReportOnlyAndCspHeadersThenInfoAlertRaised() throws Exception {
+    void givenReportOnlyAndCspHeadersThenInfoAlertRaised() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
         HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML, HEADER_REPORT_ONLY, HEADER_CSP);

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRuleUnitTest.java
@@ -30,8 +30,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class DirectoryBrowsingScanRuleUnitTest
-        extends PassiveScannerTest<DirectoryBrowsingScanRule> {
+class DirectoryBrowsingScanRuleUnitTest extends PassiveScannerTest<DirectoryBrowsingScanRule> {
 
     private HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
@@ -50,7 +49,7 @@ public class DirectoryBrowsingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseBodyIsEmpty() throws URIException {
+    void shouldNotRaiseAlertIfResponseBodyIsEmpty() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         // When
@@ -60,7 +59,7 @@ public class DirectoryBrowsingScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseBodyIsIrrelevant() throws URIException {
+    void shouldNotRaiseAlertIfResponseBodyIsIrrelevant() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody("<html><H1>Some Title</H1></html>");
@@ -71,7 +70,7 @@ public class DirectoryBrowsingScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseContainsApacheStyleIndex() throws URIException {
+    void shouldRaiseAlertIfResponseContainsApacheStyleIndex() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody("<html><title>Index of /htdocs</title></html>");
@@ -82,7 +81,7 @@ public class DirectoryBrowsingScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseContainsIisStyleIndex() throws URIException {
+    void shouldRaiseAlertIfResponseContainsIisStyleIndex() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody(

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
 /** Unit test for {@link HashDisclosureScanRule}. */
-public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDisclosureScanRule> {
+class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDisclosureScanRule> {
 
     @Override
     protected HashDisclosureScanRule createScanner() {
@@ -41,12 +41,12 @@ public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDiscl
     }
 
     @BeforeEach
-    public void before() throws HttpMalformedHeaderException {
+    void before() throws HttpMalformedHeaderException {
         rule.setAlertThreshold(AlertThreshold.LOW); // Required by MD4/MD5 tests
     }
 
     @Test
-    public void shouldRaiseAlertWhenResponseContainsUpperMd5Hash() throws Exception {
+    void shouldRaiseAlertWhenResponseContainsUpperMd5Hash() throws Exception {
         // Given - Upper MD5
         String hashVal = "DD6433D07B73FC14A2A4D03C5A8FAA90";
         HttpMessage msg = createMsg(hashVal);
@@ -59,7 +59,7 @@ public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDiscl
     }
 
     @Test
-    public void shouldRaiseAlertWhenResponseContainsLowerMd5Hash() throws Exception {
+    void shouldRaiseAlertWhenResponseContainsLowerMd5Hash() throws Exception {
         // Given - Lower MD5
         String hashVal = "cc03e747a6afbbcbf8be7668acfebee5";
         HttpMessage msg = createMsg(hashVal);
@@ -72,7 +72,7 @@ public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDiscl
     }
 
     @Test
-    public void shouldRaiseAlertWhenResponseContainsCookieWithMd5Hash() throws Exception {
+    void shouldRaiseAlertWhenResponseContainsCookieWithMd5Hash() throws Exception {
         // Given - Lower MD5
         String hashVal = "cc03e747a6afbbcbf8be7668acfebee5";
         HttpMessage msg = createMsg("");
@@ -86,7 +86,7 @@ public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDiscl
     }
 
     @Test
-    public void shouldRaiseAlertWhenResponseContainsOsxSha1AtLowThreshold() throws Exception {
+    void shouldRaiseAlertWhenResponseContainsOsxSha1AtLowThreshold() throws Exception {
         // Given
         String hashVal = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFEE37";
         HttpMessage msg = createMsg(hashVal);
@@ -103,7 +103,7 @@ public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDiscl
     @EnumSource(
             value = Plugin.AlertThreshold.class,
             names = {"HIGH", "MEDIUM"})
-    public void shouldNotRaiseAlertWhenResponseContainsOsxSha1InJsAtNonLowThreshold(
+    void shouldNotRaiseAlertWhenResponseContainsOsxSha1InJsAtNonLowThreshold(
             AlertThreshold threshold) throws Exception {
         // Given
         String hashVal = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFEE37";
@@ -117,7 +117,7 @@ public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDiscl
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenResponseContainsNonMd5Hash() throws Exception {
+    void shouldNotRaiseAlertWhenResponseContainsNonMd5Hash() throws Exception {
         // Given - Not MD5 (mm)
         String hashVal = "mm6433d07b73fc14a2a4d03c5a8faa90";
         HttpMessage msg = createMsg(hashVal);
@@ -128,7 +128,7 @@ public class HashDisclosureScanRuleUnitTest extends PassiveScannerTest<HashDiscl
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenResponseContainsObviousJsessionid() throws Exception {
+    void shouldNotRaiseAlertWhenResponseContainsObviousJsessionid() throws Exception {
         // Given - jsessionid cookie
         String hashVal = "dd6433d07b73fc14a2a4d03c5a8faa90";
         HttpMessage msg = createMsg("");

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScannerUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScannerUnitTest.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScanRule> {
+class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScanRule> {
 
     private static final String URI = "https://www.example.com/test/";
     private static final String SAFE_OPENSSL_VERSION = "OpenSSL/1.1.1";
@@ -40,7 +40,7 @@ public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScan
     }
 
     @Test
-    public void givenNoServerHeaderThenNoAlertRaised() throws IOException {
+    void givenNoServerHeaderThenNoAlertRaised() throws IOException {
         // Given
         HttpMessage msg = createMsg();
 
@@ -52,7 +52,7 @@ public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScan
     }
 
     @Test
-    public void givenServerHeaderWithSafeOpenSSLThenNoAlertRaised() throws IOException {
+    void givenServerHeaderWithSafeOpenSSLThenNoAlertRaised() throws IOException {
         // Given
         HttpMessage msg = createMsg("Apache/2.4.1 (" + SAFE_OPENSSL_VERSION + ")");
 
@@ -64,7 +64,7 @@ public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScan
     }
 
     @Test
-    public void givenServerHeaderWithoutOpenSSLThenNoAlertRaised() throws IOException {
+    void givenServerHeaderWithoutOpenSSLThenNoAlertRaised() throws IOException {
         // Given
         HttpMessage msg = createMsg("Apache/2.4.1");
 
@@ -76,8 +76,7 @@ public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScan
     }
 
     @Test
-    public void givenServerHeaderWithVulnerableLowercaseOpenSSLThenAlertRaised()
-            throws IOException {
+    void givenServerHeaderWithVulnerableLowercaseOpenSSLThenAlertRaised() throws IOException {
         // Given
         String opensslVersion = "openssl/1.0.1-beta1";
         HttpMessage msg = createMsg(String.format("Apache-Coyote/1.1 (%s)", opensslVersion));
@@ -91,7 +90,7 @@ public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScan
     }
 
     @Test
-    public void givenServerHeaderWithVulnerableOpenSSLThenAlertRaised() throws IOException {
+    void givenServerHeaderWithVulnerableOpenSSLThenAlertRaised() throws IOException {
         for (String version : HeartBleedScanRule.openSSLvulnerableVersions) {
             // Given
             alertsRaised.clear();
@@ -108,8 +107,7 @@ public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScan
     }
 
     @Test
-    public void givenServerHeaderWithVulnerableAndSafeOpenSSLVersionsThenAlertRaised()
-            throws IOException {
+    void givenServerHeaderWithVulnerableAndSafeOpenSSLVersionsThenAlertRaised() throws IOException {
         // Given
         String vulnerableVersion = "openssl/1.0.1";
         HttpMessage msg = createMsg(String.format("Apache-Coyote/1.1 (%s)", vulnerableVersion));
@@ -124,8 +122,7 @@ public class HeartBleedScannerUnitTest extends PassiveScannerTest<HeartBleedScan
     }
 
     @Test
-    public void givenServerHeaderWithSafeAndVulnerableOpenSSLVersionsThenAlertRaised()
-            throws IOException {
+    void givenServerHeaderWithSafeAndVulnerableOpenSSLVersionsThenAlertRaised() throws IOException {
         // Given
         String vulnerableVersion = "openssl/1.0.1";
         HttpMessage msg = createMsg(String.format("Apache-Coyote/1.1 (%s)", SAFE_OPENSSL_VERSION));

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<InsecureFormLoadScanRule> {
+class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<InsecureFormLoadScanRule> {
 
     private HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
@@ -52,7 +52,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsHttps() throws URIException {
+    void shouldNotRaiseAlertIfResponseIsHttps() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setSecure(true);
@@ -64,7 +64,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotStatusOk() throws URIException {
+    void shouldNotRaiseAlertIfResponseIsNotStatusOk() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
@@ -76,7 +76,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotHtml() throws URIException {
+    void shouldNotRaiseAlertIfResponseIsNotHtml() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
@@ -88,7 +88,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseContentTypeIsNull() throws URIException {
+    void shouldNotRaiseAlertIfResponseContentTypeIsNull() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
@@ -100,7 +100,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldRaiseAlertIfFormActionIsSecure() throws URIException {
+    void shouldRaiseAlertIfFormActionIsSecure() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody(
@@ -114,7 +114,7 @@ public class InsecureFormLoadScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfFormActionIsInsecure() throws URIException {
+    void shouldNotRaiseAlertIfFormActionIsInsecure() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody(

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<InsecureFormPostScanRule> {
+class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<InsecureFormPostScanRule> {
 
     private HttpMessage createMessage() throws URIException {
         HttpRequestHeader requestHeader = new HttpRequestHeader();
@@ -52,7 +52,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotHttps() throws URIException {
+    void shouldNotRaiseAlertIfResponseIsNotHttps() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setSecure(false);
@@ -64,7 +64,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotStatusOk() throws URIException {
+    void shouldNotRaiseAlertIfResponseIsNotStatusOk() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
@@ -76,7 +76,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotHtml() throws URIException {
+    void shouldNotRaiseAlertIfResponseIsNotHtml() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
@@ -88,7 +88,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseContentTypeIsNull() throws URIException {
+    void shouldNotRaiseAlertIfResponseContentTypeIsNull() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
@@ -100,7 +100,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseFormIsSecure() throws URIException {
+    void shouldNotRaiseAlertIfResponseFormIsSecure() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody(
@@ -113,7 +113,7 @@ public class InsecureFormPostScanRuleUnitTest extends PassiveScannerTest<Insecur
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseFormIsInsecure() throws URIException {
+    void shouldRaiseAlertIfResponseFormIsInsecure() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody(

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
@@ -39,7 +39,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link LinkTargetScanRule}. */
-public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> {
+class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> {
 
     private static final String HTML_CONTENT_TYPE = "text/html;charset=ISO-8859-1";
     private static final String TEXT_CONTENT_TYPE = "text/plain; charset=us-ascii";
@@ -51,7 +51,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     Session session;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(session.getContextsForUrl(anyString())).thenReturn(Collections.emptyList());
         when(model.getSession()).thenReturn(session);
         rule.setModel(model);
@@ -75,7 +75,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenNoLinks() throws HttpMalformedHeaderException {
+    void dontRaiseIssueWhenNoLinks() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -88,7 +88,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkNoTarget() throws HttpMalformedHeaderException {
+    void dontRaiseIssueWhenOneLinkNoTarget() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -101,8 +101,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkWithBlankTargetSameDomain()
-            throws HttpMalformedHeaderException {
+    void dontRaiseIssueWhenOneLinkWithBlankTargetSameDomain() throws HttpMalformedHeaderException {
         // Given
         Context context1 = new Context(session, 0);
         context1.addIncludeInContextRegex("https://www.example.com.*");
@@ -120,7 +119,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkWithBlankTargetTrustedDomain()
+    void dontRaiseIssueWhenOneLinkWithBlankTargetTrustedDomain()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -138,8 +137,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void raiseIssueWhenOneLinkWithBlankTargetUntrustedDomain()
-            throws HttpMalformedHeaderException {
+    void raiseIssueWhenOneLinkWithBlankTargetUntrustedDomain() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -159,8 +157,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void raiseIssueWhenOneLinkWithBlankTargetDifferentDomain()
-            throws HttpMalformedHeaderException {
+    void raiseIssueWhenOneLinkWithBlankTargetDifferentDomain() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -177,7 +174,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void raiseIssueWhenOneLinkWithOtherTarget() throws HttpMalformedHeaderException {
+    void raiseIssueWhenOneLinkWithOtherTarget() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -194,7 +191,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkWithOtherTargetHighThreshold()
+    void dontRaiseIssueWhenOneLinkWithOtherTargetHighThreshold()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -210,8 +207,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void raiseIssueWhenAreaWithBlankTargetDifferentDomain()
-            throws HttpMalformedHeaderException {
+    void raiseIssueWhenAreaWithBlankTargetDifferentDomain() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -235,7 +231,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenAreaWithOtherTarget() throws HttpMalformedHeaderException {
+    void dontRaiseIssueWhenAreaWithOtherTarget() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -254,7 +250,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenManyLinksWithBlankTargetSameDomain()
+    void dontRaiseIssueWhenManyLinksWithBlankTargetSameDomain()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -276,7 +272,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void raiseIssueWhenManyLinksWithBlankTargetDifferentDomain()
+    void raiseIssueWhenManyLinksWithBlankTargetDifferentDomain()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -301,7 +297,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkWithBlankTargetNoopenerNoReferrer()
+    void dontRaiseIssueWhenOneLinkWithBlankTargetNoopenerNoReferrer()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -316,7 +312,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkWithBlankTargetNoreferrerNoopener()
+    void dontRaiseIssueWhenOneLinkWithBlankTargetNoreferrerNoopener()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -331,7 +327,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenManyLinksWithOneBlankTargetSameDomain()
+    void dontRaiseIssueWhenManyLinksWithOneBlankTargetSameDomain()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -353,7 +349,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void raiseIssueWhenManyLinksWithOneBlankTargetDifferentDomain()
+    void raiseIssueWhenManyLinksWithOneBlankTargetDifferentDomain()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -378,8 +374,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkWithBlankTargetNonHtml()
-            throws HttpMalformedHeaderException {
+    void dontRaiseIssueWhenOneLinkWithBlankTargetNonHtml() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -393,8 +388,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void dontRaiseIssueWhenOneLinkWithBlankTargetInContext()
-            throws HttpMalformedHeaderException {
+    void dontRaiseIssueWhenOneLinkWithBlankTargetInContext() throws HttpMalformedHeaderException {
         // Given
         Context context = new Context(session, 0);
         context.addIncludeInContextRegex("https://www.example.com/.*");
@@ -412,8 +406,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void raiseIssueWhenOneLinkWithBlankTargetNotInContext()
-            throws HttpMalformedHeaderException {
+    void raiseIssueWhenOneLinkWithBlankTargetNotInContext() throws HttpMalformedHeaderException {
         // Given
         Context context = new Context(session, 0);
         context.addIncludeInContextRegex("https://www.example.com/.*");
@@ -434,7 +427,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void shouldNotFailIfLinkOrAreaDoesNotHaveHref() throws Exception {
+    void shouldNotFailIfLinkOrAreaDoesNotHaveHref() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -445,7 +438,7 @@ public class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetSca
     }
 
     @Test
-    public void shouldNotFailIfInvalidRegex() throws Exception {
+    void shouldNotFailIfInvalidRegex() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRuleUnitTest.java
@@ -30,8 +30,7 @@ import org.parosproxy.paros.network.HttpMessage;
  *
  * @see ModernAppDetectionScanRule
  */
-public class ModernAppDetectionScanRuleUnitTest
-        extends PassiveScannerTest<ModernAppDetectionScanRule> {
+class ModernAppDetectionScanRuleUnitTest extends PassiveScannerTest<ModernAppDetectionScanRule> {
 
     @Override
     protected ModernAppDetectionScanRule createScanner() {
@@ -39,7 +38,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWithBasicHtml() throws Exception {
+    void shouldNotRaiseAlertWithBasicHtml() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -52,7 +51,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithHashHref() throws Exception {
+    void shouldRaiseAlertWithHashHref() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -65,7 +64,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertWithFragmentHref() throws Exception {
+    void shouldNotRaiseAlertWithFragmentHref() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -77,7 +76,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithSelfTarget() throws Exception {
+    void shouldRaiseAlertWithSelfTarget() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -93,7 +92,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithEmptyHref() throws Exception {
+    void shouldRaiseAlertWithEmptyHref() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -106,7 +105,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithScriptsInBodyButNoLinks() throws Exception {
+    void shouldRaiseAlertWithScriptsInBodyButNoLinks() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -120,7 +119,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithScriptsInHeadButNoLinks() throws Exception {
+    void shouldRaiseAlertWithScriptsInHeadButNoLinks() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -134,7 +133,7 @@ public class ModernAppDetectionScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertWithNoScript() throws Exception {
+    void shouldRaiseAlertWithNoScript() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PassiveScannerTest.java
@@ -22,7 +22,7 @@ package org.zaproxy.zap.extension.pscanrulesBeta;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-public abstract class PassiveScannerTest<T extends PluginPassiveScanner>
+abstract class PassiveScannerTest<T extends PluginPassiveScanner>
         extends PassiveScannerTestUtils<T> {
 
     @Override

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRuleUnitTest.java
@@ -37,7 +37,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 
 /** Unit test for {@link PiiScanRule}. */
-public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
+class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
 
     @Override
     protected PiiScanRule createScanner() {
@@ -60,7 +60,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("cardData")
-    public void shouldRaiseAlertWhenCreditCardIsDetected(String cardName, String cardNumber)
+    void shouldRaiseAlertWhenCreditCardIsDetected(String cardName, String cardNumber)
             throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
@@ -78,8 +78,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotFailWithStackOverflowErrorWhenScanningResponseWithManyNumbers()
-            throws Exception {
+    void shouldNotFailWithStackOverflowErrorWhenScanningResponseWithManyNumbers() throws Exception {
         // Given
         HttpMessage msg = new HttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
@@ -89,7 +88,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertWhenNumberDoesntHaveWordBoundaries() throws Exception {
+    void shouldNotRaiseAlertWhenNumberDoesntHaveWordBoundaries() throws Exception {
         // Given
         String cardNumber = "8.46786664623715e-47";
         HttpMessage msg = createMsg(cardNumber);
@@ -100,7 +99,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertInLeadingLongExponentNumbers() throws Exception {
+    void shouldNotRaiseAlertInLeadingLongExponentNumbers() throws Exception {
         // Given
         String content =
                 "2.14111111111111111e-2"; // Visa - Extra digit before card number (after decimal)
@@ -112,7 +111,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertInTrailingLongNegativeExponentNumbers() throws Exception {
+    void shouldNotRaiseAlertInTrailingLongNegativeExponentNumbers() throws Exception {
         // Given
         String content = "2.41111111111111111e-2"; // Visa - Extra digit before e
         HttpMessage msg = createMsg(content);
@@ -123,7 +122,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertInTrailingLongPositiveExponentNumbers() throws Exception {
+    void shouldNotRaiseAlertInTrailingLongPositiveExponentNumbers() throws Exception {
         // Given
         String content = "2.41111111111111111e2"; // Visa - Extra digit before e
         HttpMessage msg = createMsg(content);
@@ -134,7 +133,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertInPositiveExponentNumbers() throws Exception {
+    void shouldNotRaiseAlertInPositiveExponentNumbers() throws Exception {
         // Given
         String content = "2.4111111111111111e2"; // Visa - Valid ahead of exponent
         HttpMessage msg = createMsg(content);
@@ -145,7 +144,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertInPlausiblePeriodDelimitedContent() throws Exception {
+    void shouldRaiseAlertInPlausiblePeriodDelimitedContent() throws Exception {
         // Given
         String content = "1121.4111111111111111.John Smith.808"; // Visa
         HttpMessage msg = createMsg(content);
@@ -156,7 +155,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertOnCssRequest() throws Exception {
+    void shouldNotRaiseAlertOnCssRequest() throws Exception {
         // Given
         String content = "margin-left:85.36370249136206%";
         HttpMessage msg = createMsg("");
@@ -174,7 +173,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertOnCssResponse() throws Exception {
+    void shouldNotRaiseAlertOnCssResponse() throws Exception {
         // Given
         String content = "margin-left:85.36370249136206%";
         HttpMessage msg = createMsg("");
@@ -193,7 +192,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldNotRaiseAlertOnResponseContainingCcLikeStyleAttribute() throws Exception {
+    void shouldNotRaiseAlertOnResponseContainingCcLikeStyleAttribute() throws Exception {
         // Given
         String content = "margin-left:85.36370249136206%";
         HttpMessage msg = createMsg("");
@@ -205,7 +204,7 @@ public class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertOnResponseContainingCcStringInAdditionToCcLikeStyleAttribute()
+    void shouldRaiseAlertOnResponseContainingCcStringInAdditionToCcLikeStyleAttribute()
             throws Exception {
         // Given
         String content = "margin-left:85.36370249136206%";

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRuleUnitTest.java
@@ -28,8 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class RetrievedFromCacheScanRuleUnitTest
-        extends PassiveScannerTest<RetrievedFromCacheScanRule> {
+class RetrievedFromCacheScanRuleUnitTest extends PassiveScannerTest<RetrievedFromCacheScanRule> {
 
     private static final String X_CACHE = "X-Cache";
     private static final String AGE = "Age";
@@ -49,7 +48,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void scannerNameShouldMatch() {
+    void scannerNameShouldMatch() {
         // Quick test to verify scan rule name which is used in the policy dialog but not
         // alerts
 
@@ -60,7 +59,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+    void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         // When
@@ -70,7 +69,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfXCacheWasMiss() throws URIException {
+    void shouldNotRaiseAlertIfXCacheWasMiss() throws URIException {
         // Given
         String xCacheValue = "MISS";
         HttpMessage msg = createMessage();
@@ -82,7 +81,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfXCacheWasEmpty() throws URIException {
+    void shouldNotRaiseAlertIfXCacheWasEmpty() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(X_CACHE, "");
@@ -93,7 +92,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfXCacheWasHit() throws URIException {
+    void shouldRaiseAlertIfXCacheWasHit() throws URIException {
         // Given
         String xCacheValue = "HIT";
         HttpMessage msg = createMessage();
@@ -106,7 +105,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfXCacheWasHitWithServerDetails() throws URIException {
+    void shouldRaiseAlertIfXCacheWasHitWithServerDetails() throws URIException {
         // Given
         String xCacheValue = "HIT from cache.kolich.local";
         HttpMessage msg = createMessage();
@@ -119,7 +118,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfXCacheWasHitWithMultipleServerDetails() throws URIException {
+    void shouldRaiseAlertIfXCacheWasHitWithMultipleServerDetails() throws URIException {
         // Given
         String xCacheValue = "HIT from proxy.domain.tld, MISS from proxy.local";
         HttpMessage msg = createMessage();
@@ -132,7 +131,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfAgeWasEmpty() throws URIException {
+    void shouldNotRaiseAlertIfAgeWasEmpty() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(AGE, "");
@@ -143,7 +142,7 @@ public class RetrievedFromCacheScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfAgePresentWithValue() throws URIException {
+    void shouldRaiseAlertIfAgePresentWithValue() throws URIException {
         // Given
         String ageValue = "24";
         HttpMessage msg = createMessage();

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRuleUnitTest.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class ServerHeaderInfoLeakScanRuleUnitTest
+class ServerHeaderInfoLeakScanRuleUnitTest
         extends PassiveScannerTest<ServerHeaderInfoLeakScanRule> {
 
     private static final String SERVER = "Server";
@@ -50,7 +50,7 @@ public class ServerHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void scannerNameShouldMatch() {
+    void scannerNameShouldMatch() {
         // Quick test to verify scan rule name which is used in the policy dialog but not
         // alerts
 
@@ -61,7 +61,7 @@ public class ServerHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+    void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         // When
@@ -71,7 +71,7 @@ public class ServerHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasRelevantHeader() throws URIException {
+    void shouldRaiseAlertIfResponseHasRelevantHeader() throws URIException {
         // Given
         String apacheHeader = "Apache/2.4.1 (Unix)";
         HttpMessage msg = createMessage();
@@ -84,7 +84,7 @@ public class ServerHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasRelevantContentButNoVersion() throws URIException {
+    void shouldNotRaiseAlertIfResponseHasRelevantContentButNoVersion() throws URIException {
         // Given - Default threshold (MEDIUM)
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(SERVER, "Apache");
@@ -95,7 +95,7 @@ public class ServerHeaderInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfThresholdLowResponseHasRelevantContentButNoVersion()
+    void shouldRaiseAlertIfThresholdLowResponseHasRelevantContentButNoVersion()
             throws URIException {
         // Given
         String bareApacheHeader = "Apache";

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
-public class ServletParameterPollutionScanRuleUnitTest
+class ServletParameterPollutionScanRuleUnitTest
         extends PassiveScannerTest<ServletParameterPollutionScanRule> {
 
     public static final String URI = "http://www.example.com/test/";
@@ -43,13 +43,13 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @BeforeEach
-    public void before() {
+    void before() {
         rule.setAlertThreshold(AlertThreshold.LOW);
         when(passiveScanData.getTechSet()).thenReturn(TechSet.getAllTech());
     }
 
     @Test
-    public void givenNoFormsWhenScanHttpResponseReceiveThenNoAlertsRaised() throws Exception {
+    void givenNoFormsWhenScanHttpResponseReceiveThenNoAlertsRaised() throws Exception {
         // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("");
         // When
@@ -59,7 +59,7 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void givenFormWithActionAttributeWhenScanHttpResponseReceiveThenNoAlertsRaised()
+    void givenFormWithActionAttributeWhenScanHttpResponseReceiveThenNoAlertsRaised()
             throws Exception {
         // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action='ActionMan'>");
@@ -70,9 +70,8 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void
-            givenFormWithNoActionAttributeWhenScanHttpResponseReceiveThenAlertRaisedAndAlertPopulated()
-                    throws Exception {
+    void givenFormWithNoActionAttributeWhenScanHttpResponseReceiveThenAlertRaisedAndAlertPopulated()
+            throws Exception {
         // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form />");
         // When
@@ -86,7 +85,7 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void
+    void
             givenFormWithNoActionAttributeWhenScanHttpResponseReceiveThenAtMediumThresholdThenNoAlertRaised()
                     throws Exception {
         // Given
@@ -99,7 +98,7 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void
+    void
             givenFormWithNoActionAttributeWhenScanHttpResponseReceiveThenAtHighThresholdThenNoAlertRaised()
                     throws Exception {
         // Given
@@ -112,7 +111,7 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void
+    void
             givenFormWithNoActionAttributeWhenScanHttpResponseReceiveWithTechNotRelevantThenNoAlertRaised()
                     throws Exception {
         // Given
@@ -125,9 +124,8 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void
-            givenFormWithNoActionAttributeWhenScanHttpResponseReceiveWithTechRelevantThenAlertRaised()
-                    throws Exception {
+    void givenFormWithNoActionAttributeWhenScanHttpResponseReceiveWithTechRelevantThenAlertRaised()
+            throws Exception {
         // Given
         HttpMessage msg = createHttpMessageFromHtml("<form />");
         when(passiveScanData.getTechSet()).thenReturn(new TechSet(new Tech[] {Tech.JSP_SERVLET}));
@@ -138,7 +136,7 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void givenFormWithValuelessActionAttributeWhenScanHttpResponseReceiveThenAlertRaised()
+    void givenFormWithValuelessActionAttributeWhenScanHttpResponseReceiveThenAlertRaised()
             throws Exception {
         // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action />");
@@ -149,7 +147,7 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void givenFormWithEmptyActionAttributeWhenScanHttpResponseReceiveThenAlertRaised()
+    void givenFormWithEmptyActionAttributeWhenScanHttpResponseReceiveThenAlertRaised()
             throws Exception {
         // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action='' />");
@@ -160,9 +158,8 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void
-            givenFormWithEmptyAndPopulatedActionAttributesWhenScanHttpResponseReceiveThenAlertRaised()
-                    throws Exception {
+    void givenFormWithEmptyAndPopulatedActionAttributesWhenScanHttpResponseReceiveThenAlertRaised()
+            throws Exception {
         // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form action action='ActionMan' />");
         // When
@@ -172,9 +169,8 @@ public class ServletParameterPollutionScanRuleUnitTest
     }
 
     @Test
-    public void
-            givenTwoFormsWithNoActionAttributeWhenScanHttpResponseReceiveThenOnlyOneAlertRaised()
-                    throws Exception {
+    void givenTwoFormsWithNoActionAttributeWhenScanHttpResponseReceiveThenOnlyOneAlertRaised()
+            throws Exception {
         // Given - Threshold set LOW in before()
         HttpMessage msg = createHttpMessageFromHtml("<form /><form />");
         // When

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRuleUnitTest.java
@@ -30,7 +30,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class StrictTransportSecurityScanRuleUnitTest
+class StrictTransportSecurityScanRuleUnitTest
         extends PassiveScannerTest<StrictTransportSecurityScanRule> {
 
     private static final String STS_HEADER = "Strict-Transport-Security";
@@ -52,7 +52,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void scannerNameShouldMatch() {
+    void scannerNameShouldMatch() {
         // Quick test to verify scan rule name which is used in the policy dialog but not
         // alerts
 
@@ -63,7 +63,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponsIsNotHttps() throws URIException {
+    void shouldNotRaiseAlertIfResponsIsNotHttps() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setSecure(false);
@@ -74,7 +74,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseMissingHeader() throws URIException {
+    void shouldRaiseAlertIfResponseMissingHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         // When
@@ -86,7 +86,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasWelformedHeaderAndValue() throws URIException {
+    void shouldNotRaiseAlertIfResponseHasWelformedHeaderAndValue() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(STS_HEADER, SHORT_VALUE);
@@ -97,7 +97,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasMultipleHeaders() throws URIException {
+    void shouldRaiseAlertIfResponseHasMultipleHeaders() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(STS_HEADER, SHORT_VALUE);
@@ -113,7 +113,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasStsDisablingHeader() throws URIException {
+    void shouldRaiseAlertIfResponseHasStsDisablingHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(STS_HEADER, "max-age=0");
@@ -125,7 +125,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasStsHeaderWithBlankValue() throws URIException {
+    void shouldRaiseAlertIfResponseHasStsHeaderWithBlankValue() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(STS_HEADER, "");
@@ -139,7 +139,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfHeaderValueHasJunkContent() throws URIException {
+    void shouldRaiseAlertIfHeaderValueHasJunkContent() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(STS_HEADER, SHORT_VALUE + "”"); // Append curly quote
@@ -153,7 +153,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfHeaderValueHasImproperQuotes() throws URIException {
+    void shouldRaiseAlertIfHeaderValueHasImproperQuotes() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(STS_HEADER, "\"max-age=84600\""); // Quotes before max
@@ -167,7 +167,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfThresholdLowNonSecureResponseWithHeader() throws URIException {
+    void shouldRaiseAlertIfThresholdLowNonSecureResponseWithHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setSecure(false);
@@ -183,7 +183,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThresholdLowNonSecureResponseNoHeader() throws URIException {
+    void shouldNotRaiseAlertIfThresholdLowNonSecureResponseNoHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setSecure(false);
@@ -195,7 +195,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseContainsStsHeaderAndMeta() throws URIException {
+    void shouldRaiseAlertIfResponseContainsStsHeaderAndMeta() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(STS_HEADER, HEADER_VALUE);
@@ -211,7 +211,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThresholdNotLowRedirectSameDomain() throws URIException {
+    void shouldNotRaiseAlertIfThresholdNotLowRedirectSameDomain() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(301);
@@ -223,7 +223,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfThresholdLowRedirectSameDomain() throws URIException {
+    void shouldRaiseAlertIfThresholdLowRedirectSameDomain() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(301);
@@ -238,7 +238,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfThresholdNotLowRedirectRelativePath() throws URIException {
+    void shouldNotRaiseAlertIfThresholdNotLowRedirectRelativePath() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(301);
@@ -250,7 +250,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfThresholdLowRedirectRelativePath() throws URIException {
+    void shouldRaiseAlertIfThresholdLowRedirectRelativePath() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(301);
@@ -265,7 +265,7 @@ public class StrictTransportSecurityScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfThresholdNotLowRedirectCrossDomain() throws URIException {
+    void shouldRaiseAlertIfThresholdNotLowRedirectCrossDomain() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(301);

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class UserControlledCharsetScanRuleUnitTest
+class UserControlledCharsetScanRuleUnitTest
         extends PassiveScannerTest<UserControlledCharsetScanRule> {
 
     @Override
@@ -58,7 +58,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
+    void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
@@ -70,7 +70,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+    void shouldNotRaiseAlertIfRequestHasNoGetParams() {
         // Given
         HttpMessage msg = createMessage();
         given(passiveScanData.isPage200(any())).willReturn(true);
@@ -81,7 +81,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotHtmlNorXml() {
+    void shouldNotRaiseAlertIfResponseIsNotHtmlNorXml() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
@@ -93,7 +93,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
@@ -105,7 +105,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseCharsetIsEmpty() throws Exception {
+    void shouldNotRaiseAlertIfResponseCharsetIsEmpty() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
@@ -118,7 +118,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamsAppearAsCharsetValue() throws Exception {
+    void shouldRaiseAlertIfRequestParamsAppearAsCharsetValue() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
@@ -133,7 +133,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseMetaCharsetIsEmpty() throws Exception {
+    void shouldNotRaiseAlertIfResponseMetaCharsetIsEmpty() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
@@ -147,7 +147,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseMetaIsNotContentType() throws Exception {
+    void shouldNotRaiseAlertIfResponseMetaIsNotContentType() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
@@ -160,7 +160,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamAppearAsMetaCharsetValue() throws Exception {
+    void shouldRaiseAlertIfRequestParamAppearAsMetaCharsetValue() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
@@ -175,7 +175,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfXmlResponseCharsetIsEmpty() throws Exception {
+    void shouldNotRaiseAlertIfXmlResponseCharsetIsEmpty() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));
@@ -189,7 +189,7 @@ public class UserControlledCharsetScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamsAppearAsXmlCharsetValue() throws Exception {
+    void shouldRaiseAlertIfRequestParamsAppearAsXmlCharsetValue() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?cs=utf-8", false));

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class UserControlledCookieScanRuleUnitTest
+class UserControlledCookieScanRuleUnitTest
         extends PassiveScannerTest<UserControlledCookieScanRule> {
 
     @Override
@@ -57,7 +57,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseDoesntSetCookie() {
+    void shouldNotRaiseAlertIfResponseDoesntSetCookie() {
         // Given
         HttpMessage msg = createMessage();
         // When
@@ -67,7 +67,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+    void shouldNotRaiseAlertIfRequestHasNoGetParams() {
         // Given
         HttpMessage msg = createMessage();
         // WHen
@@ -77,7 +77,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasCookiesButRequestHasNoParams() {
+    void shouldNotRaiseAlertIfResponseHasCookiesButRequestHasNoParams() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader()
@@ -89,7 +89,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
@@ -102,7 +102,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfCookieHasNoValue() throws Exception {
+    void shouldNotRaiseAlertIfCookieHasNoValue() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
@@ -115,7 +115,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfCookieIsEmpty() throws Exception {
+    void shouldNotRaiseAlertIfCookieIsEmpty() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
@@ -127,7 +127,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamsAppearAsCookieValue() throws Exception {
+    void shouldRaiseAlertIfRequestParamsAppearAsCookieValue() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
@@ -141,7 +141,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamsAppearWithinCookieValue() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamsAppearWithinCookieValue() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=fred", false));
@@ -154,7 +154,7 @@ public class UserControlledCookieScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfCookieBasedOnGetParamDuringPost() throws Exception {
+    void shouldRaiseAlertIfCookieBasedOnGetParamDuringPost() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=evil", false));

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRuleUnitTest.java
@@ -33,7 +33,7 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class UserControlledHTMLAttributesScanRuleUnitTest
+class UserControlledHTMLAttributesScanRuleUnitTest
         extends PassiveScannerTest<UserControlledHTMLAttributesScanRule> {
 
     @Override
@@ -58,7 +58,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
+    void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
@@ -70,7 +70,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotHtml() {
+    void shouldNotRaiseAlertIfResponseIsNotHtml() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
@@ -82,7 +82,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasNoContentType() {
+    void shouldNotRaiseAlertIfResponseHasNoContentType() {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseHeader(new HttpResponseHeader());
@@ -95,7 +95,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+    void shouldNotRaiseAlertIfRequestHasNoGetParams() {
         // Given
         HttpMessage msg = createMessage();
         given(passiveScanData.isPage200(any())).willReturn(true);
@@ -106,7 +106,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
@@ -118,7 +118,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseContainsNoAttributes() throws Exception {
+    void shouldNotRaiseAlertIfResponseContainsNoAttributes() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -132,7 +132,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInAttribute() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamValuesNotUsedInAttribute() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -146,7 +146,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInMetaAttribute() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamValuesNotUsedInMetaAttribute() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -161,7 +161,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamValuesUsedInMetaAttribute() throws Exception {
+    void shouldRaiseAlertIfRequestParamValuesUsedInMetaAttribute() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -176,7 +176,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInMetaRefresh() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamValuesNotUsedInMetaRefresh() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -191,7 +191,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamValuesUsedInMetaRefresh() throws Exception {
+    void shouldRaiseAlertIfRequestParamValuesUsedInMetaRefresh() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -207,7 +207,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseMultipleAlertsIfRequestParamValuesUsedInAttributes() throws Exception {
+    void shouldRaiseMultipleAlertsIfRequestParamValuesUsedInAttributes() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -227,7 +227,7 @@ public class UserControlledHTMLAttributesScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamsValuesUsedInAttributes() throws Exception {
+    void shouldRaiseAlertIfRequestParamsValuesUsedInAttributes() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class UserControlledJavascriptEventScanRuleUnitTest
+class UserControlledJavascriptEventScanRuleUnitTest
         extends PassiveScannerTest<UserControlledJavascriptEventScanRule> {
 
     @Override
@@ -57,7 +57,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
+    void shouldNotRaiseAlertIfResponseIsNotStatusOk() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.NOT_ACCEPTABLE);
@@ -69,7 +69,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotHtml() {
+    void shouldNotRaiseAlertIfResponseIsNotHtml() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, "application/json");
@@ -81,7 +81,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponsehasNoContentType() {
+    void shouldNotRaiseAlertIfResponsehasNoContentType() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader()
@@ -94,7 +94,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestHasNoGetParams() {
+    void shouldNotRaiseAlertIfRequestHasNoGetParams() {
         // Given
         HttpMessage msg = createMessage();
         given(passiveScanData.isPage200(any())).willReturn(true);
@@ -105,7 +105,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamsHaveNoValues() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://example.com/i.php?place=&name=", false));
@@ -117,7 +117,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfRequestParamValuesNotUsedInJsEvent() throws Exception {
+    void shouldNotRaiseAlertIfRequestParamValuesNotUsedInJsEvent() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -131,7 +131,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasUnknownJsEvent() throws Exception {
+    void shouldNotRaiseAlertIfResponseHasUnknownJsEvent() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()
@@ -145,7 +145,7 @@ public class UserControlledJavascriptEventScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfRequestParamValuesUsedInJsEvent() throws Exception {
+    void shouldRaiseAlertIfRequestParamValuesUsedInJsEvent() throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader()

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRuleUnitTest.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
 
-public class UserControlledOpenRedirectScanRuleUnitTest
+class UserControlledOpenRedirectScanRuleUnitTest
         extends PassiveScannerTest<UserControlledOpenRedirectScanRule> {
 
     @Override
@@ -55,7 +55,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsNotRedirect() {
+    void shouldNotRaiseAlertIfResponseIsNotRedirect() {
         // Given
         HttpMessage msg = createMessage();
         // When
@@ -65,7 +65,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsRedirectButHasNoLocationHeader() {
+    void shouldNotRaiseAlertIfResponseIsRedirectButHasNoLocationHeader() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
@@ -76,7 +76,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsRedirectHasEmptyLocationHeader() {
+    void shouldNotRaiseAlertIfResponseIsRedirectHasEmptyLocationHeader() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
@@ -91,7 +91,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderNoParam() {
+    void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderNoParam() {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().setStatusCode(HttpStatusCode.MOVED_PERMANENTLY);
@@ -103,7 +103,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderEmptyParam() {
+    void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderEmptyParam() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
@@ -118,7 +118,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderIrrelevantParam() {
+    void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderIrrelevantParam() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
@@ -133,7 +133,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseIsRedirectHasLocationHeaderBasedOnParam() {
+    void shouldRaiseAlertIfResponseIsRedirectHasLocationHeaderBasedOnParam() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
@@ -149,7 +149,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseIsTempRedirectHasLocationHeaderBasedOnParam() {
+    void shouldRaiseAlertIfResponseIsTempRedirectHasLocationHeaderBasedOnParam() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
@@ -165,7 +165,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseIsTempRedirectHasLocationHeaderBasedOnGetParamDuringPost()
+    void shouldRaiseAlertIfResponseIsTempRedirectHasLocationHeaderBasedOnGetParamDuringPost()
             throws Exception {
         // Given
         HttpMessage msg = createMessage();
@@ -184,9 +184,8 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void
-            shouldNotRaiseAlertIfLocationHeaderIsBasedOnGetParamButValueIsSameAsOriginDuringPost()
-                    throws Exception {
+    void shouldNotRaiseAlertIfLocationHeaderIsBasedOnGetParamButValueIsSameAsOriginDuringPost()
+            throws Exception {
         // Given
         HttpMessage msg = createMessage();
         msg.getRequestHeader().setURI(new URI("http://evil.com/i.php?place=evil.com", false));
@@ -203,8 +202,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void
-            shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderBasedOnParamButSameAsOrigin() {
+    void shouldNotRaiseAlertIfResponseIsRedirectHasLocationHeaderBasedOnParamButSameAsOrigin() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
@@ -219,8 +217,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void
-            shouldNotRaiseAlertIfResponseIsRedirectAndParamIsOnlyMatchingProtocolOfLocationHeader() {
+    void shouldNotRaiseAlertIfResponseIsRedirectAndParamIsOnlyMatchingProtocolOfLocationHeader() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();
@@ -235,7 +232,7 @@ public class UserControlledOpenRedirectScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseIsRedirectHasRelativeLocationHeader() {
+    void shouldNotRaiseAlertIfResponseIsRedirectHasRelativeLocationHeader() {
         // Given
         HttpMessage msg = createMessage();
         TreeSet<HtmlParameter> params = new TreeSet<HtmlParameter>();

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRuleUnitTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class XBackendServerInformationLeakScanRuleUnitTest
+class XBackendServerInformationLeakScanRuleUnitTest
         extends PassiveScannerTest<XBackendServerInformationLeakScanRule> {
 
     private static final String XBS_HEADER = "X-Backend-Server";
@@ -49,7 +49,7 @@ public class XBackendServerInformationLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+    void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         // When
@@ -59,7 +59,7 @@ public class XBackendServerInformationLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasRelevantContent() throws URIException {
+    void shouldRaiseAlertIfResponseHasRelevantContent() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(XBS_HEADER, HEADER_VALUE);

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRuleUnitTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-public class XChromeLoggerDataInfoLeakScanRuleUnitTest
+class XChromeLoggerDataInfoLeakScanRuleUnitTest
         extends PassiveScannerTest<XChromeLoggerDataInfoLeakScanRule> {
 
     private static final String XCLD = "X-ChromeLogger-Data";
@@ -62,7 +62,7 @@ public class XChromeLoggerDataInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
+    void shouldNotRaiseAlertIfResponseHasNoRelevantHeader() throws URIException {
         // Given
         HttpMessage msg = createMessage();
         msg.setResponseBody("Some text <h1>Some Title Element</h1>");
@@ -73,7 +73,7 @@ public class XChromeLoggerDataInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasRelevantHeader() throws IOException {
+    void shouldRaiseAlertIfResponseHasRelevantHeader() throws IOException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(XCLD, XCLD_VALUE);
@@ -90,7 +90,7 @@ public class XChromeLoggerDataInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasAlternateRelevantHeader() throws IOException {
+    void shouldRaiseAlertIfResponseHasAlternateRelevantHeader() throws IOException {
         // Given
         HttpMessage msg = createMessage();
         msg.getResponseHeader().addHeader(XCPD, XCLD_VALUE);
@@ -107,7 +107,7 @@ public class XChromeLoggerDataInfoLeakScanRuleUnitTest
     }
 
     @Test
-    public void shouldRaiseAlertIfResponseHasAlternateRelevantHeaderEvenWithInvalidEncoding()
+    void shouldRaiseAlertIfResponseHasAlternateRelevantHeaderEvenWithInvalidEncoding()
             throws IOException {
         // Given
         HttpMessage msg = createMessage();

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ExtensionReplacerTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class ExtensionReplacerTest {
+class ExtensionReplacerTest {
 
     private static final String MATCHING_STRING_WITH_HEX_VALUE =
             new String(new byte[] {'a', 'b', 'c', 1, 3, 2, 'd', 'e', 'f'}, US_ASCII);
@@ -43,12 +43,12 @@ public class ExtensionReplacerTest {
     private HttpMessage msg;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         msg = new HttpMessage();
     }
 
     @Test
-    public void shouldAddHeaderByHexValueInRequest() throws HttpMalformedHeaderException {
+    void shouldAddHeaderByHexValueInRequest() throws HttpMalformedHeaderException {
         // Given
         ExtensionReplacer extensionReplacer = givenAHexByteReplacementRuleFor(REQ_HEADER);
 
@@ -64,7 +64,7 @@ public class ExtensionReplacerTest {
     }
 
     @Test
-    public void shouldReplaceHexValueInRequestHeader() throws HttpMalformedHeaderException {
+    void shouldReplaceHexValueInRequestHeader() throws HttpMalformedHeaderException {
         // Given
         ExtensionReplacer extensionReplacer = givenAHexByteReplacementRuleFor(REQ_HEADER_STR);
 
@@ -80,7 +80,7 @@ public class ExtensionReplacerTest {
     }
 
     @Test
-    public void shouldReplaceHexValueInRequestBody() throws HttpMalformedHeaderException {
+    void shouldReplaceHexValueInRequestBody() throws HttpMalformedHeaderException {
         // Given
         ExtensionReplacer extensionReplacer = givenAHexByteReplacementRuleFor(REQ_BODY_STR);
 
@@ -95,7 +95,7 @@ public class ExtensionReplacerTest {
     }
 
     @Test
-    public void shouldReplaceHeaderByHexValueInResponse() throws HttpMalformedHeaderException {
+    void shouldReplaceHeaderByHexValueInResponse() throws HttpMalformedHeaderException {
         // Given
         ExtensionReplacer extensionReplacer = givenAHexByteReplacementRuleFor(RESP_HEADER);
 
@@ -111,7 +111,7 @@ public class ExtensionReplacerTest {
     }
 
     @Test
-    public void shouldReplaceHexValueInResponseHeader() throws HttpMalformedHeaderException {
+    void shouldReplaceHexValueInResponseHeader() throws HttpMalformedHeaderException {
         // Given
         ExtensionReplacer extensionReplacer = givenAHexByteReplacementRuleFor(RESP_HEADER_STR);
 
@@ -127,7 +127,7 @@ public class ExtensionReplacerTest {
     }
 
     @Test
-    public void shouldReplaceHexValueInResponseBody() throws HttpMalformedHeaderException {
+    void shouldReplaceHexValueInResponseBody() throws HttpMalformedHeaderException {
         // Given
         ExtensionReplacer extensionReplacer = givenAHexByteReplacementRuleFor(RESP_BODY_STR);
 

--- a/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
+++ b/addOns/replacer/src/test/java/org/zaproxy/zap/extension/replacer/ReplacerParamRuleTest.java
@@ -26,10 +26,10 @@ import static org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType.REQ
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
-public class ReplacerParamRuleTest {
+class ReplacerParamRuleTest {
 
     @Test
-    public void shouldSubstituteHexValuesInReplacementString() {
+    void shouldSubstituteHexValuesInReplacementString() {
         // Given
         String replacement = "abc\\x01\\xaadef";
 
@@ -48,7 +48,7 @@ public class ReplacerParamRuleTest {
     }
 
     @Test
-    public void shouldSubstituteHexValuesInReplacementStringForNonRegexMatch() {
+    void shouldSubstituteHexValuesInReplacementStringForNonRegexMatch() {
         // Given
         String replacement = "abc\\x01\\xaadef";
 
@@ -67,7 +67,7 @@ public class ReplacerParamRuleTest {
     }
 
     @Test
-    public void shouldNotSubstituteHexValuesInReplacementStringGivenBackslashIsEscaped() {
+    void shouldNotSubstituteHexValuesInReplacementStringGivenBackslashIsEscaped() {
         // Given
         String replacement = "abc\\\\x01\\\\xaadef";
 
@@ -81,7 +81,7 @@ public class ReplacerParamRuleTest {
     }
 
     @Test
-    public void shouldNotSubstituteGivenHexValueIsNotHexadecimal() {
+    void shouldNotSubstituteGivenHexValueIsNotHexadecimal() {
         // Given
         String replacement = "\\xZZ";
 
@@ -95,7 +95,7 @@ public class ReplacerParamRuleTest {
     }
 
     @Test
-    public void shouldNotSubstituteGivenThereIsOnlyOneBackSlash() {
+    void shouldNotSubstituteGivenThereIsOnlyOneBackSlash() {
         // Given
         String replacement = "\\";
 
@@ -109,7 +109,7 @@ public class ReplacerParamRuleTest {
     }
 
     @Test
-    public void shouldNotSubstituteGivenThereIsOnlyBeginningOfHexValue() {
+    void shouldNotSubstituteGivenThereIsOnlyBeginningOfHexValue() {
         // Given
         String replacement = "\\x";
 

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -59,7 +59,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class ExtensionReportsUnitTest {
+class ExtensionReportsUnitTest {
 
     private static final String HTML_REPORT_ALERT_SUMMARY_SECTION = "alertcount";
     private static final String HTML_REPORT_INSTANCE_SUMMARY_SECTION = "instancecount";
@@ -76,7 +76,7 @@ public class ExtensionReportsUnitTest {
     private static final String HTML_REPORT_PASSING_RULES_SECTION_TITLE = "Passing Rules";
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -87,7 +87,7 @@ public class ExtensionReportsUnitTest {
     }
 
     @Test
-    public void shouldExtractExpectedParams() {
+    void shouldExtractExpectedParams() {
         // Given
         String pattern = ReportParam.DEFAULT_NAME_PATTERN;
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
@@ -101,7 +101,7 @@ public class ExtensionReportsUnitTest {
     }
 
     @Test
-    public void shouldIncludeRelevantContextUrls() {
+    void shouldIncludeRelevantContextUrls() {
         // Given
         Context context = new Context(null, 1);
         context.addIncludeInContextRegex("https://www.example.com.*");
@@ -133,7 +133,7 @@ public class ExtensionReportsUnitTest {
     }
 
     @Test
-    public void shouldExcludeRelevantContextUrls() {
+    void shouldExcludeRelevantContextUrls() {
         // Given
         Context context = new Context(null, 1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
@@ -165,7 +165,7 @@ public class ExtensionReportsUnitTest {
     }
 
     @Test
-    public void shouldIncludeRelevantSiteUrls() {
+    void shouldIncludeRelevantSiteUrls() {
         // Given
         String site1 = "https://www.example.com";
         String site2 = "https://www.example.com2";
@@ -197,7 +197,7 @@ public class ExtensionReportsUnitTest {
     }
 
     @Test
-    public void shouldExcludeRelevantSiteUrls() {
+    void shouldExcludeRelevantSiteUrls() {
         // Given
         String site1 = "https://www.example.com/";
         String site2 = "https://www.example.com2/";
@@ -229,7 +229,7 @@ public class ExtensionReportsUnitTest {
     }
 
     @Test
-    public void shouldIncludeRelevantContextAndSiteUrls() {
+    void shouldIncludeRelevantContextAndSiteUrls() {
         // Given
         Context context = new Context(null, 1);
         context.addIncludeInContextRegex("https://www.example.com.*");
@@ -265,7 +265,7 @@ public class ExtensionReportsUnitTest {
     }
 
     @Test
-    public void shouldExcludeRelevantContextAndSiteUrls() {
+    void shouldExcludeRelevantContextAndSiteUrls() {
         // Given
         Context context = new Context(null, 1);
         context.addIncludeInContextRegex("https://www.example.com/.*");
@@ -320,7 +320,7 @@ public class ExtensionReportsUnitTest {
                 "traditional-md",
                 "traditional-xml"
             })
-    public void shouldGenerateReport(String reportName) throws IOException, DocumentException {
+    void shouldGenerateReport(String reportName) throws IOException, DocumentException {
         // Given
         ExtensionReports extRep = new ExtensionReports();
         ReportData reportData = getTestReportData();
@@ -337,8 +337,7 @@ public class ExtensionReportsUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"traditional-html", "traditional-html-plus", "traditional-md"})
-    public void shouldIncludeAllSectionsInReport(String reportName)
-            throws IOException, DocumentException {
+    void shouldIncludeAllSectionsInReport(String reportName) throws IOException, DocumentException {
         // Given
         ExtensionReports extRep = new ExtensionReports();
         ReportData reportData = getTestReportData();
@@ -362,7 +361,7 @@ public class ExtensionReportsUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"traditional-html", "traditional-html-plus", "traditional-md"})
-    public void shouldIncludeAlertSummarySectionInReport(String reportName)
+    void shouldIncludeAlertSummarySectionInReport(String reportName)
             throws IOException, DocumentException {
         // Given
         ExtensionReports extRep = new ExtensionReports();
@@ -385,7 +384,7 @@ public class ExtensionReportsUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"traditional-html", "traditional-html-plus", "traditional-md"})
-    public void shouldIncludeInstanceSummarySectionInReport(String reportName)
+    void shouldIncludeInstanceSummarySectionInReport(String reportName)
             throws IOException, DocumentException {
         // Given
         ExtensionReports extRep = new ExtensionReports();
@@ -409,7 +408,7 @@ public class ExtensionReportsUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"traditional-html", "traditional-html-plus", "traditional-md"})
-    public void shouldIncludeAlertDetailsSectionInReport(String reportName)
+    void shouldIncludeAlertDetailsSectionInReport(String reportName)
             throws IOException, DocumentException {
         // Given
         ExtensionReports extRep = new ExtensionReports();
@@ -432,7 +431,7 @@ public class ExtensionReportsUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"traditional-html-plus"})
-    public void shouldIncludePassingRulesSectionInReport(String reportName)
+    void shouldIncludePassingRulesSectionInReport(String reportName)
             throws IOException, DocumentException {
         // Given
         ExtensionReports extRep = new ExtensionReports();
@@ -529,7 +528,7 @@ public class ExtensionReportsUnitTest {
                 "traditional-html",
                 "traditional-html-plus"
             })
-    public void shouldGenerateExpectedReport(String templateName)
+    void shouldGenerateExpectedReport(String templateName)
             throws IOException, DocumentException, SAXException, ParserConfigurationException {
         // Given
         File t = new File("src/main/zapHomeFiles/reports/" + templateName + "/template.yaml");

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportParamUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportParamUnitTest.java
@@ -38,24 +38,24 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.utils.I18N;
 
-public class ReportParamUnitTest {
+class ReportParamUnitTest {
 
     private ReportParam reportParam;
 
     @BeforeAll
-    public static void initModel() {
+    static void initModel() {
         Constant.messages = new I18N(Locale.ENGLISH);
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
         Model.setSingletonForTesting(model);
     }
 
     @BeforeEach
-    public void init() {
+    void init() {
         reportParam = new ReportParam();
     }
 
     @Test
-    public void shouldLoadDefaultParams() {
+    void shouldLoadDefaultParams() {
         // Given
         XMLConfiguration config = new XMLConfiguration();
 
@@ -76,7 +76,7 @@ public class ReportParamUnitTest {
     }
 
     @Test
-    public void shouldLoadExpectedParams() throws IOException {
+    void shouldLoadExpectedParams() throws IOException {
         // Given
         File tempDir = Files.createTempDirectory("Test").toFile();
         XMLConfiguration config = new XMLConfiguration();
@@ -102,7 +102,7 @@ public class ReportParamUnitTest {
     }
 
     @Test
-    public void shouldSetSpecifiedParams() {
+    void shouldSetSpecifiedParams() {
         // Given
         XMLConfiguration config = new XMLConfiguration();
 

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/PassiveScannerTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/PassiveScannerTest.java
@@ -22,8 +22,7 @@ package org.zaproxy.addon.retire;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-public abstract class PassiveScannerTest<T extends PassiveScanner>
-        extends PassiveScannerTestUtils<T> {
+abstract class PassiveScannerTest<T extends PassiveScanner> extends PassiveScannerTestUtils<T> {
 
     @Override
     protected void setUpMessages() {

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -20,7 +20,6 @@
 package org.zaproxy.addon.retire;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.any;
 
@@ -34,7 +33,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.retire.model.Repo;
 
-public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
+class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
 
     @Override
     protected RetireScanRule createScanner() {
@@ -48,7 +47,7 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
     }
 
     @Test
-    public void shouldIgnoreNon200OkMessages() {
+    void shouldIgnoreNon200OkMessages() {
         // Given
         HttpMessage msg =
                 createMessage("http://example.com/ajax/libs/angularjs/1.2.19/angular.min.js", null);
@@ -61,7 +60,7 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
     }
 
     @Test
-    public void shouldIgnoreCssUrl() {
+    void shouldIgnoreCssUrl() {
         // Given
         HttpMessage msg = createMessage("https://www.example.com/assets/styles.css", null);
         given(passiveScanData.isPage200(any())).willReturn(true);
@@ -72,7 +71,7 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
     }
 
     @Test
-    public void shouldIgnoreCssResponse() {
+    void shouldIgnoreCssResponse() {
         // Given
         HttpMessage msg = createMessage("https://www.example.com/assets/styles.scss", null);
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/css");
@@ -84,7 +83,7 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
     }
 
     @Test
-    public void shouldIgnoreImageResponse() {
+    void shouldIgnoreImageResponse() {
         // Given
         HttpMessage msg = createMessage("https://www.example.com/assets/image.gif", null);
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "image/gif");
@@ -96,7 +95,7 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
     }
 
     @Test
-    public void shouldRaiseAlertOnVulnerableUrl() {
+    void shouldRaiseAlertOnVulnerableUrl() {
         // Given
         HttpMessage msg =
                 createMessage("http://example.com/ajax/libs/angularjs/1.2.19/angular.min.js", null);
@@ -105,17 +104,14 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals("/1.2.19/angular.min.js"));
-        assertTrue(
-                alertsRaised
-                        .get(0)
-                        .getReference()
-                        .equals(
-                                "https://github.com/angular/angular.js/commit/8f31f1ff43b673a24f84422d5c13d6312b2c4d94\n"));
+        assertEquals("/1.2.19/angular.min.js", alertsRaised.get(0).getEvidence());
+        assertEquals(
+                "https://github.com/angular/angular.js/commit/8f31f1ff43b673a24f84422d5c13d6312b2c4d94\n",
+                alertsRaised.get(0).getReference());
     }
 
     @Test
-    public void shouldRaiseAlertOnVulnerableFilename() {
+    void shouldRaiseAlertOnVulnerableFilename() {
         // Given
         HttpMessage msg =
                 createMessage("http://example.com/CommonElements/js/jquery-3.1.1.min.js", null);
@@ -124,16 +120,14 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals("jquery-3.1.1.min.js"));
-        assertTrue(
-                alertsRaised
-                        .get(0)
-                        .getReference()
-                        .equals("https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/\n"));
+        assertEquals("jquery-3.1.1.min.js", alertsRaised.get(0).getEvidence());
+        assertEquals(
+                "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/\n",
+                alertsRaised.get(0).getReference());
     }
 
     @Test
-    public void shouldRaiseAlertOnVulnerableContent() {
+    void shouldRaiseAlertOnVulnerableContent() {
         // Given
         String content =
                 "/*!\n"
@@ -147,16 +141,14 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(alertsRaised.get(0).getEvidence().equals("* Bootstrap v3.3.7"));
-        assertTrue(
-                alertsRaised
-                        .get(0)
-                        .getReference()
-                        .equals("https://github.com/twbs/bootstrap/issues/20184\n"));
+        assertEquals("* Bootstrap v3.3.7", alertsRaised.get(0).getEvidence());
+        assertEquals(
+                "https://github.com/twbs/bootstrap/issues/20184\n",
+                alertsRaised.get(0).getReference());
     }
 
     @Test
-    public void shouldRaiseAlertOnHashOfVulnerableContent() {
+    void shouldRaiseAlertOnHashOfVulnerableContent() {
         // Given
         String content =
                 "/*!\n"
@@ -170,25 +162,19 @@ public class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertTrue(
-                alertsRaised
-                        .get(0)
-                        .getOtherInfo()
-                        .equals(
-                                "CVE-XXXX-XXX2\n"
-                                        + "CVE-XXXX-XXX1\n"
-                                        + "CVE-XXXX-XXX0\n"
-                                        + "The library matched the known vulnerable hash e19cea51d7542303f6e8949a0ae27dd3509ea566."));
-        assertTrue(
-                alertsRaised
-                        .get(0)
-                        .getReference()
-                        .equals(
-                                "http://example.com/hash-test-entry\nhttp://example.com/hash-test-entry2\n"));
+        assertEquals(
+                "CVE-XXXX-XXX2\n"
+                        + "CVE-XXXX-XXX1\n"
+                        + "CVE-XXXX-XXX0\n"
+                        + "The library matched the known vulnerable hash e19cea51d7542303f6e8949a0ae27dd3509ea566.",
+                alertsRaised.get(0).getOtherInfo());
+        assertEquals(
+                "http://example.com/hash-test-entry\nhttp://example.com/hash-test-entry2\n",
+                alertsRaised.get(0).getReference());
     }
 
     @Test
-    public void shouldNotRaiseAlertOnDontCheckUrl() {
+    void shouldNotRaiseAlertOnDontCheckUrl() {
         // Given
         HttpMessage msg = createMessage("https://www.google-analytics.com/ga.js", null);
         // When

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireUtilUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireUtilUnitTest.java
@@ -24,10 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-public class RetireUtilUnitTest {
+class RetireUtilUnitTest {
 
     @Test
-    public void versions_should_be_above() {
+    void versions_should_be_above() {
         assertTrue(RetireUtil.isAtOrAbove("0.0.1", "0.0.0"));
         assertTrue(RetireUtil.isAtOrAbove("0.1.0", "0.0.9"));
         assertTrue(RetireUtil.isAtOrAbove("0.10.1", "0.9.0"));
@@ -40,14 +40,14 @@ public class RetireUtilUnitTest {
     }
 
     @Test
-    public void versions_should_be_at() {
+    void versions_should_be_at() {
         assertTrue(RetireUtil.isAtOrAbove("0.0.1", "0.0.1"));
         assertTrue(RetireUtil.isAtOrAbove("0.1.1", "0.1.1"));
         assertTrue(RetireUtil.isAtOrAbove("0.1.0", "0.1"));
     }
 
     @Test
-    public void versions_should_not_be_above() {
+    void versions_should_not_be_above() {
         assertFalse(RetireUtil.isAtOrAbove("0.0.1", "0.0.2"));
         assertFalse(RetireUtil.isAtOrAbove("0.0.9", "0.0.10"));
         assertFalse(RetireUtil.isAtOrAbove("0.1.1", "0.1.2"));

--- a/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/BrowserUIUnitTest.java
+++ b/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/BrowserUIUnitTest.java
@@ -29,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link BrowserUI}. */
-public class BrowserUIUnitTest {
+class BrowserUIUnitTest {
 
     @Test
-    public void shouldThrowExceptionWhenCreatingBrowserUIWithNullName() {
+    void shouldThrowExceptionWhenCreatingBrowserUIWithNullName() {
         // Given
         String name = null;
         // When / Then
@@ -40,7 +40,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenCreatingBrowserUIWithEmptyName() {
+    void shouldThrowExceptionWhenCreatingBrowserUIWithEmptyName() {
         // Given
         String name = "";
         // When / Then
@@ -48,7 +48,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenCreatingBrowserUIWithNullBrowser() {
+    void shouldThrowExceptionWhenCreatingBrowserUIWithNullBrowser() {
         // Given
         Browser browser = null;
         // When / Then
@@ -56,7 +56,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldGetNamePassedInConstructor() {
+    void shouldGetNamePassedInConstructor() {
         // Given
         String name = "Some Name";
         BrowserUI browserUI = new BrowserUI(name, Browser.FIREFOX);
@@ -67,7 +67,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldGetBrowserPassedInConstructor() {
+    void shouldGetBrowserPassedInConstructor() {
         // Given
         Browser browser = Browser.FIREFOX;
         BrowserUI browserUI = new BrowserUI("Some Name", browser);
@@ -78,7 +78,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldReturnNameFromToString() {
+    void shouldReturnNameFromToString() {
         // Given
         String name = "Some Name";
         BrowserUI browserUI = new BrowserUI(name, Browser.FIREFOX);
@@ -89,7 +89,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldReturnPositiveNumberWhenComparingWithNull() {
+    void shouldReturnPositiveNumberWhenComparingWithNull() {
         // Given
         BrowserUI browserUI = new BrowserUI("Name A", Browser.FIREFOX);
         // When
@@ -99,7 +99,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldReturnNegativeNumberWhenComparingWithGreaterName() {
+    void shouldReturnNegativeNumberWhenComparingWithGreaterName() {
         // Given
         BrowserUI browserUI = new BrowserUI("Name A", Browser.FIREFOX);
         BrowserUI otherBrowserUI = new BrowserUI("Name B", Browser.FIREFOX);
@@ -110,7 +110,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldReturnPositiveNumberWhenComparingWithLesserName() {
+    void shouldReturnPositiveNumberWhenComparingWithLesserName() {
         // Given
         BrowserUI browserUI = new BrowserUI("Name B", Browser.FIREFOX);
         BrowserUI otherBrowserUI = new BrowserUI("Name A", Browser.FIREFOX);
@@ -121,7 +121,7 @@ public class BrowserUIUnitTest {
     }
 
     @Test
-    public void shouldReturnZeroWhenComparingWithSameName() {
+    void shouldReturnZeroWhenComparingWithSameName() {
         // Given
         BrowserUI browserUI = new BrowserUI("Name A", Browser.FIREFOX);
         BrowserUI otherBrowserUI = new BrowserUI("Name A", Browser.FIREFOX);

--- a/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/BrowserUnitTest.java
+++ b/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/BrowserUnitTest.java
@@ -27,10 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link Browser}. */
-public class BrowserUnitTest {
+class BrowserUnitTest {
 
     @Test
-    public void shouldThrowExceptionWhenGettingBrowserWithNullId() {
+    void shouldThrowExceptionWhenGettingBrowserWithNullId() {
         // Given
         String id = null;
         // When / Then
@@ -38,7 +38,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenGettingBrowserWithEmptyId() {
+    void shouldThrowExceptionWhenGettingBrowserWithEmptyId() {
         // Given
         String id = "";
         // When / Then
@@ -46,7 +46,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnChromeWhenGettingBrowserWithChromeId() {
+    void shouldReturnChromeWhenGettingBrowserWithChromeId() {
         // Given
         String chromeId = "chrome";
         // When
@@ -57,7 +57,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnFirefoxWhenGettingBrowserWithFirefoxId() {
+    void shouldReturnFirefoxWhenGettingBrowserWithFirefoxId() {
         // Given
         String firefoxId = "firefox";
         // When
@@ -68,7 +68,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnHtmlUnitWhenGettingBrowserWithHtmlUnitId() {
+    void shouldReturnHtmlUnitWhenGettingBrowserWithHtmlUnitId() {
         // Given
         String htmlUnitId = "htmlunit";
         // When
@@ -79,7 +79,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnOperaWhenGettingBrowserWithOperaId() {
+    void shouldReturnOperaWhenGettingBrowserWithOperaId() {
         // Given
         String operaId = "opera";
         // When
@@ -90,7 +90,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnPhantomJSWhenGettingBrowserWithPhantomJSId() {
+    void shouldReturnPhantomJSWhenGettingBrowserWithPhantomJSId() {
         // Given
         String phantomJSId = "phantomjs";
         // When
@@ -101,7 +101,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnSafariWhenGettingBrowserWithSafariId() {
+    void shouldReturnSafariWhenGettingBrowserWithSafariId() {
         // Given
         String safariId = "safari";
         // When
@@ -112,7 +112,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnFailSafeBrowserWhenGettingBrowserWithUnknownId() {
+    void shouldReturnFailSafeBrowserWhenGettingBrowserWithUnknownId() {
         // Given
         String unknowId = "unknowId";
         // When
@@ -122,7 +122,7 @@ public class BrowserUnitTest {
     }
 
     @Test
-    public void shouldReturnHtmlUnitBrowserWhenGettingFailSafeBrowser() {
+    void shouldReturnHtmlUnitBrowserWhenGettingFailSafeBrowser() {
         // Given / When
         Browser failSafeBrowser = Browser.getFailSafeBrowser();
         // Then

--- a/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/BrowsersComboBoxModelUnitTest.java
+++ b/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/BrowsersComboBoxModelUnitTest.java
@@ -32,13 +32,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link BrowsersComboBoxModel}. */
-public class BrowsersComboBoxModelUnitTest {
+class BrowsersComboBoxModelUnitTest {
 
     private static BrowserUI FIREFOX;
     private static List<BrowserUI> browsers;
 
     @BeforeAll
-    public static void setUp() throws Exception {
+    static void setUp() throws Exception {
         FIREFOX = new BrowserUI("Firefox", Browser.FIREFOX);
 
         browsers = new ArrayList<>(3);
@@ -48,7 +48,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenCreatingBrowsersComboBoxModelWithNullList() {
+    void shouldThrowExceptionWhenCreatingBrowsersComboBoxModelWithNullList() {
         // Given
         List<BrowserUI> browsers = null;
         // When / Then
@@ -56,7 +56,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenCreatingBrowsersComboBoxModelWithEmptyList() {
+    void shouldThrowExceptionWhenCreatingBrowsersComboBoxModelWithEmptyList() {
         // Given
         List<BrowserUI> browsers = Collections.emptyList();
         // When / Then
@@ -64,12 +64,12 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldCreateBrowsersComboBoxModelWithNonEmptyList() {
+    void shouldCreateBrowsersComboBoxModelWithNonEmptyList() {
         assertDoesNotThrow(() -> new BrowsersComboBoxModel(browsers));
     }
 
     @Test
-    public void shouldGetSizeAsNumberOfBrowsersPassedInConstructor() {
+    void shouldGetSizeAsNumberOfBrowsersPassedInConstructor() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         // When
@@ -79,7 +79,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldGetElementsAtSamePositionAsBrowsersPassedInConstructor() {
+    void shouldGetElementsAtSamePositionAsBrowsersPassedInConstructor() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         for (int index = 0; index < browsers.size(); index++) {
@@ -91,7 +91,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldGetFirstItemSelectedAfterConstruction() {
+    void shouldGetFirstItemSelectedAfterConstruction() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         // When
@@ -101,7 +101,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldNotBeAffectedByModificationsOfListPassedInConstructor() {
+    void shouldNotBeAffectedByModificationsOfListPassedInConstructor() {
         // Given
         List<BrowserUI> mutableList = new ArrayList<>(browsers);
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(mutableList);
@@ -115,7 +115,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenSelectingItemWithNonBrowserUIObject() {
+    void shouldThrowExceptionWhenSelectingItemWithNonBrowserUIObject() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         // When / Then
@@ -125,7 +125,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldSetSelectedItemWithBrowserUI() {
+    void shouldSetSelectedItemWithBrowserUI() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         // When
@@ -135,7 +135,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldNotChangeSelectionWhenSettingNonContainedBrowserUI() {
+    void shouldNotChangeSelectionWhenSettingNonContainedBrowserUI() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedItem(FIREFOX);
@@ -146,7 +146,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldThrowExceptionWhenSelectingItemWithEmptyBrowserId() {
+    void shouldThrowExceptionWhenSelectingItemWithEmptyBrowserId() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         // When / Then
@@ -154,7 +154,7 @@ public class BrowsersComboBoxModelUnitTest {
                 IllegalArgumentException.class, () -> browsersComboBoxModel.setSelectedBrowser(""));
     }
 
-    public void shouldSetSelectedItemWithBrowserId() {
+    void shouldSetSelectedItemWithBrowserId() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         // When
@@ -164,7 +164,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldNotChangeSelectionWhenSettingNonContainedBrowserId() {
+    void shouldNotChangeSelectionWhenSettingNonContainedBrowserId() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedItem(FIREFOX);
@@ -175,7 +175,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldNotChangeSelectionWhenUsingNonExistentBrowserId() {
+    void shouldNotChangeSelectionWhenUsingNonExistentBrowserId() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedItem(FIREFOX);
@@ -186,7 +186,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldSetSelectedItemWithBrowser() {
+    void shouldSetSelectedItemWithBrowser() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         // When
@@ -196,7 +196,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldNotChangeSelectionWhenSettingNonContainedBrowser() {
+    void shouldNotChangeSelectionWhenSettingNonContainedBrowser() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedItem(FIREFOX);
@@ -207,7 +207,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldClearSelectionWhenSettingNullBrowserId() {
+    void shouldClearSelectionWhenSettingNullBrowserId() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedBrowser(Browser.FIREFOX);
@@ -218,7 +218,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldClearSelectionWhenSettingNullBrowser() {
+    void shouldClearSelectionWhenSettingNullBrowser() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedBrowser(Browser.FIREFOX);
@@ -229,7 +229,7 @@ public class BrowsersComboBoxModelUnitTest {
     }
 
     @Test
-    public void shouldClearSelectionWhenSettingNullItem() {
+    void shouldClearSelectionWhenSettingNullItem() {
         // Given
         BrowsersComboBoxModel browsersComboBoxModel = new BrowsersComboBoxModel(browsers);
         browsersComboBoxModel.setSelectedBrowser(Browser.FIREFOX);

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
@@ -36,12 +36,12 @@ public class ExtensionImportWSDLTestCase extends TestUtils {
     }
 
     @Test
-    public void getAuthorTest() {
+    void getAuthorTest() {
         assertNotNull(extension.getAuthor());
     }
 
     @Test
-    public void getDescriptionTest() {
+    void getDescriptionTest() {
         assertNotNull(extension.getDescription());
     }
 }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.soap;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,27 +44,27 @@ public class SOAPActionSpoofingActiveScanRuleTestCase {
     }
 
     @Test
-    public void scanResponseTest() throws Exception {
+    void scanResponseTest() throws Exception {
         SOAPActionSpoofingActiveScanRule scanner = new SOAPActionSpoofingActiveScanRule();
 
         /* Positive cases. */
         ResponseType result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == ResponseType.SOAPACTION_EXECUTED);
+        assertEquals(ResponseType.SOAPACTION_EXECUTED, result);
 
         Sample.setOriginalResponse(modifiedMsg);
         result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == ResponseType.SOAPACTION_IGNORED);
+        assertEquals(ResponseType.SOAPACTION_IGNORED, result);
 
         /* Negative cases. */
         result = scanner.scanResponse(new HttpMessage(), originalMsg);
-        assertTrue(result == ResponseType.EMPTY_RESPONSE);
+        assertEquals(ResponseType.EMPTY_RESPONSE, result);
 
         Sample.setEmptyBodyResponse(modifiedMsg);
         result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == ResponseType.EMPTY_RESPONSE);
+        assertEquals(ResponseType.EMPTY_RESPONSE, result);
 
         Sample.setInvalidFormatResponse(modifiedMsg);
         result = scanner.scanResponse(modifiedMsg, originalMsg);
-        assertTrue(result == ResponseType.INVALID_FORMAT);
+        assertEquals(ResponseType.INVALID_FORMAT, result);
     }
 }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPMsgConfigTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPMsgConfigTestCase.java
@@ -45,7 +45,7 @@ public class SOAPMsgConfigTestCase {
     }
 
     @Test
-    public void isCompleteTest() {
+    void isCompleteTest() {
         /* Positive case. */
         assertTrue(soapConfig.isComplete());
 

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRuleTestCase.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.network.HttpMessage;
 public class SOAPXMLInjectionActiveScanRuleTestCase {
 
     @Test
-    public void craftAttackMessageTest() throws Exception {
+    void craftAttackMessageTest() throws Exception {
         HttpMessage originalMsg = new HttpMessage();
         Sample.setOriginalRequest(originalMsg);
 

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SitesTreeHelperTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SitesTreeHelperTestCase.java
@@ -36,7 +36,7 @@ public class SitesTreeHelperTestCase extends TestUtils {
     }
 
     @Test
-    public void getNodeNameForSoapV1Message() throws Exception {
+    void getNodeNameForSoapV1Message() throws Exception {
         // Given
         Sample.setOriginalRequest(message);
         // When
@@ -46,7 +46,7 @@ public class SitesTreeHelperTestCase extends TestUtils {
     }
 
     @Test
-    public void getNodeNameForSoapV2Message() throws Exception {
+    void getNodeNameForSoapV2Message() throws Exception {
         // Given
         Sample.setSoapVersionTwoRequest(message);
         // When

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SoapActionUnitTest.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SoapActionUnitTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class SoapActionUnitTest {
+class SoapActionUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"http://example.com/", "", "\"ZAP\""})
@@ -60,7 +60,7 @@ public class SoapActionUnitTest {
     }
 
     @Test
-    public void getSoapActionShouldReturnEmptyStringForSoapV2MessageWithOmittedAction() {
+    void getSoapActionShouldReturnEmptyStringForSoapV2MessageWithOmittedAction() {
         HttpMessage soapMsg = new HttpMessage();
         String contentType = "application/soap+xml;charset=utf-8";
         soapMsg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
@@ -68,7 +68,7 @@ public class SoapActionUnitTest {
     }
 
     @Test
-    public void getSoapActionShouldReturnNullForInvalidSoapMessage() {
+    void getSoapActionShouldReturnNullForInvalidSoapMessage() {
         HttpMessage msg = new HttpMessage();
         msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, HttpHeader.JSON_CONTENT_TYPE);
         assertThat(SoapAction.extractFrom(msg), is(nullValue()));

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -54,7 +54,7 @@ public class WSDLCustomParserTestCase extends TestUtils {
     }
 
     @Test
-    public void parseWSDLContentTest() {
+    void parseWSDLContentTest() {
         /* Positive case. Checks the method's return value. */
         boolean result = parser.extContentWSDLImport(wsdlContent, false);
         assertTrue(result);
@@ -68,7 +68,7 @@ public class WSDLCustomParserTestCase extends TestUtils {
     }
 
     @Test
-    public void canBeWSDLparsedTest() {
+    void canBeWSDLparsedTest() {
         /* Positive case. */
         boolean result = parser.canBeWSDLparsed(wsdlContent);
         assertTrue(result);
@@ -80,7 +80,7 @@ public class WSDLCustomParserTestCase extends TestUtils {
     }
 
     @Test
-    public void createSoapRequestTest() {
+    void createSoapRequestTest() {
         parser.extContentWSDLImport(wsdlContent, false);
         /* Positive case. */
         HttpMessage result = parser.createSoapRequest(parser.getLastConfig());
@@ -91,7 +91,7 @@ public class WSDLCustomParserTestCase extends TestUtils {
     }
 
     @Test
-    public void addParameterShouldUseValueGeneratorWhenAvailable() {
+    void addParameterShouldUseValueGeneratorWhenAvailable() {
         // Given
         String path = "CelsiusToFahrenheit/Celsius";
         String paramType = "s:string";
@@ -119,7 +119,7 @@ public class WSDLCustomParserTestCase extends TestUtils {
     }
 
     @Test
-    public void addParameterShouldUseDefaultValuesWhenValueIsNotSpecified() {
+    void addParameterShouldUseDefaultValuesWhenValueIsNotSpecified() {
         // Given
         String path = "CelsiusToFahrenheit/Celsius";
         String paramType = "s:string";

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
@@ -49,7 +49,7 @@ public class WSDLFilePassiveScanRuleTestCase {
     }
 
     @Test
-    public void isWsdlTest()
+    void isWsdlTest()
             throws NoSuchMethodException, SecurityException, IllegalAccessException,
                     IllegalArgumentException, InvocationTargetException {
         WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
@@ -66,7 +66,7 @@ public class WSDLFilePassiveScanRuleTestCase {
     }
 
     @Test
-    public void shouldNotAlertWhenWsdlFileNotFound() throws IOException {
+    void shouldNotAlertWhenWsdlFileNotFound() throws IOException {
         HttpMessage wsdlMsg = new HttpMessage();
         wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
         setContentType(wsdlMsg, "text/xml");
@@ -77,7 +77,7 @@ public class WSDLFilePassiveScanRuleTestCase {
     }
 
     @Test
-    public void shouldAlertWhenWsdlFileFound() throws IOException {
+    void shouldAlertWhenWsdlFileFound() throws IOException {
         HttpMessage wsdlMsg = new HttpMessage();
         wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
         setContentType(wsdlMsg, "text/xml");
@@ -88,7 +88,7 @@ public class WSDLFilePassiveScanRuleTestCase {
     }
 
     @Test
-    public void shouldAlertWhenWsdlXmlContentTypeFound() throws IOException {
+    void shouldAlertWhenWsdlXmlContentTypeFound() throws IOException {
         HttpMessage wsdlMsg = new HttpMessage();
         wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
         setContentType(wsdlMsg, "application/wsdl+xml");

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLSpiderTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLSpiderTestCase.java
@@ -44,7 +44,7 @@ public class WSDLSpiderTestCase {
     }
 
     @Test
-    public void parseResourceTest()
+    void parseResourceTest()
             throws NoSuchMethodException, SecurityException, IllegalAccessException,
                     IllegalArgumentException, InvocationTargetException {
         WSDLSpider spider = new WSDLSpider(new WSDLCustomParser(null));

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/automation/SoapJobUnitTest.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/automation/SoapJobUnitTest.java
@@ -42,12 +42,12 @@ import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.zap.extension.soap.ExtensionImportWSDL;
 import org.zaproxy.zap.utils.I18N;
 
-public class SoapJobUnitTest {
+class SoapJobUnitTest {
 
     private ExtensionImportWSDL extSoap;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         Constant.messages = new I18N(Locale.ENGLISH);
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -60,7 +60,7 @@ public class SoapJobUnitTest {
     }
 
     @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given / When
         SoapJob job = new SoapJob();
 
@@ -73,7 +73,7 @@ public class SoapJobUnitTest {
     }
 
     @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         SoapJob job = new SoapJob();
 
@@ -87,7 +87,7 @@ public class SoapJobUnitTest {
     }
 
     @Test
-    public void shouldApplyCustomConfigParams() {
+    void shouldApplyCustomConfigParams() {
         // Given
         SoapJob job = new SoapJob();
         String wsdlFile = "C:\\Users\\ZAPBot\\Documents\\test file.wsdl";
@@ -103,7 +103,7 @@ public class SoapJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfInvalidUrl() {
+    void shouldFailIfInvalidUrl() {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
@@ -122,7 +122,7 @@ public class SoapJobUnitTest {
     }
 
     @Test
-    public void shouldFailIfInvalidFile() {
+    void shouldFailIfInvalidFile() {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
@@ -59,7 +59,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
-public class AjaxSpiderJobUnitTest {
+class AjaxSpiderJobUnitTest {
 
     private static MockedStatic<CommandLine> mockedCmdLine;
     // Disdabled due to build issues
@@ -68,17 +68,17 @@ public class AjaxSpiderJobUnitTest {
 
     // TODO Tests disabled due to build issues
     // @BeforeAll
-    public static void init() {
+    static void init() {
         mockedCmdLine = Mockito.mockStatic(CommandLine.class);
     }
 
     // @AfterAll
-    public static void close() {
+    static void close() {
         mockedCmdLine.close();
     }
 
     // @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         Constant.messages = new I18N(Locale.ENGLISH);
 
         Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
@@ -95,7 +95,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldReturnDefaultFields() {
+    void shouldReturnDefaultFields() {
         // Given / When
         AjaxSpiderJob job = new AjaxSpiderJob();
 
@@ -108,7 +108,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldReturnCustomConfigParams() {
+    void shouldReturnCustomConfigParams() {
         // Given
         AjaxSpiderJob job = new AjaxSpiderJob();
 
@@ -124,7 +124,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldApplyCustomConfigParams() {
+    void shouldApplyCustomConfigParams() {
         // Given
         AjaxSpiderJob job = new AjaxSpiderJob();
 
@@ -140,7 +140,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldReturnConfigParams() throws MalformedURLException {
+    void shouldReturnConfigParams() throws MalformedURLException {
         // Given
         AjaxSpiderJob job = new AjaxSpiderJob();
 
@@ -171,7 +171,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldRunValidJob() throws MalformedURLException {
+    void shouldRunValidJob() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
@@ -202,7 +202,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldFailIfInvalidUrl() throws MalformedURLException {
+    void shouldFailIfInvalidUrl() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
@@ -221,7 +221,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldFailIfUnknownContext() throws MalformedURLException {
+    void shouldFailIfUnknownContext() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
@@ -240,7 +240,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldUseSpecifiedContext() throws MalformedURLException, URISyntaxException {
+    void shouldUseSpecifiedContext() throws MalformedURLException, URISyntaxException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
@@ -312,7 +312,7 @@ public class AjaxSpiderJobUnitTest {
 
     /* TODO
     //@Test
-    public void shouldUseSpecifiedUrl() throws MalformedURLException {
+    void shouldUseSpecifiedUrl() throws MalformedURLException {
         Constant.messages = new I18N(Locale.ENGLISH);
         Session session = mock(Session.class);
         Context context = mock(Context.class);
@@ -343,7 +343,7 @@ public class AjaxSpiderJobUnitTest {
     */
 
     // @Test
-    public void shouldExitIfSpiderTakesTooLong() throws MalformedURLException {
+    void shouldExitIfSpiderTakesTooLong() throws MalformedURLException {
         // Given
         Session session = mock(Session.class);
         Context context = mock(Context.class);
@@ -374,7 +374,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldWarnIfLessUrlsFoundThanExpected() throws MalformedURLException {
+    void shouldWarnIfLessUrlsFoundThanExpected() throws MalformedURLException {
         // Given
         Session session = mock(Session.class);
         Context context = mock(Context.class);
@@ -405,7 +405,7 @@ public class AjaxSpiderJobUnitTest {
     }
 
     // @Test
-    public void shouldErrorIfLessUrlsFoundThanExpected() throws MalformedURLException {
+    void shouldErrorIfLessUrlsFoundThanExpected() throws MalformedURLException {
         // Given
         Session session = mock(Session.class);
         Context context = mock(Context.class);

--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLiTest.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLiTest.java
@@ -29,7 +29,7 @@ import org.jdom2.Element;
  *
  * @author yhawke (2013)
  */
-public class SQLiTest {
+class SQLiTest {
 
     /*
      * Tag: <test>

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/BaseEventStreamTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/BaseEventStreamTest.java
@@ -31,10 +31,10 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.zap.utils.I18N;
 
-public abstract class BaseEventStreamTest {
+abstract class BaseEventStreamTest {
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         // ServerSentEvent relies on this attribute to be initialized
         Constant.messages = mock(I18N.class);
     }

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
@@ -41,10 +41,10 @@ import org.mockito.stubbing.Answer;
 
 /** Unit test for {@link EventStreamListener}. */
 @ExtendWith(MockitoExtension.class)
-public class EventStreamListenerUnitTest {
+class EventStreamListenerUnitTest {
 
     @Test
-    public void shouldFireProcessEventOnce() throws IOException {
+    void shouldFireProcessEventOnce() throws IOException {
         // Given
         final String event1 = "data:blub";
 
@@ -60,7 +60,7 @@ public class EventStreamListenerUnitTest {
     }
 
     @Test
-    public void shouldFireProcessEventMultipleTimes() throws IOException {
+    void shouldFireProcessEventMultipleTimes() throws IOException {
         // Given
         final String event1 = ": test stream";
         final String event2 = "data: first event\nid: 1";
@@ -84,7 +84,7 @@ public class EventStreamListenerUnitTest {
     }
 
     @Test
-    public void shouldFireProcessEventOnceForComplexEvent() throws IOException {
+    void shouldFireProcessEventOnceForComplexEvent() throws IOException {
         // Given
         final String event1 = "event: foo\ndata: first event\nid: 1";
 
@@ -100,7 +100,7 @@ public class EventStreamListenerUnitTest {
     }
 
     @Test
-    public void shouldNotFireProcessEventForAnIncompleteEvent() throws IOException {
+    void shouldNotFireProcessEventForAnIncompleteEvent() throws IOException {
         // Given
         LinkedList<String> streamLines = new LinkedList<String>();
         streamLines.add("data:blub");
@@ -118,7 +118,7 @@ public class EventStreamListenerUnitTest {
     }
 
     @Test
-    public void shouldFireProcessEventOnAnEmptyEvent() throws IOException {
+    void shouldFireProcessEventOnAnEmptyEvent() throws IOException {
         // Given
         LinkedList<String> streamLines = new LinkedList<String>();
         streamLines.add("");

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
@@ -42,16 +42,16 @@ import org.zaproxy.zap.utils.I18N;
  * http://www.w3.org/TR/eventsource/#processField}.
  */
 @ExtendWith(MockitoExtension.class)
-public class EventStreamProxyUnitTest extends BaseEventStreamTest {
+class EventStreamProxyUnitTest extends BaseEventStreamTest {
 
     @BeforeAll
-    public static void beforeClass() {
+    static void beforeClass() {
         // ServerSentEvent relies on this attribute to be initialized
         Constant.messages = mock(I18N.class);
     }
 
     @Test
-    public void shouldForwardEventWhenAllObserversReturnTrue() throws IOException {
+    void shouldForwardEventWhenAllObserversReturnTrue() throws IOException {
         // Given
         BufferedWriter writer = mock(BufferedWriter.class);
         EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
@@ -69,7 +69,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldNotForwardEventWhenAtLeastOneObserverReturnsFalse() throws IOException {
+    void shouldNotForwardEventWhenAtLeastOneObserverReturnsFalse() throws IOException {
         // Given
         BufferedWriter writer = mock(BufferedWriter.class);
         EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
@@ -87,7 +87,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldForwardEventWithoutObservers() throws IOException {
+    void shouldForwardEventWithoutObservers() throws IOException {
         // Given
         BufferedWriter writer = mock(BufferedWriter.class);
         EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
@@ -100,7 +100,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldInformObserversWithRightObjectFromSingleEventLine() throws IOException {
+    void shouldInformObserversWithRightObjectFromSingleEventLine() throws IOException {
         // Given
         final String data = "blub";
         final String eventStream = "data:" + data;
@@ -118,7 +118,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldInformObserversWithRightObjectFromMultipleEventLines() throws IOException {
+    void shouldInformObserversWithRightObjectFromMultipleEventLines() throws IOException {
         // Given
         final String eventStream = "data: YHOO\ndata: +2\ndata: 10";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -132,7 +132,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldNotIgnoreCommentsButForwardInContrastToSpecification() throws IOException {
+    void shouldNotIgnoreCommentsButForwardInContrastToSpecification() throws IOException {
         // Given
         final String eventStream = ": test stream";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -146,7 +146,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldProcessLastEventId() throws IOException {
+    void shouldProcessLastEventId() throws IOException {
         // Given
         final String eventStream = "data: first event\nid: 2";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -162,7 +162,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldProcessEmptyLastEventId() throws IOException {
+    void shouldProcessEmptyLastEventId() throws IOException {
         // Given
         final String eventStream = "data:second event\nid";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -177,7 +177,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldRemoveFirstWhitespaceFromLineAfterColon() throws IOException {
+    void shouldRemoveFirstWhitespaceFromLineAfterColon() throws IOException {
         // Given
         final String eventStream = "data:  third event";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -191,7 +191,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldReturnEmptyObjectWhenCalledWithEmptyData() throws IOException {
+    void shouldReturnEmptyObjectWhenCalledWithEmptyData() throws IOException {
         // Given
         final String eventStream = "data";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -206,7 +206,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldReturnANewlineOfData() throws IOException {
+    void shouldReturnANewlineOfData() throws IOException {
         // Given
         final String eventStream = "data\ndata";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -221,7 +221,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldExtractEventType() throws IOException {
+    void shouldExtractEventType() throws IOException {
         // Given
         final String eventStream = "event: server-time\ndata: 1357651178";
         BufferedWriter writer = mock(BufferedWriter.class);
@@ -236,7 +236,7 @@ public class EventStreamProxyUnitTest extends BaseEventStreamTest {
     }
 
     @Test
-    public void shouldExtractRetryTime() throws IOException {
+    void shouldExtractRetryTime() throws IOException {
         // Given
         final String eventStream = "retry: 10000";
         BufferedWriter writer = mock(BufferedWriter.class);

--- a/addOns/tokengen/src/test/java/org/zaproxy/zap/extension/tokengen/CharacterFrequencyMapUnitTest.java
+++ b/addOns/tokengen/src/test/java/org/zaproxy/zap/extension/tokengen/CharacterFrequencyMapUnitTest.java
@@ -29,10 +29,10 @@ import static org.hamcrest.Matchers.nullValue;
 import org.junit.jupiter.api.Test;
 
 /** Unit test for {@link CharacterFrequencyMap}. */
-public class CharacterFrequencyMapUnitTest {
+class CharacterFrequencyMapUnitTest {
 
     @Test
-    public void shouldFailCharacterUniformityWithoutTokens() throws Exception {
+    void shouldFailCharacterUniformityWithoutTokens() throws Exception {
         // Given
         CharacterFrequencyMap cfm = new CharacterFrequencyMap();
         // When
@@ -48,7 +48,7 @@ public class CharacterFrequencyMapUnitTest {
     }
 
     @Test
-    public void shouldFailCharacterUniformityIfTokenCharsAreNotUniform() throws Exception {
+    void shouldFailCharacterUniformityIfTokenCharsAreNotUniform() throws Exception {
         // Given
         CharacterFrequencyMap cfm = new CharacterFrequencyMap();
         for (int i = 0; i < 1000; i++) {
@@ -78,7 +78,7 @@ public class CharacterFrequencyMapUnitTest {
     }
 
     @Test
-    public void shouldPassCharacterUniformityIfTokensCharsAreUniform() throws Exception {
+    void shouldPassCharacterUniformityIfTokensCharsAreUniform() throws Exception {
         // Given
         CharacterFrequencyMap cfm = new CharacterFrequencyMap();
         cfm.addToken("ABC");

--- a/addOns/tokengen/src/test/java/org/zaproxy/zap/extension/tokengen/TokenRandomStreamUnitTest.java
+++ b/addOns/tokengen/src/test/java/org/zaproxy/zap/extension/tokengen/TokenRandomStreamUnitTest.java
@@ -30,19 +30,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 /** Unit test for {@link TokenRandomStream}. */
 @ExtendWith(MockitoExtension.class)
-public class TokenRandomStreamUnitTest {
+class TokenRandomStreamUnitTest {
 
     @Mock CharacterFrequencyMap characterFrequencyMap;
 
     TokenRandomStream stream;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         stream = new TokenRandomStream(characterFrequencyMap);
     }
 
     @Test
-    public void shouldAlwaysReturnMinusOneWhenStreamIsClosed() throws Exception {
+    void shouldAlwaysReturnMinusOneWhenStreamIsClosed() throws Exception {
         // Given
         stream.closeInputStream();
         // When/Then

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAppsJsonParseUnitTest.java
@@ -27,10 +27,10 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class WappalyzerAppsJsonParseUnitTest {
+class WappalyzerAppsJsonParseUnitTest {
 
     @Test
-    public void test() throws IOException {
+    void test() throws IOException {
         // Given
         List<String> errs = new ArrayList<>();
         List<Exception> parsingExceptions = new ArrayList<>();

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
@@ -20,16 +20,15 @@
 package org.zaproxy.zap.extension.wappalyzer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-public class WappalyzerJsonParserUnitTest {
+class WappalyzerJsonParserUnitTest {
 
     @Test
-    public void shouldParseExample() {
+    void shouldParseExample() {
         // Given
         WappalyzerJsonParser wjp = new WappalyzerJsonParser();
         WappalyzerData wappData = wjp.parseAppsJson("apps.json");
@@ -40,9 +39,9 @@ public class WappalyzerJsonParserUnitTest {
         Application app = apps.get(0);
         // Then
         assertEquals(5, apps.size());
-        assertTrue(app.getName().equals("Test Entry"));
-        assertTrue(app.getDescription().equals("Test Entry is a test entry for UnitTests"));
-        assertTrue(app.getWebsite().equals("https://www.example.com/testentry"));
+        assertEquals("Test Entry", app.getName());
+        assertEquals("Test Entry is a test entry for UnitTests", app.getDescription());
+        assertEquals("https://www.example.com/testentry", app.getWebsite());
         assertEquals(expectedCategory, app.getCategories());
         assertEquals(1, app.getHeaders().size());
         assertEquals(1, app.getUrl().size());
@@ -51,11 +50,11 @@ public class WappalyzerJsonParserUnitTest {
         assertEquals(2, app.getMetas().size());
         assertEquals(0, app.getImplies().size());
         assertEquals(2, app.getDom().size());
-        assertTrue(app.getCpe().equals(""));
+        assertEquals("", app.getCpe());
         // Ignore Icon
 
         app = apps.get(2);
-        assertTrue(app.getName().equals("Apache"));
+        assertEquals("Apache", app.getName());
         assertEquals(1, app.getMetas().size());
     }
 }

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -37,8 +37,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-public class WappalyzerPassiveScannerUnitTest
-        extends PassiveScannerTestUtils<WappalyzerPassiveScanner> {
+class WappalyzerPassiveScannerUnitTest extends PassiveScannerTestUtils<WappalyzerPassiveScanner> {
 
     WappalyzerApplicationTestHolder defaultHolder;
 
@@ -68,7 +67,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void testApacheWithPhp() throws HttpMalformedHeaderException {
+    void testApacheWithPhp() throws HttpMalformedHeaderException {
         HttpMessage msg = makeHttpMessage();
         msg.setRequestHeader("GET https://www.example.com/test.php HTTP/1.1");
         msg.setResponseHeader(
@@ -82,7 +81,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchScriptElement() throws HttpMalformedHeaderException {
+    void shouldMatchScriptElement() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(
@@ -98,7 +97,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldNotMatchScriptElementContentIfNotOnScriptElement()
+    void shouldNotMatchScriptElementContentIfNotOnScriptElement()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
@@ -110,7 +109,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchDomElementWithTextAndAttribute() throws HttpMalformedHeaderException {
+    void shouldMatchDomElementWithTextAndAttribute() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(
@@ -125,7 +124,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchDomElementWithOnlyText() throws HttpMalformedHeaderException {
+    void shouldMatchDomElementWithOnlyText() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(
@@ -140,7 +139,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchDomElementWithOnlyAttribute() throws HttpMalformedHeaderException {
+    void shouldMatchDomElementWithOnlyAttribute() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(
@@ -155,7 +154,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldNotMatchDomElementIfNoContentMatches() throws HttpMalformedHeaderException {
+    void shouldNotMatchDomElementIfNoContentMatches() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(
@@ -169,7 +168,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldNotMatchOnNontextResponse() throws HttpMalformedHeaderException {
+    void shouldNotMatchOnNontextResponse() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "image/x-icon");
@@ -182,8 +181,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchOnNontextResponseWhenHeaderMatches()
-            throws HttpMalformedHeaderException {
+    void shouldMatchOnNontextResponseWhenHeaderMatches() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "image/x-icon");
@@ -199,7 +197,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchOnCssResponseWhenContentMatches() throws HttpMalformedHeaderException {
+    void shouldMatchOnCssResponseWhenContentMatches() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/css");
@@ -212,7 +210,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchOnCssRequestWhenContentMatches() throws HttpMalformedHeaderException {
+    void shouldMatchOnCssRequestWhenContentMatches() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setRequestHeader("GET https://www.example.com/styles.css HTTP/1.1");
@@ -225,8 +223,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchOnHtmlResponseWhenContentStyleMatches()
-            throws HttpMalformedHeaderException {
+    void shouldMatchOnHtmlResponseWhenContentStyleMatches() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(
@@ -239,7 +236,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldNotMatchOnHtmlResponseWhenContentStyleDoesNotMatch()
+    void shouldNotMatchOnHtmlResponseWhenContentStyleDoesNotMatch()
             throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
@@ -252,7 +249,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchOnMetaTag() throws HttpMalformedHeaderException {
+    void shouldMatchOnMetaTag() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(
@@ -265,7 +262,7 @@ public class WappalyzerPassiveScannerUnitTest
     }
 
     @Test
-    public void shouldMatchOnMetaTagWithMultipleEntries() throws HttpMalformedHeaderException {
+    void shouldMatchOnMetaTagWithMultipleEntries() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();
         msg.setResponseBody(

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertRaiserUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertRaiserUnitTest.java
@@ -31,15 +31,15 @@ import org.zaproxy.zap.extension.websocket.WebSocketChannelDTO;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
 import org.zaproxy.zap.testutils.WebSocketTestUtils;
 
-public class WebSocketAlertRaiserUnitTest extends WebSocketTestUtils {
+class WebSocketAlertRaiserUnitTest extends WebSocketTestUtils {
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         super.setUpZap();
     }
 
     @Test
-    public void shouldBuildAlert() {
+    void shouldBuildAlert() {
         // Given
         WebSocketAlertThread webSocketAlertThread = mock(WebSocketAlertThread.class);
         WebSocketMessageDTO message = mock(WebSocketMessageDTO.class);
@@ -61,7 +61,7 @@ public class WebSocketAlertRaiserUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldNotBuildAlertWhenMissingNameAndSource() {
+    void shouldNotBuildAlertWhenMissingNameAndSource() {
         // Given
         WebSocketAlertThread webSocketAlertThread = mock(WebSocketAlertThread.class);
         WebSocketMessageDTO message = mock(WebSocketMessageDTO.class);

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/client/ServerConnectionEstablisherUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/client/ServerConnectionEstablisherUnitTest.java
@@ -34,11 +34,11 @@ import org.zaproxy.zap.testutils.WebSocketTestUtils;
 import org.zaproxy.zap.testutils.websocket.server.NanoWebSocketConnection;
 import org.zaproxy.zap.testutils.websocket.server.NanoWebSocketTestServer;
 
-public class ServerConnectionEstablisherUnitTest extends WebSocketTestUtils {
+class ServerConnectionEstablisherUnitTest extends WebSocketTestUtils {
     private static final String HOST_NAME = "localhost";
 
     @BeforeEach
-    public void openWebSocketServer() throws Exception {
+    void openWebSocketServer() throws Exception {
         super.startWebSocketServer(HOST_NAME);
         super.setUpZap();
     }
@@ -55,7 +55,7 @@ public class ServerConnectionEstablisherUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldReceiveUpgradeStatusCode() throws Exception {
+    void shouldReceiveUpgradeStatusCode() throws Exception {
         ServerConnectionEstablisher establisher = new ServerConnectionEstablisher();
         NanoWebSocketTestServer webSocketServer = super.getWebSocketTestServer();
         HttpMessage handshakeRequest =
@@ -75,7 +75,7 @@ public class ServerConnectionEstablisherUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldReturnWSProxy() throws Exception {
+    void shouldReturnWSProxy() throws Exception {
         ServerConnectionEstablisher establisher = new ServerConnectionEstablisher();
         HttpMessage handshakeRequest =
                 new HttpMessage(

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/client/WebSocketProxyUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/client/WebSocketProxyUnitTest.java
@@ -36,7 +36,7 @@ import org.zaproxy.zap.extension.websocket.WebSocketProxy;
 import org.zaproxy.zap.testutils.WebSocketTestUtils;
 import org.zaproxy.zap.testutils.websocket.server.NanoWebSocketConnection;
 
-public class WebSocketProxyUnitTest extends WebSocketTestUtils {
+class WebSocketProxyUnitTest extends WebSocketTestUtils {
 
     private static final String HOST_NAME = "localhost";
 
@@ -58,7 +58,7 @@ public class WebSocketProxyUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldAnswerToPingWithPong() throws Exception {
+    void shouldAnswerToPingWithPong() throws Exception {
         ServerConnectionEstablisher establisher = new ServerConnectionEstablisher();
         HttpMessage handshakeRequest =
                 new HttpMessage(
@@ -82,7 +82,7 @@ public class WebSocketProxyUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldReceiveMessagesFromServer() throws Exception {
+    void shouldReceiveMessagesFromServer() throws Exception {
         ServerConnectionEstablisher establisher = new ServerConnectionEstablisher();
         HttpMessage handshakeRequest =
                 new HttpMessage(

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/pscan/WebSocketPassiveScannerManagerUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/pscan/WebSocketPassiveScannerManagerUnitTest.java
@@ -30,22 +30,22 @@ import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.extension.websocket.alerts.AlertManager;
 import org.zaproxy.zap.testutils.WebSocketTestUtils;
 
-public class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
+class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
 
     private WebSocketPassiveScannerManager wsPscanManager;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         wsPscanManager = new WebSocketPassiveScannerManager(mock(AlertManager.class));
     }
 
     @Test
-    public void shouldHaveNoScannerByDefault() {
+    void shouldHaveNoScannerByDefault() {
         assertFalse(wsPscanManager.getIterator().hasNext());
     }
 
     @Test
-    public void shouldAddWebSocketPassiveScanner() {
+    void shouldAddWebSocketPassiveScanner() {
         // Given
         WebSocketPassiveScanner wsScanner = mock(WebSocketPassiveScanner.class);
         // When
@@ -56,7 +56,7 @@ public class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldIgnorePassiveScannerWithSameName() {
+    void shouldIgnorePassiveScannerWithSameName() {
         // Given
         // Scanner 1
         WebSocketPassiveScanner wsScanner1 = mock(WebSocketPassiveScanner.class);
@@ -78,7 +78,7 @@ public class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldRemovePassiveScanner() {
+    void shouldRemovePassiveScanner() {
         // Given
         WebSocketPassiveScanner scanner1 = mock(WebSocketPassiveScanner.class);
         when(scanner1.getName()).thenReturn("WsScanner-1");
@@ -100,7 +100,7 @@ public class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldAllowToChangeWhileIterating() {
+    void shouldAllowToChangeWhileIterating() {
         // Given
         WebSocketPassiveScanner scanner1 = mock(WebSocketPassiveScanner.class);
         when(scanner1.getName()).thenReturn("WsScanner-1");
@@ -126,7 +126,7 @@ public class WebSocketPassiveScannerManagerUnitTest extends WebSocketTestUtils {
     }
 
     @Test
-    public void shouldDisableScanner() {
+    void shouldDisableScanner() {
         // Given
         WebSocketPassiveScanner scanner1 = mock(WebSocketPassiveScanner.class);
 

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/WebSocketNodesUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/WebSocketNodesUnitTest.java
@@ -41,14 +41,14 @@ import org.zaproxy.zap.extension.websocket.treemap.nodes.contents.RootContent;
 import org.zaproxy.zap.extension.websocket.treemap.nodes.namers.WebSocketSimpleNodeNamer;
 import org.zaproxy.zap.extension.websocket.treemap.nodes.structural.TreeNode;
 
-public class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
+class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
 
     private WebSocketNode rootFolder;
     private WebSocketSimpleNodeNamer namer;
     private static URI defaultHostName;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         setUpMessages();
 
         namer = new WebSocketSimpleNodeNamer();
@@ -62,8 +62,7 @@ public class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldAddParentsAndChildren()
-            throws DatabaseException, HttpMalformedHeaderException {
+    void shouldAddParentsAndChildren() throws DatabaseException, HttpMalformedHeaderException {
 
         // Given
         WebSocketChannelDTO channel = getWebSocketChannelDTO(1, defaultHostName.toString());
@@ -83,7 +82,7 @@ public class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldGetContent() throws DatabaseException, HttpMalformedHeaderException {
+    void shouldGetContent() throws DatabaseException, HttpMalformedHeaderException {
         // Given
         WebSocketChannelDTO channel = getWebSocketChannelDTO(1, defaultHostName.toString());
         WebSocketMessageDTO message = getTextOutgoingMessage(channel, "TestMessage", 1);
@@ -99,7 +98,7 @@ public class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldGetMessages() throws DatabaseException, HttpMalformedHeaderException {
+    void shouldGetMessages() throws DatabaseException, HttpMalformedHeaderException {
         // Given
         WebSocketChannelDTO channel = getWebSocketChannelDTO(1, defaultHostName.toString());
 
@@ -131,7 +130,7 @@ public class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldGetAllHostNodes() throws DatabaseException, HttpMalformedHeaderException {
+    void shouldGetAllHostNodes() throws DatabaseException, HttpMalformedHeaderException {
         // Given
         ArrayList<TreeNode> expectedHostNodes = new ArrayList<>();
         WebSocketChannelDTO channel;

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/content/MessageContentUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/content/MessageContentUnitTest.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.websocket.treemap.nodes.content;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -43,14 +44,14 @@ import org.zaproxy.zap.extension.websocket.treemap.nodes.contents.RootContent;
 import org.zaproxy.zap.extension.websocket.treemap.nodes.namers.WebSocketSimpleNodeNamer;
 import org.zaproxy.zap.extension.websocket.treemap.nodes.structural.TreeNode;
 
-public class MessageContentUnitTest extends WebSocketAddonTestUtils {
+class MessageContentUnitTest extends WebSocketAddonTestUtils {
 
     private WebSocketSimpleNodeNamer namer;
     private static URI defaultHostName;
     TreeNode root;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         this.setUpMessages();
         namer = new WebSocketSimpleNodeNamer();
         defaultHostName = new URI("hostname", true);
@@ -63,7 +64,7 @@ public class MessageContentUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldMessagesBeEquals() {
+    void shouldMessagesBeEquals() {
 
         // Given
         WebSocketChannelDTO channel1 = getWebSocketChannelDTO(1, defaultHostName.toString());
@@ -83,7 +84,7 @@ public class MessageContentUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldMessageShouldBeGreater() {
+    void shouldMessageShouldBeGreater() {
 
         // Given
         WebSocketChannelDTO channel1 = getWebSocketChannelDTO(1, defaultHostName.toString());
@@ -104,7 +105,7 @@ public class MessageContentUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldNotBeEqualWithDifferentDirection() {
+    void shouldNotBeEqualWithDifferentDirection() {
 
         // Given
         WebSocketChannelDTO channel1 = getWebSocketChannelDTO(1, defaultHostName.toString());
@@ -120,12 +121,12 @@ public class MessageContentUnitTest extends WebSocketAddonTestUtils {
         MessageContent messageContent2 = new MessageContent(namer, message2);
 
         // Then
-        assertTrue(messageContent1.compareTo(messageContent2) != 0);
-        assertTrue(messageContent2.compareTo(messageContent1) != 0);
+        assertNotEquals(0, messageContent1.compareTo(messageContent2));
+        assertNotEquals(0, messageContent2.compareTo(messageContent1));
     }
 
     @Test
-    public void shouldCloneBeTheSame() {
+    void shouldCloneBeTheSame() {
 
         // Given
         MessageContent messageContent =
@@ -147,8 +148,7 @@ public class MessageContentUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldGetHostNode()
-            throws URIException, DatabaseException, HttpMalformedHeaderException {
+    void shouldGetHostNode() throws URIException, DatabaseException, HttpMalformedHeaderException {
 
         // Given
         URI hostUri1 = new URI("https", null, defaultHostName.toString(), -1, "/first");
@@ -170,7 +170,7 @@ public class MessageContentUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldGetMessagesPerHost()
+    void shouldGetMessagesPerHost()
             throws URIException, DatabaseException, HttpMalformedHeaderException {
         String[] hosts = {"hostname_1", "hostname_2"};
         ArrayList<TreeNode> hostNodes = new ArrayList<>();

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/factories/SimpleNodeFactoryUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/factories/SimpleNodeFactoryUnitTest.java
@@ -42,13 +42,13 @@ import org.zaproxy.zap.extension.websocket.treemap.nodes.namers.WebSocketSimpleN
 import org.zaproxy.zap.extension.websocket.treemap.nodes.structural.TreeNode;
 import org.zaproxy.zap.extension.websocket.utility.InvalidUtf8Exception;
 
-public class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
+class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
 
     private NodeFactory nodeFactory;
     private WebSocketSimpleNodeNamer namer;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         setUpMessages();
         super.startWebSocketServer("localhost");
         namer = new WebSocketSimpleNodeNamer();
@@ -61,7 +61,7 @@ public class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldAddConnection()
+    void shouldAddConnection()
             throws URIException, DatabaseException, HttpMalformedHeaderException {
         // Given
         WebSocketChannelDTO channel = getWebSocketChannelDTO(1, getServerUrl().toString());
@@ -74,7 +74,7 @@ public class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldNotAddExistingHost() throws DatabaseException, HttpMalformedHeaderException {
+    void shouldNotAddExistingHost() throws DatabaseException, HttpMalformedHeaderException {
         // Given
         WebSocketChannelDTO channel1_1 = getWebSocketChannelDTO(1, "hostname_1");
         WebSocketChannelDTO channel2_1 = getWebSocketChannelDTO(2, "hostname_1");
@@ -94,7 +94,7 @@ public class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldAddMessagesUnderCorrectHostNode()
+    void shouldAddMessagesUnderCorrectHostNode()
             throws DatabaseException, HttpMalformedHeaderException {
         // Given
         List<WebSocketChannelDTO> channels =
@@ -136,8 +136,7 @@ public class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldUpdateMessageIfExists()
-            throws DatabaseException, HttpMalformedHeaderException {
+    void shouldUpdateMessageIfExists() throws DatabaseException, HttpMalformedHeaderException {
         // Given
         List<WebSocketChannelDTO> channels =
                 channels(
@@ -159,7 +158,7 @@ public class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
     }
 
     @Test
-    public void shouldGetRightPosition() throws DatabaseException, HttpMalformedHeaderException {
+    void shouldGetRightPosition() throws DatabaseException, HttpMalformedHeaderException {
         // Given
         WebSocketChannelDTO channelA = getWebSocketChannelDTO(1, "Hostname_A");
         WebSocketChannelDTO channelB = getWebSocketChannelDTO(2, "Hostname_B");

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/utility/Utf8UtilUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/utility/Utf8UtilUnitTest.java
@@ -26,10 +26,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-public class Utf8UtilUnitTest {
+class Utf8UtilUnitTest {
 
     @Test
-    public void shouldEncodeEmptyBytesToEmptyString() throws Exception {
+    void shouldEncodeEmptyBytesToEmptyString() throws Exception {
         // given
         byte[] utf8 = new byte[0];
         // when
@@ -39,7 +39,7 @@ public class Utf8UtilUnitTest {
     }
 
     @Test
-    public void shouldFailOnGivenInvalidUtf8Bytes() throws Exception {
+    void shouldFailOnGivenInvalidUtf8Bytes() throws Exception {
         // given
         byte[] invalidUtf8 = new byte[] {-1};
         // when / then
@@ -47,7 +47,7 @@ public class Utf8UtilUnitTest {
     }
 
     @Test
-    public void shouldEncodeSimpleUtf8Bytes() throws Exception {
+    void shouldEncodeSimpleUtf8Bytes() throws Exception {
         // given
         byte[] utf8 = new byte[] {49, 50, 51};
         // when

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/utility/WebSocketUtilsUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/utility/WebSocketUtilsUnitTest.java
@@ -25,10 +25,10 @@ import static org.hamcrest.Matchers.is;
 
 import org.junit.jupiter.api.Test;
 
-public class WebSocketUtilsUnitTest {
+class WebSocketUtilsUnitTest {
 
     @Test
-    public void shouldEncodeTest1() throws Exception {
+    void shouldEncodeTest1() throws Exception {
         // given
         String key = "JIUetocUsIRxbzKP6sOH5Q==";
         // when
@@ -38,7 +38,7 @@ public class WebSocketUtilsUnitTest {
     }
 
     @Test
-    public void shouldEncodeTest2() throws Exception {
+    void shouldEncodeTest2() throws Exception {
         // given
         String key = "dGhlIHNhbXBsZSBub25jZQ==";
         // when

--- a/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
+++ b/addOns/zest/src/test/java/org/zaproxy/zap/extension/zest/ZestZapUtilsUnitTest.java
@@ -32,10 +32,10 @@ import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import org.zaproxy.zest.core.v1.ZestRequest;
 
 /** Unit test for {@link ZestZapUtils}. */
-public class ZestZapUtilsUnitTest {
+class ZestZapUtilsUnitTest {
 
     @Test
-    public void shouldKeepAllHeadersIfIncludingAllWhenConvertingHttpMessageToZestRequest()
+    void shouldKeepAllHeadersIfIncludingAllWhenConvertingHttpMessageToZestRequest()
             throws Exception {
         // Given
         boolean includeAllHeaders = true;
@@ -51,7 +51,7 @@ public class ZestZapUtilsUnitTest {
     }
 
     @Test
-    public void shouldRemoveIgnoredHeadersIfNotIncludingAllWhenConvertingHttpMessageToZestRequest()
+    void shouldRemoveIgnoredHeadersIfNotIncludingAllWhenConvertingHttpMessageToZestRequest()
             throws Exception {
         // Given
         boolean includeAllHeaders = false;


### PR DESCRIPTION
- automation, ascanrulesBeta, openapi > Ensure Unit Tests have assertions.
- alertFilters, ascanrules, ascanrulesAlpha, ascanrulesBeta, automation, bruteforce, domxss, frontendscanner, fuzz, graphql, imagelocationscanner, kotlin, openapi, pscanrules, pscanrulesAlpha, pscanrulesBeta, replacer, reports retire, selecium, soap, spiderAjax, sse, testutils, tokengen, wappalyzer, websocket, zest > Remove public modifier on JUnit test, before, etc methods.
- ascanrules, ascanrulesBeta, fuzz > ensure assertThrows lambdas only execute a single method (extract variables to given blocks for indirectly related work).
- graphql, websocket, retire, soap, pscanrules, wappalyzer > Replace use of assertTrue and assertFalse containing equality or  nequality tests with use of assertEquals or assertNotEquals with the relevant values.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>