### PR TITLE
automation: set the environment for jobs

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -212,6 +212,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
                             Constant.messages.getString("automation.error.job.data", paramsObj));
                     continue;
                 }
+                job.setEnv(env);
                 job.verifyParameters((LinkedHashMap<?, ?>) paramsObj, progress);
                 job.verifyJobSpecificData(jobData, progress);
                 jobsToRun.put(job, jobData);

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -279,6 +279,38 @@ class ExtentionAutomationUnitTest extends TestUtils {
         assertThat(job3.wasRun(), is(equalTo(true)));
     }
 
+    @Test
+    void shouldRunWithResolvedParams() {
+        // Given
+        ExtensionAutomation extAuto = new ExtensionAutomation();
+        TestParamContainer tpc = new TestParamContainer();
+        AutomationJobImpl job =
+                new AutomationJobImpl(tpc) {
+                    @Override
+                    public String getType() {
+                        return "job";
+                    }
+
+                    @Override
+                    public Order getOrder() {
+                        return Order.EXPLORE;
+                    }
+                };
+        Path filePath = getResourcePath("resources/testplan-applyResolvedParams.yaml");
+
+        // When
+        extAuto.registerAutomationJob(job);
+        AutomationProgress progress =
+                extAuto.runAutomationFile(filePath.toAbsolutePath().toString());
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(job.wasRun(), is(equalTo(true)));
+        assertThat(tpc.getTestParam().getBoolParam(), is(equalTo(true)));
+        assertThat(tpc.getTestParam().getStringParam(), is(equalTo("envVarValue")));
+    }
+
     @Nested
     class PlanInOrderTests {
 
@@ -586,15 +618,36 @@ class ExtentionAutomationUnitTest extends TestUtils {
     private static class TestParam {
 
         private boolean boolParam;
+        private String stringParam;
 
         public void setBoolParam(boolean boolParam) {
             this.boolParam = boolParam;
+        }
+
+        public boolean getBoolParam() {
+            return boolParam;
+        }
+
+        public void setStringParam(String stringParam) {
+            this.stringParam = stringParam;
+        }
+
+        public String getStringParam() {
+            return stringParam;
         }
     }
 
     private static class AutomationJobImpl extends AutomationJob {
 
         private boolean wasRun = false;
+        private Object paramMethodObject;
+        private String paramNameMethod = "getTestParam";
+
+        public AutomationJobImpl() {}
+
+        public AutomationJobImpl(Object paramMethodObject) {
+            this.paramMethodObject = paramMethodObject;
+        }
 
         @Override
         public void runJob(
@@ -620,12 +673,12 @@ class ExtentionAutomationUnitTest extends TestUtils {
 
         @Override
         public Object getParamMethodObject() {
-            return null;
+            return paramMethodObject;
         }
 
         @Override
         public String getParamMethodName() {
-            return null;
+            return paramNameMethod;
         }
     }
 

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-applyResolvedParams.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-applyResolvedParams.yaml
@@ -1,0 +1,17 @@
+env:
+  contexts:
+    - name: example
+      urls:
+        - https://www.example.com/
+  vars:
+    myVarOne: true
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+
+jobs:
+  - type: job
+    parameters:
+      boolParam: ${myVarOne}
+      stringParam: ${myEnvVar}


### PR DESCRIPTION
Fix bug where the environment was not set for the jobs, which lead to the jobs not using resolved values. Added test to verify the same.