### PR TITLE
Report tweaks

### DIFF
--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportApi.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportApi.java
@@ -163,6 +163,8 @@ public class ReportApi extends ApiImplementor {
                     sitesList.addAll(
                             Arrays.asList(params.getString(PARAM_SITES).split(DELIMITER_REGEX)));
                     reportData.setSites(sitesList);
+                } else {
+                    reportData.setSites(ExtensionReports.getSites());
                 }
 
                 if (isContainedParam(PARAM_SECTIONS, params)) {
@@ -241,7 +243,9 @@ public class ReportApi extends ApiImplementor {
                                                 ? params.getString(PARAM_REPORT_FILE_NAME_PATTERN)
                                                 : ReportParam.DEFAULT_NAME_PATTERN,
                                         (sitesList.size() > 0 ? sitesList.get(0) : ""));
-                reportFileName += '.' + template.getExtension();
+                if (!reportFileName.endsWith(template.getExtension())) {
+                    reportFileName += '.' + template.getExtension();
+                }
                 String reportFilePath = Paths.get(paramReportDir, reportFileName).toString();
 
                 boolean display = params.optBoolean(PARAM_DISPLAY, false);

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-xml/report.xml
@@ -11,6 +11,7 @@
 					<alertitem>
 						<pluginid th:text="${alert.pluginId}"></pluginid>
 						<alertRef th:text="${alert.alertRef}"></alertRef>
+						<alert th:text="${alert.name}"></alert>
 						<name th:text="${alert.name}"></name>
 						<riskcode th:text="${alert.risk}"></riskcode>
 						<confidence th:text="${alert.confidence}"></confidence>

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -660,7 +660,7 @@ class ExtensionReportsUnitTest {
         assertThat(alertItems.getLength(), is(equalTo(1)));
 
         NodeList alertItemNodes = alertItems.item(0).getChildNodes();
-        assertThat(alertItemNodes.getLength(), is(equalTo(33)));
+        assertThat(alertItemNodes.getLength(), is(equalTo(35)));
 
         int i = 0;
         assertThat(alertItemNodes.item(i).getNodeName(), is(equalTo("#text"))); // Filler
@@ -672,6 +672,11 @@ class ExtensionReportsUnitTest {
         i++;
         assertThat(alertItemNodes.item(i).getNodeName(), is(equalTo("alertRef")));
         assertThat(alertItemNodes.item(i).getTextContent(), is(equalTo("1")));
+        i++;
+        assertThat(alertItemNodes.item(i).getNodeName(), is(equalTo("#text"))); // Filler
+        i++;
+        assertThat(alertItemNodes.item(i).getNodeName(), is(equalTo("alert")));
+        assertThat(alertItemNodes.item(i).getTextContent(), is(equalTo("XSS")));
         i++;
         assertThat(alertItemNodes.item(i).getNodeName(), is(equalTo("#text"))); // Filler
         i++;

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ReportApiUnitTest.java
@@ -304,7 +304,7 @@ class ReportApiUnitTest {
         assertAll(
                 () -> assertThat(reportData.getDescription(), is("")),
                 () -> assertThat(reportData.getContexts(), is(nullValue())),
-                () -> assertThat(reportData.getSites(), is(nullValue())),
+                () -> assertThat(reportData.getSites().size(), is(0)),
                 () -> assertThat(reportData.getSections(), is(template.getSections())),
                 () ->
                         assertThat(

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-xml.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<OWASPZAPReport version="Dev Build" generated="Thu, 17 Jun 2021 16:04:29">
+<OWASPZAPReport version="Dev Build" generated="Tue, 22 Jun 2021 15:11:26">
 	
 		<site name="http://example.com" host="example.com" port="80" ssl="false">
 			<alerts>
@@ -7,6 +7,7 @@
 					<alertitem>
 						<pluginid>1</pluginid>
 						<alertRef>1</alertRef>
+						<alert>XSS</alert>
 						<name>XSS</name>
 						<riskcode>3</riskcode>
 						<confidence>2</confidence>


### PR DESCRIPTION
Default to all sites when called by the API.
Dont append file extension via API if its already there.
Add missing `alert` element in XML report.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>