### PR TITLE
automation: Fix broken custom params verification

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -112,7 +112,7 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
      * @see #applyCustomParameter(String, String)
      */
     public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        return false;
+        return getCustomConfigParameters().containsKey(name);
     }
 
     public String getTemplateDataMin() {


### PR DESCRIPTION
Do not break existing automation jobs that have not yet implemented
the new verifyCustomParameter method (AjaxSpiderJob, OpenApiJob, SoapJob, etc.)

Signed-off-by: ricekot <ricekot@gmail.com>