### PR TITLE
Rename of Feature-Policy header to Permissions-Policy to follow spec change

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Site Isolation
   - Sub Resource Integrity
 - Maintenance changes.
+- Rename of Feature-Policy header to Permissions-Policy to follow spec change
 
 ## [30] - 2021-02-08
 

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -84,13 +84,6 @@ For more details see: <a href="https://www.zaproxy.org/blog/2014-04-03-hacking-z
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/ExampleSimplePassiveScanRule.java">ExampleSimplePassiveScanRule.java</a>
 
-<H2>Feature Policy Header Not Set</H2>
-This rule checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Feature-Policy" header, 
-and alerts if one is not found.<br>
-Redirects are ignored except at the Low threshold.
-<p>
-Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/FeaturePolicyScanRule.java">FeaturePolicyScanRule.java</a>
-
 <H2>In Page Banner Information Leak</H2>
 Analyzes response body content for the presence of web or application server banners (when the responses have error status codes).<br>
 If the Threshold is Low then status 200 - Ok responses are analyzed as well.<br>
@@ -106,6 +99,13 @@ JSO should not be used by Java programs. Strong controls must be done on seriali
 JSO are a type of vulnerabilities associated to A8:2017-Insecure Deserialization.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java">JsoScanRule.java</a>
+
+<H2>Permissions Policy Header Not Set</H2>
+This rule checks the HTTP response headers (on HTML and JavaScript responses) for inclusion of a "Permissions-Policy" header, 
+and alerts if one is not found.<br>
+Redirects are ignored except at the Low threshold.
+<p>
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRule.java">PermissionsPolicyScanRule.java</a>
 
 <H2>Source Code Disclosure</H2>
 Application Source Code was disclosed by the web server.

--- a/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
+++ b/addOns/pscanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/pscanrulesAlpha/resources/Messages.properties
@@ -7,10 +7,15 @@ pscanalpha.examplefile.other=This is for information that doesnt fit in any of t
 pscanalpha.examplefile.soln=A general description of how to solve the problem.
 pscanalpha.examplefile.refs=https://www.zaproxy.org/blog/2014-04-03-hacking-zap-3-passive-scan-rules/
 
-pscanalpha.featurepolicymissing.name=Feature Policy Header Not Set
-pscanalpha.featurepolicymissing.desc=Feature Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Feature Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.
-pscanalpha.featurepolicymissing.refs=https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy\nhttps://developers.google.com/web/updates/2018/06/feature-policy\nhttps://scotthelme.co.uk/a-new-security-header-feature-policy/\nhttps://w3c.github.io/webappsec-feature-policy/\nhttps://www.smashingmagazine.com/2018/12/feature-policy/
-pscanalpha.featurepolicymissing.soln=Ensure that your web server, application server, load balancer, etc. is configured to set the Feature-Policy header.
+pscanalpha.permissionspolicymissing.name=Permissions Policy Header Not Set
+pscanalpha.permissionspolicymissing.desc=Permissions Policy Header is an added layer of security that helps to restrict from unauthorized access or usage of browser/client features by web resources. This policy ensures the user privacy by limiting or specifying the features of the browsers can be used by the web resources. Permissions Policy provides a set of standard HTTP headers that allow website owners to limit which features of browsers can be used by the page such as camera, microphone, location, full screen etc.
+pscanalpha.permissionspolicymissing.refs=https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy\nhttps://developers.google.com/web/updates/2018/06/feature-policy\nhttps://scotthelme.co.uk/a-new-security-header-feature-policy/\nhttps://w3c.github.io/webappsec-feature-policy/\nhttps://www.smashingmagazine.com/2018/12/feature-policy/
+pscanalpha.permissionspolicymissing.soln=Ensure that your web server, application server, load balancer, etc. is configured to set the Permissions-Policy header.
+
+pscanalpha.permissionspolicymissing.deprecated.name=Deprecated Feature Policy Header Set
+pscanalpha.permissionspolicymissing.deprecated.desc=The header has now been renamed to Permissions-Policy. 
+pscanalpha.permissionspolicymissing.deprecated.refs=https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
+pscanalpha.permissionspolicymissing.deprecated.soln=Ensure that your web server, application server, load balancer, etc. is configured to set the Permissions-Policy header instead of the Feature-Policy header.
 
 pscanalpha.inpagebanner.name=In Page Banner Information Leak
 pscanalpha.inpagebanner.desc=The server returned a version banner string in the response content. Such information leaks may allow attackers to further target specific issues impacting the product and version in use.

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRuleUnitTest.java
@@ -30,9 +30,9 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 
-class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScanRule> {
+class PermissionsPolicyScanRuleUnitTest extends PassiveScannerTest<PermissionsPolicyScanRule> {
 
-    private static final String MESSAGE_PREFIX = "pscanalpha.featurepolicymissing.";
+    private static final String MESSAGE_PREFIX = "pscanalpha.permissionspolicymissing.";
     private HttpMessage msg;
 
     @BeforeEach
@@ -46,12 +46,12 @@ class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScan
     }
 
     @Override
-    protected FeaturePolicyScanRule createScanner() {
-        return new FeaturePolicyScanRule();
+    protected PermissionsPolicyScanRule createScanner() {
+        return new PermissionsPolicyScanRule();
     }
 
     @Test
-    void shouldRaiseAlertOnMissingFeaturePolicyHTML() throws Exception {
+    void shouldRaiseAlertOnMissingHeaderHTML() throws Exception {
         // Given
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
         // When
@@ -62,17 +62,18 @@ class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScan
     }
 
     @Test
-    void shouldRaiseAlertOnMissingFeaturePolicyJavaScript() throws Exception {
+    void shouldRaiseAlertOnMissingHeaderJavaScript() throws Exception {
         // Given
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/javascript");
         // When
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(alertsRaised.size(), 1);
+        assertThat(alertsRaised.get(0), hasNameLoadedWithKey(MESSAGE_PREFIX + "name"));
     }
 
     @Test
-    void shouldNotRaiseAlertOnMissingFeaturePolicyOthers() throws Exception {
+    void shouldNotRaiseAlertOnMissingHeaderOthers() throws Exception {
         // Given
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "application/json");
         // When
@@ -82,9 +83,9 @@ class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScan
     }
 
     @Test
-    void shouldNotRaiseAlertOnAvailableFeaturePolicy() throws Exception {
+    void shouldNotRaiseAlertOnAvailablePermissionsPolicyHeader() throws Exception {
         // Given
-        msg.getResponseHeader().addHeader("Feature-Policy", "vibrate 'none'");
+        msg.getResponseHeader().addHeader("Permissions-Policy", "vibrate 'none'");
         msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/HTML");
         // When
         scanHttpResponseReceive(msg);
@@ -93,7 +94,19 @@ class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScan
     }
 
     @Test
-    void shouldNotRaiseAlertOnMissingFeaturePolicyRedirectMediumThreshold() throws Exception {
+    void shouldRaiseAlertOnAvailableDeprecatedFeaturePolicyHeader() throws Exception {
+        // Given
+        msg.getResponseHeader().addHeader("Feature-Policy", "vibrate 'none'");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/HTML");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(alertsRaised.size(), 1);
+        assertThat(alertsRaised.get(0), hasNameLoadedWithKey(MESSAGE_PREFIX + "deprecated.name"));
+    }
+
+    @Test
+    void shouldNotRaiseAlertOnMissingHeaderRedirectMediumThreshold() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.MEDIUM);
         msg.setResponseHeader("HTTP/1.1 301 Moved Permanently\r\n");
@@ -105,7 +118,7 @@ class FeaturePolicyScanRuleUnitTest extends PassiveScannerTest<FeaturePolicyScan
     }
 
     @Test
-    void shouldRaiseAlertOnMissingFeaturePolicyRedirectLowThreshold() throws Exception {
+    void shouldRaiseAlertOnMissingHeaderRedirectLowThreshold() throws Exception {
         // Given
         rule.setAlertThreshold(Plugin.AlertThreshold.LOW);
         msg.setResponseHeader("HTTP/1.1 301 Moved Permanently\r\n");


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
The header has now been renamed to Permissions-Policy in the spec, and
this article will eventually be updated to reflect that change.