### PR TITLE
Enable Kotlin syntax highlighting

### DIFF
--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Use appropriate syntax style for highlighting of code (requires newer ZAP version).
 - Update minimum ZAP version to 2.10.0.
 
 ## [1.0.0] - 2020-09-14

--- a/addOns/kotlin/src/main/java/org/zaproxy/addon/kotlin/KotlinEngineWrapper.java
+++ b/addOns/kotlin/src/main/java/org/zaproxy/addon/kotlin/KotlinEngineWrapper.java
@@ -27,7 +27,6 @@ import javax.script.ScriptException;
 import javax.swing.ImageIcon;
 import kotlin.script.experimental.jsr223.KotlinJsr223DefaultScriptEngineFactory;
 import kotlin.script.experimental.jsr223.KotlinJsr223DefaultScriptEngineFactoryKt;
-import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.script.DefaultEngineWrapper;
 
@@ -58,7 +57,8 @@ public class KotlinEngineWrapper extends DefaultEngineWrapper {
 
     @Override
     public String getSyntaxStyle() {
-        return SyntaxConstants.SYNTAX_STYLE_NONE;
+        // TODO Use constant when available: SyntaxConstants.SYNTAX_STYLE_KOTLIN
+        return "text/kotlin";
     }
 
     @Override

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Allow to choose Kotlin for syntax highlighting (requires newer ZAP version).
+
 ### Changed
 - Do not show `Null` script engine in Edit Script dialogue.
 - Now using 2.10 logging infrastructure (Log4j 2.x).

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
@@ -61,6 +61,8 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
             Constant.messages.getString("scripts.syntaxtext.syntax.html");
     public static final String CSS_SYNTAX_LABEL =
             Constant.messages.getString("scripts.syntaxtext.syntax.css");
+    private static final String KOTLIN_SYNTAX_LABEL =
+            Constant.messages.getString("scripts.syntaxtext.syntax.kotlin");
 
     private Vector<SyntaxStyle> syntaxStyles;
 
@@ -94,6 +96,8 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
         addSyntaxStyle(SCALA_SYNTAX_LABEL, SyntaxConstants.SYNTAX_STYLE_SCALA);
         addSyntaxStyle(HTML_SYNTAX_LABEL, SyntaxConstants.SYNTAX_STYLE_HTML);
         addSyntaxStyle(CSS_SYNTAX_LABEL, SyntaxConstants.SYNTAX_STYLE_CSS);
+        // TODO Use constant when available: SyntaxConstants.SYNTAX_STYLE_KOTLIN
+        addSyntaxStyle(KOTLIN_SYNTAX_LABEL, "text/kotlin");
 
         initActions();
 

--- a/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
+++ b/addOns/scripts/src/main/resources/org/zaproxy/zap/extension/scripts/resources/Messages.properties
@@ -29,6 +29,7 @@ scripts.syntaxtext.syntax.plain			= Plain
 scripts.syntaxtext.syntax.clojure		= Clojure
 scripts.syntaxtext.syntax.groovy		= Groovy
 scripts.syntaxtext.syntax.javascript	= JavaScript
+scripts.syntaxtext.syntax.kotlin = Kotlin
 scripts.syntaxtext.syntax.python		= Python
 scripts.syntaxtext.syntax.ruby			= Ruby
 scripts.syntaxtext.syntax.scala			= Scala


### PR DESCRIPTION
Allow to choose Kotlin and use appropriate style.
Requires zaproxy/zaproxy#6653 for actual highlighting.