### PR TITLE
Correct dependency requirements

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct dependency requirements.
 
 ## [34] - 2021-06-17
 ### Changed

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -27,7 +27,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("custompayloads") {
-                            version.set("0.9.*")
+                            version.set(">= 0.9.0 & < 1.0.0")
                         }
                     }
                 }

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Correct dependency requirements.
+
 ## [34] - 2021-06-17
 ### Changed
 - Cache-control scan rule no longer checks if Pragma is set or not.

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -25,7 +25,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("custompayloads") {
-                            version.set("0.9.*")
+                            version.set(">= 0.9.0 & < 1.0.0")
                         }
                     }
                 }

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Correct dependency requirements.
+
 ## [31] - 2021-06-17
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -19,7 +19,7 @@ zapAddOn {
                     }
                     addOns {
                         register("custompayloads") {
-                            version.set("0.9.*")
+                            version.set(">= 0.9.0 & < 1.0.0")
                         }
                     }
                 }


### PR DESCRIPTION
Change `ascanrulesBeta`, `pscanrules`, and `pscanrulesAlpha` to use a
version range when declaring the dependency on `custompayloads` to
include more versions and allow to use the version already released.