### PR TITLE
improve: various add-ons: Even More SAST (sonar) fixes

### DIFF
--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -92,9 +93,8 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
                         Collections.emptyList(),
                         "file",
                         false));
-        // When
-        rule.scan();
-        // Then = No Exception
+        // When / Then
+        assertDoesNotThrow(() -> rule.scan());
     }
 
     @Test

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
@@ -442,7 +442,7 @@ class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldReplaceConfigVarsInEnv() {
+    void shouldReplaceConfigVarsInEnv() {
         // Given
         String contextStr =
                 "env:\n"
@@ -469,7 +469,7 @@ class AutomationEnvironmentUnitTest {
     }
 
     @Test
-    public void shouldReplaceEnvVarsInJobs() {
+    void shouldReplaceEnvVarsInJobs() {
         // Given
         String contextStr =
                 "env:\n"

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationJobUnitTest.java
@@ -168,7 +168,7 @@ class AutomationJobUnitTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void shouldSetResolvedParams() {
+    void shouldSetResolvedParams() {
         // Given
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         given(env.replaceVars(eq("${myStringParam}"))).willReturn(stringParamValue);

--- a/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/ClassLoaderTests.java
+++ b/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/ClassLoaderTests.java
@@ -33,7 +33,7 @@ import javax.script.ScriptEngine;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.ZAP;
 
-public class ClassLoaderTests {
+class ClassLoaderTests {
 
     private static final String testClassName = "testclasspath.TestClassOne";
 
@@ -72,7 +72,7 @@ public class ClassLoaderTests {
         Object retVal1 = cs.eval();
 
         assertSame(retVal1.getClass(), String.class);
-        assertEquals(retVal1, "testone");
+        assertEquals("testone", retVal1);
 
         String script2 = getScriptContents("classloaderTest2.kts");
         Object retVal2 = c.compile(script2).eval();

--- a/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/PrintOutputTests.java
+++ b/addOns/kotlin/src/test/java/org/zaproxy/addon/kotlin/PrintOutputTests.java
@@ -31,12 +31,12 @@ import javax.script.ScriptEngine;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class PrintOutputTests {
+class PrintOutputTests {
 
     private static ScriptEngine se;
 
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
         se = new KotlinEngineWrapper(Thread.currentThread().getContextClassLoader()).getEngine();
     }
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRuleUnitTest.java
@@ -135,8 +135,7 @@ class InformationDisclosureInUrlScanRuleUnitTest
 
     @Test
     @Disabled(value = "Scanner does not yet eliminate dashes when looking for credit card numbers.")
-    public void creditCardDashesInURLParamValue()
-            throws HttpMalformedHeaderException, URIException {
+    void creditCardDashesInURLParamValue() throws HttpMalformedHeaderException, URIException {
 
         // Given
         String testURI = URI + "?docid=6011-0009-9013-9424&hl=en";

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/ExtensionImportWSDLTestCase.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class ExtensionImportWSDLTestCase extends TestUtils {
+class ExtensionImportWSDLTestCase extends TestUtils {
 
     ExtensionImportWSDL extension;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         extension = new ExtensionImportWSDL();
         mockMessages(extension);
     }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPActionSpoofingActiveScanRuleTestCase.java
@@ -27,13 +27,13 @@ import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.soap.SOAPActionSpoofingActiveScanRule.ResponseType;
 
-public class SOAPActionSpoofingActiveScanRuleTestCase {
+class SOAPActionSpoofingActiveScanRuleTestCase {
 
     private HttpMessage originalMsg = new HttpMessage();
     private HttpMessage modifiedMsg = new HttpMessage();
 
     @BeforeEach
-    public void setUp() throws HttpMalformedHeaderException {
+    void setUp() throws HttpMalformedHeaderException {
         /* Original. */
         Sample.setOriginalRequest(originalMsg);
         Sample.setOriginalResponse(originalMsg);

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPMsgConfigTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPMsgConfigTestCase.java
@@ -29,12 +29,12 @@ import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SOAPMsgConfigTestCase {
+class SOAPMsgConfigTestCase {
 
     private SOAPMsgConfig soapConfig;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         /* Empty configuration object. */
         soapConfig = new SOAPMsgConfig();
         soapConfig.setWsdl(new Definitions());

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SOAPXMLInjectionActiveScanRuleTestCase.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class SOAPXMLInjectionActiveScanRuleTestCase {
+class SOAPXMLInjectionActiveScanRuleTestCase {
 
     @Test
     void craftAttackMessageTest() throws Exception {

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SitesTreeHelperTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SitesTreeHelperTestCase.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class SitesTreeHelperTestCase extends TestUtils {
+class SitesTreeHelperTestCase extends TestUtils {
     HttpMessage message;
 
     @BeforeEach
-    public void setup() throws Exception {
+    void setup() throws Exception {
         setUpZap();
         message = new HttpMessage();
     }

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SoapActionUnitTest.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/SoapActionUnitTest.java
@@ -34,7 +34,7 @@ class SoapActionUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"http://example.com/", "", "\"ZAP\""})
-    public void getSoapActionForSoapV1Message(String soapAction) {
+    void getSoapActionForSoapV1Message(String soapAction) {
         HttpMessage soapMsg = new HttpMessage();
         soapMsg.getRequestHeader().setHeader("SOAPAction", soapAction);
         assertThat(SoapAction.extractFrom(soapMsg), is(equalTo(soapAction)));
@@ -42,7 +42,7 @@ class SoapActionUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"http://example.com/", "", "\"ZAP\""})
-    public void getSoapActionForSoapV2Message(String soapAction) {
+    void getSoapActionForSoapV2Message(String soapAction) {
         HttpMessage soapMsg = new HttpMessage();
         String contentType = "application/soap+xml;charset=utf-8;action=" + soapAction;
         soapMsg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
@@ -51,7 +51,7 @@ class SoapActionUnitTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"http://example.com/", "", "\"ZAP\""})
-    public void getSoapActionForSoapV2MessageWithActionBeforeCharsetInContentTypeHeader(
+    void getSoapActionForSoapV2MessageWithActionBeforeCharsetInContentTypeHeader(
             String soapAction) {
         HttpMessage soapMsg = new HttpMessage();
         String contentType = "application/soap+xml;action=" + soapAction + ";charset=utf-8";

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLCustomParserTestCase.java
@@ -39,13 +39,13 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.testutils.TestUtils;
 
-public class WSDLCustomParserTestCase extends TestUtils {
+class WSDLCustomParserTestCase extends TestUtils {
 
     private String wsdlContent;
     private WSDLCustomParser parser;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         /* Gets test wsdl file and retrieves its content as String. */
         Path wsdlPath = getResourcePath("resources/test.wsdl");
         wsdlContent = new String(Files.readAllBytes(wsdlPath), StandardCharsets.UTF_8);

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class WSDLFilePassiveScanRuleTestCase {
+class WSDLFilePassiveScanRuleTestCase {
     private HttpMessage wsdlMsg = new HttpMessage();
 
     private static void setContentType(HttpMessage msg, String contentType) {
@@ -37,7 +37,7 @@ public class WSDLFilePassiveScanRuleTestCase {
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         try {
             wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
             wsdlMsg = Sample.setResponseHeaderContent(wsdlMsg);

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLSpiderTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLSpiderTestCase.java
@@ -27,12 +27,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class WSDLSpiderTestCase {
+class WSDLSpiderTestCase {
 
     private HttpMessage wsdlMsg = new HttpMessage();
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         try {
             wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
             wsdlMsg = Sample.setResponseHeaderContent(wsdlMsg);


### PR DESCRIPTION
- ascanrulesBeta > HiddenFlieScanRuleUnitTest, ensure unit tests have an assertion.
- "JUnit5 test classes and methods should have default package visibility"
  - Automation
  - commonlib
  - Kotlin
  - pscanrules
  - soap

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>