### PR TITLE
Automation: Change contexts to support list of URLs

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Support for using variables in the config.
 - Support for data jobs.
+- Support for multiple top level URLs in a context.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.zaproxy.zap.model.Context;
+
+public class ContextWrapper {
+
+    private final Context context;
+
+    private final List<String> urls = new ArrayList<>();
+
+    public ContextWrapper(Context context) {
+        this.context = context;
+    }
+
+    public Context getContext() {
+        return this.context;
+    }
+
+    public void addUrl(String url) {
+        this.urls.add(url);
+    }
+
+    public List<String> getUrls() {
+        return this.urls;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -34,11 +34,11 @@ import org.parosproxy.paros.core.scanner.PluginFactory;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.addon.automation.JobResultData;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
-import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.Target;
 
 public class ActiveScanJob extends AutomationJob {
@@ -100,21 +100,20 @@ public class ActiveScanJob extends AutomationJob {
     public void runJob(
             AutomationEnvironment env, LinkedHashMap<?, ?> jobData, AutomationProgress progress) {
 
-        Context context;
+        ContextWrapper context;
         if (contextName != null) {
-            context = env.getContext(contextName);
+            context = env.getContextWrapper(contextName);
             if (context == null) {
                 progress.error(
                         Constant.messages.getString(
-                                "automation.error.context.unknown",
-                                env.getUrlStringForContext(context)));
+                                "automation.error.context.unknown", contextName));
                 return;
             }
         } else {
-            context = env.getDefaultContext();
+            context = env.getDefaultContextWrapper();
         }
 
-        Target target = new Target(context);
+        Target target = new Target(context.getContext());
         target.setRecurse(true);
         List<Object> contextSpecificObjects = new ArrayList<>();
 

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
@@ -14,7 +14,7 @@ This section of the YAML configuration file defines the applications which the r
 env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
-      url:                             # The top level url, mandatory, everything under this will be included
+      urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # TBA: An optional list of regexes to include
       excludePaths:                    # TBA: An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -21,9 +21,11 @@ automation.error.ascan.threshold = Invalid threshold for job {0} : {1}
 automation.error.badurl = Invalid URL for job {0} : {1}
 
 automation.error.context.badurl = Invalid URL: {0}
+automation.error.context.badurlslist = Context URLs should be a list: {0}
 automation.error.context.noname = Missing name for context: {0}
-automation.error.context.nourl = Missing URL for context: {0}
+automation.error.context.nourl = Missing URLs for context: {0}
 automation.error.context.unknown = Unrecognised context: {0}
+automation.error.context.url.deprecated = The context 'url' field has been replaced with a 'urls' list field
 
 automation.error.env.missing = Missing environment: {0}
 automation.error.env.nocontexts = Missing contexts in environment: {0}
@@ -51,6 +53,11 @@ automation.error.urlsfound = Job {0} only found {1} URLs, expected at least {2}
 automation.error.unexpected = Unexpected error accessing file {0} : {1} - see log for details
 
 automation.error.pscan.rule.unknown = Unrecognised passive scan rule id for job {0} : {1}
+
+automation.error.spider.url.notok = Job {0} failed to access URL {1} status code returned : {2} expected 200
+automation.error.spider.url.badhost.proxychain = Job {0} failed to access URL {1} your proxy chain may be wrong : {2}
+automation.error.spider.url.badhost = Job {0} failed to access URL {1} check that it is valid : {2}
+automation.error.spider.url.failed = Job {0} failed to access URL {1} : {2}
 
 automation.info.ascan.rule.setstrength = Job {0} set rule {1} strength to {2}
 automation.info.ascan.rule.setthreshold = Job {0} set rule {1} threshold to {2}

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
@@ -2,7 +2,7 @@
 env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
-      url:                             # The top level url, mandatory, everything under this will be included
+      urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # TBA: An optional list of regexes to include
       excludePaths:                    # TBA: An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -63,6 +63,7 @@ import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob.Order;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
@@ -193,9 +194,8 @@ class ActiveScanJobUnitTest {
     void shouldRunValidJob() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
-        Session session = mock(Session.class);
         Context context = mock(Context.class);
-        given(session.getNewContext(any())).willReturn(context);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
 
         given(extAScan.startScan(any(), any(), any())).willReturn(1);
 
@@ -206,7 +206,7 @@ class ActiveScanJobUnitTest {
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         // When
         ActiveScanJob job = new ActiveScanJob();
@@ -253,6 +253,8 @@ class ActiveScanJobUnitTest {
         given(session.getNewContext("context2")).willReturn(context2);
         Target target1 = new Target(context1);
         Target target2 = new Target(context2);
+        ContextWrapper contextWrapper1 = new ContextWrapper(context1);
+        ContextWrapper contextWrapper2 = new ContextWrapper(context2);
 
         given(extAScan.startScan(any(), any(), any())).willReturn(1);
 
@@ -263,9 +265,10 @@ class ActiveScanJobUnitTest {
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
         given(env.getContext("context1")).willReturn(context1);
         given(env.getContext("context2")).willReturn(context2);
+        given(env.getContextWrapper("context1")).willReturn(contextWrapper1);
+        given(env.getContextWrapper("context2")).willReturn(contextWrapper2);
         given(env.getDefaultContext()).willReturn(context1);
 
         // When
@@ -301,9 +304,8 @@ class ActiveScanJobUnitTest {
     @Test
     void shouldExitIfActiveScanTakesTooLong() throws MalformedURLException {
         // Given
-        Session session = mock(Session.class);
         Context context = mock(Context.class);
-        given(session.getNewContext(any())).willReturn(context);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
 
         given(extAScan.startScan(any(), any(), any())).willReturn(1);
 
@@ -314,7 +316,7 @@ class ActiveScanJobUnitTest {
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         ActiveScanJob job = new ActiveScanJob();
 

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
@@ -2,7 +2,7 @@
 env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
-      url:                             # The top level url, mandatory, everything under this will be included
+      urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # TBA: An optional list of regexes to include
       excludePaths:                    # TBA: An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -2,7 +2,7 @@
 env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
-      url:                             # The top level url, mandatory, everything under this will be included
+      urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # TBA: An optional list of regexes to include
       excludePaths:                    # TBA: An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -2,7 +2,7 @@
 env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
-      url:                             # The top level url, mandatory, everything under this will be included
+      urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # TBA: An optional list of regexes to include
       excludePaths:                    # TBA: An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnErrorApplyingParameters.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnErrorApplyingParameters.yaml
@@ -1,7 +1,8 @@
 env:
   contexts:
     - name: example
-      url: https://www.example.com/
+      urls: 
+      - https://www.example.com/
   parameters:
     failOnError: true
     failOnWarning: false

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnWarningApplyingParameters.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testPlan-failOnWarningApplyingParameters.yaml
@@ -1,7 +1,8 @@
 env:
   contexts:
     - name: example
-      url: https://www.example.com/
+      urls: 
+      - https://www.example.com/
   parameters:
     failOnError: false
     failOnWarning: true

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-dontfail.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-dontfail.yaml
@@ -1,7 +1,8 @@
 env:
   contexts:
     - name: example
-      url: https://www.example.com/        # The top level url, and the only mandatory parameter in the file, everything under this url will be included
+      urls: 
+      - https://www.example.com/
   parameters:
     failOnError: false                  
     failOnWarning: false               

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonerror.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonerror.yaml
@@ -1,7 +1,8 @@
 env:
   contexts:
     - name: example
-      url: https://www.example.com/        # The top level url, and the only mandatory parameter in the file, everything under this url will be included
+      urls: 
+      - https://www.example.com/
   parameters:
     failOnError: true                  
     failOnWarning: false               

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonwarning.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-failonwarning.yaml
@@ -1,7 +1,8 @@
 env:
   contexts:
     - name: example
-      url: https://www.example.com/        # The top level url, and the only mandatory parameter in the file, everything under this url will be included
+      urls: 
+      - https://www.example.com/
   parameters:
     failOnError: true                  
     failOnWarning: true               

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-withwarnings.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-withwarnings.yaml
@@ -1,7 +1,8 @@
 env:
   contexts:
     - name: example
-      url: https://www.example.com/        # The top level url, and the only mandatory parameter in the file, everything under this url will be included
+      urls: 
+      - https://www.example.com/
   parameters:
     failOnError: false                  
     failOnWarning: false               

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Handle multiple context URLs in automation.
 
 ## [0.3.0] - 2021-05-06
 ### Added

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -24,7 +24,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.2.0")
+                            version.set(">=0.3.0")
                         }
                     }
                 }

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -72,7 +72,7 @@ public class ReportJob extends AutomationJob {
         // Work out the file name based on the pattern
         String fileName =
                 ExtensionReports.getNameFromPattern(
-                                reportFile, env.getUrlStringForContext(env.getDefaultContext()))
+                                reportFile, env.getDefaultContextWrapper().getUrls().get(0))
                         + "."
                         + template.getExtension();
 

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
+- Handle multiple context URLs in automation.
 
 ## [23.3.0] - 2021-03-09
 ### Added

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -21,7 +21,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set("0.*")
+                            version.set(">=0.3.0")
                         }
                     }
                 }

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
@@ -52,6 +52,7 @@ import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob.Order;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderParam;
 import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderTarget;
 import org.zaproxy.zap.extension.spiderAjax.ExtensionAjax;
@@ -174,16 +175,15 @@ class AjaxSpiderJobUnitTest {
     void shouldRunValidJob() throws MalformedURLException {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
-        Session session = mock(Session.class);
         Context context = mock(Context.class);
-        given(session.getNewContext(any())).willReturn(context);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
 
         given(extAjax.isSpiderRunning()).willReturn(false);
 
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         AjaxSpiderJob job = new AjaxSpiderJob();
         job.setInScopeOnly(false);
@@ -250,6 +250,8 @@ class AjaxSpiderJobUnitTest {
         given(session.getNewContext("context2")).willReturn(context2);
         given(context1.isInContext(anyString())).willReturn(true);
         given(context2.isInContext(anyString())).willReturn(true);
+        ContextWrapper contextWrapper1 = new ContextWrapper(context1);
+        ContextWrapper contextWrapper2 = new ContextWrapper(context2);
 
         AjaxSpiderParam options = new AjaxSpiderParam();
         FileConfiguration tempConfig = new XMLConfiguration();
@@ -276,9 +278,8 @@ class AjaxSpiderJobUnitTest {
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
-        given(env.getContext("context1")).willReturn(context1);
-        given(env.getContext("context2")).willReturn(context2);
+        given(env.getContextWrapper("context1")).willReturn(contextWrapper1);
+        given(env.getContextWrapper("context2")).willReturn(contextWrapper2);
         given(env.getDefaultContext()).willReturn(context1);
 
         // When
@@ -345,16 +346,15 @@ class AjaxSpiderJobUnitTest {
     // @Test
     void shouldExitIfSpiderTakesTooLong() throws MalformedURLException {
         // Given
-        Session session = mock(Session.class);
         Context context = mock(Context.class);
-        given(session.getNewContext(any())).willReturn(context);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
 
         given(extAjax.isSpiderRunning()).willReturn(false);
 
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         AjaxSpiderJob job = new AjaxSpiderJob();
         job.setInScopeOnly(false);
@@ -376,16 +376,15 @@ class AjaxSpiderJobUnitTest {
     // @Test
     void shouldWarnIfLessUrlsFoundThanExpected() throws MalformedURLException {
         // Given
-        Session session = mock(Session.class);
         Context context = mock(Context.class);
-        given(session.getNewContext(any())).willReturn(context);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
 
         given(extAjax.isSpiderRunning()).willReturn(false);
 
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         AjaxSpiderJob job = new AjaxSpiderJob();
         job.setInScopeOnly(false);
@@ -407,16 +406,15 @@ class AjaxSpiderJobUnitTest {
     // @Test
     void shouldErrorIfLessUrlsFoundThanExpected() throws MalformedURLException {
         // Given
-        Session session = mock(Session.class);
         Context context = mock(Context.class);
-        given(session.getNewContext(any())).willReturn(context);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
 
         given(extAjax.isSpiderRunning()).willReturn(false);
 
         AutomationProgress progress = new AutomationProgress();
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
-        given(env.getUrlStringForContext(any())).willReturn("https://www.example.com");
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
 
         AjaxSpiderJob job = new AjaxSpiderJob();
         job.setInScopeOnly(false);


### PR DESCRIPTION
This is to support contexts that include more than one top level URL, eg https://www.example.com and https://www.example.org - this use case is not supported without this change.

Quite a few knock on changes for this seemingly simple change :/
The SpiderJob now requests each of the top level URLs otherwise it wont work.

WIP as I intend to add at least one test which checks that the URLs are really requested by the SpiderJob and to clean up the option not to request the URLs.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>