### PR TITLE
Remove unnecessary methods in passive scan rules

### DIFF
--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Minimum ZAP version is now 2.10.
+- Maintenance changes.
 
 ## [2] - 2020-07-03
 ### Added

--- a/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
+++ b/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
@@ -60,11 +60,6 @@ public class ImageLocationScanRule extends PluginPassiveScanner {
     }
 
 	@Override
-	public void scanHttpRequestSend(HttpMessage msg, int id) {
-		return;
-	}
-
-	@Override
 	public int getPluginId() {
 		return PLUGIN_ID;
 	}

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -144,17 +144,6 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
     }
 
     /**
-     * Scan the request. Currently it does nothing.
-     *
-     * @param msg the HTTP message
-     * @param id the id of the request
-     */
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Do Nothing it's related to response managed
-    }
-
-    /**
      * Perform the passive scanning of application errors inside the response content
      *
      * @param msg the message that need to be checked

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java
@@ -77,11 +77,6 @@ public class CharsetMismatchScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getResponseBody().length() == 0) {
             return;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -81,11 +81,6 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         boolean cspHeaderFound = false;
         int noticesRisk = Alert.RISK_INFO;

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
@@ -36,11 +36,6 @@ public class ContentTypeMissingScanRule extends PluginPassiveScanner {
     private static final int PLUGIN_ID = 10019;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getResponseBody().length() > 0) {
             List<String> contentType =

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -50,11 +50,6 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         IteratorChain iterator = new IteratorChain();
         List<String> cookies1 = msg.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -51,11 +51,6 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         List<HttpCookie> cookies =
                 msg.getResponseHeader().getHttpCookies(msg.getRequestHeader().getHostName());

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
@@ -50,11 +50,6 @@ public class CookieSameSiteScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         checkCookies(msg, id, HttpHeader.SET_COOKIE);
         checkCookies(msg, id, HttpHeader.SET_COOKIE2);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -50,11 +50,6 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!msg.getRequestHeader().isSecure()) {
             // If SSL isn't used then the Secure flag has not to be checked

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
@@ -57,15 +57,6 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner {
     }
 
     /**
-     * scans the HTTP request sent (in fact, does nothing)
-     *
-     * @param msg
-     * @param id
-     */
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    /**
      * scans the HTTP response for cross-domain mis-configurations
      *
      * @param msg

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
@@ -48,9 +48,6 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
     private Model model = null;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getResponseBody().length() > 0 && msg.getResponseHeader().isHtml()) {
             List<Element> sourceElements = source.getAllElements(HTMLElementName.SCRIPT);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -67,12 +67,6 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
         // Nothing to do.
     }
 
-    /** does nothing. The request itself is not scanned. Only the response is scanned. */
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
     /**
      * gets the plugin id for this extension
      *

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
@@ -117,11 +117,6 @@ public class InfoPrivateAddressDisclosureScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         String host = msg.getRequestHeader().getHostName();
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
@@ -130,18 +130,6 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner {
         // Nothing to do.
     }
 
-    /**
-     * Scan the request. Currently it does nothing.
-     *
-     * @param msg the HTTP message
-     * @param id the id of the response
-     */
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do Nothing. All work currently is done in the scanHttpResponseReceive()
-        // method.
-    }
-
     private static final Pattern PATHSESSIONIDPATTERN =
             Pattern.compile(
                     "jsessionid=[\\dA-Z]{" + SESSION_TOKEN_MIN_LENGTH + ",}",

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
@@ -49,9 +49,6 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
     private List<String> errors = null;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         // At medium or high exclude javascript responses
         if (!AlertThreshold.LOW.equals(this.getAlertThreshold())

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.htmlparser.jericho.Source;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -100,9 +99,6 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner {
             }
         }
     }
-
-    @Override
-    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {}
 
     private void raiseAlert(HttpMessage msg, int id, String param, String evidence, String other) {
         newAlert()

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.htmlparser.jericho.Source;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
@@ -210,9 +209,6 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner 
         }
         return null;
     }
-
-    @Override
-    public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {}
 
     @Override
     public int getPluginId() {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -59,9 +59,6 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
     private static List<Pattern> patterns = null;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         List<Pattern> patterns = getPatterns();

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
@@ -73,12 +73,6 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // You can also detect potential vulnerabilities here, with the same
-        // caveats as below.
-    }
-
-    @Override
     public int getPluginId() {
         return 90001; // This is be changed if included in the ZAP code base
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
@@ -43,11 +43,6 @@ public class MixedContentScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!msg.getRequestHeader().isSecure()) {
             // If SSL/TLS isn't used then this check isn't relevant

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -95,17 +95,6 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
     }
 
     /**
-     * scans the HTTP request sent (in fact, does nothing)
-     *
-     * @param msg
-     * @param id
-     */
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // TODO: implement checks for timestamps in the request?
-    }
-
-    /**
      * scans the HTTP response for timestamp signatures
      *
      * @param msg

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
@@ -74,11 +74,6 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         List<User> scanUsers = getUsers();
         if (scanUsers.isEmpty()) { // Should continue if not empty

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
@@ -46,11 +46,6 @@ public class ViewstateScanRule extends PluginPassiveScanner {
     private static Pattern hiddenFieldPattern = Pattern.compile("__.*");
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Nothing to do on send
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         Map<String, StartTag> hiddenFields = getHiddenFields(source);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
@@ -50,9 +50,6 @@ public class XAspNetVersionScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         for (String header : xAspNetHeaders) {
             List<String> found = msg.getResponseHeader().getHeaderValues(header);

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
@@ -38,9 +38,6 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner {
     private static final int PLUGIN_ID = 10021;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         boolean includeErrorRedirectResponses = false;
         switch (this.getAlertThreshold()) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
@@ -53,11 +53,6 @@ public class XDebugTokenScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
@@ -49,9 +49,6 @@ public class XFrameOptionScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         boolean includeErrorsAndRedirects = false;
 

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
@@ -52,11 +52,6 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -84,11 +84,6 @@ public class Base64Disclosure extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // TODO: implement checks for base64 encoding in the request?
-    }
-
     /**
      * scans the HTTP response for base64 signatures
      *

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
@@ -93,11 +93,6 @@ public class CacheableScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this scan rule
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         // TODO: standardise the logic in the case of duplicate / conflicting headers.

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
@@ -49,11 +49,6 @@ public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this scan rule
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
@@ -62,11 +62,6 @@ public class JsFunctionScanRule extends PluginPassiveScanner {
     private static List<Pattern> patterns = null;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // This rule only scans responses received
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getResponseBody().length() <= 0
                 || (!msg.getResponseHeader().isHtml() && !msg.getResponseHeader().isJavaScript())) {

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
@@ -635,11 +635,6 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
     /**
      * scans the HTTP response for Source Code signatures
      *

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
@@ -90,11 +90,6 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner 
     private static final String MESSAGE_PREFIX = "pscanalpha.sri-integrity.";
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         List<Element> sourceElements = source.getAllElements();

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
@@ -48,11 +48,6 @@ public class BigRedirectsScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this rule
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
@@ -51,11 +51,6 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java
@@ -74,17 +74,6 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
     }
 
     /**
-     * scans the HTTP request sent (in fact, does nothing)
-     *
-     * @param msg
-     * @param id
-     */
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    /**
      * scans the HTTP response for signatures that might indicate Directory Browsing
      *
      * @param msg

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java
@@ -70,11 +70,6 @@ public class HeartBleedScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
     /**
      * scans the HTTP response for signatures that might indicate the Heartbleed OpenSSL
      * vulnerability

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
@@ -45,11 +45,6 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!getHelper().isPage200(msg) || isHttps(msg) || !isResponseHTML(msg, source)) {
             return;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
@@ -45,11 +45,6 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!getHelper().isPage200(msg) || !isHttps(msg) || !isResponseHTML(msg, source)) {
             return;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
@@ -63,9 +63,6 @@ public class LinkTargetScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public int getPluginId() {
         return 10108;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java
@@ -41,11 +41,6 @@ public class ModernAppDetectionScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!msg.getResponseHeader().isHtml()) {
             // Only check HTML responses

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
@@ -85,9 +85,6 @@ public class PiiScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getResponseHeader().isCss() || msg.getRequestHeader().isCss()) {
             return;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
@@ -47,11 +47,6 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
 
         try {

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
@@ -51,11 +51,6 @@ public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
@@ -54,11 +54,6 @@ public class ServletParameterPollutionScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Ignore
-    }
-
-    @Override
     public int getPluginId() {
         return PLUGIN_ID;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
@@ -87,11 +87,6 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner {
         // Nothing to do.
     }
 
-    @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
     private void raiseAlert(VulnType currentVT, String evidence, HttpMessage msg, int id) {
         newAlert()
                 .setName(getAlertElement(currentVT, "name"))

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
@@ -50,11 +50,6 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!getHelper().isPage200(msg)) {
             return;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java
@@ -50,11 +50,6 @@ public class UserControlledCookieScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         List<String> cookies = msg.getResponseHeader().getHeaderValues(HttpHeader.SET_COOKIE);
         if (cookies.isEmpty()) {

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
@@ -52,11 +52,6 @@ public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!getHelper().isPage200(msg) || !isResponseHTML(msg, source)) {
             return;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
@@ -92,11 +92,6 @@ public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner 
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!getHelper().isPage200(msg)) {
             return;

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
@@ -54,11 +54,6 @@ public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getResponseHeader().getStatusCode() == HttpStatusCode.MOVED_PERMANENTLY
                 || msg.getResponseHeader().getStatusCode() == HttpStatusCode.FOUND) {

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
@@ -49,11 +49,6 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner 
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
@@ -51,11 +51,6 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response for this plugin
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         long start = System.currentTimeMillis();
 

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -54,11 +54,6 @@ public class RetireScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (!getHelper().isPage200(msg) || getRepo() == null) {
             return;

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java
@@ -38,9 +38,6 @@ public class SAMLPassiveScanner extends PluginPassiveScanner {
     private PassiveScanThread parent;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {}
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         scanMessage(msg, id);
     }

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
@@ -37,11 +37,6 @@ public class WSDLFilePassiveScanRule extends PluginPassiveScanner {
     private PassiveScanThread parent = null;
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // Only checking the response.
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (isWsdl(msg)) {
             HttpResponseHeader header = msg.getResponseHeader();

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -60,11 +60,6 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
     }
 
     @Override
-    public void scanHttpRequestSend(HttpMessage msg, int id) {
-        // do nothing
-    }
-
-    @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         String siteIdentifier = getSiteIdentifier(msg);
 


### PR DESCRIPTION
Remove override of `scanHttpRequestSend` and `scanHttpResponseReceive`
when not doing anything, those methods no longer need to be implemented.
Update changelog where needed.

Ref zaproxy/zaproxy#5546.