### PR TITLE
Requester: Add button to update content length

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Warn when unable to save (malformed) HTTP message (Issue 4235).
 - Update minimum ZAP version to 2.10.0.
 - Maintenance changes.
+- Add button to automatically update content length (Issue 6254).
 
 ## [4] - 2020-07-15
 ### Added

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/HttpPanelSender.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/HttpPanelSender.java
@@ -49,6 +49,7 @@ import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
 import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
 import org.zaproxy.zap.extension.httppanel.Message;
+import org.zaproxy.zap.extension.httppanel.view.impl.models.http.HttpPanelViewModelUtils;
 import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.network.HttpRedirectionValidator;
 import org.zaproxy.zap.network.HttpRequestConfig;
@@ -63,6 +64,7 @@ public class HttpPanelSender implements MessageSender {
 
     private HttpSender delegate;
 
+    private JToggleButton fixContentLength = null;
     private JToggleButton followRedirect = null;
     private JToggleButton useTrackingSessionState = null;
     private JToggleButton useCookies = null;
@@ -77,6 +79,8 @@ public class HttpPanelSender implements MessageSender {
         requestPanel.addOptions(getButtonUseCookies(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
         requestPanel.addOptions(
                 getButtonFollowRedirects(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
+        requestPanel.addOptions(
+                getButtonFixContentLength(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
 
         final boolean isSessionTrackingEnabled =
                 Model.getSingleton().getOptionsParam().getConnectionParam().isHttpStateEnabled();
@@ -88,6 +92,10 @@ public class HttpPanelSender implements MessageSender {
         final HttpMessage httpMessage = (HttpMessage) aMessage;
         // Reset the user before sending (e.g. Forced User mode sets the user, if needed).
         httpMessage.setRequestingUser(null);
+
+        if (getButtonFixContentLength().isSelected()) {
+            HttpPanelViewModelUtils.updateRequestContentLength(httpMessage);
+        }
         try {
             final ModeRedirectionValidator redirectionValidator = new ModeRedirectionValidator();
             boolean followRedirects = getButtonFollowRedirects().isSelected();
@@ -266,6 +274,20 @@ public class HttpPanelSender implements MessageSender {
                     e -> setUseCookies(e.getStateChange() == ItemEvent.SELECTED));
         }
         return useCookies;
+    }
+
+    private JToggleButton getButtonFixContentLength() {
+        if (fixContentLength == null) {
+            fixContentLength =
+                    new JToggleButton(
+                            new ImageIcon(
+                                    HttpPanelSender.class.getResource(
+                                            "/resource/icon/fugue/application-resize.png")),
+                            true);
+            fixContentLength.setToolTipText(
+                    Constant.messages.getString("manReq.checkBox.fixLength"));
+        }
+        return fixContentLength;
     }
 
     public void addPersistentConnectionListener(PersistentConnectionListener listener) {


### PR DESCRIPTION
This commit adds the button to automatically update the content length. The code was copied from the Resend Request window in ZAP core (see https://github.com/zaproxy/zaproxy/pull/6193).

Closes https://github.com/zaproxy/zaproxy/issues/6254

![zap-requester-screenshot](https://user-images.githubusercontent.com/62751754/123217437-dc556b80-d4ca-11eb-88b4-4ff7d5c653b0.png)
