### PR TITLE
fix: automation: Typo

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
@@ -59,7 +59,7 @@ public class SpiderJobDialog extends StandardFieldsDialog {
     private static final String FIELD_ADVANCED = "automation.dialog.spider.advanced";
 
     private static final String ACCEPT_COOKIES_PARAM = "automation.dialog.spider.acceptcookies";
-    private static final String HANDLE_OODATA_PARAM = "automation.dialog.spider.handleoodata";
+    private static final String HANDLE_ODATA_PARAM = "automation.dialog.spider.handleodata";
     private static final String HANDLE_PARAMS_PARAM = "automation.dialog.spider.handleparams";
     private static final String MAX_PARSE_PARAM = "automation.dialog.spider.maxparse";
     private static final String PARSE_COMMENTS_PARAM = "automation.dialog.spider.parsecomments";
@@ -210,7 +210,7 @@ public class SpiderJobDialog extends StandardFieldsDialog {
                 JobUtils.unBox(this.job.getParameters().getAcceptCookies()));
         this.addCheckBoxField(
                 2,
-                HANDLE_OODATA_PARAM,
+                HANDLE_ODATA_PARAM,
                 JobUtils.unBox(this.job.getParameters().getHandleODataParametersVisited()));
 
         this.addCheckBoxField(
@@ -268,7 +268,7 @@ public class SpiderJobDialog extends StandardFieldsDialog {
             this.job.getParameters().setAcceptCookies(this.getBoolValue(ACCEPT_COOKIES_PARAM));
             this.job
                     .getParameters()
-                    .setHandleODataParametersVisited(this.getBoolValue(HANDLE_OODATA_PARAM));
+                    .setHandleODataParametersVisited(this.getBoolValue(HANDLE_ODATA_PARAM));
             this.job.getParameters().setMaxParseSizeBytes(this.getIntValue(MAX_PARSE_PARAM));
             this.job.getParameters().setParseComments(this.getBoolValue(PARSE_COMMENTS_PARAM));
             this.job.getParameters().setParseGit(this.getBoolValue(PARSE_GIT_PARAM));

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -150,7 +150,7 @@ automation.dialog.spider.tab.adv = Advanced
 automation.dialog.spider.tab.parse = Parsing
 
 automation.dialog.spider.acceptcookies = Accept Cookies:
-automation.dialog.spider.handleoodata = Handle OOData:
+automation.dialog.spider.handleodata = Handle OData:
 automation.dialog.spider.handleparams = Handle Parameters:
 automation.dialog.spider.maxparse Max Size to Parse in Bytes:
 automation.dialog.spider.parsecomments = Parse Comments:


### PR DESCRIPTION
I noticed this when I watched the ZAPCon after hours video.

OOData should be OData, per:
https://github.com/zaproxy/zaproxy/blob/80fb2ab540fb3d580b8b208ebc5ed1674e20c749/zap/src/main/resources/org/zaproxy/zap/resources/Messages.properties#L2994

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>