### PR TITLE
improve: various add-ons: Address SAST (sonar) Vulnerabilities

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Don't set the font color for inherited entries (Issue 6397).
 - Update minimum ZAP version to 2.10.0.
-- Maintenance changes.
+- Maintenance changes (some changes impact the visibility of variables and add getters/setters, which may impact third party add-ons or scripts).
 
 ## [6] - 2020-10-06
 

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAPI.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAPI.java
@@ -101,7 +101,8 @@ public class AccessControlAPI extends ApiImplementor {
 
                 AccessControlScanStartOptions startOptions = new AccessControlScanStartOptions();
 
-                startOptions.targetContext = ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID);
+                startOptions.setTargetContext(
+                        ApiUtils.getContextByParamId(params, PARAM_CONTEXT_ID));
 
                 Mode mode = Control.getSingleton().getMode();
                 if (Mode.safe.equals(mode)) {
@@ -110,12 +111,12 @@ public class AccessControlAPI extends ApiImplementor {
                             Constant.messages.getString(
                                     "accessControl.scanOptions.error.mode.safe"));
                 } else if (Mode.protect.equals(mode)) {
-                    if (!startOptions.targetContext.isInScope()) {
+                    if (!startOptions.getTargetContext().isInScope()) {
                         throw new ApiException(
                                 ApiException.Type.MODE_VIOLATION,
                                 Constant.messages.getString(
                                         "accessControl.scanOptions.error.mode.protected",
-                                        startOptions.targetContext.getName()));
+                                        startOptions.getTargetContext().getName()));
                     }
                 }
 
@@ -143,7 +144,8 @@ public class AccessControlAPI extends ApiImplementor {
                     }
                     User userToAdd =
                             usersExtension
-                                    .getContextUserAuthManager(startOptions.targetContext.getId())
+                                    .getContextUserAuthManager(
+                                            startOptions.getTargetContext().getId())
                                     .getUserById(userID);
                     if (userToAdd != null) {
                         users.add(userToAdd);
@@ -154,19 +156,19 @@ public class AccessControlAPI extends ApiImplementor {
                     }
                 }
 
-                startOptions.targetUsers = users;
+                startOptions.setTargetUsers(users);
 
                 // Add unauthenticated user
                 if (params.optBoolean(PARAM_UNAUTH_USER, false)) {
-                    startOptions.targetUsers.add(null);
+                    startOptions.getTargetUsers().add(null);
                 }
 
-                startOptions.raiseAlerts = params.optBoolean(PARAM_RAISE_ALERT, true);
+                startOptions.setRaiseAlerts(params.optBoolean(PARAM_RAISE_ALERT, true));
 
-                startOptions.alertRiskLevel =
-                        params.optInt(PARAM_ALERT_RISK_LEVEL, Alert.RISK_HIGH);
-                if (!(startOptions.alertRiskLevel >= Alert.RISK_INFO
-                        && startOptions.alertRiskLevel <= Alert.RISK_HIGH)) {
+                startOptions.setAlertRiskLevel(
+                        params.optInt(PARAM_ALERT_RISK_LEVEL, Alert.RISK_HIGH));
+                if (!(startOptions.getAlertRiskLevel() >= Alert.RISK_INFO
+                        && startOptions.getAlertRiskLevel() <= Alert.RISK_HIGH)) {
                     throw new ApiException(
                             ApiException.Type.ILLEGAL_PARAMETER,
                             "The parsed Alert Risk Level was outside the range: "

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlAlertsProcessor.java
@@ -62,8 +62,8 @@ public class AccessControlAlertsProcessor {
                         Control.getSingleton()
                                 .getExtensionLoader()
                                 .getExtension(ExtensionAlert.NAME);
-        this.shouldRun = alertExtension != null && scanOptions.raiseAlerts;
-        this.alertRiskLevel = scanOptions.alertRiskLevel;
+        this.shouldRun = alertExtension != null && scanOptions.isRaiseAlerts();
+        this.alertRiskLevel = scanOptions.getAlertRiskLevel();
     }
 
     public void processScanResult(AccessControlResultEntry result) {

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlScannerThread.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/AccessControlScannerThread.java
@@ -310,18 +310,50 @@ public class AccessControlScannerThread
      * testing.
      */
     public static class AccessControlScanStartOptions implements ScanStartOptions {
-        public Context targetContext;
-        public List<User> targetUsers;
-        public boolean raiseAlerts;
+        private Context targetContext;
+        private List<User> targetUsers;
+        private boolean raiseAlerts;
         /**
          * Defines the risk level with which alerts should be raised and corresponds to the alert
          * levels from {@link Alert#MSG_RISK}, such as {@link Alert#RISK_HIGH}.
          */
-        public int alertRiskLevel;
+        private int alertRiskLevel;
 
         public AccessControlScanStartOptions() {
             super();
             this.targetUsers = new LinkedList<>();
+        }
+
+        public Context getTargetContext() {
+            return targetContext;
+        }
+
+        public void setTargetContext(Context targetContext) {
+            this.targetContext = targetContext;
+        }
+
+        public List<User> getTargetUsers() {
+            return targetUsers;
+        }
+
+        public void setTargetUsers(List<User> targetUsers) {
+            this.targetUsers = targetUsers;
+        }
+
+        public boolean isRaiseAlerts() {
+            return raiseAlerts;
+        }
+
+        public void setRaiseAlerts(boolean raiseAlerts) {
+            this.raiseAlerts = raiseAlerts;
+        }
+
+        public int getAlertRiskLevel() {
+            return alertRiskLevel;
+        }
+
+        public void setAlertRiskLevel(int alertRiskLevel) {
+            this.alertRiskLevel = alertRiskLevel;
         }
     }
 

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/ExtensionAccessControl.java
@@ -173,7 +173,7 @@ public class ExtensionAccessControl extends ExtensionAdaptor
                 activeActions.add(
                         MessageFormat.format(
                                 activeActionPrefix,
-                                scan.getStartOptions().targetContext.getName()));
+                                scan.getStartOptions().getTargetContext().getName()));
             }
         }
         return activeActions;
@@ -231,7 +231,7 @@ public class ExtensionAccessControl extends ExtensionAdaptor
      */
     @SuppressWarnings("fallthrough")
     public void startScan(AccessControlScanStartOptions startOptions) {
-        int contextId = startOptions.targetContext.getId();
+        int contextId = startOptions.getTargetContext().getId();
         AccessControlScannerThread scannerThread = threadManager.getScannerThread(contextId);
         if (scannerThread.isRunning()) {
             log.warn("Access control scan already running for context: {}", contextId);
@@ -242,10 +242,10 @@ public class ExtensionAccessControl extends ExtensionAdaptor
             case safe:
                 throw new IllegalStateException("Access control scan is not allowed in Safe mode.");
             case protect:
-                if (!startOptions.targetContext.isInScope()) {
+                if (!startOptions.getTargetContext().isInScope()) {
                     throw new IllegalStateException(
                             "Access control scan is not allowed with a context out of scope when in Protected mode: "
-                                    + startOptions.targetContext.getName());
+                                    + startOptions.getTargetContext().getName());
                 }
             case standard:
             case attack:
@@ -306,7 +306,7 @@ public class ExtensionAccessControl extends ExtensionAdaptor
             this.threadManager.stopAllScannerThreads();
         } else if (Mode.protect.equals(mode)) {
             for (AccessControlScannerThread scan : threadManager.getAllThreads()) {
-                if (scan.isRunning() && !scan.getStartOptions().targetContext.isInScope()) {
+                if (scan.isRunning() && !scan.getStartOptions().getTargetContext().isInScope()) {
                     scan.stopScan();
                 }
             }
@@ -386,7 +386,7 @@ public class ExtensionAccessControl extends ExtensionAdaptor
         }
 
         // Create a sorted list of users based on id (null/unauthenticated user first)
-        List<User> users = new ArrayList<>(scanThread.getStartOptions().targetUsers);
+        List<User> users = new ArrayList<>(scanThread.getStartOptions().getTargetUsers());
         Collections.sort(
                 users,
                 (o1, o2) -> {

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlScanOptionsDialog.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlScanOptionsDialog.java
@@ -90,21 +90,21 @@ public class AccessControlScanOptionsDialog extends StandardFieldsDialog {
     public void save() {
         // In this case, the 'Save' action corresponds to starting a scan with the specified options
         AccessControlScanStartOptions startOptions = new AccessControlScanStartOptions();
-        startOptions.targetContext =
-                ((ContextSelectComboBox) getField(FIELD_CONTEXT)).getSelectedContext();
-        startOptions.targetUsers = usersSelectTable.getSelectedUsers();
+        startOptions.setTargetContext(
+                ((ContextSelectComboBox) getField(FIELD_CONTEXT)).getSelectedContext());
+        startOptions.setTargetUsers(usersSelectTable.getSelectedUsers());
         // If the un-authenticated user was selected, replace it with a 'null' user
-        if (startOptions.targetUsers.remove(unauthenticatedUser)) {
-            startOptions.targetUsers.add(null);
+        if (startOptions.getTargetUsers().remove(unauthenticatedUser)) {
+            startOptions.getTargetUsers().add(null);
         }
-        startOptions.raiseAlerts = ((JCheckBox) getField(FIELD_RAISE_ALERTS)).isSelected();
+        startOptions.setRaiseAlerts(((JCheckBox) getField(FIELD_RAISE_ALERTS)).isSelected());
         // Just to make sure we have a reference here to MSG_RISK for taking care when refactoring
         // and that this still works if somehow the connection between index and value is lost, we
         // perform a quick search
         @SuppressWarnings("unchecked")
         String selectedAlertRisk =
                 (String) ((JComboBox<String>) getField(FIELD_ALERTS_RISK)).getSelectedItem();
-        startOptions.alertRiskLevel = ArrayUtils.indexOf(Alert.MSG_RISK, selectedAlertRisk);
+        startOptions.setAlertRiskLevel(ArrayUtils.indexOf(Alert.MSG_RISK, selectedAlertRisk));
         extension.startScan(startOptions);
     }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HeartBleedActiveScanRule.java
@@ -1028,7 +1028,7 @@ public class HeartBleedActiveScanRule extends AbstractHostPlugin {
             }
         } catch (Exception e) {
             // needed to catch exceptions from the "finally" statement
-            log.error("Error scanning a node for HeartBleed: " + e.getMessage(), e);
+            log.error("Error scanning a node for HeartBleed: {}", e.getMessage(), e);
         }
     }
 
@@ -1258,11 +1258,11 @@ public class HeartBleedActiveScanRule extends AbstractHostPlugin {
      *
      * @author 70pointer@gmail.com
      */
-    public static class SSLRecord {
-        public byte typ;
-        public short ver;
-        public short len;
-        public byte[] pay;
+    private static class SSLRecord {
+        private final byte typ;
+        private final short ver;
+        private final short len;
+        private final byte[] pay;
 
         SSLRecord(byte typ, short ver, short len, byte[] pay) {
             this.typ = typ;

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
@@ -65,7 +65,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
 
     static final String PAYLOADS_FILE_PATH = "json/hidden_files.json";
 
-    public static final List<String> HIDDEN_FILES = new ArrayList<>();
+    private static final List<String> HIDDEN_FILES = new ArrayList<>();
     private static final Supplier<Iterable<String>> DEFAULT_PAYLOAD_PROVIDER = () -> HIDDEN_FILES;
     public static final String HIDDEN_FILE_PAYLOAD_CATEGORY = "Hidden-File";
     private static Supplier<Iterable<String>> payloadProvider = DEFAULT_PAYLOAD_PROVIDER;
@@ -365,6 +365,10 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
 
     private static Supplier<Iterable<String>> getHiddenFilePayloads() {
         return payloadProvider;
+    }
+
+    public static List<String> getHiddenFiles() {
+        return HIDDEN_FILES;
     }
 
     /**

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
@@ -56,18 +56,18 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
     /** Prefix for internationalized messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanbeta.proxydisclosure.";
 
-    public static final List<String> MAX_FORWARD_METHODS =
+    private static final List<String> MAX_FORWARD_METHODS =
             new LinkedList<>(
                     Arrays.asList(
                             new String[] {
                                 HttpRequestHeader.TRACE, HttpRequestHeader.OPTIONS,
                             }));
 
-    public static final Pattern NOT_SUPPORTED_APACHE_PATTERN =
+    private static final Pattern NOT_SUPPORTED_APACHE_PATTERN =
             Pattern.compile(
                     "^<address>(.+)\\s+Server[^<]*</address>$",
                     Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
-    public static final Pattern MAX_FORWARDS_RESPONSE_PATTERN =
+    private static final Pattern MAX_FORWARDS_RESPONSE_PATTERN =
             Pattern.compile(
                     "^Max-Forwards:\\s*([0-9]+)\\s*$",
                     Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
@@ -76,7 +76,7 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
      * a map of patterns indicating any cookies set by a proxy. Use a capture group for the cookie
      * name.
      */
-    public static final Map<Pattern, String> PROXY_COOKIES = new LinkedHashMap<>();
+    private static final Map<Pattern, String> PROXY_COOKIES = new LinkedHashMap<>();
 
     static {
         // Citrix NetScaler
@@ -91,7 +91,7 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
      * a map of any request headers set by a proxy. Use a capture group for the header name, and
      * another for the value.
      */
-    public static final Map<Pattern, String> PROXY_REQUEST_HEADERS = new LinkedHashMap<>();
+    private static final Map<Pattern, String> PROXY_REQUEST_HEADERS = new LinkedHashMap<>();
 
     static {
         // product-specific headers go first..
@@ -124,41 +124,6 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
         // detecting a proxy. D'oh!
         // PROXY_REQUEST_HEADERS.put(Pattern.compile("^(Cache-Control):\\s*(.+)\\s*$",
         // Pattern.CASE_INSENSITIVE |  Pattern.MULTILINE | Pattern.DOTALL), "");
-    }
-
-    /**
-     * a map of any response headers set by a proxy. Use a capture group for the header name, and
-     * another for the value.
-     */
-    public static final Map<Pattern, String> PROXY_RESPONSE_HEADERS = new LinkedHashMap<>();
-
-    static {
-        PROXY_RESPONSE_HEADERS.put(
-                Pattern.compile(
-                        "^(X-RBT-Optimized-By):\\s*(.+)\\s*$",
-                        Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL),
-                "Riverbed Steelhead");
-
-        PROXY_RESPONSE_HEADERS.put(
-                Pattern.compile(
-                        "^(X-Cache):\\s*(.+)\\s*$",
-                        Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL),
-                "");
-        PROXY_RESPONSE_HEADERS.put(
-                Pattern.compile(
-                        "^(X-Cache-Lookup):\\s*(.+)\\s*$",
-                        Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL),
-                "");
-        PROXY_RESPONSE_HEADERS.put(
-                Pattern.compile(
-                        "^(Via):\\s*(.+)\\s*$",
-                        Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL),
-                "");
-        PROXY_RESPONSE_HEADERS.put(
-                Pattern.compile(
-                        "^(Cache-Control):\\s*(.+)\\s*$",
-                        Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL),
-                "");
     }
 
     /** the number of Max-Forwards to apply. Set depending on the Attack strength. */

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java
@@ -59,7 +59,7 @@ public class UserAgentScanRule extends AbstractAppPlugin {
     private static final String I_PHONE_3 =
             "Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_0 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7A341 Safari/528.16";
 
-    public static final List<String> USER_AGENTS =
+    private static final List<String> USER_AGENTS =
             Arrays.asList(
                     INTERNET_EXPLORER_8,
                     INTERNET_EXPLORER_7,
@@ -128,6 +128,10 @@ public class UserAgentScanRule extends AbstractAppPlugin {
 
     private static Supplier<Iterable<String>> getUserAgentPayloads() {
         return payloadProvider;
+    }
+
+    public static List<String> getUserAgents() {
+        return USER_AGENTS;
     }
 
     private void attack(String userAgent) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/payloader/ExtensionPayloader.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/payloader/ExtensionPayloader.java
@@ -61,14 +61,14 @@ public class ExtensionPayloader extends ExtensionAdaptor {
         uaCategory =
                 new PayloadCategory(
                         UserAgentScanRule.USER_AGENT_PAYLOAD_CATEGORY,
-                        UserAgentScanRule.USER_AGENTS);
+                        UserAgentScanRule.getUserAgents());
         ecp.addPayloadCategory(uaCategory);
         UserAgentScanRule.setPayloadProvider(uaCategory::getPayloadsIterator);
 
         hfCategory =
                 new PayloadCategory(
                         HiddenFilesScanRule.HIDDEN_FILE_PAYLOAD_CATEGORY,
-                        HiddenFilesScanRule.HIDDEN_FILES);
+                        HiddenFilesScanRule.getHiddenFiles());
         ecp.addPayloadCategory(hfCategory);
         HiddenFilesScanRule.setPayloadProvider(hfCategory::getPayloadsIterator);
     }

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/ExtensionBugTracker.java
@@ -21,9 +21,7 @@ package org.zaproxy.zap.extension.bugtracker;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.View;
@@ -32,7 +30,6 @@ import org.parosproxy.paros.view.View;
 public class ExtensionBugTracker extends ExtensionAdaptor {
 
     public static final String NAME = "ExtensionBugTracker";
-    public Set<Alert> alerts = null;
 
     protected static final String PREFIX = "bugtracker";
 

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/PopupSemiAutoIssue.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/PopupSemiAutoIssue.java
@@ -40,7 +40,6 @@ public class PopupSemiAutoIssue extends PopupMenuItemAlert {
 
     private void showRaiseSemiAutoIssueDialog(Set<Alert> alerts) {
         if (raiseSemiAutoIssueDialog == null) {
-            this.extBT.alerts = alerts;
             raiseSemiAutoIssueDialog =
                     new RaiseSemiAutoIssueDialog(
                             this.extBT,

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/RaiseSemiAutoIssueDialog.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/RaiseSemiAutoIssueDialog.java
@@ -42,9 +42,7 @@ public class RaiseSemiAutoIssueDialog extends StandardFieldsDialog {
     public RaiseSemiAutoIssueDialog(ExtensionBugTracker ext, Frame owner, Dimension dim) {
         super(owner, "bugtracker.dialog.semi.title", dim);
         this.extension = ext;
-        this.alerts = ext.alerts;
         bugTrackers = extension.getBugTrackers();
-        initialize();
     }
 
     public void setAlert(Set<Alert> alerts) {

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -247,7 +247,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
 
                             // is the ViewState protected by a MAC?
                             Matcher hmaclessmatcher =
-                                    ViewStateDecoder.patternNoHMAC.matcher(viewstatexml);
+                                    ViewStateDecoder.PATTERN_NO_HMAC.matcher(viewstatexml);
                             macless = hmaclessmatcher.find();
 
                             log.debug("MAC-less??? {}", macless);

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ViewStateDecoder.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ViewStateDecoder.java
@@ -37,7 +37,7 @@ public class ViewStateDecoder {
             Pattern.compile("[<>\\&]+", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
     /** a pattern to use when looking at the output to check if a ViewState is protected by a MAC */
-    public static Pattern patternNoHMAC =
+    protected static final Pattern PATTERN_NO_HMAC =
             Pattern.compile(
                     "^\\s*\\<hmac\\>false\\</hmac\\>\\s*$",
                     Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
@@ -405,7 +405,7 @@ public class ViewStateDecoder {
         } else {
             // No unread bytes --> no MAC. The Viewstate can be messed with!! Yee-Ha!
             representation.append(getIndentation(this.indentationlevel));
-            // NOTE: if this pattern changes, change patternNoHMAC
+            // NOTE: if this pattern changes, change PATTERN_NO_HMAC
             representation.append("<hmac>false</hmac>\n");
         }
         // put in the original ViewState value, in Base64 encoded form.

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -67,24 +67,24 @@ public class ExtensionQuickStart extends ExtensionAdaptor
 
     public static final String NAME = "ExtensionQuickStart";
     public static final String RESOURCES = "/org/zaproxy/zap/extension/quickstart/resources";
-    public static ImageIcon ZAP_ICON =
+    public static final ImageIcon ZAP_ICON =
             DisplayUtils.getScaledIcon(
                     new ImageIcon(
                             QuickStartSubPanel.class.getResource(RESOURCES + "/zap64x64.png")));
-    public static ImageIcon HUD_ICON =
+    public static final ImageIcon HUD_ICON =
             DisplayUtils.getScaledIcon(
                     new ImageIcon(
                             QuickStartSubPanel.class.getResource(
                                     RESOURCES + "/hud_logo_64px.png")));
-    public static ImageIcon HELP_ICON =
+    public static final ImageIcon HELP_ICON =
             DisplayUtils.getScaledIcon(
                     new ImageIcon(QuickStartSubPanel.class.getResource(RESOURCES + "/help.png")));
-    public static ImageIcon ONLINE_DOC_ICON =
+    public static final ImageIcon ONLINE_DOC_ICON =
             DisplayUtils.getScaledIcon(
                     new ImageIcon(
                             QuickStartSubPanel.class.getResource(
                                     RESOURCES + "/document-globe.png")));
-    public static ImageIcon PDF_DOC_ICON =
+    public static final ImageIcon PDF_DOC_ICON =
             DisplayUtils.getScaledIcon(
                     new ImageIcon(
                             QuickStartSubPanel.class.getResource(

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Update links to zaproxy repo.
-- Maintenance changes.
+- Maintenance changes (some changes impact the visibility of variables and getters/setters, which may impact third party add-ons or scripts).
 
 ## [15.3.0] - 2020-12-15
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
@@ -63,11 +63,11 @@ public enum Browser {
 
     private final String id;
 
-    private boolean isHeadless = false;
+    private final boolean headless;
 
     private Browser(String id, boolean isHeadless) {
         this.id = id;
-        this.isHeadless = isHeadless;
+        this.headless = isHeadless;
     }
 
     /**
@@ -296,10 +296,6 @@ public enum Browser {
     }
 
     public boolean isHeadless() {
-        return isHeadless;
-    }
-
-    public void setHeadless(boolean isHeadless) {
-        this.isHeadless = isHeadless;
+        return headless;
     }
 }

--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLiPayloadManager.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLiPayloadManager.java
@@ -51,7 +51,7 @@ public class SQLiPayloadManager {
     public static final int TECHNIQUE_UNION = 6;
 
     // Map for technique retrieval
-    public static final Map<Integer, String> SQLI_TECHNIQUES = new HashMap<>();
+    static final Map<Integer, String> SQLI_TECHNIQUES = new HashMap<>();
 
     static {
         SQLI_TECHNIQUES.put(TECHNIQUE_BOOLEAN, "boolean-based blind");

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
-- Maintenance changes.
+- Maintenance changes (some changes impact the visibility of variables and add getters/setters, which may impact third party add-ons or scripts).
 
 ## [23] - 2020-12-18
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketAPI.java
@@ -378,11 +378,11 @@ public class WebSocketAPI extends ApiImplementor {
     private boolean sendWebSocketMessage(WebSocketProxy proxy, boolean outgoing, String message)
             throws IOException {
         WebSocketMessageDTO resp = new WebSocketMessageDTO();
-        resp.channel = proxy.getDTO();
-        resp.payload = message;
-        resp.payloadLength = message.length();
-        resp.opcode = WebSocketMessage.OPCODE_TEXT;
-        resp.isOutgoing = outgoing;
+        resp.setChannel(proxy.getDTO());
+        resp.setPayload(message);
+        resp.setPayloadLength(message.length());
+        resp.setOpcode(WebSocketMessage.OPCODE_TEXT);
+        resp.setOutgoing(outgoing);
         boolean sent = proxy.send(resp, Initiator.WEB_SOCKET);
         if (sent) {
             try {
@@ -412,7 +412,7 @@ public class WebSocketAPI extends ApiImplementor {
                         extension.getChannels(new WebSocketChannelDTO());
                 for (WebSocketChannelDTO channel : channels) {
                     Map<String, String> map = new HashMap<>();
-                    map.put("id", Integer.toString(channel.id));
+                    map.put("id", Integer.toString(channel.getId()));
                     map.put("displayName", channel.toString());
                     map.put("connected", Boolean.toString(channel.isConnected()));
                     map.put("inScope", Boolean.toString(channel.isInScope()));
@@ -550,7 +550,7 @@ public class WebSocketAPI extends ApiImplementor {
                             "No currently intercepted message");
                 } else if (msg instanceof WebSocketMessageDTO) {
                     WebSocketMessageDTO ws = (WebSocketMessageDTO) msg;
-                    ws.payload = params.optString(PARAM_MESSAGE, "");
+                    ws.setPayload(params.optString(PARAM_MESSAGE, ""));
                     extBreak.getBreakpointManagementInterface()
                             .setMessage(ws, params.getBoolean(PARAM_OUTGOING));
                 } else {

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketChannelDTO.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketChannelDTO.java
@@ -31,25 +31,25 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 public class WebSocketChannelDTO implements Comparable<WebSocketChannelDTO> {
 
     /** ChannelId. */
-    public Integer id;
+    private Integer id;
 
     /** Is not necessarily the same as the {@link WebSocketChannelDTO#url}. */
-    public String host;
+    private String host;
 
     /** Port where this channel is connected at. Usually 80 or 443. */
-    public Integer port;
+    private Integer port;
 
     /** URL used in HTTP handshake. */
-    public String url;
+    private String url;
 
     /** Timestamp taken, when connection was established successfully. */
-    public Long startTimestamp;
+    private Long startTimestamp;
 
     /** Timestamp of close, otherwise <code>null</code>. */
-    public Long endTimestamp;
+    private Long endTimestamp;
 
     /** Id of handshake message. */
-    public Integer historyId;
+    private Integer historyId;
 
     public WebSocketChannelDTO() {}
 
@@ -179,5 +179,61 @@ public class WebSocketChannelDTO implements Comparable<WebSocketChannelDTO> {
             regex.append(port);
         }
         return regex.toString();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public Long getStartTimestamp() {
+        return startTimestamp;
+    }
+
+    public void setStartTimestamp(Long startTimestamp) {
+        this.startTimestamp = startTimestamp;
+    }
+
+    public Long getEndTimestamp() {
+        return endTimestamp;
+    }
+
+    public void setEndTimestamp(Long endTimestamp) {
+        this.endTimestamp = endTimestamp;
+    }
+
+    public Integer getHistoryId() {
+        return historyId;
+    }
+
+    public void setHistoryId(Integer historyId) {
+        this.historyId = historyId;
     }
 }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketEventPublisher.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketEventPublisher.java
@@ -86,7 +86,7 @@ public final class WebSocketEventPublisher implements EventPublisher, WebSocketS
                     () -> {
                         Map<String, String> map = new HashMap<>();
                         map.put(FIELD_CHANNEL_ID, Integer.toString(channelId));
-                        map.put(FIELD_CHANNEL_HOST, message.getDTO().channel.host);
+                        map.put(FIELD_CHANNEL_HOST, message.getDTO().getChannel().getHost());
                         map.put(FIELD_TIME_IN_MS, Long.toString(message.getTimestamp().getTime()));
                         map.put(FIELD_OP_CODE, Integer.toString(message.getOpcode()));
                         map.put(FIELD_OP_CODE_STRING, message.getOpcodeString());

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketMessage.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketMessage.java
@@ -24,6 +24,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.zaproxy.zap.extension.websocket.WebSocketProxy.Mode;
 
 /**
@@ -138,9 +141,10 @@ public abstract class WebSocketMessage {
 
     // 1015 is another reserved status code
 
-    public static final int[] OPCODES = {
-        OPCODE_TEXT, OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG
-    };
+    private static final List<Integer> OPCODES =
+            Collections.unmodifiableList(
+                    Arrays.asList(
+                            OPCODE_TEXT, OPCODE_BINARY, OPCODE_CLOSE, OPCODE_PING, OPCODE_PONG));
 
     /**
      * Indicates the opcode of this message. Initially it is set to -1, meaning that its type is
@@ -399,28 +403,28 @@ public abstract class WebSocketMessage {
     public WebSocketMessageDTO getDTO() {
         // build upon base dto attribute set in constructor,
         // such that existing instances are updated with changed values.
-        dto.channel = proxy.getDTO();
+        dto.setChannel(proxy.getDTO());
 
         Timestamp ts = getTimestamp();
         dto.setTime(ts);
 
-        dto.opcode = getOpcode();
-        dto.readableOpcode = getOpcodeString();
+        dto.setOpcode(getOpcode());
+        dto.setReadableOpcode(getOpcodeString());
 
         if (isBinary()) {
-            dto.payload = getPayload();
+            dto.setPayload(getPayload());
         } else {
-            dto.payload = getReadablePayload();
+            dto.setPayload(getReadablePayload());
 
-            if (dto.payload == null) {
+            if (dto.getPayload() == null) {
                 // prevents NullPointerException
-                dto.payload = "";
+                dto.setPayload("");
             }
         }
 
-        dto.isOutgoing = (getDirection() == Direction.OUTGOING) ? true : false;
+        dto.setOutgoing((getDirection() == Direction.OUTGOING) ? true : false);
 
-        dto.payloadLength = getPayloadLength();
+        dto.setPayloadLength(getPayloadLength());
 
         return dto;
     }
@@ -432,5 +436,9 @@ public abstract class WebSocketMessage {
     @Override
     public String toString() {
         return "WebSocketMessage#" + getMessageId();
+    }
+
+    public static List<Integer> getOpcodes() {
+        return OPCODES;
     }
 }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketMessageDTO.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketMessageDTO.java
@@ -42,44 +42,44 @@ import org.zaproxy.zap.extension.websocket.utility.Utf8Util;
 public class WebSocketMessageDTO implements Message {
 
     /** Each message is sent on a specific connection. Ensure that it is not <code>null</code>! */
-    public WebSocketChannelDTO channel;
+    private WebSocketChannelDTO channel;
 
     /** Consecutive number for each message unique for one given channel. */
-    public Integer id;
+    private Integer id;
 
     /** Used for sorting, containing time of arrival in milliseconds. */
-    public Long timestamp;
+    private Long timestamp;
 
     /** When the message was finished (it might consist of several frames). */
-    public String dateTime;
+    private String dateTime;
 
     /**
      * You can retrieve a textual version of this opcode via: {@link
      * WebSocketMessage#opcode2string(int)}.
      */
-    public Integer opcode;
+    private Integer opcode;
 
     /** Textual representation of {@link WebSocketMessageDTO#opcode}. */
-    public String readableOpcode;
+    private String readableOpcode;
 
     /**
      * Might be either a string (readable representation for TEXT frames) OR byte[].
      *
      * <p>If it is a byte[] then it might be readable though.
      */
-    public Object payload;
+    private Object payload;
 
     /** For close messages, there is always a reason. */
-    public Integer closeCode;
+    private Integer closeCode;
 
     /** Outgoing or incoming message. */
-    public Boolean isOutgoing;
+    private Boolean outgoing;
 
     /** Number of the payload bytes. */
-    public Integer payloadLength;
+    private Integer payloadLength;
 
     /** Temporary object holding arbitrary values. */
-    public volatile Object tempUserObj;
+    private volatile Object tempUserObj;
 
     /** Used to format {@link WebSocketMessage#timestamp} in user's locale. */
     protected static final FastDateFormat dateFormatter;
@@ -88,7 +88,7 @@ public class WebSocketMessageDTO implements Message {
      * Marks this object as changed, indicating that frame headers have to be built manually on
      * forwarding.
      */
-    public boolean hasChanged;
+    private boolean hasChanged;
 
     /** Use the static initializer for setting up one date formatter for all instances. */
     static {
@@ -131,8 +131,8 @@ public class WebSocketMessageDTO implements Message {
 
     @Override
     public String toString() {
-        if (channel.id != null && id != null) {
-            return "#" + channel.id + "." + id;
+        if (channel.getId() != null && id != null) {
+            return "#" + channel.getId() + "." + id;
         }
         return "";
     }
@@ -146,7 +146,7 @@ public class WebSocketMessageDTO implements Message {
         other.channel = this.channel;
         other.closeCode = this.closeCode;
         other.dateTime = this.dateTime;
-        other.isOutgoing = this.isOutgoing;
+        other.outgoing = this.outgoing;
         other.id = this.id;
         other.opcode = this.opcode;
         other.payload = this.payload;
@@ -209,9 +209,9 @@ public class WebSocketMessageDTO implements Message {
         map.put("opcode", Integer.toString(this.opcode));
         map.put("opcodeString", this.readableOpcode);
         map.put("timestamp", Long.toString(this.timestamp));
-        map.put("outgoing", Boolean.toString(this.isOutgoing));
-        map.put("channelId", Integer.toString(this.channel.id));
-        map.put("channelHost", this.channel.host);
+        map.put("outgoing", Boolean.toString(this.outgoing));
+        map.put("channelId", Integer.toString(this.channel.getId()));
+        map.put("channelHost", this.channel.getHost());
         map.put("thisId", Integer.toString(this.id));
         map.put("payloadLength", Integer.toString(this.payloadLength));
         if (fullPayload) {
@@ -248,5 +248,101 @@ public class WebSocketMessageDTO implements Message {
     @Override
     public Map<String, String> toEventData() {
         return this.toMap(true);
+    }
+
+    public WebSocketChannelDTO getChannel() {
+        return channel;
+    }
+
+    public void setChannel(WebSocketChannelDTO channel) {
+        this.channel = channel;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getDateTime() {
+        return dateTime;
+    }
+
+    public void setDateTime(String dateTime) {
+        this.dateTime = dateTime;
+    }
+
+    public Integer getOpcode() {
+        return opcode;
+    }
+
+    public void setOpcode(Integer opcode) {
+        this.opcode = opcode;
+    }
+
+    public String getReadableOpcode() {
+        return readableOpcode;
+    }
+
+    public void setReadableOpcode(String readableOpcode) {
+        this.readableOpcode = readableOpcode;
+    }
+
+    public Object getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Object payload) {
+        this.payload = payload;
+    }
+
+    public Integer getCloseCode() {
+        return closeCode;
+    }
+
+    public void setCloseCode(Integer closeCode) {
+        this.closeCode = closeCode;
+    }
+
+    public Boolean isOutgoing() {
+        return outgoing;
+    }
+
+    public void setOutgoing(Boolean isOutgoing) {
+        this.outgoing = isOutgoing;
+    }
+
+    public Integer getPayloadLength() {
+        return payloadLength;
+    }
+
+    public void setPayloadLength(Integer payloadLength) {
+        this.payloadLength = payloadLength;
+    }
+
+    public Object getTempUserObj() {
+        return tempUserObj;
+    }
+
+    public void setTempUserObj(Object tempUserObj) {
+        this.tempUserObj = tempUserObj;
+    }
+
+    public boolean hasChanged() {
+        return hasChanged;
+    }
+
+    public void setHasChanged(boolean hasChanged) {
+        this.hasChanged = hasChanged;
     }
 }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketProxy.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketProxy.java
@@ -730,11 +730,11 @@ public abstract class WebSocketProxy {
      */
     private void sendPongResponse(WebSocketMessage webSocketMessage) {
         WebSocketMessageDTO webSocketMessageDTO = webSocketMessage.getDTO();
-        webSocketMessageDTO.readableOpcode =
-                WebSocketMessage.opcode2string(WebSocketMessage.OPCODE_PONG);
-        webSocketMessageDTO.opcode = WebSocketMessage.OPCODE_PONG;
-        webSocketMessageDTO.isOutgoing = !webSocketMessageDTO.isOutgoing;
-        webSocketMessageDTO.hasChanged = true;
+        webSocketMessageDTO.setReadableOpcode(
+                WebSocketMessage.opcode2string(WebSocketMessage.OPCODE_PONG));
+        webSocketMessageDTO.setOpcode(WebSocketMessage.OPCODE_PONG);
+        webSocketMessageDTO.setOutgoing(!webSocketMessageDTO.isOutgoing());
+        webSocketMessageDTO.setHasChanged(true);
 
         try {
             sendAndNotify(webSocketMessageDTO, Initiator.MANUAL_REQUEST);
@@ -911,19 +911,19 @@ public abstract class WebSocketProxy {
 
     public WebSocketChannelDTO getDTO() {
         WebSocketChannelDTO dto = new WebSocketChannelDTO();
-        dto.id = getChannelId();
-        dto.host = host;
-        dto.port = port;
-        dto.startTimestamp = (start != null) ? start.getTime() : null;
-        dto.endTimestamp = (end != null) ? end.getTime() : null;
+        dto.setId(getChannelId());
+        dto.setHost(host);
+        dto.setPort(port);
+        dto.setStartTimestamp((start != null) ? start.getTime() : null);
+        dto.setEndTimestamp((end != null) ? end.getTime() : null);
 
         HistoryReference handshakeRef = getHandshakeReference();
         if (handshakeRef != null) {
-            dto.url = handshakeRef.getURI().toString();
-            dto.historyId = handshakeRef.getHistoryId();
+            dto.setUrl(handshakeRef.getURI().toString());
+            dto.setHistoryId(handshakeRef.getHistoryId());
         } else {
-            dto.url = "";
-            dto.historyId = null;
+            dto.setUrl("");
+            dto.setHistoryId(null);
         }
 
         return dto;
@@ -955,7 +955,7 @@ public abstract class WebSocketProxy {
             return localListener.getOutputStream();
         }
 
-        if (msg.isOutgoing) {
+        if (msg.isOutgoing()) {
             // an outgoing message is caught by the local listener
             // and forwarded to its output stream
             return localListener.getOutputStream();

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketProxyV13.java
@@ -320,23 +320,23 @@ public class WebSocketProxyV13 extends WebSocketProxy {
         public WebSocketMessageV13(WebSocketProxy proxy, WebSocketMessageDTO message)
                 throws WebSocketException {
             super(proxy, getIncrementedMessageCount(), message);
-            message.id = getMessageId();
+            message.setId(getMessageId());
 
             Calendar calendar = Calendar.getInstance();
             timestamp = new Timestamp(calendar.getTimeInMillis());
             message.setTime(timestamp);
 
             isFinished = true;
-            opcode = message.opcode;
-            closeCode = (message.closeCode == null) ? -1 : message.closeCode;
-            direction = message.isOutgoing ? Direction.OUTGOING : Direction.INCOMING;
-            hasChanged = message.hasChanged;
+            opcode = message.getOpcode();
+            closeCode = (message.getCloseCode() == null) ? -1 : message.getCloseCode();
+            direction = message.isOutgoing() ? Direction.OUTGOING : Direction.INCOMING;
+            hasChanged = message.hasChanged();
 
             payload = ByteBuffer.allocate(0);
-            if (message.payload instanceof byte[]) {
-                setPayload((byte[]) message.payload);
+            if (message.getPayload() instanceof byte[]) {
+                setPayload((byte[]) message.getPayload());
             } else {
-                setReadablePayload((String) message.payload);
+                setReadablePayload((String) message.getPayload());
             }
         }
 
@@ -754,8 +754,8 @@ public class WebSocketProxyV13 extends WebSocketProxy {
         public WebSocketMessageDTO getDTO() {
             WebSocketMessageDTO message = super.getDTO();
 
-            message.channel.id = getChannelId();
-            message.id = getMessageId();
+            message.getChannel().setId(getChannelId());
+            message.setId(getMessageId());
 
             return message;
         }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertWrapper.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertWrapper.java
@@ -190,11 +190,11 @@ public class WebSocketAlertWrapper {
 
             try {
                 handshakeMessage =
-                        webSocketMessageDTO.channel.getHandshakeReference().getHttpMessage();
+                        webSocketMessageDTO.getChannel().getHandshakeReference().getHttpMessage();
             } catch (Exception e) {
                 LOGGER.info(
                         "Couldn't get the Handshake Http Message for this specific channel. Channel ID: {}",
-                        webSocketMessageDTO.channel.id,
+                        webSocketMessageDTO.getChannel().getId(),
                         e);
                 return this;
             }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogAdd.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogAdd.java
@@ -87,6 +87,10 @@ public class WebSocketBreakDialogAdd extends WebSocketBreakDialog {
      */
     public void setMessage(WebSocketMessageDTO aMessage) {
         resetDialogValues();
-        setDialogValues(aMessage.readableOpcode, aMessage.channel.id, null, aMessage.isOutgoing);
+        setDialogValues(
+                aMessage.getReadableOpcode(),
+                aMessage.getChannel().getId(),
+                null,
+                aMessage.isOutgoing());
     }
 }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakpointMessage.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakpointMessage.java
@@ -120,20 +120,20 @@ public class WebSocketBreakpointMessage extends AbstractBreakPointMessage {
             WebSocketMessageDTO msg = (WebSocketMessageDTO) aMessage;
 
             if (opcode != null) {
-                if (!msg.readableOpcode.equals(opcode)) {
+                if (!msg.getReadableOpcode().equals(opcode)) {
                     return false;
                 }
             }
 
             if (channelId != null) {
-                if (!channelId.equals(msg.channel.id)) {
+                if (!channelId.equals(msg.getChannel().getId())) {
                     return false;
                 }
             }
 
             if (payloadPattern != null) {
-                if (msg.payload instanceof String) {
-                    Matcher m = payloadPattern.matcher((String) msg.payload);
+                if (msg.getPayload() instanceof String) {
+                    Matcher m = payloadPattern.matcher((String) msg.getPayload());
                     if (!m.find()) {
                         // when m.matches() is used, the whole string has to match
                         return false;
@@ -145,9 +145,9 @@ public class WebSocketBreakpointMessage extends AbstractBreakPointMessage {
             }
 
             if (direction != null) {
-                if (msg.isOutgoing && !direction.equals(Direction.OUTGOING)) {
+                if (msg.isOutgoing() && !direction.equals(Direction.OUTGOING)) {
                     return false;
-                } else if (!msg.isOutgoing && !direction.equals(Direction.INCOMING)) {
+                } else if (!msg.isOutgoing() && !direction.equals(Direction.INCOMING)) {
                     return false;
                 }
             }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakpointMessageHandler.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakpointMessageHandler.java
@@ -82,7 +82,7 @@ public class WebSocketBreakpointMessageHandler extends BreakpointMessageHandler2
     protected boolean isBreakOnStepping(Message aMessage, boolean isRequest) {
         if (aMessage instanceof WebSocketMessageDTO
                 && super.isBreakOnStepping(aMessage, isRequest)) {
-            return isBreakOnOpcode(((WebSocketMessageDTO) aMessage).opcode);
+            return isBreakOnOpcode(((WebSocketMessageDTO) aMessage).getOpcode());
         }
         return false;
     }
@@ -97,7 +97,7 @@ public class WebSocketBreakpointMessageHandler extends BreakpointMessageHandler2
      */
     private boolean isBreakOnAllWebSocket(Message aMessage, boolean isRequest) {
         if (aMessage instanceof WebSocketMessageDTO && config.isBreakOnAll()) {
-            return isBreakOnOpcode(((WebSocketMessageDTO) aMessage).opcode);
+            return isBreakOnOpcode(((WebSocketMessageDTO) aMessage).getOpcode());
         }
         return false;
     }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketProxyListenerBreak.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketProxyListenerBreak.java
@@ -100,19 +100,19 @@ public class WebSocketProxyListenerBreak implements WebSocketObserver {
             return continueNotifying;
         }
 
-        if (message.isOutgoing) {
+        if (message.isOutgoing()) {
             // already safe => onlyIfInScope can be false
             if (wsBrkMessageHandler.handleMessageReceivedFromClient(message, false)) {
                 // As the DTO that is shown and modified in the
                 // Request/Response panels we must set the content to message
                 // here.
-                setPayload(wsMessage, message.payload);
+                setPayload(wsMessage, message.getPayload());
                 continueNotifying = true;
             }
         } else {
             // already safe => onlyIfInScope can be false
             if (wsBrkMessageHandler.handleMessageReceivedFromServer(message, false)) {
-                setPayload(wsMessage, message.payload);
+                setPayload(wsMessage, message.getPayload());
                 continueNotifying = true;
             }
         }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/WebSocketFuzzerHandler.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/WebSocketFuzzerHandler.java
@@ -120,7 +120,7 @@ public class WebSocketFuzzerHandler implements FuzzerHandler<WebSocketMessageDTO
                                 View.getSingleton().getMainFrame(),
                                 defaultOptions,
                                 message,
-                                message.isOutgoing,
+                                message.isOutgoing(),
                                 new WebSocketFuzzerHandlerOptionsPanel(),
                                 new WebSocketFuzzerMessageProcessorCollection(
                                         message, messageProcessors));
@@ -189,7 +189,10 @@ public class WebSocketFuzzerHandler implements FuzzerHandler<WebSocketMessageDTO
 
     private String createFuzzerName(WebSocketMessageDTO message) {
         StringBuilder strBuilder = new StringBuilder();
-        strBuilder.append(message.channel.host).append(" #").append(message.channel.id);
+        strBuilder
+                .append(message.getChannel().getHost())
+                .append(" #")
+                .append(message.getChannel().getId());
         if (strBuilder.length() > 30) {
             strBuilder.setLength(27);
             strBuilder.append("...");

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/WebSocketFuzzerTask.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/WebSocketFuzzerTask.java
@@ -61,13 +61,13 @@ public class WebSocketFuzzerTask extends AbstractFuzzerTask<WebSocketMessageDTO>
 
     private WebSocketFuzzMessageDTO sendMessage(
             Map<Integer, WebSocketProxy> wsProxies, WebSocketFuzzMessageDTO message) {
-        if (!wsProxies.containsKey(message.channel.id)) {
+        if (!wsProxies.containsKey(message.getChannel().getId())) {
             getParent().stopScan();
             return null;
         }
 
         try {
-            WebSocketProxy wsProxy = wsProxies.get(message.channel.id);
+            WebSocketProxy wsProxy = wsProxies.get(message.getChannel().getId());
 
             message.fuzzId = getParent().getId();
             if (wsProxy.send(message, Initiator.FUZZER)) {

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/WebSocketFuzzerTaskProcessorUtils.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/WebSocketFuzzerTaskProcessorUtils.java
@@ -75,7 +75,7 @@ public class WebSocketFuzzerTaskProcessorUtils {
 
     public boolean sendMessage(String message, boolean includeInResults) {
         WebSocketProxy wsProxy =
-                websocketFuzzer.getWebSocketProxies().get(originalMessage.channel.id);
+                websocketFuzzer.getWebSocketProxies().get(originalMessage.getChannel().getId());
         if (wsProxy == null) {
             websocketFuzzer.stopScan();
             return false;
@@ -87,8 +87,8 @@ public class WebSocketFuzzerTaskProcessorUtils {
             originalMessage.copyInto(newMessage);
 
             newMessage.fuzzId = websocketFuzzer.getId();
-            newMessage.payload = message;
-            newMessage.payloadLength = Integer.valueOf(message.length());
+            newMessage.setPayload(message);
+            newMessage.setPayloadLength(Integer.valueOf(message.length()));
             newMessage.fuzz = "";
 
             if (wsProxy.send(newMessage, Initiator.FUZZER)) {

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/messagelocations/TextWebSocketMessageLocationReplacer.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/messagelocations/TextWebSocketMessageLocationReplacer.java
@@ -56,12 +56,12 @@ public class TextWebSocketMessageLocationReplacer
             throw new IllegalStateException("Replacer not initialised.");
         }
 
-        if (!(message.payload instanceof String)) {
+        if (!(message.getPayload() instanceof String)) {
             // TODO: Exclude popup menu or support fuzzing binary payloads - why not?
             return copyMessage(message);
         }
 
-        Replacer replacer = new Replacer((String) message.payload);
+        Replacer replacer = new Replacer((String) message.getPayload());
         for (MessageLocationReplacement<?> replacement : replacements) {
             MessageLocation location = replacement.getMessageLocation();
             if (!(location instanceof TextWebSocketMessageLocation)) {
@@ -76,8 +76,8 @@ public class TextWebSocketMessageLocationReplacer
         }
 
         WebSocketFuzzMessageDTO replacedMessage = copyMessage(message);
-        replacedMessage.payload = replacer.toString();
-        replacedMessage.payloadLength = Integer.valueOf(replacer.length());
+        replacedMessage.setPayload(replacer.toString());
+        replacedMessage.setPayloadLength(Integer.valueOf(replacer.length()));
 
         return replacedMessage;
     }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/ManualWebSocketSendEditorDialog.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/ManualWebSocketSendEditorDialog.java
@@ -194,7 +194,7 @@ public class ManualWebSocketSendEditorDialog extends ManualRequestEditorDialog {
                         if (message == null) {
                             setDefaultMessage();
                         } else if (message instanceof WebSocketMessageDTO
-                                && ((WebSocketMessageDTO) message).opcode == null) {
+                                && ((WebSocketMessageDTO) message).getOpcode() == null) {
                             setDefaultMessage();
                         }
                         setVisible(true);
@@ -206,9 +206,9 @@ public class ManualWebSocketSendEditorDialog extends ManualRequestEditorDialog {
     @Override
     public void setDefaultMessage() {
         WebSocketMessageDTO msg = new WebSocketMessageDTO();
-        msg.isOutgoing = true;
-        msg.opcode = WebSocketMessage.OPCODE_TEXT;
-        msg.readableOpcode = WebSocketMessage.opcode2string(msg.opcode);
+        msg.setOutgoing(true);
+        msg.setOpcode(WebSocketMessage.OPCODE_TEXT);
+        msg.setReadableOpcode(WebSocketMessage.opcode2string(msg.getOpcode()));
 
         setMessage(msg);
     }
@@ -292,23 +292,23 @@ public class ManualWebSocketSendEditorDialog extends ManualRequestEditorDialog {
         }
 
         public void setMessageMetadata(WebSocketMessageDTO message) {
-            if (message.channel != null && message.channel.id != null) {
-                wsUiHelper.getChannelSingleSelect().setSelectedItem(message.channel);
+            if (message.getChannel() != null && message.getChannel().getId() != null) {
+                wsUiHelper.getChannelSingleSelect().setSelectedItem(message.getChannel());
             }
 
-            if (message.opcode != null) {
-                wsUiHelper.getOpcodeSingleSelect().setSelectedItem(message.readableOpcode);
+            if (message.getOpcode() != null) {
+                wsUiHelper.getOpcodeSingleSelect().setSelectedItem(message.getReadableOpcode());
             }
 
-            if (message.isOutgoing != null) {
-                wsUiHelper.setDirectionSingleSelect(message.isOutgoing);
+            if (message.isOutgoing() != null) {
+                wsUiHelper.setDirectionSingleSelect(message.isOutgoing());
             }
         }
 
         public void setMetadata(WebSocketMessageDTO msg) {
-            msg.channel = wsUiHelper.getSelectedChannelDTO();
-            msg.isOutgoing = wsUiHelper.isDirectionSingleSelectOutgoing();
-            msg.opcode = wsUiHelper.getSelectedOpcodeInteger();
+            msg.setChannel(wsUiHelper.getSelectedChannelDTO());
+            msg.setOutgoing(wsUiHelper.isDirectionSingleSelectOutgoing());
+            msg.setOpcode(wsUiHelper.getSelectedOpcodeInteger());
         }
 
         public void loadConfig() {

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/WebSocketPanelSender.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/WebSocketPanelSender.java
@@ -66,7 +66,8 @@ public class WebSocketPanelSender implements MessageSender, WebSocketObserver {
     public void handleSendMessage(Message aMessage) throws IOException {
         final WebSocketMessageDTO websocketMessage = (WebSocketMessageDTO) aMessage;
 
-        if (websocketMessage.channel == null || websocketMessage.channel.id == null) {
+        if (websocketMessage.getChannel() == null
+                || websocketMessage.getChannel().getId() == null) {
             logger.warn(
                     "Invalid WebSocket channel selected. Unable to send manual crafted message!");
             throw new IllegalArgumentException(
@@ -75,7 +76,7 @@ public class WebSocketPanelSender implements MessageSender, WebSocketObserver {
                             + Constant.messages.getString("websocket.manual_send.fail"));
         }
 
-        if (websocketMessage.opcode == null) {
+        if (websocketMessage.getOpcode() == null) {
             logger.warn(
                     "Invalid WebSocket opcode selected. Unable to send manual crafted message!");
             throw new IllegalArgumentException(
@@ -84,8 +85,8 @@ public class WebSocketPanelSender implements MessageSender, WebSocketObserver {
                             + Constant.messages.getString("websocket.manual_send.fail"));
         }
 
-        WebSocketProxy wsProxy = getDelegate(websocketMessage.channel.id);
-        if (!websocketMessage.isOutgoing && wsProxy.isClientMode()) {
+        WebSocketProxy wsProxy = getDelegate(websocketMessage.getChannel().getId());
+        if (!websocketMessage.isOutgoing() && wsProxy.isClientMode()) {
             logger.warn(
                     "Invalid WebSocket direction 'incoming' selected for Proxy in Client Mode. Unable to send manual crafted message!");
             throw new IllegalArgumentException(

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/NodesUtilities.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/NodesUtilities.java
@@ -40,7 +40,7 @@ public class NodesUtilities {
         } else {
             scheme = "ws";
         }
-        host.append(scheme).append("://").append(channel.host);
+        host.append(scheme).append("://").append(channel.getHost());
 
         if ((port != 80 && port != 443)) {
             host.append(":").append(port);
@@ -51,8 +51,8 @@ public class NodesUtilities {
 
     private static int getPort(WebSocketChannelDTO channel)
             throws DatabaseException, HttpMalformedHeaderException {
-        return channel.port != -1
-                ? channel.port
+        return channel.getPort() != -1
+                ? channel.getPort()
                 : channel.getHandshakeReference()
                         .getHttpMessage()
                         .getRequestHeader()

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/contents/MessageContent.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/contents/MessageContent.java
@@ -74,8 +74,8 @@ public class MessageContent extends WebSocketContent {
                                 .getReadablePayload()
                                 .compareTo(that.getMessage().getReadablePayload());
                 if (compareResult == 0
-                        && !this.getMessage().isOutgoing.equals(that.getMessage().isOutgoing)) {
-                    compareResult = that.getMessage().isOutgoing ? 1 : -1;
+                        && !this.getMessage().isOutgoing().equals(that.getMessage().isOutgoing())) {
+                    compareResult = that.getMessage().isOutgoing() ? 1 : -1;
                 }
             } catch (InvalidUtf8Exception ignored) {
                 compareResult = super.compareTo(that);

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/factories/SimpleNodeFactory.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/treemap/nodes/factories/SimpleNodeFactory.java
@@ -81,7 +81,7 @@ public class SimpleNodeFactory implements NodeFactory {
         try {
             hostNode =
                     root.getChildrenWhen(
-                            TreeNode::getHost, NodesUtilities.getHostName(message.channel));
+                            TreeNode::getHost, NodesUtilities.getHostName(message.getChannel()));
         } catch (Exception ignored) {
         }
         if (hostNode == null) return null;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ChannelSortedListModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ChannelSortedListModel.java
@@ -74,7 +74,7 @@ public class ChannelSortedListModel extends SortedListModel<WebSocketChannelDTO>
             final int index = indexOf(channel);
             if (index != -1) {
                 WebSocketChannelDTO old = getElementAt(index);
-                old.endTimestamp = channel.endTimestamp;
+                old.setEndTimestamp(channel.getEndTimestamp());
 
                 fireContentsChanged(this, index, index);
             }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ComboBoxChannelModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ComboBoxChannelModel.java
@@ -43,7 +43,7 @@ public class ComboBoxChannelModel implements ComboBoxModel<WebSocketChannelDTO> 
 
         for (int i = 0; i < getSize(); i++) {
             WebSocketChannelDTO channel = getElementAt(i);
-            if (channelId.equals(channel.id)) {
+            if (channelId.equals(channel.getId())) {
                 setSelectedItem(channel);
                 return;
             }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ComboBoxChannelRenderer.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ComboBoxChannelRenderer.java
@@ -67,7 +67,7 @@ public class ComboBoxChannelRenderer extends JLabel
         if (channel != null) {
             text = channel.toString();
 
-            if (channel.id != null) {
+            if (channel.getId() != null) {
                 setWebSocketIcon(channel);
             } else {
                 // unset icon

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ExcludeFromWebSocketsMenuItem.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ExcludeFromWebSocketsMenuItem.java
@@ -103,7 +103,7 @@ public class ExcludeFromWebSocketsMenuItem extends WebSocketMessagesPopupMenuIte
         }
 
         WebSocketChannelDTO channel = new WebSocketChannelDTO();
-        channel.id = message.channel.id;
+        channel.setId(message.getChannel().getId());
 
         try {
             List<WebSocketChannelDTO> channels = extWs.getChannels(channel);

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketFromContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketFromContextMenu.java
@@ -80,7 +80,7 @@ public class PopupExcludeWebSocketFromContextMenu extends ExtensionPopupMenuItem
     protected void performAction() throws SQLException {
         WebSocketMessageDTO message = wsPopupHelper.getSelectedMessage();
         if (message != null) {
-            String url = Pattern.quote(message.channel.getContextUrl());
+            String url = Pattern.quote(message.getChannel().getContextUrl());
 
             Session session = Model.getSingleton().getSession();
 
@@ -104,7 +104,7 @@ public class PopupExcludeWebSocketFromContextMenu extends ExtensionPopupMenuItem
             WebSocketMessageDTO message = wsPopupHelper.getSelectedMessage();
 
             if (message != null) {
-                String url = message.channel.getContextUrl();
+                String url = message.getChannel().getContextUrl();
                 setEnabled(isEnabledForUrl(url));
             } else {
                 setEnabled(false);

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
@@ -89,11 +89,11 @@ public class PopupIncludeWebSocketInContextMenu extends ExtensionPopupMenuItem {
     protected void performAction() throws SQLException {
         WebSocketMessageDTO message = wsPopupHelper.getSelectedMessage();
         if (message != null) {
-            String url = Pattern.quote(message.channel.getContextUrl());
+            String url = Pattern.quote(message.getChannel().getContextUrl());
 
             Session session = Model.getSingleton().getSession();
             if (context == null) {
-                context = session.getNewContext(message.channel.host);
+                context = session.getNewContext(message.getChannel().getHost());
             }
             View.getSingleton().getSessionDialog().recreateUISharedContexts(session);
 
@@ -115,7 +115,7 @@ public class PopupIncludeWebSocketInContextMenu extends ExtensionPopupMenuItem {
             WebSocketMessageDTO message = wsPopupHelper.getSelectedMessage();
 
             if (message != null) {
-                setEnabled(isEnabledForUrl(message.channel.getContextUrl()));
+                setEnabled(isEnabledForUrl(message.getChannel().getContextUrl()));
             } else {
                 setEnabled(false);
             }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesPayloadFilter.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesPayloadFilter.java
@@ -121,8 +121,8 @@ public class WebSocketMessagesPayloadFilter {
      */
     public boolean isMessageValidWithPattern(WebSocketMessageDTO webSocketMessageDTO) {
         return inverted
-                ? !payloadPattern.matcher((String) webSocketMessageDTO.payload).find()
-                : payloadPattern.matcher((String) webSocketMessageDTO.payload).find();
+                ? !payloadPattern.matcher((String) webSocketMessageDTO.getPayload()).find()
+                : payloadPattern.matcher((String) webSocketMessageDTO.getPayload()).find();
     }
 
     /**

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesView.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesView.java
@@ -216,7 +216,7 @@ public class WebSocketMessagesView implements Runnable {
                 final WebSocketMessageDTO msg = message;
                 EventQueue.invokeAndWait(
                         () -> {
-                            if (msg.isOutgoing.booleanValue()) {
+                            if (msg.isOutgoing().booleanValue()) {
                                 requestPanel.setMessage(msg);
                                 responsePanel.clearView(false);
                                 requestPanel.setTabFocus();
@@ -257,7 +257,8 @@ public class WebSocketMessagesView implements Runnable {
                 displayQueue.clear();
             }
 
-            message.tempUserObj = WebSocketPanel.connectedChannelIds.contains(message.channel.id);
+            message.setTempUserObj(
+                    WebSocketPanel.connectedChannelIds.contains(message.getChannel().getId()));
             displayQueue.add(message);
         }
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewFilter.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewFilter.java
@@ -107,26 +107,26 @@ public class WebSocketMessagesViewFilter {
      * @return True if the given entry is filtered out, false if valid.
      */
     public boolean isDenylisted(WebSocketMessageDTO message) {
-        if (isShowJustInScope && !message.channel.isInScope()) {
+        if (isShowJustInScope && !message.getChannel().isInScope()) {
             return true;
         }
 
         if (opcodeList != null) {
-            if (!opcodeList.contains(message.opcode)) {
+            if (!opcodeList.contains(message.getOpcode())) {
                 return true;
             }
         }
 
         if (direction != null) {
-            if (message.isOutgoing && !direction.equals(Direction.OUTGOING)) {
+            if (message.isOutgoing() && !direction.equals(Direction.OUTGOING)) {
                 return true;
-            } else if (!message.isOutgoing && !direction.equals(Direction.INCOMING)) {
+            } else if (!message.isOutgoing() && !direction.equals(Direction.INCOMING)) {
                 return true;
             }
         }
 
         if (payloadFilter != null
-                && message.payload instanceof String
+                && message.getPayload() instanceof String
                 && !payloadFilter.isMessageValidWithPattern(message)) {
             return true;
             // binary messages are not affected by pattern

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
@@ -283,14 +283,14 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
                     e -> {
                         WebSocketChannelDTO channel =
                                 (WebSocketChannelDTO) channelSelect.getSelectedItem();
-                        if (channel != null && channel.id != null) {
+                        if (channel != null && channel.getId() != null) {
                             // has valid element selected + a valid reference
-                            useModel(channel.id);
+                            useModel(channel.getId());
                         } else {
                             useJoinedModel();
                         }
 
-                        if (channel != null && channel.historyId != null) {
+                        if (channel != null && channel.getHistoryId() != null) {
                             getShowHandshakeButton().setEnabled(true);
                         } else {
                             getShowHandshakeButton().setEnabled(false);
@@ -487,12 +487,12 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
         boolean isNewChannel = false;
 
         synchronized (connectedChannelIds) {
-            boolean isConnectedChannel = connectedChannelIds.contains(channel.id);
+            boolean isConnectedChannel = connectedChannelIds.contains(channel.getId());
 
             switch (state) {
                 case CLOSED:
-                    if (isConnectedChannel && channel.endTimestamp != null) {
-                        connectedChannelIds.remove(channel.id);
+                    if (isConnectedChannel && channel.getEndTimestamp() != null) {
+                        connectedChannelIds.remove(channel.getId());
 
                         // updates icon
                         channelsModel.updateElement(channel);
@@ -501,15 +501,15 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
 
                 case EXCLUDED:
                     // remove from UI
-                    connectedChannelIds.remove(channel.id);
+                    connectedChannelIds.remove(channel.getId());
                     channelsModel.removeElement(channel);
 
                     messagesModel.fireTableDataChanged();
                     break;
 
                 case OPEN:
-                    if (!isConnectedChannel && channel.endTimestamp == null) {
-                        connectedChannelIds.add(channel.id);
+                    if (!isConnectedChannel && channel.getEndTimestamp() == null) {
+                        connectedChannelIds.add(channel.getId());
                         channelsModel.addElement(channel);
                         isNewChannel = true;
                     }
@@ -517,7 +517,7 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
 
                 case INCLUDED:
                     // add to UI (probably again)
-                    connectedChannelIds.add(channel.id);
+                    connectedChannelIds.add(channel.getId());
                     channelsModel.addElement(channel);
 
                     messagesModel.fireTableDataChanged();
@@ -660,9 +660,10 @@ public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
 
         // show channel if not already active
         Integer activeChannelId = messagesModel.getActiveChannelId();
-        if (message.channel.id != null && !message.channel.id.equals(activeChannelId)) {
-            messagesModel.setActiveChannel(message.channel.id);
-            channelSelectModel.setSelectedChannelId(message.channel.id);
+        if (message.getChannel().getId() != null
+                && !message.getChannel().getId().equals(activeChannelId)) {
+            messagesModel.setActiveChannel(message.getChannel().getId());
+            channelSelectModel.setSelectedChannelId(message.getChannel().getId());
         }
 
         // check if message is filtered out

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketUiHelper.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketUiHelper.java
@@ -138,7 +138,7 @@ public class WebSocketUiHelper {
 
         String opcodeString = (String) getOpcodeSingleSelect().getSelectedItem();
 
-        for (int opcode : WebSocketMessage.OPCODES) {
+        for (int opcode : WebSocketMessage.getOpcodes()) {
             if (WebSocketMessage.opcode2string(opcode).equals(opcodeString)) {
                 return opcode;
             }
@@ -155,7 +155,7 @@ public class WebSocketUiHelper {
 
     private JList<String> getOpcodeList() {
         if (opcodeList == null) {
-            int itemsCount = WebSocketMessage.OPCODES.length + 1;
+            int itemsCount = WebSocketMessage.getOpcodes().size() + 1;
 
             opcodeList = new JList<>(getOpcodeModel());
             opcodeList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
@@ -168,13 +168,13 @@ public class WebSocketUiHelper {
 
     private String[] getOpcodeModel() {
         int i = 0;
-        String[] opcodes = new String[WebSocketMessage.OPCODES.length + 1];
+        String[] opcodes = new String[WebSocketMessage.getOpcodes().size() + 1];
 
         // all opcodes
         opcodes[i++] = SELECT_ALL_OPCODES;
 
         // specific opcode
-        for (int opcode : WebSocketMessage.OPCODES) {
+        for (int opcode : WebSocketMessage.getOpcodes()) {
             opcodes[i++] = WebSocketMessage.opcode2string(opcode);
         }
 
@@ -210,7 +210,7 @@ public class WebSocketUiHelper {
         }
 
         List<Integer> values = new ArrayList<>();
-        for (int opcode : WebSocketMessage.OPCODES) {
+        for (int opcode : WebSocketMessage.getOpcodes()) {
             if (opcodes.contains(WebSocketMessage.opcode2string(opcode))) {
                 values.add(opcode);
             }
@@ -282,7 +282,7 @@ public class WebSocketUiHelper {
         }
         WebSocketChannelDTO channel =
                 (WebSocketChannelDTO) getChannelSingleSelect().getSelectedItem();
-        return channel.id;
+        return channel.getId();
     }
 
     public WebSocketChannelDTO getSelectedChannelDTO() {
@@ -298,7 +298,7 @@ public class WebSocketUiHelper {
         if (channelId != null) {
             for (int i = 0; i < channelsModel.getSize(); i++) {
                 WebSocketChannelDTO channel = channelsModel.getElementAt(i);
-                if (channelId.equals(channel.id)) {
+                if (channelId.equals(channel.getId())) {
                     channelsComboBox.setSelectedItem(channel);
                     return;
                 }
@@ -339,7 +339,7 @@ public class WebSocketUiHelper {
         List<Integer> values = new ArrayList<>();
 
         for (WebSocketChannelDTO value : channels.getSelectedValuesList()) {
-            Integer channelId = value.id;
+            Integer channelId = value.getId();
             if (channelId == null) {
                 isSelectAll = true;
                 break;
@@ -363,7 +363,7 @@ public class WebSocketUiHelper {
             ListModel<WebSocketChannelDTO> model = channelsList.getModel();
             for (int i = 0, j = 0; i < model.getSize(); i++) {
                 WebSocketChannelDTO channel = model.getElementAt(i);
-                if (channelIds.contains(channel.id)) {
+                if (channelIds.contains(channel.getId())) {
                     selectedIndices[j++] = i;
                 }
             }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/component/WebSocketComponent.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/component/WebSocketComponent.java
@@ -153,18 +153,18 @@ public class WebSocketComponent
         StringBuilder sb = new StringBuilder();
 
         sb.append(message.toString()).append(" - ");
-        if (message.dateTime != null) {
-            sb.append(message.dateTime).append(" - ");
+        if (message.getDateTime() != null) {
+            sb.append(message.getDateTime()).append(" - ");
         }
-        if (message.readableOpcode != null) {
-            sb.append(message.readableOpcode);
+        if (message.getReadableOpcode() != null) {
+            sb.append(message.getReadableOpcode());
         }
 
         informationLabel.setText(sb.toString());
 
         views.setMessage(message);
-        if (message.tempUserObj instanceof Boolean) {
-            Boolean isConnected = (Boolean) message.tempUserObj;
+        if (message.getTempUserObj() instanceof Boolean) {
+            Boolean isConnected = (Boolean) message.getTempUserObj();
 
             ImageIcon icon;
             if (isConnected) {

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/models/ByteWebSocketPanelViewModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/models/ByteWebSocketPanelViewModel.java
@@ -26,14 +26,14 @@ public class ByteWebSocketPanelViewModel extends AbstractWebSocketBytePanelViewM
 
     @Override
     public byte[] getData() {
-        if (webSocketMessage == null || webSocketMessage.payload == null) {
+        if (webSocketMessage == null || webSocketMessage.getPayload() == null) {
             return new byte[0];
         }
 
-        if (webSocketMessage.payload instanceof String) {
-            return ((String) webSocketMessage.payload).getBytes();
-        } else if (webSocketMessage.payload instanceof byte[]) {
-            return (byte[]) webSocketMessage.payload;
+        if (webSocketMessage.getPayload() instanceof String) {
+            return ((String) webSocketMessage.getPayload()).getBytes();
+        } else if (webSocketMessage.getPayload() instanceof byte[]) {
+            return (byte[]) webSocketMessage.getPayload();
         }
 
         return new byte[0];
@@ -41,17 +41,17 @@ public class ByteWebSocketPanelViewModel extends AbstractWebSocketBytePanelViewM
 
     @Override
     public void setData(byte[] data) {
-        if (webSocketMessage.opcode != null) {
-            if (webSocketMessage.opcode == WebSocketMessage.OPCODE_BINARY) {
-                webSocketMessage.payload = data;
+        if (webSocketMessage.getOpcode() != null) {
+            if (webSocketMessage.getOpcode() == WebSocketMessage.OPCODE_BINARY) {
+                webSocketMessage.setPayload(data);
             } else {
-                webSocketMessage.payload = new String(data, Charset.forName("UTF-8"));
+                webSocketMessage.setPayload(new String(data, Charset.forName("UTF-8")));
             }
         } else {
-            if (webSocketMessage.payload instanceof String) {
-                webSocketMessage.payload = new String(data, Charset.forName("UTF-8"));
-            } else if (webSocketMessage.payload instanceof byte[]) {
-                webSocketMessage.payload = data;
+            if (webSocketMessage.getPayload() instanceof String) {
+                webSocketMessage.setPayload(new String(data, Charset.forName("UTF-8")));
+            } else if (webSocketMessage.getPayload() instanceof byte[]) {
+                webSocketMessage.setPayload(data);
             }
         }
     }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/models/StringWebSocketPanelViewModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/models/StringWebSocketPanelViewModel.java
@@ -35,7 +35,7 @@ public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelV
     @Override
     public String getData() {
         String data;
-        if (webSocketMessage == null || webSocketMessage.payload == null) {
+        if (webSocketMessage == null || webSocketMessage.getPayload() == null) {
             data = "";
         } else if (editable) {
             try {
@@ -43,14 +43,14 @@ public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelV
                 isErrorMessage = false;
             } catch (InvalidUtf8Exception e) {
                 isErrorMessage = true;
-                if (webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_BINARY)) {
+                if (webSocketMessage.getOpcode().equals(WebSocketMessage.OPCODE_BINARY)) {
                     data = Constant.messages.getString("websocket.payload.unreadable_binary");
                 } else {
                     data = Constant.messages.getString("websocket.payload.invalid_utf8");
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(
                                 "Unable to decode {} as UTF-8.",
-                                Arrays.toString((byte[]) webSocketMessage.payload),
+                                Arrays.toString((byte[]) webSocketMessage.getPayload()),
                                 e);
                     }
                 }
@@ -64,28 +64,28 @@ public class StringWebSocketPanelViewModel extends AbstractWebSocketStringPanelV
     @Override
     public void setData(String data) {
         if (isErrorMessage
-                && ((webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_BINARY)
+                && ((webSocketMessage.getOpcode().equals(WebSocketMessage.OPCODE_BINARY)
                                 && data.equals(
                                         Constant.messages.getString(
                                                 "websocket.payload.unreadable_binary")))
-                        || webSocketMessage.opcode.equals(WebSocketMessage.OPCODE_TEXT)
+                        || webSocketMessage.getOpcode().equals(WebSocketMessage.OPCODE_TEXT)
                                 && data.equals(
                                         Constant.messages.getString(
                                                 "websocket.payload.invalid_utf8")))) {
             // do not set data if it is an error message and has not been modified
             return;
         }
-        if (webSocketMessage.opcode != null) {
-            if (webSocketMessage.opcode == WebSocketMessage.OPCODE_BINARY) {
-                webSocketMessage.payload = data.getBytes();
+        if (webSocketMessage.getOpcode() != null) {
+            if (webSocketMessage.getOpcode() == WebSocketMessage.OPCODE_BINARY) {
+                webSocketMessage.setPayload(data.getBytes());
             } else {
-                webSocketMessage.payload = data;
+                webSocketMessage.setPayload(data);
             }
         } else {
-            if (webSocketMessage.payload instanceof String) {
-                webSocketMessage.payload = data;
-            } else if (webSocketMessage.payload instanceof byte[]) {
-                webSocketMessage.payload = data.getBytes();
+            if (webSocketMessage.getPayload() instanceof String) {
+                webSocketMessage.setPayload(data);
+            } else if (webSocketMessage.getPayload() instanceof byte[]) {
+                webSocketMessage.setPayload(data.getBytes());
             }
         }
     }

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/views/large/WebSocketLargePayloadUtil.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/views/large/WebSocketLargePayloadUtil.java
@@ -28,10 +28,10 @@ public class WebSocketLargePayloadUtil extends LargeResponseUtil {
     public static boolean isLargePayload(Message aMessage) {
         if (aMessage instanceof WebSocketMessageDTO) {
             WebSocketMessageDTO message = (WebSocketMessageDTO) aMessage;
-            if (message.payloadLength == null || minContentLength == -1) {
+            if (message.getPayloadLength() == null || minContentLength == -1) {
                 return false;
             }
-            return message.payloadLength > minContentLength;
+            return message.getPayloadLength() > minContentLength;
         }
 
         return false;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/views/large/WebSocketLargetPayloadViewModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/views/large/WebSocketLargetPayloadViewModel.java
@@ -26,7 +26,7 @@ public class WebSocketLargetPayloadViewModel extends StringWebSocketPanelViewMod
 
     @Override
     public String getData() {
-        if (webSocketMessage == null || webSocketMessage.payloadLength == 0) {
+        if (webSocketMessage == null || webSocketMessage.getPayloadLength() == 0) {
             return "";
         }
 

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketfuzzerprocessor/Fuzzer WebSocket Processor default template.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketfuzzerprocessor/Fuzzer WebSocket Processor default template.js
@@ -24,7 +24,7 @@ function processMessage(utils, message) {
 	//    utils.sendMessage(myMessage, false)
 
 	// Process fuzzed message...
-	message.payload = "123"
+	message.setPayload("123");
 	count++;
 }
 

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Application Error Scanner.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Application Error Scanner.js
@@ -131,7 +131,7 @@ regexErrors.forEach(function(pattern){
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
     var message = String(msg.getReadablePayload());

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Base64 Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Base64 Disclosure.js
@@ -21,7 +21,7 @@ JavaString = Java.type("java.lang.String");
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
     var message = String(msg.getReadablePayload());

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Debug Error Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Debug Error Disclosure.js
@@ -44,7 +44,7 @@ var debug_messages = [
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
     var message = String(msg.getReadablePayload());

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Email Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Email Disclosure.js
@@ -11,7 +11,7 @@ var emailRegex = new RegExp("([a-z0-9_.+-]+@[a-z0-9]+[a-z0-9-]*\.[a-z0-9-.]*[a-z
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
     var message = String(msg.getReadablePayload());

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/PII Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/PII Disclosure.js
@@ -25,7 +25,7 @@ creditCards = {
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
     var message = String(msg.getReadablePayload());

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Passive WebSocket Scan Template.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Passive WebSocket Scan Template.js
@@ -58,7 +58,7 @@ CONFIDENCE_HIGH = 3;
  */
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
 

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Passive WebSocket Scan Template.py
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Passive WebSocket Scan Template.py
@@ -60,7 +60,7 @@ CONFIDENCE_HIGH = 3
 """
 def scan(helper,msg):
 
-    if( msg.opcode != OPCODE_TEXT or msg.isOutgoing):
+    if( msg.getOpcode() != OPCODE_TEXT or msg.isOutgoing()):
         return
 
     print(msg.getReadablePayload())

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Private IP Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Private IP Disclosure.js
@@ -59,7 +59,7 @@ patternPre.push(
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
     var ipRegex = new RegExp(patternPre.join(""),"gim");

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Username Idor Scanner.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Username Idor Scanner.js
@@ -20,7 +20,7 @@ var usersList = null;
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing || (usersList = getUsers()) == null){
+    if(msg.getOpcode() != OPCODE_TEXT || msg.isOutgoing() || (usersList = getUsers()) == null){
         return;
     }
     var message = String(msg.getReadablePayload());

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/XML Comments Disclosure.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/XML Comments Disclosure.js
@@ -35,7 +35,7 @@ var commentPatterns = [/\bTODO\b/gmi,
 
 function scan(helper,msg) {
 
-    if(msg.opcode != OPCODE_TEXT || msg.isOutgoing){
+    if(msg.getOpcode()!= OPCODE_TEXT || msg.isOutgoing()){
         return;
     }
 

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/WebSocketAddonTestUtils.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/WebSocketAddonTestUtils.java
@@ -55,9 +55,9 @@ public abstract class WebSocketAddonTestUtils extends WebSocketTestUtils {
 
     public WebSocketMessageDTO sendOutgoingMessage(WebSocketProxy webSocketProxy, String message) {
         WebSocketMessageDTO webSocketMessage = new WebSocketMessageDTO(webSocketProxy.getDTO());
-        webSocketMessage.payload = message;
-        webSocketMessage.opcode = WebSocketMessage.OPCODE_TEXT;
-        webSocketMessage.isOutgoing = true;
+        webSocketMessage.setPayload(message);
+        webSocketMessage.setOpcode(WebSocketMessage.OPCODE_TEXT);
+        webSocketMessage.setOutgoing(true);
 
         try {
             return webSocketProxy.send(webSocketMessage, WebSocketProxy.Initiator.MANUAL_REQUEST)
@@ -91,15 +91,15 @@ public abstract class WebSocketAddonTestUtils extends WebSocketTestUtils {
         WebSocketProxy proxy = mock(WebSocketProxy.class);
         when(proxy.getDTO()).thenReturn(channel);
         when(proxy.getHandshakeReference()).thenReturn(handshakeRef);
-        when(proxy.getChannelId()).thenReturn(channel.id);
+        when(proxy.getChannelId()).thenReturn(channel.getId());
         return proxy;
     }
 
     public WebSocketChannelDTO getWebSocketChannelDTO(int id, String hostName, String url) {
         WebSocketChannelDTO channel = new WebSocketChannelDTO(hostName);
-        channel.id = id;
-        channel.port = 443;
-        channel.url = url;
+        channel.setId(id);
+        channel.setPort(443);
+        channel.setUrl(url);
         return channel;
     }
 
@@ -114,12 +114,12 @@ public abstract class WebSocketAddonTestUtils extends WebSocketTestUtils {
             Object payload,
             int id) {
         WebSocketMessageDTO message = new WebSocketMessageDTO(channel);
-        message.isOutgoing = isOutgoing;
-        message.opcode = opcode;
-        message.id = id;
-        message.payload = payload;
+        message.setOutgoing(isOutgoing);
+        message.setOpcode(opcode);
+        message.setId(id);
+        message.setPayload(payload);
         if (payload instanceof String) {
-            message.payloadLength = ((String) payload).length() * 4;
+            message.setPayloadLength(((String) payload).length() * 4);
         }
         return message;
     }

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertRaiserUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertRaiserUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.websocket.alerts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,8 @@ class WebSocketAlertRaiserUnitTest extends WebSocketTestUtils {
         // Given
         WebSocketAlertThread webSocketAlertThread = mock(WebSocketAlertThread.class);
         WebSocketMessageDTO message = mock(WebSocketMessageDTO.class);
-        message.channel = mock(WebSocketChannelDTO.class);
+        given(message.getChannel()).willReturn(mock(WebSocketChannelDTO.class));
+        given(message.getChannel().getId()).willReturn(1);
         WebSocketAlertRaiser alertRaiser =
                 new WebSocketAlertRaiser(webSocketAlertThread, 0, message);
 
@@ -65,7 +67,8 @@ class WebSocketAlertRaiserUnitTest extends WebSocketTestUtils {
         // Given
         WebSocketAlertThread webSocketAlertThread = mock(WebSocketAlertThread.class);
         WebSocketMessageDTO message = mock(WebSocketMessageDTO.class);
-        message.channel = mock(WebSocketChannelDTO.class);
+        given(message.getChannel()).willReturn(mock(WebSocketChannelDTO.class));
+        given(message.getChannel().getId()).willReturn(1);
         WebSocketAlertRaiser alertRaiser =
                 new WebSocketAlertRaiser(webSocketAlertThread, 0, message);
         // When

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/WebSocketNodesUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/WebSocketNodesUnitTest.java
@@ -94,7 +94,7 @@ class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
         WebSocketNode messageNode = new WebSocketNode(hostNode, new MessageContent(namer, message));
 
         // Then
-        assertEquals(messageNode.getMessage().id, message.id);
+        assertEquals(messageNode.getMessage().getId(), message.getId());
     }
 
     @Test
@@ -124,8 +124,8 @@ class WebSocketNodesUnitTest extends WebSocketAddonTestUtils {
 
         // Then
         for (int i = 0; i < expectedMessages.size(); i++) {
-            assertEquals(expectedMessages.get(i).id, messagesFromRoot.get(i).id);
-            assertEquals(expectedMessages.get(i).id, messagesFromHost.get(i).id);
+            assertEquals(expectedMessages.get(i).getId(), messagesFromRoot.get(i).getId());
+            assertEquals(expectedMessages.get(i).getId(), messagesFromHost.get(i).getId());
         }
     }
 

--- a/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/factories/SimpleNodeFactoryUnitTest.java
+++ b/addOns/websocket/src/test/java/org/zaproxy/zap/extension/websocket/treemap/nodes/factories/SimpleNodeFactoryUnitTest.java
@@ -127,12 +127,12 @@ class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
         host2Messages.sort(comparator);
 
         // Then
-        assertEquals(host1Messages.get(0).id, messages.get(0).id);
-        assertEquals(host1Messages.get(1).id, messages.get(2).id);
-        assertEquals(host1Messages.get(2).id, messages.get(4).id);
+        assertEquals(host1Messages.get(0).getId(), messages.get(0).getId());
+        assertEquals(host1Messages.get(1).getId(), messages.get(2).getId());
+        assertEquals(host1Messages.get(2).getId(), messages.get(4).getId());
 
-        assertEquals(host2Messages.get(0).id, messages.get(1).id);
-        assertEquals(host2Messages.get(1).id, messages.get(3).id);
+        assertEquals(host2Messages.get(0).getId(), messages.get(1).getId());
+        assertEquals(host2Messages.get(1).getId(), messages.get(3).getId());
     }
 
     @Test
@@ -153,8 +153,8 @@ class SimpleNodeFactoryUnitTest extends WebSocketAddonTestUtils {
         // Then
         WebSocketMessageDTO actualMessage =
                 nodeFactory.getRoot().getMessagesPerHost(new HashMap<>()).get(hostNode).get(0);
-        assertEquals(expectedMessage.id, actualMessage.id);
-        assertEquals(expectedMessage.channel, actualMessage.channel);
+        assertEquals(expectedMessage.getId(), actualMessage.getId());
+        assertEquals(expectedMessage.getChannel(), actualMessage.getChannel());
     }
 
     @Test


### PR DESCRIPTION

- accessControl > Make variables non-public and provide/use accessors (which may impact third party add-ons or scripts).
- ascanrulesBeta
  - HeartBleedActiveScanRule reduce visibility of fields in nested class SSLRecord. (Fix one missed Log4j 2.x change.)
  - HiddenFileScanRule reduce visibility of PAYLOADS_FILE_PATH.
  - ProxyDisclosureScanRule reduce visibility of some constants, remove unused constant PROXY_RESPONSE_HEADERS.
  - UserAgentScanRule reduce visibility of USER_AGENTS constant, add and leverage a getter.
- bugtracker > Make variable non-public and provide/use accessors.
- pscanruelsAlpha > Make HMAC pattern protected and final, and name as a constant.
- quickstart > Mark icon constants final.
- selenium > Reduce visibility, and subsequently remove unused Browser.setHeadless(boolean). (Some changes impact the visibility of variables and getters/setters, which may impact third party add-ons or scripts).
- sqlplugin > Reduce visibility of SQLiPayLoadManager.SQLI_TECHNIQUES.
- websocket > Make variables non-public and provide/use accessors. (some changes impact the visibility of variables and add getters/setters, which may impact third party add-ons or scripts.). Updated packaged scripts to use new getters.

Updated CHANGELOGs where applicable.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>