### PR TITLE
improve: wappalyzer: Catch/Log DOM pattern exceptions & adjust DOM use

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated with upstream Wappalyzer icon and pattern changes.
 - Update RE2/J library to latest version (1.6).
 - Maintenance changes.
+- DOM patterns are now only attempted against HTML responses.
 
 ## [21.1.0] - 2021-03-03
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -163,6 +163,9 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
     }
 
     private void checkDomElementMatches(HttpMessage message) {
+        if (!message.getResponseHeader().isHtml()) {
+            return;
+        }
         Document doc = Jsoup.parse(message.getResponseBody().toString());
         for (Map<String, Map<String, Map<String, AppPattern>>> domSelectorMap :
                 currentApp.getDom()) {

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -139,6 +139,22 @@ class WappalyzerPassiveScannerUnitTest extends PassiveScannerTestUtils<Wappalyze
     }
 
     @Test
+    void shouldNotMatchDomElementWithOnlyTextIfResponseNotHtml()
+            throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = makeHttpMessage();
+        msg.setResponseBody(
+                "<html><body>"
+                        + "<a href=\"https://www.modern.com\"  style=\"border: 5px groove rgb(244, 250, 88);\">Modern</a>"
+                        + "</body></html>");
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "application/something");
+        // When
+        scan(msg);
+        // Then
+        assertNull(getDefaultHolder().getAppsForSite("https://www.example.com"));
+    }
+
+    @Test
     void shouldMatchDomElementWithOnlyAttribute() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();


### PR DESCRIPTION
- WappalyzerPassiveScanner
  - Only attempt to check DOM patterns when response is HTML.
- WappalyzerPassiveScannerUnitTest > Add a test to assert the new behavior.
- WappalyzerJonParser > Remove unnecessary throws declarations, add IOException to an existing catch block. Check that Selector Queries are valid before adding them for use.

* WappalyzerAppsJsonParseUnitTest > Will now record an exception if Selector Queries don't parse properly (so the scheduled update jobs will error out on bad upstream Selector Queries).

See: zaproxy/zaproxy#6607

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>