### PR TITLE
Automation: Edit job GUI

### DIFF
--- a/addOns/automation/automation.gradle.kts
+++ b/addOns/automation/automation.gradle.kts
@@ -11,8 +11,9 @@ zapAddOn {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.0")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.12.0")
-    implementation("org.snakeyaml:snakeyaml-engine:2.2.1")
+    api("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.9.6")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.0")
+    api("com.fasterxml.jackson.core:jackson-databind:2.12.0")
+    api("org.snakeyaml:snakeyaml-engine:2.2.1")
     testImplementation(project(":testutils"))
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AbstractAutomationTest.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AbstractAutomationTest.java
@@ -25,19 +25,44 @@ import org.parosproxy.paros.Constant;
 
 public abstract class AbstractAutomationTest {
 
-    enum OnFail {
+    public enum OnFail {
         WARN,
         ERROR,
-        INFO
+        INFO;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case ERROR:
+                    return Constant.messages.getString("automation.dialog.test.onfail.error");
+                case INFO:
+                    return Constant.messages.getString("automation.dialog.test.onfail.info");
+                case WARN:
+                    return Constant.messages.getString("automation.dialog.test.onfail.warn");
+                default:
+                    return null;
+            }
+        }
+
+        public static OnFail i18nToOnFail(String str) {
+            for (OnFail o : OnFail.values()) {
+                if (o.toString().equals(str)) {
+                    return o;
+                }
+            }
+            return null;
+        }
     }
 
     private LinkedHashMap<?, ?> testData;
     private final OnFail onFail;
-    private final String jobType;
+    private final AutomationJob job;
     private Boolean passed;
+    private String name;
 
-    public AbstractAutomationTest(LinkedHashMap<?, ?> testData, String jobType) {
+    public AbstractAutomationTest(LinkedHashMap<?, ?> testData, AutomationJob job) {
         this.testData = testData;
+        this.job = job;
         String onFailStr = AutomationJob.safeCast(testData.get("onFail"), String.class);
 
         if (!EnumUtils.isValidEnumIgnoreCase(OnFail.class, onFailStr)) {
@@ -46,16 +71,15 @@ public abstract class AbstractAutomationTest {
                             "automation.tests.invalidOnFail", getJobType(), onFailStr));
         }
         this.onFail = EnumUtils.getEnumIgnoreCase(OnFail.class, onFailStr);
-        this.jobType = jobType;
     }
 
-    public AbstractAutomationTest(String name, String onFail, String jobType) {
+    public AbstractAutomationTest(String name, String onFail, AutomationJob job) {
+        this.job = job;
         if (!EnumUtils.isValidEnumIgnoreCase(OnFail.class, onFail)) {
             throw new IllegalArgumentException(
                     Constant.messages.getString("automation.tests.invalidOnFail", name, onFail));
         }
         this.onFail = EnumUtils.getEnumIgnoreCase(OnFail.class, onFail);
-        this.jobType = jobType;
     }
 
     public void logToProgress(AutomationProgress progress) throws RuntimeException {
@@ -79,8 +103,12 @@ public abstract class AbstractAutomationTest {
         }
     }
 
+    public final AutomationJob getJob() {
+        return this.job;
+    }
+
     public final String getJobType() {
-        return this.jobType;
+        return this.job.getType();
     }
 
     public boolean hasPassed() {
@@ -99,7 +127,23 @@ public abstract class AbstractAutomationTest {
         return testData;
     }
 
-    public abstract String getName();
+    public void showDialog() {}
+
+    public AutomationData getData() {
+        return null;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSummary() {
+        return "";
+    };
 
     public abstract String getTestType();
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationData.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import java.lang.reflect.Method;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@JsonFilter("ignoreDefaultFilter")
+public abstract class AutomationData {
+
+    private static final Logger LOG = LogManager.getLogger(AutomationData.class);
+
+    public boolean isDefaultValue(String name) {
+        String getter = "get" + name.substring(0, 1).toUpperCase() + name.substring(1);
+        try {
+            Method method = this.getClass().getMethod(getter);
+            return method.invoke(this) == null;
+        } catch (Exception e) {
+            LOG.debug("Class " + this.getClass().getCanonicalName() + " no getter " + getter);
+        }
+        return false;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEventPublisher.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEventPublisher.java
@@ -42,9 +42,15 @@ public class AutomationEventPublisher implements EventPublisher {
 
     public static final String PLAN_INFO_MESSAGE = "plan.info";
 
+    public static final String PLAN_CHANGED = "plan.changed";
+
+    public static final String PLAN_SAVED = "plan.saved";
+
     public static final String JOB_STARTED = "job.started";
 
     public static final String JOB_FINISHED = "job.finished";
+
+    public static final String JOB_CHANGED = "job.changed";
 
     public static final String JOB_ID = "jobId";
     public static final String JOB_NAME = "jobName";
@@ -69,8 +75,11 @@ public class AutomationEventPublisher implements EventPublisher {
                             PLAN_ERROR_MESSAGE,
                             PLAN_WARNING_MESSAGE,
                             PLAN_INFO_MESSAGE,
+                            PLAN_CHANGED,
+                            PLAN_SAVED,
                             JOB_STARTED,
-                            JOB_FINISHED);
+                            JOB_FINISHED,
+                            JOB_CHANGED);
         }
         return publisher;
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ContextWrapper.java
@@ -21,16 +21,22 @@ package org.zaproxy.addon.automation;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.parosproxy.paros.model.Session;
 import org.zaproxy.zap.model.Context;
 
 public class ContextWrapper {
 
-    private final Context context;
+    private Context context;
 
-    private final List<String> urls = new ArrayList<>();
+    private Data data;
+
+    public ContextWrapper(Data data) {
+        this.data = data;
+    }
 
     public ContextWrapper(Context context) {
         this.context = context;
+        this.data = new Data();
     }
 
     public Context getContext() {
@@ -38,10 +44,74 @@ public class ContextWrapper {
     }
 
     public void addUrl(String url) {
-        this.urls.add(url);
+        this.data.getUrls().add(url);
     }
 
     public List<String> getUrls() {
-        return this.urls;
+        return this.data.getUrls();
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    public void setData(Data data) {
+        this.data = data;
+    }
+
+    public void createContext(Session session, AutomationEnvironment env) {
+        Context oldContext = session.getContext(getData().getName());
+        if (oldContext != null) {
+            session.deleteContext(oldContext);
+        }
+        this.context = session.getNewContext(getData().getName());
+        for (String url : getData().getUrls()) {
+            this.context.addIncludeInContextRegex(env.replaceVars(url) + ".*");
+        }
+        for (String path : getData().getIncludePaths()) {
+            this.context.addIncludeInContextRegex(env.replaceVars(path));
+        }
+        for (String path : getData().getExcludePaths()) {
+            this.context.addExcludeFromContextRegex(env.replaceVars(path));
+        }
+    }
+
+    public static class Data {
+        private String name;
+        private List<String> urls = new ArrayList<>();
+        private List<String> includePaths;
+        private List<String> excludePaths;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public List<String> getUrls() {
+            return urls;
+        }
+
+        public void setUrls(List<String> urls) {
+            this.urls = urls;
+        }
+
+        public List<String> getIncludePaths() {
+            return includePaths;
+        }
+
+        public void setIncludePaths(List<String> includePaths) {
+            this.includePaths = includePaths;
+        }
+
+        public List<String> getExcludePaths() {
+            return excludePaths;
+        }
+
+        public void setExcludePaths(List<String> excludePaths) {
+            this.excludePaths = excludePaths;
+        }
     }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/DefaultPropertyFilter.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/DefaultPropertyFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
+
+public class DefaultPropertyFilter extends SimpleBeanPropertyFilter {
+    @Override
+    public void serializeAsField(
+            Object pojo, JsonGenerator jgen, SerializerProvider provider, PropertyWriter writer)
+            throws Exception {
+        if (include(writer)) {
+            if (pojo instanceof AutomationData) {
+                if (((AutomationData) pojo).isDefaultValue(writer.getName())) {
+                    return;
+                }
+            }
+            writer.serializeAsField(pojo, jgen, provider);
+        } else if (!jgen.canOmitFields()) {
+            writer.serializeAsOmittedField(pojo, jgen, provider);
+        }
+    }
+
+    @Override
+    protected boolean include(BeanPropertyWriter writer) {
+        return true;
+    }
+
+    @Override
+    protected boolean include(PropertyWriter writer) {
+        return true;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/TestData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/TestData.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation;
+
+public abstract class TestData extends AutomationData {
+
+    private AbstractAutomationTest test;
+
+    public TestData(AbstractAutomationTest test) {
+        this.test = test;
+    }
+
+    @Override
+    public boolean isDefaultValue(String name) {
+        if ("name".equals(name)) {
+            return name.equals(getType());
+        }
+        return super.isDefaultValue(name);
+    }
+
+    public void setType(String type) {
+        // Ignore, but method needed for reflection
+    }
+
+    public String getType() {
+        return this.test.getTestType();
+    }
+
+    public String getName() {
+        return this.test.getName();
+    }
+
+    public void setName(String name) {
+        this.test.setName(name);
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
@@ -1,0 +1,392 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.ActiveScanJob;
+import org.zaproxy.addon.automation.jobs.ActiveScanJob.Parameters;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class ActiveScanJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LogManager.getLogger(ActiveScanJobDialog.class);
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.tab.params",
+        "automation.dialog.ascan.tab.policydefaults",
+        "automation.dialog.ascan.tab.policyrules",
+        "automation.dialog.ascan.tab.adv"
+    };
+
+    private static final String TITLE = "automation.dialog.ascan.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String CONTEXT_PARAM = "automation.dialog.ascan.context";
+    private static final String POLICY_PARAM = "automation.dialog.ascan.policy";
+    private static final String MAX_RULE_DURATION_PARAM = "automation.dialog.ascan.maxruleduration";
+    private static final String MAX_SCAN_DURATION_PARAM = "automation.dialog.ascan.maxscanduration";
+    private static final String FIELD_ADVANCED = "automation.dialog.ascan.advanced";
+
+    private static final String DEFAULT_THRESHOLD_PARAM =
+            "automation.dialog.ascan.defaultthreshold";
+    private static final String DEFAULT_STRENGTH_PARAM = "automation.dialog.ascan.defaultstrength";
+
+    private static final String DELAY_IN_MS_PARAM = "automation.dialog.ascan.delayinms";
+    private static final String THREADS_PER_HOST_PARAM = "automation.dialog.ascan.threads";
+    private static final String ADD_QUERY_PARAM = "automation.dialog.ascan.addquery";
+    private static final String HANDLE_ANTI_CSRF_PARAM = "automation.dialog.ascan.handleanticsrf";
+    private static final String INJECT_PLUGIN_ID_PARAM = "automation.dialog.ascan.injectid";
+    private static final String SCAN_HEADERS_PARAM = "automation.dialog.ascan.scanheaders";
+
+    private ActiveScanJob job;
+
+    private JButton addButton = null;
+    private JButton modifyButton = null;
+    private JButton removeButton = null;
+
+    private JTable rulesTable = null;
+    private AscanRulesTableModel rulesModel = null;
+
+    public ActiveScanJobDialog(ActiveScanJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 300),
+                TAB_LABELS);
+        this.job = job;
+
+        this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+        List<String> contextNames = this.job.getEnv().getContextNames();
+        // Add blank option
+        contextNames.add(0, "");
+        this.addComboField(0, CONTEXT_PARAM, contextNames, this.job.getParameters().getContext());
+        this.addTextField(0, POLICY_PARAM, this.job.getParameters().getPolicy());
+        this.addNumberField(
+                0,
+                MAX_RULE_DURATION_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(JobUtils.unBox(job.getParameters().getMaxRuleDurationInMins())));
+        this.addNumberField(
+                0,
+                MAX_SCAN_DURATION_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(JobUtils.unBox(job.getParameters().getMaxScanDurationInMins())));
+        this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
+        this.addFieldListener(
+                FIELD_ADVANCED,
+                new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+                    }
+                });
+
+        this.addPadding(0);
+
+        String thresholdName =
+                JobUtils.thresholdToI18n(job.getData().getPolicyDefinition().getDefaultThreshold());
+        if (thresholdName.isEmpty()) {
+            thresholdName = JobUtils.thresholdToI18n(AlertThreshold.MEDIUM.name());
+        }
+        String strengthName =
+                JobUtils.strengthToI18n(job.getData().getPolicyDefinition().getDefaultStrength());
+        if (strengthName.isEmpty()) {
+            strengthName = JobUtils.strengthToI18n(AttackStrength.MEDIUM.name());
+        }
+
+        List<String> allthresholds = new ArrayList<>();
+
+        for (AlertThreshold at : AlertThreshold.values()) {
+            if (AlertThreshold.DEFAULT.equals(at)) {
+                continue;
+            }
+            allthresholds.add(JobUtils.thresholdToI18n(at.name()));
+        }
+
+        this.addComboField(1, DEFAULT_THRESHOLD_PARAM, allthresholds, thresholdName);
+
+        List<String> allstrengths = new ArrayList<>();
+
+        for (AttackStrength at : AttackStrength.values()) {
+            if (AttackStrength.DEFAULT.equals(at)) {
+                continue;
+            }
+            allstrengths.add(JobUtils.strengthToI18n(at.name()));
+        }
+
+        this.addComboField(1, DEFAULT_STRENGTH_PARAM, allstrengths, strengthName);
+
+        this.addPadding(1);
+
+        List<JButton> buttons = new ArrayList<>();
+        buttons.add(getAddButton());
+        buttons.add(getModifyButton());
+        buttons.add(getRemoveButton());
+
+        this.addTableField(2, getRulesTable(), buttons);
+
+        this.addNumberField(
+                3,
+                DELAY_IN_MS_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(JobUtils.unBox(job.getParameters().getDelayInMs())));
+        this.addNumberField(
+                3,
+                THREADS_PER_HOST_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(JobUtils.unBox(job.getParameters().getThreadPerHost())));
+        this.addCheckBoxField(
+                3, ADD_QUERY_PARAM, JobUtils.unBox(job.getParameters().getAddQueryParam()));
+        this.addCheckBoxField(
+                3,
+                HANDLE_ANTI_CSRF_PARAM,
+                JobUtils.unBox(job.getParameters().getHandleAntiCSRFTokens()));
+        this.addCheckBoxField(
+                3,
+                INJECT_PLUGIN_ID_PARAM,
+                JobUtils.unBox(job.getParameters().getInjectPluginIdInHeader()));
+        this.addCheckBoxField(
+                3,
+                SCAN_HEADERS_PARAM,
+                JobUtils.unBox(job.getParameters().getScanHeadersAllRequests()));
+
+        this.addPadding(3);
+
+        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+    }
+
+    private boolean advOptionsSet() {
+        Parameters params = this.job.getParameters();
+        return params.getDelayInMs() != null
+                || params.getThreadPerHost() != null
+                || params.getAddQueryParam() != null
+                || params.getHandleAntiCSRFTokens() != null
+                || params.getInjectPluginIdInHeader() != null
+                || params.getScanHeadersAllRequests() != null;
+    }
+
+    private void setAdvancedTabs(boolean visible) {
+        // Show/hide the advanced tab
+        this.setTabsVisible(new String[] {"automation.dialog.ascan.tab.adv"}, visible);
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setContext(this.getStringValue(CONTEXT_PARAM));
+        this.job.getParameters().setPolicy(this.getStringValue(POLICY_PARAM));
+        this.job
+                .getParameters()
+                .setMaxRuleDurationInMins(this.getIntValue(MAX_RULE_DURATION_PARAM));
+        this.job
+                .getParameters()
+                .setMaxScanDurationInMins(this.getIntValue(MAX_SCAN_DURATION_PARAM));
+
+        this.job
+                .getData()
+                .getPolicyDefinition()
+                .setDefaultStrength(
+                        JobUtils.i18nToStrength(this.getStringValue(DEFAULT_STRENGTH_PARAM)));
+        this.job
+                .getData()
+                .getPolicyDefinition()
+                .setDefaultThreshold(
+                        JobUtils.i18nToStrength(this.getStringValue(DEFAULT_THRESHOLD_PARAM)));
+
+        if (this.getBoolValue(FIELD_ADVANCED)) {
+            this.job.getParameters().setDelayInMs(this.getIntValue(DELAY_IN_MS_PARAM));
+            this.job.getParameters().setThreadPerHost(this.getIntValue(THREADS_PER_HOST_PARAM));
+            this.job.getParameters().setAddQueryParam(this.getBoolValue(ADD_QUERY_PARAM));
+            this.job
+                    .getParameters()
+                    .setHandleAntiCSRFTokens(this.getBoolValue(HANDLE_ANTI_CSRF_PARAM));
+            this.job
+                    .getParameters()
+                    .setInjectPluginIdInHeader(this.getBoolValue(INJECT_PLUGIN_ID_PARAM));
+            this.job
+                    .getParameters()
+                    .setScanHeadersAllRequests(this.getBoolValue(SCAN_HEADERS_PARAM));
+        } else {
+            this.job.getParameters().setDelayInMs(null);
+            this.job.getParameters().setThreadPerHost(null);
+            this.job.getParameters().setAddQueryParam(null);
+            this.job.getParameters().setHandleAntiCSRFTokens(null);
+            this.job.getParameters().setInjectPluginIdInHeader(null);
+            this.job.getParameters().setScanHeadersAllRequests(null);
+        }
+        this.job.getData().getPolicyDefinition().setRules(this.getRulesModel().getRules());
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+
+    private JButton getAddButton() {
+        if (this.addButton == null) {
+            this.addButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addButton.addActionListener(
+                    e -> {
+                        AddAscanRuleDialog dialog;
+                        try {
+                            dialog = new AddAscanRuleDialog(getRulesModel());
+                            dialog.setVisible(true);
+                        } catch (ConfigurationException e1) {
+                            LOG.error(e1.getMessage(), e1);
+                        }
+                    });
+        }
+        return this.addButton;
+    }
+
+    private JButton getModifyButton() {
+        if (this.modifyButton == null) {
+            this.modifyButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            this.modifyButton.addActionListener(
+                    e -> {
+                        int row = getRulesTable().getSelectedRow();
+                        try {
+                            AddAscanRuleDialog dialog =
+                                    new AddAscanRuleDialog(
+                                            getRulesModel(),
+                                            getRulesModel().getRules().get(row),
+                                            row);
+                            dialog.setVisible(true);
+                        } catch (ConfigurationException e1) {
+                            LOG.error(e1.getMessage(), e1);
+                        }
+                    });
+        }
+        return this.modifyButton;
+    }
+
+    private JButton getRemoveButton() {
+        if (this.removeButton == null) {
+            this.removeButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeButton.setEnabled(false);
+            final ActiveScanJobDialog parent = this;
+            this.removeButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.ascan.remove.confirm"))) {
+                            getRulesModel().remove(getRulesTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeButton;
+    }
+
+    private JTable getRulesTable() {
+        if (rulesTable == null) {
+            rulesTable = new JTable();
+            rulesTable.setModel(getRulesModel());
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(0)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(50));
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(1)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(170));
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(2)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(100));
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(3)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(100));
+            rulesTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                if (getRulesTable().getSelectedRowCount() == 0) {
+                                    modifyButton.setEnabled(false);
+                                    removeButton.setEnabled(false);
+                                } else if (getRulesTable().getSelectedRowCount() == 1) {
+                                    modifyButton.setEnabled(true);
+                                    removeButton.setEnabled(true);
+                                } else {
+                                    modifyButton.setEnabled(false);
+                                    removeButton.setEnabled(false);
+                                }
+                            });
+            rulesTable.addMouseListener(
+                    new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent me) {
+                            if (me.getClickCount() == 2) {
+                                int row = getRulesTable().getSelectedRow();
+                                try {
+                                    AddAscanRuleDialog dialog =
+                                            new AddAscanRuleDialog(
+                                                    getRulesModel(),
+                                                    getRulesModel().getRules().get(row),
+                                                    row);
+                                    dialog.setVisible(true);
+                                } catch (ConfigurationException e1) {
+                                    LOG.error(e1.getMessage(), e1);
+                                }
+                            }
+                        }
+                    });
+        }
+        return rulesTable;
+    }
+
+    private AscanRulesTableModel getRulesModel() {
+        if (rulesModel == null) {
+            rulesModel = new AscanRulesTableModel();
+            rulesModel.setRules(job.getData().getPolicyDefinition().getRules());
+        }
+        return rulesModel;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAddOnsDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAddOnsDialog.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AddAddOnsDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.addaddon.title";
+    private static final String ADDON_ID_PARAM = "automation.dialog.addaddon.id";
+
+    private AddOnsTableModel model;
+
+    public AddAddOnsDialog(AddOnsTableModel model) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(300, 200));
+        this.model = model;
+
+        this.addTextField(ADDON_ID_PARAM, "");
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.model.add(this.getStringValue(ADDON_ID_PARAM));
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
@@ -1,0 +1,136 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.configuration.ConfigurationException;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.ActiveScanJob;
+import org.zaproxy.addon.automation.jobs.ActiveScanJob.Rule;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AddAscanRuleDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.addrule.title";
+    private static final String RULE_PARAM = "automation.dialog.addrule.rule";
+    private static final String THREHOLD_PARAM = "automation.dialog.addrule.threshold";
+    private static final String STRENGTH_PARAM = "automation.dialog.addrule.strength";
+
+    private ActiveScanJob.Rule rule;
+    private int tableIndex;
+    private AscanRulesTableModel model;
+    private Map<String, Plugin> nameToPlugin = new HashMap<>();
+    private List<Plugin> allRules = null;
+
+    public AddAscanRuleDialog(AscanRulesTableModel model) throws ConfigurationException {
+        this(model, null, -1);
+    }
+
+    public AddAscanRuleDialog(AscanRulesTableModel model, ActiveScanJob.Rule rule, int tableIndex)
+            throws ConfigurationException {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(300, 150));
+        this.rule = rule;
+        this.model = model;
+        this.tableIndex = tableIndex;
+
+        String thresholdName = "";
+        if (rule != null) {
+            thresholdName = JobUtils.thresholdToI18n(rule.getThreshold());
+        }
+
+        String strengthName = "";
+        if (rule != null) {
+            strengthName = JobUtils.strengthToI18n(rule.getStrength());
+        }
+
+        allRules = model.getAllScanRules();
+
+        List<String> allNames =
+                allRules.stream().map(Plugin::getName).sorted().collect(Collectors.toList());
+        // Remove any rules already set
+        allNames.removeAll(
+                model.getRules().stream().map(Rule::getName).collect(Collectors.toList()));
+        nameToPlugin =
+                allRules.stream().collect(Collectors.toMap(Plugin::getName, Function.identity()));
+
+        if (rule == null) {
+            this.addComboField(RULE_PARAM, allNames, "");
+        } else {
+            this.addReadOnlyField(RULE_PARAM, rule.getName(), false);
+        }
+
+        List<String> allthresholds = new ArrayList<>();
+
+        for (AlertThreshold at : AlertThreshold.values()) {
+            allthresholds.add(JobUtils.thresholdToI18n(at.name()));
+        }
+
+        this.addComboField(THREHOLD_PARAM, allthresholds, thresholdName);
+
+        List<String> allstrengths = new ArrayList<>();
+
+        for (AttackStrength at : AttackStrength.values()) {
+            allstrengths.add(JobUtils.strengthToI18n(at.name()));
+        }
+
+        this.addComboField(STRENGTH_PARAM, allstrengths, strengthName);
+
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        if (rule == null) {
+            rule = new Rule();
+            Plugin plugin = this.nameToPlugin.get(this.getStringValue(RULE_PARAM));
+            rule.setId(plugin.getId());
+            rule.setName(plugin.getName());
+            rule.setThreshold(JobUtils.i18nToThreshold(this.getStringValue(THREHOLD_PARAM)));
+            rule.setStrength(JobUtils.i18nToStrength(this.getStringValue(STRENGTH_PARAM)));
+            this.model.add(rule);
+        } else {
+            rule.setThreshold(JobUtils.i18nToThreshold(this.getStringValue(THREHOLD_PARAM)));
+            rule.setStrength(JobUtils.i18nToStrength(this.getStringValue(STRENGTH_PARAM)));
+            this.model.update(tableIndex, rule);
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        if (JobUtils.i18nToThreshold(this.getStringValue(THREHOLD_PARAM)).equals("default")
+                && JobUtils.i18nToStrength(this.getStringValue(STRENGTH_PARAM)).equals("default")) {
+            return Constant.messages.getString("automation.dialog.addrule.error.defaults");
+        }
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
@@ -1,0 +1,226 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.AddOnJob;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AddOnJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.addon.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String UPDATE_ADDONS_PARAM = "automation.dialog.addon.updateaddons";
+    private static final String INSTALL_ADDONS_PARAM = "automation.dialog.addon.installaddons";
+    private static final String UNINSTALL_ADDONS_PARAM = "automation.dialog.addon.uninstalladdons";
+
+    private AddOnJob job;
+
+    private JButton addInstButton = null;
+    private JButton removeInstButton = null;
+    private JButton addUninstButton = null;
+    private JButton removeUninstButton = null;
+
+    private JTable addOnsInstallTable = null;
+    private AddOnsTableModel addOnsInstallModel = null;
+    private JTable addOnsUninstallTable = null;
+    private AddOnsTableModel addOnsUninstallModel = null;
+
+    public AddOnJobDialog(AddOnJob job) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(400, 400));
+        this.job = job;
+
+        this.addTextField(NAME_PARAM, this.job.getData().getName());
+
+        this.addCheckBoxField(UPDATE_ADDONS_PARAM, this.job.getParameters().getUpdateAddOns());
+
+        List<JButton> instButtons = new ArrayList<>();
+        instButtons.add(getAddInstButton());
+        instButtons.add(getRemoveInstButton());
+
+        this.addTableField(INSTALL_ADDONS_PARAM, getAddOnsInstallTable(), instButtons);
+
+        List<JButton> uninstButtons = new ArrayList<>();
+        uninstButtons.add(getAddUninstButton());
+        uninstButtons.add(getRemoveUninstButton());
+
+        this.addTableField(UNINSTALL_ADDONS_PARAM, getAddOnsUninstallTable(), uninstButtons);
+    }
+
+    private JButton getAddInstButton() {
+        if (this.addInstButton == null) {
+            this.addInstButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addInstButton.addActionListener(
+                    e -> {
+                        AddAddOnsDialog dialog = new AddAddOnsDialog(getAddOnsInstallModel());
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.addInstButton;
+    }
+
+    private JButton getRemoveInstButton() {
+        if (this.removeInstButton == null) {
+            this.removeInstButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeInstButton.setEnabled(false);
+            final AddOnJobDialog parent = this;
+            this.removeInstButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.addon.remove.confirm"))) {
+                            getAddOnsInstallModel()
+                                    .remove(getAddOnsInstallTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeInstButton;
+    }
+
+    private JButton getAddUninstButton() {
+        if (this.addUninstButton == null) {
+            this.addUninstButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addUninstButton.addActionListener(
+                    e -> {
+                        AddAddOnsDialog dialog = new AddAddOnsDialog(getAddOnsUninstallModel());
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.addUninstButton;
+    }
+
+    private JButton getRemoveUninstButton() {
+        if (this.removeUninstButton == null) {
+            this.removeUninstButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeUninstButton.setEnabled(false);
+            final AddOnJobDialog parent = this;
+            this.removeUninstButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.addon.remove.confirm"))) {
+                            getAddOnsUninstallModel()
+                                    .remove(getAddOnsUninstallTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeUninstButton;
+    }
+
+    private JTable getAddOnsInstallTable() {
+        if (addOnsInstallTable == null) {
+            addOnsInstallTable = new JTable();
+            addOnsInstallTable.setModel(getAddOnsInstallModel());
+            addOnsInstallTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                if (getAddOnsInstallTable().getSelectedRowCount() == 0) {
+                                    removeInstButton.setEnabled(false);
+                                } else if (getAddOnsInstallTable().getSelectedRowCount() == 1) {
+                                    removeInstButton.setEnabled(true);
+                                } else {
+                                    removeInstButton.setEnabled(false);
+                                }
+                            });
+        }
+        return addOnsInstallTable;
+    }
+
+    private AddOnsTableModel getAddOnsInstallModel() {
+        if (addOnsInstallModel == null) {
+            addOnsInstallModel = new AddOnsTableModel();
+            addOnsInstallModel.setAddOns(job.getData().getInstall());
+        }
+        return addOnsInstallModel;
+    }
+
+    private JTable getAddOnsUninstallTable() {
+        if (addOnsUninstallTable == null) {
+            addOnsUninstallTable = new JTable();
+            addOnsUninstallTable.setModel(getAddOnsUninstallModel());
+            addOnsUninstallTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                if (getAddOnsUninstallTable().getSelectedRowCount() == 0) {
+                                    removeUninstButton.setEnabled(false);
+                                } else if (getAddOnsUninstallTable().getSelectedRowCount() == 1) {
+                                    removeUninstButton.setEnabled(true);
+                                } else {
+                                    removeUninstButton.setEnabled(false);
+                                }
+                            });
+        }
+        return addOnsUninstallTable;
+    }
+
+    private AddOnsTableModel getAddOnsUninstallModel() {
+        if (addOnsUninstallModel == null) {
+            addOnsUninstallModel = new AddOnsTableModel();
+            addOnsUninstallModel.setAddOns(job.getData().getUninstall());
+        }
+        return addOnsUninstallModel;
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setUpdateAddOns(this.getBoolValue(UPDATE_ADDONS_PARAM));
+        List<String> addOns = this.getAddOnsInstallModel().getAddOns();
+        if (addOns.size() == 0) {
+            this.job.getData().setInstall(null);
+        } else {
+            this.job.getData().setInstall(addOns);
+        }
+        addOns = this.getAddOnsUninstallModel().getAddOns();
+        if (addOns.size() == 0) {
+            this.job.getData().setUninstall(null);
+        } else {
+            this.job.getData().setUninstall(addOns);
+        }
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnsTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnsTableModel.java
@@ -1,0 +1,98 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+
+public class AddOnsTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] columnNames = {
+        Constant.messages.getString("automation.dialog.addon.table.header.addons")
+    };
+
+    private List<String> addOns = new ArrayList<>();
+
+    public AddOnsTableModel() {
+        super();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return addOns.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        return this.addOns.get(row);
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return columnNames[col];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<String> getAddOns() {
+        return addOns;
+    }
+
+    public void setAddOns(List<String> addOns) {
+        if (addOns == null) {
+            this.addOns = new ArrayList<>();
+        } else {
+            this.addOns = addOns;
+        }
+    }
+
+    public void clear() {
+        this.addOns.clear();
+    }
+
+    public void add(String addOn) {
+        this.addOns.add(addOn);
+        this.fireTableRowsInserted(this.addOns.size() - 1, this.addOns.size() - 1);
+    }
+
+    public void remove(int index) {
+        if (index < this.addOns.size()) {
+            this.addOns.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddPscanRuleDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddPscanRuleDialog.java
@@ -1,0 +1,122 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
+import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob.Rule;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AddPscanRuleDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.addrule.title";
+    private static final String RULE_PARAM = "automation.dialog.addrule.rule";
+    private static final String THREHOLD_PARAM = "automation.dialog.addrule.threshold";
+
+    private PassiveScanConfigJob.Rule rule;
+    private int tableIndex;
+    private PscanRulesTableModel model;
+    private Map<String, PluginPassiveScanner> nameToPlugin = new HashMap<>();;
+
+    public AddPscanRuleDialog(PscanRulesTableModel model) {
+        this(model, null, -1);
+    }
+
+    public AddPscanRuleDialog(
+            PscanRulesTableModel model, PassiveScanConfigJob.Rule rule, int tableIndex) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(400, 200));
+        this.rule = rule;
+        this.model = model;
+        this.tableIndex = tableIndex;
+
+        String thresholdName = "";
+        if (rule != null) {
+            thresholdName = JobUtils.thresholdToI18n(rule.getThreshold());
+        }
+
+        List<PluginPassiveScanner> allRules = model.getAllScanRules();
+
+        List<String> allNames =
+                allRules.stream()
+                        .map(PluginPassiveScanner::getName)
+                        .sorted()
+                        .collect(Collectors.toList());
+        // Remove any rules already set
+        allNames.removeAll(
+                model.getRules().stream().map(Rule::getName).collect(Collectors.toList()));
+        nameToPlugin =
+                allRules.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        PluginPassiveScanner::getName, Function.identity()));
+
+        if (rule == null) {
+            this.addComboField(RULE_PARAM, allNames, "");
+        } else {
+            this.addReadOnlyField(RULE_PARAM, rule.getName(), false);
+        }
+
+        List<String> allthresholds = new ArrayList<>();
+
+        for (AlertThreshold at : AlertThreshold.values()) {
+            if (AlertThreshold.DEFAULT.equals(at)) {
+                continue;
+            }
+            allthresholds.add(JobUtils.thresholdToI18n(at.name()));
+        }
+
+        this.addComboField(THREHOLD_PARAM, allthresholds, thresholdName);
+
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        if (rule == null) {
+            rule = new Rule();
+            PluginPassiveScanner plugin = this.nameToPlugin.get(this.getStringValue(RULE_PARAM));
+            rule.setId(plugin.getPluginId());
+            rule.setName(plugin.getName());
+            rule.setThreshold(JobUtils.i18nToThreshold(this.getStringValue(THREHOLD_PARAM)));
+            this.model.add(rule);
+        } else {
+            rule.setThreshold(JobUtils.i18nToStrength(this.getStringValue(THREHOLD_PARAM)));
+            this.model.update(tableIndex, rule);
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddRequestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddRequestDialog.java
@@ -1,0 +1,98 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.awt.Component;
+import javax.swing.JTextField;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.automation.jobs.RequestorJob;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AddRequestDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.addreq.title";
+    private static final String URL_PARAM = "automation.dialog.addreq.url";
+    private static final String NAME_PARAM = "automation.dialog.addreq.name";
+    private static final String METHOD_PARAM = "automation.dialog.addreq.method";
+    private static final String DATA_PARAM = "automation.dialog.addreq.data";
+    private static final String CODE_PARAM = "automation.dialog.addreq.responsecode";
+
+    private RequestorJob.Request rule;
+    private boolean addRequest = false;
+    private int tableIndex;
+    private RequestsTableModel model;
+
+    public AddRequestDialog(RequestsTableModel model) {
+        this(model, null, -1);
+    }
+
+    public AddRequestDialog(RequestsTableModel model, RequestorJob.Request rule, int tableIndex) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(550, 400));
+        if (rule == null) {
+            rule = new RequestorJob.Request();
+            this.addRequest = true;
+        }
+        this.rule = rule;
+        this.model = model;
+        this.tableIndex = tableIndex;
+
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(URL_PARAM, null, true, false);
+        Component urlField = this.getField(URL_PARAM);
+        if (urlField instanceof JTextField) {
+            ((JTextField) urlField).setText(rule.getUrl());
+        }
+
+        this.addTextField(NAME_PARAM, rule.getName());
+        this.addTextField(METHOD_PARAM, rule.getMethod());
+        this.addMultilineField(DATA_PARAM, rule.getData());
+        this.addNumberField(
+                CODE_PARAM, 0, Integer.MAX_VALUE, JobUtils.unBox(rule.getResponseCode()));
+    }
+
+    @Override
+    public void save() {
+        rule.setUrl(this.getStringValue(URL_PARAM));
+        rule.setName(this.getStringValue(NAME_PARAM));
+        rule.setMethod(this.getStringValue(METHOD_PARAM));
+        rule.setData(this.getStringValue(DATA_PARAM));
+        if (this.getIntValue(CODE_PARAM) == 0) {
+            rule.setResponseCode(null);
+        } else {
+            rule.setResponseCode(this.getIntValue(CODE_PARAM));
+        }
+
+        if (addRequest) {
+            this.model.add(rule);
+        } else {
+            this.model.update(tableIndex, rule);
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        // TODO check url present & ok
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AlertTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AlertTestDialog.java
@@ -1,0 +1,179 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.Arrays;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.AbstractAutomationTest.OnFail;
+import org.zaproxy.addon.automation.AutomationAlertTest;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AlertTestDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.alerttest.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String ACTION_PARAM = "automation.dialog.alerttest.action";
+    private static final String SCAN_RULE_ID_PARAM = "automation.dialog.alerttest.ruleid";
+    private static final String ALERT_NAME_PARAM = "automation.dialog.alerttest.alertname";
+    private static final String URL_PARAM = "automation.dialog.alerttest.url";
+    private static final String METHOD_PARAM = "automation.dialog.alerttest.method";
+    private static final String ATTACK_PARAM = "automation.dialog.alerttest.attack";
+    private static final String PARAM_PARAM = "automation.dialog.alerttest.param";
+    private static final String EVIDENCE_PARAM = "automation.dialog.alerttest.evidence";
+    private static final String CONFIDENCE_PARAM = "automation.dialog.alerttest.confidence";
+    private static final String RISK_PARAM = "automation.dialog.alerttest.risk";
+    private static final String OTHER_PARAM = "automation.dialog.alerttest.other";
+    private static final String ON_FAIL_PARAM = "automation.dialog.alerttest.onfail";
+
+    private AutomationAlertTest test;
+
+    public AlertTestDialog(AutomationAlertTest test) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(400, 500));
+        this.test = test;
+
+        this.addTextField(NAME_PARAM, test.getName());
+        this.addComboField(
+                ON_FAIL_PARAM,
+                Arrays.asList(OnFail.values()).stream()
+                        .map(o -> o.toString())
+                        .toArray(String[]::new),
+                test.getData().getOnFail().toString());
+        this.addComboField(
+                ACTION_PARAM,
+                new String[] {
+                    actionToi18n(AutomationAlertTest.ACTION_PASS_IF_ABSENT),
+                    actionToi18n(AutomationAlertTest.ACTION_PASS_IF_PRESENT)
+                },
+                actionToi18n(test.getData().getAction()));
+        this.addNumberField(
+                SCAN_RULE_ID_PARAM, 0, Integer.MAX_VALUE, test.getData().getScanRuleId());
+
+        String conf = "";
+        Integer confInt = JobUtils.parseAlertConfidence(test.getData().getConfidence());
+        if (confInt != null) {
+            conf = Constant.messages.getString("automation.tests.alert.confidence." + confInt);
+        }
+        this.addComboField(
+                CONFIDENCE_PARAM,
+                new String[] {
+                    "",
+                    Constant.messages.getString("automation.tests.alert.confidence.0"),
+                    Constant.messages.getString("automation.tests.alert.confidence.1"),
+                    Constant.messages.getString("automation.tests.alert.confidence.2"),
+                    Constant.messages.getString("automation.tests.alert.confidence.3"),
+                },
+                conf);
+
+        String risk = "";
+        Integer riskInt = JobUtils.parseAlertRisk(test.getData().getRisk());
+        if (riskInt != null) {
+            risk = Constant.messages.getString("automation.tests.alert.risk." + riskInt);
+        }
+        this.addComboField(
+                RISK_PARAM,
+                new String[] {
+                    "",
+                    Constant.messages.getString("automation.tests.alert.risk.0"),
+                    Constant.messages.getString("automation.tests.alert.risk.1"),
+                    Constant.messages.getString("automation.tests.alert.risk.2"),
+                    Constant.messages.getString("automation.tests.alert.risk.3"),
+                },
+                risk);
+
+        this.addTextField(ALERT_NAME_PARAM, test.getData().getAlertName());
+        this.addTextField(URL_PARAM, test.getData().getUrl());
+        this.addTextField(METHOD_PARAM, test.getData().getMethod());
+        this.addTextField(ATTACK_PARAM, test.getData().getAttack());
+        this.addTextField(PARAM_PARAM, test.getData().getParam());
+        this.addTextField(EVIDENCE_PARAM, test.getData().getEvidence());
+        this.addTextField(OTHER_PARAM, test.getData().getOtherInfo());
+        this.addPadding();
+    }
+
+    private String actionToi18n(String action) {
+        if (AutomationAlertTest.ACTION_PASS_IF_PRESENT.equals(action)) {
+            return Constant.messages.getString("automation.tests.alert.action.passIfPresent");
+        }
+        return Constant.messages.getString("automation.tests.alert.action.passIfAbsent");
+    }
+
+    private String i18nToAction(String i18n) {
+        if (i18n.equals(
+                Constant.messages.getString("automation.tests.alert.action.passIfPresent"))) {
+            return AutomationAlertTest.ACTION_PASS_IF_PRESENT;
+        }
+        return AutomationAlertTest.ACTION_PASS_IF_ABSENT;
+    }
+
+    private String emptyToNull(String str) {
+        if (str != null && str.trim().isEmpty()) {
+            return null;
+        }
+        return str;
+    }
+
+    @Override
+    public void save() {
+        this.test.getData().setName(this.getStringValue(NAME_PARAM));
+        this.test.getData().setOnFail(OnFail.i18nToOnFail(this.getStringValue(ON_FAIL_PARAM)));
+        this.test.getData().setAction(i18nToAction(this.getStringValue(ACTION_PARAM)));
+        this.test.getData().setScanRuleId(this.getIntValue(SCAN_RULE_ID_PARAM));
+        this.test.getData().setUrl(emptyToNull(this.getStringValue(URL_PARAM)));
+        this.test.getData().setMethod(emptyToNull(this.getStringValue(METHOD_PARAM)));
+        this.test.getData().setAttack(emptyToNull(this.getStringValue(ATTACK_PARAM)));
+        this.test.getData().setParam(emptyToNull(this.getStringValue(PARAM_PARAM)));
+        this.test.getData().setEvidence(emptyToNull(this.getStringValue(EVIDENCE_PARAM)));
+        this.test.getData().setOtherInfo(emptyToNull(this.getStringValue(OTHER_PARAM)));
+
+        String confI18n = this.getStringValue(CONFIDENCE_PARAM);
+        String conf = null;
+        for (int i = 0; i < Alert.MSG_CONFIDENCE.length; i++) {
+            if (confI18n.equals(
+                    Constant.messages.getString("automation.tests.alert.confidence." + i))) {
+                conf = Alert.MSG_CONFIDENCE[i].toLowerCase();
+                break;
+            }
+        }
+        this.test.getData().setConfidence(conf);
+
+        String riskI18n = this.getStringValue(RISK_PARAM);
+        String risk = null;
+        for (int i = 0; i < Alert.MSG_RISK.length; i++) {
+            if (riskI18n.equals(Constant.messages.getString("automation.tests.alert.risk." + i))) {
+                risk = Alert.MSG_RISK[i].toLowerCase();
+                break;
+            }
+        }
+        this.test.getData().setRisk(risk);
+        this.test.getJob().getPlan().setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // TODO check valid regexes
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AscanRulesTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AscanRulesTableModel.java
@@ -1,0 +1,148 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.apache.commons.configuration.ConfigurationException;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.zaproxy.addon.automation.jobs.ActiveScanJob;
+import org.zaproxy.addon.automation.jobs.ActiveScanJob.Rule;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+
+public class AscanRulesTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] columnNames = {
+        Constant.messages.getString("automation.dialog.ascan.table.header.id"),
+        Constant.messages.getString("automation.dialog.ascan.table.header.name"),
+        Constant.messages.getString("automation.dialog.ascan.table.header.threshold"),
+        Constant.messages.getString("automation.dialog.ascan.table.header.strength")
+    };
+
+    private List<ActiveScanJob.Rule> rules = new ArrayList<>();
+
+    private ExtensionActiveScan extAscan;
+
+    public AscanRulesTableModel() {
+        super();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return rules.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        ActiveScanJob.Rule rule = this.rules.get(row);
+        if (rule != null) {
+            switch (col) {
+                case 0:
+                    return rule.getId();
+                case 1:
+                    return rule.getName();
+                case 2:
+                    return JobUtils.thresholdToI18n(rule.getThreshold());
+                case 3:
+                    return JobUtils.strengthToI18n(rule.getStrength());
+                default:
+                    return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return columnNames[col];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<ActiveScanJob.Rule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<ActiveScanJob.Rule> rules) {
+        if (rules == null) {
+            this.rules = new ArrayList<>();
+        } else {
+            this.rules = rules;
+        }
+    }
+
+    public void clear() {
+        this.rules.clear();
+    }
+
+    public void add(Rule rule) {
+        this.rules.add(rule);
+        this.fireTableRowsInserted(this.rules.size() - 1, this.rules.size() - 1);
+    }
+
+    public void update(int tableIndex, Rule rule) {
+        this.rules.set(tableIndex, rule);
+        this.fireTableRowsUpdated(tableIndex, tableIndex);
+    }
+
+    public void remove(int index) {
+        if (index < this.rules.size()) {
+            this.rules.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+
+    private ExtensionActiveScan getExtAscan() {
+        if (this.extAscan == null) {
+            this.extAscan =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionActiveScan.class);
+        }
+        return this.extAscan;
+    }
+
+    public List<Plugin> getAllScanRules() throws ConfigurationException {
+        return this.getExtAscan()
+                .getPolicyManager()
+                .getTemplatePolicy()
+                .getPluginFactory()
+                .getAllPlugin();
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
@@ -1,0 +1,144 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.lang.StringUtils;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.ContextWrapper;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class ContextDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.context.tab.context",
+        "automation.dialog.context.tab.include",
+        "automation.dialog.context.tab.exclude"
+    };
+
+    private static final String TITLE = "automation.dialog.context.title";
+    private static final String NAME_PARAM = "automation.dialog.context.name";
+    private static final String URLS_PARAM = "automation.dialog.context.urls";
+    private static final String INCLUDE_PARAM = "automation.dialog.context.include";
+    private static final String EXCLUDE_PARAM = "automation.dialog.context.exclude";
+
+    private boolean isNew = false;
+    private EnvironmentDialog envDialog;
+    private ContextWrapper.Data context;
+
+    public ContextDialog(EnvironmentDialog owner) {
+        this(owner, null);
+    }
+
+    public ContextDialog(EnvironmentDialog owner, ContextWrapper.Data context) {
+        super(owner, TITLE, DisplayUtils.getScaledDimension(400, 300), TAB_LABELS);
+        this.envDialog = owner;
+        if (context == null) {
+            context = new ContextWrapper.Data();
+            this.isNew = true;
+        }
+        this.context = context;
+
+        this.addTextField(0, NAME_PARAM, context.getName());
+        this.addMultilineField(0, URLS_PARAM, StringUtils.join(context.getUrls().toArray()));
+
+        this.addMultilineField(1, INCLUDE_PARAM, listToString(context.getIncludePaths()));
+
+        this.addMultilineField(2, EXCLUDE_PARAM, listToString(context.getExcludePaths()));
+    }
+
+    private String listToString(List<String> list) {
+        if (list != null) {
+            return StringUtils.join(list, "\n");
+        }
+        return "";
+    }
+
+    private List<String> stringParamToList(String param) {
+        // Return a list of the trimmed and non empty strings
+        return Arrays.asList(this.getStringValue(param).split("\n")).stream()
+                .map(String::trim)
+                .filter(item -> !item.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void save() {
+        this.context.setName(this.getStringValue(NAME_PARAM).trim());
+        this.context.setUrls(stringParamToList(URLS_PARAM));
+        this.context.setIncludePaths(stringParamToList(INCLUDE_PARAM));
+        this.context.setExcludePaths(stringParamToList(EXCLUDE_PARAM));
+        if (this.isNew) {
+            envDialog.addContext(context);
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        if (this.getStringValue(NAME_PARAM).trim().isEmpty()) {
+            return Constant.messages.getString("automation.dialog.context.error.badname");
+        }
+        List<String> urls = stringParamToList(URLS_PARAM);
+        if (urls.isEmpty()) {
+            return Constant.messages.getString("automation.dialog.context.error.nourls");
+        }
+        for (String str : urls) {
+            if (!str.contains("${")) {
+                // Can only validate strings that dont contain env vars
+                try {
+                    new URI(str, true);
+                } catch (Exception e) {
+                    return Constant.messages.getString(
+                            "automation.dialog.context.error.badurl", str);
+                }
+            }
+        }
+        for (String str : stringParamToList(INCLUDE_PARAM)) {
+            if (!str.contains("${")) {
+                // Can only validate strings that dont contain env vars
+                try {
+                    Pattern.compile(str);
+                } catch (Exception e) {
+                    return Constant.messages.getString(
+                            "automation.dialog.context.error.incregex", str);
+                }
+            }
+        }
+        for (String str : stringParamToList(EXCLUDE_PARAM)) {
+            if (!str.contains("${")) {
+                // Can only validate strings that dont contain env vars
+                try {
+                    Pattern.compile(str);
+                } catch (Exception e) {
+                    return Constant.messages.getString(
+                            "automation.dialog.context.error.excregex", str);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextsTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextsTableModel.java
@@ -1,0 +1,108 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.ContextWrapper;
+
+public class ContextsTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] columnNames = {
+        Constant.messages.getString("automation.dialog.contexts.table.header.name"),
+    };
+
+    private List<ContextWrapper> contexts = new ArrayList<>();
+
+    public ContextsTableModel() {
+        super();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return contexts.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        ContextWrapper context = this.contexts.get(row);
+        if (context != null) {
+            return context.getData().getName();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return columnNames[col];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<ContextWrapper> getContexts() {
+        return contexts;
+    }
+
+    public void setContexts(List<ContextWrapper> contexts) {
+        if (contexts == null) {
+            this.contexts = new ArrayList<>();
+        } else {
+            this.contexts = contexts;
+        }
+    }
+
+    public void clear() {
+        this.contexts.clear();
+    }
+
+    public void add(ContextWrapper context) {
+        this.contexts.add(context);
+        this.fireTableRowsInserted(this.contexts.size() - 1, this.contexts.size() - 1);
+    }
+
+    public void update(int tableIndex, ContextWrapper context) {
+        this.contexts.set(tableIndex, context);
+        this.fireTableRowsUpdated(tableIndex, tableIndex);
+    }
+
+    public void remove(int index) {
+        if (index < this.contexts.size()) {
+            this.contexts.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarDialog.java
@@ -1,0 +1,71 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class EnvVarDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.envvar.title";
+    private static final String KEY_PARAM = "automation.dialog.envvar.key";
+    private static final String VALUE_PARAM = "automation.dialog.envvar.value";
+
+    private boolean isNew = false;
+    private EnvironmentDialog envDialog;
+    private EnvVarTableModel.EnvVar envVar;
+
+    public EnvVarDialog(EnvironmentDialog owner) {
+        this(owner, null);
+    }
+
+    public EnvVarDialog(EnvironmentDialog owner, EnvVarTableModel.EnvVar envVar) {
+        super(owner, TITLE, DisplayUtils.getScaledDimension(300, 150));
+        this.envDialog = owner;
+        if (envVar == null) {
+            envVar = new EnvVarTableModel.EnvVar();
+            this.isNew = true;
+        }
+        this.envVar = envVar;
+
+        this.addTextField(KEY_PARAM, envVar.getKey());
+        this.addTextField(VALUE_PARAM, envVar.getValue());
+    }
+
+    @Override
+    public void save() {
+        this.envVar.setKey(this.getStringValue(KEY_PARAM).trim());
+        this.envVar.setValue(this.getStringValue(VALUE_PARAM).trim());
+        if (this.isNew) {
+            envDialog.addEnvVar(envVar);
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        if (this.getStringValue(KEY_PARAM).trim().isEmpty()) {
+            return Constant.messages.getString("automation.dialog.envvar.error.badkey");
+        }
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarTableModel.java
@@ -1,0 +1,155 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+
+public class EnvVarTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] columnNames = {
+        Constant.messages.getString("automation.dialog.env.table.header.key"),
+        Constant.messages.getString("automation.dialog.env.table.header.value")
+    };
+
+    private List<EnvVar> envVars = new ArrayList<>();
+
+    public EnvVarTableModel() {
+        super();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return envVars.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        EnvVar ev = this.envVars.get(row);
+        if (ev != null) {
+            switch (col) {
+                case 0:
+                    return ev.getKey();
+                case 1:
+                    return ev.getValue();
+                default:
+                    return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return columnNames[col];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<EnvVar> getEnvVars() {
+        return envVars;
+    }
+
+    public Map<String, String> getEnvVarMap() {
+        LinkedHashMap<String, String> map = new LinkedHashMap<>();
+        for (EnvVar ev : envVars) {
+            map.put(ev.getKey(), ev.getValue());
+        }
+        return map;
+    }
+
+    public void setEnvVars(Map<String, String> map) {
+        this.envVars.clear();
+        if (map != null) {
+            for (Entry<String, String> entry : map.entrySet()) {
+                this.envVars.add(new EnvVar(entry.getKey(), entry.getValue()));
+            }
+        }
+    }
+
+    public void clear() {
+        this.envVars.clear();
+    }
+
+    public void add(EnvVar rule) {
+        this.envVars.add(rule);
+        this.fireTableRowsInserted(this.envVars.size() - 1, this.envVars.size() - 1);
+    }
+
+    public void update(int tableIndex, EnvVar rule) {
+        this.envVars.set(tableIndex, rule);
+        this.fireTableRowsUpdated(tableIndex, tableIndex);
+    }
+
+    public void remove(int index) {
+        if (index < this.envVars.size()) {
+            this.envVars.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+
+    public static class EnvVar {
+        private String Key;
+        private String value;
+
+        public EnvVar() {}
+
+        public EnvVar(String key, String value) {
+            Key = key;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return Key;
+        }
+
+        public void setKey(String key) {
+            Key = key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
@@ -1,0 +1,320 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.ContextWrapper;
+import org.zaproxy.addon.automation.ContextWrapper.Data;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class EnvironmentDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.env.tab.contexts",
+        "automation.dialog.tab.params",
+        "automation.dialog.env.tab.vars"
+    };
+
+    private static final String TITLE = "automation.dialog.env.title";
+    private static final String FAIL_ON_ERROR_PARAM = "automation.dialog.env.failonerror";
+    private static final String FAIL_ON_WARNING_PARAM = "automation.dialog.env.failonwarning";
+    private static final String PROGRESS_TO_STDOUT_PARAM = "automation.dialog.env.progresstostdout";
+
+    private AutomationEnvironment env;
+
+    private JButton addContextButton = null;
+    private JButton modifyContextButton = null;
+    private JButton removeContextButton = null;
+
+    private JTable contextsTable = null;
+    private ContextsTableModel contextsModel = null;
+
+    private JButton addEnvVarButton = null;
+    private JButton modifyEnvVarButton = null;
+    private JButton removeEnvVarButton = null;
+
+    private JTable envVarTable = null;
+    private EnvVarTableModel envVarModel = null;
+
+    public EnvironmentDialog(AutomationEnvironment env) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 300),
+                TAB_LABELS);
+        this.env = env;
+
+        List<JButton> contextButtons = new ArrayList<>();
+        contextButtons.add(getAddContextButton());
+        contextButtons.add(getModifyContextButton());
+        contextButtons.add(getRemoveContextButton());
+
+        this.addTableField(0, getContextsTable(), contextButtons);
+
+        this.addCheckBoxField(
+                1, FAIL_ON_ERROR_PARAM, env.getData().getParameters().getFailOnError());
+        this.addCheckBoxField(
+                1, FAIL_ON_WARNING_PARAM, env.getData().getParameters().getFailOnWarning());
+        this.addCheckBoxField(
+                1, PROGRESS_TO_STDOUT_PARAM, env.getData().getParameters().getProgressToStdout());
+        this.addPadding(1);
+
+        List<JButton> envVarButtons = new ArrayList<>();
+        envVarButtons.add(getAddEnvVarButton());
+        envVarButtons.add(getModifyEnvVarButton());
+        envVarButtons.add(getRemoveEnvVarButton());
+
+        this.addTableField(2, getEnvVarsTable(), envVarButtons);
+    }
+
+    @Override
+    public void save() {
+        this.env.getData().getParameters().setFailOnError(this.getBoolValue(FAIL_ON_ERROR_PARAM));
+        this.env
+                .getData()
+                .getParameters()
+                .setFailOnWarning(this.getBoolValue(FAIL_ON_WARNING_PARAM));
+        this.env
+                .getData()
+                .getParameters()
+                .setProgressToStdout(this.getBoolValue(PROGRESS_TO_STDOUT_PARAM));
+
+        this.env.setContexts(this.getContextsModel().getContexts());
+        this.env.getData().setVars(this.getEnvVarsModel().getEnvVarMap());
+        this.env.getPlan().setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        if (this.getContextsModel().getContexts().isEmpty()) {
+            return Constant.messages.getString("automation.dialog.env.error.nocontext");
+        }
+        return null;
+    }
+
+    private JButton getAddContextButton() {
+        if (this.addContextButton == null) {
+            this.addContextButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addContextButton.addActionListener(
+                    e -> {
+                        ContextDialog dialog = new ContextDialog(this);
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.addContextButton;
+    }
+
+    private JButton getModifyContextButton() {
+        if (this.modifyContextButton == null) {
+            this.modifyContextButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            this.modifyContextButton.addActionListener(
+                    e -> {
+                        int row = getContextsTable().getSelectedRow();
+                        ContextDialog dialog =
+                                new ContextDialog(
+                                        this, this.contextsModel.getContexts().get(row).getData());
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.modifyContextButton;
+    }
+
+    private JButton getRemoveContextButton() {
+        if (this.removeContextButton == null) {
+            this.removeContextButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeContextButton.setEnabled(false);
+            final EnvironmentDialog parent = this;
+            this.removeContextButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.env.remove.confirm"))) {
+                            getContextsModel().remove(getContextsTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeContextButton;
+    }
+
+    private JTable getContextsTable() {
+        if (contextsTable == null) {
+            contextsTable = new JTable();
+            contextsTable.setModel(getContextsModel());
+            contextsTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                if (getContextsTable().getSelectedRowCount() == 0) {
+                                    modifyContextButton.setEnabled(false);
+                                    removeContextButton.setEnabled(false);
+                                } else if (getContextsTable().getSelectedRowCount() == 1) {
+                                    modifyContextButton.setEnabled(true);
+                                    removeContextButton.setEnabled(true);
+                                } else {
+                                    modifyContextButton.setEnabled(false);
+                                    removeContextButton.setEnabled(false);
+                                }
+                            });
+            contextsTable.addMouseListener(
+                    new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent me) {
+                            if (me.getClickCount() == 2) {
+                                int row = contextsTable.getSelectedRow();
+                                ContextDialog dialog =
+                                        new ContextDialog(
+                                                EnvironmentDialog.this,
+                                                contextsModel.getContexts().get(row).getData());
+                                dialog.setVisible(true);
+                            }
+                        }
+                    });
+        }
+        return contextsTable;
+    }
+
+    private ContextsTableModel getContextsModel() {
+        if (contextsModel == null) {
+            contextsModel = new ContextsTableModel();
+            contextsModel.setContexts(env.getContextWrappers());
+        }
+        return contextsModel;
+    }
+
+    public void addContext(Data context) {
+        getContextsModel().add(new ContextWrapper(context));
+    }
+
+    private JButton getAddEnvVarButton() {
+        if (this.addEnvVarButton == null) {
+            this.addEnvVarButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addEnvVarButton.addActionListener(
+                    e -> {
+                        EnvVarDialog dialog = new EnvVarDialog(this);
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.addEnvVarButton;
+    }
+
+    private JButton getModifyEnvVarButton() {
+        if (this.modifyEnvVarButton == null) {
+            this.modifyEnvVarButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            this.modifyEnvVarButton.addActionListener(
+                    e -> {
+                        int row = getEnvVarsTable().getSelectedRow();
+                        EnvVarDialog dialog =
+                                new EnvVarDialog(this, this.envVarModel.getEnvVars().get(row));
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.modifyEnvVarButton;
+    }
+
+    private JButton getRemoveEnvVarButton() {
+        if (this.removeEnvVarButton == null) {
+            this.removeEnvVarButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeEnvVarButton.setEnabled(false);
+            final EnvironmentDialog parent = this;
+            this.removeEnvVarButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.env.remove.confirm"))) {
+                            getEnvVarsModel().remove(getEnvVarsTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeEnvVarButton;
+    }
+
+    private JTable getEnvVarsTable() {
+        if (envVarTable == null) {
+            envVarTable = new JTable();
+            envVarTable.setModel(getEnvVarsModel());
+            envVarTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                if (getEnvVarsTable().getSelectedRowCount() == 0) {
+                                    modifyEnvVarButton.setEnabled(false);
+                                    removeEnvVarButton.setEnabled(false);
+                                } else if (getEnvVarsTable().getSelectedRowCount() == 1) {
+                                    modifyEnvVarButton.setEnabled(true);
+                                    removeEnvVarButton.setEnabled(true);
+                                } else {
+                                    modifyEnvVarButton.setEnabled(false);
+                                    removeEnvVarButton.setEnabled(false);
+                                }
+                            });
+            envVarTable.addMouseListener(
+                    new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent me) {
+                            if (me.getClickCount() == 2) {
+                                int row = envVarTable.getSelectedRow();
+                                EnvVarDialog dialog =
+                                        new EnvVarDialog(
+                                                EnvironmentDialog.this,
+                                                envVarModel.getEnvVars().get(row));
+                                dialog.setVisible(true);
+                            }
+                        }
+                    });
+        }
+        return envVarTable;
+    }
+
+    private EnvVarTableModel getEnvVarsModel() {
+        if (envVarModel == null) {
+            envVarModel = new EnvVarTableModel();
+            envVarModel.setEnvVars(env.getData().getVars());
+        }
+        return envVarModel;
+    }
+
+    public void addEnvVar(EnvVarTableModel.EnvVar envVar) {
+        getEnvVarsModel().add(envVar);
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
@@ -1,0 +1,223 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class PassiveScanConfigJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.tab.params", "automation.dialog.pscanconfig.tab.rules"
+    };
+
+    private static final String TITLE = "automation.dialog.pscanconfig.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String MAX_ALERTS_PER_RULE_PARAM =
+            "automation.dialog.pscanconfig.maxalertsperrule";
+    private static final String SCAN_ONLY_IN_SCOPE_PARAM =
+            "automation.dialog.pscanconfig.scanonlyinscope";
+    private static final String MAX_BODY_SIZE_PARAM = "automation.dialog.pscanconfig.maxbodysize";
+    private static final String ENABLE_TAGS_PARAM = "automation.dialog.pscanconfig.enabletags";
+
+    private PassiveScanConfigJob job;
+
+    private JButton addButton = null;
+    private JButton modifyButton = null;
+    private JButton removeButton = null;
+
+    private JTable rulesTable = null;
+    private PscanRulesTableModel rulesModel = null;
+
+    public PassiveScanConfigJobDialog(PassiveScanConfigJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 300),
+                TAB_LABELS);
+        this.job = job;
+
+        this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+        this.addNumberField(
+                0,
+                MAX_ALERTS_PER_RULE_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxAlertsPerRule()));
+        this.addNumberField(
+                0,
+                MAX_BODY_SIZE_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxBodySizeInBytesToScan()));
+        this.addCheckBoxField(
+                0,
+                SCAN_ONLY_IN_SCOPE_PARAM,
+                JobUtils.unBox(this.job.getParameters().getScanOnlyInScope()));
+        this.addCheckBoxField(
+                0, ENABLE_TAGS_PARAM, JobUtils.unBox(this.job.getParameters().getEnableTags()));
+        this.addPadding(0);
+
+        List<JButton> buttons = new ArrayList<>();
+        buttons.add(getAddButton());
+        buttons.add(getModifyButton());
+        buttons.add(getRemoveButton());
+
+        this.addTableField(1, getRulesTable(), buttons);
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setMaxAlertsPerRule(this.getIntValue(MAX_ALERTS_PER_RULE_PARAM));
+        this.job.getParameters().setScanOnlyInScope(this.getBoolValue(SCAN_ONLY_IN_SCOPE_PARAM));
+        this.job.getParameters().setMaxBodySizeInBytesToScan(this.getIntValue(MAX_BODY_SIZE_PARAM));
+        this.job.getParameters().setEnableTags(this.getBoolValue(ENABLE_TAGS_PARAM));
+        this.job.getData().setRules(this.getRulesModel().getRules());
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+
+    private JButton getAddButton() {
+        if (this.addButton == null) {
+            this.addButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addButton.addActionListener(
+                    e -> {
+                        AddPscanRuleDialog dialog = new AddPscanRuleDialog(getRulesModel());
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.addButton;
+    }
+
+    private JButton getModifyButton() {
+        if (this.modifyButton == null) {
+            this.modifyButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            this.modifyButton.addActionListener(
+                    e -> {
+                        int row = getRulesTable().getSelectedRow();
+                        AddPscanRuleDialog dialog =
+                                new AddPscanRuleDialog(
+                                        getRulesModel(), getRulesModel().getRules().get(row), row);
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.modifyButton;
+    }
+
+    private JButton getRemoveButton() {
+        if (this.removeButton == null) {
+            this.removeButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeButton.setEnabled(false);
+            final PassiveScanConfigJobDialog parent = this;
+            this.removeButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.pscanconfig.remove.confirm"))) {
+                            getRulesModel().remove(getRulesTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeButton;
+    }
+
+    private JTable getRulesTable() {
+        if (rulesTable == null) {
+            rulesTable = new JTable();
+            rulesTable.setModel(getRulesModel());
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(0)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(50));
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(1)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(270));
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(2)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(80));
+            rulesTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                if (getRulesTable().getSelectedRowCount() == 0) {
+                                    modifyButton.setEnabled(false);
+                                    removeButton.setEnabled(false);
+                                } else if (getRulesTable().getSelectedRowCount() == 1) {
+                                    modifyButton.setEnabled(true);
+                                    removeButton.setEnabled(true);
+                                } else {
+                                    modifyButton.setEnabled(false);
+                                    removeButton.setEnabled(false);
+                                }
+                            });
+            rulesTable.addMouseListener(
+                    new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent me) {
+                            if (me.getClickCount() == 2) {
+                                int row = getRulesTable().getSelectedRow();
+                                AddPscanRuleDialog dialog =
+                                        new AddPscanRuleDialog(
+                                                getRulesModel(),
+                                                getRulesModel().getRules().get(row),
+                                                row);
+                                dialog.setVisible(true);
+                            }
+                        }
+                    });
+        }
+        return rulesTable;
+    }
+
+    private PscanRulesTableModel getRulesModel() {
+        if (rulesModel == null) {
+            rulesModel = new PscanRulesTableModel();
+            rulesModel.setRules(job.getData().getRules());
+        }
+        return rulesModel;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanWaitJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanWaitJobDialog.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class PassiveScanWaitJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.pscanwait.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String MAX_DURATION_PARAM = "automation.dialog.pscanwait.maxduration";
+
+    private PassiveScanWaitJob job;
+
+    public PassiveScanWaitJobDialog(PassiveScanWaitJob job) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(300, 200));
+        this.job = job;
+
+        this.addTextField(NAME_PARAM, this.job.getData().getName());
+        this.addNumberField(
+                MAX_DURATION_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                this.job.getParameters().getMaxDuration());
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setMaxDuration(this.getIntValue(MAX_DURATION_PARAM));
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PlanTreeTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PlanTreeTableModel.java
@@ -122,6 +122,7 @@ public class PlanTreeTableModel extends DefaultTreeModel implements TreeTableMod
                 case TYPE_INDEX:
                     return "env";
                 case INFO_INDEX:
+                    // TODO
                     return "";
                 default:
             }
@@ -171,8 +172,7 @@ public class PlanTreeTableModel extends DefaultTreeModel implements TreeTableMod
                                 "automation.panel.table.info.warning",
                                 jobResults.getWarnings().toString());
                     } else if (job.getStatus().equals(AutomationJob.Status.NOT_STARTED)) {
-                        return Constant.messages.getString(
-                                "automation.panel.table.info.config", job.getJobData().toString());
+                        return job.getSummary();
                     } else {
                         return Constant.messages.getString(
                                 "automation.panel.table.info.ok", jobResults.getInfos().toString());

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PscanRulesTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PscanRulesTableModel.java
@@ -1,0 +1,144 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
+import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob.Rule;
+import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class PscanRulesTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] columnNames = {
+        Constant.messages.getString("automation.dialog.pscanconfig.table.header.id"),
+        Constant.messages.getString("automation.dialog.pscanconfig.table.header.name"),
+        Constant.messages.getString("automation.dialog.pscanconfig.table.header.threshold")
+    };
+
+    private List<PassiveScanConfigJob.Rule> rules = new ArrayList<>();
+
+    private ExtensionPassiveScan extPscan;
+
+    public PscanRulesTableModel() {
+        super();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return rules.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        PassiveScanConfigJob.Rule rule = this.rules.get(row);
+        if (rule != null) {
+            switch (col) {
+                case 0:
+                    return rule.getId();
+                case 1:
+                    return rule.getName();
+                case 2:
+                    return JobUtils.thresholdToI18n(rule.getThreshold());
+                default:
+                    return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return columnNames[col];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<PassiveScanConfigJob.Rule> getRules() {
+        return rules;
+    }
+
+    public void setRules(List<PassiveScanConfigJob.Rule> rules) {
+        if (rules == null) {
+            this.rules = new ArrayList<>();
+        } else {
+            this.rules = rules;
+        }
+    }
+
+    public void clear() {
+        this.rules.clear();
+    }
+
+    public void add(Rule rule) {
+        this.rules.add(rule);
+        this.fireTableRowsInserted(this.rules.size() - 1, this.rules.size() - 1);
+    }
+
+    public void update(int tableIndex, Rule rule) {
+        this.rules.set(tableIndex, rule);
+        this.fireTableRowsUpdated(tableIndex, tableIndex);
+    }
+
+    public void remove(int index) {
+        if (index < this.rules.size()) {
+            this.rules.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+
+    private ExtensionPassiveScan getExtPscan() {
+        if (this.extPscan == null) {
+            this.extPscan =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionPassiveScan.class);
+        }
+        return this.extPscan;
+    }
+
+    public List<PluginPassiveScanner> getAllScanRules() {
+        return this.getExtPscan().getPluginPassiveScanners();
+    }
+
+    public PluginPassiveScanner getScanRule(int id) {
+        return this.getExtPscan().getPluginPassiveScanner(id);
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
@@ -1,0 +1,195 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.RequestorJob;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class RequestorJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.tab.params", "automation.dialog.requestor.tab.requests"
+    };
+
+    private static final String TITLE = "automation.dialog.requestor.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+
+    private RequestorJob job;
+
+    private JButton addButton = null;
+    private JButton modifyButton = null;
+    private JButton removeButton = null;
+
+    private JTable rulesTable = null;
+    private RequestsTableModel rulesModel = null;
+
+    public RequestorJobDialog(RequestorJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 300),
+                TAB_LABELS);
+        this.job = job;
+
+        List<JButton> buttons = new ArrayList<>();
+        buttons.add(getAddButton());
+        buttons.add(getModifyButton());
+        buttons.add(getRemoveButton());
+
+        this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+        this.addPadding(0);
+
+        this.addTableField(1, getRulesTable(), buttons);
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        job.getData().setRequests(this.getRulesModel().getRules());
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+
+    private JButton getAddButton() {
+        if (this.addButton == null) {
+            this.addButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addButton.addActionListener(
+                    e -> {
+                        AddRequestDialog dialog = new AddRequestDialog(getRulesModel());
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.addButton;
+    }
+
+    private JButton getModifyButton() {
+        if (this.modifyButton == null) {
+            this.modifyButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            this.modifyButton.setEnabled(false);
+            this.modifyButton.addActionListener(
+                    e -> {
+                        int row = getRulesTable().getSelectedRow();
+                        AddRequestDialog dialog =
+                                new AddRequestDialog(
+                                        getRulesModel(), getRulesModel().getRules().get(row), row);
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.modifyButton;
+    }
+
+    private JButton getRemoveButton() {
+        if (this.removeButton == null) {
+            this.removeButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeButton.setEnabled(false);
+            final RequestorJobDialog parent = this;
+            this.removeButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.requestor.remove.confirm"))) {
+                            getRulesModel().remove(getRulesTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeButton;
+    }
+
+    private JTable getRulesTable() {
+        if (rulesTable == null) {
+            rulesTable = new JTable();
+            rulesTable.setModel(getRulesModel());
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(0)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(80));
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(1)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(240));
+            rulesTable
+                    .getColumnModel()
+                    .getColumn(2)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(80));
+            rulesTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                if (getRulesTable().getSelectedRowCount() == 0) {
+                                    modifyButton.setEnabled(false);
+                                    removeButton.setEnabled(false);
+                                } else if (getRulesTable().getSelectedRowCount() == 1) {
+                                    modifyButton.setEnabled(true);
+                                    removeButton.setEnabled(true);
+                                } else {
+                                    modifyButton.setEnabled(false);
+                                    removeButton.setEnabled(false);
+                                }
+                            });
+            rulesTable.addMouseListener(
+                    new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent me) {
+                            if (me.getClickCount() == 2) {
+                                int row = getRulesTable().getSelectedRow();
+                                AddRequestDialog dialog =
+                                        new AddRequestDialog(
+                                                getRulesModel(),
+                                                getRulesModel().getRules().get(row),
+                                                row);
+                                dialog.setVisible(true);
+                            }
+                        }
+                    });
+        }
+        return rulesTable;
+    }
+
+    private RequestsTableModel getRulesModel() {
+        if (rulesModel == null) {
+            rulesModel = new RequestsTableModel();
+            rulesModel.setRules(job.getData().getRequests());
+        }
+        return rulesModel;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestsTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestsTableModel.java
@@ -1,0 +1,119 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.jobs.RequestorJob;
+
+public class RequestsTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] columnNames = {
+        Constant.messages.getString("automation.dialog.requests.table.header.method"),
+        Constant.messages.getString("automation.dialog.requests.table.header.url"),
+        Constant.messages.getString("automation.dialog.requests.table.header.code")
+    };
+
+    private List<RequestorJob.Request> requests = new ArrayList<>();
+
+    public RequestsTableModel() {
+        super();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return requests.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        RequestorJob.Request rule = this.requests.get(row);
+        if (rule != null) {
+            switch (col) {
+                case 0:
+                    return rule.getMethod();
+                case 1:
+                    return rule.getUrl();
+                case 2:
+                    return rule.getResponseCode();
+                default:
+                    return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return columnNames[col];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<RequestorJob.Request> getRules() {
+        return requests;
+    }
+
+    public void setRules(List<RequestorJob.Request> rules) {
+        if (rules == null) {
+            this.requests = new ArrayList<>();
+        } else {
+            this.requests = rules;
+        }
+    }
+
+    public void clear() {
+        this.requests.clear();
+    }
+
+    public void add(RequestorJob.Request rule) {
+        this.requests.add(rule);
+        this.fireTableRowsInserted(this.requests.size() - 1, this.requests.size() - 1);
+    }
+
+    public void update(int tableIndex, RequestorJob.Request rule) {
+        this.requests.set(tableIndex, rule);
+        this.fireTableRowsUpdated(tableIndex, tableIndex);
+    }
+
+    public void remove(int index) {
+        if (index < this.requests.size()) {
+            this.requests.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
@@ -1,0 +1,315 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.Arrays;
+import java.util.List;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JTextField;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.automation.jobs.SpiderJob;
+import org.zaproxy.addon.automation.jobs.SpiderJob.Parameters;
+import org.zaproxy.zap.spider.SpiderParam;
+import org.zaproxy.zap.spider.SpiderParam.HandleParametersOption;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class SpiderJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.tab.params",
+        "automation.dialog.spider.tab.parse",
+        "automation.dialog.spider.tab.adv"
+    };
+
+    private static final String TITLE = "automation.dialog.spider.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String CONTEXT_PARAM = "automation.dialog.spider.context";
+    private static final String URL_PARAM = "automation.dialog.spider.url";
+    private static final String MAX_DURATION_PARAM = "automation.dialog.spider.maxduration";
+    private static final String MAX_DEPTH_PARAM = "automation.dialog.spider.maxdepth";
+    private static final String MAX_CHILDREN_PARAM = "automation.dialog.spider.maxchildren";
+    private static final String FIELD_ADVANCED = "automation.dialog.spider.advanced";
+
+    private static final String ACCEPT_COOKIES_PARAM = "automation.dialog.spider.acceptcookies";
+    private static final String HANDLE_OODATA_PARAM = "automation.dialog.spider.handleoodata";
+    private static final String HANDLE_PARAMS_PARAM = "automation.dialog.spider.handleparams";
+    private static final String MAX_PARSE_PARAM = "automation.dialog.spider.maxparse";
+    private static final String PARSE_COMMENTS_PARAM = "automation.dialog.spider.parsecomments";
+    private static final String PARSE_GIT_PARAM = "automation.dialog.spider.parsegit";
+    private static final String PARSE_ROBOTS_PARAM = "automation.dialog.spider.parserobots";
+    private static final String PARSE_SITEMAP_PARAM = "automation.dialog.spider.parsesitemap";
+    private static final String PARSE_SVN_PARAM = "automation.dialog.spider.parsessvn";
+    private static final String POST_FORM_PARAM = "automation.dialog.spider.postform";
+    private static final String PROCESS_FORM_PARAM = "automation.dialog.spider.processform";
+    private static final String REQ_WAIT_TIME_PARAM = "automation.dialog.spider.reqwaittime";
+    private static final String SEND_REFERER_PARAM = "automation.dialog.spider.sendreferer";
+    private static final String THREAD_COUNT_PARAM = "automation.dialog.spider.threadcount";
+    private static final String USER_AGENT_PARAM = "automation.dialog.spider.useragent";
+
+    private SpiderJob job;
+    private DefaultComboBoxModel<SpiderParam.HandleParametersOption> handleParamsModel;
+
+    public SpiderJobDialog(SpiderJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 400),
+                TAB_LABELS);
+        this.job = job;
+
+        this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+        List<String> contextNames = this.job.getEnv().getContextNames();
+        // Add blank option
+        contextNames.add(0, "");
+        this.addComboField(0, CONTEXT_PARAM, contextNames, this.job.getParameters().getContext());
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(0, URL_PARAM, null, true, false);
+        Component urlField = this.getField(URL_PARAM);
+        if (urlField instanceof JTextField) {
+            ((JTextField) urlField).setText(this.job.getParameters().getUrl());
+        }
+        this.addNumberField(
+                0,
+                MAX_DURATION_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxDuration()));
+        this.addNumberField(
+                0,
+                MAX_DEPTH_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxDepth()));
+        this.addNumberField(
+                0,
+                MAX_CHILDREN_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxChildren()));
+        this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
+
+        this.addFieldListener(
+                FIELD_ADVANCED,
+                new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+                    }
+                });
+
+        this.addPadding(0);
+
+        this.addCheckBoxField(
+                1,
+                PARSE_COMMENTS_PARAM,
+                JobUtils.unBox(this.job.getParameters().getParseComments()));
+        this.addCheckBoxField(
+                1, PARSE_GIT_PARAM, JobUtils.unBox(this.job.getParameters().getParseGit()));
+        this.addCheckBoxField(
+                1,
+                PARSE_ROBOTS_PARAM,
+                JobUtils.unBox(this.job.getParameters().getParseRobotsTxt()));
+        this.addCheckBoxField(
+                1,
+                PARSE_SITEMAP_PARAM,
+                JobUtils.unBox(this.job.getParameters().getParseSitemapXml()));
+        this.addCheckBoxField(
+                1, PARSE_SVN_PARAM, JobUtils.unBox(this.job.getParameters().getParseSVNEntries()));
+
+        this.addPadding(1);
+
+        this.addNumberField(
+                2,
+                MAX_PARSE_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxParseSizeBytes()));
+        this.addNumberField(
+                2,
+                REQ_WAIT_TIME_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getRequestWaitTime()));
+        this.addNumberField(
+                2,
+                THREAD_COUNT_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getThreadCount()));
+
+        handleParamsModel = new DefaultComboBoxModel<SpiderParam.HandleParametersOption>();
+        Arrays.stream(SpiderParam.HandleParametersOption.values())
+                .forEach(v -> handleParamsModel.addElement(v));
+        DefaultListCellRenderer renderer =
+                new DefaultListCellRenderer() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Component getListCellRendererComponent(
+                            JList<?> list,
+                            Object value,
+                            int index,
+                            boolean isSelected,
+                            boolean cellHasFocus) {
+                        JLabel label =
+                                (JLabel)
+                                        super.getListCellRendererComponent(
+                                                list, value, index, isSelected, cellHasFocus);
+                        if (value instanceof HandleParametersOption) {
+                            // The name is i18n'ed
+                            label.setText(((HandleParametersOption) value).getName());
+                        }
+                        return label;
+                    }
+                };
+
+        SpiderParam.HandleParametersOption hpo = null;
+        if (this.job.getParameters().getHandleParameters() != null) {
+            hpo =
+                    SpiderParam.HandleParametersOption.valueOf(
+                            this.job.getParameters().getHandleParameters());
+            handleParamsModel.setSelectedItem(hpo);
+        }
+        this.addComboField(2, HANDLE_PARAMS_PARAM, handleParamsModel);
+        Component acField = this.getField(HANDLE_PARAMS_PARAM);
+        if (acField instanceof JComboBox) {
+            ((JComboBox<?>) acField).setRenderer(renderer);
+        }
+
+        this.addCheckBoxField(
+                2,
+                ACCEPT_COOKIES_PARAM,
+                JobUtils.unBox(this.job.getParameters().getAcceptCookies()));
+        this.addCheckBoxField(
+                2,
+                HANDLE_OODATA_PARAM,
+                JobUtils.unBox(this.job.getParameters().getHandleODataParametersVisited()));
+
+        this.addCheckBoxField(
+                2, POST_FORM_PARAM, JobUtils.unBox(this.job.getParameters().getPostForm()));
+        this.addCheckBoxField(
+                2, PROCESS_FORM_PARAM, JobUtils.unBox(this.job.getParameters().getProcessForm()));
+        this.addCheckBoxField(
+                2,
+                SEND_REFERER_PARAM,
+                JobUtils.unBox(this.job.getParameters().getSendRefererHeader()));
+        this.addTextField(2, USER_AGENT_PARAM, this.job.getParameters().getUserAgent());
+
+        this.addPadding(2);
+
+        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+    }
+
+    private boolean advOptionsSet() {
+        Parameters params = this.job.getParameters();
+        return params.getAcceptCookies() != null
+                || params.getHandleODataParametersVisited() != null
+                || params.getMaxParseSizeBytes() != null
+                || params.getParseComments() != null
+                || params.getParseGit() != null
+                || params.getParseRobotsTxt() != null
+                || params.getParseSitemapXml() != null
+                || params.getParseSVNEntries() != null
+                || params.getPostForm() != null
+                || params.getProcessForm() != null
+                || params.getRequestWaitTime() != null
+                || params.getSendRefererHeader() != null
+                || params.getThreadCount() != null
+                || params.getUserAgent() != null;
+    }
+
+    private void setAdvancedTabs(boolean visible) {
+        // Show/hide all except from the first tab
+        this.setTabsVisible(
+                new String[] {
+                    "automation.dialog.spider.tab.parse", "automation.dialog.spider.tab.adv"
+                },
+                visible);
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setContext(this.getStringValue(CONTEXT_PARAM));
+        this.job.getParameters().setUrl(this.getStringValue(URL_PARAM));
+        this.job.getParameters().setMaxDuration(this.getIntValue(MAX_DURATION_PARAM));
+        this.job.getParameters().setMaxDepth(this.getIntValue(MAX_DEPTH_PARAM));
+        this.job.getParameters().setMaxChildren(this.getIntValue(MAX_CHILDREN_PARAM));
+
+        if (this.getBoolValue(FIELD_ADVANCED)) {
+            this.job.getParameters().setAcceptCookies(this.getBoolValue(ACCEPT_COOKIES_PARAM));
+            this.job
+                    .getParameters()
+                    .setHandleODataParametersVisited(this.getBoolValue(HANDLE_OODATA_PARAM));
+            this.job.getParameters().setMaxParseSizeBytes(this.getIntValue(MAX_PARSE_PARAM));
+            this.job.getParameters().setParseComments(this.getBoolValue(PARSE_COMMENTS_PARAM));
+            this.job.getParameters().setParseGit(this.getBoolValue(PARSE_GIT_PARAM));
+            this.job.getParameters().setParseRobotsTxt(this.getBoolValue(PARSE_ROBOTS_PARAM));
+            this.job.getParameters().setParseSitemapXml(this.getBoolValue(PARSE_SITEMAP_PARAM));
+            this.job.getParameters().setParseSVNEntries(this.getBoolValue(PARSE_SVN_PARAM));
+            this.job.getParameters().setPostForm(this.getBoolValue(POST_FORM_PARAM));
+            this.job.getParameters().setProcessForm(this.getBoolValue(PROCESS_FORM_PARAM));
+            this.job.getParameters().setRequestWaitTime(this.getIntValue(REQ_WAIT_TIME_PARAM));
+            this.job.getParameters().setSendRefererHeader(this.getBoolValue(SEND_REFERER_PARAM));
+            this.job.getParameters().setUserAgent(this.getStringValue(USER_AGENT_PARAM));
+
+            Object hpoObj = handleParamsModel.getSelectedItem();
+            if (hpoObj instanceof SpiderParam.HandleParametersOption) {
+                SpiderParam.HandleParametersOption hpo =
+                        (SpiderParam.HandleParametersOption) hpoObj;
+                this.job.getParameters().setHandleParameters(hpo.name());
+            }
+
+        } else {
+            this.job.getParameters().setAcceptCookies(null);
+            this.job.getParameters().setHandleODataParametersVisited(null);
+            this.job.getParameters().setMaxParseSizeBytes(null);
+            this.job.getParameters().setParseComments(null);
+            this.job.getParameters().setParseGit(null);
+            this.job.getParameters().setParseRobotsTxt(null);
+            this.job.getParameters().setParseSitemapXml(null);
+            this.job.getParameters().setParseSVNEntries(null);
+            this.job.getParameters().setPostForm(null);
+            this.job.getParameters().setProcessForm(null);
+            this.job.getParameters().setRequestWaitTime(null);
+            this.job.getParameters().setSendRefererHeader(null);
+            this.job.getParameters().setUserAgent(null);
+            this.job.getParameters().setHandleParameters(null);
+        }
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do TODO validate url - coping with envvars :O
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/StatisticTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/StatisticTestDialog.java
@@ -1,0 +1,91 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.Arrays;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.AbstractAutomationTest.OnFail;
+import org.zaproxy.addon.automation.AutomationStatisticTest;
+import org.zaproxy.addon.automation.AutomationStatisticTest.Operator;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class StatisticTestDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.statistictest.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String STATISTIC_PARAM = "automation.dialog.statistictest.statistic";
+    private static final String OPERATOR_PARAM = "automation.dialog.statistictest.operator";
+    private static final String VALUE_PARAM = "automation.dialog.statistictest.value";
+    private static final String ON_FAIL_PARAM = "automation.dialog.statistictest.onfail";
+
+    private AutomationStatisticTest test;
+
+    public StatisticTestDialog(AutomationStatisticTest test) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(400, 250));
+        this.test = test;
+
+        this.addTextField(NAME_PARAM, test.getData().getName());
+        this.addComboField(
+                ON_FAIL_PARAM,
+                Arrays.asList(OnFail.values()).stream()
+                        .map(o -> o.toString())
+                        .toArray(String[]::new),
+                test.getData().getOnFail().toString());
+        int i = 0;
+        Long l = test.getData().getValue();
+        if (l != null) {
+            try {
+                i = Math.toIntExact(test.getData().getValue());
+            } catch (Exception e) {
+                i = Integer.MAX_VALUE;
+            }
+        }
+        this.addTextField(STATISTIC_PARAM, test.getData().getStatistic());
+
+        this.addComboField(
+                OPERATOR_PARAM,
+                Arrays.asList(Operator.values()).stream()
+                        .map(o -> o.getSymbol())
+                        .toArray(String[]::new),
+                test.getData().getOperator());
+
+        this.addNumberField(VALUE_PARAM, 0, Integer.MAX_VALUE, i);
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.test.getData().setName(this.getStringValue(NAME_PARAM));
+        this.test.getData().setStatistic(this.getStringValue(STATISTIC_PARAM));
+        this.test.getData().setOperator(this.getStringValue(OPERATOR_PARAM));
+        this.test.getData().setValue(Long.valueOf(this.getIntValue(VALUE_PARAM)));
+        this.test.getData().setOnFail(OnFail.i18nToOnFail(this.getStringValue(ON_FAIL_PARAM)));
+        this.test.getJob().getPlan().setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -24,18 +24,22 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.lang.StringUtils;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
 import org.parosproxy.paros.core.scanner.PluginFactory;
+import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.addon.automation.JobResultData;
+import org.zaproxy.addon.automation.gui.ActiveScanJobDialog;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
@@ -47,18 +51,17 @@ public class ActiveScanJob extends AutomationJob {
     private static final String OPTIONS_METHOD_NAME = "getScannerParam";
 
     private static final String PARAM_CONTEXT = "context";
-    private static final String PARAM_MAX_SCAN_DURATION = "maxScanDurationInMins";
     private static final String PARAM_POLICY = "policy";
 
     private ExtensionActiveScan extAScan;
 
-    // Local copy
-    private int maxDuration = 0;
+    private Parameters parameters = new Parameters();
+    private PolicyDefinition policyDefinition = new PolicyDefinition();
+    private Data data;
 
-    private String contextName;
-    private String policy;
-
-    public ActiveScanJob() {}
+    public ActiveScanJob() {
+        data = new Data(this, this.parameters, this.policyDefinition);
+    }
 
     private ExtensionActiveScan getExtAScan() {
         if (extAScan == null) {
@@ -70,77 +73,26 @@ public class ActiveScanJob extends AutomationJob {
         return extAScan;
     }
 
-    private boolean verifyOrApplyCustomParameter(
-            String name, String value, AutomationProgress progress) {
-        switch (name) {
-            case PARAM_CONTEXT:
-                contextName = value;
-                return true;
-            case PARAM_MAX_SCAN_DURATION:
-                if (progress != null) {
-                    try {
-                        Integer.parseInt(value);
-                    } catch (NumberFormatException e) {
-                        progress.error(
-                                Constant.messages.getString(
-                                        "automation.error.options.badint",
-                                        this.getType(),
-                                        name,
-                                        value));
-                    }
-                } else {
-                    maxDuration = Integer.parseInt(value);
-                }
-                // Don't consume this as we still want it to be applied to the ascan params
-                return false;
-            case PARAM_POLICY:
-                if (progress != null) {
-                    try {
-                        this.getExtAScan().getPolicyManager().getPolicy(value);
-                    } catch (ConfigurationException e) {
-                        progress.error(
-                                Constant.messages.getString(
-                                        "automation.error.ascan.policy.name",
-                                        this.getName(),
-                                        value));
-                    }
-                } else {
-                    policy = value;
-                }
-                return true;
-            default:
-                // Ignore
-                break;
+    @Override
+    public void verifyParameters(AutomationProgress progress) {
+        LinkedHashMap<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
         }
-        return false;
-    }
+        LinkedHashMap<?, ?> params = (LinkedHashMap<?, ?>) jobData.get("parameters");
+        JobUtils.applyParamsToObject(params, this.parameters, this.getName(), null, progress);
 
-    @Override
-    public boolean applyCustomParameter(String name, String value) {
-        return this.verifyOrApplyCustomParameter(name, value, null);
-    }
-
-    @Override
-    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        return this.verifyOrApplyCustomParameter(name, value, progress);
-    }
-
-    @Override
-    public Map<String, String> getCustomConfigParameters() {
-        Map<String, String> map = super.getCustomConfigParameters();
-        map.put(PARAM_CONTEXT, "");
-        return map;
-    }
-
-    @Override
-    public void verifyJobSpecificData(AutomationProgress progress) {
+        // Parse the policy defn
         Object policyDefn = this.getJobData().get("policyDefinition");
         if (policyDefn instanceof LinkedHashMap<?, ?>) {
             LinkedHashMap<?, ?> policyDefnData = (LinkedHashMap<?, ?>) policyDefn;
-            JobUtils.parseAttackStrength(
-                    policyDefnData.get("defaultStrength"), this.getName(), progress);
-            JobUtils.parseAlertThreshold(
-                    policyDefnData.get("defaultThreshold"), this.getName(), progress);
+
+            JobUtils.applyParamsToObject(
+                    policyDefnData,
+                    this.policyDefinition,
+                    this.getName(),
+                    new String[] {"rules"},
+                    progress);
 
             ScanPolicy scanPolicy = new ScanPolicy();
             PluginFactory pluginFactory = scanPolicy.getPluginFactory();
@@ -148,16 +100,30 @@ public class ActiveScanJob extends AutomationJob {
             Object o = policyDefnData.get("rules");
             if (o instanceof ArrayList<?>) {
                 ArrayList<?> ruleData = (ArrayList<?>) o;
-                for (Object rule : ruleData) {
-                    if (rule instanceof LinkedHashMap<?, ?>) {
-                        LinkedHashMap<?, ?> ruleMap = (LinkedHashMap<?, ?>) rule;
+                for (Object ruleObj : ruleData) {
+                    if (ruleObj instanceof LinkedHashMap<?, ?>) {
+                        LinkedHashMap<?, ?> ruleMap = (LinkedHashMap<?, ?>) ruleObj;
                         Integer id = (Integer) ruleMap.get("id");
                         Plugin plugin = pluginFactory.getPlugin(id);
                         if (plugin != null) {
-                            JobUtils.parseAttackStrength(
-                                    ruleMap.get("strength"), this.getName(), progress);
-                            JobUtils.parseAlertThreshold(
-                                    ruleMap.get("threshold"), this.getName(), progress);
+                            AttackStrength strength =
+                                    JobUtils.parseAttackStrength(
+                                            ruleMap.get("strength"), this.getName(), progress);
+                            AlertThreshold threshold =
+                                    JobUtils.parseAlertThreshold(
+                                            ruleMap.get("threshold"), this.getName(), progress);
+
+                            Rule rule = new Rule();
+                            rule.setId(id);
+                            rule.setName(plugin.getName());
+                            if (threshold != null) {
+                                rule.setThreshold(threshold.name().toLowerCase());
+                            }
+                            if (strength != null) {
+                                rule.setStrength(strength.name().toLowerCase());
+                            }
+                            this.getData().getPolicyDefinition().addRule(rule);
+
                         } else {
                             progress.warn(
                                     Constant.messages.getString(
@@ -184,15 +150,34 @@ public class ActiveScanJob extends AutomationJob {
     }
 
     @Override
+    public void applyParameters(AutomationProgress progress) {
+        JobUtils.applyObjectToObject(
+                this.parameters,
+                JobUtils.getJobOptions(this, progress),
+                this.getName(),
+                new String[] {PARAM_POLICY},
+                progress,
+                this.getPlan().getEnv());
+    }
+
+    @Override
+    public Map<String, String> getCustomConfigParameters() {
+        Map<String, String> map = super.getCustomConfigParameters();
+        map.put(PARAM_CONTEXT, "");
+        return map;
+    }
+
+    @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
 
         ContextWrapper context;
-        if (contextName != null) {
-            context = env.getContextWrapper(contextName);
+        if (this.getParameters().getContext() != null) {
+            context = env.getContextWrapper(this.getParameters().getContext());
             if (context == null) {
                 progress.error(
                         Constant.messages.getString(
-                                "automation.error.context.unknown", contextName));
+                                "automation.error.context.unknown",
+                                this.getParameters().getContext()));
                 return;
             }
         } else {
@@ -204,9 +189,12 @@ public class ActiveScanJob extends AutomationJob {
         List<Object> contextSpecificObjects = new ArrayList<>();
 
         ScanPolicy scanPolicy = null;
-        if (policy != null) {
+        if (this.getParameters().getPolicy() != null) {
             try {
-                scanPolicy = this.getExtAScan().getPolicyManager().getPolicy(policy);
+                scanPolicy =
+                        this.getExtAScan()
+                                .getPolicyManager()
+                                .getPolicy(this.getParameters().getPolicy());
             } catch (ConfigurationException e) {
                 // Error already raised above
             }
@@ -220,12 +208,13 @@ public class ActiveScanJob extends AutomationJob {
         int scanId = this.getExtAScan().startScan(target, null, contextSpecificObjects.toArray());
 
         long endTime = Long.MAX_VALUE;
-        if (maxDuration > 0) {
+        if (JobUtils.unBox(this.getParameters().getMaxScanDurationInMins()) > 0) {
             // The active scan should stop, if it doesnt we will stop it (after a few seconds
             // leeway)
             endTime =
                     System.currentTimeMillis()
-                            + TimeUnit.MINUTES.toMillis(maxDuration)
+                            + TimeUnit.MINUTES.toMillis(
+                                    this.getParameters().getMaxScanDurationInMins())
                             + TimeUnit.SECONDS.toMillis(5);
         }
 
@@ -267,21 +256,14 @@ public class ActiveScanJob extends AutomationJob {
     }
 
     protected ScanPolicy getScanPolicy(AutomationProgress progress) {
-        LinkedHashMap<?, ?> jobData = this.getJobData();
-        if (jobData == null) {
-            return null;
-        }
-        Object policyDefn = jobData.get("policyDefinition");
-        if (policyDefn == null) {
-            return null;
-        }
-        LinkedHashMap<?, ?> policyDefnData = (LinkedHashMap<?, ?>) policyDefn;
         ScanPolicy scanPolicy = new ScanPolicy();
 
         // Set default strength
         AttackStrength st =
                 JobUtils.parseAttackStrength(
-                        policyDefnData.get("defaultStrength"), this.getName(), progress);
+                        this.getData().getPolicyDefinition().getDefaultStrength(),
+                        this.getName(),
+                        progress);
         if (st != null) {
             scanPolicy.setDefaultStrength(st);
             progress.info(
@@ -293,7 +275,9 @@ public class ActiveScanJob extends AutomationJob {
         PluginFactory pluginFactory = scanPolicy.getPluginFactory();
         AlertThreshold th =
                 JobUtils.parseAlertThreshold(
-                        policyDefnData.get("defaultThreshold"), this.getName(), progress);
+                        this.getData().getPolicyDefinition().getDefaultThreshold(),
+                        this.getName(),
+                        progress);
         if (th != null) {
             scanPolicy.setDefaultThreshold(th);
             if (th == AlertThreshold.OFF) {
@@ -309,45 +293,35 @@ public class ActiveScanJob extends AutomationJob {
         }
 
         // Configure any rules
-        Object o = policyDefnData.get("rules");
-        if (o instanceof ArrayList<?>) {
-            ArrayList<?> ruleData = (ArrayList<?>) o;
-            for (Object rule : ruleData) {
-                if (rule instanceof LinkedHashMap<?, ?>) {
-                    LinkedHashMap<?, ?> ruleMap = (LinkedHashMap<?, ?>) rule;
-                    Integer id = (Integer) ruleMap.get("id");
-                    Plugin plugin = pluginFactory.getPlugin(id);
-                    if (plugin == null) {
-                        // Will have already warned about this
-                        continue;
-                    }
-                    AttackStrength pluginSt =
-                            JobUtils.parseAttackStrength(
-                                    ruleMap.get("strength"), this.getName(), progress);
-                    if (pluginSt != null) {
-                        plugin.setAttackStrength(pluginSt);
-                        plugin.setEnabled(true);
-                        progress.info(
-                                Constant.messages.getString(
-                                        "automation.info.ascan.rule.setstrength",
-                                        this.getName(),
-                                        id,
-                                        pluginSt.name()));
-                    }
-                    AlertThreshold pluginTh =
-                            JobUtils.parseAlertThreshold(
-                                    ruleMap.get("threshold"), this.getName(), progress);
-                    if (pluginTh != null) {
-                        plugin.setAlertThreshold(pluginTh);
-                        plugin.setEnabled(true);
-                        progress.info(
-                                Constant.messages.getString(
-                                        "automation.info.ascan.rule.setthreshold",
-                                        this.getName(),
-                                        id,
-                                        pluginTh.name()));
-                    }
-                }
+        for (Rule rule : this.getData().getPolicyDefinition().getRules()) {
+            Plugin plugin = pluginFactory.getPlugin(rule.getId());
+            if (plugin == null) {
+                // Will have already warned about this
+                continue;
+            }
+            AttackStrength pluginSt =
+                    JobUtils.parseAttackStrength(rule.getStrength(), this.getName(), progress);
+            if (pluginSt != null) {
+                plugin.setAttackStrength(pluginSt);
+                plugin.setEnabled(true);
+                progress.info(
+                        Constant.messages.getString(
+                                "automation.info.ascan.rule.setstrength",
+                                this.getName(),
+                                rule.getId(),
+                                pluginSt.name()));
+            }
+            AlertThreshold pluginTh =
+                    JobUtils.parseAlertThreshold(rule.getThreshold(), this.getName(), progress);
+            if (pluginTh != null) {
+                plugin.setAlertThreshold(pluginTh);
+                plugin.setEnabled(true);
+                progress.info(
+                        Constant.messages.getString(
+                                "automation.info.ascan.rule.setthreshold",
+                                this.getName(),
+                                rule.getId(),
+                                pluginTh.name()));
             }
         }
         return scanPolicy;
@@ -374,12 +348,23 @@ public class ActiveScanJob extends AutomationJob {
         }
     }
 
-    public int getMaxDuration() {
-        return maxDuration;
+    @Override
+    public String getSummary() {
+        String context = this.getParameters().getContext();
+        if (StringUtils.isEmpty(context)) {
+            context = Constant.messages.getString("automation.dialog.default");
+        }
+        return Constant.messages.getString("automation.dialog.ascan.summary", context);
     }
 
-    public String getPolicy() {
-        return policy;
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
     }
 
     @Override
@@ -400,5 +385,224 @@ public class ActiveScanJob extends AutomationJob {
     @Override
     public String getParamMethodName() {
         return OPTIONS_METHOD_NAME;
+    }
+
+    @Override
+    public void showDialog() {
+        new ActiveScanJobDialog(this).setVisible(true);
+    }
+
+    public static class Rule extends AutomationData {
+        private int id;
+        private String name;
+        private String threshold;
+        private String strength;
+
+        public Rule() {}
+
+        public Rule(int id, String name, String threshold, String strength) {
+            this.id = id;
+            this.name = name;
+            this.threshold = threshold;
+            this.strength = strength;
+        }
+
+        public Rule copy() {
+            return new Rule(id, name, threshold, strength);
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getThreshold() {
+            return threshold;
+        }
+
+        public void setThreshold(String threshold) {
+            this.threshold = threshold;
+        }
+
+        public String getStrength() {
+            return strength;
+        }
+
+        public void setStrength(String strength) {
+            this.strength = strength;
+        }
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+        private PolicyDefinition policyDefinition;
+
+        public Data(AutomationJob job, Parameters parameters, PolicyDefinition policyDefinition) {
+            super(job);
+            this.parameters = parameters;
+            this.policyDefinition = policyDefinition;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+
+        public PolicyDefinition getPolicyDefinition() {
+            return policyDefinition;
+        }
+    }
+
+    public static class PolicyDefinition extends AutomationData {
+        private String defaultStrength;
+        private String defaultThreshold;
+        private List<Rule> rules = new ArrayList<>();
+
+        public String getDefaultStrength() {
+            return defaultStrength;
+        }
+
+        public void setDefaultStrength(String defaultStrength) {
+            this.defaultStrength = defaultStrength;
+        }
+
+        public String getDefaultThreshold() {
+            return defaultThreshold;
+        }
+
+        public void setDefaultThreshold(String defaultThreshold) {
+            this.defaultThreshold = defaultThreshold;
+        }
+
+        public List<Rule> getRules() {
+            return rules.stream().map(r -> r.copy()).collect(Collectors.toList());
+        }
+
+        public void addRule(Rule rule) {
+            this.rules.add(rule);
+        }
+
+        public void removeRule(Rule rule) {
+            this.rules.remove(rule);
+        }
+
+        public void setRules(List<Rule> rules) {
+            this.rules = rules;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+
+        private String context;
+        private String policy;
+        private Integer maxRuleDurationInMins;
+        private Integer maxScanDurationInMins;
+        private Boolean addQueryParam;
+        private String defaultPolicy;
+        private Integer delayInMs;
+        private Boolean handleAntiCSRFTokens;
+        private Boolean injectPluginIdInHeader;
+        private Boolean scanHeadersAllRequests;
+        private Integer threadPerHost;
+
+        public Parameters() {}
+
+        public String getContext() {
+            return context;
+        }
+
+        public void setContext(String context) {
+            this.context = context;
+        }
+
+        public String getPolicy() {
+            return policy;
+        }
+
+        public void setPolicy(String policy) {
+            this.policy = policy;
+        }
+
+        public Integer getMaxRuleDurationInMins() {
+            return maxRuleDurationInMins;
+        }
+
+        public void setMaxRuleDurationInMins(Integer maxRuleDurationInMins) {
+            this.maxRuleDurationInMins = maxRuleDurationInMins;
+        }
+
+        public Integer getMaxScanDurationInMins() {
+            return maxScanDurationInMins;
+        }
+
+        public void setMaxScanDurationInMins(Integer maxScanDurationInMins) {
+            this.maxScanDurationInMins = maxScanDurationInMins;
+        }
+
+        public Boolean getAddQueryParam() {
+            return addQueryParam;
+        }
+
+        public void setAddQueryParam(Boolean addQueryParam) {
+            this.addQueryParam = addQueryParam;
+        }
+
+        public String getDefaultPolicy() {
+            return defaultPolicy;
+        }
+
+        public void setDefaultPolicy(String defaultPolicy) {
+            this.defaultPolicy = defaultPolicy;
+        }
+
+        public Integer getDelayInMs() {
+            return delayInMs;
+        }
+
+        public void setDelayInMs(Integer delayInMs) {
+            this.delayInMs = delayInMs;
+        }
+
+        public Boolean getHandleAntiCSRFTokens() {
+            return handleAntiCSRFTokens;
+        }
+
+        public void setHandleAntiCSRFTokens(Boolean handleAntiCSRFTokens) {
+            this.handleAntiCSRFTokens = handleAntiCSRFTokens;
+        }
+
+        public Boolean getInjectPluginIdInHeader() {
+            return injectPluginIdInHeader;
+        }
+
+        public void setInjectPluginIdInHeader(Boolean injectPluginIdInHeader) {
+            this.injectPluginIdInHeader = injectPluginIdInHeader;
+        }
+
+        public Boolean getScanHeadersAllRequests() {
+            return scanHeadersAllRequests;
+        }
+
+        public void setScanHeadersAllRequests(Boolean scanHeadersAllRequests) {
+            this.scanHeadersAllRequests = scanHeadersAllRequests;
+        }
+
+        public Integer getThreadPerHost() {
+            return threadPerHost;
+        }
+
+        public void setThreadPerHost(Integer threadPerHost) {
+            this.threadPerHost = threadPerHost;
+        }
     }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/AddOnJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/AddOnJob.java
@@ -22,13 +22,17 @@ package org.zaproxy.addon.automation.jobs;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.commons.configuration.XMLPropertiesConfiguration;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.gui.AddOnJobDialog;
 import org.zaproxy.zap.control.AddOnCollection;
 import org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate;
 import org.zaproxy.zap.extension.autoupdate.OptionsParamCheckForUpdates;
@@ -39,35 +43,77 @@ public class AddOnJob extends AutomationJob {
 
     private static final String PARAM_UPDATE_ADDONS = "updateAddOns";
 
-    private boolean updateAddOns = true;
+    private Parameters parameters = new Parameters();
+    private Data data;
 
-    public AddOnJob() {}
-
-    @Override
-    public void verifyJobSpecificData(AutomationProgress progress) {
-        LinkedHashMap<?, ?> jobData = this.getJobData();
-        Object installAddOnsObj = jobData.get("install");
-        if (installAddOnsObj != null && !(installAddOnsObj instanceof ArrayList<?>)) {
-            progress.error(
-                    Constant.messages.getString(
-                            "automation.error.addons.addon.data", installAddOnsObj));
-        }
-        Object uninstallAddOnsObj = jobData.get("uninstall");
-        if (uninstallAddOnsObj != null && !(uninstallAddOnsObj instanceof ArrayList<?>)) {
-            progress.error(
-                    Constant.messages.getString(
-                            "automation.error.addons.addon.data", uninstallAddOnsObj));
-        }
+    public AddOnJob() {
+        data = new Data(this, this.parameters);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public void runJob(AutomationEnvironment env, AutomationProgress progress) {
-
+    public void verifyParameters(AutomationProgress progress) {
         LinkedHashMap<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
+        }
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
+        for (Object key : jobData.keySet()) {
+            if ("install".equals(key)) {
+                Object installAddOnsObj = jobData.get(key);
+                if (installAddOnsObj == null) {
+                    continue;
+                }
+                if (installAddOnsObj instanceof ArrayList<?>) {
+                    try {
+                        this.data.setInstall((ArrayList<String>) installAddOnsObj);
+                    } catch (Exception e) {
+                        progress.error(
+                                Constant.messages.getString(
+                                        "automation.error.addons.addon.data", installAddOnsObj));
+                    }
+                } else {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "automation.error.addons.addon.data", installAddOnsObj));
+                }
+            } else if ("uninstall".equals(key)) {
+                Object uninstallAddOnsObj = jobData.get(key);
+                if (uninstallAddOnsObj == null) {
+                    continue;
+                }
+                if (uninstallAddOnsObj instanceof ArrayList<?>) {
+                    try {
+                        this.data.setUninstall((ArrayList<String>) uninstallAddOnsObj);
+                    } catch (Exception e) {
+                        progress.error(
+                                Constant.messages.getString(
+                                        "automation.error.addons.addon.data", uninstallAddOnsObj));
+                    }
+                } else {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "automation.error.addons.addon.data", uninstallAddOnsObj));
+                }
+            }
+        }
+    }
+
+    @Override
+    public void applyParameters(AutomationProgress progress) {
+        // Nothing to do
+    }
+
+    @Override
+    public void runJob(AutomationEnvironment env, AutomationProgress progress) {
         ExtensionAutoUpdate extAutoUpd =
                 Control.getSingleton().getExtensionLoader().getExtension(ExtensionAutoUpdate.class);
-        if (updateAddOns) {
+        if (this.parameters.getUpdateAddOns()) {
             try {
                 // Unfortunately we need to do some nasty reflection :/
                 Method glviMethod = extAutoUpd.getClass().getDeclaredMethod("getLatestVersionInfo");
@@ -102,60 +148,20 @@ public class AddOnJob extends AutomationJob {
                 return;
             }
         }
-        Object installAddOnsObj = jobData.get("install");
-        if (installAddOnsObj != null) {
-            ArrayList<?> instAddOns = (ArrayList<?>) installAddOnsObj;
-            String result = extAutoUpd.installAddOns((ArrayList<String>) instAddOns);
+        if (this.data.getInstall() != null) {
+            String result = extAutoUpd.installAddOns(this.data.getInstall());
             if (result.length() > 0) {
                 progress.error(result);
                 return;
             }
         }
-
-        Object uninstallAddOnsObj = jobData.get("uninstall");
-        if (uninstallAddOnsObj != null) {
-            ArrayList<?> uninstAddOns = (ArrayList<?>) uninstallAddOnsObj;
-            String result = extAutoUpd.uninstallAddOns((ArrayList<String>) uninstAddOns);
+        if (this.data.getUninstall() != null) {
+            String result = extAutoUpd.uninstallAddOns(this.data.getUninstall());
             if (result.length() > 0) {
                 progress.error(result);
                 return;
             }
         }
-    }
-
-    private boolean verifyOrApplyCustomParameter(
-            String name, String value, AutomationProgress progress) {
-        switch (name) {
-            case PARAM_UPDATE_ADDONS:
-                if (progress != null) {
-                    String s = value.trim().toLowerCase();
-                    if (!"true".equals(s) && !"false".equals(s)) {
-                        progress.error(
-                                Constant.messages.getString(
-                                        "automation.error.options.badbool",
-                                        this.getType(),
-                                        name,
-                                        value));
-                    }
-                } else {
-                    updateAddOns = Boolean.parseBoolean(value);
-                }
-                return true;
-            default:
-                // Ignore
-                break;
-        }
-        return false;
-    }
-
-    @Override
-    public boolean applyCustomParameter(String name, String value) {
-        return this.verifyOrApplyCustomParameter(name, value, null);
-    }
-
-    @Override
-    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        return this.verifyOrApplyCustomParameter(name, value, progress);
     }
 
     @Override
@@ -172,7 +178,7 @@ public class AddOnJob extends AutomationJob {
     }
 
     public boolean isUpdateAddOns() {
-        return updateAddOns;
+        return this.parameters.getUpdateAddOns();
     }
 
     @Override
@@ -193,5 +199,77 @@ public class AddOnJob extends AutomationJob {
     @Override
     public String getParamMethodName() {
         return null;
+    }
+
+    @Override
+    public void showDialog() {
+        new AddOnJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "automation.dialog.addon.summary",
+                this.getData().getInstall() == null ? "[]" : this.getData().getInstall(),
+                this.getData().getUninstall() == null ? "[]" : this.getData().getUninstall());
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+        private List<String> install;
+        private List<String> uninstall;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+
+        public List<String> getInstall() {
+            if (install == null) {
+                return null;
+            }
+            return install.stream().collect(Collectors.toList());
+        }
+
+        public void setInstall(List<String> install) {
+            this.install = install;
+        }
+
+        public List<String> getUninstall() {
+            if (uninstall == null) {
+                return null;
+            }
+            return uninstall.stream().collect(Collectors.toList());
+        }
+
+        public void setUninstall(List<String> uninstall) {
+            this.uninstall = uninstall;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private boolean updateAddOns = true;
+
+        public boolean getUpdateAddOns() {
+            return updateAddOns;
+        }
+
+        public void setUpdateAddOns(boolean updateAddOns) {
+            this.updateAddOns = updateAddOns;
+        }
     }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobData.java
@@ -1,0 +1,65 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.jobs;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.zaproxy.addon.automation.AbstractAutomationTest;
+import org.zaproxy.addon.automation.AutomationData;
+import org.zaproxy.addon.automation.AutomationJob;
+
+public abstract class JobData extends AutomationData {
+
+    private AutomationJob job;
+
+    public JobData(AutomationJob job) {
+        super();
+        this.job = job;
+    }
+
+    @Override
+    public boolean isDefaultValue(String name) {
+        if ("name".equals(name)) {
+            return name.equals(getType());
+        }
+        return super.isDefaultValue(name);
+    }
+
+    public String getType() {
+        return this.job.getType();
+    }
+
+    public String getName() {
+        return this.job.getName();
+    }
+
+    public void setName(String name) {
+        this.job.setName(name);
+    }
+
+    public List<AutomationData> getTests() {
+        List<AbstractAutomationTest> tests = this.job.getTests();
+        if (tests.isEmpty()) {
+            // So that no test element included in the YAML
+            return null;
+        }
+        return tests.stream().map(t -> t.getData()).collect(Collectors.toList());
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -20,13 +20,47 @@
 package org.zaproxy.addon.automation.jobs;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.core.scanner.Plugin.AttackStrength;
+import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
 
 public class JobUtils {
+
+    private static final String THRESHOLD_I18N_PREFIX = "ascan.options.level.";
+    private static final String STRENGTH_I18N_PREFIX = "ascan.options.strength.";
+
+    private static Map<String, String> strengthI18nToStr;
+    private static Map<String, String> thresholdI18nToStr;
+
+    private static final Logger LOG = LogManager.getLogger(JobUtils.class);
+
+    static {
+        strengthI18nToStr = new HashMap<>();
+        for (AttackStrength at : AttackStrength.values()) {
+            strengthI18nToStr.put(
+                    JobUtils.strengthToI18n(at.name()), at.name().toLowerCase(Locale.ROOT));
+        }
+        thresholdI18nToStr = new HashMap<>();
+        for (AlertThreshold at : AlertThreshold.values()) {
+            thresholdI18nToStr.put(
+                    JobUtils.thresholdToI18n(at.name()), at.name().toLowerCase(Locale.ROOT));
+        }
+    }
 
     public static AttackStrength parseAttackStrength(
             Object o, String jobName, AutomationProgress progress) {
@@ -72,6 +106,76 @@ public class JobUtils {
         return threshold;
     }
 
+    public static Integer parseAlertConfidence(Object o) {
+        return parseAlertConfidence(o, null, null);
+    }
+
+    public static Integer parseAlertConfidence(
+            Object o, String jobName, AutomationProgress progress) {
+        if (o == null) {
+            return null;
+        }
+        String str = o.toString().trim().toLowerCase();
+        if (str.isEmpty()) {
+            return null;
+        }
+        for (int i = 0; i < Alert.MSG_CONFIDENCE.length; i++) {
+            if (Alert.MSG_CONFIDENCE[i].toLowerCase().equals(str)) {
+                return i;
+            }
+        }
+        if (progress != null) {
+            progress.warn(
+                    Constant.messages.getString("automation.error.badconfidence", jobName, o));
+        }
+        return null;
+    }
+
+    public static Integer parseAlertRisk(Object o) {
+        return parseAlertRisk(o, null, null);
+    }
+
+    public static Integer parseAlertRisk(Object o, String jobName, AutomationProgress progress) {
+        if (o == null) {
+            return null;
+        }
+        String str = o.toString().trim().toLowerCase();
+        if (str.isEmpty()) {
+            return null;
+        }
+        for (int i = 0; i < Alert.MSG_RISK.length; i++) {
+            if (Alert.MSG_RISK[i].toLowerCase().equals(str)) {
+                return i;
+            }
+        }
+        if (progress != null) {
+            progress.warn(Constant.messages.getString("automation.error.badrisk", jobName, o));
+        }
+        return null;
+    }
+
+    public static String strengthToI18n(String str) {
+        if (str == null) {
+            return "";
+        }
+        return Constant.messages.getString(STRENGTH_I18N_PREFIX + str.toLowerCase(Locale.ROOT));
+    }
+
+    public static String i18nToStrength(String str) {
+        return strengthI18nToStr.get(str);
+    }
+
+    public static String thresholdToI18n(String str) {
+        if (str == null) {
+            return "";
+        }
+        return Constant.messages.getString(THRESHOLD_I18N_PREFIX + str.toLowerCase(Locale.ROOT));
+    }
+
+    public static String i18nToThreshold(String str) {
+        return thresholdI18nToStr.get(str);
+    }
+
     public static Object getJobOptions(AutomationJob job, AutomationProgress progress) {
         Object obj = job.getParamMethodObject();
         String optionsGetterName = job.getParamMethodName();
@@ -91,5 +195,267 @@ public class JobUtils {
             }
         }
         return null;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static void applyParamsToObject(
+            LinkedHashMap<?, ?> params,
+            Object object,
+            String objectName,
+            String[] ignore,
+            AutomationProgress progress) {
+        if (params == null || object == null) {
+            return;
+        }
+        Map<String, Method> methodMap = null;
+        List<String> ignoreList = Collections.emptyList();
+        if (ignore != null) {
+            ignoreList = Arrays.asList(ignore);
+        }
+
+        try {
+            Method[] methods = object.getClass().getMethods();
+            methodMap = new HashMap<>(methods.length);
+            for (Method m : methods) {
+                methodMap.put(m.getName(), m);
+            }
+        } catch (Exception e1) {
+            LOG.error(e1.getMessage(), e1);
+            progress.error(
+                    Constant.messages.getString(
+                            "automation.error.options.methods",
+                            objectName, // TODO changed params
+                            e1.getMessage()));
+            return;
+        }
+
+        for (Entry<?, ?> param : params.entrySet()) {
+            String key = param.getKey().toString();
+            if (param.getValue() == null) {
+                continue;
+            }
+            if (ignoreList.contains(key)) {
+                continue;
+            }
+
+            String resolvedValue = param.getValue().toString();
+            String paramMethodName = "set" + key.toUpperCase().charAt(0) + key.substring(1);
+            Method optMethod = methodMap.get(paramMethodName);
+            if (optMethod != null) {
+                if (optMethod.getParameterCount() > 0) {
+                    Object value = null;
+                    Class<?> paramType = optMethod.getParameterTypes()[0];
+                    try {
+                        value = stringToType(resolvedValue, paramType);
+                    } catch (NumberFormatException e1) {
+                        progress.error(
+                                Constant.messages.getString(
+                                        "automation.error.options.badint",
+                                        objectName,
+                                        key,
+                                        param.getValue()));
+                        continue;
+                    } catch (IllegalArgumentException e1) {
+                        if (Enum.class.isAssignableFrom(paramType)) {
+                            progress.error(
+                                    Constant.messages.getString(
+                                            "automation.error.options.badenum",
+                                            objectName,
+                                            key,
+                                            EnumUtils.getEnumList((Class<Enum>) paramType)));
+                        } else {
+                            progress.error(
+                                    Constant.messages.getString(
+                                            "automation.error.options.badbool",
+                                            objectName,
+                                            key,
+                                            param.getValue()));
+                        }
+                        continue;
+                    }
+                    if (value != null) {
+                        try {
+                            optMethod.invoke(object, value);
+                            progress.info(
+                                    Constant.messages.getString(
+                                            "automation.info.setparam",
+                                            objectName, // TODO changed param
+                                            key,
+                                            value));
+                        } catch (Exception e) {
+                            progress.error(
+                                    Constant.messages.getString(
+                                            "automation.error.options.badcall",
+                                            objectName,
+                                            paramMethodName,
+                                            e.getMessage()));
+                        }
+                    } else {
+                        progress.error(
+                                Constant.messages.getString(
+                                        "automation.error.options.badtype",
+                                        objectName, // TODO changed param
+                                        paramMethodName,
+                                        optMethod.getParameterTypes()[0].getCanonicalName()));
+                    }
+                }
+            } else {
+                // This is likely to be caused by the user using an invalid name, rather than a
+                // coding issue
+                progress.warn(
+                        Constant.messages.getString(
+                                "automation.error.options.unknown", objectName, key));
+            }
+        }
+    }
+
+    public static void applyObjectToObject(
+            Object srcObject,
+            Object destObject,
+            String objectName,
+            String[] ignore,
+            AutomationProgress progress,
+            AutomationEnvironment env) {
+        if (srcObject == null || destObject == null) {
+            return;
+        }
+        List<String> ignoreList = Collections.emptyList();
+        if (ignore != null) {
+            ignoreList = Arrays.asList(ignore);
+        }
+
+        try {
+            Method[] methods = srcObject.getClass().getMethods();
+            for (Method m : methods) {
+                String getterName = m.getName();
+                if (getterName.startsWith("get")
+                        && m.getParameterCount() == 0
+                        && !getterName.equals("getClass")
+                        && !ignoreList.contains(getterName)) {
+                    // Its a getter so process it
+                    String setterName = "s" + getterName.substring(1);
+                    try {
+                        Object value = m.invoke(srcObject);
+                        if (value == null) {
+                            continue;
+                        }
+
+                        Method setterMethod = null;
+                        try {
+                            setterMethod =
+                                    destObject.getClass().getMethod(setterName, m.getReturnType());
+                        } catch (Exception e) {
+                            // Ignore
+                        }
+                        if (setterMethod == null) {
+                            Class<?> c = toBaseClass(m.getReturnType());
+                            if (c != null) {
+                                try {
+                                    setterMethod = destObject.getClass().getMethod(setterName, c);
+                                } catch (Exception e) {
+                                    // Ignore
+                                }
+                            }
+                        }
+                        if (setterMethod != null) {
+                            if (value instanceof String) {
+                                // Can only really replace envvars in Strings otherwise it will
+                                // break GUI controls
+                                value = env.replaceVars(value);
+                            }
+                            setterMethod.invoke(destObject, value);
+                        } else {
+                            LOG.error(
+                                    "Automation Framework failed to find method "
+                                            + setterName
+                                            + " on "
+                                            + destObject.getClass().getCanonicalName());
+                        }
+
+                    } catch (Exception e) {
+                        LOG.error(e.getMessage(), e);
+                    }
+                }
+            }
+
+        } catch (Exception e1) {
+            LOG.error(e1.getMessage(), e1);
+            progress.error(
+                    Constant.messages.getString(
+                            "automation.error.options.methods",
+                            objectName, // TODO changed params
+                            e1.getMessage()));
+            return;
+        }
+    }
+
+    private static Class<?> toBaseClass(Class<?> origClass) {
+        if (origClass.equals(Integer.class)) {
+            return int.class;
+        }
+        if (origClass.equals(Long.class)) {
+            return long.class;
+        }
+        if (origClass.equals(Boolean.class)) {
+            return boolean.class;
+        }
+        return null;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <T> T stringToType(String str, T t) {
+        if (String.class.equals(t)) {
+            return (T) str;
+        } else if (Integer.class.equals(t) || int.class.equals(t)) {
+            return (T) (Object) Integer.parseInt(str);
+        } else if (Long.class.equals(t) || long.class.equals(t)) {
+            return (T) (Object) Long.parseLong(str);
+        } else if (Boolean.class.equals(t) || boolean.class.equals(t)) {
+            // Don't use Boolean.parseBoolean as it won't reject illegal values
+            String s = str.trim().toLowerCase();
+            if ("true".equals(s)) {
+                return (T) Boolean.TRUE;
+            } else if ("false".equals(s)) {
+                return (T) Boolean.FALSE;
+            }
+            throw new IllegalArgumentException("Invalid boolean value: " + str);
+        } else if (Enum.class.isAssignableFrom((Class<T>) t)) {
+            T enumType = (T) EnumUtils.getEnumIgnoreCase((Class<Enum>) t, str);
+            if (enumType != null) {
+                return enumType;
+            }
+            throw new IllegalArgumentException(
+                    "Enum value must be one of " + EnumUtils.getEnumList((Class<Enum>) t));
+        }
+
+        return null;
+    }
+
+    public static int unBox(Integer i) {
+        if (i == null) {
+            return 0;
+        }
+        return i;
+    }
+
+    public static long unBox(Long i) {
+        if (i == null) {
+            return 0;
+        }
+        return i;
+    }
+
+    public static boolean unBox(Boolean i) {
+        if (i == null) {
+            return false;
+        }
+        return i;
+    }
+
+    public static String unBox(String s, String defaultStr) {
+        if (s == null) {
+            return defaultStr;
+        }
+        return s;
     }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ParamsJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ParamsJob.java
@@ -61,6 +61,11 @@ public class ParamsJob extends AutomationJob {
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {}
 
     @Override
+    public String getSummary() {
+        return "";
+    }
+
+    @Override
     public String getType() {
         return JOB_NAME;
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJob.java
@@ -21,13 +21,17 @@ package org.zaproxy.addon.automation.jobs;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.gui.PassiveScanConfigJobDialog;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.pscan.PassiveScanParam;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -41,9 +45,13 @@ public class PassiveScanConfigJob extends AutomationJob {
     private static final String PARAM_ENABLE_TAGS = "enableTags";
 
     private ExtensionPassiveScan extPScan;
-    private boolean enableTags = false;
 
-    public PassiveScanConfigJob() {}
+    private Parameters parameters = new Parameters();
+    private Data data;
+
+    public PassiveScanConfigJob() {
+        data = new Data(this, this.parameters);
+    }
 
     private ExtensionPassiveScan getExtPScan() {
         if (extPScan == null) {
@@ -56,54 +64,19 @@ public class PassiveScanConfigJob extends AutomationJob {
     }
 
     @Override
-    public boolean applyCustomParameter(String name, String value) {
-        switch (name) {
-            case PARAM_ENABLE_TAGS:
-                enableTags = Boolean.parseBoolean(value);
-                return true;
-            default:
-                // Ignore
-                break;
+    public void verifyParameters(AutomationProgress progress) {
+        LinkedHashMap<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
         }
-        return false;
-    }
-
-    @Override
-    public boolean verifyCustomParameter(String name, String value, AutomationProgress progress) {
-        switch (name) {
-            case PARAM_ENABLE_TAGS:
-                String s = value.trim().toLowerCase();
-                if (!"true".equals(s) && !"false".equals(s)) {
-                    progress.error(
-                            Constant.messages.getString(
-                                    "automation.error.options.badbool",
-                                    this.getName(),
-                                    name,
-                                    value));
-                }
-
-                if (Model.getSingleton().getOptionsParam().getParamSet(PassiveScanParam.class)
-                        == null) {
-                    progress.error(
-                            Constant.messages.getString(
-                                    "automation.error.pscan.nooptions", this.getName()));
-                }
-                return true;
-            default:
-                // Ignore
-                break;
-        }
-        return false;
-    }
-
-    @Override
-    public void verifyJobSpecificData(AutomationProgress progress) {
+        LinkedHashMap<?, ?> params = (LinkedHashMap<?, ?>) jobData.get("parameters");
+        JobUtils.applyParamsToObject(params, this.parameters, this.getName(), null, progress);
         Object o = this.getJobData().get("rules");
         if (o instanceof ArrayList<?>) {
             ArrayList<?> ruleData = (ArrayList<?>) o;
-            for (Object rule : ruleData) {
-                if (rule instanceof LinkedHashMap<?, ?>) {
-                    LinkedHashMap<?, ?> ruleMap = (LinkedHashMap<?, ?>) rule;
+            for (Object ruleObj : ruleData) {
+                if (ruleObj instanceof LinkedHashMap<?, ?>) {
+                    LinkedHashMap<?, ?> ruleMap = (LinkedHashMap<?, ?>) ruleObj;
                     try {
                         Object idObj = ruleMap.get(PARAM_ID);
                         if (idObj == null) {
@@ -120,7 +93,19 @@ public class PassiveScanConfigJob extends AutomationJob {
                                             "automation.error.pscan.rule.unknown",
                                             this.getName(),
                                             id));
+                            continue;
                         }
+                        AlertThreshold pluginTh =
+                                JobUtils.parseAlertThreshold(
+                                        ruleMap.get("threshold"), this.getName(), progress);
+
+                        Rule rule = new Rule();
+                        rule.setId(id);
+                        rule.setName(plugin.getName());
+                        if (pluginTh != null) {
+                            rule.setThreshold(pluginTh.name().toLowerCase());
+                        }
+                        this.getData().addRule(rule);
                     } catch (NumberFormatException e) {
                         progress.error(
                                 Constant.messages.getString(
@@ -139,30 +124,37 @@ public class PassiveScanConfigJob extends AutomationJob {
     }
 
     @Override
+    public void applyParameters(AutomationProgress progress) {
+        AutomationEnvironment env = null;
+        if (this.getPlan() != null) {
+            // Should only happen in unit tests
+            env = this.getPlan().getEnv();
+        }
+        JobUtils.applyObjectToObject(
+                this.parameters,
+                JobUtils.getJobOptions(this, progress),
+                this.getName(),
+                new String[] {PARAM_ENABLE_TAGS},
+                progress,
+                env);
+    }
+
+    @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
         // Configure any rules
-        Object o = this.getJobData().get("rules");
-        ArrayList<?> ruleData = (ArrayList<?>) o;
-        if (ruleData != null) {
-            for (Object rule : ruleData) {
-                if (rule instanceof LinkedHashMap<?, ?>) {
-                    LinkedHashMap<?, ?> ruleMap = (LinkedHashMap<?, ?>) rule;
-                    Integer id = (Integer) ruleMap.get(PARAM_ID);
-                    PluginPassiveScanner plugin = getExtPScan().getPluginPassiveScanner(id);
-                    AlertThreshold pluginTh =
-                            JobUtils.parseAlertThreshold(
-                                    ruleMap.get("threshold"), this.getName(), progress);
-                    if (pluginTh != null && plugin != null) {
-                        plugin.setAlertThreshold(pluginTh);
-                        plugin.setEnabled(!AlertThreshold.OFF.equals(pluginTh));
-                        progress.info(
-                                Constant.messages.getString(
-                                        "automation.info.pscan.rule.setthreshold",
-                                        this.getName(),
-                                        id,
-                                        pluginTh.name()));
-                    }
-                }
+        for (Rule rule : this.getData().getRules()) {
+            PluginPassiveScanner plugin = getExtPScan().getPluginPassiveScanner(rule.getId());
+            AlertThreshold pluginTh =
+                    JobUtils.parseAlertThreshold(rule.getThreshold(), this.getName(), progress);
+            if (pluginTh != null && plugin != null) {
+                plugin.setAlertThreshold(pluginTh);
+                plugin.setEnabled(!AlertThreshold.OFF.equals(pluginTh));
+                progress.info(
+                        Constant.messages.getString(
+                                "automation.info.pscan.rule.setthreshold",
+                                this.getName(),
+                                rule.getId(),
+                                pluginTh.name()));
             }
         }
         // enable / disable pscan tags
@@ -171,7 +163,9 @@ public class PassiveScanConfigJob extends AutomationJob {
         if (pscanParam != null) {
             pscanParam
                     .getAutoTagScanners()
-                    .forEach(tagScanner -> tagScanner.setEnabled(enableTags));
+                    .forEach(
+                            tagScanner ->
+                                    tagScanner.setEnabled(this.getParameters().getEnableTags()));
         }
     }
 
@@ -185,8 +179,14 @@ public class PassiveScanConfigJob extends AutomationJob {
         }
     }
 
-    public boolean isEnableTags() {
-        return enableTags;
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
     }
 
     @Override
@@ -207,5 +207,129 @@ public class PassiveScanConfigJob extends AutomationJob {
     @Override
     public String getParamMethodName() {
         return OPTIONS_METHOD_NAME;
+    }
+
+    @Override
+    public void showDialog() {
+        new PassiveScanConfigJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "automation.dialog.pscanconfig.summary", this.getData().getRules().size());
+    }
+
+    public static class Rule extends AutomationData {
+        private int id;
+        private String name;
+        private String threshold;
+
+        public Rule() {}
+
+        public Rule(int id, String name, String threshold) {
+            this.id = id;
+            this.name = name;
+            this.threshold = threshold;
+        }
+
+        public Rule copy() {
+            return new Rule(id, name, threshold);
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getThreshold() {
+            return threshold;
+        }
+
+        public void setThreshold(String threshold) {
+            this.threshold = threshold;
+        }
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+        private List<Rule> rules = new ArrayList<>();
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+
+        public List<Rule> getRules() {
+            return rules.stream().map(r -> r.copy()).collect(Collectors.toList());
+        }
+
+        public void addRule(Rule rule) {
+            this.rules.add(rule);
+        }
+
+        public void removeRule(Rule rule) {
+            this.rules.remove(rule);
+        }
+
+        public void setRules(List<Rule> rules) {
+            this.rules = rules;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private Integer maxAlertsPerRule;
+        private Boolean scanOnlyInScope = true;
+        private Integer maxBodySizeInBytesToScan;
+        private Boolean enableTags = false;
+
+        public Parameters() {}
+
+        public Integer getMaxAlertsPerRule() {
+            return maxAlertsPerRule;
+        }
+
+        public void setMaxAlertsPerRule(Integer maxAlertsPerRule) {
+            this.maxAlertsPerRule = maxAlertsPerRule;
+        }
+
+        public Boolean getScanOnlyInScope() {
+            return scanOnlyInScope;
+        }
+
+        public void setScanOnlyInScope(Boolean scanOnlyInScope) {
+            this.scanOnlyInScope = scanOnlyInScope;
+        }
+
+        public Integer getMaxBodySizeInBytesToScan() {
+            return maxBodySizeInBytesToScan;
+        }
+
+        public void setMaxBodySizeInBytesToScan(Integer maxBodySizeInBytesToScan) {
+            this.maxBodySizeInBytesToScan = maxBodySizeInBytesToScan;
+        }
+
+        public Boolean getEnableTags() {
+            return enableTags;
+        }
+
+        public void setEnableTags(Boolean enableTags) {
+            this.enableTags = enableTags;
+        }
     }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/RequestorJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/RequestorJob.java
@@ -22,6 +22,8 @@ package org.zaproxy.addon.automation.jobs;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
@@ -33,20 +35,19 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.gui.RequestorJobDialog;
 import org.zaproxy.zap.utils.ThreadUtils;
 
 public class RequestorJob extends AutomationJob {
 
     public static final String JOB_NAME = "requestor";
     private static final String REQUESTS = "requests";
-    private static final String URL = "url";
-    private static final String METHOD = "method";
-    private static final String RESPONSECODE = "responseCode";
-    private static final String NAME = "name";
-    private static final String DATA = "data";
+
+    private Data data;
 
     private static final Logger LOG = LogManager.getLogger(RequestorJob.class);
     private HttpSender httpSender =
@@ -55,14 +56,17 @@ public class RequestorJob extends AutomationJob {
                     true,
                     HttpSender.MANUAL_REQUEST_INITIATOR);
 
-    public RequestorJob() {}
+    public RequestorJob() {
+        this.data = new Data(this);
+    }
 
     public RequestorJob(HttpSender httpSender) {
+        this();
         this.httpSender = httpSender;
     }
 
     @Override
-    public void verifyJobSpecificData(AutomationProgress progress) {
+    public void verifyParameters(AutomationProgress progress) {
         LinkedHashMap<?, ?> jobData = this.getJobData();
         Object o = jobData.get(REQUESTS);
         if (o == null) {
@@ -75,124 +79,86 @@ public class RequestorJob extends AutomationJob {
         ArrayList<?> requests = (ArrayList<?>) o;
         for (Object request : requests) {
             if (request instanceof LinkedHashMap<?, ?>) {
-                LinkedHashMap<?, ?> requestMap = (LinkedHashMap<?, ?>) request;
-                Object url = requestMap.get(URL);
-                if (url instanceof String) {
-                    String mUrl = (String) url;
+                Request req = new Request();
+                JobUtils.applyParamsToObject(
+                        (LinkedHashMap<?, ?>) request, req, this.getName(), null, progress);
+                if (req.getUrl() == null) {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "automation.error.requestor.badurl",
+                                    this.getName(),
+                                    req.getUrl(),
+                                    request));
+                    continue;
+                } else if (!req.getUrl().contains("${")) {
                     try {
-                        new URI(mUrl, true);
+                        new URI(req.getUrl(), true);
                     } catch (URIException e) {
                         progress.error(
                                 Constant.messages.getString(
                                         "automation.error.requestor.badurl",
                                         this.getName(),
-                                        mUrl,
+                                        req.getUrl(),
                                         request));
                     }
-                } else {
-                    progress.error(
-                            Constant.messages.getString(
-                                    "automation.error.requestor.badurl",
-                                    this.getName(),
-                                    url,
-                                    request));
                 }
-                Object method = requestMap.get(METHOD);
-                if (method != null && !(method instanceof String)) {
-                    progress.error(
-                            Constant.messages.getString(
-                                    "automation.error.requestor.invalidmethod",
-                                    this.getName(),
-                                    method,
-                                    request));
-                }
-                Object responseCode = requestMap.get(RESPONSECODE);
-                if (responseCode instanceof String) {
-                    String mResponseCode = (String) responseCode;
-                    try {
-                        int code = Integer.parseInt(mResponseCode);
-                        if (code < 100 || code > 599) {
-                            progress.warn(
-                                    Constant.messages.getString(
-                                            "automation.error.requestor.badcode",
-                                            this.getName(),
-                                            mResponseCode,
-                                            request));
-                        }
-                    } catch (NumberFormatException e) {
-                        progress.warn(
-                                Constant.messages.getString(
-                                        "automation.error.requestor.badcode",
-                                        this.getName(),
-                                        mResponseCode,
-                                        request));
-                    }
-                } else if (responseCode != null) {
+                if (req.getResponseCode() != null
+                        && (req.getResponseCode() < 100 || req.getResponseCode() > 599)) {
                     progress.warn(
                             Constant.messages.getString(
                                     "automation.error.requestor.badcode",
                                     this.getName(),
-                                    responseCode,
+                                    req.getResponseCode(),
                                     request));
                 }
+                this.getData().addRequest(req);
             }
         }
     }
 
     @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
-        LinkedHashMap<?, ?> jobData = this.getJobData();
-        ArrayList<?> requests = (ArrayList<?>) jobData.get(REQUESTS);
-        if (requests != null) {
-            for (Object request : requests) {
-                LinkedHashMap<?, ?> requestMap = (LinkedHashMap<?, ?>) request;
-                HttpMessage msg = new HttpMessage();
-                String method = (String) requestMap.get(METHOD);
-                if (method == null || method.isEmpty()) {
-                    method = "GET";
-                }
-                msg.getRequestHeader().setMethod(method);
-                try {
-                    msg.getRequestHeader().setURI(new URI((String) requestMap.get(URL), true));
-                } catch (URIException e) {
-                    // Handled above
-                }
-                String name;
-                if (requestMap.get(NAME) != null) {
-                    name = (String) requestMap.get(NAME);
-                } else {
-                    name =
-                            msg.getRequestHeader().getMethod()
-                                    + msg.getRequestHeader().getURI().toString();
-                }
-                if (requestMap.get(DATA) != null) {
-                    msg.getRequestBody().setBody((String) requestMap.get(DATA));
-                    msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
-                }
-                try {
-                    httpSender.sendAndReceive(msg);
-                } catch (IOException e) {
+
+        for (Request req : this.getData().getRequests()) {
+            HttpMessage msg = new HttpMessage();
+            String method = req.getMethod();
+            if (method == null || method.isEmpty()) {
+                method = "GET";
+            }
+            msg.getRequestHeader().setMethod(method);
+            try {
+                msg.getRequestHeader().setURI(new URI(req.getUrl(), true));
+            } catch (URIException e) {
+                // Handled above
+            }
+            String name = req.getName();
+            if (name == null) {
+                name =
+                        msg.getRequestHeader().getMethod()
+                                + msg.getRequestHeader().getURI().toString();
+            }
+            if (req.getData() != null) {
+                msg.getRequestBody().setBody(req.getData());
+                msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
+            }
+            try {
+                httpSender.sendAndReceive(msg);
+            } catch (IOException e) {
+                progress.warn(
+                        Constant.messages.getString(
+                                "automation.error.requestor.badnetwork", this.getName(), name, e));
+                return;
+            }
+            persistToHistoryAndSitesTree(msg);
+            if (req.getResponseCode() != null) {
+                int receivedCode = msg.getResponseHeader().getStatusCode();
+                if (receivedCode != req.getResponseCode()) {
                     progress.warn(
                             Constant.messages.getString(
-                                    "automation.error.requestor.badnetwork",
-                                    this.getName(),
-                                    name,
-                                    e));
-                    return;
-                }
-                persistToHistoryAndSitesTree(msg);
-                Object o = requestMap.get(RESPONSECODE);
-                if (o instanceof Integer) {
-                    int expectedCode = (Integer) o;
-                    int receivedCode = msg.getResponseHeader().getStatusCode();
-                    if (receivedCode != expectedCode) {
-                        progress.warn(
-                                Constant.messages.getString(
-                                        "automation.error.requestor.codemismatch",
-                                        msg,
-                                        expectedCode,
-                                        receivedCode));
-                    }
+                                    "automation.error.requestor.codemismatch",
+                                    msg,
+                                    req.getResponseCode(),
+                                    receivedCode));
                 }
             }
         }
@@ -247,5 +213,103 @@ public class RequestorJob extends AutomationJob {
     @Override
     public String getParamMethodName() {
         return null;
+    }
+
+    @Override
+    public void showDialog() {
+        new RequestorJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "automation.dialog.requestor.summary", this.getData().getRequests().size());
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    public static class Data extends JobData {
+        private List<Request> requests = new ArrayList<>();
+
+        public Data(AutomationJob job) {
+            super(job);
+        }
+
+        public List<Request> getRequests() {
+            return requests.stream().map(r -> r.copy()).collect(Collectors.toList());
+        }
+
+        public void setRequests(List<Request> requests) {
+            this.requests = requests;
+        }
+
+        public void addRequest(Request req) {
+            this.requests.add(req);
+        }
+    }
+
+    public static class Request extends AutomationData {
+        private String url;
+        private String name;
+        private String method;
+        private String data;
+        private Integer responseCode;
+
+        public Request() {}
+
+        public Request(String url, String name, String method, String data, Integer responseCode) {
+            this.url = url;
+            this.name = name;
+            this.method = method;
+            this.data = data;
+            this.responseCode = responseCode;
+        }
+
+        public Request copy() {
+            return new Request(url, name, method, data, responseCode);
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getMethod() {
+            return method;
+        }
+
+        public void setMethod(String method) {
+            this.method = method;
+        }
+
+        public String getData() {
+            return data;
+        }
+
+        public void setData(String data) {
+            this.data = data;
+        }
+
+        public Integer getResponseCode() {
+            return responseCode;
+        }
+
+        public void setResponseCode(Integer responseCode) {
+            this.responseCode = responseCode;
+        }
     }
 }

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/tests.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/tests.html
@@ -68,7 +68,7 @@ A job can have tests for multiple alerts, and multiple tests can be created for 
         evidence:                              # String: The evidence corresponding to the alert generated, optional
         confidence:                            # String: The confidence of the alert, one of 'False Positive', 'Low', 'Medium', 'High', 'Confirmed', optional
         risk:                                  # String: The risk of the alert, one of 'Informational', 'Low', 'Medium', 'High', optional
-        otherInfo:                             # String: Addional information corresponding to the alert, optional
+        otherInfo:                             # String: Additional information corresponding to the alert, optional
         onFail: 'warn'                         # One of 'warn', 'error', 'ignore'
   
 </pre>

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -10,6 +10,180 @@ automation.cmdline.autogenmax.help = Generate template automation file with all 
 automation.cmdline.autogenconf.help = Generate template automation file using the current configuration
 automation.cmdline.out.template = Writing template to {0}
 
+automation.dialog.addaddon.title = Add-On
+automation.dialog.addaddon.id = Add-On Id:
+
+automation.dialog.addon.summary = Install: {0}, Uninstall {1}
+automation.dialog.addon.title = Add-On Job
+automation.dialog.addon.remove.confirm = Are you sure you want to remove this Add-On?
+automation.dialog.addon.updateaddons = Update Add-Ons:
+automation.dialog.addon.installaddons = Install Add-Ons:
+automation.dialog.addon.uninstalladdons = Uninstall Add-Ons:
+automation.dialog.addon.table.header.addons = AddOns
+
+automation.dialog.addreq.title = Request
+automation.dialog.addreq.url = URL:
+automation.dialog.addreq.name = Name:
+automation.dialog.addreq.method = Method:
+automation.dialog.addreq.data = Data:
+automation.dialog.addreq.responsecode = Response Code:
+
+automation.dialog.addrule.title = Rule
+automation.dialog.addrule.rule = Rule:
+automation.dialog.addrule.threshold = Threshold:
+automation.dialog.addrule.strength = Strength:
+automation.dialog.addrule.error.defaults = Either the Strength or the Threshold must be non Default.\nTo set both to Default delete the rule.
+
+automation.dialog.alerttest.title = Alert Test
+automation.dialog.alerttest.action = Action:
+automation.dialog.alerttest.ruleid = Scan Rule Id:
+automation.dialog.alerttest.alertname = Alert Name (regex):
+automation.dialog.alerttest.url = URL (regex):
+automation.dialog.alerttest.method = Method (regex):
+automation.dialog.alerttest.attack = Attack (regex):
+automation.dialog.alerttest.param = Param (regex):
+automation.dialog.alerttest.evidence = Evidence:
+automation.dialog.alerttest.confidence = Confidence:
+automation.dialog.alerttest.risk = Risk:
+automation.dialog.alerttest.other = Other Info (regex):
+automation.dialog.alerttest.onfail = On Fail:
+
+automation.dialog.all.name = Job Name:
+
+automation.dialog.ascan.summary = Context: {0}
+automation.dialog.ascan.title = Active Scan Job
+automation.dialog.ascan.context = Context:
+automation.dialog.ascan.defaultthreshold = Default Threshold:
+automation.dialog.ascan.defaultstrength = Default Strength:
+automation.dialog.ascan.policy = Policy:
+automation.dialog.ascan.maxruleduration = Max Rule Duration (in mins):
+automation.dialog.ascan.maxscanduration = Max Scan Duration (in mins):
+automation.dialog.ascan.advanced = Show Advanced Options:
+automation.dialog.ascan.remove.confirm = Are you sure you want to remove this rule?
+
+automation.dialog.ascan.delayinms = Delay In MS:
+automation.dialog.ascan.threads = Threads Per Host:
+automation.dialog.ascan.addquery = Add Query Parameter:
+automation.dialog.ascan.handleanticsrf = Handle Anti CSRF Tokens:
+automation.dialog.ascan.injectid = Inject Plugin Id:
+automation.dialog.ascan.scanheaders = Scan 
+
+automation.dialog.ascan.tab.adv = Advanced
+automation.dialog.ascan.tab.policydefaults = Policy Defaults
+automation.dialog.ascan.tab.policyrules = Policy Rules
+
+automation.dialog.ascan.table.header.id = Id
+automation.dialog.ascan.table.header.name = Name
+automation.dialog.ascan.table.header.threshold = Threshold
+automation.dialog.ascan.table.header.strength = Strength
+
+automation.dialog.button.add = Add
+automation.dialog.button.modify = Modify
+automation.dialog.button.remove = Remove
+
+automation.dialog.contexts.table.header.name = Name
+
+automation.dialog.context.tab.context = Context
+automation.dialog.context.tab.include = Include
+automation.dialog.context.tab.exclude = Exclude
+	
+automation.dialog.context.title = Context
+automation.dialog.context.name = Name:
+automation.dialog.context.urls = URLs:
+automation.dialog.context.include = Include RegExs:
+automation.dialog.context.exclude = Exclude RegExs:
+automation.dialog.context.error.badname = You must supply a name
+automation.dialog.context.error.badurl = Invalid URL: {0}
+automation.dialog.context.error.incregex = Invalid 'Include' RegEx: {0}
+automation.dialog.context.error.excregex = Invalid 'Exclude' RegEx: {0}
+automation.dialog.context.error.nourls = You must specify at least one URL
+
+automation.dialog.default = Default
+
+automation.dialog.env.failonerror = Fail On Error:
+automation.dialog.env.failonwarning = Fail On Warning:
+automation.dialog.env.progresstostdout = Progresss To Stdout:
+automation.dialog.env.remove.confirm = Are you sure you want to remove this Context?
+automation.dialog.env.tab.contexts = Contexts
+automation.dialog.env.tab.vars = Variables
+automation.dialog.env.title = Environment
+automation.dialog.env.error.nocontext = You must define at least one Context
+automation.dialog.env.table.header.key = Key
+automation.dialog.env.table.header.value = Value
+
+automation.dialog.envvar.title = Environmental Variable
+automation.dialog.envvar.key = Key:
+automation.dialog.envvar.value = Value:
+automation.dialog.envvar.error.badkey = You must supply a valid Key
+
+automation.dialog.error.save = Failed to save plan: {0}
+
+automation.dialog.pscanconfig.summary = Rule Count: {0}
+automation.dialog.pscanconfig.tab.rules = Rules
+automation.dialog.pscanconfig.table.header.id = Id
+automation.dialog.pscanconfig.table.header.name = Name
+automation.dialog.pscanconfig.table.header.threshold = Threshold
+automation.dialog.pscanconfig.title = Passive Scan Config Job
+automation.dialog.pscanconfig.maxalertsperrule = Max Alerts Per Rule:
+automation.dialog.pscanconfig.scanonlyinscope = Scan Only in Scope:
+automation.dialog.pscanconfig.maxbodysize = Maximum Body Size In Bytes To Scan:
+automation.dialog.pscanconfig.enabletags = Enable Tags:
+
+automation.dialog.pscanwait.summary = Duration: {0}
+automation.dialog.pscanwait.title = Passive Scan Wait Job
+automation.dialog.pscanwait.maxduration = Max Duration:
+automation.dialog.pscanconfig.remove.confirm = Are you sure you want to remove this Rule?
+
+automation.dialog.requestor.summary = URL Count: {0}
+automation.dialog.requestor.title = Requestor Job
+automation.dialog.requestor.tab.requests = Requests
+
+automation.dialog.requests.table.header.method = Method
+automation.dialog.requests.table.header.url = URL
+automation.dialog.requests.table.header.code = Code
+
+automation.dialog.spider.advanced = Show Advanced Options:
+automation.dialog.spider.summary = Context: {0}, URL: {1}
+automation.dialog.spider.title = Spider Job
+automation.dialog.spider.context = Context:
+automation.dialog.spider.url = URL:
+automation.dialog.spider.maxduration = Max Duration:
+automation.dialog.spider.maxdepth = Max Depth:
+automation.dialog.spider.maxchildren = Max Children:
+automation.dialog.spider.tab.adv = Advanced
+automation.dialog.spider.tab.parse = Parsing
+
+automation.dialog.spider.acceptcookies = Accept Cookies:
+automation.dialog.spider.handleoodata = Handle OOData:
+automation.dialog.spider.handleparams = Handle Parameters:
+automation.dialog.spider.maxparse Max Size to Parse in Bytes:
+automation.dialog.spider.parsecomments = Parse Comments:
+automation.dialog.spider.parsegit = Parse GIT:
+automation.dialog.spider.parserobots = Parse Robots.txt:
+automation.dialog.spider.parsesitemap = Parse Sitemap:
+automation.dialog.spider.parsessvn = Parse SVN:
+
+automation.dialog.spider.postform = Post Forms:
+automation.dialog.spider.processform = Process Forms:
+automation.dialog.spider.reqwaittime = Request Wait Time
+automation.dialog.spider.sendreferer = Send "Referer" Header:
+automation.dialog.spider.threadcount = Number of Threads:
+automation.dialog.spider.useragent = User Agent:
+
+automation.dialog.statistictest.title = Statistic Test
+automation.dialog.statistictest.statistic = Statistic:
+automation.dialog.statistictest.operator = Operator:
+automation.dialog.statistictest.value = Value
+automation.dialog.statistictest.onfail = OnFail:
+
+automation.dialog.tab.params = Parameters
+
+automation.dialog.test.onfail.error = Error
+automation.dialog.test.onfail.info = Info
+automation.dialog.test.onfail.warn = Warn
+
+automation.env.name = Environment
+
 automation.error.addons.update = Failed to update add-ons: {0}
 automation.error.addons.addon.data = Unsupported add-on data format: {0}
 
@@ -18,6 +192,8 @@ automation.error.ascan.rule.unknown = Unrecognised active scan rule id for job {
 automation.error.ascan.strength = Invalid strength for job {0} : {1}
 automation.error.ascan.threshold = Invalid threshold for job {0} : {1}
 
+automation.error.badconfidence = Invalid confidence for job {0} : {1}
+automation.error.badrisk = Invalid risk for job {0} : {1}
 automation.error.badurl = Invalid URL for job {0} : {1}
 
 automation.error.context.badurl = Invalid URL: {0}
@@ -34,6 +210,7 @@ automation.error.env.missing = Missing environment: {0}
 automation.error.env.nocontexts = Missing contexts in environment: {0}
 automation.error.env.badcontext = Invalid context in environment: {0}
 automation.error.env.badcontexts = Invalid contexts in environment: {0}
+automation.error.env.badvars = Invalid vars in environment: {0}
 automation.error.env.novar = Variable {0} used but not specified
 
 automation.error.nofile = Cannot access file: {0}
@@ -42,6 +219,7 @@ automation.error.write = Cannot write to file: {0}
 automation.error.job.data = Unsupported job data format: {0}
 automation.error.job.name = Unsupported job name format: {0}
 automation.error.job.unknown = Unrecognised job type: {0}
+automation.error.job.internal = Job {0} internal error: {1}
 automation.error.job.notype = Missing job type: {0}
 automation.error.job.template = Failed to get template for job type: {0}
 automation.error.options.methods = Failed to access {0} methods for {1} : {2}
@@ -122,13 +300,37 @@ automation.params.type.unknown = Unknown
 automation.tests.invalidType = Unknown test type {0}
 automation.tests.invalidOnFail = Cannot create test {0}: Invalid onFail value {1}
 automation.tests.missingOrInvalidProperties = Job {0} skipped a test of type '{1}' with missing or invalid properties
+
+
+
 automation.tests.add = Job {0} adding test of type {1} : {2}
 automation.tests.pass = Job {0} test of type {1} passed: {2} [{3}]
 automation.tests.fail = Job {0} test of type {1} failed: {2} [{3}]
 
-automation.tests.stats.invalidOperator = Job {0} cannot create statistic test {1}: invalid operator {2}
+automation.tests.error.badonfail = Job {0} test of type {1}: invalid onFail {2}
+
+automation.tests.stats.error.badoperator = Job {0} test of type {1}: invalid operator {2}
+automation.tests.stats.error.nooperator = Job {0} test of type '{1}' missing operator
+automation.tests.stats.error.nostatistic = Job {0} test of type '{1}' missing statistic
+automation.tests.stats.error.novalue = Job {0} test of type '{1}' missing value
 automation.tests.stats.nullInMemoryStats = Job {0} in memory stats haven't been initialised, stats tests may give unexpected results
 
+automation.tests.alert.action.passIfAbsent = Pass if Absent
+automation.tests.alert.action.passIfPresent = Pass if Present
+
+automation.tests.alert.confidence.0 = False Positive
+automation.tests.alert.confidence.1 = Low
+automation.tests.alert.confidence.2 = Medium
+automation.tests.alert.confidence.3 = High
+automation.tests.alert.confidence.4 = Confirmed
+
+automation.tests.alert.risk.0 = Informational
+automation.tests.alert.risk.1 = Low
+automation.tests.alert.risk.2 = Medium
+automation.tests.alert.risk.3 = High
+
+automation.tests.alert.error.badaction = Job {0} test of type {1}: invalid action {2}
+automation.tests.alert.error.noscanruleid = Job {0} test of type '{1}' missing scanRuleId
 automation.tests.alert.invalidJobType = Job {0} does not support test of type alert
 automation.tests.alert.nullExtension = Job {0} can not check for generated alerts as the Alert Extension is disabled
 automation.tests.alert.invalidConfidence = Job {0} cannot create alert test {1}: invalid confidence {2}

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
@@ -2,6 +2,7 @@
     parameters:
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
+        name:                          # String: Optional name for the request, for documentation only
         method:                        # String: A non-empty request method, default: GET
         data:                          # String: Optional data to send in the request body
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationAlertTestUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationAlertTestUnitTest.java
@@ -51,7 +51,6 @@ public class AutomationAlertTestUnitTest extends TestUtils {
     private final String name = "example name";
     private final Integer scanRuleId = 100;
     private final String onFail = "warn";
-    private final String jobType = ActiveScanJob.JOB_NAME;
     private LinkedHashMap<String, Object> testData = new LinkedHashMap<>();
     private ActiveScanJobResultData data;
     private Alert alert;
@@ -98,7 +97,7 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         Object resolvedValue = setupAlert(alert, key, value);
 
         testData.put(key, resolvedValue);
-        AutomationAlertTest test = new AutomationAlertTest(testData, jobType);
+        AutomationAlertTest test = new AutomationAlertTest(testData, new ActiveScanJob(), progress);
 
         alertDataMap.put(alert.getAlertId(), alert);
         given(data.getAllAlertData()).willReturn(alertDataMap.values());
@@ -110,7 +109,8 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         // Then
         assertThat(progress.hasWarnings(), is(false));
         assertThat(progress.hasErrors(), is(false));
-        assertThat(progress.getInfos().get(0), is("!automation.tests.pass!"));
+        assertThat(progress.getInfos().size(), is(6));
+        assertThat(progress.getInfos().get(5), is("!automation.tests.pass!"));
         assertThat(test.runTest(progress), is(true));
     }
 
@@ -127,7 +127,7 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         Object resolvedValue = setupAlert(alert, key, value);
 
         testData.put(key, resolvedValue);
-        AutomationAlertTest test = new AutomationAlertTest(testData, jobType);
+        AutomationAlertTest test = new AutomationAlertTest(testData, new ActiveScanJob(), progress);
 
         alertDataMap.put(alert.getAlertId(), alert);
         given(data.getAllAlertData()).willReturn(alertDataMap.values());
@@ -209,7 +209,7 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         }
 
         testData.put(key, resolvedValue);
-        AutomationAlertTest test = new AutomationAlertTest(testData, jobType);
+        AutomationAlertTest test = new AutomationAlertTest(testData, new ActiveScanJob(), progress);
 
         alertDataMap.put(alert.getAlertId(), alert);
         given(data.getAllAlertData()).willReturn(alertDataMap.values());
@@ -221,7 +221,8 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         // Then
         assertThat(progress.hasWarnings(), is(false));
         assertThat(progress.hasErrors(), is(false));
-        assertThat(progress.getInfos().get(0), is("!automation.tests.pass!"));
+        assertThat(progress.getInfos().size(), is(6));
+        assertThat(progress.getInfos().get(5), is("!automation.tests.pass!"));
         assertThat(test.runTest(progress), is(true));
     }
 
@@ -249,7 +250,7 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         }
 
         testData.put(key, resolvedValue);
-        AutomationAlertTest test = new AutomationAlertTest(testData, jobType);
+        AutomationAlertTest test = new AutomationAlertTest(testData, new ActiveScanJob(), progress);
 
         alertDataMap.put(alert.getAlertId(), alert);
         given(data.getAllAlertData()).willReturn(alertDataMap.values());
@@ -276,7 +277,7 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         testData.put(AutomationAlertTest.PARAM_ON_FAIL, "warn");
         testData.put(AutomationAlertTest.PARAM_ALERT_NAME, "exampleAlertName");
 
-        AutomationAlertTest test = new AutomationAlertTest(testData, jobType);
+        AutomationAlertTest test = new AutomationAlertTest(testData, new ActiveScanJob(), progress);
         alertDataMap.put(alert.getAlertId(), alert);
         given(data.getAllAlertData()).willReturn(alertDataMap.values());
         progress.addJobResultData(data);
@@ -296,14 +297,13 @@ public class AutomationAlertTestUnitTest extends TestUtils {
     void shouldLogErrorsIfSpecifiedErrorOnFail() {
         // Given
         String action = "passIfPresent";
-        String onFail = "error";
         Map<Integer, Alert> alertDataMap = new HashMap<>();
         AutomationProgress progress = new AutomationProgress();
         testData.put(AutomationAlertTest.PARAM_ACTION, action);
         testData.put(AutomationAlertTest.PARAM_ON_FAIL, "error");
         testData.put(AutomationAlertTest.PARAM_ALERT_NAME, "exampleAlertName");
 
-        AutomationAlertTest test = new AutomationAlertTest(testData, jobType);
+        AutomationAlertTest test = new AutomationAlertTest(testData, new ActiveScanJob(), progress);
         alertDataMap.put(alert.getAlertId(), alert);
         given(data.getAllAlertData()).willReturn(alertDataMap.values());
         progress.addJobResultData(data);
@@ -323,14 +323,13 @@ public class AutomationAlertTestUnitTest extends TestUtils {
     void shouldLogInfoIfSpecifiedInfoOnFail() {
         // Given
         String action = "passIfPresent";
-        String onFail = "info";
         Map<Integer, Alert> alertDataMap = new HashMap<>();
         AutomationProgress progress = new AutomationProgress();
         testData.put(AutomationAlertTest.PARAM_ACTION, action);
         testData.put(AutomationAlertTest.PARAM_ON_FAIL, "info");
         testData.put(AutomationAlertTest.PARAM_ALERT_NAME, "exampleAlertName");
 
-        AutomationAlertTest test = new AutomationAlertTest(testData, jobType);
+        AutomationAlertTest test = new AutomationAlertTest(testData, new ActiveScanJob(), progress);
         alertDataMap.put(alert.getAlertId(), alert);
         given(data.getAllAlertData()).willReturn(alertDataMap.values());
         progress.addJobResultData(data);
@@ -341,7 +340,7 @@ public class AutomationAlertTestUnitTest extends TestUtils {
         // Then
         assertThat(progress.hasWarnings(), is(false));
         assertThat(progress.hasErrors(), is(false));
-        assertThat(progress.getInfos().size(), is(1));
-        assertThat(progress.getInfos().get(0), is("!automation.tests.fail!"));
+        assertThat(progress.getInfos().size(), is(6));
+        assertThat(progress.getInfos().get(5), is("!automation.tests.fail!"));
     }
 }

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationEnvironmentUnitTest.java
@@ -767,8 +767,11 @@ class AutomationEnvironmentUnitTest {
         List<Context> contexts = env.getContexts();
 
         // Then
-        assertThat(env.getVar("myPrefix"), is(equalTo("prefix")));
-        assertThat(env.getVar("myVar"), is(equalTo("prefix.suffix")));
+        assertThat(env.getData().getVars().get("myPrefix"), is(equalTo("prefix")));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(env.getContextWrappers().size(), is(equalTo(1)));
+        assertThat(contexts.size(), is(equalTo(1)));
         verify(contexts.get(0)).addIncludeInContextRegex("https://www.prefix.example.com.*");
     }
 
@@ -796,7 +799,7 @@ class AutomationEnvironmentUnitTest {
 
         // Then
         verify(contexts.get(0)).addIncludeInContextRegex("https://www.envVarValue.example.com.*");
-        assertThat(env.getVar("myVar"), is(equalTo("envVarValue.suffix")));
+        assertThat(env.getData().getVars().get("myVar"), is(equalTo("${myEnvVar}.suffix")));
     }
 
     @Test

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationStatisticTestUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/AutomationStatisticTestUnitTest.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.automation.jobs.ActiveScanJob;
 import org.zaproxy.zap.extension.stats.ExtensionStats;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -76,9 +77,9 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         String name = "example name";
         String key = "stats.job.something";
         String onFail = "warn";
-        String type = "job1";
         AutomationStatisticTest test =
-                new AutomationStatisticTest(key, name, operator, value, onFail, type);
+                new AutomationStatisticTest(
+                        key, name, operator, value, onFail, new ActiveScanJob(), progress);
 
         // When
         boolean hasRunFirst = test.hasRun();
@@ -89,10 +90,11 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         assertThat(hasRunFirst, is(false));
         assertThat(test.getName(), is(name));
         assertThat(test.getTestType(), is(AutomationStatisticTest.TEST_TYPE));
-        assertThat(test.getJobType(), is(type));
+        assertThat(test.getJobType(), is("activeScan"));
         assertThat(progress.hasWarnings(), is(false));
         assertThat(progress.hasErrors(), is(false));
-        assertThat(progress.getInfos().get(0), is("!automation.tests.pass!"));
+        assertThat(progress.getInfos().size(), is(6));
+        assertThat(progress.getInfos().get(5), is("!automation.tests.pass!"));
         assertThat(test.hasRun(), is(true));
         assertThat(test.hasPassed(), is(true));
     }
@@ -117,7 +119,8 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         String key = "stats.job.something";
         String onFail = "warn";
         AutomationStatisticTest test =
-                new AutomationStatisticTest(key, name, operator, value, onFail, null);
+                new AutomationStatisticTest(
+                        key, name, operator, value, onFail, new ActiveScanJob(), progress);
 
         // When
         when(extStats.getInMemoryStats().getStat(key)).thenReturn(statValue);
@@ -139,7 +142,8 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         String key = "stats.job.something";
         long value = 5;
         AutomationStatisticTest test =
-                new AutomationStatisticTest(key, "example name", "==", value, "warn", "job1");
+                new AutomationStatisticTest(
+                        key, "example name", "==", value, "warn", new ActiveScanJob(), progress);
 
         // When
         when(extStats.getInMemoryStats().getStat(key)).thenReturn(value);
@@ -165,7 +169,8 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         String onFail = "warn";
         long value = 10;
         AutomationStatisticTest test =
-                new AutomationStatisticTest(key, name, operator, value, onFail, null);
+                new AutomationStatisticTest(
+                        key, name, operator, value, onFail, new ActiveScanJob(), progress);
 
         // When
         when(extStats.getInMemoryStats().getStat(key)).thenReturn(value - 1);
@@ -188,7 +193,8 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         String onFail = "error";
         long value = 10;
         AutomationStatisticTest test =
-                new AutomationStatisticTest(key, name, operator, value, onFail, null);
+                new AutomationStatisticTest(
+                        key, name, operator, value, onFail, new ActiveScanJob(), progress);
 
         // When
         when(extStats.getInMemoryStats().getStat(key)).thenReturn(value - 1);
@@ -211,7 +217,8 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         String onFail = "info";
         long value = 10;
         AutomationStatisticTest test =
-                new AutomationStatisticTest(key, name, operator, value, onFail, null);
+                new AutomationStatisticTest(
+                        key, name, operator, value, onFail, new ActiveScanJob(), progress);
 
         // When
         when(extStats.getInMemoryStats().getStat(key)).thenReturn(value - 1);
@@ -220,7 +227,7 @@ class AutomationStatisticTestUnitTest extends TestUtils {
         // Then
         assertThat(progress.hasWarnings(), is(false));
         assertThat(progress.hasErrors(), is(false));
-        assertThat(progress.getInfos().size(), is(1));
-        assertThat(progress.getInfos().get(0), is("!automation.tests.fail!"));
+        assertThat(progress.getInfos().size(), is(6));
+        assertThat(progress.getInfos().get(5), is("!automation.tests.fail!"));
     }
 }

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -323,8 +323,7 @@ class ExtentionAutomationUnitTest extends TestUtils {
         assertThat(runJobs.size(), is(equalTo(1)));
         assertThat(runJobs.get(0).getName(), is(equalTo("job")));
         assertThat(((AutomationJobImpl) runJobs.get(0)).wasRun(), is(equalTo(true)));
-        assertThat(tpc.getTestParam().getBoolParam(), is(equalTo(true)));
-        assertThat(tpc.getTestParam().getStringParam(), is(equalTo("envVarValue")));
+        assertThat(tpc.getTestParam().getStringParam(), is(equalTo("true")));
     }
 
     @Nested
@@ -813,6 +812,11 @@ class ExtentionAutomationUnitTest extends TestUtils {
         @Override
         public Order getOrder() {
             return order;
+        }
+
+        @Override
+        public String getSummary() {
+            return "";
         }
 
         @Override

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/AddOnJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/AddOnJobUnitTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -84,27 +83,6 @@ class AddOnJobUnitTest {
         assertThat(params.containsValue("true"), is(equalTo(true)));
     }
 
-    @Test
-    void shouldApplyCustomConfigParams() {
-        // Given
-        AddOnJob job = new AddOnJob();
-
-        // When
-        job.applyCustomParameter("updateAddOns", "false");
-
-        // Then
-        assertThat(job.isUpdateAddOns(), is(equalTo(false)));
-    }
-
-    @Test
-    void shouldIgnoreUnknownCustomConfigParams() {
-        // Given
-        AddOnJob job = new AddOnJob();
-
-        // When / Than
-        assertFalse(job.applyCustomParameter("test", "test"));
-    }
-
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
     void shouldApplyParams() {
@@ -119,6 +97,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
 
         // Then
@@ -142,6 +121,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
 
         // Then
@@ -164,7 +144,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
-        job.verifyJobSpecificData(progress);
+        job.verifyParameters(progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(false)));
@@ -187,7 +167,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
-        job.verifyJobSpecificData(progress);
+        job.verifyParameters(progress);
 
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(false)));
@@ -232,6 +212,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(env, progress);
 
@@ -266,6 +247,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(env, progress);
 
@@ -297,6 +279,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(env, progress);
 
@@ -329,6 +312,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(env, progress);
 
@@ -362,6 +346,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(env, progress);
 
@@ -394,6 +379,7 @@ class AddOnJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(env, progress);
 

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
@@ -104,7 +104,7 @@ class PassiveScanConfigJobUnitTest {
         assertThat(job.getOrder(), is(equalTo(Order.CONFIGS)));
         assertThat(job.getParamMethodObject(), is(extPscan));
         assertThat(job.getParamMethodName(), is("getPassiveScanParam"));
-        assertThat(job.isEnableTags(), is(equalTo(false)));
+        assertThat(job.getParameters().getEnableTags(), is(equalTo(false)));
     }
 
     @Test
@@ -157,6 +157,7 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.verifyParameters(progress);
         job.applyParameters(progress);
 
         // Then
@@ -165,7 +166,7 @@ class PassiveScanConfigJobUnitTest {
         assertThat(psp.getMaxAlertsPerRule(), is(equalTo(2)));
         assertThat(psp.isScanOnlyInScope(), is(equalTo(true)));
         assertThat(psp.getMaxBodySizeInBytesToScan(), is(equalTo(1000)));
-        assertThat(job.isEnableTags(), is(equalTo(true)));
+        assertThat(job.getParameters().getEnableTags(), is(equalTo(true)));
     }
 
     @Test
@@ -186,6 +187,7 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.verifyParameters(progress);
         job.applyParameters(progress);
 
         // Then
@@ -195,7 +197,7 @@ class PassiveScanConfigJobUnitTest {
         assertThat(
                 progress.getWarnings().get(0), is(equalTo("!automation.error.options.unknown!")));
         assertThat(psp.getMaxAlertsPerRule(), is(equalTo(2)));
-        assertThat(psp.isScanOnlyInScope(), is(equalTo(false)));
+        assertThat(psp.isScanOnlyInScope(), is(equalTo(true)));
         assertThat(psp.getMaxBodySizeInBytesToScan(), is(equalTo(1000)));
     }
 
@@ -223,6 +225,8 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(data);
+        job.verifyParameters(progress);
+        job.applyParameters(progress);
         job.runJob(null, progress);
 
         // Then
@@ -257,7 +261,8 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(data);
-        job.verifyJobSpecificData(progress);
+        job.verifyParameters(progress);
+        job.applyParameters(progress);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(false)));
@@ -288,7 +293,8 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(data);
-        job.verifyJobSpecificData(progress);
+        job.verifyParameters(progress);
+        job.applyParameters(progress);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(false)));
@@ -300,13 +306,18 @@ class PassiveScanConfigJobUnitTest {
     @Test
     void shouldRejectBadEnableTagsParam() {
         // Given
+        String yamlStr = "parameters:\n" + "  enableTags: test";
         AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
         PassiveScanConfigJob job = new PassiveScanConfigJob();
         PassiveScanParam psp = (PassiveScanParam) JobUtils.getJobOptions(job, progress);
         psp.load(new ZapXmlConfiguration());
 
         // When
-        job.verifyCustomParameter("enableTags", "test", progress);
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.verifyParameters(progress);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(true)));
@@ -335,6 +346,7 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(null, progress);
 
@@ -365,6 +377,7 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(null, progress);
 
@@ -395,6 +408,7 @@ class PassiveScanConfigJobUnitTest {
 
         // When
         job.setJobData(((LinkedHashMap<?, ?>) data));
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(null, progress);
 

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanWaitJobUnitTest.java
@@ -125,10 +125,11 @@ class PassiveScanWaitJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
 
         // Then
-        assertThat(job.getMaxDuration(), is(equalTo(duration)));
+        assertThat(job.getParameters().getMaxDuration(), is(equalTo(duration)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(false)));
     }
@@ -147,6 +148,7 @@ class PassiveScanWaitJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
 
         // Then
@@ -223,6 +225,7 @@ class PassiveScanWaitJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.applyParameters(progress);
         job.runJob(env, progress);
 

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/RequestorJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/RequestorJobUnitTest.java
@@ -102,7 +102,7 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
-        job.verifyJobSpecificData(progress);
+        job.verifyParameters(progress);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(true)));
@@ -110,6 +110,27 @@ class RequestorJobUnitTest {
         assertThat(progress.getErrors().size(), is(equalTo(1)));
         assertThat(
                 progress.getErrors().get(0), is(equalTo("!automation.error.requestor.badlist!")));
+    }
+
+    @Test
+    void shouldFailIfMissingUrl() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        RequestorJob job = new RequestorJob();
+
+        String yamlStr = "requests:\n" + "- method: GET\n";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> jobData = (LinkedHashMap<?, ?>) yaml.load(yamlStr);
+
+        // When
+        job.setJobData(jobData);
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!automation.error.requestor.badurl!")));
     }
 
     @Test
@@ -124,7 +145,7 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
-        job.verifyJobSpecificData(progress);
+        job.verifyParameters(progress);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(true)));
@@ -147,6 +168,7 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -174,6 +196,7 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -188,7 +211,7 @@ class RequestorJobUnitTest {
     }
 
     @Test
-    void shouldWarnIfInvalidResponseCode() {
+    void shouldErrorIfInvalidResponseCode() {
         // Given
         AutomationProgress progress = new AutomationProgress();
         RequestorJob job = new RequestorJob();
@@ -203,7 +226,32 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
-        job.verifyJobSpecificData(progress);
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!automation.error.options.badint!")));
+    }
+
+    @Test
+    void shouldWarnIfUnexpectedResponseCode() {
+        // Given
+        AutomationProgress progress = new AutomationProgress();
+        RequestorJob job = new RequestorJob();
+
+        String yamlStr =
+                "requests:\n"
+                        + "- url: https://www.example.com\n"
+                        + "  method: GET\n"
+                        + "  responseCode: 999\n";
+        Yaml yaml = new Yaml();
+        LinkedHashMap<?, ?> jobData = (LinkedHashMap<?, ?>) yaml.load(yamlStr);
+
+        // When
+        job.setJobData(jobData);
+        job.verifyParameters(progress);
 
         // Then
         assertThat(progress.hasErrors(), is(equalTo(false)));
@@ -240,6 +288,7 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -274,6 +323,7 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -303,6 +353,7 @@ class RequestorJobUnitTest {
 
         // When
         job.setJobData(jobData);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -32,6 +32,7 @@ jobs:
     parameters:
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
+        name:                          # String: Optional name for the request, for documentation only
         method:                        # String: A non-empty request method, default: GET
         data:                          # String: Optional data to send in the request body
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-applyResolvedParams.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/testplan-applyResolvedParams.yaml
@@ -13,5 +13,4 @@ env:
 jobs:
   - type: job
     parameters:
-      boolParam: ${myVarOne}
-      stringParam: ${myEnvVar}
+      stringParam: ${myVarOne}

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Automation Framework GUI
+
 ### Changed
 - Maintenance changes.
 - Report no URL specified in automation job as info instead of failure.

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
@@ -21,15 +21,19 @@ package org.zaproxy.addon.graphql.automation;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.jobs.JobData;
+import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.addon.graphql.ExtensionGraphQl;
 import org.zaproxy.addon.graphql.GraphQlParser;
 import org.zaproxy.addon.graphql.HistoryPersister;
@@ -45,29 +49,36 @@ public class GraphQlJob extends AutomationJob {
 
     private static final String RESOURCES_DIR = "/org/zaproxy/addon/graphql/resources/";
 
-    private String endpoint;
-    private String schemaUrl;
-    private String schemaFile;
+    private Data data;
+    private Parameters parameters = new Parameters();
 
-    public GraphQlJob() {}
+    public GraphQlJob() {
+        this.data = new Data(this, parameters);
+    }
 
     @Override
-    public boolean applyCustomParameter(String name, String value) {
-        switch (name) {
-            case PARAM_ENDPOINT:
-                endpoint = value;
-                return true;
-            case PARAM_SCHEMA_URL:
-                schemaUrl = value;
-                return true;
-            case PARAM_SCHEMA_FILE:
-                schemaFile = value;
-                return true;
-            default:
-                // Ignore
-                break;
+    public void verifyParameters(AutomationProgress progress) {
+        LinkedHashMap<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
         }
-        return false;
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
+    }
+
+    @Override
+    public void applyParameters(AutomationProgress progress) {
+        JobUtils.applyObjectToObject(
+                this.parameters,
+                JobUtils.getJobOptions(this, progress),
+                this.getName(),
+                new String[] {PARAM_ENDPOINT, PARAM_SCHEMA_URL, PARAM_SCHEMA_FILE},
+                progress,
+                this.getPlan().getEnv());
     }
 
     @Override
@@ -82,6 +93,7 @@ public class GraphQlJob extends AutomationJob {
     @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
 
+        String endpoint = this.getParameters().getEndpoint();
         if (endpoint == null || endpoint.isEmpty()) {
             progress.info(Constant.messages.getString("graphql.info.emptyendurl"));
             return;
@@ -91,6 +103,9 @@ public class GraphQlJob extends AutomationJob {
             GraphQlParser parser =
                     new GraphQlParser(endpoint, HttpSender.MANUAL_REQUEST_INITIATOR, true);
             parser.addRequesterListener(new HistoryPersister());
+
+            String schemaFile = this.getParameters().getSchemaFile();
+            String schemaUrl = this.getParameters().getSchemaUrl();
 
             if (schemaFile != null && !schemaFile.isEmpty()) {
                 progress.info(Constant.messages.getString("graphql.automation.info.import.file"));
@@ -131,21 +146,6 @@ public class GraphQlJob extends AutomationJob {
         return "";
     }
 
-    // For Unit Tests
-    protected String getEndpoint() {
-        return endpoint;
-    }
-
-    // For Unit Tests
-    protected String getSchemaFile() {
-        return schemaFile;
-    }
-
-    // For Unit Tests
-    protected String getSchemaUrl() {
-        return schemaUrl;
-    }
-
     @Override
     public Order getOrder() {
         return Order.EXPLORE;
@@ -164,5 +164,143 @@ public class GraphQlJob extends AutomationJob {
     @Override
     public String getParamMethodName() {
         return OPTIONS_METHOD_NAME;
+    }
+
+    @Override
+    public void showDialog() {
+        new GraphQlJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "graphql.automation.dialog.summary",
+                JobUtils.unBox(this.getParameters().getSchemaUrl(), "''"),
+                JobUtils.unBox(this.getParameters().getSchemaFile(), "''"));
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private String endpoint;
+        private String schemaUrl;
+        private String schemaFile;
+        private Integer maxQueryDepth;
+        private Boolean lenientMaxQueryDepthEnabled;
+        private Integer maxAdditionalQueryDepth;
+        private Integer maxArgsDepth;
+        private Boolean optionalArgsEnabled;
+        private String argsType;
+        private String querySplitType;
+        private String requestMethod;
+
+        public String getEndpoint() {
+            return endpoint;
+        }
+
+        public void setEndpoint(String endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        public String getSchemaUrl() {
+            return schemaUrl;
+        }
+
+        public void setSchemaUrl(String schemaUrl) {
+            this.schemaUrl = schemaUrl;
+        }
+
+        public String getSchemaFile() {
+            return schemaFile;
+        }
+
+        public void setSchemaFile(String schemaFile) {
+            this.schemaFile = schemaFile;
+        }
+
+        public Integer getMaxQueryDepth() {
+            return maxQueryDepth;
+        }
+
+        public void setMaxQueryDepth(Integer maxQueryDepth) {
+            this.maxQueryDepth = maxQueryDepth;
+        }
+
+        public Boolean getLenientMaxQueryDepthEnabled() {
+            return lenientMaxQueryDepthEnabled;
+        }
+
+        public void setLenientMaxQueryDepthEnabled(Boolean lenientMaxQueryDepthEnabled) {
+            this.lenientMaxQueryDepthEnabled = lenientMaxQueryDepthEnabled;
+        }
+
+        public Integer getMaxAdditionalQueryDepth() {
+            return maxAdditionalQueryDepth;
+        }
+
+        public void setMaxAdditionalQueryDepth(Integer maxAdditionalQueryDepth) {
+            this.maxAdditionalQueryDepth = maxAdditionalQueryDepth;
+        }
+
+        public Integer getMaxArgsDepth() {
+            return maxArgsDepth;
+        }
+
+        public void setMaxArgsDepth(Integer maxArgsDepth) {
+            this.maxArgsDepth = maxArgsDepth;
+        }
+
+        public Boolean getOptionalArgsEnabled() {
+            return optionalArgsEnabled;
+        }
+
+        public void setOptionalArgsEnabled(Boolean optionalArgsEnabled) {
+            this.optionalArgsEnabled = optionalArgsEnabled;
+        }
+
+        public String getArgsType() {
+            return argsType;
+        }
+
+        public void setArgsType(String argsType) {
+            this.argsType = argsType;
+        }
+
+        public String getQuerySplitType() {
+            return querySplitType;
+        }
+
+        public void setQuerySplitType(String querySplitType) {
+            this.querySplitType = querySplitType;
+        }
+
+        public String getRequestMethod() {
+            return requestMethod;
+        }
+
+        public void setRequestMethod(String requestMethod) {
+            this.requestMethod = requestMethod;
+        }
     }
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
@@ -1,0 +1,342 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql.automation;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.io.File;
+import java.util.Arrays;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JTextField;
+import org.apache.commons.lang3.StringUtils;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.graphql.GraphQlParam;
+import org.zaproxy.addon.graphql.automation.GraphQlJob.Parameters;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class GraphQlJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "graphql.automation.dialog.tab.params", "graphql.automation.dialog.tab.adv"
+    };
+
+    private static final String TITLE = "graphql.automation.dialog.title";
+    private static final String NAME_PARAM = "graphql.automation.dialog.name";
+    private static final String ENDPOINT_PARAM = "graphql.automation.dialog.endpoint";
+    private static final String SCHEMA_URL_PARAM = "graphql.automation.dialog.schemaurl";
+    private static final String SCHEMA_FILE_PARAM = "graphql.automation.dialog.schemafile";
+    private static final String FIELD_ADVANCED = "graphql.automation.dialog.advanced";
+
+    private static final String MAX_QUERY_DEPTH_PARAM = "graphql.automation.dialog.maxquerydepth";
+    private static final String LENIENT_MAX_QUERY_DEPTH_PARAM =
+            "graphql.automation.dialog.lenientmaxquery";
+    private static final String MAX_ADD_QUERY_DEPTH_PARAM =
+            "graphql.automation.dialog.maxaddquerydepth";
+    private static final String MAX_ARGS_DEPTH_PARAM = "graphql.automation.dialog.maxargsdepth";
+    private static final String OPTIONAL_ARGS_ENABLED_PARAM =
+            "graphql.automation.dialog.optargsenabled";
+    private static final String ARGS_TYPE_PARAM = "graphql.automation.dialog.argstype";
+    private static final String QUERY_SPLIT_TYPE_PARAM = "graphql.automation.dialog.querysplittype";
+    private static final String REQUEST_METHOD_PARAM = "graphql.automation.dialog.requestmethod";
+
+    private GraphQlJob job;
+
+    private DefaultComboBoxModel<GraphQlParam.ArgsTypeOption> argsTypeModel;
+    private DefaultComboBoxModel<GraphQlParam.QuerySplitOption> querySplitModel;
+    private DefaultComboBoxModel<GraphQlParam.RequestMethodOption> requestMethodModel;
+
+    public GraphQlJobDialog(GraphQlJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 400),
+                TAB_LABELS);
+        this.job = job;
+
+        this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(0, ENDPOINT_PARAM, null, true, false);
+        Component endpointField = this.getField(ENDPOINT_PARAM);
+        if (endpointField instanceof JTextField) {
+            ((JTextField) endpointField).setText(this.job.getParameters().getEndpoint());
+        }
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(0, SCHEMA_URL_PARAM, null, true, false);
+        Component schemaUrlField = this.getField(SCHEMA_URL_PARAM);
+        if (schemaUrlField instanceof JTextField) {
+            ((JTextField) schemaUrlField).setText(this.job.getParameters().getSchemaUrl());
+        }
+        String fileName = this.job.getData().getParameters().getSchemaFile();
+        File f = null;
+        if (fileName != null && !fileName.isEmpty()) {
+            f = new File(fileName);
+        }
+        this.addFileSelectField(0, SCHEMA_FILE_PARAM, f, JFileChooser.FILES_AND_DIRECTORIES, null);
+
+        this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
+
+        this.addFieldListener(
+                FIELD_ADVANCED,
+                new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+                    }
+                });
+
+        this.addPadding(0);
+
+        this.addNumberField(
+                1,
+                MAX_QUERY_DEPTH_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxQueryDepth()));
+        this.addCheckBoxField(
+                1,
+                LENIENT_MAX_QUERY_DEPTH_PARAM,
+                JobUtils.unBox(this.job.getParameters().getLenientMaxQueryDepthEnabled()));
+        this.addNumberField(
+                1,
+                MAX_ADD_QUERY_DEPTH_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxAdditionalQueryDepth()));
+        this.addNumberField(
+                1,
+                MAX_ARGS_DEPTH_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxArgsDepth()));
+        this.addCheckBoxField(
+                1,
+                OPTIONAL_ARGS_ENABLED_PARAM,
+                JobUtils.unBox(this.job.getParameters().getOptionalArgsEnabled()));
+
+        argsTypeModel = new DefaultComboBoxModel<GraphQlParam.ArgsTypeOption>();
+        Arrays.stream(GraphQlParam.ArgsTypeOption.values())
+                .forEach(v -> argsTypeModel.addElement(v));
+        DefaultListCellRenderer argsTypeRenderer =
+                new DefaultListCellRenderer() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Component getListCellRendererComponent(
+                            JList<?> list,
+                            Object value,
+                            int index,
+                            boolean isSelected,
+                            boolean cellHasFocus) {
+                        JLabel label =
+                                (JLabel)
+                                        super.getListCellRendererComponent(
+                                                list, value, index, isSelected, cellHasFocus);
+                        if (value instanceof GraphQlParam.ArgsTypeOption) {
+                            // The name is i18n'ed
+                            label.setText(((GraphQlParam.ArgsTypeOption) value).getName());
+                        }
+                        return label;
+                    }
+                };
+
+        GraphQlParam.ArgsTypeOption hpo = null;
+        if (this.job.getParameters().getArgsType() != null) {
+            hpo =
+                    GraphQlParam.ArgsTypeOption.valueOf(
+                            this.job.getParameters().getArgsType().toUpperCase());
+        } else {
+            hpo = GraphQlParam.ArgsTypeOption.BOTH;
+        }
+        argsTypeModel.setSelectedItem(hpo);
+        this.addComboField(1, ARGS_TYPE_PARAM, argsTypeModel);
+        Component acField = this.getField(ARGS_TYPE_PARAM);
+        if (acField instanceof JComboBox) {
+            ((JComboBox<?>) acField).setRenderer(argsTypeRenderer);
+        }
+
+        querySplitModel = new DefaultComboBoxModel<GraphQlParam.QuerySplitOption>();
+        Arrays.stream(GraphQlParam.QuerySplitOption.values())
+                .forEach(v -> querySplitModel.addElement(v));
+        DefaultListCellRenderer querySplitRenderer =
+                new DefaultListCellRenderer() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Component getListCellRendererComponent(
+                            JList<?> list,
+                            Object value,
+                            int index,
+                            boolean isSelected,
+                            boolean cellHasFocus) {
+                        JLabel label =
+                                (JLabel)
+                                        super.getListCellRendererComponent(
+                                                list, value, index, isSelected, cellHasFocus);
+                        if (value instanceof GraphQlParam.QuerySplitOption) {
+                            // The name is i18n'ed
+                            label.setText(((GraphQlParam.QuerySplitOption) value).getName());
+                        }
+                        return label;
+                    }
+                };
+
+        GraphQlParam.QuerySplitOption qso = null;
+        if (this.job.getParameters().getQuerySplitType() != null) {
+            qso =
+                    GraphQlParam.QuerySplitOption.valueOf(
+                            this.job.getParameters().getQuerySplitType().toUpperCase());
+        } else {
+            qso = GraphQlParam.QuerySplitOption.LEAF;
+        }
+        querySplitModel.setSelectedItem(qso);
+        this.addComboField(1, QUERY_SPLIT_TYPE_PARAM, querySplitModel);
+        Component qsField = this.getField(QUERY_SPLIT_TYPE_PARAM);
+        if (acField instanceof JComboBox) {
+            ((JComboBox<?>) qsField).setRenderer(querySplitRenderer);
+        }
+
+        requestMethodModel = new DefaultComboBoxModel<GraphQlParam.RequestMethodOption>();
+        Arrays.stream(GraphQlParam.RequestMethodOption.values())
+                .forEach(v -> requestMethodModel.addElement(v));
+        DefaultListCellRenderer requestMethodRenderer =
+                new DefaultListCellRenderer() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Component getListCellRendererComponent(
+                            JList<?> list,
+                            Object value,
+                            int index,
+                            boolean isSelected,
+                            boolean cellHasFocus) {
+                        JLabel label =
+                                (JLabel)
+                                        super.getListCellRendererComponent(
+                                                list, value, index, isSelected, cellHasFocus);
+                        if (value instanceof GraphQlParam.RequestMethodOption) {
+                            // The name is i18n'ed
+                            label.setText(((GraphQlParam.RequestMethodOption) value).getName());
+                        }
+                        return label;
+                    }
+                };
+
+        GraphQlParam.RequestMethodOption rmo = null;
+        if (this.job.getParameters().getRequestMethod() != null) {
+            rmo =
+                    GraphQlParam.RequestMethodOption.valueOf(
+                            this.job.getParameters().getRequestMethod().toUpperCase());
+        } else {
+            rmo = GraphQlParam.RequestMethodOption.POST_JSON;
+        }
+        requestMethodModel.setSelectedItem(rmo);
+        this.addComboField(1, REQUEST_METHOD_PARAM, requestMethodModel);
+        Component rmField = this.getField(REQUEST_METHOD_PARAM);
+        if (acField instanceof JComboBox) {
+            ((JComboBox<?>) rmField).setRenderer(requestMethodRenderer);
+        }
+        this.addPadding(1);
+
+        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+    }
+
+    private boolean advOptionsSet() {
+        Parameters params = this.job.getParameters();
+        return params.getMaxAdditionalQueryDepth() != null
+                || params.getLenientMaxQueryDepthEnabled() != null
+                || params.getMaxAdditionalQueryDepth() != null
+                || params.getMaxArgsDepth() != null
+                || params.getOptionalArgsEnabled() != null
+                || !StringUtils.isEmpty(params.getQuerySplitType())
+                || !StringUtils.isEmpty(params.getRequestMethod());
+    }
+
+    private void setAdvancedTabs(boolean visible) {
+        // Show/hide all except from the first tab
+        this.setTabsVisible(new String[] {"graphql.automation.dialog.tab.adv"}, visible);
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setEndpoint(this.getStringValue(ENDPOINT_PARAM));
+        this.job.getParameters().setSchemaUrl(this.getStringValue(SCHEMA_URL_PARAM));
+        this.job.getParameters().setSchemaFile(this.getStringValue(SCHEMA_FILE_PARAM));
+
+        if (this.getBoolValue(FIELD_ADVANCED)) {
+            this.job.getParameters().setMaxQueryDepth(this.getIntValue(MAX_QUERY_DEPTH_PARAM));
+            this.job
+                    .getParameters()
+                    .setLenientMaxQueryDepthEnabled(
+                            this.getBoolValue(LENIENT_MAX_QUERY_DEPTH_PARAM));
+            this.job
+                    .getParameters()
+                    .setMaxAdditionalQueryDepth(this.getIntValue(MAX_ADD_QUERY_DEPTH_PARAM));
+            this.job.getParameters().setMaxArgsDepth(this.getIntValue(MAX_ARGS_DEPTH_PARAM));
+            this.job
+                    .getParameters()
+                    .setOptionalArgsEnabled(this.getBoolValue(OPTIONAL_ARGS_ENABLED_PARAM));
+
+            Object atObj = argsTypeModel.getSelectedItem();
+            if (atObj instanceof GraphQlParam.ArgsTypeOption) {
+                GraphQlParam.ArgsTypeOption at = (GraphQlParam.ArgsTypeOption) atObj;
+                this.job.getParameters().setArgsType(at.name().toLowerCase());
+            }
+            Object sqObj = querySplitModel.getSelectedItem();
+            if (sqObj instanceof GraphQlParam.QuerySplitOption) {
+                GraphQlParam.QuerySplitOption sq = (GraphQlParam.QuerySplitOption) sqObj;
+                this.job.getParameters().setQuerySplitType(sq.name().toLowerCase());
+            }
+
+            Object rmObj = requestMethodModel.getSelectedItem();
+            if (rmObj instanceof GraphQlParam.RequestMethodOption) {
+                GraphQlParam.RequestMethodOption rm = (GraphQlParam.RequestMethodOption) rmObj;
+                this.job.getParameters().setRequestMethod(rm.name().toLowerCase());
+            }
+
+        } else {
+            this.job.getParameters().setMaxQueryDepth(null);
+            this.job.getParameters().setLenientMaxQueryDepthEnabled(null);
+            this.job.getParameters().setMaxAdditionalQueryDepth(null);
+            this.job.getParameters().setMaxArgsDepth(null);
+            this.job.getParameters().setOptionalArgsEnabled(null);
+            this.job.getParameters().setArgsType(null);
+            this.job.getParameters().setQuerySplitType(null);
+            this.job.getParameters().setRequestMethod(null);
+        }
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -39,6 +39,24 @@ graphql.automation.info.import.file = Job graphql importing schema from file
 graphql.automation.info.import.url = Job graphql importing schema from URL
 graphql.automation.info.import.introspect = Job graphql importing schema using introspection
 
+graphql.automation.dialog.summary = URL: {0}, File: {1}
+graphql.automation.dialog.tab.params = Parameters
+graphql.automation.dialog.tab.adv = Advanced
+graphql.automation.dialog.title = GraphQL Job
+graphql.automation.dialog.name = Job Name:
+graphql.automation.dialog.endpoint = Endpoint:
+graphql.automation.dialog.schemaurl = Schema URL:
+graphql.automation.dialog.schemafile = SchemaFile:
+graphql.automation.dialog.advanced = Show Advanced Options:
+graphql.automation.dialog.maxquerydepth = Max Query Depth:
+graphql.automation.dialog.lenientmaxquery = Lenient Max Query Depth Enabled:
+graphql.automation.dialog.maxaddquerydepth = Max Additional Query Depth:
+graphql.automation.dialog.maxargsdepth = Max Arguments Depth:
+graphql.automation.dialog.optargsenabled = Optional Arguments Enabled:
+graphql.automation.dialog.argstype = Arguments Type:
+graphql.automation.dialog.querysplittype = Query Split Type:
+graphql.automation.dialog.requestmethod = Request Method:
+
 graphql.cmdline.file.help = Imports a GraphQL Schema from a File
 graphql.cmdline.url.help = Imports a GraphQL Schema from a URL
 graphql.cmdline.endurl.help = Sets the Endpoint URL

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Automation Framework GUI
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
@@ -1,0 +1,82 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.automation;
+
+import java.awt.Component;
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.JTextField;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class OpenApiJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "openapi.automation.dialog.title";
+    private static final String NAME_PARAM = "openapi.automation.dialog.name";
+    private static final String API_FILE_PARAM = "openapi.automation.dialog.apifile";
+    private static final String API_URL_PARAM = "openapi.automation.dialog.apiurl";
+    private static final String TARGET_URL_PARAM = "openapi.automation.dialog.targeturl";
+
+    private OpenApiJob job;
+
+    public OpenApiJobDialog(OpenApiJob job) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 200));
+        this.job = job;
+
+        this.addTextField(NAME_PARAM, this.job.getData().getName());
+        String fileName = this.job.getData().getParameters().getApiFile();
+        File f = null;
+        if (fileName != null && !fileName.isEmpty()) {
+            f = new File(fileName);
+        }
+        this.addFileSelectField(API_FILE_PARAM, f, JFileChooser.FILES_AND_DIRECTORIES, null);
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(API_URL_PARAM, null, true, false);
+        Component apiUrlField = this.getField(API_URL_PARAM);
+        if (apiUrlField instanceof JTextField) {
+            ((JTextField) apiUrlField).setText(this.job.getParameters().getApiUrl());
+        }
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(TARGET_URL_PARAM, null, true, false);
+        Component targetUrlField = this.getField(TARGET_URL_PARAM);
+        if (targetUrlField instanceof JTextField) {
+            ((JTextField) targetUrlField).setText(this.job.getParameters().getTargetUrl());
+        }
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setApiFile(this.getStringValue(API_FILE_PARAM));
+        this.job.getParameters().setApiUrl(this.getStringValue(API_URL_PARAM));
+        this.job.getParameters().setTargetUrl(this.getStringValue(TARGET_URL_PARAM));
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -15,6 +15,13 @@ openapi.automation.error.misc = Job {0} error: {1}
 openapi.automation.error.url = Job {0} invalid URL: {1}
 openapi.automation.info.urlsadded = Job {0} added {1} URLs
 
+openapi.automation.dialog.summary = URL: {0}, File: {1}
+openapi.automation.dialog.title = OpenAPI Job
+openapi.automation.dialog.name = Job Name:
+openapi.automation.dialog.apifile = API File:
+openapi.automation.dialog.apiurl = API URL:
+openapi.automation.dialog.targeturl = Target URL:
+
 openapi.cmdline.file.help = Imports an OpenAPI definition from the specified file name
 openapi.cmdline.url.help = Imports an OpenAPI definition from the specified URL
 openapi.cmdline.targeturl.help = The Target URL, to override the server URL present in the OpenAPI definition. Refer to the help for supported format.

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
+import org.yaml.snakeyaml.Yaml;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
@@ -88,33 +90,52 @@ class OpenApiJobUnitTest {
     }
 
     @Test
-    void shouldApplyCustomConfigParams() {
-        // Given
-        OpenApiJob job = new OpenApiJob();
+    void shouldApplyParams() {
+        Constant.messages = new I18N(Locale.ENGLISH);
+        AutomationProgress progress = new AutomationProgress();
         String apiFile = "C:\\Users\\ZAPBot\\Documents\\test file.json";
         String apiUrl = "https://example.com/test%20file.json";
         String targetUrl = "https://example.com/endpoint/";
+        String yamlStr =
+                "parameters:\n"
+                        + "  apiUrl: "
+                        + apiUrl
+                        + "\n"
+                        + "  apiFile: "
+                        + apiFile
+                        + "\n"
+                        + "  targetUrl: "
+                        + targetUrl;
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        OpenApiJob job = new OpenApiJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
 
         // When
-        job.applyCustomParameter("apiFile", apiFile);
-        job.applyCustomParameter("apiUrl", apiUrl);
-        job.applyCustomParameter("targetUrl", targetUrl);
+        job.verifyParameters(progress);
 
         // Then
-        assertThat(job.getApiFile(), is(equalTo(apiFile)));
-        assertThat(job.getApiUrl(), is(equalTo(apiUrl)));
-        assertThat(job.getTargetUrl(), is(equalTo(targetUrl)));
+        assertThat(job.getParameters().getApiFile(), is(equalTo(apiFile)));
+        assertThat(job.getParameters().getApiUrl(), is(equalTo(apiUrl)));
+        assertThat(job.getParameters().getTargetUrl(), is(equalTo(targetUrl)));
     }
 
     @Test
     void shouldFailIfInvalidUrl() {
         // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
+        String yamlStr = "parameters:\n" + "  apiUrl: 'Invalid URL.'";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        OpenApiJob job = new OpenApiJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
 
         // When
-        OpenApiJob job = new OpenApiJob();
-        job.applyCustomParameter("apiUrl", "Invalid URL.");
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -126,12 +147,18 @@ class OpenApiJobUnitTest {
     @Test
     void shouldFailIfInvalidFile() {
         // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
+        String yamlStr = "parameters:\n" + "  apiFile: 'Invalid file path'";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        OpenApiJob job = new OpenApiJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
 
         // When
-        OpenApiJob job = new OpenApiJob();
-        job.applyCustomParameter("apiFile", "Invalid file path.");
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Automation Framework 'theme' parameter.
+- Automation Framework GUI
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -27,12 +27,14 @@ import java.util.Map;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.jobs.JobData;
+import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.addon.reports.ReportData;
-import org.zaproxy.addon.reports.ReportParam;
 import org.zaproxy.addon.reports.Template;
 
 public class ReportJob extends AutomationJob {
@@ -40,72 +42,139 @@ public class ReportJob extends AutomationJob {
     private static final String JOB_NAME = "report";
 
     private static final String PARAM_TEMPLATE = "template";
+    private static final String PARAM_THEME = "theme";
     private static final String PARAM_REPORT_DIR = "reportDir";
     private static final String PARAM_REPORT_FILE = "reportFile";
     private static final String PARAM_REPORT_TITLE = "reportTitle";
     private static final String PARAM_REPORT_DESC = "reportDescription";
     private static final String PARAM_DISPLAY_REPORT = "displayReport";
 
-    private String templateName = "traditional-html";
-    private String reportDir = null;
-    private String reportFile = ReportParam.DEFAULT_NAME_PATTERN;
-    private String reportTitle = null;
-    private String reportDesc = null;
-    private boolean displayReport = false;
-
     private ExtensionReports extReport;
+
+    private Parameters parameters = new Parameters();
+    private Data data;
+
+    public ReportJob() {
+        data = new Data(this, this.parameters);
+    }
+
+    @Override
+    public void verifyParameters(AutomationProgress progress) {
+        LinkedHashMap<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
+        }
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
+
+        List<String> list = getJobDataList(jobData, "risks", progress);
+        if (!list.isEmpty()) {
+            // Validate
+            list.stream().map(risk -> riskStringToInt(risk, progress));
+            this.getData().setRisks(list);
+        }
+
+        list = getJobDataList(jobData, "confidences", progress);
+        if (!list.isEmpty()) {
+            // Validate
+            list.stream().map(conf -> confidenceStringToInt(conf, progress));
+            this.getData().setConfidences(list);
+        }
+
+        Template template =
+                getExtReport().getTemplateByConfigName(this.getParameters().getTemplate());
+        if (template == null) {
+            progress.error(
+                    Constant.messages.getString(
+                            "reports.automation.error.badtemplate",
+                            this.getName(),
+                            this.getParameters().getTemplate()));
+        }
+
+        list = getJobDataList(jobData, "sections", progress);
+        if (!list.isEmpty()) {
+            if (template != null) {
+                // Validate
+                List<String> validSections = template.getSections();
+                for (String section : list) {
+                    if (!validSections.contains(section)) {
+                        progress.warn(
+                                Constant.messages.getString(
+                                        "reports.automation.error.badsection",
+                                        this.getName(),
+                                        section,
+                                        template.getConfigName(),
+                                        validSections));
+                    }
+                }
+            }
+            this.getData().setSections(list);
+        }
+    }
 
     @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
         ReportData reportData = new ReportData();
-        Template template = getExtReport().getTemplateByConfigName(templateName);
+        Template template =
+                getExtReport().getTemplateByConfigName(this.getParameters().getTemplate());
+
+        if (template == null) {
+            progress.error(
+                    Constant.messages.getString(
+                            "reports.automation.error.badtemplate",
+                            this.getName(),
+                            this.getParameters().getTemplate()));
+            return;
+        }
+        reportData.setTheme(this.getParameters().getTheme());
 
         // Work out the file name based on the pattern
         String fileName =
                 ExtensionReports.getNameFromPattern(
-                        reportFile, env.getDefaultContextWrapper().getUrls().get(0));
+                        this.getParameters().getReportFile(),
+                        env.getDefaultContextWrapper().getUrls().get(0));
 
         if (!fileName.endsWith("." + template.getExtension())) {
             fileName += "." + template.getExtension();
         }
 
         File file;
+        String reportDir = this.getParameters().getReportDir();
         if (reportDir != null && reportDir.length() > 0) {
             file = new File(reportDir, fileName);
         } else {
             file = new File(fileName);
         }
-        reportData.setTitle(this.reportTitle);
-        reportData.setDescription(this.reportDesc);
+        reportData.setTitle(this.getParameters().getReportTitle());
+        reportData.setDescription(this.getParameters().getReportDescription());
         reportData.setContexts(env.getContexts());
         reportData.setSites(ExtensionReports.getSites());
 
-        LinkedHashMap<?, ?> jobData = this.getJobData();
-
-        List<String> list = getJobDataList(jobData, "risks", progress);
-        if (list.isEmpty()) {
+        if (this.getData().getRisks() == null) {
             reportData.setIncludeAllRisks(true);
         } else {
-            for (String risk : list) {
+            for (String risk : this.getData().getRisks()) {
                 reportData.setIncludeRisk(riskStringToInt(risk, progress), true);
             }
         }
 
-        list = getJobDataList(jobData, "confidences", progress);
-        if (list.isEmpty()) {
+        if (this.getData().getConfidences() == null) {
             reportData.setIncludeAllConfidences(true);
         } else {
-            for (String confidence : list) {
+            for (String confidence : this.getData().getConfidences()) {
                 reportData.setIncludeConfidence(confidenceStringToInt(confidence, progress), true);
             }
         }
 
-        list = getJobDataList(jobData, "sections", progress);
-        if (list.isEmpty()) {
+        if (this.getData().getSections() == null) {
             reportData.setSections(template.getSections());
         } else {
             List<String> validSections = template.getSections();
-            for (String section : list) {
+            for (String section : this.getData().getSections()) {
                 if (validSections.contains(section)) {
                     reportData.addSection(section);
                 } else {
@@ -119,13 +188,17 @@ public class ReportJob extends AutomationJob {
                 }
             }
         }
+
         reportData.setAlertTreeRootNode(getExtReport().getFilteredAlertTree(reportData));
 
         try {
             file =
                     getExtReport()
                             .generateReport(
-                                    reportData, template, file.getAbsolutePath(), displayReport);
+                                    reportData,
+                                    template,
+                                    file.getAbsolutePath(),
+                                    JobUtils.unBox(this.getParameters().getDisplayReport()));
             progress.info(
                     Constant.messages.getString(
                             "reports.automation.info.reportgen",
@@ -207,42 +280,17 @@ public class ReportJob extends AutomationJob {
     }
 
     @Override
-    public boolean applyCustomParameter(String name, String value) {
-        switch (name) {
-            case PARAM_TEMPLATE:
-                templateName = value;
-                return true;
-            case PARAM_REPORT_DIR:
-                reportDir = value;
-                return true;
-            case PARAM_REPORT_FILE:
-                reportFile = value;
-                return true;
-            case PARAM_REPORT_TITLE:
-                reportTitle = value;
-                return true;
-            case PARAM_REPORT_DESC:
-                reportDesc = value;
-                return true;
-            case PARAM_DISPLAY_REPORT:
-                displayReport = Boolean.parseBoolean(value);
-                return true;
-            default:
-                // Ignore
-                break;
-        }
-        return false;
-    }
-
-    @Override
     public Map<String, String> getCustomConfigParameters() {
         Map<String, String> map = super.getCustomConfigParameters();
-        map.put(PARAM_TEMPLATE, templateName);
-        map.put(PARAM_REPORT_DIR, null);
-        map.put(PARAM_REPORT_FILE, this.reportFile);
-        map.put(PARAM_REPORT_TITLE, this.reportTitle);
-        map.put(PARAM_REPORT_DESC, this.reportDesc);
-        map.put(PARAM_DISPLAY_REPORT, Boolean.toString(displayReport));
+        map.put(PARAM_TEMPLATE, this.getParameters().getTemplate());
+        map.put(PARAM_THEME, this.getParameters().getTheme());
+        map.put(PARAM_REPORT_DIR, this.getParameters().getReportDir());
+        map.put(PARAM_REPORT_FILE, this.getParameters().getReportFile());
+        map.put(PARAM_REPORT_TITLE, this.getParameters().getReportTitle());
+        map.put(PARAM_REPORT_DESC, this.getParameters().getReportDescription());
+        map.put(
+                PARAM_DISPLAY_REPORT,
+                Boolean.toString(JobUtils.unBox(this.getParameters().getDisplayReport())));
         return map;
     }
 
@@ -274,5 +322,136 @@ public class ReportJob extends AutomationJob {
     @Override
     public String getParamMethodName() {
         return null;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void showDialog() {
+        new ReportJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "reports.automation.dialog.summary", this.getParameters().getTemplate());
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+        private List<String> risks;
+        private List<String> confidences;
+        private List<String> sections;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+
+        public List<String> getRisks() {
+            return risks;
+        }
+
+        public void setRisks(List<String> risks) {
+            this.risks = risks;
+        }
+
+        public List<String> getConfidences() {
+            return confidences;
+        }
+
+        public void setConfidences(List<String> confidences) {
+            this.confidences = confidences;
+        }
+
+        public List<String> getSections() {
+            return sections;
+        }
+
+        public void setSections(List<String> sections) {
+            this.sections = sections;
+        }
+
+        public void setParameters(Parameters parameters) {
+            this.parameters = parameters;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private String template;
+        private String theme;
+        private String reportDir;
+        private String reportFile;
+        private String reportTitle;
+        private String reportDescription;
+        private Boolean displayReport;
+
+        public String getTemplate() {
+            return template;
+        }
+
+        public void setTemplate(String template) {
+            this.template = template;
+        }
+
+        public String getTheme() {
+            return theme;
+        }
+
+        public void setTheme(String theme) {
+            this.theme = theme;
+        }
+
+        public String getReportDir() {
+            return reportDir;
+        }
+
+        public void setReportDir(String reportDir) {
+            this.reportDir = reportDir;
+        }
+
+        public String getReportFile() {
+            return reportFile;
+        }
+
+        public void setReportFile(String reportFile) {
+            this.reportFile = reportFile;
+        }
+
+        public String getReportTitle() {
+            return reportTitle;
+        }
+
+        public void setReportTitle(String reportTitle) {
+            this.reportTitle = reportTitle;
+        }
+
+        public String getReportDescription() {
+            return reportDescription;
+        }
+
+        public void setReportDescription(String reportDescription) {
+            this.reportDescription = reportDescription;
+        }
+
+        public Boolean getDisplayReport() {
+            return displayReport;
+        }
+
+        public void setDisplayReport(Boolean displayReport) {
+            this.displayReport = displayReport;
+        }
     }
 }

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
@@ -1,0 +1,326 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.reports.automation;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import javax.swing.BoxLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import org.apache.commons.lang.WordUtils;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.reports.ExtensionReports;
+import org.zaproxy.addon.reports.Template;
+import org.zaproxy.addon.reports.automation.ReportJob.Parameters;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class ReportJobDialog extends StandardFieldsDialog {
+
+    private static final String FIELD_NAME = "reports.automation.dialog.field.name";
+    private static final String FIELD_TITLE = "reports.dialog.field.title";
+    private static final String FIELD_TEMPLATE = "reports.dialog.field.template";
+    private static final String FIELD_REPORT_DIR = "reports.dialog.field.reportdir";
+    private static final String FIELD_REPORT_NAME = "reports.dialog.field.reportname";
+    private static final String FIELD_DESCRIPTION = "reports.dialog.field.description";
+    private static final String FIELD_DISPLAY_REPORT = "reports.dialog.field.display";
+    private static final String FIELD_CONFIDENCE_HEADER = "reports.dialog.field.confidence";
+    private static final String FIELD_CONFIDENCE_0 = "reports.dialog.field.confidence.0";
+    private static final String FIELD_CONFIDENCE_1 = "reports.dialog.field.confidence.1";
+    private static final String FIELD_CONFIDENCE_2 = "reports.dialog.field.confidence.2";
+    private static final String FIELD_CONFIDENCE_3 = "reports.dialog.field.confidence.3";
+    private static final String FIELD_CONFIDENCE_4 = "reports.dialog.field.confidence.4";
+    private static final String FIELD_RISK_HEADER = "reports.dialog.field.risk";
+    private static final String FIELD_RISK_0 = "reports.dialog.field.risk.0";
+    private static final String FIELD_RISK_1 = "reports.dialog.field.risk.1";
+    private static final String FIELD_RISK_2 = "reports.dialog.field.risk.2";
+    private static final String FIELD_RISK_3 = "reports.dialog.field.risk.3";
+    private static final String FIELD_SECTIONS = "reports.dialog.field.sections";
+    private static final String FIELD_THEME = "reports.dialog.field.theme";
+
+    private static final String[] TAB_LABELS = {
+        "reports.dialog.tab.scope", "reports.dialog.tab.template", "reports.dialog.tab.filter"
+    };
+
+    private static final int TAB_SCOPE = 0;
+    private static final int TAB_TEMPLATE = 1;
+    private static final int TAB_FILTER = 2;
+
+    private static final long serialVersionUID = 1L;
+
+    private ExtensionReports extension = null;
+    private ReportJob job;
+
+    private JScrollPane sectionsPane;
+    private Map<String, JCheckBox> sectionsMap;
+
+    public ReportJobDialog(ReportJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                "reports.automation.dialog.title",
+                DisplayUtils.getScaledDimension(600, 450),
+                TAB_LABELS);
+        this.job = job;
+        this.extension =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionReports.class);
+
+        Parameters params = job.getData().getParameters();
+
+        this.addTextField(TAB_SCOPE, FIELD_NAME, this.job.getData().getName());
+        this.addTextField(TAB_SCOPE, FIELD_TITLE, params.getReportTitle());
+
+        this.addTextField(TAB_SCOPE, FIELD_REPORT_NAME, params.getReportFile());
+        this.addFileSelectField(
+                TAB_SCOPE,
+                FIELD_REPORT_DIR,
+                new File(params.getReportDir()),
+                JFileChooser.DIRECTORIES_ONLY,
+                null);
+        this.addMultilineField(TAB_SCOPE, FIELD_DESCRIPTION, params.getReportDescription());
+        this.addCheckBoxField(
+                TAB_SCOPE, FIELD_DISPLAY_REPORT, JobUtils.unBox(params.getDisplayReport()));
+
+        Template defaultTemplate = extension.getTemplateByConfigName(params.getTemplate());
+        List<String> templates = extension.getTemplateNames();
+        Collections.sort(templates);
+        this.addComboField(
+                TAB_TEMPLATE,
+                FIELD_TEMPLATE,
+                templates,
+                defaultTemplate != null ? defaultTemplate.getDisplayName() : null);
+
+        ((JComboBox<?>) this.getField(FIELD_TEMPLATE))
+                .addActionListener(
+                        e -> {
+                            resetTemplateFields();
+                        });
+
+        List<String> themes = new ArrayList<>();
+        if (defaultTemplate != null) {
+            themes = defaultTemplate.getThemeNames();
+        }
+
+        this.addComboField(TAB_TEMPLATE, FIELD_THEME, themes, params.getTheme());
+
+        this.addCustomComponent(TAB_TEMPLATE, FIELD_SECTIONS, getSectionsScrollPane());
+        resetTemplateFields();
+        this.addPadding(TAB_TEMPLATE);
+
+        this.addTextFieldReadOnly(TAB_FILTER, FIELD_RISK_HEADER, "");
+        List<String> stdRisks;
+        List<String> risks = job.getData().getRisks();
+        if (risks != null) {
+            stdRisks =
+                    risks.stream()
+                            .map(r -> WordUtils.capitalize(r.trim().toLowerCase(Locale.ROOT)))
+                            .collect(Collectors.toList());
+        } else {
+            stdRisks = Arrays.asList(Alert.MSG_RISK);
+        }
+        this.addCheckBoxField(TAB_FILTER, FIELD_RISK_3, stdRisks.contains(Alert.MSG_RISK[3]));
+        this.addCheckBoxField(TAB_FILTER, FIELD_RISK_2, stdRisks.contains(Alert.MSG_RISK[2]));
+        this.addCheckBoxField(TAB_FILTER, FIELD_RISK_1, stdRisks.contains(Alert.MSG_RISK[1]));
+        this.addCheckBoxField(TAB_FILTER, FIELD_RISK_0, stdRisks.contains(Alert.MSG_RISK[0]));
+
+        this.addTextFieldReadOnly(TAB_FILTER, FIELD_CONFIDENCE_HEADER, "");
+        List<String> stdConfs;
+        List<String> confs = job.getData().getConfidences();
+        if (confs != null) {
+            stdConfs =
+                    confs.stream()
+                            .map(r -> WordUtils.capitalize(r.trim().toLowerCase(Locale.ROOT)))
+                            .collect(Collectors.toList());
+        } else {
+            stdConfs = Arrays.asList(Alert.MSG_CONFIDENCE);
+        }
+        this.addCheckBoxField(
+                TAB_FILTER, FIELD_CONFIDENCE_4, stdConfs.contains(Alert.MSG_CONFIDENCE[4]));
+        this.addCheckBoxField(
+                TAB_FILTER, FIELD_CONFIDENCE_3, stdConfs.contains(Alert.MSG_CONFIDENCE[3]));
+        this.addCheckBoxField(
+                TAB_FILTER, FIELD_CONFIDENCE_2, stdConfs.contains(Alert.MSG_CONFIDENCE[2]));
+        this.addCheckBoxField(
+                TAB_FILTER, FIELD_CONFIDENCE_1, stdConfs.contains(Alert.MSG_CONFIDENCE[1]));
+        this.addCheckBoxField(
+                TAB_FILTER, FIELD_CONFIDENCE_0, stdConfs.contains(Alert.MSG_CONFIDENCE[0]));
+        this.addPadding(TAB_FILTER);
+
+        this.pack();
+    }
+
+    private JScrollPane getSectionsScrollPane() {
+        if (sectionsPane == null) {
+            sectionsPane = new JScrollPane();
+        }
+        return sectionsPane;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void resetTemplateFields() {
+        JPanel sectionPanel = new JPanel();
+        sectionPanel.setLayout(new BoxLayout(sectionPanel, BoxLayout.Y_AXIS));
+
+        Template template = extension.getTemplateByDisplayName(getStringValue(FIELD_TEMPLATE));
+        if (template != null) {
+            JComboBox<String> themeCombo = ((JComboBox<String>) this.getField(FIELD_THEME));
+            themeCombo.removeAllItems();
+            for (String theme : template.getThemeNames()) {
+                themeCombo.addItem(theme);
+            }
+            if (template.getThemeNames().size() > 0) {
+                String defaultTheme = extension.getReportParam().getTheme(template.getConfigName());
+                if (defaultTheme != null) {
+                    themeCombo.setSelectedItem(template.getThemeName(defaultTheme));
+                } else {
+                    themeCombo.setSelectedIndex(0);
+                }
+            }
+
+            List<String> sections = template.getSections();
+            sectionsMap = new HashMap<>();
+            if (sections.size() == 0) {
+                sectionPanel.add(
+                        new JLabel(
+                                Constant.messages.getString("reports.dialog.field.sections.none")));
+            } else {
+                List<String> sectionList = job.getData().getSections();
+                for (String section : sections) {
+                    JCheckBox cb =
+                            new JCheckBox(
+                                    template.getI18nString(
+                                            "report.template.section." + section, null));
+                    cb.setSelected(
+                            sectionList == null
+                                    || sectionList.size() == 0
+                                    || sectionList.contains(section));
+                    sectionsMap.put(section, cb);
+                    sectionPanel.add(cb);
+                }
+            }
+        }
+        getSectionsScrollPane().setViewportView(sectionPanel);
+    }
+
+    @Override
+    public void save() {
+        Template template = extension.getTemplateByDisplayName(getStringValue(FIELD_TEMPLATE));
+        job.getData().setName(this.getStringValue(FIELD_NAME));
+        job.getData().getParameters().setTemplate(template.getConfigName());
+        job.getData().getParameters().setReportTitle(this.getStringValue(FIELD_TITLE));
+        job.getData().getParameters().setReportFile(this.getStringValue(FIELD_REPORT_NAME));
+        job.getData().getParameters().setReportDir(this.getStringValue(FIELD_REPORT_DIR));
+        job.getData().getParameters().setReportDescription(this.getStringValue(FIELD_DESCRIPTION));
+        job.getData().getParameters().setDisplayReport(this.getBoolValue(FIELD_DISPLAY_REPORT));
+
+        job.getData().getParameters().setTheme(this.getStringValue(FIELD_THEME));
+
+        List<String> sections = new ArrayList<>();
+        for (Entry<String, JCheckBox> entry : sectionsMap.entrySet()) {
+            if (entry.getValue().isSelected()) {
+                sections.add(entry.getKey());
+            }
+        }
+        if (sections.size() == 0) {
+            job.getData().setSections(null);
+        } else {
+            job.getData().setSections(sections);
+        }
+
+        String[] riskFields = {FIELD_RISK_0, FIELD_RISK_1, FIELD_RISK_2, FIELD_RISK_3};
+        List<String> risks = new ArrayList<>();
+        for (int i = 0; i < riskFields.length; i++) {
+            if (this.getBoolValue(riskFields[i])) {
+                risks.add(Alert.MSG_RISK[i].toLowerCase());
+            }
+        }
+        if (risks.size() == 0) {
+            job.getData().setRisks(null);
+        } else {
+            job.getData().setRisks(risks);
+        }
+
+        String[] confFields = {
+            FIELD_CONFIDENCE_0,
+            FIELD_CONFIDENCE_1,
+            FIELD_CONFIDENCE_2,
+            FIELD_CONFIDENCE_3,
+            FIELD_CONFIDENCE_4
+        };
+        List<String> confs = new ArrayList<>();
+        for (int i = 0; i < confFields.length; i++) {
+            if (this.getBoolValue(confFields[i])) {
+                confs.add(Alert.MSG_CONFIDENCE[i].toLowerCase());
+            }
+        }
+        if (confs.size() == 0) {
+            job.getData().setConfidences(null);
+        } else {
+            job.getData().setConfidences(confs);
+        }
+        this.job.setChanged();
+    }
+
+    private File getReportFile() {
+        return new File(
+                this.getStringValue(FIELD_REPORT_DIR), this.getStringValue(FIELD_REPORT_NAME));
+    }
+
+    @Override
+    public void setVisible(boolean show) {
+        super.setVisible(show);
+    }
+
+    @Override
+    public String validateFields() {
+        Template template = extension.getTemplateByDisplayName(getStringValue(FIELD_TEMPLATE));
+        if (template == null) {
+            return Constant.messages.getString("reports.dialog.error.notemplate");
+        }
+
+        File f = getReportFile();
+        if (!f.exists()) {
+            if (!f.getParentFile().canWrite()) {
+                return Constant.messages.getString(
+                        "reports.dialog.error.dirperms", f.getParentFile().getAbsolutePath());
+            }
+        } else if (!f.canWrite()) {
+            return Constant.messages.getString(
+                    "reports.dialog.error.fileperms", f.getAbsolutePath());
+        }
+
+        return null;
+    }
+}

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/Messages.properties
@@ -40,6 +40,11 @@ reports.automation.error.roparent = Job {0} no write access to parent directory 
 reports.automation.error.badrisk = Job {0} invalid risk: {1}
 reports.automation.error.badsection = Job {0} invalid section {1} for template {2}, valid sections: {3}
 reports.automation.error.badsummaryfile = Job {0} failed to create summary file: {1}
+reports.automation.error.badtemplate = Job {0} invalid template: {1}
+
+reports.automation.dialog.summary = Template: {0}
+reports.automation.dialog.title = Report Job
+reports.automation.dialog.field.name = Job Name:
 
 reports.dialog.button.generate = Generate Report
 reports.dialog.button.reset = Reset

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-max.yaml
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-max.yaml
@@ -1,6 +1,7 @@
   - type: report                       # Report generation
     parameters:
       template:                        # String: The template id, default : traditional-html
+      theme:                           # String: The template theme, default: the first theme defined for the template (if any)
       reportDir:                       # String: The directory into which the report will be written
       reportFile:                      # String: The report file name pattern, default: {{yyyy-MM-dd}}-ZAP-Report-[[site]]
       reportTitle:                     # String: The report title

--- a/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-min.yaml
+++ b/addOns/reports/src/main/resources/org/zaproxy/addon/reports/resources/report-min.yaml
@@ -1,6 +1,7 @@
   - type: report                       # Report generation
     parameters:
       template:                        # String: The template id, default : traditional-html
+      theme:                           # String: The template theme, default: the first theme defined for the template (if any)
       reportDir:                       # String: The directory into which the report will be written
       reportFile:                      # String: The report file name pattern, default: {{yyyy-MM-dd}}-ZAP-Report-[[site]]
       reportTitle:                     # String: The report title

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
@@ -55,6 +55,7 @@ import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData;
 import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData.RuleData;
 import org.zaproxy.addon.reports.ExtensionReports;
+import org.zaproxy.addon.reports.automation.OutputSummaryJob.Format;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.utils.I18N;
@@ -106,7 +107,11 @@ class OutputSummaryJobUnitTest {
 
         // Then
         assertThat(realProgress.hasErrors(), is(equalTo(true)));
-        assertThat(realProgress.getErrors(), contains("!reports.automation.error.badformat!"));
+        assertThat(
+                realProgress.getErrors(),
+                contains(
+                        "!automation.error.options.badenum!",
+                        "!reports.automation.error.noparent!"));
     }
 
     @Test
@@ -139,7 +144,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         // When
         job.runJob(env, progress);
@@ -166,7 +171,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         LinkedHashMap<String, Object> ruleDefn = new LinkedHashMap<>();
         ruleDefn.put("id", 1);
@@ -179,6 +184,7 @@ class OutputSummaryJobUnitTest {
 
         // When
         job.setJobData(data);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -203,7 +209,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         LinkedHashMap<String, Object> ruleDefn = new LinkedHashMap<>();
         ruleDefn.put("id", 1);
@@ -216,6 +222,7 @@ class OutputSummaryJobUnitTest {
 
         // When
         job.setJobData(data);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -240,7 +247,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         LinkedHashMap<String, Object> ruleDefn = new LinkedHashMap<>();
         ruleDefn.put("id", 1);
@@ -253,6 +260,7 @@ class OutputSummaryJobUnitTest {
 
         // When
         job.setJobData(data);
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -285,8 +293,6 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
-
         ArrayList<LinkedHashMap<?, ?>> rulesDefn = new ArrayList<>();
 
         LinkedHashMap<String, Object> rule1Defn = new LinkedHashMap<>();
@@ -309,6 +315,8 @@ class OutputSummaryJobUnitTest {
 
         // When
         job.setJobData(data);
+        job.verifyParameters(progress);
+        job.getData().getParameters().setFormat(Format.LONG);
         job.runJob(env, progress);
 
         // Then
@@ -327,7 +335,7 @@ class OutputSummaryJobUnitTest {
     void shouldWarnOnNoURLs() throws Exception {
         // Given
         given(ext.countNumberOfUrls()).willReturn(0);
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         // When
         job.runJob(env, progress);
@@ -359,7 +367,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         // When
         job.runJob(env, progress);
@@ -391,7 +399,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         // When
         job.runJob(env, progress);
@@ -422,7 +430,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         // When
         job.runJob(env, progress);
@@ -462,7 +470,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setFormat(Format.LONG);
 
         // When
         job.runJob(env, progress);
@@ -505,7 +513,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "SHORT");
+        job.getData().getParameters().setFormat(Format.SHORT);
 
         // When
         job.runJob(env, progress);
@@ -542,7 +550,7 @@ class OutputSummaryJobUnitTest {
 
         given(psJobResData.getAllRuleData()).willReturn(list);
 
-        job.applyCustomParameter("format", "NONE");
+        job.getData().getParameters().setFormat(Format.NONE);
 
         // When
         job.runJob(env, progress);
@@ -600,8 +608,8 @@ class OutputSummaryJobUnitTest {
         given(psJobResData.getAllRuleData()).willReturn(list);
 
         File f = File.createTempFile("zap.reports.outputsummary", "json");
-        job.applyCustomParameter("summaryFile", f.getAbsolutePath());
-        job.applyCustomParameter("format", "LONG");
+        job.getData().getParameters().setSummaryFile(f.getAbsolutePath());
+        job.getData().getParameters().setFormat(Format.LONG);
 
         // When
         job.runJob(env, progress);

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Automation Framework GUI
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJob.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJob.java
@@ -23,15 +23,19 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.jobs.JobData;
+import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.extension.soap.ExtensionImportWSDL;
 
 public class SoapJob extends AutomationJob {
@@ -44,8 +48,12 @@ public class SoapJob extends AutomationJob {
 
     private ExtensionImportWSDL extSoap;
 
-    private String wsdlFile;
-    private String wsdlUrl;
+    private Parameters parameters = new Parameters();
+    private Data data;
+
+    public SoapJob() {
+        data = new Data(this, this.parameters);
+    }
 
     private ExtensionImportWSDL getExtSoap() {
         if (extSoap == null) {
@@ -58,19 +66,17 @@ public class SoapJob extends AutomationJob {
     }
 
     @Override
-    public boolean applyCustomParameter(String name, String value) {
-        switch (name) {
-            case PARAM_WSDL_FILE:
-                wsdlFile = value;
-                return true;
-            case PARAM_WSDL_URL:
-                wsdlUrl = value;
-                return true;
-            default:
-                // Ignore
-                break;
+    public void verifyParameters(AutomationProgress progress) {
+        LinkedHashMap<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
         }
-        return false;
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
     }
 
     @Override
@@ -84,6 +90,7 @@ public class SoapJob extends AutomationJob {
     @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
 
+        String wsdlFile = this.getParameters().getWsdlFile();
         if (wsdlFile != null && !wsdlFile.isEmpty()) {
             File file = new File(wsdlFile);
             if (!file.exists() || !file.canRead()) {
@@ -93,6 +100,7 @@ public class SoapJob extends AutomationJob {
             }
         }
 
+        String wsdlUrl = this.getParameters().getWsdlUrl();
         if (wsdlUrl != null && !wsdlUrl.isEmpty()) {
             try {
                 new URI(wsdlUrl, true);
@@ -101,16 +109,6 @@ public class SoapJob extends AutomationJob {
                 progress.error(Constant.messages.getString("soap.automation.error.url", wsdlUrl));
             }
         }
-    }
-
-    // For Unit Tests
-    protected String getWsdlFile() {
-        return wsdlFile;
-    }
-
-    // For Unit Tests
-    protected String getWsdlUrl() {
-        return wsdlUrl;
     }
 
     @Override
@@ -154,5 +152,66 @@ public class SoapJob extends AutomationJob {
     @Override
     public String getParamMethodName() {
         return null;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void showDialog() {
+        new SoapJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "soap.automation.dialog.summary",
+                JobUtils.unBox(this.getParameters().getWsdlUrl(), "''"),
+                JobUtils.unBox(this.getParameters().getWsdlFile(), "''"));
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+
+        public void setParameters(Parameters parameters) {
+            this.parameters = parameters;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private String wsdlFile;
+        private String wsdlUrl;
+
+        public String getWsdlFile() {
+            return wsdlFile;
+        }
+
+        public void setWsdlFile(String wsdlFile) {
+            this.wsdlFile = wsdlFile;
+        }
+
+        public String getWsdlUrl() {
+            return wsdlUrl;
+        }
+
+        public void setWsdlUrl(String wsdlUrl) {
+            this.wsdlUrl = wsdlUrl;
+        }
     }
 }

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.soap.automation;
+
+import java.awt.Component;
+import java.io.File;
+import javax.swing.JFileChooser;
+import javax.swing.JTextField;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class SoapJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "soap.automation.dialog.title";
+    private static final String NAME_PARAM = "soap.automation.dialog.name";
+    private static final String WSDL_FILE_PARAM = "soap.automation.dialog.wsdlfile";
+    private static final String WSDL_URL_PARAM = "soap.automation.dialog.wsdlurl";
+
+    private SoapJob job;
+
+    public SoapJobDialog(SoapJob job) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 200));
+        this.job = job;
+
+        this.addTextField(NAME_PARAM, this.job.getData().getName());
+        String fileName = this.job.getData().getParameters().getWsdlFile();
+        File f = null;
+        if (fileName != null && !fileName.isEmpty()) {
+            f = new File(fileName);
+        }
+        this.addFileSelectField(WSDL_FILE_PARAM, f, JFileChooser.FILES_AND_DIRECTORIES, null);
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(WSDL_URL_PARAM, null, true, false);
+        Component urlField = this.getField(WSDL_URL_PARAM);
+        if (urlField instanceof JTextField) {
+            ((JTextField) urlField).setText(this.job.getParameters().getWsdlUrl());
+        }
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setWsdlFile(this.getStringValue(WSDL_FILE_PARAM));
+        this.job.getParameters().setWsdlUrl(this.getStringValue(WSDL_URL_PARAM));
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
+++ b/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
@@ -8,6 +8,12 @@ soap.automation.name = SOAP Automation
 soap.automation.error.file = Job soap cannot read file: {0}
 soap.automation.error.url = Job soap invalid URL: {0}
 
+soap.automation.dialog.summary = URL: {0}, File: {1}
+soap.automation.dialog.title = SOAP Job
+soap.automation.dialog.name = Job Name:
+soap.automation.dialog.wsdlfile = WSDL File:
+soap.automation.dialog.wsdlurl = WSDL URL:
+
 soap.desc=Allows you to import a WSDL file containing operations which ZAP will access, adding them to the Sites tree.
 soap.topmenu.import.importWSDL=Import a WSDL file from local file system
 soap.topmenu.import.importWSDL.tooltip=The file must be a formal described WSDL file.

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/automation/SoapJobUnitTest.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/automation/SoapJobUnitTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.withSettings;
 
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,6 +37,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
+import org.yaml.snakeyaml.Yaml;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
@@ -89,17 +91,24 @@ class SoapJobUnitTest {
     @Test
     void shouldApplyCustomConfigParams() {
         // Given
-        SoapJob job = new SoapJob();
+        Constant.messages = new I18N(Locale.ENGLISH);
+        AutomationProgress progress = new AutomationProgress();
         String wsdlFile = "C:\\Users\\ZAPBot\\Documents\\test file.wsdl";
         String wsdlUrl = "https://example.com/test%20file.wsdl";
+        String yamlStr =
+                "parameters:\n" + "  wsdlUrl: " + wsdlUrl + "\n" + "  wsdlFile: " + wsdlFile;
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        SoapJob job = new SoapJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
 
         // When
-        job.applyCustomParameter("wsdlFile", wsdlFile);
-        job.applyCustomParameter("wsdlUrl", wsdlUrl);
+        job.verifyParameters(progress);
 
         // Then
-        assertThat(job.getWsdlFile(), is(equalTo(wsdlFile)));
-        assertThat(job.getWsdlUrl(), is(equalTo(wsdlUrl)));
+        assertThat(job.getParameters().getWsdlFile(), is(equalTo(wsdlFile)));
+        assertThat(job.getParameters().getWsdlUrl(), is(equalTo(wsdlUrl)));
     }
 
     @Test
@@ -108,11 +117,15 @@ class SoapJobUnitTest {
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
+        String yamlStr = "parameters:\n" + "  wsdlUrl: 'https://example.com/test file.wsdl'";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        SoapJob job = new SoapJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
 
         // When
-        SoapJob job = new SoapJob();
-        // The following URL is invalid because it is not escaped.
-        job.applyCustomParameter("wsdlUrl", "https://example.com/test file.wsdl");
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then
@@ -127,10 +140,15 @@ class SoapJobUnitTest {
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
+        String yamlStr = "parameters:\n" + "  wsdlFile: 'Invalid file path'";
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        SoapJob job = new SoapJob();
+        job.setJobData(((LinkedHashMap<?, ?>) data));
 
         // When
-        SoapJob job = new SoapJob();
-        job.applyCustomParameter("wsdlFile", "Invalid file path.");
+        job.verifyParameters(progress);
         job.runJob(env, progress);
 
         // Then

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Automation Framework GUI
+
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobDialog.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobDialog.java
@@ -1,0 +1,241 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.spiderAjax.automation;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JTextField;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
+import org.zaproxy.zap.extension.selenium.ProvidedBrowserUI;
+import org.zaproxy.zap.extension.spiderAjax.automation.AjaxSpiderJob.Parameters;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AjaxSpiderJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "spiderajax.automation.dialog.tab.params", "spiderajax.automation.dialog.ajaxspider.tab.adv"
+    };
+
+    private static final String TITLE = "spiderajax.automation.dialog.ajaxspider.title";
+    private static final String CONTEXT_PARAM = "spiderajax.automation.dialog.ajaxspider.context";
+    private static final String URL_PARAM = "spiderajax.automation.dialog.ajaxspider.url";
+    private static final String MAX_DURATION_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.maxduration";
+    private static final String MAX_CRAWL_DEPTH_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.maxcrawldepth";
+    private static final String NUM_BROWSERS_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.numbrowsers";
+    private static final String FIELD_ADVANCED = "spiderajax.automation.dialog.ajaxspider.advanced";
+
+    private static final String BROWSER_ID_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.browserid";
+    private static final String MAX_CRAWL_STATES_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.maxcrawlstates";
+    private static final String EVENT_WAIT_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.eventwait";
+    private static final String RELOAD_WAIT_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.reloadwait";
+    private static final String CLICK_DEFAULT_ELEMS_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.clickdefaultelems";
+    private static final String CLICK_ELEMS_ONCE_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.clickelemsonce";
+    private static final String RANDOM_INPUTS_PARAM =
+            "spiderajax.automation.dialog.ajaxspider.randominputs";
+
+    private AjaxSpiderJob job;
+    private ExtensionSelenium extSel = null;
+
+    public AjaxSpiderJobDialog(AjaxSpiderJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(450, 400),
+                TAB_LABELS);
+        this.job = job;
+
+        List<String> contextNames = this.job.getEnv().getContextNames();
+        // Add blank option
+        contextNames.add(0, "");
+        this.addComboField(0, CONTEXT_PARAM, contextNames, this.job.getParameters().getContext());
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(0, URL_PARAM, null, true, false);
+        Component urlField = this.getField(URL_PARAM);
+        if (urlField instanceof JTextField) {
+            ((JTextField) urlField).setText(this.job.getParameters().getUrl());
+        }
+        this.addNumberField(
+                0,
+                MAX_DURATION_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxDuration()));
+        this.addNumberField(
+                0,
+                MAX_CRAWL_DEPTH_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxCrawlDepth()));
+        this.addNumberField(
+                0,
+                NUM_BROWSERS_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getNumberOfBrowsers()));
+        this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
+
+        this.addFieldListener(
+                FIELD_ADVANCED,
+                new ActionListener() {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+                    }
+                });
+
+        this.addPadding(0);
+
+        List<ProvidedBrowserUI> browserList = getExtSelenium().getProvidedBrowserUIList();
+        List<String> browserNames = new ArrayList<>();
+        String defaultBrowser = "";
+        browserNames.add(""); // Default to empty
+        for (ProvidedBrowserUI browser : browserList) {
+            browserNames.add(browser.getName());
+            if (browser.getBrowser().getId().equals(this.job.getParameters().getBrowserId())) {
+                defaultBrowser = browser.getName();
+            }
+        }
+        this.addComboField(1, BROWSER_ID_PARAM, browserNames, defaultBrowser);
+
+        this.addNumberField(
+                1,
+                MAX_CRAWL_STATES_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxCrawlStates()));
+        this.addNumberField(
+                1,
+                EVENT_WAIT_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getEventWait()));
+        this.addNumberField(
+                1,
+                RELOAD_WAIT_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getReloadWait()));
+        this.addCheckBoxField(
+                1,
+                CLICK_DEFAULT_ELEMS_PARAM,
+                JobUtils.unBox(this.job.getParameters().getClickDefaultElems()));
+        this.addCheckBoxField(
+                1,
+                CLICK_ELEMS_ONCE_PARAM,
+                JobUtils.unBox(this.job.getParameters().getClickElemsOnce()));
+        this.addCheckBoxField(
+                1, RANDOM_INPUTS_PARAM, JobUtils.unBox(this.job.getParameters().getRandomInputs()));
+
+        this.addPadding(1);
+
+        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+    }
+
+    private boolean advOptionsSet() {
+        Parameters params = this.job.getParameters();
+        return params.getBrowserId() != null
+                || params.getMaxCrawlStates() != null
+                || params.getEventWait() != null
+                || params.getReloadWait() != null
+                || params.getClickDefaultElems() != null
+                || params.getClickElemsOnce() != null
+                || params.getRandomInputs() != null;
+    }
+
+    private void setAdvancedTabs(boolean visible) {
+        // Show/hide all except from the first tab
+        this.setTabsVisible(
+                new String[] {"spiderajax.automation.dialog.ajaxspider.tab.adv"}, visible);
+    }
+
+    private ExtensionSelenium getExtSelenium() {
+        if (extSel == null) {
+            extSel =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionSelenium.class);
+        }
+        return extSel;
+    }
+
+    @Override
+    public void save() {
+        this.job.getParameters().setContext(this.getStringValue(CONTEXT_PARAM));
+        this.job.getParameters().setUrl(this.getStringValue(URL_PARAM));
+        this.job.getParameters().setMaxDuration(this.getIntValue(MAX_DURATION_PARAM));
+        this.job.getParameters().setMaxCrawlDepth(this.getIntValue(MAX_CRAWL_DEPTH_PARAM));
+        this.job.getParameters().setNumberOfBrowsers(this.getIntValue(NUM_BROWSERS_PARAM));
+
+        if (this.getBoolValue(FIELD_ADVANCED)) {
+            String browserName = this.getStringValue(BROWSER_ID_PARAM);
+            if (browserName.isEmpty()) {
+                this.job.getParameters().setBrowserId(null);
+            } else {
+                List<ProvidedBrowserUI> browserList = getExtSelenium().getProvidedBrowserUIList();
+                for (ProvidedBrowserUI bui : browserList) {
+                    if (browserName.equals(bui.getName())) {
+                        this.job.getParameters().setBrowserId(bui.getBrowser().getId());
+                        break;
+                    }
+                }
+            }
+            this.job.getParameters().setMaxCrawlStates(this.getIntValue(MAX_CRAWL_STATES_PARAM));
+            this.job.getParameters().setEventWait(this.getIntValue(EVENT_WAIT_PARAM));
+            this.job.getParameters().setReloadWait(this.getIntValue(RELOAD_WAIT_PARAM));
+            this.job
+                    .getParameters()
+                    .setClickDefaultElems(this.getBoolValue(CLICK_DEFAULT_ELEMS_PARAM));
+            this.job.getParameters().setClickElemsOnce(this.getBoolValue(CLICK_ELEMS_ONCE_PARAM));
+            this.job.getParameters().setRandomInputs(this.getBoolValue(RANDOM_INPUTS_PARAM));
+        } else {
+            this.job.getParameters().setBrowserId(null);
+            this.job.getParameters().setMaxCrawlStates(null);
+            this.job.getParameters().setEventWait(null);
+            this.job.getParameters().setReloadWait(null);
+            this.job.getParameters().setClickDefaultElems(null);
+            this.job.getParameters().setClickElemsOnce(null);
+            this.job.getParameters().setRandomInputs(null);
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        // TODO validate url - coping with envvars :O
+        return null;
+    }
+}

--- a/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
+++ b/addOns/spiderAjax/src/main/resources/org/zaproxy/zap/extension/spiderAjax/resources/Messages.properties
@@ -57,9 +57,29 @@ spiderajax.api.action.setOptionReloadWait = Sets the time to wait after the page
 spiderajax.api.action.setOptionReloadWait.param.Integer = The number of milliseconds the AJAX Spider should wait after a page is loaded (default is 1000).
 spiderajax.api.action.stop = Stops the AJAX Spider.
 
+spiderajax.automation.default: Default
 spiderajax.automation.desc = Ajax Spider Automation Framework Integration
 spiderajax.automation.name = Ajax Spider Automation
 spiderajax.automation.error.nofile = Cannot access file:  {0}
+
+spiderajax.automation.dialog.summary = Context: {0}, URL : {1}
+spiderajax.automation.dialog.tab.params = Parameters
+spiderajax.automation.dialog.ajaxspider.tab.adv = Advanced
+spiderajax.automation.dialog.ajaxspider.title = Ajax Spider Job
+spiderajax.automation.dialog.ajaxspider.context = Context:
+spiderajax.automation.dialog.ajaxspider.url = URL:
+spiderajax.automation.dialog.ajaxspider.maxduration = Max Duration (in mins):
+spiderajax.automation.dialog.ajaxspider.maxcrawldepth = Max Crawl Depth:
+spiderajax.automation.dialog.ajaxspider.numbrowsers = Number Of Browsers:
+spiderajax.automation.dialog.ajaxspider.advanced = Show Advanced Options:
+
+spiderajax.automation.dialog.ajaxspider.browserid = Browser Id:
+spiderajax.automation.dialog.ajaxspider.maxcrawlstates = Max Crawl States:
+spiderajax.automation.dialog.ajaxspider.eventwait = Event Wait (in msec):
+spiderajax.automation.dialog.ajaxspider.reloadwait = Reload Wait (in msec):
+spiderajax.automation.dialog.ajaxspider.clickdefaultelems = Click Default Elements:
+spiderajax.automation.dialog.ajaxspider.clickelemsonce = Click Elements Once:
+spiderajax.automation.dialog.ajaxspider.randominputs = Use Random Inputs:
 
 spiderajax.active.action = AJAX Spider scan
 spiderajax.desc                     = AJAX Spider, uses Crawljax

--- a/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
+++ b/addOns/spiderAjax/src/test/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobUnitTest.java
@@ -141,7 +141,7 @@ class AjaxSpiderJobUnitTest {
         job.applyCustomParameter("maxDuration", "12");
 
         // Then
-        assertThat(job.getMaxDuration(), is(equalTo(12)));
+        assertThat(job.getParameters().getMaxDuration(), is(equalTo(12)));
     }
 
     // @Test
@@ -390,7 +390,7 @@ class AjaxSpiderJobUnitTest {
         // When
         job.addTest(
                 new AutomationStatisticTest(
-                        "spiderAjax.urls.added", null, ">", 1, "warn", job.getType()));
+                        "spiderAjax.urls.added", null, ">", 1, "warn", job, progress));
         job.logTestsToProgress(progress);
 
         // Then


### PR DESCRIPTION
Sorry this is so big :(

Its nearly there, and the remaining changes should be very similar to other examples in the PR so feel free to start reviewing now if you have the time :)

Obviously theres loads of code for the new dialogs.
I've also had to add a load of inner classes which represent the data - we can easily apply "unknown" parameters via reflection but we do need to know about them for the UI.
I've also changed the tests to load even if they have errors - that way people can correct them in the UI rather than have to re add them from scratch.

Still todo:

- [x] OpenAPI - dialog
- [x] SOAP Job - dialog
- [x] GraphQL Job - define new parameters
- [x] GraphQL Job - dialog
- [x] Statistics test - dialog
- [ ] Delete soon to be unused AutomationJob methods
- [x] Actually save plans rather than dumping them to std out
- [x] Make Info column more useful
- [ ] Misc tidying up ;)

Signed-off-by: Simon Bennetts <psiinon@gmail.com>