### PR TITLE
fix: pscanrules: CacheControl scan rule CSS & Threshold adjustment

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - JSF ViewState
   - MS ViewState
   - X-Content-Type-Options
+- Cache-control scan rule no longer checks CSS messages unless threshold is Low (Issue 6596).
 
 ## [33] - 2021-01-29
 ### Added

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -25,8 +25,8 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
  
 <H2>Cache Control</H2>
 Checks "Cache-Control" response headers against general industry best practice settings for protection of sensitive content.<br>
-At MEDIUM and HIGH thresholds only non-error or non-redirect text responses (excluding JavaScript) are considered.<br>
-At LOW threshold all responses apart from images and CSS are considered including errors and redirects.
+At MEDIUM and HIGH thresholds only non-error or non-redirect text responses (excluding JavaScript and CSS) are considered.<br>
+At LOW threshold all responses are considered including errors and redirects.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java">CacheControlScanRule.java</a>
 


### PR DESCRIPTION
- CacheControlScanRule > CSS traffic is now skipped unless threshold is Low. Clean code: Merged some conditional statements, removed some unused parameters in private methods, remove empty method for which there is now a default.
- CacheControlScanRuleUnitTest > Parameterized some tests. Added tests to assert new CSS behavior.
- pscanrules.html > Updated help to reflect current threshold handling details.
- CHANGELOG > Added change note.

Fixes zaproxy/zaproxy#6596

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>