### PR TITLE
commonlib: correct cookie expiration calculation

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Take into account the timezone when checking if a cookie is expired (Issue 6550).
 
 ## [1.3.0] - 2021-05-10
 ### Added


### PR DESCRIPTION
Take into account the timezones when checking if a cookie is expired.

Fix zaproxy/zaproxy#6550.