### PR TITLE
Use Java 8 when building for ZAP releases

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -34,8 +34,15 @@ subprojects {
     apply(plugin = "org.zaproxy.add-on")
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        // Compile with Java 8 when building ZAP releases.
+        if (System.getenv("ZAP_RELEASE") != null) {
+            toolchain {
+                languageVersion.set(JavaLanguageVersion.of(8))
+            }
+        } else {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
     }
 
     jacoco {


### PR DESCRIPTION
Always use Java 8 when building for ZAP releases as the core build now
requires running with Java 11, which could lead to wrong compilation.