### PR TITLE
Wappalyzer - make data available for reports

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Support for using variables in the config.
+- Support for data jobs.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -80,6 +80,14 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
 
     public abstract String getParamMethodName();
 
+    /**
+     * Returns true if this job is just a way to make data available to reports - running it will do
+     * nothing.
+     */
+    public boolean isDataJob() {
+        return false;
+    }
+
     public boolean applyCustomParameter(String name, String value) {
         return false;
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -120,8 +120,10 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
             this.sortedJobs.forEach(
                     j -> {
                         try {
-                            fw.write(j.getConfigFileData());
-                            fw.write("\n");
+                            if (!j.isDataJob()) {
+                                fw.write(j.getConfigFileData());
+                                fw.write("\n");
+                            }
                         } catch (IOException e) {
                             CommandLine.error(
                                     Constant.messages.getString(

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Wappalyzer data to the traditional-html-plus report, if it is available.
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/Messages.properties
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/Messages.properties
@@ -16,5 +16,10 @@ report.template.stats.auth = Authentication Statistics
 report.template.stats.auth.none = No Authentication Statistics Found
 report.template.stats.httpcode = HTTP Response Code
 report.template.stats.respcount = Number of Responses
+report.template.tech.name = Technology
+report.template.tech.version = Version
+report.template.tech.categories = Categories
+report.template.tech.implies = Implies
+
 report.template.theme.light = Light
 report.template.theme.dark = Dark

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
@@ -232,6 +232,35 @@
 				</th:block>
 			</table>
 		</th:block>
+		<th:block
+			th:if="${reportData.reportObjects.get('wappalyzerData') != null &amp;&amp; reportData.reportObjects.get('wappalyzerData').getTechnologyForSite(site).size() &gt; 0}">
+			<table class="summary">
+				<tr>
+					<th th:text="#{report.template.tech.name}">Technology</th>
+					<th th:text="#{report.template.tech.version}">Version</th>
+					<th th:text="#{report.template.tech.categories}">Categories</th>
+					<th th:text="#{report.template.tech.implies}">Implies</th>
+				</tr>
+
+				<th:block
+					th:each="tech : ${reportData.reportObjects.get('wappalyzerData').getTechnologyForSite(site)}">
+					<tr>
+						<td>
+							<div th:text="${tech.name}">Name</div>
+						</td>
+						<td>
+							<div th:text="${tech.version}">Version</div>
+						</td>
+						<td><th:block th:each="category : ${tech.categories}">
+								<div th:text="${category}">Category</div>
+							</th:block></td>
+						<td><th:block th:each="imply : ${tech.implies}">
+								<div th:text="${imply}">Imply</div>
+							</th:block></td>
+					</tr>
+				</th:block>
+			</table>
+		</th:block>
 		<div class="spacer-lg"></div>
 	</th:block>
 

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+## Added
+- Support for automation job data to make it available in reports.
+
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
 - Update RE2/J library to latest version (1.6).

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechTableModel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechTableModel.java
@@ -84,19 +84,27 @@ public class TechTableModel extends AbstractTableModel {
                 obj = app.getVersion();
                 break;
             case 2:
-                obj = categoriesToString(app.getApplication().getCategories());
+                obj = getCategoriesString(app.getApplication());
                 break;
             case 3:
                 obj = app.getApplication().getWebsite();
                 break;
             case 4:
-                obj = listToString(app.getApplication().getImplies());
+                obj = getImpliesString(app.getApplication());
                 break;
             case 5:
                 obj = app.getApplication().getCpe();
                 // case 5: obj = app.getConfidence(); break;
         }
         return obj;
+    }
+
+    public String getCategoriesString(Application app) {
+        return categoriesToString(app.getCategories());
+    }
+
+    public String getImpliesString(Application app) {
+        return listToString(app.getImplies());
     }
 
     private String categoriesToString(List<String> list) {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerAPI.java
@@ -90,13 +90,15 @@ public class WappalyzerAPI extends ApiImplementor {
         TechTableModel ttm = extension.getTechModelForSite(site);
         for (int i = 0; i < ttm.getRowCount(); i++) {
             Map<String, String> map = new HashMap<>();
-            map.put("name", ((Application) ttm.getValueAt(i, 0)).toString());
-            map.put("description", ttm.getApp(i).getDescription());
-            map.put("version", (String) ttm.getValueAt(i, 1));
-            map.put("category", (String) ttm.getValueAt(i, 2));
-            map.put("website", (String) ttm.getValueAt(i, 3));
-            map.put("implies", (String) ttm.getValueAt(i, 4));
-            map.put("cpe", (String) ttm.getValueAt(i, 5));
+            ApplicationMatch appMatch = ttm.getApplicationAtRow(i);
+            Application app = appMatch.getApplication();
+            map.put("name", app.getName());
+            map.put("description", app.getDescription());
+            map.put("version", appMatch.getVersion());
+            map.put("category", ttm.getCategoriesString(app));
+            map.put("website", app.getWebsite());
+            map.put("implies", ttm.getImpliesString(app));
+            map.put("cpe", app.getCpe());
             resultList.addItem(new ApiResponseSet<>("app", map));
         }
         return resultList;

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/ExtensionWappalyzerAutomation.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/ExtensionWappalyzerAutomation.java
@@ -17,42 +17,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.spiderAjax.automation;
+package org.zaproxy.zap.extension.wappalyzer.automation;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.zaproxy.addon.automation.ExtensionAutomation;
-import org.zaproxy.zap.extension.spiderAjax.ExtensionAjax;
+import org.zaproxy.zap.extension.wappalyzer.ExtensionWappalyzer;
 
-public class ExtensionAjaxAutomation extends ExtensionAdaptor {
+public class ExtensionWappalyzerAutomation extends ExtensionAdaptor {
 
-    public static final String NAME = "ExtensionAjaxAutomation";
+    public static final String NAME = "ExtensionWappalyzerAutomation";
 
-    private static final String RESOURCES_DIR = "/org/zaproxy/zap/extension/spiderAjax/resources/";
+    private WappalyzerJob job;
 
     private static final List<Class<? extends Extension>> DEPENDENCIES;
 
-    private AjaxSpiderJob job;
-
     static {
         List<Class<? extends Extension>> dependencies = new ArrayList<>(2);
-        dependencies.add(ExtensionAjax.class);
+        dependencies.add(ExtensionWappalyzer.class);
         dependencies.add(ExtensionAutomation.class);
         DEPENDENCIES = Collections.unmodifiableList(dependencies);
     }
 
-    public ExtensionAjaxAutomation() {
+    public ExtensionWappalyzerAutomation() {
         super(NAME);
     }
 
@@ -66,7 +59,7 @@ public class ExtensionAjaxAutomation extends ExtensionAdaptor {
         super.hook(extensionHook);
         ExtensionAutomation extAuto =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutomation.class);
-        job = new AjaxSpiderJob();
+        job = new WappalyzerJob();
         extAuto.registerAutomationJob(job);
     }
 
@@ -88,27 +81,13 @@ public class ExtensionAjaxAutomation extends ExtensionAdaptor {
         return DEPENDENCIES;
     }
 
-    public static String getResourceAsString(String name) {
-        try (InputStream in = ExtensionAutomation.class.getResourceAsStream(RESOURCES_DIR + name)) {
-            return new BufferedReader(new InputStreamReader(in))
-                            .lines()
-                            .collect(Collectors.joining("\n"))
-                    + "\n";
-        } catch (Exception e) {
-            CommandLine.error(
-                    Constant.messages.getString(
-                            "spiderajax.automation.error.nofile", RESOURCES_DIR + name));
-        }
-        return "";
-    }
-
     @Override
     public String getDescription() {
-        return Constant.messages.getString("spiderajax.automation.desc");
+        return Constant.messages.getString("wappalyzer.automation.desc");
     }
 
     @Override
     public String getUIName() {
-        return Constant.messages.getString("spiderajax.automation.name");
+        return Constant.messages.getString("wappalyzer.automation.name");
     }
 }

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJob.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJob.java
@@ -1,0 +1,77 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.wappalyzer.automation;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.JobResultData;
+
+public class WappalyzerJob extends AutomationJob {
+
+    private static final String JOB_NAME = "wappalyzer";
+
+    public WappalyzerJob() {}
+
+    @Override
+    public boolean isDataJob() {
+        return true;
+    }
+
+    @Override
+    public List<JobResultData> getJobResultData() {
+        return Collections.singletonList(new WappalyzerJobResultData(this.getName()));
+    }
+
+    public String getTemplateDataMin() {
+        return "";
+    }
+
+    public String getTemplateDataMax() {
+        return "";
+    }
+
+    @Override
+    public Order getOrder() {
+        return Order.LAST_EXPLORE;
+    }
+
+    @Override
+    public void runJob(
+            AutomationEnvironment env, LinkedHashMap<?, ?> jobData, AutomationProgress progress) {}
+
+    @Override
+    public String getType() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public Object getParamMethodObject() {
+        return null;
+    }
+
+    @Override
+    public String getParamMethodName() {
+        return null;
+    }
+}

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJobResultData.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJobResultData.java
@@ -1,0 +1,120 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.wappalyzer.automation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.parosproxy.paros.control.Control;
+import org.zaproxy.addon.automation.JobResultData;
+import org.zaproxy.zap.extension.wappalyzer.ApplicationMatch;
+import org.zaproxy.zap.extension.wappalyzer.ExtensionWappalyzer;
+import org.zaproxy.zap.extension.wappalyzer.TechTableModel;
+
+public class WappalyzerJobResultData extends JobResultData {
+
+    public static final String DATA_KEY = "wappalyzerData";
+
+    private Map<String, List<TechnologyData>> siteTechMap = new HashMap<>();
+
+    public WappalyzerJobResultData(String jobName) {
+        super(jobName);
+
+        ExtensionWappalyzer ext =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionWappalyzer.class);
+
+        for (String site : ext.getSites()) {
+            List<TechnologyData> techList = new ArrayList<>();
+            TechTableModel model = ext.getTechModelForSite(site);
+            for (ApplicationMatch appMatch : model.getApps()) {
+                techList.add(new TechnologyData(appMatch));
+            }
+            siteTechMap.put(site, techList);
+        }
+    }
+
+    public List<TechnologyData> getTechnologyForSite(String site) {
+        List<TechnologyData> data = this.siteTechMap.get(site);
+        if (data == null) {
+            return Collections.emptyList();
+        }
+        return data;
+    }
+
+    public Set<String> getAllSites() {
+        return this.siteTechMap.keySet();
+    }
+
+    @Override
+    public String getKey() {
+        return DATA_KEY;
+    }
+
+    public static class TechnologyData {
+        private final String name;
+        private final String description;
+        private final String version;
+        private final List<String> categories;
+        private final String website;
+        private final List<String> implies;
+        private final String cpe;
+
+        public TechnologyData(ApplicationMatch appMatch) {
+            name = appMatch.getApplication().getName();
+            description = appMatch.getApplication().getDescription();
+            version = appMatch.getVersion();
+            website = appMatch.getApplication().getWebsite();
+            categories = appMatch.getApplication().getCategories();
+            implies = appMatch.getApplication().getImplies();
+            cpe = appMatch.getApplication().getCpe();
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public List<String> getCategories() {
+            return categories;
+        }
+
+        public String getWebsite() {
+            return website;
+        }
+
+        public List<String> getImplies() {
+            return implies;
+        }
+
+        public String getCpe() {
+            return cpe;
+        }
+    }
+}

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -28,6 +28,11 @@ passive scanner.
 The toolbar includes an enable/disable toggle button which controls whether the technology detection passive scan rule is functioning or not. 
 This enabled state is persisted between ZAP sessions.
 
+<H2>Reporting</H2>
+
+Technology data is available to reports via the 
+<a href="https://github.com/zaproxy/zap-extensions/tree/master/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJobResultData">WappalyzerJobResultData</a> class.
+
 <H2>External Links</H2>
 <table>
 <tr>

--- a/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
+++ b/addOns/wappalyzer/src/main/resources/org/zaproxy/zap/extension/wappalyzer/resources/Messages.properties
@@ -5,6 +5,9 @@ wappalyzer.api.view.listSite = Lists all the applications (technologies) associa
 wappalyzer.api.view.listSite.site = The site for which the applications (technologies) should be returned. (See listSites).
 wappalyzer.api.view.listSites =  Lists all the sites recognized by the wappalyzer addon.
 
+wappalyzer.automation.name = Wappalyzer Automation Framework Integration
+wappalyzer.automation.desc = Wappalyzer Automation 
+
 wappalyzer.desc	= Technology detection using Wappalyzer - http://wappalyzer.com/
 wappalyzer.panel.mnemonic = t
 wappalyzer.panel.title = Technology

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -11,6 +11,20 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/technology-detection/")
+        extensions {
+            register("org.zaproxy.zap.extension.wappalyzer.automation.ExtensionWappalyzerAutomation") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.zap.extension.wappalyzer.automation"))
+                }
+                dependencies {
+                    addOns {
+                        register("automation") {
+                            version.set("0.*")
+                        }
+                    }
+                }
+            }
+        }
     }
 
     apiClientGen {
@@ -20,6 +34,7 @@ zapAddOn {
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("automation")!!)
     implementation("com.google.re2j:re2j:1.6")
 
     val batikVersion = "1.13"


### PR DESCRIPTION
I've not added any help as I'm not sure where it would or should go :/
I've also not added a section for it - if the datas available then it will be included - the add-on is optional after all.

Example report snippet:
![Screenshot_2021-05-18 ZAP Scanning Report](https://user-images.githubusercontent.com/1081115/118650297-2e281900-b7dc-11eb-8fc8-f02e028cfe65.png)


Signed-off-by: Simon Bennetts <psiinon@gmail.com>