### PR TITLE
automation: address "failed to find method" errors

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+ - Address errors when running an automation plan with spiders and passive scan config.
 
 ## [0.4.1] - 2021-08-07
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -321,7 +322,10 @@ public class JobUtils {
         }
         List<String> ignoreList = Collections.emptyList();
         if (ignore != null) {
-            ignoreList = Arrays.asList(ignore);
+            ignoreList =
+                    Arrays.asList(ignore).stream()
+                            .map(e -> "get" + e.toUpperCase().charAt(0) + e.substring(1))
+                            .collect(Collectors.toList());
         }
 
         try {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
@@ -107,7 +107,9 @@ public class SpiderJob extends AutomationJob {
                 this.parameters,
                 JobUtils.getJobOptions(this, progress),
                 this.getName(),
-                new String[] {PARAM_FAIL_IF_LESS_URLS, PARAM_WARN_IF_LESS_URLS},
+                new String[] {
+                    PARAM_CONTEXT, PARAM_URL, PARAM_FAIL_IF_LESS_URLS, PARAM_WARN_IF_LESS_URLS
+                },
                 progress,
                 this.getPlan().getEnv());
     }

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/JobUtilsUnitTest.java
@@ -1,0 +1,91 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.jobs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link JobUtils}. */
+class JobUtilsUnitTest {
+
+    @BeforeAll
+    static void setUp() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @Test
+    void shouldApplyObjectToObject() {
+        // Given
+        Data source = new Data("A");
+        Data dest = new Data();
+        AutomationProgress progress = mock(AutomationProgress.class);
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.replaceVars(any())).willAnswer(invocation -> invocation.getArgument(0));
+        // When
+        JobUtils.applyObjectToObject(source, dest, "name", new String[] {}, progress, env);
+        // Then
+        assertThat(dest.getValueString(), is(equalTo("A")));
+    }
+
+    @Test
+    void shouldApplyObjectToObjectWhileIgnoringSpecifiedPropertyNames() {
+        // Given
+        Data source = new Data("A");
+        Data dest = new Data();
+        AutomationProgress progress = mock(AutomationProgress.class);
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.replaceVars(any())).willAnswer(invocation -> invocation.getArgument(0));
+        // When
+        JobUtils.applyObjectToObject(
+                source, dest, "name", new String[] {"valueString"}, progress, env);
+        // Then
+        assertThat(dest.getValueString(), is(nullValue()));
+    }
+
+    private static class Data {
+        private String valueString;
+
+        Data() {}
+
+        Data(String valueString) {
+            this.valueString = valueString;
+        }
+
+        public String getValueString() {
+            return valueString;
+        }
+
+        public void setValueString(String valueString) {
+            this.valueString = valueString;
+        }
+    }
+}

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+ - Address errors when running the AJAX Spider with Automation Framework.
 
 ## [23.4.0] - 2021-08-05
 ### Added

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
@@ -101,7 +101,9 @@ public class AjaxSpiderJob extends AutomationJob {
                 this.parameters,
                 JobUtils.getJobOptions(this, progress),
                 this.getName(),
-                new String[] {PARAM_FAIL_IF_LESS_URLS, PARAM_WARN_IF_LESS_URLS},
+                new String[] {
+                    PARAM_CONTEXT, PARAM_URL, PARAM_FAIL_IF_LESS_URLS, PARAM_WARN_IF_LESS_URLS
+                },
                 progress,
                 this.getPlan().getEnv());
     }


### PR DESCRIPTION
Correctly ignore the parameters that shouldn't be copied to param
objects (convert the parameter names to getter names).
Ignore context and URL parameters in spiders, they are not present in
the param objects.