### PR TITLE
Correctly wire Crowdin upload source tasks

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -169,6 +169,8 @@ subprojects {
             tagMessage.set(message)
             title.set(message)
         }
+
+        val crowdinUploadSourceFiles = if (useCrowdin) project.tasks.named("crowdinUploadSourceFiles") else null
         releaseAddOn {
             dependsOn(createReleaseAddOn)
 
@@ -176,7 +178,7 @@ subprojects {
             dependsOn(createPullRequestNextDevIter)
 
             if (useCrowdin) {
-                dependsOn("crowdinUploadSourceFiles")
+                dependsOn(crowdinUploadSourceFiles)
             }
         }
 


### PR DESCRIPTION
Depend on the task of the add-on being released instead of the task of
add-ons project (which would have no effect).