### PR TITLE
Include support for include/exclude regexes in automation framework

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for data jobs.
 - Support for multiple top level URLs in a context.
 - Passive scan config enableTags parameter
+- Support for include/exclude regexes.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
@@ -15,8 +15,8 @@ env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
-      includePaths:                    # TBA: An optional list of regexes to include
-      excludePaths:                    # TBA: An optional list of regexes to exclude
+      includePaths:                    # An optional list of regexes to include
+      excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
   parameters:
     failOnError: true                  # If set exit on an error         

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -21,7 +21,10 @@ automation.error.ascan.threshold = Invalid threshold for job {0} : {1}
 automation.error.badurl = Invalid URL for job {0} : {1}
 
 automation.error.context.badurl = Invalid URL: {0}
+automation.error.context.badincludelist = Incude regexes should be a list: {0}
+automation.error.context.badexcludelist = Exclude regexes should be a list: {0}
 automation.error.context.badurlslist = Context URLs should be a list: {0}
+automation.error.context.badregex = Invalid value for regex: {0} : {1}
 automation.error.context.noname = Missing name for context: {0}
 automation.error.context.nourl = Missing URLs for context: {0}
 automation.error.context.unknown = Unrecognised context: {0}

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
@@ -3,8 +3,8 @@ env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
-      includePaths:                    # TBA: An optional list of regexes to include
-      excludePaths:                    # TBA: An optional list of regexes to exclude
+      includePaths:                    # An optional list of regexes to include
+      excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
   vars:                                # List of 1 or more variables, can be used throughout the config
   parameters:

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
@@ -319,6 +319,226 @@ class AutomationEnvironmentUnitTest {
     }
 
     @Test
+    void shouldFailIfBadIncludeRegexList() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      includePaths: https://www.testregex.example.com.*";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        new AutomationEnvironment(contextData, progress, session);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(
+                progress.getErrors().get(0),
+                is(equalTo("!automation.error.context.badincludelist!")));
+    }
+
+    @Test
+    void shouldFailIfBadExcludeRegexList() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      excludePaths: https://www.testregex.example.com.*";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        new AutomationEnvironment(contextData, progress, session);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(
+                progress.getErrors().get(0),
+                is(equalTo("!automation.error.context.badexcludelist!")));
+    }
+
+    @Test
+    void shouldFailIfBadIncludeRegexValue() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      includePaths:\n"
+                        + "      - Test\\";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        new AutomationEnvironment(contextData, progress, session);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!automation.error.context.badregex!")));
+    }
+
+    @Test
+    void shouldFailIfBadExcludeRegexValue() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      excludePaths:\n"
+                        + "      - Test\\";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        new AutomationEnvironment(contextData, progress, session);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!automation.error.context.badregex!")));
+    }
+
+    @Test
+    void shouldAddIncludeInContextRegexes() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      includePaths:\n"
+                        + "        - https://www.firstregex.example.com.*\n"
+                        + "        - https://www.secondregex.example.com.*\n";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        AutomationEnvironment env = new AutomationEnvironment(contextData, progress, session);
+        List<Context> contexts = env.getContexts();
+
+        // Then
+        verify(contexts.get(0)).addIncludeInContextRegex("https://www.example.com.*");
+        verify(contexts.get(0)).addIncludeInContextRegex("https://www.firstregex.example.com.*");
+        verify(contexts.get(0)).addIncludeInContextRegex("https://www.secondregex.example.com.*");
+    }
+
+    @Test
+    void shouldAddExcludeFromContextRegexes() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      excludePaths:\n"
+                        + "        - https://www.firstregex.example.com.*\n"
+                        + "        - https://www.secondregex.example.com.*\n";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        AutomationEnvironment env = new AutomationEnvironment(contextData, progress, session);
+        List<Context> contexts = env.getContexts();
+
+        // Then
+        verify(contexts.get(0)).addIncludeInContextRegex("https://www.example.com.*");
+        verify(contexts.get(0)).addExcludeFromContextRegex("https://www.firstregex.example.com.*");
+        verify(contexts.get(0)).addExcludeFromContextRegex("https://www.secondregex.example.com.*");
+    }
+
+    @Test
+    void shouldSetResolvedIncludeRegexes() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      includePaths:\n"
+                        + "        - https://www.${myPrefix}.${myEnvVar}.example.com.*\n"
+                        + "  vars:\n"
+                        + "    myPrefix: prefix\n";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        AutomationEnvironment env = new AutomationEnvironment(contextData, progress, session);
+        List<Context> contexts = env.getContexts();
+
+        // Then
+        verify(contexts.get(0)).addIncludeInContextRegex("https://www.example.com.*");
+        verify(contexts.get(0))
+                .addIncludeInContextRegex("https://www.prefix.envVarValue.example.com.*");
+    }
+
+    @Test
+    void shouldSetResolvedExcludeRegexes() {
+        // Given
+        String contextStr =
+                "env:\n"
+                        + "  contexts:\n"
+                        + "    - name: context 1\n"
+                        + "      urls:\n"
+                        + "      - https://www.example.com\n"
+                        + "      excludePaths:\n"
+                        + "        - https://www.${myPrefix}.${myEnvVar}.example.com.*\n"
+                        + "  vars:\n"
+                        + "    myPrefix: prefix\n";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> data =
+                yaml.load(new ByteArrayInputStream(contextStr.getBytes(StandardCharsets.UTF_8)));
+        LinkedHashMap<?, ?> contextData = (LinkedHashMap<?, ?>) data.get("env");
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        AutomationEnvironment env = new AutomationEnvironment(contextData, progress, session);
+        List<Context> contexts = env.getContexts();
+
+        // Then
+        verify(contexts.get(0)).addIncludeInContextRegex("https://www.example.com.*");
+        verify(contexts.get(0))
+                .addExcludeFromContextRegex("https://www.prefix.envVarValue.example.com.*");
+    }
+
+    @Test
     void shouldSetValidParams() {
         // Given
         String contextStr =

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/SpiderJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/SpiderJobUnitTest.java
@@ -75,11 +75,7 @@ class SpiderJobUnitTest extends TestUtils {
     private ExtensionSpider extSpider;
     private ExtensionLoader extensionLoader;
 
-    private static UrlRequester urlRequester =
-            new UrlRequester("test") {
-                @Override
-                public void requestUrl(String url, AutomationProgress progress) {}
-            };
+    private static UrlRequester urlRequester = mock(UrlRequester.class);
 
     @BeforeAll
     static void init() {

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
@@ -3,8 +3,8 @@ env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
-      includePaths:                    # TBA: An optional list of regexes to include
-      excludePaths:                    # TBA: An optional list of regexes to exclude
+      includePaths:                    # An optional list of regexes to include
+      excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
   vars:                                # List of 1 or more variables, can be used throughout the config
   parameters:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -3,8 +3,8 @@ env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
-      includePaths:                    # TBA: An optional list of regexes to include
-      excludePaths:                    # TBA: An optional list of regexes to exclude
+      includePaths:                    # An optional list of regexes to include
+      excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
   vars:                                # List of 1 or more variables, can be used throughout the config
   parameters:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -3,8 +3,8 @@ env:                                   # The environment, mandatory
   contexts :                           # List of 1 or more contexts, mandatory
     - name: context 1                  # Name to be used to refer to this context in other jobs, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
-      includePaths:                    # TBA: An optional list of regexes to include
-      excludePaths:                    # TBA: An optional list of regexes to exclude
+      includePaths:                    # An optional list of regexes to include
+      excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
   vars:                                # List of 1 or more variables, can be used throughout the config
   parameters:


### PR DESCRIPTION
The user can now specify regexes to be included/excluded from the context. 
Modified documentation, added tests and updated the Changelog