### PR TITLE
fix: pscanrules: Cookie SameSite Attribute "none" handling

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - MS ViewState
   - X-Content-Type-Options
 - Cache-control scan rule no longer checks CSS messages unless threshold is Low (Issue 6596).
+- Cookie SameSite Attribute scan rule now handles the value "none" (Issue 6482).
 
 ## [33] - 2021-01-29
 ### Added

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -76,7 +76,12 @@ A cookie set with the secure flag will not be sent during a plain HTTP session.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java">CookieSecureFlagScanRule.java</a>
 
 <H2>Cookie Without SameSite Attribute</H2>
-This reports any cookies that do not have the SameSite attribute or that do not have a recognised valid value for that attribute.
+This reports any cookies that:
+<ul>
+  <li>do not have the SameSite attribute</li>
+  <li>have the attribute set to "None" (ignored at HIGH Threshold)</li>
+  <li>do not have a recognised valid value for that attribute</li>
+</ul>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java">CookieSameSiteScanRule.java</a>
 

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -26,10 +26,14 @@ pscanrules.charsetmismatch.extrainfo.html.header_metacharset_mismatch=There was 
 pscanrules.charsetmismatch.extrainfo.html.metacontenttype_metacharset_mismatch=There was a charset mismatch between the META charset and the META content-type encoding declaration: [{0}] and [{1}] do not match.
 pscanrules.charsetmismatch.extrainfo.xml=There was a charset mismatch between the HTTP Header and the XML encoding declaration: [{0}] and [{1}] do not match.
 
-pscanrules.cookiesamesite.name = Cookie Without SameSite Attribute
+pscanrules.cookiesamesite.name = Cookie without SameSite Attribute
+pscanrules.cookiesamesite.none.name = Cookie with SameSite Attribute None
 pscanrules.cookiesamesite.desc=A cookie has been set without the SameSite attribute, which means that the cookie can be sent as a result of a 'cross-site' request. \
 The SameSite attribute is an effective counter measure to cross-site request forgery, cross-site script inclusion, and timing attacks.
-pscanrules.cookiesamesite.badval=A cookie has been set with an invalid SameSite attribute value, which means that the cookie can be sent as a result of a 'cross-site' request. \
+pscanrules.cookiesamesite.none.desc=A cookie has been set with its SameSite attribute set to "none", which means that the cookie can be sent as a result of a 'cross-site' request. \
+The SameSite attribute is an effective counter measure to cross-site request forgery, cross-site script inclusion, and timing attacks.
+pscanrules.cookiesamesite.badval.name = Cookie with Invalid SameSite Attribute
+pscanrules.cookiesamesite.badval.desc=A cookie has been set with an invalid SameSite attribute value, which means that the cookie can be sent as a result of a 'cross-site' request. \
 The SameSite attribute is an effective counter measure to cross-site request forgery, cross-site script inclusion, and timing attacks.
 pscanrules.cookiesamesite.soln=Ensure that the SameSite attribute is set to either 'lax' or ideally 'strict' for all cookies.
 pscanrules.cookiesamesite.refs=https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site


### PR DESCRIPTION
- CookieSameSiteScanRule > Added logic to handle "none" SameSite value. Removed unused variable handling in a private method.
- CookieSameSiteScanRuleUnitTest > Added tests to assert the updated behavior. Clean code: Added a convenience method for message creation (to reduce code duplication). Added Given, When, Then comments and reduced unnecessary whitespace.
- Messages.properties > Added keys/values to support new "none" related alerts.
- pscanrules.html > Updated help entry.
- CHANGELOG > Added change note.

Fixes zaproxy/zaproxy#6482

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>