### PR TITLE
fix: pscanrulesAlpha: Dangerous JS func word boundary FPs

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -11,7 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Site Isolation
   - Sub Resource Integrity
 - Maintenance changes.
-- Rename of Feature-Policy header to Permissions-Policy to follow spec change
+- Rename of Feature-Policy header to Permissions-Policy to follow spec change.
+
+### Fixed
+- Dangerous JS Function scan rule, use word boundaries to reduce false positives (Issue 6594).
 
 ## [30] - 2021-02-08
 

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
@@ -90,7 +90,7 @@ public class JsFunctionScanRule extends PluginPassiveScanner {
             searchPatterns(evidence, content);
         }
         if (evidence.length() > 0) {
-            this.raiseAlert(msg, id, evidence.toString());
+            this.raiseAlert(evidence.toString());
         }
     }
 
@@ -104,7 +104,7 @@ public class JsFunctionScanRule extends PluginPassiveScanner {
         }
     }
 
-    private void raiseAlert(HttpMessage msg, int id, String evidence) {
+    private void raiseAlert(String evidence) {
         newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_LOW)
@@ -157,7 +157,9 @@ public class JsFunctionScanRule extends PluginPassiveScanner {
     }
 
     private static void addPattern(String line, List<Pattern> list) {
-        list.add(Pattern.compile(Pattern.quote(line), Pattern.CASE_INSENSITIVE));
+        // Strip leading $, it's optionally included in the assembled patterns
+        line = line.replace("$", "");
+        list.add(Pattern.compile("\\b\\$?" + line + "\\b", Pattern.CASE_INSENSITIVE));
     }
 
     public static void setPayloadProvider(Supplier<Iterable<String>> provider) {

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -122,6 +122,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addO
 This scan rule checks for any dangerous JS functions present in a site response.<br>
 <strong>Note:</strong> If the Custom Payloads addon is installed you can add your own function names (payloads) in the Custom Payloads options panel.
 They will also be searched for in responses as they're passively scanned. Keep in mind that the greater the number of payloads the greater the amount of time needed to passively scan.
+<strong>Note:</strong> &dollar; is stripped from the start of the strings/payloads and is optionally included when the patterns are assembled.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/master/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java">JsFunctionScanRule.java</a>
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
@@ -33,6 +33,8 @@ import java.util.List;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -130,7 +132,7 @@ class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> 
 
         // Then
         assertThat(alertsRaised, hasSize(1));
-        assertEquals("$badFunction", alertsRaised.get(0).getEvidence());
+        assertEquals("badFunction", alertsRaised.get(0).getEvidence());
     }
 
     @Test
@@ -195,6 +197,21 @@ class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> 
         // Then
         assertThat(alertsRaised, hasSize(1));
         assertEquals("bypassSecurityTrustHtml", alertsRaised.get(0).getEvidence());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"globalEval", "parentPromiseValue"})
+    void shouldNotAlertOnMatchingSubString(String funcName)
+            throws HttpMalformedHeaderException, URIException {
+        // Given
+        String body = "Some text <script>" + funcName + "()</script>\n";
+        HttpMessage msg = createHttpMessageWithRespBody(body, "text/javascript;charset=ISO-8859-1");
+
+        // When
+        scanHttpResponseReceive(msg);
+
+        // Then
+        assertThat(alertsRaised, hasSize(0));
     }
 
     private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)


### PR DESCRIPTION
- CHANGELOG.md > Added fix note.
- JsFunctionScanRule > Don't java quote patterns, but do apply boundary markers on either side as well as an optional $ at the start, when assembling the patterns list. Clean code: Remove unnecessary parameters being passed in private method.
- JsFunctionScanRule > Add rule to assert the new boundary behavior.
- pscanalpha.html > Update help info.

Fixes zaproxy/zaproxy#6594

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>