### PR TITLE
improve: wappalyzer: Reduce visibility of 'Unexpected header type' msgs

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
 - Maintenance changes.
+- Reduce logging of "Unexpected header type" messages from error to debug (related to Issue 6607).
 
 ## [21.2.0] - 2021-06-17
 ### Changed

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -281,7 +281,10 @@ public class WappalyzerJsonParser {
             }
         } else if (json != null) {
             logger.error(
-                    "Unexpected header type for {} {}", json, json.getClass().getCanonicalName());
+                    "Unexpected JSON type for {} pattern: {} {}",
+                    type,
+                    json,
+                    json.getClass().getCanonicalName());
         }
         return list;
     }
@@ -349,8 +352,11 @@ public class WappalyzerJsonParser {
                 }
             }
         } else {
-            logger.error(
-                    "Unexpected header type for {} : {}", json, json.getClass().getCanonicalName());
+            logger.debug(
+                    "Unexpected JSON type for {} pattern: {} {}",
+                    type,
+                    json,
+                    json.getClass().getCanonicalName());
         }
         return list;
     }


### PR DESCRIPTION
- WappalyzerJsonParser > Move "Unexpected header type" messages from error to debug logging.
- CHANGELOG > Added change note.

Related to zaproxy/zaproxy#6607

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>