### PR TITLE
improve: wappalyzer: Added Cookie Patterns Support

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Reduce logging of "Unexpected header type" messages from error to debug (related to Issue 6607).
 
+### Added
+- Support for cookie patterns.
+
 ## [21.2.0] - 2021-06-17
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
@@ -33,6 +33,7 @@ public class Application {
     private List<String> categories = new ArrayList<>();
     private String cpe;
     private List<Map<String, AppPattern>> headers;
+    private List<Map<String, AppPattern>> cookies;
     private List<AppPattern> url = new ArrayList<>();
     private List<AppPattern> html = new ArrayList<>();
     private List<Map<String, AppPattern>> metas;
@@ -86,6 +87,10 @@ public class Application {
         this.headers = headers;
     }
 
+    public void setCookies(List<Map<String, AppPattern>> cookies) {
+        this.cookies = cookies;
+    }
+
     public void setUrl(List<AppPattern> url) {
         this.url = url;
     }
@@ -120,6 +125,10 @@ public class Application {
 
     public List<Map<String, AppPattern>> getHeaders() {
         return headers;
+    }
+
+    public List<Map<String, AppPattern>> getCookies() {
+        return cookies;
     }
 
     public void addHeaders(Map<String, AppPattern> header) {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -138,6 +138,7 @@ public class WappalyzerJsonParser {
                 app.setCategories(
                         this.jsonToCategoryList(result.getCategories(), appData.get("cats")));
                 app.setHeaders(this.jsonToAppPatternMapList("HEADER", appData.get("headers")));
+                app.setCookies(this.jsonToAppPatternMapList("COOKIE", appData.get("cookies")));
                 app.setUrl(this.jsonToPatternList("URL", appData.get("url")));
                 app.setHtml(this.jsonToPatternList("HTML", appData.get("html")));
                 app.setScript(this.jsonToPatternList("SCRIPT", appData.get("scripts")));

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -35,6 +35,7 @@ import org.jsoup.select.Elements;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PassiveScanner;
@@ -113,6 +114,7 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
     private void checkAppMatches(HttpMessage msg, Source source) {
         checkUrlMatches(msg);
         checkHeadersMatches(msg);
+        checkCookieMatches(msg);
         if (!msg.getResponseHeader().isText()) {
             return; // Don't check body if not text'ish
         }
@@ -208,6 +210,19 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
                 if (header != null) {
                     AppPattern p = entry.getValue();
                     addIfMatches(p, header);
+                }
+            }
+        }
+    }
+
+    private void checkCookieMatches(HttpMessage msg) {
+        for (Map<String, AppPattern> sp : currentApp.getCookies()) {
+            for (Map.Entry<String, AppPattern> entry : sp.entrySet()) {
+                for (HtmlParameter cookie : msg.getCookieParams()) {
+                    if (entry.getKey().equals(cookie.getName())) {
+                        AppPattern p = entry.getValue();
+                        addIfMatches(p, cookie.getValue());
+                    }
                 }
             }
         }

--- a/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
+++ b/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
@@ -24,6 +24,9 @@
           "Generator 2"
         ]
       },
+      "cookies": {
+        "foo": "bar"
+      },
       "dom": {
         "a[href='https://www.example.com'][title*='version']": {
           "attributes": {


### PR DESCRIPTION
Per zaproxy/zap-extensions#3046

- apps.json > Updated with test content.
- CHANGELOG > Updated with addition note.
- WappalyzerPassiveScanner > Updated to parse and handle cookie patterns.
- WappalyzerPassiveScannerUnitTest > Updated to test cookie patterns. Also tweaked local assertion method name, and made more test methods leverage it.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>