### PR TITLE
chore: Update Gradle to 7.0.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=81003f83b0056d20eedf48cddd4f52a9813163d4ba185bcf8abd34b8eeea4cbd
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Per https://docs.gradle.org/current/userguide/gradle_wrapper.html via
`./gradlew wrapper --gradle-version 7.0.2 --distribution-type all
--gradle-distribution-sha256-sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d`

If everything is good with this one I'll tackle the other repos too.

Edit: Note, I did initially have the sha value wrong because I trusted a documentation page instead of DL/release info 😞 Fixed now. (Wanted to mention just in case someone looked at the actions or other commits.)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>