### PR TITLE
improve: various add-ons more SAST (sonar) fixes

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Directory Browsing
     - Attack is now the URL of the request
     - Evidence added
+- Parameter Tampering scan rule, adjusted regular expression related to VBScript errors.
 
 ### Fixed
 - Fix XSS false positive (Issue 5958).

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
@@ -62,7 +62,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
     private static Pattern patternErrorJava2 =
             Pattern.compile("invoke.+exception|exception.+invoke", PATTERN_PARAM);
     private static Pattern patternErrorVBScript =
-            Pattern.compile("Microsoft(\\s+|&nbsp)*VBScript(\\s+|&nbsp)+error", PATTERN_PARAM);
+            Pattern.compile("Microsoft(?:\\s|&nbsp)+VBScript(?:\\s|&nbsp)+error", PATTERN_PARAM);
     private static Pattern patternErrorODBC1 =
             Pattern.compile("Microsoft OLE DB Provider for ODBC Drivers.*error", PATTERN_PARAM);
     private static Pattern patternErrorODBC2 =

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRuleUnitTest.java
@@ -153,6 +153,26 @@ class ParameterTamperScanRuleUnitTest extends ActiveScannerTest<ParameterTamperS
     }
 
     @Test
+    void shouldAlertIfAttackResponseContainsVbScriptError() throws Exception {
+        // Given
+        ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/", 2);
+        nano.addHandler(serverErrorOnAttack);
+        serverErrorOnAttack.setError("Microsoft VBScript error");
+        rule.init(getHttpMessage("/?p=v"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(4));
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(alertsRaised.get(0).getEvidence(), is(equalTo("Microsoft VBScript error")));
+        assertThat(alertsRaised.get(0).getParam(), is(equalTo("p")));
+        assertThat(alertsRaised.get(0).getAttack(), is(equalTo("@")));
+        assertThat(alertsRaised.get(0).getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alertsRaised.get(0).getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
+        assertThat(alertsRaised.get(0).getOtherInfo(), is(equalTo("")));
+    }
+
+    @Test
     void shouldNotAlertIfAttackResponseDoesNotContainsJavaServletError() throws Exception {
         // Given
         ServerErrorOnAttack serverErrorOnAttack = new ServerErrorOnAttack("/");

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update links to zaproxy repo.
 - Target 2.10 core and use new logging infrastructure (Log4j 2.x).
 - The LDAP Injection scan rule was modified to make use of the Dice algorithm for calculating the match percentage, thus improving its performance.
+- Maintenance changes.
 
 ### Added
 - CORS active scan rule.

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/CorsScanRule.java
@@ -69,7 +69,7 @@ public class CorsScanRule extends AbstractAppPlugin {
         };
 
         boolean secScheme = false;
-        if (scheme == "https") {
+        if ("https".equals(scheme)) {
             secScheme = true;
             payloads[5] = "http://" + authority;
         }

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - XPath Injection
     - Added evidence
 - The Source Code Disclosure - File Inclusion scan rule was modified to make use of the Dice algorithm for calculating the match percentage, thus improving its performance.
+- Maintenance changes.
 
 ## [33] - 2020-12-15
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
@@ -659,7 +659,10 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
                         // delete the temp file.
                         // this will be deleted when the VM is shut down anyway, but better to be
                         // safe than to run out of disk space.
-                        tempSqliteFile.delete();
+                        boolean success = tempSqliteFile.delete();
+                        if (!success) {
+                            log.debug("Could not delete {}.", tempSqliteFile.getAbsolutePath());
+                        }
                     }
 
                     break; // out of the while loop

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -77,7 +77,7 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
             "?name=abc#<img src=\"random.gif\" onerror=alert(1)>";
 
     // In order of effectiveness vs benchmark apps
-    public static final String[] ATTACK_STRINGS = {
+    private static final String[] ATTACK_STRINGS = {
         POLYGLOT_ALERT,
         HASH_JAVASCRIPT_ALERT,
         QUERY_HASH_IMG_ALERT,
@@ -93,7 +93,9 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
     private static final String SCRIPT_ALERT = "<script>alert(1)</script>";
     private static final String JAVASCRIPT_ALERT = "javascript:alert(1)";
 
-    public static final String[] PARAM_ATTACK_STRINGS = {SCRIPT_ALERT, JAVASCRIPT_ALERT, IMG_ALERT};
+    private static final String[] PARAM_ATTACK_STRINGS = {
+        SCRIPT_ALERT, JAVASCRIPT_ALERT, IMG_ALERT
+    };
 
     /** The name of the rule to obtain the ID of the browser. */
     private static final String RULE_BROWSER_ID = "rules.domxss.browserid";

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/OptionsFormHandlerPanel.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/OptionsFormHandlerPanel.java
@@ -41,11 +41,7 @@ public class OptionsFormHandlerPanel extends AbstractParamPanel {
 
     public OptionsFormHandlerPanel() {
         super();
-        initialize();
-    }
 
-    /** This method initializes this */
-    private void initialize() {
         this.setName(Constant.messages.getString("formhandler.options.title"));
         this.setLayout(new GridBagLayout());
 

--- a/addOns/importLogFiles/CHANGELOG.md
+++ b/addOns/importLogFiles/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.10.0.
 - Add import menu to (new) top level Import menu instead of Analyse menu.
 - Change info URL to link to the site.
+- Maintenance changes.
 
 ## 4 - 2017-05-05
 

--- a/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
+++ b/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
@@ -263,34 +263,19 @@ public class ImportLogAPI extends ApiImplementor {
             String httpPOSTData) {
         // Not appending the file with client state info as REST should produce a resource based on
         // the request indefinitely.
-        String sourceFilePath = filePath;
         String targetfileName =
-                sourceFilePath.substring(
-                                sourceFilePath.lastIndexOf("\\") + 1,
-                                sourceFilePath.lastIndexOf("."))
+                filePath.substring(filePath.lastIndexOf("\\") + 1, filePath.lastIndexOf("."))
                         + ".txt";
         String absoluteTargetFilePath = getLoggingStorageDirectory(logType) + "\\" + targetfileName;
         File targetFile = new File(absoluteTargetFilePath);
 
-        if (!targetFile.isFile() /* && !FileAlreadyExists(new File(sourceFilePath)) */) {
-            try {
-                targetFile.createNewFile();
-                // TODO investigate how to check for uniqueness of the file. Potentially hashing
-                // (md5) the string[] of the read
-                // file. Might be overkill?
-                // appendAddedFilesHashes(targetFile);
-            } catch (Exception ex) {
-                return new ApiResponseElement(
-                        "Parsing logs files to ZAPs site tree",
-                        "Failed - Could not create file on server");
-            }
-        } else {
+        if (targetFile.isFile()) {
             return new ApiResponseElement(
                     "Parsing logs files to ZAPs site tree", "Not processed - File already added");
         }
 
         if (httpPOSTData == null) {
-            try (BufferedReader br = new BufferedReader(new FileReader(sourceFilePath));
+            try (BufferedReader br = new BufferedReader(new FileReader(filePath));
                     BufferedWriter wr = new BufferedWriter(new FileWriter(targetFile))) {
                 String sCurrentLine;
 

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/OptionsInvokePanel.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/OptionsInvokePanel.java
@@ -43,11 +43,7 @@ public class OptionsInvokePanel extends AbstractParamPanel {
     public OptionsInvokePanel(ExtensionInvoke extension) {
         super();
         this.extension = extension;
-        initialize();
-    }
 
-    /** This method initializes this */
-    private void initialize() {
         this.setName(Constant.messages.getString("invoke.options.title"));
         this.setLayout(new GridBagLayout());
 

--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.10.0.
 - Update default values in the options to match the ones in the default configuration file.
+- Maintenance changes.
 
 ## 8 - 2017-11-24
 

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/OptionsPortScanPanel.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/OptionsPortScanPanel.java
@@ -47,15 +47,11 @@ public class OptionsPortScanPanel extends AbstractParamPanel {
 
     public OptionsPortScanPanel() {
         super();
-        initialize();
-    }
-
-    /** This method initializes this */
-    private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("ports.options.title"));
         this.add(getPanelPortScan(), getPanelPortScan().getName());
     }
+
     /**
      * This method initializes panelPortScan
      *

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Feature Policy
   - Site Isolation
   - Sub Resource Integrity
+- Maintenance changes.
 
 ## [30] - 2021-02-08
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.util.DateParseException;
 import org.apache.commons.httpclient.util.DateUtil;
@@ -81,6 +82,7 @@ public class CacheableScanRule extends PluginPassiveScanner {
     private static final String MESSAGE_PREFIX_STORABLE_NONCACHEABLE =
             "pscanalpha.storablenoncacheable.";
     private static final String MESSAGE_PREFIX_STORABLE_CACHEABLE = "pscanalpha.storablecacheable.";
+    private static final long SECONDS_IN_YEAR = TimeUnit.SECONDS.convert(365, TimeUnit.DAYS);
     private static final int PLUGIN_ID = 10049;
 
     private static final Logger logger = LogManager.getLogger(CacheableScanRule.class);
@@ -605,7 +607,7 @@ public class CacheableScanRule extends PluginPassiveScanner {
                         "{} has no caching lifetime expiry of any form, so assuming that it is set 'heuristically' to 1 year (as a form of worst case)",
                         msg.getRequestHeader().getURI());
                 lifetimeFound = true;
-                lifetime = 60 * 60 * 24 * 365;
+                lifetime = SECONDS_IN_YEAR;
                 // a liberal heuristic was assumed, for which no actual evidence exists
                 freshEvidence = null;
                 otherInfo =

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLConfiguration.java
@@ -85,7 +85,6 @@ public class SAMLConfiguration implements AttributeListener {
             }
             // try to copy configuration to user directory
             try {
-                confFile.createNewFile();
                 BufferedReader reader =
                         new BufferedReader(new InputStreamReader(confURL.openStream()));
                 BufferedWriter writer = new BufferedWriter(new FileWriter(confFile));


### PR DESCRIPTION
- ascanrules
  - ParameterTamperScanRule - Change VBScript pattern so use non-capturing groups and put repetition modifiers on the group instead of within the group. (CHANGELOG added change note, also added unit test.)
- ascanrulesBeta
  - SourceCodeDisclosureSvnScanRUle - Use the return value from deleting the temporary sqlite file, log a warning if the delete isn't successful.
- ascanrulesAlpha
  - CorsScanRule - Use .equals for string equality conditionals.
- domxss
  - DomXssScanRule - Make public arrays protected.
- formhandler
  - OptionsFormHandlerPanel - Remove initialize and add content to constructor (to not overlap with parents method), remove pointless javadoc.
- importLogFiles
  - ImportLogAPI - Don't explicitly create the file, allow it to be created while writing.
- invoke
  - OptionsInvokePanel  - Remove initialize and add content to constructor (to not overlap with parents method), remove pointless javadoc.
- portscan
  - OptionsPortScanPanel - Relocate initialize code to constructor (to not overlap with parents method).
- pscanrulesAlpha
  - CacheableScanRule - Use TimeUnit to calculate the long number of seconds in a year (vs. integer multiplication) and extract to a constant.
- saml
  - SAMLConfiguration - Don't explicitly create the file, allow it to be created while writing.

CHANGELOGs - Added maint note where applicable.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>