### PR TITLE
Reports: OutputSummary config file support phase 1

### DIFF
--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ExtensionReports.java
@@ -238,7 +238,7 @@ public class ExtensionReports extends ExtensionAdaptor {
         return true;
     }
 
-    private AlertNode getRootAlertNode()
+    public AlertNode getRootAlertNode()
             throws NoSuchMethodException, SecurityException, IllegalAccessException,
                     IllegalArgumentException, InvocationTargetException {
         ExtensionAlert extAlert =

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/HttpStatusReason.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/HttpStatusReason.java
@@ -20,12 +20,15 @@
 package org.zaproxy.addon.reports;
 
 /**
- * The reason for the HTTP status codes.
+ * <strong>Note:</strong> Internal class. The reason for the HTTP status codes.
+ *
+ * <p>It is only public as it is used by classes in a sub-package. It should not be used by other
+ * add-ons.
  *
  * @see <a href="https://www.iana.org/assignments/http-status-codes/http-status-codes.txt">Status
  *     Code Registry</a>
  */
-final class HttpStatusReason {
+public final class HttpStatusReason {
 
     private HttpStatusReason() {}
 
@@ -35,7 +38,7 @@ final class HttpStatusReason {
      * @param code the status code.
      * @return the reason for the given code, or an empty string if unknown.
      */
-    static String get(int code) {
+    public static String get(int code) {
         switch (code) {
             case 100:
                 return "Continue";


### PR DESCRIPTION
Initial support for the packaged scan config files.
Supports setting the alerts to IGNORE/INFO/WARN/FAIL.
It does not yet support the OUTOFSCOPE elements so will not be enabled in the baseline scan just yet.

However this PR also includes some tweaks to make the output more backwards compatible, based on tests created for the baseline scan.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>