### PR TITLE
Automation: Added passiveScan-config enableTags param

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support for using variables in the config.
 - Support for data jobs.
 - Support for multiple top level URLs in a context.
+- Passive scan config enableTags parameter
 
 ### Changed
 - Maintenance changes.

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-pscanconf.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-pscanconf.html
@@ -22,6 +22,7 @@ However you can run this job later, or multiple times, if you want different job
       maxAlertsPerRule: 10             # Int: Maximum number of alerts to raise per rule
       scanOnlyInScope: true            # Bool: Only scan URLs in scope (recommended)
       maxBodySizeInBytesToScan:        # Int: Maximum body size to scan, default: 0 - will scan all messages
+      enableTags: false                # Bool: Enable passive scan tags, default: false - enabling them can impact performance
     rules:                             # A list of one or more passive scan rules and associated settings which override the defaults
     - id:                              # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
       name:                            # String: The name of the rule for documentation purposes - this is not required or actually used

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -53,6 +53,7 @@ automation.error.urlsfound = Job {0} only found {1} URLs, expected at least {2}
 automation.error.unexpected = Unexpected error accessing file {0} : {1} - see log for details
 
 automation.error.pscan.rule.unknown = Unrecognised passive scan rule id for job {0} : {1}
+automation.error.pscan.nooptions = Failed to access passive scan options for job {0}
 
 automation.error.spider.url.notok = Job {0} failed to access URL {1} status code returned : {2} expected 200
 automation.error.spider.url.badhost.proxychain = Job {0} failed to access URL {1} your proxy chain may be wrong : {2}

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/passiveScan-config-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/passiveScan-config-max.yaml
@@ -3,6 +3,7 @@
       maxAlertsPerRule: 10             # Int: Maximum number of alerts to raise per rule
       scanOnlyInScope: true            # Bool: Only scan URLs in scope (recommended)
       maxBodySizeInBytesToScan:        # Int: Maximum body size to scan, default: 0 - will scan all messages
+      enableTags: false                # Bool: Enable passive scan tags, default: false - enabling them can impact performance
     rules:                             # A list of one or more passive scan rules and associated settings which override the defaults
     - id:                              # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
       name:                            # String: The name of the rule for documentation purposes - this is not required or actually used

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -23,6 +23,7 @@ jobs:
       maxAlertsPerRule: 10             # Int: Maximum number of alerts to raise per rule
       scanOnlyInScope: true            # Bool: Only scan URLs in scope (recommended)
       maxBodySizeInBytesToScan:        # Int: Maximum body size to scan, default: 0 - will scan all messages
+      enableTags: false                # Bool: Enable passive scan tags, default: false - enabling them can impact performance
     rules:                             # A list of one or more passive scan rules and associated settings which override the defaults
     - id:                              # Int: The rule id as per https://www.zaproxy.org/docs/alerts/
       name:                            # String: The name of the rule for documentation purposes - this is not required or actually used


### PR DESCRIPTION
We already disable the pscan tags in the packaged scans - this can give a significant performance improvement, esp for the passive scanning.
Unlike the packaged scans the user will be able to override the setting.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>