### PR TITLE
fix: pscanrulesBeta: PII Scan rule ignore images and handle decimal like values

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- PII Disclosure scan rule now ignores images (Issue 6697).
 
 ## [25] - 2021-06-17
 ### Changed

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - PII Disclosure scan rule now ignores images (Issue 6697).
+- PII Disclosure scan rule will now ignore seeming decimal numbers unless at Low threshold (Issue 6639).
 
 ## [25] - 2021-06-17
 ### Changed

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
@@ -86,7 +86,10 @@ public class PiiScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (msg.getResponseHeader().isCss() || msg.getRequestHeader().isCss()) {
+        if (msg.getResponseHeader().isCss()
+                || msg.getRequestHeader().isCss()
+                || msg.getRequestHeader().isImage()
+                || msg.getResponseHeader().isImage()) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -80,6 +80,9 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 
 <H2>PII Disclosure</H2>
 PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number (images and CSS are ignored).
+<br>
+At MEDIUM and HIGH threshold it attempts to use three characters of context on each side of potential matches to exclude matches within deicmal like content.
+At LOW threshold, alerts will be raised for such matches.
 <p>
 Note: In the case of suspected credit card values, the potential credit card numbers are looked up against a Bank Identification Number List 
 (BINList). If a match is found the alert is raised at High confidence and additional details are added to the 'Other Information' field in the 

--- a/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
+++ b/addOns/pscanrulesBeta/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesBeta/resources/help/contents/pscanbeta.html
@@ -79,7 +79,7 @@ This check looks at user-supplied input in query string parameters and POST data
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java">UserControlledOpenRedirectScanRule.java</a>
 
 <H2>PII Disclosure</H2>
-PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number.
+PII is information like credit card number, SSN etc. This check currently reports only numbers which match credit card numbers and pass Luhn checksum, which gives high confidence, that this is a credit card number (images and CSS are ignored).
 <p>
 Note: In the case of suspected credit card values, the potential credit card numbers are looked up against a Bank Identification Number List 
 (BINList). If a match is found the alert is raised at High confidence and additional details are added to the 'Other Information' field in the 

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRuleUnitTest.java
@@ -192,6 +192,29 @@ class PiiScanRuleUnitTest extends PassiveScannerTest<PiiScanRule> {
     }
 
     @Test
+    void shouldNotRaiseAlertOnImageRequest() throws Exception {
+        // Given
+        HttpMessage msg = createMsg("4111111111111111");
+        msg.getRequestHeader().setURI(new URI("https://www.example.com/image.gif", true));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
+    void shouldNotRaiseAlertOnImageResponse() throws Exception {
+        // Given
+        HttpMessage msg = createMsg("4111111111111111");
+        msg.getRequestHeader().setURI(new URI("https://www.example.com/assets/image", true));
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "image/gif");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(0));
+    }
+
+    @Test
     void shouldNotRaiseAlertOnResponseContainingCcLikeStyleAttribute() throws Exception {
         // Given
         String content = "margin-left:85.36370249136206%";


### PR DESCRIPTION
- Ignore images
    - PiiScanRule > Add request and response isImage checks.
    - PiiScanRuleUnitTets> Add tests to assert the updated behavior.
    - CHANGELOG > Add fix note.
 
Fixes zaproxy/zaproxy#6697

- Ignore decimal'ish numbers
    - PiiScanRule > Add checks for decimal'ish values.
    - PiiScanRuleUnitTets> Add tests to assert the updated behavior.
    - CHANGELOG > Add fix note.
    - pscanbeta.html > Added note about threshold handling.

Fixes zaproxy/zaproxy#6639