### PR TITLE
Use/report URIs in encoded form not decoded

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- The SQL Injection scan rule will raise alerts with the URI field in encoded form.
 
+### Fixed
+- Correct Context check in SQL Injection scan rule.
 
 ## [39] - 2021-05-10
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -187,7 +187,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
             while (javaClassesFound.size() > 0) {
                 String classname = javaClassesFound.get(0);
                 URI classURI = getClassURI(originalURI, classname);
-                log.debug("Looking for Class file: {}", classURI.getURI());
+                log.debug("Looking for Class file: {}", classURI);
 
                 HttpMessage classfilemsg = new HttpMessage(classURI);
                 sendAndReceive(classfilemsg, false); // do not follow redirects

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -1622,7 +1622,9 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
 
                     // using the session, get the list of contexts for the url
                     List<Context> contextList =
-                            extAuth.getModel().getSession().getContextsForUrl(requestUri.getURI());
+                            extAuth.getModel()
+                                    .getSession()
+                                    .getContextsForUrl(requestUri.toString());
 
                     // now loop, and see if the url is a login url in each of the contexts in turn..
                     for (Context context : contextList) {
@@ -1660,7 +1662,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
                             .setName(vulnname)
                             .setDescription(vulndesc)
-                            .setUri(refreshedmessage.getRequestHeader().getURI().getURI())
+                            .setUri(refreshedmessage.getRequestHeader().getURI().toString())
                             .setParam(param)
                             .setAttack(sqlInjectionAttack)
                             .setMessage(getBaseMsg())

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update links to zaproxy repo.
 - Target 2.10 core and use new logging infrastructure (Log4j 2.x).
-- The LDAP Injection scan rule was modified to make use of the Dice algorithm for calculating the match percentage, thus improving its performance.
+- The LDAP Injection scan rule was modified to use:
+  - The Dice algorithm for calculating the match percentage, thus improving its performance.
+  - The URI in encoded form in alerts' other info field.
 - Maintenance changes.
 
 ### Added
@@ -17,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 - Unused file, it was used by promoted scan rule.
+
+### Fixed
+- Correct Context check in NoSQL Injection - MongoDB scan rule.
 
 ## [30] - 2020-11-26
 ### Changed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -359,7 +359,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                                     I18N_PREFIX + "ldapinjection.booleanbased.alert.extrainfo",
                                     paramname,
                                     getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI().getURI(),
+                                    getBaseMsg().getRequestHeader().getURI(),
                                     appendTrueAttack,
                                     randomparameterAttack);
 
@@ -459,7 +459,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                                     I18N_PREFIX + "ldapinjection.booleanbased.alert.extrainfo",
                                     paramname,
                                     getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI().getURI(),
+                                    getBaseMsg().getRequestHeader().getURI(),
                                     hopefullyTrueAttack,
                                     randomparameterAttack);
 
@@ -581,7 +581,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                                 I18N_PREFIX + "ldapinjection.alert.extrainfo",
                                 parameterName,
                                 getBaseMsg().getRequestHeader().getMethod(),
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
+                                getBaseMsg().getRequestHeader().getURI(),
                                 errorAttack,
                                 LDAP_ERRORS.get(errorPattern),
                                 errorPattern);
@@ -616,7 +616,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
                                             + "on parameter [{2}], using an attack with LDAP meta-characters [{3}], "
                                             + "yielding known [{4}] error message [{5}], which was not present in the original response.",
                                     getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI().getURI(),
+                                    getBaseMsg().getRequestHeader().getURI(),
                                     parameterName,
                                     errorAttack,
                                     LDAP_ERRORS.get(errorPattern),

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/MongoDbInjectionScanRule.java
@@ -523,7 +523,9 @@ public class MongoDbInjectionScanRule extends AbstractAppParamPlugin {
                 URI requestUri = getBaseMsg().getRequestHeader().getURI();
                 try {
                     List<Context> contextList =
-                            extAuth.getModel().getSession().getContextsForUrl(requestUri.getURI());
+                            extAuth.getModel()
+                                    .getSession()
+                                    .getContextsForUrl(requestUri.toString());
                     for (Context context : contextList) {
                         URI loginUri = extAuth.getLoginRequestURIForContext(context);
                         if (loginUri != null) {

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -10,10 +10,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The trace.axd file scan rule now performs a content check to reduce false positives (Issue 6517).
 - XML External Entity Attack scan rule changed to detect a possible XML File Reflection Attack when XML validation is present. (Issue 6204)
 - Added/updated the details of some alerts (some changes might break Alert Filters)
+  - Backup File Disclosure
+    - The attack, evidence, and other info will use URIs in encoded form.
+  - Insecure HTTP Method
+    - The URI field will be in encoded form.
   - Integer Overflow
     - Added evidence
-  - SQLi SQLite
+  - Relative Path Confusion
+    - The attack and URI field will use URIs in encoded form.
+  - Source Code Disclosure - File Inclusion
+    - The URI field will be in encoded form.
+  - Source Code Disclosure - Git
+    - The URI field will be in encoded form.
+  - Source Code Disclosure - SVN
+    - The URI field will be in encoded form.
+  - SQL Injection - Hypersonic SQL
+    - The URI field will be in encoded form.
+  - SQL Injection - MySQL
+    - The URI field will be in encoded form.
+  - SQL Injection - Oracle
+    - The URI field will be in encoded form.
+  - SQL Injection - PostgreSQL
+    - The URI field will be in encoded form.
+  - SQL Injection - SQLite
     - Evidence is now the string that was matched in the response
+    - The URI field will be in encoded form.
   - XPath Injection
     - Added evidence
 - The Source Code Disclosure - File Inclusion scan rule was modified to make use of the Dice algorithm for calculating the match percentage, thus improving its performance.
@@ -21,6 +42,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Add missing file, used by Hidden File Finder scan rule.
+- Correct Context check in scan rules:
+  - Session Fixation
+  - Possible Username Enumeration
 
 ## [33] - 2020-12-15
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
@@ -721,8 +721,8 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                                         && (!Arrays.equals(disclosedData, nonexistfilemsgdata))))) {
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setAttack(candidateBackupFileURI.getURI())
-                            .setOtherInfo(originalMessage.getRequestHeader().getURI().getURI())
+                            .setAttack(candidateBackupFileURI.toString())
+                            .setOtherInfo(originalMessage.getRequestHeader().getURI().toString())
                             .setSolution(
                                     Constant.messages.getString(
                                             "ascanbeta.backupfiledisclosure.soln"))
@@ -730,7 +730,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                                     Constant.messages.getString(
                                             "ascanbeta.backupfiledisclosure.evidence",
                                             originalURI,
-                                            candidateBackupFileURI.getURI()))
+                                            candidateBackupFileURI))
                             .setMessage(requestmsg)
                             .raise();
                 }
@@ -776,8 +776,8 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                             .setName(
                                     Constant.messages.getString(
                                             "ascanbeta.backupfiledisclosure.name"))
-                            .setAttack(candidateBackupFileURI.getURI())
-                            .setOtherInfo(originalMessage.getRequestHeader().getURI().getURI())
+                            .setAttack(candidateBackupFileURI.toString())
+                            .setOtherInfo(originalMessage.getRequestHeader().getURI().toString())
                             .setSolution(
                                     Constant.messages.getString(
                                             "ascanbeta.backupfiledisclosure.soln"))
@@ -785,7 +785,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                                     Constant.messages.getString(
                                             "ascanbeta.backupfiledisclosure.evidence",
                                             originalURI,
-                                            candidateBackupFileURI.getURI()))
+                                            candidateBackupFileURI))
                             .setMessage(requestmsg)
                             .raise();
                 }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GitMetadata.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/GitMetadata.java
@@ -145,11 +145,11 @@ public class GitMetadata {
         HttpMessage msg = messagecache.getMessage(uri, basemsg, false);
 
         if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
-            throw new FileNotFoundException(uri.getURI());
+            throw new FileNotFoundException(uri.toString());
         }
         // record the URI if it came back with a 200 (see the condition above)
-        if (this.urisUsed == null || this.urisUsed.equals("")) this.urisUsed = uri.getURI();
-        else this.urisUsed = this.urisUsed + ", " + uri.getURI();
+        if (this.urisUsed == null || this.urisUsed.equals("")) this.urisUsed = uri.toString();
+        else this.urisUsed = this.urisUsed + ", " + uri;
         data = msg.getResponseBody().getBytes();
 
         if (inflate) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -376,7 +376,7 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
                     .setDescription(
                             Constant.messages.getString(
                                     "ascanbeta.insecurehttpmethod.trace.exploitable.desc", method))
-                    .setUri(msg.getRequestHeader().getURI().getURI())
+                    .setUri(msg.getRequestHeader().getURI().toString())
                     .setOtherInfo(
                             Constant.messages.getString(
                                     "ascanbeta.insecurehttpmethod.trace.exploitable.extrainfo",
@@ -516,14 +516,14 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
             String randomResource =
                     RandomStringUtils.random(10, "abcdefghijklmnopqrstuvwxyz0123456789");
             String requestBody = '"' + randomKey + "\":\"" + randomValue + '"';
-            String newURI = msg.getRequestHeader().getURI().getURI();
+            String newURI = msg.getRequestHeader().getURI().toString();
             if (newURI.endsWith("/")) {
                 newURI += randomResource;
             } else {
                 newURI += '/' + randomResource;
             }
 
-            msg.getRequestHeader().setURI(new URI(newURI, false, URI.getDefaultProtocolCharset()));
+            msg.getRequestHeader().setURI(new URI(newURI, true));
             msg.setRequestBody(requestBody);
         }
 

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -612,8 +612,8 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin {
                 // alert it..
                 newAlert()
                         .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                        .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
-                        .setAttack(hackedUri.getURI())
+                        .setUri(getBaseMsg().getRequestHeader().getURI().toString())
+                        .setAttack(hackedUri.toString())
                         .setOtherInfo(extraInfo)
                         .setEvidence(relativeReferenceEvidence)
                         .setMessage(hackedMessage)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RemoteCodeExecutionCve20121823ScanRule.java
@@ -165,7 +165,7 @@ public class RemoteCodeExecutionCve20121823ScanRule extends AbstractAppPlugin {
             if (isPage200(attackmsg)
                     && attackResponseBody.length >= RANDOM_STRING.length()
                     && responseBody.startsWith(RANDOM_STRING)) {
-                log.debug("Remote Code Execution alert for: {}", originalURI.getURI());
+                log.debug("Remote Code Execution alert for: {}", originalURI);
 
                 // bingo.
                 newAlert()

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
@@ -122,7 +122,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
 
             // using the session, get the list of contexts for the url
             List<Context> contextList =
-                    extAuth.getModel().getSession().getContextsForUrl(requestUri.getURI());
+                    extAuth.getModel().getSession().getContextsForUrl(requestUri.toString());
 
             // now loop, and see if the url is a login url in each of the contexts in turn...
             for (Context context : contextList) {
@@ -450,7 +450,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                                 currentHtmlParameter.getType(),
                                 currentHtmlParameter.getName(),
                                 getBaseMsg().getRequestHeader().getMethod(),
-                                getBaseMsg().getRequestHeader().getURI().getURI());
+                                getBaseMsg().getRequestHeader().getURI());
                         // Note: do NOT continue to the next field at this point..
                         // since we still need to check for Session Fixation.
                     }
@@ -507,7 +507,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                         log.debug(
                                 "A session identifier in [{}] URL [{}] {} field: [{}] may be accessible to JavaScript",
                                 getBaseMsg().getRequestHeader().getMethod(),
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
+                                getBaseMsg().getRequestHeader().getURI(),
                                 currentHtmlParameter.getType(),
                                 currentHtmlParameter.getName());
                         // Note: do NOT continue to the next field at this point..
@@ -685,7 +685,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                                 "A session identifier in [{}] URL [{}] {} field: "
                                         + "[{}] may be accessed until [{}], unless the session is destroyed.",
                                 getBaseMsg().getRequestHeader().getMethod(),
-                                getBaseMsg().getRequestHeader().getURI().getURI(),
+                                getBaseMsg().getRequestHeader().getURI(),
                                 currentHtmlParameter.getType(),
                                 currentHtmlParameter.getName(),
                                 sessionExpiryDescription);
@@ -1078,7 +1078,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
                             log.debug(
                                     "An exposed session identifier has been found at [{}] URL [{}] on {} {} field: [{}]",
                                     getBaseMsg().getRequestHeader().getMethod(),
-                                    getBaseMsg().getRequestHeader().getURI().getURI(),
+                                    getBaseMsg().getRequestHeader().getURI(),
                                     (isPseudoUrlParameter ? "pseudo " : ""),
                                     currentHtmlParameter.getType(),
                                     currentHtmlParameter.getName());

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureCve20121823ScanRule.java
@@ -160,7 +160,7 @@ public class SourceCodeDisclosureCve20121823ScanRule extends AbstractAppPlugin {
                 boolean match2 = matcher2.matches();
 
                 if ((!responseBody.equals(responseBodyDecoded)) && (match1 || match2)) {
-                    log.debug("Source Code Disclosure alert for: {}", originalURI.getURI());
+                    log.debug("Source Code Disclosure alert for: {}", originalURI);
 
                     String sourceCode = null;
                     if (match1) {

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureFileInclusionScanRule.java
@@ -326,7 +326,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
                                     .setDescription(
                                             Constant.messages.getString(
                                                     "ascanbeta.sourcecodedisclosure.desc"))
-                                    .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                                    .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                                     .setParam(paramname)
                                     .setAttack(prefixedUrlfilename)
                                     .setOtherInfo(
@@ -423,7 +423,7 @@ public class SourceCodeDisclosureFileInclusionScanRule extends AbstractAppParamP
                                     .setDescription(
                                             Constant.messages.getString(
                                                     "ascanbeta.sourcecodedisclosure.desc"))
-                                    .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                                    .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                                     .setParam(paramname)
                                     .setAttack(prefixedUrlfilename)
                                     .setOtherInfo(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureGitScanRule.java
@@ -260,13 +260,13 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
                                 null,
                                 null);
                 try {
-                    log.debug("Trying for a Git index file {}", gitindexuri.getURI());
+                    log.debug("Trying for a Git index file {}", gitindexuri);
 
                     if (!gitindexentrycache.isIndexCached(gitindexuri)) {
                         // The Git index is not cached, so parse it and cache it.
                         log.debug(
                                 "Git Index {} is not cached. We will parse and cache it",
-                                gitindexuri.getURI().toString());
+                                gitindexuri);
 
                         data = git.getURIResponseBody(gitindexuri, false, originalMessage);
                         // get the list of relative file paths and Git SHA1s from the file
@@ -293,8 +293,8 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
                                 // cache the entry..
                                 log.debug(
                                         "Caching Git Index file {}, Index Entry {}, SHA1 {}",
-                                        gitindexuri.getURI().toString(),
-                                        gitIndexEntryUri.getURI().toString(),
+                                        gitindexuri,
+                                        gitIndexEntryUri,
                                         gitSHA1Temp);
                                 gitindexentrycache.putIndexEntry(
                                         gitindexuri, gitIndexEntryUri, gitSHA1Temp);
@@ -394,7 +394,7 @@ public class SourceCodeDisclosureGitScanRule extends AbstractAppPlugin {
                     // it's the least worst way of doing it, IMHO.
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setOtherInfo(new String(disclosedData))
                             .setEvidence(getEvidence(filename, gitURIs))
                             .setMessage(originalMessage)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SourceCodeDisclosureSvnScanRule.java
@@ -350,7 +350,7 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
                     // attack. alert it.
                     newAlert()
                             .setConfidence(getConfidence(svnsourcefileattackmsg))
-                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setAttack(attackFilename)
                             .setOtherInfo(getExtraInfo(urlfilename, attackFilename))
                             .setEvidence(evidence)
@@ -598,7 +598,7 @@ public class SourceCodeDisclosureSvnScanRule extends AbstractAppPlugin {
                                                                 getBaseMsg()
                                                                         .getRequestHeader()
                                                                         .getURI()
-                                                                        .getURI())
+                                                                        .toString())
                                                         .setAttack(attackFilename)
                                                         .setOtherInfo(
                                                                 getExtraInfo(

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
@@ -373,7 +373,7 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
                             .setName(getName() + " - Time Based")
-                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setParam(paramName)
                             .setAttack(attack)
                             .setOtherInfo(extraInfo)
@@ -383,7 +383,7 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "A likely Time Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}]",
                             msgAttack.getRequestHeader().getMethod(),
-                            msgAttack.getRequestHeader().getURI().getURI(),
+                            msgAttack.getRequestHeader().getURI(),
                             paramName);
                     return;
                 } // query took longer than the amount of time we attempted to retard it by

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMyqlScanRule.java
@@ -411,7 +411,7 @@ public class SqlInjectionMyqlScanRule extends AbstractAppParamPlugin {
                     // raise the alert
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setParam(paramName)
                             .setAttack(newTimeBasedInjectionValue)
                             .setOtherInfo(extraInfo)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
@@ -307,7 +307,7 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
 
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setName(getName() + " - Time Based")
                             .setParam(paramName)
                             .setAttack(attack)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java
@@ -360,7 +360,7 @@ public class SqlInjectionPostgreScanRule extends AbstractAppParamPlugin {
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
                             .setName(getName() + " - Time Based")
-                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setParam(paramName)
                             .setAttack(attack)
                             .setOtherInfo(extraInfo)
@@ -370,7 +370,7 @@ public class SqlInjectionPostgreScanRule extends AbstractAppParamPlugin {
                     log.debug(
                             "A likely Time Based SQL Injection Vulnerability has been found with [{}] URL [{}] on field: [{}]",
                             msgAttack.getRequestHeader().getMethod(),
-                            msgAttack.getRequestHeader().getURI().toString(),
+                            msgAttack.getRequestHeader().getURI(),
                             paramName);
                     return;
                 } // query took longer than the amount of time we attempted to retard it by

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
@@ -435,7 +435,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                             // raise the alert
                             newAlert()
                                     .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                                    .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                                     .setParam(paramName)
                                     .setAttack(newTimeBasedInjectionValue)
                                     .setOtherInfo(extraInfo)
@@ -576,7 +576,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
 
                     newAlert()
                             .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                            .setUri(getBaseMsg().getRequestHeader().getURI().getURI())
+                            .setUri(getBaseMsg().getRequestHeader().getURI().toString())
                             .setParam(paramName)
                             .setAttack(detectableDelayParameter)
                             .setOtherInfo(extraInfo)
@@ -728,7 +728,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                                                                     getBaseMsg()
                                                                             .getRequestHeader()
                                                                             .getURI()
-                                                                            .getURI())
+                                                                            .toString())
                                                             .setParam(paramName)
                                                             .setAttack(unionAttack)
                                                             .setOtherInfo(extraInfo)

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UsernameEnumerationScanRule.java
@@ -141,7 +141,7 @@ public class UsernameEnumerationScanRule extends AbstractAppPlugin {
 
             // using the session, get the list of contexts for the url
             List<Context> contextList =
-                    extAuth.getModel().getSession().getContextsForUrl(requestUri.getURI());
+                    extAuth.getModel().getSession().getContextsForUrl(requestUri.toString());
 
             // now loop, and see if the url is a login url in each of the contexts in turn...
             for (Context context : contextList) {

--- a/addOns/callgraph/src/main/java/org/zaproxy/zap/extension/callgraph/PopupMenuCallGraph.java
+++ b/addOns/callgraph/src/main/java/org/zaproxy/zap/extension/callgraph/PopupMenuCallGraph.java
@@ -118,11 +118,7 @@ class PopupMenuCallGraph extends PopupMenuHttpMessageContainer {
             String sitePattern = ".*";
             String title = null;
             if (httpMessage != null) {
-                try {
-                    uri = httpMessage.getRequestHeader().getURI().getURI();
-                } catch (Exception e1) {
-                    log.debug("The URI is not valid");
-                }
+                uri = httpMessage.getRequestHeader().getURI().toString();
             }
 
             switch (nodeType) {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRule.java
@@ -60,14 +60,8 @@ public class InsecureAuthenticationScanRule extends PluginPassiveScanner {
             return;
         }
 
-        // get the URI
-        try {
-            uri = msg.getRequestHeader().getURI().getURI().toString();
-            method = msg.getRequestHeader().getMethod();
-        } catch (Exception e) {
-            log.error("Error getting URI from message [{}]", msg);
-            return;
-        }
+        uri = msg.getRequestHeader().getURI().toString();
+        method = msg.getRequestHeader().getMethod();
 
         List<String> headers = msg.getRequestHeader().getHeaderValues(HttpHeader.AUTHORIZATION);
         if (!headers.isEmpty()) {

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InsecureAuthenticationScanRuleUnitTest.java
@@ -90,7 +90,7 @@ class InsecureAuthenticationScanRuleUnitTest
                 containsOtherInfoLoadedWithKey(
                         BASIC_AUTH_KEY,
                         HttpRequestHeader.POST,
-                        requestHeader.getURI().getURI(),
+                        requestHeader.getURI(),
                         AUTHORIZATION_BASIC,
                         user,
                         pass));
@@ -124,7 +124,7 @@ class InsecureAuthenticationScanRuleUnitTest
                 containsOtherInfoLoadedWithKey(
                         BASIC_AUTH_KEY,
                         HttpRequestHeader.POST,
-                        requestHeader.getURI().getURI(),
+                        requestHeader.getURI(),
                         AUTHORIZATION_BASIC,
                         user,
                         null));
@@ -183,7 +183,7 @@ class InsecureAuthenticationScanRuleUnitTest
                 containsOtherInfoLoadedWithKey(
                         DIGEST_AUTH_KEY,
                         HttpRequestHeader.POST,
-                        requestHeader.getURI().getURI(),
+                        requestHeader.getURI(),
                         AUTHORIZATION_DIGEST,
                         user,
                         digestValue));

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java
@@ -52,7 +52,7 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
         try {
             logger.debug(
                     "Checking URL {} to see if was served from a shared cache",
-                    msg.getRequestHeader().getURI().getURI());
+                    msg.getRequestHeader().getURI());
 
             // X-Cache: HIT
             // X-Cache: HIT from cache.kolich.local					<-- was the data actually served from the
@@ -87,7 +87,7 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
                                 String evidence = proxyServerDetails;
                                 logger.debug(
                                         "{} was served from a cache, due to presence of a 'HIT' in the 'X-Cache' response header",
-                                        msg.getRequestHeader().getURI().getURI());
+                                        msg.getRequestHeader().getURI());
                                 // could be from HTTP/1.0 or HTTP/1.1. We don't know which.
                                 newAlert()
                                         .setRisk(Alert.RISK_INFO)
@@ -126,7 +126,7 @@ public class RetrievedFromCacheScanRule extends PluginPassiveScanner {
                         String evidence = "Age: " + ageHeader;
                         logger.debug(
                                 "{} was served from a HTTP/1.1 cache, due to presence of a valid (non-negative decimal integer) 'Age' response header value",
-                                msg.getRequestHeader().getURI().getURI());
+                                msg.getRequestHeader().getURI());
                         newAlert()
                                 .setRisk(Alert.RISK_INFO)
                                 .setConfidence(Alert.CONFIDENCE_MEDIUM)


### PR DESCRIPTION
Raise alerts and log with URIs in encoded form, decoding the URI might
change its meaning.
Use URIs in encoded form when checking if they are in context, that's
the expected form.