### PR TITLE
Reports: XML template fixes

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Include all relevant alerts in XML report templates (Issue 6627).
+- Made XML reports more backwards compatible and fixed issue with generating it via the API.
 
 ## [0.3.0] - 2021-05-06
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -28,8 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.swing.BoxLayout;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
@@ -48,8 +46,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
-import org.parosproxy.paros.model.SiteMap;
-import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.alert.AlertNode;
 import org.zaproxy.zap.model.Context;
@@ -103,7 +99,6 @@ public class ReportDialog extends StandardFieldsDialog {
     private ExtensionReports extension = null;
     private JButton[] extraButtons = null;
     private DefaultListModel<Context> contextsModel;
-    private DefaultListModel<String> sitesModel;
 
     private JList<Context> contextsSelector;
     private JList<String> sitesSelector;
@@ -123,7 +118,6 @@ public class ReportDialog extends StandardFieldsDialog {
         this.removeAllFields();
         // Ensure the contexts and sites get re-read as they may well have changed
         this.contextsModel = null;
-        this.sitesModel = null;
         this.contextsSelector = null;
         this.sitesSelector = null;
 
@@ -390,25 +384,12 @@ public class ReportDialog extends StandardFieldsDialog {
         return contextsSelector;
     }
 
-    private DefaultListModel<String> getSitesModel() {
-        if (sitesModel == null) {
-            sitesModel = new DefaultListModel<>();
-            SiteMap siteMap = Model.getSingleton().getSession().getSiteTree();
-            SiteNode root = siteMap.getRoot();
-            if (root.getChildCount() > 0) {
-                SiteNode child = (SiteNode) root.getFirstChild();
-                while (child != null) {
-                    sitesModel.addElement(child.getName());
-                    child = (SiteNode) root.getChildAfter(child);
-                }
-            }
-        }
-        return sitesModel;
-    }
-
     private JList<String> getSitesSelector() {
         if (sitesSelector == null) {
-            sitesSelector = new JList<>(getSitesModel());
+            List<String> list = ExtensionReports.getSites();
+            String[] arr = new String[list.size()];
+            list.toArray(arr);
+            sitesSelector = new JList<String>(arr);
         }
         return sitesSelector;
     }
@@ -453,10 +434,7 @@ public class ReportDialog extends StandardFieldsDialog {
         reportData.setTheme(template.getThemeForName(getStringValue(FIELD_THEME)));
         if (reportData.getSites().isEmpty()) {
             // None selected so add all
-            reportData.setSites(
-                    IntStream.range(0, getSitesModel().size())
-                            .mapToObj(getSitesModel()::get)
-                            .collect(Collectors.toList()));
+            reportData.setSites(ExtensionReports.getSites());
         }
         reportData.setIncludeConfidence(0, this.getBoolValue(FIELD_CONFIDENCE_0));
         reportData.setIncludeConfidence(1, this.getBoolValue(FIELD_CONFIDENCE_1));

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -72,9 +72,11 @@ public class ReportJob extends AutomationJob {
         // Work out the file name based on the pattern
         String fileName =
                 ExtensionReports.getNameFromPattern(
-                                reportFile, env.getDefaultContextWrapper().getUrls().get(0))
-                        + "."
-                        + template.getExtension();
+                        reportFile, env.getDefaultContextWrapper().getUrls().get(0));
+
+        if (!fileName.endsWith("." + template.getExtension())) {
+            fileName += "." + template.getExtension();
+        }
 
         File file;
         if (reportDir != null && reportDir.length() > 0) {
@@ -85,6 +87,7 @@ public class ReportJob extends AutomationJob {
         reportData.setTitle(this.reportTitle);
         reportData.setDescription(this.reportDesc);
         reportData.setContexts(env.getContexts());
+        reportData.setSites(ExtensionReports.getSites());
 
         List<String> list = getJobDataList(jobData, "risks", progress);
         if (list.isEmpty()) {

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
@@ -18,7 +18,8 @@
 							th:text="${helper.getRiskString(alert.risk) + ' (' + helper.getConfidenceString(alert.confidence) + ')'}"></riskdesc>
 						<confidencedesc
 							th:text="${helper.getConfidenceString(alert.confidence)}"></confidencedesc>
-						<desc th:text="${alert.description}"></desc>
+						<desc
+							th:text="${helper.legacyEscapeParagraph(alert.description)}"></desc>
 						<instances>
 							<th:block th:each="instance: ${instances}">
 								<instance>
@@ -31,9 +32,12 @@
 							</th:block>
 						</instances>
 						<count th:text="${instances.size()}"></count>
-						<solution th:text="${alert.solution}"></solution>
-						<otherinfo th:text="${alert.otherinfo}"></otherinfo>
-						<reference th:text="${alert.reference}"></reference>
+						<solution
+							th:text="${helper.legacyEscapeParagraph(alert.solution)}"></solution>
+						<otherinfo
+							th:text="${helper.legacyEscapeParagraph(alert.otherinfo)}"></otherinfo>
+						<reference
+							th:text="${helper.legacyEscapeParagraph(alert.reference)}"></reference>
 						<cweid th:text="${alert.cweid}"></cweid>
 						<wascid th:text="${alert.wascid}"></wascid>
 						<sourceid th:text="${alert.sourceHistoryId}"></sourceid>

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
@@ -1,39 +1,37 @@
 <?xml version="1.0"?>
-<OWASPZAPReport version="Dev Build" generated="Wed, 21 Apr 2021 13:32:55">
+<OWASPZAPReport version="Dev Build" generated="Thu, 3 Jun 2021 12:53:50">
 	
 		<site name="http://example.com" host="example.com" port="80" ssl="false">
 			<alerts>
 				
-					
-						<alertitem>
-							<pluginid>1</pluginid>
-							<alertRef>1</alertRef>
-							<name>XSS</name>
-							<riskcode>3</riskcode>
-							<confidence>2</confidence>
-							<riskdesc>!reports.report.risk.3! (!reports.report.confidence.2!)</riskdesc>
-							<confidencedesc>!reports.report.confidence.2!</confidencedesc>
-							<desc>XSS Description</desc>
-							<instances>
-								
-									<instance>
-										<uri>http://example.com/example_3</uri>
-										<method>GET</method>
-										<param>Test Param</param>
-										<attack>Test Attack</attack>
-										<evidence>Test Evidence</evidence>
-									</instance>
-								
-							</instances>
-							<count>1</count>
-							<solution>Test Solution</solution>
-							<otherinfo>Test Other</otherinfo>
-							<reference>Test Reference</reference>
-							<cweid>123</cweid>
-							<wascid>456</wascid>
-							<sourceid>0</sourceid>
-						</alertitem>
-					
+					<alertitem>
+						<pluginid>1</pluginid>
+						<alertRef>1</alertRef>
+						<name>XSS</name>
+						<riskcode>3</riskcode>
+						<confidence>2</confidence>
+						<riskdesc>!reports.report.risk.3! (!reports.report.confidence.2!)</riskdesc>
+						<confidencedesc>!reports.report.confidence.2!</confidencedesc>
+						<desc>&lt;p&gt;XSS Description&lt;/p&gt;</desc>
+						<instances>
+							
+								<instance>
+									<uri>http://example.com/example_3</uri>
+									<method>GET</method>
+									<param>Test Param</param>
+									<attack>Test Attack</attack>
+									<evidence>Test Evidence</evidence>
+								</instance>
+							
+						</instances>
+						<count>1</count>
+						<solution>&lt;p&gt;Test Solution&lt;/p&gt;</solution>
+						<otherinfo>&lt;p&gt;Test Other&lt;/p&gt;</otherinfo>
+						<reference>&lt;p&gt;Test Reference&lt;/p&gt;</reference>
+						<cweid>123</cweid>
+						<wascid>456</wascid>
+						<sourceid>0</sourceid>
+					</alertitem>
 				
 			</alerts>
 		</site>


### PR DESCRIPTION
Fixed issue where report was not generated via the API.
Made more backwards compatible as per #2952
Fixed issue where you could end up with report.xml.xml (applies to all reports).
Added more detailed tests for the report.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>