### PR TITLE
automation: Fix job run order

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -180,7 +180,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
             return progress;
         }
 
-        Map<AutomationJob, LinkedHashMap<?, ?>> jobsToRun = new HashMap<>();
+        Map<AutomationJob, LinkedHashMap<?, ?>> jobsToRun = new LinkedHashMap<>();
 
         for (Object jobObj : jobsData) {
             if (!(jobObj instanceof LinkedHashMap<?, ?>)) {


### PR DESCRIPTION
Fix a bug due to which the jobs ran in a different order than the one specified in the config. Added tests to verify the same.