### PR TITLE
pscanrulesAlpha: correct dependency declaration

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Correct dependency declaration on Common Library add-on (Issue 6674).
 
 ## [32] - 2021-07-06
 ### Changed

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -6,17 +6,19 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">= 1.4.0 & < 2.0.0")
+                }
+            }
+        }
         extensions {
             register("org.zaproxy.zap.extension.pscanrulesAlpha.payloader.ExtensionPayloader") {
                 classnames {
                     allowed.set(listOf("org.zaproxy.zap.extension.pscanrulesAlpha.payloader"))
                 }
                 dependencies {
-                    addOns {
-                        register("commonlib") {
-                            version.set(">= 1.4.0 & < 2.0.0")
-                        }
-                    }
                     addOns {
                         register("custompayloads") {
                             version.set(">= 0.9.0 & < 1.0.0")


### PR DESCRIPTION
Make `commonlib` a dependency of the whole add-on not just the
extension.

Fix zaproxy/zaproxy#6674.