### PR TITLE
improve: ci workflow add concurrency grouping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group:  ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #2894.
This group identifier should work for both PRs and push.
See: https://github.community/t/concurrecy-not-work-for-push/183068/ for more info.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>