### PR TITLE
fix: ascanrules: Source Code Disclosure WEB-INF no longer skipped

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Correct Context check in SQL Injection scan rule.
+- "Source Code Disclosure - /WEB-INF folder" is no longer skipped on Java 9+ (Issue 4038).
 
 ## [39] - 2021-05-10
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -32,7 +32,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.lang.SystemUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -131,19 +130,6 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
             return sb.toString();
         }
         return "Failed to load vulnerability reference from file";
-    }
-
-    @Override
-    public void init() {
-        // Does not work with Java 9+
-        // https://github.com/zaproxy/zaproxy/issues/4038
-        if (SystemUtils.isJavaVersionAtLeast(1.9f)) {
-            getParent()
-                    .pluginSkipped(
-                            this,
-                            Constant.messages.getString(
-                                    "ascanrules.sourcecodedisclosurewebinf.skipJava9"));
-        }
     }
 
     @Override

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -145,8 +145,7 @@ a pattern indicating the SSI was successful, an alert is raised and the scanner 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java">ServerSideIncludeScanRule.java</a>
 
 <H2>Source Code Disclosure - /WEB-INF</H2>
-Exploit the presence of an unprotected /WEB-INF folder to download and decompile Java classes, to disclose Java source code.<br>
-<strong>Note:</strong> Currently not supported on Java 9 and above.
+Exploit the presence of an unprotected /WEB-INF folder to download and decompile Java classes, to disclose Java source code.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java">SourceCodeDisclosureWebInfScanRule.java</a>
 

--- a/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
+++ b/addOns/ascanrules/src/main/resources/org/zaproxy/zap/extension/ascanrules/resources/Messages.properties
@@ -35,7 +35,6 @@ ascanrules.htaccess.soln = Ensure the .htaccess file is not accessible.
 ascanrules.sourcecodedisclosurewebinf.name = Source Code Disclosure - /WEB-INF folder
 ascanrules.sourcecodedisclosurewebinf.desc = Java source code was disclosed by the web server in Java class files in the WEB-INF folder. The class files can be dis-assembled to produce source code which very closely matches the original source code.  
 ascanrules.sourcecodedisclosurewebinf.soln = The web server should be configured to not serve the /WEB-INF folder or its contents to web browsers, since it contains sensitive information such as compiled Java source code and properties files which may contain credentials. Java classes deployed with the application should be obfuscated, as an additional layer of defence in a "defence-in-depth" approach.
-ascanrules.sourcecodedisclosurewebinf.skipJava9 = not supported on Java 9+
 ascanrules.sourcecodedisclosurewebinf.propertiesfile.name = Properties File Disclosure - /WEB-INF folder
 ascanrules.sourcecodedisclosurewebinf.propertiesfile.desc = A Java class in the /WEB-INF folder disclosed the presence of the properties file. Properties file are not intended to be publicly accessible, and typically contain configuration information, application credentials, or cryptographic keys.   
 ascanrules.sourcecodedisclosurewebinf.propertiesfile.soln = The web server should be configured to not serve the /WEB-INF folder or its contents to web browsers.  It may also be possible to remove the /WEB-INF folder.  

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebinfScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebinfScanRuleUnitTest.java
@@ -32,18 +32,11 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
 /** Unit test for {@link SourceCodeDisclosureWebInfScanRule}. */
-// XXX Does not work with Java 9+ because of procyon-decompiler.
-// Refs:
-// - https://github.com/zaproxy/zaproxy/issues/4038
-// - https://bitbucket.org/mstrobel/procyon/issues/320/java-9-sunmiscurlclasspath-and
-@EnabledOnJre(JRE.JAVA_8)
 class SourceCodeDisclosureWebinfScanRuleUnitTest
         extends ActiveScannerTest<SourceCodeDisclosureWebInfScanRule> {
 


### PR DESCRIPTION
See:
- https://github.com/mstrobel/procyon/issues/12
- zaproxy/zaproxy#4038 / zaproxy/zap-extensions#2338 / 
  - Related to zaproxy/zaproxy#2602
- Reverts zaproxy/zap-extensions#1723

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>