### PR TITLE
automation: Fix bug in which known custom parameters raise warnings

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -107,10 +107,13 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
      * @param name name of the parameter
      * @param value value of the parameter
      * @param progress to store the warnings/errors which occurred during verification
+     * @return {@code true} if the parameter was verified, {@code false} otherwise.
      * @since 0.3.0
      * @see #applyCustomParameter(String, String)
      */
-    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {}
+    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
+        return false;
+    }
 
     public String getTemplateDataMin() {
         return ExtensionAutomation.getResourceAsString(this.getType() + "-min.yaml");
@@ -195,7 +198,9 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
                     continue;
                 }
             } else {
-                verifyCustomParameter(key, resolvedValue, progress);
+                if (verifyCustomParameter(key, resolvedValue, progress)) {
+                    continue;
+                }
             }
             if (methodMap != null) {
                 String paramMethodName = "set" + key.toUpperCase().charAt(0) + key.substring(1);

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -121,8 +121,8 @@ public class ActiveScanJob extends AutomationJob {
     }
 
     @Override
-    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        this.verifyOrApplyCustomParameter(name, value, progress);
+    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
+        return this.verifyOrApplyCustomParameter(name, value, progress);
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/AddOnJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/AddOnJob.java
@@ -153,8 +153,8 @@ public class AddOnJob extends AutomationJob {
     }
 
     @Override
-    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        this.verifyOrApplyCustomParameter(name, value, progress);
+    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
+        return this.verifyOrApplyCustomParameter(name, value, progress);
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJob.java
@@ -110,8 +110,8 @@ public class PassiveScanWaitJob extends AutomationJob {
     }
 
     @Override
-    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        verifyOrApplyCustomParameter(name, value, progress);
+    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
+        return this.verifyOrApplyCustomParameter(name, value, progress);
     }
 
     public int getMaxDuration() {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
@@ -136,8 +136,8 @@ public class SpiderJob extends AutomationJob {
     }
 
     @Override
-    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        this.verifyOrApplyCustomParameter(name, value, progress);
+    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
+        return this.verifyOrApplyCustomParameter(name, value, progress);
     }
 
     @Override

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/OutputSummaryJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/OutputSummaryJob.java
@@ -179,7 +179,7 @@ public class OutputSummaryJob extends AutomationJob {
     }
 
     @Override
-    public void verifyCustomParameter(String name, String value, AutomationProgress progress) {
+    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
         switch (name) {
             case PARAM_FORMAT:
                 try {
@@ -192,7 +192,7 @@ public class OutputSummaryJob extends AutomationJob {
                                     value,
                                     Format.values()));
                 }
-                break;
+                return true;
             case PARAM_SUMMARY_FILE:
                 File parent = new File(value).getParentFile();
                 if (!parent.exists()) {
@@ -208,11 +208,12 @@ public class OutputSummaryJob extends AutomationJob {
                                     this.getName(),
                                     parent.getAbsolutePath()));
                 }
-                break;
+                return true;
             default:
                 // Ignore
                 break;
         }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Modified the verifyCustomParameter method to indicate whether the parameter was verified. Added tests to validate that no warnings are raised. Updated existing tests to replace applyParameters by verifyParameters where necessary.