### PR TITLE
openapi: Updates for data-driven node parsing and multi-file schema support

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Support multi-file schema format.
 
 ## [19] - 2021-06-29
 ### Added

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Support multi-file schema format.
+- Generate Data Driven Nodes with schema import.
 
 ## [19] - 2021-06-29
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -19,12 +19,14 @@
  */
 package org.zaproxy.zap.extension.openapi;
 
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.httpclient.URI;
-import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.CommandLine;
@@ -253,13 +255,23 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             OpenApiResults results = new OpenApiResults();
             Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
             requestor.addListener(new HistoryPersister(results));
-            results.setErrors(
-                    importOpenApiDefinition(
-                            FileUtils.readFileToString(file, "UTF-8"),
-                            targetUrl,
-                            null,
-                            initViaUi,
-                            requestor));
+
+            if (!file.exists()) {
+                throw new IOException(file.getAbsolutePath() + " does not exist.");
+            }
+
+            SwaggerParseResult swaggerParseResult = SwaggerConverter.parse(file);
+            OpenAPI openApi = swaggerParseResult.getOpenAPI();
+
+            List<String> errors;
+            if (openApi == null || !swaggerParseResult.getMessages().isEmpty()) {
+                errors = swaggerParseResult.getMessages();
+            } else {
+                errors =
+                        importOpenApiDefinition(
+                                Json.pretty(openApi), targetUrl, null, initViaUi, requestor);
+            }
+            results.setErrors(errors);
             return results;
         } catch (IOException e) {
             if (initViaUi) {
@@ -328,6 +340,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                                                         + Constant.messages.getString(
                                                                 "openapi.parse.trailer"));
                             }
+                            errors.add(Constant.messages.getString("openapi.parse.error", e));
                             logErrors(errors, initViaUi);
                             LOG.warn(e.getMessage(), e);
                         }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -43,6 +43,7 @@ import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.openapi.converter.swagger.InvalidUrlException;
 import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerConverter;
+import org.zaproxy.zap.extension.openapi.network.RequestModel;
 import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
 import org.zaproxy.zap.model.ValueGenerator;
@@ -194,6 +195,30 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
     public OpenApiResults importOpenApiDefinitionV2(
             final URI uri, final String targetUrl, boolean initViaUi) {
+        return importOpenApiDefinitionV2(uri, targetUrl, initViaUi, -1);
+    }
+
+    /**
+     * Imports the API definition from a URI.
+     *
+     * @param uri the URI locating the API definition.
+     * @param targetUrl the URL to override the URL defined in the API, might be {@code null}.
+     * @param initViaUi {@code true} if the import is being done through the GUI, {@code false}
+     *     otherwise.
+     * @param contextId The contextId to add structural modifiers (data driven nodes) from openapi
+     *     spec path parameters {@code null}
+     * @return the list of errors, if any. Returns {@code null} if the import is being done through
+     *     the GUI, or, if not done through the GUI the target was not accessed (caused by an {@code
+     *     IOException}).
+     * @throws InvalidUrlException if the target URL is not valid.
+     */
+    public List<String> importOpenApiDefinition(
+            final URI uri, final String targetUrl, boolean initViaUi, int contextId) {
+        return this.importOpenApiDefinitionV2(uri, targetUrl, initViaUi, contextId).getErrors();
+    }
+
+    public OpenApiResults importOpenApiDefinitionV2(
+            final URI uri, final String targetUrl, boolean initViaUi, int contextId) {
         OpenApiResults results = new OpenApiResults();
         Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
         requestor.addListener(new HistoryPersister(results));
@@ -208,7 +233,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                             targetUrl,
                             uri.getScheme() + "://" + uri.getAuthority() + path,
                             initViaUi,
-                            requestor));
+                            requestor,
+                            contextId));
             return results;
         } catch (IOException e) {
             if (initViaUi) {
@@ -250,7 +276,29 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
     public OpenApiResults importOpenApiDefinitionV2(
             final File file, final String targetUrl, boolean initViaUi) {
+        return importOpenApiDefinitionV2(file, targetUrl, initViaUi, -1);
+    }
 
+    /**
+     * Imports the API definition from a file.
+     *
+     * @param file the file with the API definition.
+     * @param targetUrl the URL to override the URL defined in the API, might be {@code null}.
+     * @param initViaUi {@code true} if the import is being done through the GUI, {@code false}
+     *     otherwise.
+     * @param contextId The contextId to add structural modifiers (data driven nodes) from openapi
+     *     spec path parameters {@code null}
+     * @return the list of errors, if any. Returns {@code null} if the import is being done through
+     *     the GUI.
+     * @throws InvalidUrlException if the target URL is not valid.
+     */
+    public List<String> importOpenApiDefinition(
+            final File file, final String targetUrl, boolean initViaUi, int contextId) {
+        return this.importOpenApiDefinitionV2(file, targetUrl, initViaUi, contextId).getErrors();
+    }
+
+    public OpenApiResults importOpenApiDefinitionV2(
+            final File file, final String targetUrl, boolean initViaUi, int contextId) {
         try {
             OpenApiResults results = new OpenApiResults();
             Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
@@ -269,7 +317,12 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             } else {
                 errors =
                         importOpenApiDefinition(
-                                Json.pretty(openApi), targetUrl, null, initViaUi, requestor);
+                                Json.pretty(openApi),
+                                targetUrl,
+                                null,
+                                initViaUi,
+                                requestor,
+                                contextId);
             }
             results.setErrors(errors);
             return results;
@@ -288,7 +341,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             final String targetUrl,
             final String definitionUrl,
             boolean initViaUi,
-            final Requestor requestor) {
+            final Requestor requestor,
+            int contextId) {
         final List<String> errors = new ArrayList<>();
         SwaggerConverter converter =
                 new SwaggerConverter(targetUrl, definitionUrl, defn, getValueGenerator());
@@ -298,7 +352,9 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                     @Override
                     public void run() {
                         try {
-                            errors.addAll(requestor.run(converter.getRequestModels()));
+                            List<RequestModel> requestModels = converter.getRequestModels();
+                            converter.setStructuralNodeModifiers(contextId);
+                            errors.addAll(requestor.run(requestModels));
                             // Needs to be called after converter.getRequestModels() to get loop
                             // errors
                             errors.addAll(converter.getErrorMessages());

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
@@ -24,6 +24,7 @@ import java.util.List;
 import net.sf.json.JSONObject;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiImplementor;
@@ -31,6 +32,8 @@ import org.zaproxy.zap.extension.api.ApiResponse;
 import org.zaproxy.zap.extension.api.ApiResponseElement;
 import org.zaproxy.zap.extension.api.ApiResponseList;
 import org.zaproxy.zap.extension.openapi.converter.swagger.InvalidUrlException;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.utils.ApiUtils;
 
 public class OpenApiAPI extends ApiImplementor {
 
@@ -40,6 +43,7 @@ public class OpenApiAPI extends ApiImplementor {
     private static final String PARAM_URL = "url";
     private static final String PARAM_FILE = "file";
     private static final String PARAM_TARGET = "target";
+    private static final String PARAM_CONTEXT_ID = "contextId";
 
     private static final String PARAM_HOST_OVERRIDE = "hostOverride";
     private ExtensionOpenApi extension = null;
@@ -55,12 +59,12 @@ public class OpenApiAPI extends ApiImplementor {
                 new ApiAction(
                         ACTION_IMPORT_FILE,
                         new String[] {PARAM_FILE},
-                        new String[] {PARAM_TARGET}));
+                        new String[] {PARAM_TARGET, PARAM_CONTEXT_ID}));
         this.addApiAction(
                 new ApiAction(
                         ACTION_IMPORT_URL,
                         new String[] {PARAM_URL},
-                        new String[] {PARAM_HOST_OVERRIDE}));
+                        new String[] {PARAM_HOST_OVERRIDE, PARAM_CONTEXT_ID}));
     }
 
     @Override
@@ -81,8 +85,9 @@ public class OpenApiAPI extends ApiImplementor {
             }
             List<String> errors;
             String target = params.optString(PARAM_TARGET, "");
+            int ctxId = getContextId(params);
             try {
-                errors = extension.importOpenApiDefinition(file, target, false);
+                errors = extension.importOpenApiDefinition(file, target, false, ctxId);
             } catch (InvalidUrlException e) {
                 throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_TARGET);
             }
@@ -106,7 +111,10 @@ public class OpenApiAPI extends ApiImplementor {
 
                 List<String> errors =
                         extension.importOpenApiDefinition(
-                                new URI(params.getString(PARAM_URL), false), override, false);
+                                new URI(params.getString(PARAM_URL), false),
+                                override,
+                                false,
+                                getContextId(params));
 
                 if (errors == null) {
                     throw new ApiException(
@@ -128,5 +136,17 @@ public class OpenApiAPI extends ApiImplementor {
         } else {
             throw new ApiException(ApiException.Type.BAD_ACTION);
         }
+    }
+
+    private static int getContextId(JSONObject params) throws ApiException {
+        if (params.containsKey(PARAM_CONTEXT_ID) && !params.getString(PARAM_CONTEXT_ID).isEmpty()) {
+            return ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID).getId();
+        }
+
+        List<Context> contexts = Model.getSingleton().getSession().getContexts();
+        if (!contexts.isEmpty()) {
+            return contexts.get(0).getId();
+        }
+        return -1;
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -39,17 +39,22 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.openapi.converter.Converter;
 import org.zaproxy.zap.extension.openapi.generators.Generators;
 import org.zaproxy.zap.extension.openapi.network.RequestModel;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.StructuralNodeModifier;
 import org.zaproxy.zap.model.ValueGenerator;
 
 public class SwaggerConverter implements Converter {
@@ -58,6 +63,7 @@ public class SwaggerConverter implements Converter {
     private static final String BASE_KEY_I18N = "openapi.swaggerconverter.";
 
     private static Logger LOG = LogManager.getLogger(SwaggerConverter.class);
+    private static final Pattern PATH_PART_PATTERN = Pattern.compile("\\{.*}");
     private final UriBuilder targetUriBuilder;
     private final UriBuilder definitionUriBuilder;
     private String defn;
@@ -65,6 +71,8 @@ public class SwaggerConverter implements Converter {
     private RequestModelConverter requestConverter;
     private Generators generators;
     private List<String> errors = new ArrayList<>();
+    private Set<String> apiUrls;
+    private OpenAPI openAPI;
 
     public SwaggerConverter(String defn, ValueGenerator valGen) {
         this(null, null, defn, valGen);
@@ -170,7 +178,7 @@ public class SwaggerConverter implements Converter {
     }
 
     private List<OperationModel> readOpenAPISpec() throws SwaggerException {
-        OpenAPI openAPI = getOpenAPI();
+        openAPI = getOpenAPI();
         if (openAPI == null) {
             throw new SwaggerException(
                     Constant.messages.getString(BASE_KEY_I18N + "parse.defn.exception", defn));
@@ -179,8 +187,8 @@ public class SwaggerConverter implements Converter {
         List<OperationModel> operations = new ArrayList<>();
         List<UriBuilder> serverUriBuilders =
                 createUriBuilders(openAPI.getServers(), definitionUriBuilder);
-        for (String url :
-                createApiUrls(serverUriBuilders, targetUriBuilder, definitionUriBuilder)) {
+        apiUrls = createApiUrls(serverUriBuilders, targetUriBuilder, definitionUriBuilder);
+        for (String url : apiUrls) {
             addOperations(openAPI, url, operations);
         }
         return operations;
@@ -408,5 +416,105 @@ public class SwaggerConverter implements Converter {
 
         swaggerParseResult.setMessages(errors);
         return swaggerParseResult;
+    }
+
+    private List<StructuralNodeModifier> getStructuralNodeModifiers() {
+        if (openAPI == null) {
+            throw new IllegalStateException("The OpenAPI was not yet imported.");
+        }
+
+        String targetUrl = apiUrls.stream().findFirst().get();
+
+        Set<String> ddnRegexStrings = new HashSet<>();
+        // check for DDN on each key (path) in the spec
+        for (Map.Entry<String, PathItem> entry : openAPI.getPaths().entrySet()) {
+            String key = entry.getKey();
+            try {
+                List<String> params = getPathParameters(key);
+                String ddnPattern = createStructuralNodeRegexString(params, targetUrl, key);
+                if (ddnPattern != null) {
+                    ddnRegexStrings.add(ddnPattern);
+                }
+            } catch (Exception e) {
+                LOG.error("error evaluating DDN for key: {}", key, e);
+            }
+        }
+
+        List<StructuralNodeModifier> structuralNodeModifiers = new ArrayList<>();
+        int ddnCnt = 0;
+        for (String regexString : ddnRegexStrings) {
+            try {
+                Pattern pattern = Pattern.compile(regexString);
+                StructuralNodeModifier structuralNodeModifier =
+                        createStructuralNode(pattern, "DDN" + ddnCnt++);
+                structuralNodeModifiers.add(structuralNodeModifier);
+            } catch (Exception e) {
+                LOG.error("error adding structural node", e);
+            }
+        }
+
+        return structuralNodeModifiers;
+    }
+
+    public void setStructuralNodeModifiers(int contextId) {
+        if (contextId == -1) {
+            return;
+        }
+
+        try {
+            List<StructuralNodeModifier> structuralNodeModifiers = getStructuralNodeModifiers();
+            Context ctx = Model.getSingleton().getSession().getContext(contextId);
+            ctx.setDataDrivenNodes(structuralNodeModifiers);
+        } catch (Exception e) {
+            LOG.error("Error setting data driven nodes from spec for contextId: {}", contextId, e);
+            errors.add(e.getMessage());
+        }
+    }
+
+    private static StructuralNodeModifier createStructuralNode(Pattern pattern, String ddnName) {
+        return new StructuralNodeModifier(
+                StructuralNodeModifier.Type.DataDrivenNode, pattern, ddnName);
+    }
+
+    private static String createStructuralNodeRegexString(
+            List<String> params, String finalTargetUrl, String key) {
+        if (params.isEmpty()) {
+            return null;
+        }
+        // get last param as the DDN for the key
+        String lastParam = params.get(params.size() - 1);
+
+        StringBuilder sb = new StringBuilder();
+        if (finalTargetUrl != null) {
+            sb.append(finalTargetUrl);
+        }
+
+        sb.append('(');
+        String pathTill = key.split(lastParam)[0].replace("{", "");
+        // replace other params with .+? regex in the first path grouping
+        for (String param : params) {
+            if (!param.equals(lastParam)) {
+                pathTill = pathTill.replace(param, ".+?");
+            }
+        }
+        sb.append(pathTill);
+        // add trailing matcher for this DDN
+        sb.append(")(.+?)(/.*)");
+        return removeBrackets(sb.toString());
+    }
+
+    private static List<String> getPathParameters(String key) {
+        String[] pathParts = key.split("/");
+        List<String> params = new ArrayList<>();
+        for (String part : pathParts) {
+            if (PATH_PART_PATTERN.matcher(part).matches()) {
+                params.add(removeBrackets(part));
+            }
+        }
+        return params;
+    }
+
+    private static String removeBrackets(String str) {
+        return str.replace("{", "").replace("}", "");
     }
 }

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -42,8 +42,35 @@ The following operations are added to the API:
 </ul>
 Both <code>target</code> and <code>hostOverride</code> support the <code>Target URL</code> format explained earlier.
 
-The definitions will be imported synchronously and any warnings will be returned. 
+The definitions will be imported synchronously and any warnings will be returned.
 
+<H3>Data Driven Nodes</H3>
+<span style="white-space: pre;">
+When the OpenAPI schema contains path params the plugin will automatically generate data driven nodes in either the default context or for the context from the provided <code>contextId</code>.
+
+For example, the following OpenAPI definition will result in at least one data driven node.
+
+<strong>openapi.yml</strong>
+<code >
+    ...
+    /users/v1/{username}/email:
+      ...
+      parameters:
+        - name: username
+        in: path
+        description: username to update email
+        required: true
+        schema:
+          type: string
+    ...
+</code>
+
+<strong>Default Context > Structure > Structural Modifiers</strong>
+<code>
+    DDN0: (/)(.+?)(/.*)
+    DDN1: (/users/v1/)(.+?)(/.*)
+</code>
+</span>
 <H2>Command Line</H2>
 The following Command Line options are added:
 <ul>
@@ -57,7 +84,7 @@ The definitions will be imported synchronously and any warnings will be displaye
 <H2>User Specified Values</H2>
 Default values are used when importing OpenAPI definitions.<br>
 These can be overridden using the Form Handler add-on which allows you to specify your own values.<br>
-In most cases these will be simple values (like strings and integers) but in some cases you may need to specify structured values, 
+In most cases these will be simple values (like strings and integers) but in some cases you may need to specify structured values,
 e.g. <pre>{ "id": 0, "name": "Freda" }</pre>
 
 <H2>Statistics</H2>

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
@@ -1,0 +1,180 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import fi.iki.elonen.NanoHTTPD;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+class ExtensionOpenApiTest extends AbstractServerTest {
+
+    private ExtensionOpenApi extensionOpenApi;
+
+    @BeforeEach
+    void setupExtension() throws Exception {
+        extensionOpenApi = new ExtensionOpenApi();
+
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
+
+        given(extensionLoader.getExtension(ExtensionSpider.class))
+                .willReturn(mock(ExtensionSpider.class));
+    }
+
+    @Test
+    void shouldImportFile() throws IOException {
+        // Given
+        this.nano.addHandler(new EmptyServerHandler());
+        File definition = createLocalDefinition("v2/PetStore_defn.json").toFile();
+
+        // When
+        List<String> errors = extensionOpenApi.importOpenApiDefinition(definition, false);
+
+        // Then
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void shouldImportMultiFileV3() throws IOException {
+        // Given
+        this.nano.addHandler(new EmptyServerHandler());
+        File definition =
+                createLocalMultiFileDefinition(
+                        "v3/multi-file/", "api.yaml", "pet.api.yaml", "pet.model.yaml");
+
+        // When
+        List<String> errors = extensionOpenApi.importOpenApiDefinition(definition, false);
+
+        // Then
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void shouldImportMultiFileV2() throws IOException {
+        // Given
+        this.nano.addHandler(new EmptyServerHandler());
+        File definition =
+                createLocalMultiFileDefinition("v2/multi-file/", "api.yaml", "person.yaml");
+
+        // When
+        List<String> errors = extensionOpenApi.importOpenApiDefinition(definition, false);
+
+        // Then
+        assertThat(errors, is(empty()));
+    }
+
+    @Test
+    void shouldFailNonOpenApiURL() throws URIException {
+        // Given
+        this.nano.addHandler(new EmptyServerHandler());
+        URI uri = new URI("http://localhost:" + this.nano.getListeningPort() + "/non-defn", false);
+
+        // When
+        List<String> errors = extensionOpenApi.importOpenApiDefinition(uri, null, false);
+
+        // Then
+        assertThat(errors, is(not(empty())));
+    }
+
+    @Test
+    void shouldFailBadJson() {
+        // Given
+        File file = getResourcePath("bad-json.json").toFile();
+
+        // When
+        List<String> errors = extensionOpenApi.importOpenApiDefinition(file, false);
+
+        // Then
+        assertThat(errors, is(not(empty())));
+    }
+
+    @Test
+    void shouldFailBadYaml() {
+        // Given
+        File file = getResourcePath("bad-yaml.yml").toFile();
+
+        // When
+        List<String> errors = extensionOpenApi.importOpenApiDefinition(file, false);
+
+        // Then
+        assertThat(errors, is(not(empty())));
+    }
+
+    private Path createLocalDefinition(String path) throws IOException {
+        Path directory = Files.createTempDirectory("local-defn");
+        Path localDefinition = directory.resolve(path.substring(path.lastIndexOf("/") + 1));
+        String fileContents =
+                getHtml(
+                        path,
+                        new String[][] {{"PORT", String.valueOf(this.nano.getListeningPort())}});
+        Files.write(localDefinition, fileContents.getBytes(StandardCharsets.UTF_8));
+        return localDefinition;
+    }
+
+    private File createLocalMultiFileDefinition(String dir, String definition, String... resources)
+            throws IOException {
+        Path localDefinition = createLocalDefinition(dir + definition);
+
+        Path parentDirectory = localDefinition.getParent();
+        for (String name : resources) {
+            Files.write(
+                    parentDirectory.resolve(name),
+                    getHtml(dir + name).getBytes(StandardCharsets.UTF_8));
+        }
+        return localDefinition.toFile();
+    }
+
+    private static class EmptyServerHandler extends NanoServerHandler {
+
+        EmptyServerHandler() {
+            super("ServerHandler");
+        }
+
+        @Override
+        protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
+            return newFixedLengthResponse("");
+        }
+    }
+}

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
@@ -34,16 +35,31 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.StructuralNodeModifier;
 import org.zaproxy.zap.testutils.NanoServerHandler;
+import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 class ExtensionOpenApiTest extends AbstractServerTest {
@@ -52,6 +68,10 @@ class ExtensionOpenApiTest extends AbstractServerTest {
 
     @BeforeEach
     void setupExtension() throws Exception {
+        Constant.messages = new I18N(Locale.ENGLISH);
+        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        Model.setSingletonForTesting(model);
+
         extensionOpenApi = new ExtensionOpenApi();
 
         ExtensionLoader extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
@@ -142,6 +162,46 @@ class ExtensionOpenApiTest extends AbstractServerTest {
         assertThat(errors, is(not(empty())));
     }
 
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldGenerateDataDrivenNodesOnContext(String target) throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/PetStore_defn.json").toFile();
+        Context ctx = createContext();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        String targetUrl = target != null ? serverUrl + "/v1" : null;
+        String expectedUrl = target != null ? targetUrl : serverUrl + "/PetStore";
+
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, targetUrl, false, ctx.getId());
+
+        // Then
+        assertThat(
+                ctx.getDataDrivenNodes(),
+                contains(
+                        expectedUrl + "(/pet/)(.+?)(/.*)",
+                        expectedUrl + "(/store/order/)(.+?)(/.*)",
+                        expectedUrl + "(/user/)(.+?)(/.*)"));
+    }
+
+    @Test
+    void shouldGenerateDataDrivenNodesOnContextForMultiVarPath() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/MultiVarPath_defn.yaml").toFile();
+        Context ctx = createContext();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, null, false, ctx.getId());
+
+        // Then
+        assertThat(
+                ctx.getDataDrivenNodes(),
+                contains(
+                        serverUrl + "(/api/stuff/.+?/subthing/)(.+?)(/.*)",
+                        serverUrl + "(/api/stuff/)(.+?)(/.*)"));
+    }
+
     private Path createLocalDefinition(String path) throws IOException {
         Path directory = Files.createTempDirectory("local-defn");
         Path localDefinition = directory.resolve(path.substring(path.lastIndexOf("/") + 1));
@@ -166,6 +226,10 @@ class ExtensionOpenApiTest extends AbstractServerTest {
         return localDefinition.toFile();
     }
 
+    private static Context createContext() {
+        return Model.getSingleton().getSession().getNewContext("Test Context");
+    }
+
     private static class EmptyServerHandler extends NanoServerHandler {
 
         EmptyServerHandler() {
@@ -176,5 +240,56 @@ class ExtensionOpenApiTest extends AbstractServerTest {
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
             return newFixedLengthResponse("");
         }
+    }
+
+    private static Matcher<List<StructuralNodeModifier>> contains(String... regexes) {
+        List<String> expectedValues = new ArrayList<>();
+        expectedValues.addAll(Arrays.asList(regexes));
+        Collections.sort(expectedValues);
+
+        return new BaseMatcher<List<StructuralNodeModifier>>() {
+
+            @Override
+            public boolean matches(Object actualValue) {
+                @SuppressWarnings("unchecked")
+                List<StructuralNodeModifier> values = (List<StructuralNodeModifier>) actualValue;
+                if (values.isEmpty()) {
+                    return false;
+                }
+
+                List<String> matched = new ArrayList<>(expectedValues);
+                for (StructuralNodeModifier value : values) {
+                    if (!matched.remove(value.getPattern().pattern())) {
+                        return false;
+                    }
+                }
+                return matched.isEmpty();
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description
+                        .appendText("the DDN regular expressions to be ")
+                        .appendValue(expectedValues);
+            }
+
+            @Override
+            public void describeMismatch(Object item, Description description) {
+                @SuppressWarnings("unchecked")
+                List<StructuralNodeModifier> values = (List<StructuralNodeModifier>) item;
+                if (values.isEmpty()) {
+                    description.appendText("had no DDNs");
+                } else {
+                    description
+                            .appendText("were ")
+                            .appendValue(
+                                    values.stream()
+                                            .map(StructuralNodeModifier::getPattern)
+                                            .map(Pattern::pattern)
+                                            .sorted()
+                                            .collect(Collectors.toList()));
+                }
+            }
+        };
     }
 }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/OpenApiAPIUnitTest.java
@@ -27,7 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -37,6 +39,7 @@ import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.model.DefaultNameValuePair;
 import org.zaproxy.zap.model.NameValuePair;
@@ -52,6 +55,8 @@ class OpenApiAPIUnitTest extends AbstractServerTest {
     void prepare() {
         extension = mock(ExtensionOpenApi.class);
         openApiAPI = new OpenApiAPI(extension);
+        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        Model.setSingletonForTesting(model);
     }
 
     @Test
@@ -74,7 +79,7 @@ class OpenApiAPIUnitTest extends AbstractServerTest {
         void shouldThrowIllegalParameterIfFailedToAccessTarget() {
             // Given
             JSONObject params = params(param("url", "http://not-reachable.example.com"));
-            given(extension.importOpenApiDefinition(any(URI.class), eq(""), eq(false)))
+            given(extension.importOpenApiDefinition(any(URI.class), eq(""), eq(false), eq(-1)))
                     .willReturn(null);
             // When / Then
             ApiException exception =

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/bad-json.json
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/bad-json.json
@@ -1,0 +1,3 @@
+{
+   "notswagger:"x.0"
+}

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/bad-yaml.yml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/bad-yaml.yml
@@ -1,0 +1,1 @@
+this -: ddd : ddd

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/multi-file/api.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/multi-file/api.yaml
@@ -1,0 +1,68 @@
+swagger: "2.0"
+
+info:
+  version: 1.0.0
+  title: Simple API
+  description: A simple API to learn how to write OpenAPI Specification
+
+schemes:
+  - http
+host: localhost:@@@PORT@@@
+basePath: /
+
+paths:
+  /persons:
+    get:
+      summary: Gets some persons
+      description: Returns a list containing all persons. The list supports paging.
+      parameters:
+        - name: pageSize
+          in: query
+          description: Number of persons returned
+          type: integer
+        - name: pageNumber
+          in: query
+          description: Page number
+          type: integer
+      responses:
+        200:
+          description: A list of Person
+          schema:
+            $ref: "#/definitions/Persons"
+    post:
+      summary: Creates a person
+      description: Adds a new person to the persons list.
+      parameters:
+        - name: person
+          in: body
+          description: The person to create.
+          schema:
+            $ref: "person.yaml#/Person"
+      responses:
+        204:
+          description: Persons succesfully created.
+        400:
+          description: Persons couldn't have been created.
+  /persons/{username}:
+    get:
+      summary: Gets a person
+      description: Returns a single person for its username.
+      parameters:
+        - name: username
+          in: path
+          required: true
+          description: The person's username
+          type: string
+      responses:
+        200:
+          description: A Person
+          schema:
+            $ref: "person.yaml#/Person"
+        404:
+          description: The Person does not exists.
+
+definitions:
+  Persons:
+    type: array
+    items:
+      $ref: "person.yaml#/Person"

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/multi-file/person.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v2/multi-file/person.yaml
@@ -1,0 +1,10 @@
+Person:
+  required:
+    - username
+  properties:
+    firstName:
+      type: string
+    lastName:
+      type: string
+    username:
+      type: string

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/MultiVarPath_defn.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/MultiVarPath_defn.yaml
@@ -1,0 +1,90 @@
+openapi: 3.0.1
+info:
+  title: Thing API
+  description: OpenAPI v3 specs for Thing
+  version: "0.1"
+servers:
+  - url: http://localhost:@@@PORT@@@/
+components: {}
+paths:
+  /api/stuff/static:
+    get:
+      tags:
+        - static
+      responses:
+        200:
+          description: Successfully display thing1
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    val1:
+                      type: string
+                    val2:
+                      type: string
+        404:
+          description: static not found
+          content: { }
+  /api/stuff/{thingid}:
+    get:
+      tags:
+        - thingid
+      parameters:
+        - name: thingid
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successfully display thing1
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    val1:
+                      type: string
+                    val2:
+                      type: string
+        404:
+          description: thing1 not found
+          content: { }
+  /api/stuff/{thingid}/subthing/{thingid2}:
+    get:
+      tags:
+        - thingconn
+      parameters:
+        - name: thingid
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: thingid2
+          in: path
+          required: true
+          schema:
+            type: string
+
+      responses:
+        200:
+          description: Successfully display thing conn
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    val1:
+                      type: string
+                    val2:
+                      type: string
+        404:
+          description: thing1 not found
+          content: { }

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/multi-file/api.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/multi-file/api.yaml
@@ -1,0 +1,61 @@
+openapi: 3.0.1
+info:
+  title: Swagger Petstore
+  description: 'This is a sample server Petstore server.  You can find out more about     Swagger
+    at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For
+    this sample, you can use the api key `special-key` to test the authorization filters.'
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+  - url: http://localhost:@@@PORT@@@
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+  - name: user
+    description: Operations about user
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+paths:
+  /pet:
+    $ref: 'pet.api.yaml#/pet'
+  /pet/findByTags:
+    $ref: 'pet.api.yaml#/pet-findByTags'
+  /pet/{petId}:
+    $ref: 'pet.api.yaml#/pet-petId'
+
+components:
+  schemas:
+    Tag:
+      $ref: 'pet.model.yaml#/Tag'
+    Pet:
+      $ref: 'pet.model.yaml#/Pet'
+    ApiResponse:
+      $ref: 'pet.model.yaml#/ApiResponse'
+
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: http://petstore.swagger.io/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/multi-file/pet.api.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/multi-file/pet.api.yaml
@@ -1,0 +1,108 @@
+pet:
+  put:
+    tags:
+      - pet
+    summary: Update an existing pet
+    operationId: updatePet
+    requestBody:
+      description: Pet object that needs to be added to the store
+      content:
+        application/json:
+          schema:
+            $ref: 'pet.model.yaml#/Pet'
+        application/xml:
+          schema:
+            $ref: 'pet.model.yaml#/Pet'
+      required: true
+    responses:
+      400:
+        description: Invalid ID supplied
+        content: {}
+      404:
+        description: Pet not found
+        content: {}
+      405:
+        description: Validation exception
+        content: {}
+    security:
+      - petstore_auth:
+          - write:pets
+          - read:pets
+    x-codegen-request-body-name: body
+
+pet-petId:
+  get:
+    tags:
+      - pet
+    summary: Find pet by ID
+    description: Returns a single pet
+    operationId: getPetById
+    parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+    responses:
+      200:
+        description: successful operation
+        content:
+          application/xml:
+            schema:
+              $ref: 'pet.model.yaml#/Pet'
+          application/json:
+            schema:
+              $ref: 'pet.model.yaml#/Pet'
+      400:
+        description: Invalid ID supplied
+        content: {}
+      404:
+        description: Pet not found
+        content: {}
+    security:
+      - api_key: []
+
+pet-findByTags:
+  get:
+    tags:
+      - pet
+    summary: Finds Pets by tags
+    description: Muliple tags can be provided with comma separated strings. Use         tag1,
+      tag2, tag3 for testing.
+    operationId: findPetsByTags
+    parameters:
+      - name: tags
+        in: query
+        description: Tags to filter by
+        required: true
+        style: form
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+    responses:
+      200:
+        description: successful operation
+        content:
+          application/xml:
+            schema:
+              type: array
+              items:
+                $ref: 'pet.model.yaml#/Pet'
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: 'pet.model.yaml#/Pet'
+      400:
+        description: Invalid tag value
+        content: {}
+    deprecated: true
+    security:
+      - petstore_auth:
+          - write:pets
+          - read:pets
+

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/multi-file/pet.model.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/multi-file/pet.model.yaml
@@ -1,0 +1,42 @@
+Pet:
+  required:
+    - name
+  type: object
+  properties:
+    id:
+      type: integer
+      format: int64
+    name:
+      type: string
+      example: doggie
+    tags:
+      type: array
+      xml:
+        name: tag
+        wrapped: true
+      items:
+        $ref: '#/Tag'
+  xml:
+    name: Pet
+
+Tag:
+  type: object
+  properties:
+    id:
+      type: integer
+      format: int64
+    name:
+      type: string
+  xml:
+    name: Tag
+
+ApiResponse:
+  type: object
+  properties:
+    code:
+      type: integer
+      format: int32
+    type:
+      type: string
+    message:
+      type: string


### PR DESCRIPTION
* Build and return a `StructuralNodeModifier` list based on path parameters found
  in the provided OpenAPI spec
* Handle multiple path variables and generate appropriate regex for data driven nodes
* Use default context for adding DDNs if not provided
* Add multi-file schema support

Signed-off-by: Adam Baldwin <adam.baldwin@stackhawk.com>