### PR TITLE
improve: alertFilters: Add apply and test API endpoints

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.10.0.
 - Maintenance changes.
 
+### Added
+- API endpoints "applyAll", "applyContext", and "applyGlobal" to apply enabled Alert Filters to existing alerts (Issue 5966).
+- API endpoints "testAll", "testContext", and "testGlobal" to test enabled Alert Filters against existing alerts.
+
 ## [10] - 2020-01-17
 ### Added
 - Add info and repo URLs.

--- a/addOns/alertFilters/src/main/resources/org/zaproxy/zap/extension/alertFilters/resources/Messages.properties
+++ b/addOns/alertFilters/src/main/resources/org/zaproxy/zap/extension/alertFilters/resources/Messages.properties
@@ -7,7 +7,13 @@ alertFilters.api.action.addAlertFilter = Adds a new alert filter for the context
 alertFilters.api.action.removeAlertFilter = Removes an alert filter from the context with the given ID.
 alertFilters.api.view.globalAlertFilterList = Lists the global alert filters.
 alertFilters.api.action.addGlobalAlertFilter = Adds a new global alert filter. 
+alertFilters.api.action.applyAll = Applies all currently enabled Global and Context alert filters.
+alertFilters.api.action.applyContext = Applies all currently enabled Context alert filters.
+alertFilters.api.action.applyGlobal = Applies all currently enabled Global alert filters.
 alertFilters.api.action.removeGlobalAlertFilter = Removes a global alert filter.
+alertFilters.api.action.testAll = Tests all currently enabled Global and Context alert filters.
+alertFilters.api.action.testContext = Tests all currently enabled Context alert filters.
+alertFilters.api.action.testGlobal = Tests all currently enabled Global alert filters.
 
 alertFilters.desc					= Context alert rules filter
 


### PR DESCRIPTION
To apply Alert Filters to existing alerts.

AlertFilterAPI > Added endpoints and functionality.
CHANGELOG > Added addition note.
Messages.properties > Added endpoint description key/value pairs.

Fixes zaproxy/zaproxy#5966

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>