### PR TITLE
Modified the reverse tabnabbing(link target) scanning rule.

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Reverse Tabnabbing Scan Rule will now alert when the 'opener' keyword is present. 
 
 ## [26] - 2021-07-29
 ### Fixed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
@@ -47,8 +47,8 @@ public class LinkTargetScanRule extends PluginPassiveScanner {
     private static final String REL_ATTRIBUTE = "rel";
     private static final String TARGET_ATTRIBUTE = "target";
     private static final String _BLANK = "_blank";
+    private static final String OPENER = "opener";
     private static final String NOOPENER = "noopener";
-    private static final String NOREFERRER = "noreferrer";
 
     private String trustedConfig = "";
     private List<String> trustedDomainRegexes = new ArrayList<>();
@@ -152,8 +152,10 @@ public class LinkTargetScanRule extends PluginPassiveScanner {
             String relAtt = link.getAttributeValue(REL_ATTRIBUTE);
             if (relAtt != null) {
                 relAtt = relAtt.toLowerCase();
-                if (relAtt.contains(NOOPENER) && relAtt.contains(NOREFERRER)) {
+                if (!relAtt.contains(OPENER)) {
                     // Its ok
+                    return false;
+                } else if (relAtt.contains(NOOPENER)) {
                     return false;
                 }
             }

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -97,7 +97,7 @@ This scan rule detects content that has been served from a shared cache.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/RetrievedFromCacheScanRule.java">RetrievedFromCacheScanRule.java</a>
 
 <H2>Reverse Tabnabbing</H2>
-This checks to see if any links use a target attribute without using both of the "noopener" and "noreferrer" keywords in the "rel" attribute, as this will allow target pages to take over the page that opens them.<br>
+This checks to see if any links use a target attribute using "opener" keyword in the "rel" attribute, as this may allow target pages to take over the page that opens them.<br>
 By default this rule will ignore all links that are in the same context as the page. At the LOW threshold it will only ignore links that are on the same host.<br>
 At HIGH threshold it will only report links that use the "_blank" target.<br>
 You can specify a comma separated list of URL regex patterns using the <code>rules.domains.trusted</code> parameter via the Options 'Rule configuration' panel.

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
@@ -111,7 +111,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
         msg.setResponseBody(
-                "<html><a href=\"https://www.example2.com/\" target=\"_blank\">link</a></html>");
+                "<html><a href=\"https://www.example2.com/\" rel=\"opener\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
@@ -129,7 +129,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
                         LinkTargetScanRule.TRUSTED_DOMAINS_PROPERTY, "https://www.example2.com/.*");
         // When
         msg.setResponseBody(
-                "<html><a href=\"https://www.example2.com/page1\" target=\"_blank\">link</a></html>");
+                "<html><a href=\"https://www.example2.com/page1\" rel=\"opener\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
@@ -146,14 +146,15 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
                         LinkTargetScanRule.TRUSTED_DOMAINS_PROPERTY, "https://www.example2.com/.*");
         // When
         msg.setResponseBody(
-                "<html><a href=\"https://www.example3.com/page1\" target=\"_blank\">link</a></html>");
+                "<html><a href=\"https://www.example3.com/page1\" rel=\"opener\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getEvidence(),
-                equalTo("<a href=\"https://www.example3.com/page1\" target=\"_blank\">link</a>"));
+                equalTo(
+                        "<a href=\"https://www.example3.com/page1\" rel=\"opener\" target=\"_blank\">link</a>"));
     }
 
     @Test
@@ -163,14 +164,15 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
         msg.setResponseBody(
-                "<html><a href=\"http://www.example2.com\" target=\"_blank\">link</a></html>");
+                "<html><a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getEvidence(),
-                equalTo("<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"));
+                equalTo(
+                        "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"));
     }
 
     @Test
@@ -180,14 +182,15 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
         msg.setResponseBody(
-                "<html><a href=\"http://www.example2.com\" target=\"other\">link</a></html>");
+                "<html><a href=\"http://www.example2.com\" rel=\"opener\" target=\"other\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getEvidence(),
-                equalTo("<a href=\"http://www.example2.com\" target=\"other\">link</a>"));
+                equalTo(
+                        "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"other\">link</a>"));
     }
 
     @Test
@@ -199,7 +202,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         rule.setAlertThreshold(AlertThreshold.HIGH);
         // When
         msg.setResponseBody(
-                "<html><a href=\"http://www.example2.com\" target=\"other\">link</a></html>");
+                "<html><a href=\"http://www.example2.com\" rel=\"opener\" target=\"other\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
@@ -215,9 +218,9 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setResponseBody(
                 "<html> <img src=\"planets.gif\" width=\"145\" height=\"126\" alt=\"Planets\"  usemap=\"#planetmap\">"
                         + "<map name=\"planetmap\">"
-                        + "  <area shape=\"rect\" coords=\"0,0,82,126\" href=\"https://www.example.com/sun.html\" target=\"_blank\" alt=\"Sun\">"
-                        + "  <area shape=\"circle\" coords=\"90,58,3\" href=\"https://www.example.com2/mercur.html\" target=\"_blank\" alt=\"Mercury\">"
-                        + "  <area shape=\"circle\" coords=\"124,58,8\" href=\"https://www.example.com/venus.html\" target=\"_blank\" alt=\"Venus\">"
+                        + "  <area shape=\"rect\" coords=\"0,0,82,126\" href=\"https://www.example.com/sun.html\" rel=\"opener\" target=\"_blank\" alt=\"Sun\">"
+                        + "  <area shape=\"circle\" coords=\"90,58,3\" href=\"https://www.example.com2/mercur.html\" rel=\"opener\" target=\"_blank\" alt=\"Mercury\">"
+                        + "  <area shape=\"circle\" coords=\"124,58,8\" href=\"https://www.example.com/venus.html\" rel=\"opener\" target=\"_blank\" alt=\"Venus\">"
                         + "</map> </html>");
 
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
@@ -227,7 +230,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         assertThat(
                 alertsRaised.get(0).getEvidence(),
                 equalTo(
-                        "<area shape=\"circle\" coords=\"90,58,3\" href=\"https://www.example.com2/mercur.html\" target=\"_blank\" alt=\"Mercury\">"));
+                        "<area shape=\"circle\" coords=\"90,58,3\" href=\"https://www.example.com2/mercur.html\" rel=\"opener\" target=\"_blank\" alt=\"Mercury\">"));
     }
 
     @Test
@@ -239,9 +242,9 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setResponseBody(
                 "<html> <img src=\"planets.gif\" width=\"145\" height=\"126\" alt=\"Planets\"  usemap=\"#planetmap\">"
                         + "<map name=\"planetmap\">"
-                        + "  <area shape=\"rect\" coords=\"0,0,82,126\" href=\"https://www.example.com/sun.html\" target=\"_blank\" alt=\"Sun\">"
-                        + "  <area shape=\"circle\" coords=\"90,58,3\" href=\"mercur.html\"  target=\"_blank\"alt=\"Mercury\">"
-                        + "  <area shape=\"circle\" coords=\"124,58,8\" href=\"https://www.example.com/venus.html\" target=\"_blank\" alt=\"Venus\">"
+                        + "  <area shape=\"rect\" coords=\"0,0,82,126\" href=\"https://www.example.com/sun.html\" rel=\"opener\" target=\"_blank\" alt=\"Sun\">"
+                        + "  <area shape=\"circle\" coords=\"90,58,3\" href=\"mercur.html\" rel=\"opener\" target=\"_blank\"alt=\"Mercury\">"
+                        + "  <area shape=\"circle\" coords=\"124,58,8\" href=\"https://www.example.com/venus.html\" rel=\"opener\" target=\"_blank\" alt=\"Venus\">"
                         + "</map> </html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
@@ -258,12 +261,12 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         // When
         msg.setResponseBody(
                 "<html>"
-                        + "<a href=\"http://www.example.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example.com\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example.com\" rel=\"opener\" target=\"_blank\">link</a>"
                         + "</html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
@@ -280,12 +283,12 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         // When
         msg.setResponseBody(
                 "<html>"
-                        + "<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"
-                        + "<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"
                         + "</html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
@@ -293,7 +296,8 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getEvidence(),
-                equalTo("<a href=\"http://www.example2.com\" target=\"_blank\">link</a>"));
+                equalTo(
+                        "<a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a>"));
     }
 
     @Test
@@ -337,7 +341,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
                 "<html>"
                         + "<a href=\"http://www.example.com/1\">link</a>"
                         + "<a href=\"http://www.example.com/2\">link</a>"
-                        + "<a href=\"http://www.example.com/3\" target=\"other\">link</a>"
+                        + "<a href=\"http://www.example.com/3\" rel=\"opener\" target=\"other\">link</a>"
                         + "<a href=\"http://www.example.com/4\" target=\"_blank\" rel=\"noopener\">link</a>"
                         + "<a href=\"http://www.example.com/5\" target=\"_blank\" rel=\"noopener\">link</a>"
                         + "<a href=\"http://www.example.com/6\" target=\"_blank\">link</a>"
@@ -362,7 +366,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
                         + "<a href=\"http://www.example2.com/3\">link</a>"
                         + "<a href=\"http://www.example2.com/4\" target=\"_blank\" rel=\"noopener noreferrer\">link</a>"
                         + "<a href=\"http://www.example2.com/5\" target=\"_blank\" rel=\"noreferrer noopener\">link</a>"
-                        + "<a href=\"http://www.example2.com/6\" target=\"_blank\">link</a>"
+                        + "<a href=\"http://www.example2.com/6\" target=\"_blank\" rel=\"opener\">link</a>"
                         + "</html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
@@ -370,7 +374,8 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getEvidence(),
-                equalTo("<a href=\"http://www.example2.com/6\" target=\"_blank\">link</a>"));
+                equalTo(
+                        "<a href=\"http://www.example2.com/6\" target=\"_blank\" rel=\"opener\">link</a>"));
     }
 
     @Test
@@ -380,7 +385,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
         msg.setResponseBody(
-                "<html><a href=\"http://www.example2.com\" target=\"_blank\">link</a></html>");
+                "<html><a href=\"http://www.example2.com\" rel=\"opener\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(TEXT_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
@@ -398,7 +403,7 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
         msg.setResponseBody(
-                "<html><a href=\"https://www.example2.com/\" target=\"_blank\">link</a></html>");
+                "<html><a href=\"https://www.example2.com/\" rel=\"opener\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
@@ -416,14 +421,15 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
         msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
         // When
         msg.setResponseBody(
-                "<html><a href=\"http://www.example3.com/\" target=\"_blank\">link</a></html>");
+                "<html><a href=\"http://www.example3.com/\" rel=\"opener\" target=\"_blank\">link</a></html>");
         msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
         scanHttpResponseReceive(msg);
         // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(
                 alertsRaised.get(0).getEvidence(),
-                equalTo("<a href=\"http://www.example3.com/\" target=\"_blank\">link</a>"));
+                equalTo(
+                        "<a href=\"http://www.example3.com/\" rel=\"opener\" target=\"_blank\">link</a>"));
     }
 
     @Test


### PR DESCRIPTION
The default value of rel in Chrome, Firefox, safari, etc. has been changed to noopener, so I think the scanning rule needs to be changed 🤔

so I modified from existing if statements to finding `rel=opener`.

## References
* https://chromium-review.googlesource.com/c/chromium/src/+/1630010
* https://twitter.com/mikewest/status/1325694207546318851

## Testing for reverse tabnabbing
### 1. only `target=_blank`
```html
<a href="https://www.hahwul.com/phoenix/reverse-tabnabbing-1" target="_blank">Click me</a>
```
![1414](https://user-images.githubusercontent.com/13212227/119007301-11523800-b9cc-11eb-98eb-efd9c425164f.jpg)

### 2. with `target=_blank` and `rel=opener`
```html
<a href="https://www.hahwul.com/phoenix/reverse-tabnabbing-1" target="_blank" rel="opener">Click me</a>
```
![1415](https://user-images.githubusercontent.com/13212227/119007764-7e65cd80-b9cc-11eb-8428-eeb01ca26a59.jpg)