### PR TITLE
Updated the env file rule and test with a bit more accurate information

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
-- The .env file scan rule now performs a simple content check to reduce false positives (Issue 6099).
+- The .env file scan rule now performs even better checks to reduce false positives (Issue 6099, 6629).
 - The trace.axd file scan rule now performs a content check to reduce false positives (Issue 6517).
 - XML External Entity Attack scan rule changed to detect a possible XML File Reflection Attack when XML validation is present. (Issue 6204)
 - Added/updated the details of some alerts (some changes might break Alert Filters)

--- a/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
+++ b/addOns/ascanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesBeta/resources/help/contents/ascanbeta.html
@@ -53,6 +53,11 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 <H2>.env Information Leak</H2>
 Checks for web accessible .env files which may leak sensitive information 
 (such as usernames, passwords, API or APP keys, etc.).
+Environment files come in many flavors but mostly they are KEY=VALUE formatted. <br>
+This rule checks for how servers deliver them by default;
+NGINX returns them as binary/octet-stream content-type Apache just returns the text
+with no content-type. This rule also check for content length over 500 characters to try and exclude
+larger, possibly intentional, files.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/EnvFileScanRule.java">EnvFileScanRule.java</a>
 


### PR DESCRIPTION
Resolves zaproxy/zaproxy#6629 Adding better content type checking for .env files content and more checks based on how most default webservers serve this content if exposed.