### PR TITLE
accessControl: remove formatter related comments

### DIFF
--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
@@ -90,7 +90,6 @@ public class AccessControlAlertsProcessor {
         } catch (HttpMalformedHeaderException | DatabaseException e) {
             log.debug(e);
         }
-        // @formatter:off
         alert.setDetail(
                 Vulnerabilities.getDescription(vulnerabilityAuthorization),
                 result.getUri(),
@@ -107,7 +106,6 @@ public class AccessControlAlertsProcessor {
                 285, // CWE Id
                 2, // WASC Id
                 msg);
-        // @formatter:on
 
         alertExtension.alertFound(alert, result.getHistoryReference());
     }
@@ -122,7 +120,6 @@ public class AccessControlAlertsProcessor {
         } catch (HttpMalformedHeaderException | DatabaseException e) {
             log.debug(e);
         }
-        // @formatter:off
         alert.setDetail(
                 Vulnerabilities.getDescription(vulnerabilityAuthentication),
                 result.getUri(),
@@ -138,7 +135,6 @@ public class AccessControlAlertsProcessor {
                 287, // CWE Id
                 1, // WASC Id
                 msg);
-        // @formatter:on
 
         alertExtension.alertFound(alert, result.getHistoryReference());
     }


### PR DESCRIPTION
The comments to enable/disable the formatter no longer have any effect.