### PR TITLE
httpsInfo: correct Crowdin path

### DIFF
--- a/addOns/httpsInfo/httpsInfo.gradle.kts
+++ b/addOns/httpsInfo/httpsInfo.gradle.kts
@@ -22,7 +22,7 @@ crowdin {
     configuration {
         val resourcesPath = "org/zaproxy/zap/extension/httpsinfo/resources/"
         tokens.set(mutableMapOf(
-            "%addOnId%" to zapAddOn.addOnId.get(),
+            "%addOnId%" to "httpsinfo",
             "%messagesPath%" to resourcesPath,
             "%helpPath%" to resourcesPath))
     }


### PR DESCRIPTION
Use all lower case for the name of the add-on when uploading the files
to Crowdin.