### PR TITLE
Reports - fix slash issue

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Include all relevant alerts in XML report templates (Issue 6627).
 - Made XML reports more backwards compatible and fixed issue with generating it via the API.
+- Issue with reports for sites with trailing slashes
 
 ## [0.3.0] - 2021-05-06
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -517,6 +517,10 @@ public class ExtensionReports extends ExtensionAdaptor {
             if (i >= 0) {
                 site = site.substring(0, i);
             }
+            i = site.indexOf("/");
+            if (i >= 0) {
+                site = site.substring(0, i);
+            }
         }
         while (name.contains(SITE_PATTERN)) {
             name = name.replace(SITE_PATTERN, site);

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -101,10 +101,18 @@ class ExtensionReportsUnitTest {
 
         // When
         String dateStr = sdf.format(new Date());
-        String name = ExtensionReports.getNameFromPattern(pattern, "https://www.example.com");
+        String expectedName = dateStr + "-ZAP-Report-www.example.com";
+        String name1 = ExtensionReports.getNameFromPattern(pattern, "https://www.example.com");
+        String name2 = ExtensionReports.getNameFromPattern(pattern, "https://www.example.com/");
+        String name3 =
+                ExtensionReports.getNameFromPattern(pattern, "https://www.example.com:8443/");
+        String name4 = ExtensionReports.getNameFromPattern(pattern, "https://www.example.com/path");
 
         // Then
-        assertThat(name, is(equalTo(dateStr + "-ZAP-Report-www.example.com")));
+        assertThat(name1, is(equalTo(expectedName)));
+        assertThat(name2, is(equalTo(expectedName)));
+        assertThat(name3, is(equalTo(expectedName)));
+        assertThat(name4, is(equalTo(expectedName)));
     }
 
     @Test


### PR DESCRIPTION
The trailing slash (and path) were not being striped off the name which meant that directories were incorectly being created.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>