### PR TITLE
Check isStop at start of loops in ascanrules

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Correct Context check in SQL Injection scan rule.
 - "Source Code Disclosure - /WEB-INF folder" is no longer skipped on Java 9+ (Issue 4038).
+- Fix ascan rules not enforcing MaxRuleDuration when getting IOExceptions (Issue 6647).
 
 ## [39] - 2021-05-10
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
@@ -169,6 +169,10 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
      */
     private boolean testPhpInjection(String paramName) {
         for (String phpPayload : PHP_PAYLOADS) {
+            if (isStop()) {
+                break;
+            }
+
             HttpMessage msg = getNewMsg();
             setParameter(msg, paramName, phpPayload);
 
@@ -207,14 +211,6 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
                 // parameters on the same request (to reduce performance impact)
                 return true;
             }
-
-            // Check if the scan has been stopped
-            // if yes dispose resources and exit
-            if (isStop()) {
-                // Dispose all resources
-                // Exit the scan rule
-                break;
-            }
         }
 
         return false;
@@ -232,6 +228,10 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
         int bignum2 = RAND.nextInt(MAX_VALUE);
 
         for (String aspPayload : ASP_PAYLOADS) {
+            if (isStop()) {
+                break;
+            }
+
             HttpMessage msg = getNewMsg();
             setParameter(msg, paramName, MessageFormat.format(aspPayload, bignum1, bignum2));
 
@@ -267,11 +267,6 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
                         .setMessage(msg)
                         .raise();
                 return true;
-            }
-
-            if (isStop()) {
-                // Exit the scan rule
-                break;
             }
         }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
@@ -207,6 +207,9 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
         String redirectUrl;
 
         for (int h = 0; h < targetCount; h++) {
+            if (isStop()) {
+                return;
+            }
 
             payload = REDIRECT_TARGETS[h];
 
@@ -251,13 +254,6 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
                     // parameters on the same request (to reduce performance impact)
                     return;
                 }
-
-                // Check if the scan has been stopped
-                // if yes dispose resources and exit
-                if (isStop()) {
-                    return;
-                }
-
             } catch (IOException ex) {
                 // Do not try to internationalize this.. we need an error message in any event..
                 // if it's in English, it's still better than not having it at all.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -483,6 +483,9 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
                     // for the url filename, try each of the prefixes in turn
                     for (String prefix : LOCAL_FILE_RELATIVE_PREFIXES) {
+                        if (isStop()) {
+                            return;
+                        }
 
                         prefixedUrlfilename = prefix + urlfilename;
                         msg = getNewMsg();
@@ -527,14 +530,6 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
 
                             // All done. No need to look for vulnerabilities on subsequent
                             // parameters on the same request (to reduce performance impact)
-                            return;
-                        }
-
-                        // Check if the scan has been stopped
-                        // if yes dispose resources and exit
-                        if (isStop()) {
-                            // Dispose all resources
-                            // Exit the scan rule
                             return;
                         }
                     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
@@ -190,6 +190,10 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
 
                 // for each target in turn
                 for (int i = 0; i < REMOTE_FILE_TARGETS.length; i++) {
+                    if (isStop()) {
+                        return;
+                    }
+
                     String target = REMOTE_FILE_TARGETS[i];
 
                     // get a new copy of the original message (request only) for each parameter
@@ -234,14 +238,6 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
                             // parameters on the same request (to reduce performance impact)
                             return;
                         }
-                    }
-
-                    // Check if the scan has been stopped
-                    // if yes dispose resources and exit
-                    if (isStop()) {
-                        // Dispose all resources
-                        // Exit the scan rule
-                        return;
                     }
                 }
             }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -646,6 +646,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 for (int prefixIndex = 0;
                         prefixIndex < prefixStrings.length && !sqlInjectionFoundForUrl;
                         prefixIndex++) {
+                    // bale out if we were asked nicely
+                    if (isStop()) {
+                        log.debug("Stopping the scan due to a user request");
+                        return;
+                    }
 
                     // new message for each value we attack with
                     HttpMessage msg1 = getNewMsg();
@@ -675,6 +680,12 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                     // Note: do NOT check the HTTP error code just yet, as the result could come
                     // back with one of various codes.
                     for (RDBMS rdbms : RDBMS.values()) {
+                        // bale out if we were asked nicely
+                        if (isStop()) {
+                            log.debug("Stopping the scan due to a user request");
+                            return;
+                        }
+
                         if (getTechSet().includes(rdbms.getTech())
                                 && checkSpecificErrors(rdbms, msg1, param, sqlErrValue)) {
                             sqlInjectionFoundForUrl = true;
@@ -683,11 +694,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             sqlInjectionAttack = sqlErrValue;
                             break;
                         }
-                        // bale out if we were asked nicely
-                        if (isStop()) {
-                            log.debug("Stopping the scan due to a user request");
-                            return;
-                        }
                     } // end of the loop to check for RDBMS specific error messages
 
                     if (this.doGenericErrorBased && !sqlInjectionFoundForUrl) {
@@ -695,6 +701,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                                 RDBMS.GenericRDBMS.getErrorPatterns().iterator();
 
                         while (errorPatternIterator.hasNext() && !sqlInjectionFoundForUrl) {
+                            if (isStop()) {
+                                log.debug("Stopping the scan due to a user request");
+                                return;
+                            }
+
                             Pattern errorPattern = errorPatternIterator.next();
                             String errorPatternRDBMS = RDBMS.GenericRDBMS.getName();
 
@@ -733,11 +744,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
 
                                 sqlInjectionFoundForUrl = true;
                                 continue;
-                            }
-                            // bale out if we were asked nicely
-                            if (isStop()) {
-                                log.debug("Stopping the scan due to a user request");
-                                return;
                             }
                         } // end of the loop to check for RDBMS specific error messages
                     }
@@ -934,6 +940,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             && doBooleanBased
                             && countBooleanBasedRequests < doBooleanMaxRequests;
                     i++) {
+                if (isStop()) {
+                    log.debug("Stopping the scan due to a user request");
+                    return;
+                }
+
                 // needs a new message for each type of AND to be issued
                 HttpMessage msg2 = getNewMsg();
                 // ZAP: Removed getURLDecode()
@@ -971,6 +982,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 for (int booleanStrippedUnstrippedIndex = 0;
                         booleanStrippedUnstrippedIndex < 2;
                         booleanStrippedUnstrippedIndex++) {
+                    if (isStop()) {
+                        log.debug("Stopping the scan due to a user request");
+                        return;
+                    }
+
                     // if the results of the "AND 1=1" match the original query (using either the
                     // stipped or unstripped versions), we may be onto something.
                     if (andTrueBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
@@ -1242,11 +1258,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             log.debug("DIFFS: {}", tempDiff);
                         }
                     }
-                    // bale out if we were asked nicely
-                    if (isStop()) {
-                        log.debug("Stopping the scan due to a user request");
-                        return;
-                    }
                 } // end of boolean logic output index (unstripped + stripped)
             }
             // end of check 2
@@ -1264,6 +1275,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             && doBooleanBased
                             && countBooleanBasedRequests < doBooleanMaxRequests;
                     i++) {
+                if (isStop()) {
+                    log.debug("Stopping the scan due to a user request");
+                    return;
+                }
+
                 HttpMessage msg2 = getNewMsg();
                 String sqlBooleanOrTrueValue = origParamValue + SQL_LOGIC_OR_TRUE[i];
                 String sqlBooleanAndFalseValue = origParamValue + SQL_LOGIC_AND_FALSE[i];
@@ -1376,6 +1392,10 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             && doUnionBased
                             && countUnionBasedRequests < doUnionMaxRequests;
                     sqlUnionStringIndex++) {
+                if (isStop()) {
+                    log.debug("Stopping the scan due to a user request");
+                    return;
+                }
 
                 // new message for each value we attack with
                 HttpMessage msg3 = getNewMsg();
@@ -1400,6 +1420,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 // TODO: maybe also try looking at a differentiation based approach?? Prone to false
                 // positives though.
                 for (RDBMS rdbms : RDBMS.values()) {
+                    if (isStop()) {
+                        log.debug("Stopping the scan due to a user request");
+                        return;
+                    }
+
                     if (getTechSet().includes(rdbms.getTech())
                             && checkUnionErrors(
                                     rdbms,
@@ -1414,11 +1439,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                         // necessary
                         sqlInjectionAttack = sqlUnionValue;
                         break;
-                    }
-                    // bale out if we were asked nicely
-                    if (isStop()) {
-                        log.debug("Stopping the scan due to a user request");
-                        return;
                     }
                 } // end of the loop to check for RDBMS specific UNION error messages
             } //// for each SQL UNION combination to try
@@ -1505,6 +1525,11 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 for (int booleanStrippedUnstrippedIndex = 0;
                         booleanStrippedUnstrippedIndex < 2;
                         booleanStrippedUnstrippedIndex++) {
+                    if (isStop()) {
+                        log.debug("Stopping the scan due to a user request");
+                        return;
+                    }
+
                     // if the results of the modified request match the original query, we may be
                     // onto something.
                     if (ascendingBodyOutput[booleanStrippedUnstrippedIndex].compareTo(
@@ -1593,11 +1618,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                             sqlInjectionFoundForUrl = true;
                             break; // No further need to loop
                         }
-                    }
-                    // bale out if we were asked nicely
-                    if (isStop()) {
-                        log.debug("Stopping the scan due to a user request");
-                        return;
                     }
                 }
             }


### PR DESCRIPTION
Fixes [zaproxy/zaproxy#6647](https://github.com/zaproxy/zaproxy/issues/6647)

The original issue was only for the CodeInjectionScanRule. This change also updates other rules that had the same problem.

Doesn't look like any of the rules currently unit test responding to stops and I did not see a straightforward way to add tests. Please let me know if anyone with more experience on the code base has thoughts for testing.