### PR TITLE
Remove the specification of the JaCoCo version

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -26,11 +26,6 @@ val parentProjects = listOf(
     "webdrivers"
 )
 
-val jacocoToolVersion = "0.8.5"
-jacoco {
-    toolVersion = jacocoToolVersion
-}
-
 val ghReleaseDataProvider = provider {
     subprojects.first().zapAddOn.gitHubRelease
 }
@@ -93,10 +88,6 @@ subprojects {
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
         }
-    }
-
-    jacoco {
-        toolVersion = jacocoToolVersion
     }
 
     tasks.named<JacocoReport>("jacocoTestReport") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `kotlin-dsl`
-    id("com.diffplug.spotless") version "5.12.1"
+    id("com.diffplug.spotless") version "5.14.2"
 }
 
 repositories {
@@ -30,7 +30,7 @@ tasks.withType<JavaCompile>().configureEach {
 dependencies {
     implementation("commons-codec:commons-codec:1.15")
     implementation("io.github.bonigarcia:webdrivermanager:3.7.1")
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:5.12.1")
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:5.14.2")
 }
 
 java {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     api("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")
     api("org.junit.jupiter:junit-jupiter-params:$jupiterVersion")
     runtimeOnly("org.junit.jupiter:junit-jupiter-engine:$jupiterVersion")
-    api("org.mockito:mockito-junit-jupiter:3.6.28")
+    api("org.mockito:mockito-junit-jupiter:3.11.2")
 
     api("org.nanohttpd:nanohttpd-webserver:$nanohttpdVersion")
     api("org.nanohttpd:nanohttpd-websocket:$nanohttpdVersion")


### PR DESCRIPTION
- Remove hardcoded JaCoCo version and rely on Gradle default.
- Update other libraries and Gradle plugins to newer versions.

Signed-off-by: ricekot <ricekot@gmail.com>