### PR TITLE
improve: exim: Address SAST (sonar) findings

### DIFF
--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
@@ -22,20 +22,17 @@ package org.zaproxy.addon.exim;
 import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.JMenu;
-import javax.swing.filechooser.FileFilter;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
-import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 abstract class AbstractPopupMenuSaveMessage extends PopupMenuHttpMessageContainer {
 
     private static final long serialVersionUID = 8080417865825721164L;
 
-    public static enum MessageComponent {
+    public enum MessageComponent {
         REQUEST,
         REQUEST_HEADER,
         REQUEST_BODY,
@@ -201,54 +198,12 @@ abstract class AbstractPopupMenuSaveMessage extends PopupMenuHttpMessageContaine
         }
 
         private File getOutputFile() {
-            SaveFileChooser fileChooser = new SaveFileChooser();
+            JFileChooser fileChooser = new EximFileChooser(fileExtension, fileDescription);
             int rc = fileChooser.showSaveDialog(View.getSingleton().getMainFrame());
             if (rc == JFileChooser.APPROVE_OPTION) {
                 return fileChooser.getSelectedFile();
             }
             return null;
-        }
-
-        private class SaveFileChooser extends WritableFileChooser {
-
-            private static final long serialVersionUID = -5743352709683023906L;
-
-            public SaveFileChooser() {
-                super(Model.getSingleton().getOptionsParam().getUserDirectory());
-                setFileFilter(new SpecificFileFilter());
-            }
-
-            @Override
-            public void approveSelection() {
-                File file = getSelectedFile();
-                if (file != null) {
-                    String fileName = file.getAbsolutePath();
-                    if (!fileName.endsWith(fileExtension)) {
-                        fileName += fileExtension;
-                        setSelectedFile(new File(fileName));
-                    }
-                }
-
-                super.approveSelection();
-            }
-        }
-
-        private class SpecificFileFilter extends FileFilter {
-
-            @Override
-            public boolean accept(File file) {
-                if (file.isDirectory()) {
-                    return true;
-                } else if (file.isFile() && file.getName().endsWith(fileExtension)) {
-                    return true;
-                }
-                return false;
-            }
-
-            @Override
-            public String getDescription() {
-                return fileDescription;
-            }
         }
     }
 

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/EximFileChooser.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/EximFileChooser.java
@@ -1,0 +1,72 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim;
+
+import java.io.File;
+import javax.swing.filechooser.FileFilter;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.view.widgets.WritableFileChooser;
+
+public class EximFileChooser extends WritableFileChooser {
+
+    private static final long serialVersionUID = 495386048962640141L;
+    private final String fileExtension;
+
+    public EximFileChooser(String fileExtension, String fileDescription) {
+        super(Model.getSingleton().getOptionsParam().getUserDirectory());
+        this.fileExtension = fileExtension;
+        setFileFilter(new EximFileFilter(fileExtension, fileDescription));
+    }
+
+    @Override
+    public void approveSelection() {
+        File file = getSelectedFile();
+        if (file != null) {
+            String fileName = file.getAbsolutePath();
+            if (!fileName.endsWith(fileExtension)) {
+                fileName += fileExtension;
+                setSelectedFile(new File(fileName));
+            }
+        }
+
+        super.approveSelection();
+    }
+
+    private static class EximFileFilter extends FileFilter {
+
+        private final String fileExtension;
+        private final String fileDescription;
+
+        EximFileFilter(String fileExtension, String fileDescription) {
+            this.fileExtension = fileExtension;
+            this.fileDescription = fileDescription;
+        }
+
+        @Override
+        public boolean accept(File file) {
+            return file.isDirectory() || (file.isFile() && file.getName().endsWith(fileExtension));
+        }
+
+        @Override
+        public String getDescription() {
+            return fileDescription;
+        }
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -43,11 +43,13 @@ import org.zaproxy.zap.network.HttpResponseBody;
 import org.zaproxy.zap.utils.HarUtils;
 import org.zaproxy.zap.utils.ThreadUtils;
 
-public class HarImporter {
+public final class HarImporter {
 
     private static final Logger LOG = LogManager.getLogger(HarImporter.class);
 
     private static ExtensionHistory extHistory;
+
+    private HarImporter() {}
 
     public static List<HttpMessage> getHttpMessages(HarLog log)
             throws HttpMalformedHeaderException {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
@@ -29,16 +29,14 @@ import java.io.OutputStream;
 import java.text.MessageFormat;
 import java.util.List;
 import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.exim.EximFileChooser;
 import org.zaproxy.zap.utils.HarUtils;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
-import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
 public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContainer {
 
@@ -104,52 +102,11 @@ public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContain
     }
 
     private static File getOutputFile() {
-        SaveHarFileChooser fileChooser = new SaveHarFileChooser();
+        JFileChooser fileChooser = new EximFileChooser(HAR_FILE_EXTENSION, FILE_DESCRIPTION);
         int rc = fileChooser.showSaveDialog(View.getSingleton().getMainFrame());
         if (rc == JFileChooser.APPROVE_OPTION) {
             return fileChooser.getSelectedFile();
         }
         return null;
-    }
-
-    private static class SaveHarFileChooser extends WritableFileChooser {
-
-        private static final long serialVersionUID = -5743352709683023906L;
-
-        public SaveHarFileChooser() {
-            super(Model.getSingleton().getOptionsParam().getUserDirectory());
-            setFileFilter(
-                    new FileFilter() {
-                        @Override
-                        public boolean accept(File file) {
-                            if (file.isDirectory()) {
-                                return true;
-                            } else if (file.isFile()
-                                    && file.getName().endsWith(HAR_FILE_EXTENSION)) {
-                                return true;
-                            }
-                            return false;
-                        }
-
-                        @Override
-                        public String getDescription() {
-                            return FILE_DESCRIPTION;
-                        }
-                    });
-        }
-
-        @Override
-        public void approveSelection() {
-            File file = getSelectedFile();
-            if (file != null) {
-                String fileName = file.getAbsolutePath();
-                if (!fileName.endsWith(HAR_FILE_EXTENSION)) {
-                    fileName += HAR_FILE_EXTENSION;
-                    setSelectedFile(new File(fileName));
-                }
-            }
-
-            super.approveSelection();
-        }
     }
 }


### PR DESCRIPTION
- Remove static modifier on enum, which is implicitly static.
- Return logical comparisons directly instead of within another conditional.
- Add private constructor to utility class (to prevent java from implicitly offering a public constructor).

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>