### PR TITLE
bugtracker: remove usage of custom repository

### DIFF
--- a/addOns/bugtracker/bugtracker.gradle.kts
+++ b/addOns/bugtracker/bugtracker.gradle.kts
@@ -5,11 +5,6 @@ tasks.withType<JavaCompile> {
     options.compilerArgs = options.compilerArgs - "-Werror" + "-proc:none"
 }
 
-repositories {
-    // Required by dependencies of org.kohsuke:github-api:1.75.
-    maven(url = "https://repo.jenkins-ci.org/releases/")
-}
-
 zapAddOn {
     addOnName.set("Bug Tracker")
     zapVersion.set("2.10.0")


### PR DESCRIPTION
The newer versions of the dependencies no longer require the repository.