### PR TITLE
renamed to Permissions-Policy in the spec

### DIFF
--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java
@@ -63,7 +63,9 @@ public class FeaturePolicyScanRule extends PluginPassiveScanner {
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Browser_compatibility
         List<String> featurePolicyOptions =
                 httpMessage.getResponseHeader().getHeaderValues("Feature-Policy");
-        if (featurePolicyOptions.isEmpty()) {
+        List<String> permissionPolicyOptions =
+                httpMessage.getResponseHeader().getHeaderValues("Permissions-Policy");
+        if (featurePolicyOptions.isEmpty() && permissionPolicyOptions.isEmpty()) {
             newAlert()
                     .setRisk(Alert.RISK_LOW)
                     .setConfidence(Alert.CONFIDENCE_MEDIUM)


### PR DESCRIPTION
see -> https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy

Warning
The header has now been renamed to Permissions-Policy in the spec, and this article will eventually be updated to reflect that change.