### PR TITLE
GraphQL - dont fail if no URL in automation job

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Report no URL specified in automation job as info instead of failure.
 
 ## [0.3.0] - 2021-03-30
 ### Changed

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
@@ -46,8 +46,6 @@ public class GraphQlJob extends AutomationJob {
 
     private static final String RESOURCES_DIR = "/org/zaproxy/addon/graphql/resources/";
 
-    private ExtensionGraphQl extGraphQl;
-
     private String endpoint;
     private String schemaUrl;
     private String schemaFile;
@@ -87,7 +85,7 @@ public class GraphQlJob extends AutomationJob {
             AutomationEnvironment env, LinkedHashMap<?, ?> jobData, AutomationProgress progress) {
 
         if (endpoint == null || endpoint.isEmpty()) {
-            progress.error(Constant.messages.getString("graphql.error.emptyendurl"));
+            progress.info(Constant.messages.getString("graphql.info.emptyendurl"));
             return;
         }
 

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -61,9 +61,10 @@ graphql.importfromfiledialog.title = Import a GraphQL Schema from a File
 graphql.importfromfiledialog.labelfile = Schema File
 graphql.importfromfiledialog.choosefilebutton = Choose File
 
+graphql.info.emptyendurl = No GraphQL URL specified.
+
 graphql.error.importfile = An error occurred while importing from file.
 graphql.error.filenotfound = Cannot find the specified file.
-graphql.error.emptyendurl = Endpoint URL must be specified.
 graphql.error.invalidurl = Please enter a valid URL.\n{0}
 
 graphql.options.panelName = GraphQL

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
@@ -135,7 +135,7 @@ class GraphQlJobUnitTest {
     }
 
     @Test
-    void shouldFailIfEmptyEndpoint() {
+    void shouldInfoIfEmptyEndpoint() {
         // Given
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
@@ -143,16 +143,16 @@ class GraphQlJobUnitTest {
         // When
         GraphQlJob job = new GraphQlJob();
         job.applyCustomParameter("endpoint", "");
-        // The job should fail even if other parameters are specified
+        // The job should info even if other parameters are specified
         job.applyCustomParameter("schemaUrl", "http://example.com/schema.graphql");
         job.applyCustomParameter("schemaFile", "/home/zap/schema.graphql");
         job.runJob(env, null, progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(false)));
-        assertThat(progress.hasErrors(), is(equalTo(true)));
-        assertThat(progress.getErrors().size(), is(equalTo(1)));
-        assertThat(progress.getErrors().get(0), is(equalTo("!graphql.error.emptyendurl!")));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.getInfos().size(), is(equalTo(1)));
+        assertThat(progress.getInfos().get(0), is(equalTo("!graphql.info.emptyendurl!")));
     }
 
     @Test


### PR DESCRIPTION
The docs even say `default: null, no schema is imported`

Signed-off-by: Simon Bennetts <psiinon@gmail.com>