### PR TITLE
bruteforce: address warnings

### DIFF
--- a/addOns/bruteforce/bruteforce.gradle.kts
+++ b/addOns/bruteforce/bruteforce.gradle.kts
@@ -3,10 +3,6 @@ import org.zaproxy.gradle.addon.AddOnStatus
 version = "11"
 description = "Forced browsing of files and directories using code from the OWASP DirBuster tool"
 
-tasks.withType<JavaCompile> {
-    options.compilerArgs = options.compilerArgs - "-Werror"
-}
-
 zapAddOn {
     addOnName.set("Forced Browse")
     addOnStatus.set(AddOnStatus.BETA)

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/DirToCheck.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/DirToCheck.java
@@ -27,10 +27,10 @@ import java.util.Vector;
 /** @author james */
 public class DirToCheck {
     String name = "";
-    private Vector exts = new Vector(10, 10);
+    private Vector<ExtToCheck> exts = new Vector<>(10, 10);
 
     /** Creates a new instance of DirToCheck */
-    public DirToCheck(String name, Vector exts) {
+    public DirToCheck(String name, Vector<ExtToCheck> exts) {
         this.name = name;
         this.exts = exts;
     }
@@ -39,11 +39,11 @@ public class DirToCheck {
         return name;
     }
 
-    public Vector getExts() {
+    public Vector<ExtToCheck> getExts() {
         return exts;
     }
 
-    public void setExts(Vector exts) {
+    public void setExts(Vector<ExtToCheck> exts) {
         this.exts = exts;
     }
 }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/HTMLparse.java
@@ -24,7 +24,6 @@ import com.sittinglittleduck.DirBuster.SimpleHttpClient.HttpMethod;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Iterator;
 import java.util.Vector;
 import net.htmlparser.jericho.Attribute;
 import net.htmlparser.jericho.Attributes;
@@ -60,6 +59,7 @@ public class HTMLparse extends Thread {
         this.interrupt();
     }
 
+    @Override
     public void run() {
         while (continueWorking) {
             working = false;
@@ -82,23 +82,19 @@ public class HTMLparse extends Thread {
                     LOG.debug("Parsing text from {}", work.getWork());
                     LOG.debug("Parsed text - {}", sourceAsString);
 
-                    Vector links = new Vector(50, 10);
-                    Vector imageLinks = new Vector(50, 10);
-                    Vector foundItems = new Vector(20, 10);
+                    Vector<String> links = new Vector<>(50, 10);
+                    Vector<String> foundItems = new Vector<>(20, 10);
 
                     // create the source
                     Source source = new Source(sourceAsString);
 
-                    Vector elementsToParse = manager.getElementsToParse();
+                    Vector<HTMLelementToParse> elementsToParse = manager.getElementsToParse();
 
                     // loop trought all the things we wish to parse
                     for (int z = 0; z < elementsToParse.size(); z++) {
-                        HTMLelementToParse elementToParse =
-                                (HTMLelementToParse) elementsToParse.elementAt(z);
+                        HTMLelementToParse elementToParse = elementsToParse.elementAt(z);
 
-                        for (Iterator i = source.getAllElements(elementToParse.getTag()).iterator();
-                                i.hasNext(); ) {
-                            Element element = (Element) i.next();
+                        for (Element element : source.getAllElements(elementToParse.getTag())) {
                             Attributes attributes = element.getAttributes();
                             Attribute attr = attributes.get(elementToParse.getAttr());
                             // System.out.println(href.getValue());
@@ -116,11 +112,11 @@ public class HTMLparse extends Thread {
                                                     .equalsIgnoreCase(work.getWork().getHost())) {
                                         // add to vector to remove duplicates
                                         // links.addElement(urlString);
-                                        Vector found = processURL(tempURL);
+                                        Vector<String> found = processURL(tempURL);
 
                                         if (found != null) {
                                             for (int a = 0; a < found.size(); a++) {
-                                                String item = (String) found.elementAt(a);
+                                                String item = found.elementAt(a);
                                                 if (!foundItems.contains(item)) {
                                                     foundItems.addElement(item);
                                                 }
@@ -144,14 +140,13 @@ public class HTMLparse extends Thread {
 
                     // process all the found items
                     for (int a = 0; a < foundItems.size(); a++) {
-                        String founditem = (String) foundItems.elementAt(a);
+                        String founditem = foundItems.elementAt(a);
                         // System.out.println((String) foundItems.elementAt(a));
 
                         boolean process = true;
 
                         for (int b = 0; b < manager.extsToMiss.size(); b++) {
-                            if (founditem.endsWith(
-                                    "." + (String) manager.extsToMiss.elementAt(b))) {
+                            if (founditem.endsWith("." + manager.extsToMiss.elementAt(b))) {
                                 process = false;
                                 break;
                             }
@@ -223,9 +218,9 @@ public class HTMLparse extends Thread {
      *
      * @param url url to be processed
      */
-    private Vector processURL(URL url) {
+    private Vector<String> processURL(URL url) {
         try {
-            Vector foundItems = new Vector(10, 10);
+            Vector<String> foundItems = new Vector<>(10, 10);
 
             String toProcess = url.getPath();
             boolean noFile = url.getPath().endsWith("/");

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessChecker.java
@@ -29,7 +29,7 @@ public class ProcessChecker extends TimerTask {
     private final Manager manager;
     private long timeStarted;
     private long lastTotal = 0L;
-    private Vector lastTen = new Vector(10, 1);
+    private Vector<Long> lastTen = new Vector<>(10, 1);
 
     /* Logger object for the class */
     private static final Logger LOG = LogManager.getLogger(ProcessChecker.class);
@@ -45,6 +45,7 @@ public class ProcessChecker extends TimerTask {
         timeStarted = System.currentTimeMillis();
     }
 
+    @Override
     public void run() {
         long timePassed = (scheduledExecutionTime() - timeStarted) / 1000;
         if (timePassed > 0) {
@@ -102,7 +103,7 @@ public class ProcessChecker extends TimerTask {
 
             long lastTenTotal = 0;
             for (int a = 0; a < lastTen.size(); a++) {
-                long temp = (Long) lastTen.elementAt(a);
+                long temp = lastTen.elementAt(a);
                 lastTenTotal = lastTenTotal + temp;
             }
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessEnd.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ProcessEnd.java
@@ -36,17 +36,18 @@ public class ProcessEnd extends TimerTask {
         this.manager = manager;
     }
 
+    @Override
     public void run() {
         if (manager.dirQueue.isEmpty()
                 && manager.workQueue.isEmpty()
                 && manager.parseQueue.isEmpty()) {
             // test to see if all the workers are done
             boolean allWorkersFinished = true;
-            Vector workers = manager.getWorkers();
-            Vector parsers = manager.getParseWorkers();
+            Vector<Worker> workers = manager.getWorkers();
+            Vector<HTMLparse> parsers = manager.getParseWorkers();
 
             for (int a = 0; a < workers.size(); a++) {
-                if (((Worker) workers.elementAt(a)).isWorking()) {
+                if (workers.elementAt(a).isWorking()) {
                     // there is a worker still working so break
                     allWorkersFinished = false;
                     break;
@@ -54,7 +55,7 @@ public class ProcessEnd extends TimerTask {
             }
 
             for (int a = 0; a < parsers.size(); a++) {
-                if (((HTMLparse) parsers.elementAt(a)).isWorking()) {
+                if (parsers.elementAt(a).isWorking()) {
                     allWorkersFinished = false;
                     break;
                 }
@@ -70,11 +71,11 @@ public class ProcessEnd extends TimerTask {
             if (manager.urlFuzz || manager.pureBrutefuzz) {
                 if (manager.isURLFuzzGenFinished()) {
                     boolean allWorkersFinished = true;
-                    Vector workers = manager.getWorkers();
-                    Vector parsers = manager.getParseWorkers();
+                    Vector<Worker> workers = manager.getWorkers();
+                    Vector<HTMLparse> parsers = manager.getParseWorkers();
 
                     for (int a = 0; a < workers.size(); a++) {
-                        if (((Worker) workers.elementAt(a)).isWorking()) {
+                        if (workers.elementAt(a).isWorking()) {
                             // there is a worker still working so break
                             allWorkersFinished = false;
                             break;
@@ -82,7 +83,7 @@ public class ProcessEnd extends TimerTask {
                     }
 
                     for (int a = 0; a < parsers.size(); a++) {
-                        if (((HTMLparse) parsers.elementAt(a)).isWorking()) {
+                        if (parsers.elementAt(a).isWorking()) {
                             allWorkersFinished = false;
                             break;
                         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ReportWriter.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/ReportWriter.java
@@ -49,8 +49,8 @@ public class ReportWriter {
         Vector<HeadlessResult> files = new Vector<>(100, 10);
         Vector<HeadlessResult> errors = new Vector<>(100, 10);
 
-        Vector dirCodes = new Vector(100, 10);
-        Vector fileCodes = new Vector(100, 10);
+        Vector<String> dirCodes = new Vector<>(100, 10);
+        Vector<String> fileCodes = new Vector<>(100, 10);
 
         for (int a = 0; a < data.size(); a++) {
             if (data.elementAt(a).getType() == HeadlessResult.FILE) {
@@ -92,7 +92,7 @@ public class ReportWriter {
                 out.newLine();
                 out.newLine();
                 for (int a = 0; a < dirCodes.size(); a++) {
-                    String foundCode = (String) dirCodes.elementAt(a);
+                    String foundCode = dirCodes.elementAt(a);
                     int foundCodeInt = Integer.parseInt(foundCode);
                     out.write("Dirs found with a " + foundCode + " response:");
                     out.newLine();
@@ -120,7 +120,7 @@ public class ReportWriter {
                 out.newLine();
                 out.newLine();
                 for (int a = 0; a < fileCodes.size(); a++) {
-                    String foundCode = (String) fileCodes.elementAt(a);
+                    String foundCode = fileCodes.elementAt(a);
                     int foundCodeInt = Integer.parseInt(foundCode);
                     out.write("Files found with a " + foundCode + " responce:");
                     out.newLine();

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/Worker.java
@@ -62,6 +62,7 @@ public class Worker implements Runnable {
     }
 
     /** Run method of the thread */
+    @Override
     public void run() {
 
         queue = manager.workQueue;
@@ -90,7 +91,7 @@ public class Worker implements Runnable {
 
             try {
 
-                work = (WorkUnit) queue.take();
+                work = queue.take();
                 working = true;
                 url = work.getWork();
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceURLFuzz.java
@@ -30,7 +30,6 @@ import com.sittinglittleduck.DirBuster.WorkUnit;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,7 +49,6 @@ public class BruteForceURLFuzz implements Runnable {
     private String started;
 
     private String currentDir = "/";
-    Vector extToCheck = new Vector(10, 5);
 
     private String urlFuzzStart;
     private String urlFuzzEnd;
@@ -77,6 +75,7 @@ public class BruteForceURLFuzz implements Runnable {
         urlFuzzEnd = manager.getUrlFuzzEnd();
     }
 
+    @Override
     public void run() {
         // checks if the server surports heads requests
 
@@ -106,8 +105,6 @@ public class BruteForceURLFuzz implements Runnable {
             DirToCheck tempDirToCheck = dirQueue.take();
             // get dir name
             currentDir = tempDirToCheck.getName();
-            // get any extention that need to be checked
-            extToCheck = tempDirToCheck.getExts();
         } catch (InterruptedException e) {
             LOG.debug(e);
         }

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/BruteForceWorkGenerator.java
@@ -58,7 +58,7 @@ public class BruteForceWorkGenerator implements Runnable {
     // private String failString = Config.failCaseString;
 
     private String currentDir = "/";
-    Vector extToCheck = new Vector(10, 5);
+    Vector<ExtToCheck> extToCheck = new Vector<>(10, 5);
     private int failcode = 404;
     private boolean doingDirs = true;
 
@@ -85,6 +85,7 @@ public class BruteForceWorkGenerator implements Runnable {
         firstPart = manager.getFirstPartOfURL();
     }
 
+    @Override
     public void run() {
         boolean recursive = true;
 
@@ -158,7 +159,7 @@ public class BruteForceWorkGenerator implements Runnable {
                 BaseCase baseCaseObj = null;
                 URL failurl = null;
                 for (int b = 0; b < extToCheck.size(); b++) {
-                    ExtToCheck tempExt = (ExtToCheck) extToCheck.elementAt(b);
+                    ExtToCheck tempExt = extToCheck.elementAt(b);
                     if (tempExt.toCheck()) {
                         fileExtention = "";
                         if (tempExt.getName().equals(ExtToCheck.BLANK_EXT)) {

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGenerator.java
@@ -80,10 +80,11 @@ public class WorkerGenerator implements Runnable {
     }
 
     /** Thread run method */
+    @Override
     public void run() {
         String currentDir = "/";
         String line;
-        Vector extToCheck = new Vector(10, 5);
+        Vector<ExtToCheck> extToCheck = new Vector<>(10, 5);
         boolean recursive = true;
         int passTotal = 0;
 
@@ -290,7 +291,7 @@ public class WorkerGenerator implements Runnable {
                 // loop for all the different file extentions
                 for (int b = 0; b < extToCheck.size(); b++) {
                     // only test if we are surposed to
-                    ExtToCheck extTemp = (ExtToCheck) extToCheck.elementAt(b);
+                    ExtToCheck extTemp = extToCheck.elementAt(b);
 
                     if (extTemp.toCheck()) {
 

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/workGenerators/WorkerGeneratorURLFuzz.java
@@ -37,7 +37,6 @@ import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Vector;
 import java.util.concurrent.BlockingQueue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -90,6 +89,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
     }
 
     /** Thread run method */
+    @Override
     public void run() {
 
         /*
@@ -101,7 +101,6 @@ public class WorkerGeneratorURLFuzz implements Runnable {
             manager.setURLFuzzGenFinished(false);
             String currentDir = "/";
             String line;
-            Vector extToCheck = new Vector(10, 5);
             boolean recursive = true;
             int passTotal = 0;
 
@@ -167,7 +166,7 @@ public class WorkerGeneratorURLFuzz implements Runnable {
                     }
 
                     // url encode all the items
-                    line = URLEncoder.encode(line);
+                    line = URLEncoder.encode(line, "UTF-8");
 
                     URL currentURL = new URL(firstPart + urlFuzzStart + line + urlFuzzEnd);
                     // BaseCase baseCaseObj = new BaseCase(currentURL, failcode, true, failurl,


### PR DESCRIPTION
Address the following warnings:
 - Add missing type arguments.
 - Add missing override annotations.
 - Address deprecation.
 - Remove casts no longer needed.
 - Remove unused vectors.

Use default compiler flags (no more warnings).