### PR TITLE
reports: hardcode ZAP version in tests

### DIFF
--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/ExtensionReportsUnitTest.java
@@ -91,6 +91,8 @@ class ExtensionReportsUnitTest {
         ExtensionLoader extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
         Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
         Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
+
+        Constant.PROGRAM_VERSION = "Dev Build";
     }
 
     @Test


### PR DESCRIPTION
Use hardcoded version when testing the generated reports to not rely on
the order the tests are executed, some tests make use of the ZAP home
which resolve the ZAP version to `2.10.0`, while the test reports are
expected to have `Dev Build`.