### PR TITLE
Use commonlib to parse/format HTTP dates

### DIFF
--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -15,7 +15,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.3.0 & < 2.0.0")
+                    version.set(">= 1.4.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- An HTTP date parser/formatter.
+
 ### Fixed
 - Take into account the timezone when checking if a cookie is expired (Issue 6550).
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CookieUtils.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CookieUtils.java
@@ -21,18 +21,12 @@ package org.zaproxy.addon.commonlib;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.commonlib.http.HttpDateUtils;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 
 /**
@@ -42,19 +36,7 @@ import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
  */
 public final class CookieUtils {
 
-    private static final DateTimeFormatter FORMATTER_RFC7231 =
-            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ROOT);
-    private static final DateTimeFormatter FORMATTER_RFC850 =
-            DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz", Locale.ROOT);
-    private static final DateTimeFormatter FORMATTER_ASCTIME =
-            DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss yyyy", Locale.ROOT)
-                    .withZone(ZoneOffset.UTC);
-
-    static final List<DateTimeFormatter> DATE_FORMATTERS =
-            Arrays.asList(FORMATTER_RFC7231, FORMATTER_RFC850, FORMATTER_ASCTIME);
-
     private static final int NOT_FOUND = -1;
-    private static final Logger LOGGER = LogManager.getLogger(CookieUtils.class);
 
     private CookieUtils() {
         // Utility class.
@@ -241,15 +223,7 @@ public final class CookieUtils {
         }
 
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-        ZonedDateTime expiresAt = null;
-        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
-            try {
-                expiresAt = ZonedDateTime.parse(expiry, formatter);
-                break;
-            } catch (DateTimeParseException ex) {
-                LOGGER.debug("Couldn't parse expire date {} with {} : {}", expiry, formatter, ex);
-            }
-        }
+        ZonedDateTime expiresAt = HttpDateUtils.parse(expiry);
         return expiresAt == null || expiresAt.isBefore(now);
     }
 }

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/HttpDateUtils.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/http/HttpDateUtils.java
@@ -1,0 +1,105 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Utility class to parse/format HTTP related dates.
+ *
+ * @since 1.4.0
+ */
+public final class HttpDateUtils {
+
+    private static final Logger LOGGER = LogManager.getLogger(HttpDateUtils.class);
+
+    private static final DateTimeFormatter FORMATTER_RFC_1123 =
+            DateTimeFormatter.RFC_1123_DATE_TIME.withLocale(Locale.ROOT);
+    private static final DateTimeFormatter FORMATTER_RFC_1123_HYPHENS =
+            DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz", Locale.ROOT);
+    private static final DateTimeFormatter FORMATTER_RFC_1036 =
+            new DateTimeFormatterBuilder()
+                    .parseCaseInsensitive()
+                    .parseLenient()
+                    .appendPattern("EEEE, dd-MMM-")
+                    .appendValueReduced(
+                            ChronoField.YEAR_OF_ERA, 2, 2, LocalDate.now().minusYears(50))
+                    .appendPattern(" HH:mm:ss zzz")
+                    .toFormatter(Locale.ENGLISH);
+    private static final DateTimeFormatter FORMATTER_ASCTIME =
+            DateTimeFormatter.ofPattern("EEE MMM ppd HH:mm:ss yyyy", Locale.ROOT)
+                    .withZone(ZoneOffset.UTC);
+
+    static final List<DateTimeFormatter> FORMATTERS =
+            Arrays.asList(
+                    FORMATTER_RFC_1123,
+                    FORMATTER_RFC_1123_HYPHENS,
+                    FORMATTER_RFC_1036,
+                    FORMATTER_ASCTIME);
+
+    private HttpDateUtils() {}
+
+    /**
+     * Parses the given date.
+     *
+     * <p>Several formats are supported.
+     *
+     * @param date the date as string.
+     * @return the parsed date, or {@code null} if not able to parse it.
+     */
+    public static ZonedDateTime parse(String date) {
+        if (date == null || date.isEmpty()) {
+            return null;
+        }
+
+        for (DateTimeFormatter formatter : FORMATTERS) {
+            try {
+                return ZonedDateTime.parse(date, formatter);
+            } catch (DateTimeParseException ex) {
+                LOGGER.debug("Couldn't parse date {} with {} : {}", date, formatter, ex);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Formats the given instant.
+     *
+     * @param instant the instant to format.
+     * @return the formatted date.
+     * @throws DateTimeException if an error occurred while formatting the instant.
+     */
+    public static String format(Instant instant) {
+        return FORMATTER_RFC_1123.format(instant.atOffset(ZoneOffset.UTC));
+    }
+}

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CookieUtilsUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CookieUtilsUnitTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.addon.commonlib.http.HttpDateUtilsUnitTest;
 
 /** Unit test for {@link CookieUtils}. */
 class CookieUtilsUnitTest {
@@ -276,6 +277,6 @@ class CookieUtilsUnitTest {
     static Stream<String> expiresFutureProvider() {
         ZonedDateTime future =
                 ZonedDateTime.ofInstant(Instant.now().plus(1, ChronoUnit.DAYS), ZoneOffset.UTC);
-        return CookieUtils.DATE_FORMATTERS.stream().map(e -> e.format(future));
+        return HttpDateUtilsUnitTest.formatters().stream().map(e -> e.format(future));
     }
 }

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/http/HttpDateUtilsUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/http/HttpDateUtilsUnitTest.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit test for {@link HttpDateUtils}. */
+public class HttpDateUtilsUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "Sun, 06 Nov 1994 08:49:37 GMT",
+                "Sun, 06-Nov-1994 08:49:37 GMT",
+                "Sunday, 06-Nov-94 08:49:37 GMT",
+                "Sun Nov  6 08:49:37 1994"
+            })
+    void shouldParseKnownFormats(String date) {
+        // Given / When
+        ZonedDateTime parsedDate = HttpDateUtils.parse(date);
+        // Then
+        assertThat(parsedDate, is(notNullValue()));
+        assertThat(parsedDate.getYear(), is(equalTo(1994)));
+        assertThat(parsedDate.getMonthValue(), is(equalTo(11)));
+        assertThat(parsedDate.getDayOfMonth(), is(equalTo(6)));
+        assertThat(parsedDate.getHour(), is(equalTo(8)));
+        assertThat(parsedDate.getMinute(), is(equalTo(49)));
+        assertThat(parsedDate.getSecond(), is(equalTo(37)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Unkown Format"})
+    void shouldFailToParseUnknownFormats(String date) {
+        // Given / When
+        ZonedDateTime parsedDate = HttpDateUtils.parse(date);
+        // Then
+        assertThat(parsedDate, is(nullValue()));
+    }
+
+    @Test
+    void shouldFormatInstant() {
+        // Given
+        Instant instant = Instant.ofEpochMilli(1621421285000L);
+        // When
+        String formattedDate = HttpDateUtils.format(instant);
+        // Then
+        assertThat(formattedDate, is(equalTo("Wed, 19 May 2021 10:48:05 GMT")));
+    }
+
+    public static List<DateTimeFormatter> formatters() {
+        return HttpDateUtils.FORMATTERS;
+    }
+}

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.http.HttpDateUtils;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -235,11 +236,8 @@ class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHttpOnlySc
         // When
         msg.setResponseBody("<html></html>");
 
-        DateTimeFormatter df =
-                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
-                        .withZone(ZoneOffset.UTC);
-        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
-        String expiry = dateTime.format(df);
+        String expiry =
+                HttpDateUtils.format(LocalDateTime.now().plusYears(1).toInstant(ZoneOffset.UTC));
 
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRuleUnitTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.withSettings;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -39,6 +38,7 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.addon.commonlib.http.HttpDateUtils;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -212,32 +212,8 @@ class CookieSameSiteScanRuleUnitTest extends PassiveScannerTest<CookieSameSiteSc
     @Test
     void shouldAlertWhenFutureExpiry() throws HttpMalformedHeaderException {
         // Given - value empty, expiry in +1 year
-        DateTimeFormatter df =
-                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
-                        .withZone(ZoneOffset.UTC);
-        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
-        String expiry = dateTime.format(df);
-
-        HttpMessage msg = createMessage();
-        msg.getResponseHeader()
-                .setHeader(
-                        HttpResponseHeader.SET_COOKIE, "test=\"\"; expires=" + expiry + "; Path=/");
-        // Then
-        scanHttpResponseReceive(msg);
-        // Then
-        assertThat(alertsRaised.size(), equalTo(1));
-        assertThat(alertsRaised.get(0).getParam(), equalTo("test"));
-        assertThat(alertsRaised.get(0).getEvidence(), equalTo("Set-Cookie: test"));
-    }
-
-    @Test
-    void shouldAlertWhenFutureExpiryHyphenatedDate() throws HttpMalformedHeaderException {
-        // Given - value empty, expiry in +1 year
-        DateTimeFormatter df =
-                DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz")
-                        .withZone(ZoneOffset.UTC);
-        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
-        String expiry = dateTime.format(df);
+        String expiry =
+                HttpDateUtils.format(LocalDateTime.now().plusYears(1).toInstant(ZoneOffset.UTC));
 
         HttpMessage msg = createMessage();
         msg.getResponseHeader()

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.http.HttpDateUtils;
 import org.zaproxy.zap.extension.ruleconfig.RuleConfigParam;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
@@ -234,11 +235,8 @@ class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieSecureFl
         // When
         msg.setResponseBody("<html></html>");
 
-        DateTimeFormatter df =
-                DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz")
-                        .withZone(ZoneOffset.UTC);
-        LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
-        String expiry = dateTime.format(df);
+        String expiry =
+                HttpDateUtils.format(LocalDateTime.now().plusYears(1).toInstant(ZoneOffset.UTC));
 
         msg.setResponseHeader(
                 "HTTP/1.1 200 OK\r\n"

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -14,6 +14,11 @@ zapAddOn {
                 }
                 dependencies {
                     addOns {
+                        register("commonlib") {
+                            version.set(">= 1.4.0 & < 2.0.0")
+                        }
+                    }
+                    addOns {
                         register("custompayloads") {
                             version.set("0.9.*")
                         }
@@ -26,8 +31,10 @@ zapAddOn {
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
 
+    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRule.java
@@ -19,13 +19,12 @@
  */
 package org.zaproxy.zap.extension.pscanrulesAlpha;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import net.htmlparser.jericho.Source;
-import org.apache.commons.httpclient.util.DateParseException;
-import org.apache.commons.httpclient.util.DateUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -33,6 +32,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.http.HttpDateUtils;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
@@ -701,14 +701,12 @@ public class CacheableScanRule extends PluginPassiveScanner {
         }
     }
 
-    private Date parseDate(String dateStr) {
-        Date newDate = null;
-        try {
-            newDate = DateUtil.parseDate(dateStr);
-        } catch (DateParseException dpe) {
-            // There was an error parsing the date, leave the var null
+    private static Date parseDate(String dateStr) {
+        ZonedDateTime dateTime = HttpDateUtils.parse(dateStr);
+        if (dateTime != null) {
+            return new Date(dateTime.toInstant().toEpochMilli());
         }
-        return newDate;
+        return null;
     }
 
     @Override

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/CacheableScanRuleUnitTest.java
@@ -22,16 +22,16 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-import java.util.Date;
+import java.time.Instant;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.util.DateUtil;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.http.HttpDateUtils;
 
 /* All test-cases should raise storeable and cacheable alerts
  * or should verfiy the absence of exceptions.
@@ -96,7 +96,7 @@ class CacheableScanRuleUnitTest extends PassiveScannerTest<CacheableScanRule> {
                         + "Expires: 0\r\n"
                         + // http-date expected, Ex: "Wed, 21 Oct 2015 07:28:00 GMT"
                         "Date: "
-                        + DateUtil.formatDate(new Date())
+                        + HttpDateUtils.format(Instant.now())
                         + "\r\n\r\n");
         // When
         scanHttpResponseReceive(msg);


### PR DESCRIPTION
Add utility class to parse/format HTTP dates.
Update codebase to make use of the new class.
Remove redundant test in `CookieSameSiteScanRuleUnitTest`, the supported
formats are now being tested in the corresponding class.