### PR TITLE
Reports: Output summary job

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Wappalyzer data to the traditional-html-plus report, if it is available.
 - Traditional JSON report
+- Automation job: outputSummary, aimed at mimicking the output of the packaged scans.
 
 ### Changed
 - Maintenance changes.

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -54,6 +54,7 @@ import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteMap;
 import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
@@ -412,6 +413,37 @@ public class ExtensionReports extends ExtensionAdaptor {
         }
 
         return alertCounts;
+    }
+
+    public List<HttpMessage> getHttpMessagesForRule(int ruleId, int max) {
+        List<HttpMessage> list = new ArrayList<>();
+
+        try {
+            Enumeration<?> alertEnum = this.getRootAlertNode().children();
+            while (alertEnum.hasMoreElements()) {
+                AlertNode alertNode = (AlertNode) alertEnum.nextElement();
+                if (alertNode.getUserObject().getPluginId() == ruleId) {
+                    Enumeration<?> instEnum = alertNode.children();
+                    while (instEnum.hasMoreElements() && list.size() < max) {
+                        AlertNode instNode = (AlertNode) instEnum.nextElement();
+                        list.add(instNode.getUserObject().getMessage());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to get HttpMessages for rule Id " + ruleId, e);
+        }
+
+        return list;
+    }
+
+    public Map<Integer, Integer> getAlertCountsByRule() {
+        try {
+            return this.getAlertCountsByRule(this.getRootAlertNode());
+        } catch (Exception e) {
+            LOGGER.error("Failed to access alerts tree", e);
+        }
+        return new HashMap<>();
     }
 
     private Map<Integer, Integer> getAlertCountsByRule(AlertNode rootNode) {

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ExtensionReportAutomation.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ExtensionReportAutomation.java
@@ -21,17 +21,23 @@ package org.zaproxy.addon.reports.automation;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.automation.ExtensionAutomation;
 import org.zaproxy.addon.automation.JobResultData;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.addon.reports.ExtensionReports.ReportDataHandler;
 import org.zaproxy.addon.reports.ReportData;
+import org.zaproxy.zap.model.SessionStructure;
+import org.zaproxy.zap.model.StructuralNode;
 
 public class ExtensionReportAutomation extends ExtensionAdaptor {
 
@@ -39,7 +45,8 @@ public class ExtensionReportAutomation extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES;
 
-    private ReportJob job;
+    private ReportJob reportJob;
+    private OutputSummaryJob outputSummaryJob;
 
     private ReportDataHandler reportDataHandler;
 
@@ -63,8 +70,10 @@ public class ExtensionReportAutomation extends ExtensionAdaptor {
         super.hook(extensionHook);
         ExtensionAutomation extAuto =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutomation.class);
-        job = new ReportJob();
-        extAuto.registerAutomationJob(job);
+        reportJob = new ReportJob();
+        extAuto.registerAutomationJob(reportJob);
+        outputSummaryJob = new OutputSummaryJob(this);
+        extAuto.registerAutomationJob(outputSummaryJob);
         reportDataHandler = new ReportDataHandlerImpl(extAuto);
         Control.getSingleton()
                 .getExtensionLoader()
@@ -82,7 +91,8 @@ public class ExtensionReportAutomation extends ExtensionAdaptor {
         ExtensionAutomation extAuto =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutomation.class);
 
-        extAuto.unregisterAutomationJob(job);
+        extAuto.unregisterAutomationJob(reportJob);
+        extAuto.unregisterAutomationJob(outputSummaryJob);
         Control.getSingleton()
                 .getExtensionLoader()
                 .getExtension(ExtensionReports.class)
@@ -102,6 +112,21 @@ public class ExtensionReportAutomation extends ExtensionAdaptor {
     @Override
     public String getUIName() {
         return Constant.messages.getString("reports.automation.name");
+    }
+
+    public int countNumberOfUrls() {
+        Set<String> urls = new HashSet<>();
+        collectUrls(SessionStructure.getRootNode(Model.getSingleton()), urls);
+        return urls.size();
+    }
+
+    private void collectUrls(StructuralNode node, Set<String> urls) {
+        Iterator<StructuralNode> iter = node.getChildIterator();
+        while (iter.hasNext()) {
+            StructuralNode childNode = iter.next();
+            urls.add(childNode.getURI().toString());
+            collectUrls(childNode, urls);
+        }
     }
 
     private static class ReportDataHandlerImpl implements ReportDataHandler {

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/OutputSummaryJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/OutputSummaryJob.java
@@ -1,0 +1,274 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.reports.automation;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import net.sf.json.JSONObject;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData;
+import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData.RuleData;
+import org.zaproxy.addon.reports.ExtensionReports;
+
+public class OutputSummaryJob extends AutomationJob {
+
+    public static final String JOB_NAME = "outputSummary";
+
+    private static final String PARAM_FORMAT = "format";
+    private static final String PARAM_SUMMARY_FILE = "summaryFile";
+
+    private ExtensionReportAutomation ext;
+    private PrintStream out = System.out;
+
+    private enum Format {
+        NONE,
+        SHORT,
+        LONG
+    };
+
+    private Format format = Format.NONE;
+    private String summaryFile;
+
+    private ExtensionReports extReport;
+
+    public OutputSummaryJob(ExtensionReportAutomation ext) {
+        this.ext = ext;
+    }
+
+    /**
+     * Prints a summary to std out as per the packaged scans. The output is deliberately not
+     * internationalised as neither was the output of the packaged scans.
+     */
+    @Override
+    public void runJob(
+            AutomationEnvironment env, LinkedHashMap<?, ?> jobData, AutomationProgress progress) {
+        if (Format.NONE.equals(format)) {
+            return;
+        }
+
+        int pass = 0;
+        int warn = 0;
+
+        // Number of URLs, as per logic behind the core.urls API endpoint
+        int numUrls = ext.countNumberOfUrls();
+        if (numUrls == 0) {
+            out.println(
+                    "No URLs found - is the target URL accessible? Local services may not be accessible from a Docker container");
+        } else {
+            if (Format.LONG.equals(format)) {
+                out.println("Total of " + numUrls + " URLs");
+            }
+
+            // Passing rules, for now just passive, ordered by id
+            PassiveScanJobResultData pscanData =
+                    (PassiveScanJobResultData) progress.getJobResultData("passiveScanData");
+            if (pscanData != null) {
+                Collection<RuleData> pscanRuleData = pscanData.getAllRuleData();
+                Map<Integer, Integer> alertCounts = getExtReport().getAlertCountsByRule();
+
+                RuleData[] pscanRuleArray = new RuleData[pscanRuleData.size()];
+                pscanRuleData.toArray(pscanRuleArray);
+                Arrays.sort(
+                        pscanRuleArray,
+                        new Comparator<RuleData>() {
+
+                            @Override
+                            public int compare(RuleData o1, RuleData o2) {
+                                // Compare as strings, for backwards compatibility
+                                return Integer.toString(o1.getId())
+                                        .compareTo(Integer.toString(o2.getId()));
+                            }
+                        });
+
+                for (RuleData rule : pscanRuleArray) {
+                    if (!alertCounts.containsKey(rule.getId())) {
+                        if (Format.LONG.equals(format)) {
+                            out.println("PASS: " + rule.getName() + " [" + rule.getId() + "]");
+                        }
+                        pass++;
+                    }
+                }
+
+                // Warning rules, for now just passive, ordered by id
+                for (RuleData rule : pscanRuleArray) {
+                    if (alertCounts.containsKey(rule.getId())) {
+                        int count = alertCounts.get(rule.getId());
+                        out.println(
+                                "WARN-NEW: "
+                                        + rule.getName()
+                                        + " ["
+                                        + rule.getId()
+                                        + "] x "
+                                        + count);
+                        if (Format.LONG.equals(format)) {
+                            for (HttpMessage msg :
+                                    getExtReport().getHttpMessagesForRule(rule.getId(), 5)) {
+                                out.println(
+                                        "\t"
+                                                + msg.getRequestHeader().getURI()
+                                                + " ("
+                                                + msg.getResponseHeader().getStatusCode()
+                                                + ")");
+                            }
+                        }
+                        warn++;
+                    }
+                }
+            }
+
+            // Obviously most of these are not supported yet :)
+            out.println(
+                    "FAIL-NEW: 0\tFAIL-INPROG: 0\tWARN-NEW: "
+                            + warn
+                            + "\tWARN-INPROG: 0\tINFO: 0\tIGNORE: 0\tPASS: "
+                            + pass);
+
+            if (summaryFile != null) {
+                JSONObject summary = new JSONObject();
+                summary.put("pass", pass);
+                summary.put("warn", warn);
+                summary.put("fail", 0); // Not yet supported
+
+                try {
+                    Files.write(Paths.get(summaryFile), summary.toString().getBytes("utf-8"));
+                } catch (IOException e) {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "reports.automation.error.badsummaryfile",
+                                    this.getName(),
+                                    e.getMessage()));
+                }
+            }
+        }
+    }
+
+    /** Only to be used for the unit tests. */
+    void setOutput(PrintStream ps) {
+        this.out = ps;
+    }
+
+    @Override
+    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {
+        switch (name) {
+            case PARAM_FORMAT:
+                try {
+                    Format.valueOf(value.toUpperCase(Locale.ROOT));
+                } catch (Exception e) {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "reports.automation.error.badformat",
+                                    this.getName(),
+                                    value,
+                                    Format.values()));
+                }
+                break;
+            case PARAM_SUMMARY_FILE:
+                File parent = new File(value).getParentFile();
+                if (!parent.exists()) {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "reports.automation.error.noparent",
+                                    this.getName(),
+                                    parent.getAbsolutePath()));
+                } else if (!parent.canWrite()) {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "reports.automation.error.roparent",
+                                    this.getName(),
+                                    parent.getAbsolutePath()));
+                }
+                break;
+            default:
+                // Ignore
+                break;
+        }
+    }
+
+    @Override
+    public boolean applyCustomParameter(String name, String value) {
+        switch (name) {
+            case PARAM_FORMAT:
+                format = Format.valueOf(value.toUpperCase(Locale.ROOT));
+                return true;
+            case PARAM_SUMMARY_FILE:
+                summaryFile = value;
+                return true;
+            default:
+                // Ignore
+                break;
+        }
+        return false;
+    }
+
+    public String getFormat() {
+        return format.name();
+    }
+
+    @Override
+    public Map<String, String> getCustomConfigParameters() {
+        Map<String, String> map = super.getCustomConfigParameters();
+        map.put(PARAM_FORMAT, Format.NONE.name());
+        return map;
+    }
+
+    private ExtensionReports getExtReport() {
+        if (extReport == null) {
+            extReport =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionReports.class);
+        }
+        return extReport;
+    }
+
+    @Override
+    public String getType() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public Order getOrder() {
+        return Order.REPORT;
+    }
+
+    @Override
+    public Object getParamMethodObject() {
+        return null;
+    }
+
+    @Override
+    public String getParamMethodName() {
+        return null;
+    }
+}

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
@@ -33,9 +33,13 @@ reports.automation.desc = Report Generation Automation Integration
 reports.automation.name = Report Generation Automation Integration
 reports.automation.info.reportgen = Job {0} generated report {1}
 reports.automation.error.generate = Job {0} failed to generate report: {1}
+reports.automation.error.badformat = Job {0} invalid format '{1}' : should be one of {2}
 reports.automation.error.badlist = Job {0} invalid list for '{1}' : {2}
+reports.automation.error.noparent = Job {0} parent directory of summaryFile does not exist {1}
+reports.automation.error.roparent = Job {0} no write access to parent directory of summaryFile {1}
 reports.automation.error.badrisk = Job {0} invalid risk: {1}
 reports.automation.error.badsection = Job {0} invalid section {1} for template {2}, valid sections: {3}
+reports.automation.error.badsummaryfile = Job {0} failed to create summary file: {1}
 
 reports.dialog.button.generate = Generate Report
 reports.dialog.button.reset = Reset

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/outputSummary-max.yaml
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/outputSummary-max.yaml
@@ -1,0 +1,4 @@
+  - type: outputSummary                # Print summary to stdout, primarily to mimic the behaviour of the packaged scans
+    parameters:
+      format: None                     # String: The format of the output, one of None, Short, Long, default: None
+      summaryFile:                     # String: The full path of a file into which will be written a JSON summary of the scan, default empty

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
@@ -1,0 +1,470 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.reports.automation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.yaml.snakeyaml.Yaml;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData;
+import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData.RuleData;
+import org.zaproxy.addon.reports.ExtensionReports;
+import org.zaproxy.zap.extension.pscan.PassiveScanThread;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.utils.I18N;
+
+class OutputSummaryJobUnitTest {
+
+    private OutputSummaryJob job;
+    private ExtensionReportAutomation ext;
+    private ExtensionReports extReport;
+    private ByteArrayOutputStream os;
+    private AutomationEnvironment env;
+    private AutomationProgress progress;
+    private PassiveScanJobResultData psJobResData;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Constant.messages = new I18N(Locale.ENGLISH);
+
+        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        Model.setSingletonForTesting(model);
+        ExtensionLoader extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+
+        ext = mock(ExtensionReportAutomation.class);
+        extReport = mock(ExtensionReports.class);
+        env = mock(AutomationEnvironment.class);
+        progress = mock(AutomationProgress.class);
+        psJobResData = mock(PassiveScanJobResultData.class);
+        job = new OutputSummaryJob(ext);
+        os = new ByteArrayOutputStream();
+        job.setOutput(new PrintStream(os));
+
+        given(extensionLoader.getExtension(ExtensionReports.class)).willReturn(extReport);
+        given(progress.getJobResultData(any())).willReturn(psJobResData);
+    }
+
+    @Test
+    void shouldReportBadFormat() throws Exception {
+        // Given
+        String yamlStr = "parameters:\n  format: bad_format";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+        AutomationProgress realProgress = new AutomationProgress();
+
+        // When
+        LinkedHashMap<?, ?> params =
+                (LinkedHashMap<?, ?>) ((LinkedHashMap<?, ?>) data).get("parameters");
+
+        job.verifyParameters(params, realProgress);
+
+        // Then
+        assertThat(realProgress.hasErrors(), is(equalTo(true)));
+        assertThat(realProgress.getErrors(), contains("!reports.automation.error.badformat!"));
+    }
+
+    @Test
+    void shouldReportBadSummaryFile() throws Exception {
+        // Given
+        String yamlStr = "parameters:\n  summaryFile: /bad/path";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+        AutomationProgress realProgress = new AutomationProgress();
+
+        // When
+        LinkedHashMap<?, ?> params =
+                (LinkedHashMap<?, ?>) ((LinkedHashMap<?, ?>) data).get("parameters");
+
+        job.verifyParameters(params, realProgress);
+
+        // Then
+        assertThat(realProgress.hasErrors(), is(equalTo(true)));
+        assertThat(realProgress.getErrors(), contains("!reports.automation.error.noparent!"));
+    }
+
+    @Test
+    void shouldWarnOnRuleWithAlerts() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(3);
+
+        Map<Integer, Integer> alertCounts = new HashMap<>();
+        alertCounts.put(1, 3);
+        given(extReport.getAlertCountsByRule()).willReturn(alertCounts);
+
+        List<RuleData> list = Arrays.asList(new RuleData(new TestPluginPassiveScanner(1, "rule1")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        job.applyCustomParameter("format", "LONG");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(
+                os.toString(),
+                is(
+                        "Total of 3 URLs\n"
+                                + "WARN-NEW: rule1 [1] x 3\n"
+                                + "FAIL-NEW: 0\tFAIL-INPROG: 0\tWARN-NEW: 1\tWARN-INPROG: 0\tINFO: 0\tIGNORE: 0\tPASS: 0\n"));
+    }
+
+    @Test
+    void shouldWarnOnNoURLs() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(0);
+        job.applyCustomParameter("format", "LONG");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(
+                os.toString(),
+                is(
+                        "No URLs found - is the target URL accessible? Local services may not be accessible from a Docker container\n"));
+    }
+
+    @Test
+    void shouldShowUrlsOnRuleWithAlerts() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(8);
+
+        Map<Integer, Integer> alertCounts = new HashMap<>();
+        alertCounts.put(1, 3);
+        given(extReport.getAlertCountsByRule()).willReturn(alertCounts);
+
+        List<HttpMessage> msgList =
+                Arrays.asList(
+                        new HttpMessage(new URI("https://www.example.com", true)),
+                        new HttpMessage(new URI("https://www.example.com/a", true)),
+                        new HttpMessage(new URI("https://www.example.com/b", true)));
+        given(extReport.getHttpMessagesForRule(1, 5)).willReturn(msgList);
+
+        List<RuleData> list = Arrays.asList(new RuleData(new TestPluginPassiveScanner(1, "rule1")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        job.applyCustomParameter("format", "LONG");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(
+                os.toString(),
+                is(
+                        "Total of 8 URLs\n"
+                                + "WARN-NEW: rule1 [1] x 3\n"
+                                + "\thttps://www.example.com (0)\n"
+                                + "\thttps://www.example.com/a (0)\n"
+                                + "\thttps://www.example.com/b (0)\n"
+                                + "FAIL-NEW: 0\tFAIL-INPROG: 0\tWARN-NEW: 1\tWARN-INPROG: 0\tINFO: 0\tIGNORE: 0\tPASS: 0\n"));
+    }
+
+    @Test
+    void shouldPassIfNoAlerts() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(10);
+
+        given(extReport.getAlertCountsByRule()).willReturn(new HashMap<>());
+
+        List<RuleData> list =
+                Arrays.asList(
+                        new RuleData(new TestPluginPassiveScanner(3, "rule3")),
+                        new RuleData(new TestPluginPassiveScanner(2, "rule2")),
+                        new RuleData(new TestPluginPassiveScanner(1, "rule1")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        job.applyCustomParameter("format", "LONG");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(
+                os.toString(),
+                is(
+                        "Total of 10 URLs\n"
+                                + "PASS: rule1 [1]\n"
+                                + "PASS: rule2 [2]\n"
+                                + "PASS: rule3 [3]\n"
+                                + "FAIL-NEW: 0\tFAIL-INPROG: 0\tWARN-NEW: 0\tWARN-INPROG: 0\tINFO: 0\tIGNORE: 0\tPASS: 3\n"));
+    }
+
+    @Test
+    void shouldOutputJobsInAlphabeticIdOrder() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(10);
+
+        given(extReport.getAlertCountsByRule()).willReturn(new HashMap<>());
+
+        List<RuleData> list =
+                Arrays.asList(
+                        new RuleData(new TestPluginPassiveScanner(20, "rule20")),
+                        new RuleData(new TestPluginPassiveScanner(1001, "rule1001")),
+                        new RuleData(new TestPluginPassiveScanner(9, "rule9")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        job.applyCustomParameter("format", "LONG");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(
+                os.toString(),
+                is(
+                        "Total of 10 URLs\n"
+                                + "PASS: rule1001 [1001]\n"
+                                + "PASS: rule20 [20]\n"
+                                + "PASS: rule9 [9]\n"
+                                + "FAIL-NEW: 0\tFAIL-INPROG: 0\tWARN-NEW: 0\tWARN-INPROG: 0\tINFO: 0\tIGNORE: 0\tPASS: 3\n"));
+    }
+
+    @Test
+    void shouldOutputCorrectLongReport() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(20);
+
+        Map<Integer, Integer> alertCounts = new HashMap<>();
+        alertCounts.put(1, 3);
+        given(extReport.getAlertCountsByRule()).willReturn(alertCounts);
+
+        List<HttpMessage> msgList =
+                Arrays.asList(
+                        new HttpMessage(new URI("https://www.example.com", true)),
+                        new HttpMessage(new URI("https://www.example.com/a", true)),
+                        new HttpMessage(new URI("https://www.example.com/b", true)));
+        given(extReport.getHttpMessagesForRule(1, 5)).willReturn(msgList);
+
+        List<RuleData> list =
+                Arrays.asList(
+                        new RuleData(new TestPluginPassiveScanner(1, "rule1")),
+                        new RuleData(new TestPluginPassiveScanner(2, "rule2")),
+                        new RuleData(new TestPluginPassiveScanner(3, "rule3")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        job.applyCustomParameter("format", "LONG");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(
+                os.toString(),
+                is(
+                        "Total of 20 URLs\n"
+                                + "PASS: rule2 [2]\n"
+                                + "PASS: rule3 [3]\n"
+                                + "WARN-NEW: rule1 [1] x 3\n"
+                                + "\thttps://www.example.com (0)\n"
+                                + "\thttps://www.example.com/a (0)\n"
+                                + "\thttps://www.example.com/b (0)\n"
+                                + "FAIL-NEW: 0\tFAIL-INPROG: 0\tWARN-NEW: 1\tWARN-INPROG: 0\tINFO: 0\tIGNORE: 0\tPASS: 2\n"));
+    }
+
+    @Test
+    void shouldOutputCorrectShortReport() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(20);
+
+        Map<Integer, Integer> alertCounts = new HashMap<>();
+        alertCounts.put(1, 3);
+        given(extReport.getAlertCountsByRule()).willReturn(alertCounts);
+
+        List<HttpMessage> msgList =
+                Arrays.asList(
+                        new HttpMessage(new URI("https://www.example.com", true)),
+                        new HttpMessage(new URI("https://www.example.com/a", true)),
+                        new HttpMessage(new URI("https://www.example.com/b", true)));
+        given(extReport.getHttpMessagesForRule(1, 5)).willReturn(msgList);
+
+        List<RuleData> list =
+                Arrays.asList(
+                        new RuleData(new TestPluginPassiveScanner(1, "rule1")),
+                        new RuleData(new TestPluginPassiveScanner(2, "rule2")),
+                        new RuleData(new TestPluginPassiveScanner(3, "rule3")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        job.applyCustomParameter("format", "SHORT");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(
+                os.toString(),
+                is(
+                        "WARN-NEW: rule1 [1] x 3\n"
+                                + "FAIL-NEW: 0\tFAIL-INPROG: 0\tWARN-NEW: 1\tWARN-INPROG: 0\tINFO: 0\tIGNORE: 0\tPASS: 2\n"));
+    }
+
+    @Test
+    void shouldOutputNothingForNoneReport() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(20);
+
+        Map<Integer, Integer> alertCounts = new HashMap<>();
+        alertCounts.put(1, 3);
+        given(extReport.getAlertCountsByRule()).willReturn(alertCounts);
+
+        List<HttpMessage> msgList =
+                Arrays.asList(
+                        new HttpMessage(new URI("https://www.example.com", true)),
+                        new HttpMessage(new URI("https://www.example.com/a", true)),
+                        new HttpMessage(new URI("https://www.example.com/b", true)));
+        given(extReport.getHttpMessagesForRule(1, 5)).willReturn(msgList);
+
+        List<RuleData> list =
+                Arrays.asList(
+                        new RuleData(new TestPluginPassiveScanner(1, "rule1")),
+                        new RuleData(new TestPluginPassiveScanner(2, "rule2")),
+                        new RuleData(new TestPluginPassiveScanner(3, "rule3")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        job.applyCustomParameter("format", "NONE");
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(os.toString(), is(""));
+    }
+
+    @Test
+    void shouldOutputNothingByDefault() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(20);
+
+        Map<Integer, Integer> alertCounts = new HashMap<>();
+        alertCounts.put(1, 3);
+        given(extReport.getAlertCountsByRule()).willReturn(alertCounts);
+
+        List<HttpMessage> msgList =
+                Arrays.asList(
+                        new HttpMessage(new URI("https://www.example.com", true)),
+                        new HttpMessage(new URI("https://www.example.com/a", true)),
+                        new HttpMessage(new URI("https://www.example.com/b", true)));
+        given(extReport.getHttpMessagesForRule(1, 5)).willReturn(msgList);
+
+        List<RuleData> list =
+                Arrays.asList(
+                        new RuleData(new TestPluginPassiveScanner(1, "rule1")),
+                        new RuleData(new TestPluginPassiveScanner(2, "rule2")),
+                        new RuleData(new TestPluginPassiveScanner(3, "rule3")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        // When
+        job.runJob(env, null, progress);
+
+        // Then
+        assertThat(os.toString(), is(""));
+    }
+
+    @Test
+    void shouldGenerateSummaryFile() throws Exception {
+        // Given
+        given(ext.countNumberOfUrls()).willReturn(20);
+
+        Map<Integer, Integer> alertCounts = new HashMap<>();
+        alertCounts.put(1, 3);
+        given(extReport.getAlertCountsByRule()).willReturn(alertCounts);
+
+        List<RuleData> list =
+                Arrays.asList(
+                        new RuleData(new TestPluginPassiveScanner(1, "rule1")),
+                        new RuleData(new TestPluginPassiveScanner(2, "rule2")),
+                        new RuleData(new TestPluginPassiveScanner(3, "rule3")));
+
+        given(psJobResData.getAllRuleData()).willReturn(list);
+
+        File f = File.createTempFile("zap.reports.outputsummary", "json");
+        job.applyCustomParameter("summaryFile", f.getAbsolutePath());
+        job.applyCustomParameter("format", "LONG");
+
+        // When
+        job.runJob(env, null, progress);
+
+        String summary = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+
+        // Then
+        assertThat(summary, is("{\"pass\":2,\"warn\":1,\"fail\":0}"));
+    }
+
+    class TestPluginPassiveScanner extends PluginPassiveScanner {
+
+        private int id;
+        private String name;
+
+        public TestPluginPassiveScanner(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        @Override
+        public void setParent(PassiveScanThread parent) {}
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public int getPluginId() {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION
Part of https://github.com/zaproxy/zaproxy/issues/6483

Required to replicate the packaged scan functionality.

No unit tests, but not really sure what useful ones could be added :/
I've been manually testing the new baseline code - thats much easier as you can then compare the output side by side...

Signed-off-by: Simon Bennetts <psiinon@gmail.com>