### PR TITLE
Fix for ZAP Source Code Disclosure-Java-false positive Issue 6595

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Ignore CSS or JavaScript files when scanning for source code disclosures (Issue 6595).
 
 ## [33] - 2021-07-07
 ### Fixed

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
@@ -644,6 +644,12 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
      */
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
+        if (msg.getResponseHeader().isCss()
+                || msg.getResponseHeader().isJavaScript()
+                || msg.getRequestHeader().isCss()) {
+            return;
+        }
+
         // get the body contents as a String, so we can match against it
         String responsebody = msg.getResponseBody().toString();
 

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -108,7 +108,8 @@ Redirects are ignored except at the Low threshold.
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRule.java">PermissionsPolicyScanRule.java</a>
 
 <H2>Source Code Disclosure</H2>
-Application Source Code was disclosed by the web server.
+Application Source Code was disclosed by the web server.<br>
+NOTE: Ignores CSS and JavaScript files.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
 


### PR DESCRIPTION
As discussed in zaproxy/zaproxy#6595, modified SourceCodeDisclosureScanRule to ignore HttpResponse with content type header as css or javascript.

Fix zaproxy/zaproxy#6595.