### PR TITLE
Automation: Fix var support in URLs

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
  - Address errors when running an automation plan with spiders and passive scan config.
+ - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
 
 ## [0.4.1] - 2021-08-07
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/SpiderJob.java
@@ -96,7 +96,7 @@ public class SpiderJob extends AutomationJob {
             progress.warn(
                     Constant.messages.getString(
                             "automation.error.spider.failIfUrlsLessThan.deprecated",
-                            getType(),
+                            getName(),
                             "automation.spider.urls.added"));
         }
     }
@@ -138,19 +138,23 @@ public class SpiderJob extends AutomationJob {
             context = env.getDefaultContextWrapper();
         }
         URI uri = null;
-        String url = parameters.getUrl();
+        String urlStr = parameters.getUrl();
         try {
-            if (url != null) {
-                uri = new URI(url, true);
+            if (urlStr != null) {
+                urlStr = env.replaceVars(urlStr);
+                uri = new URI(urlStr, true);
             }
         } catch (Exception e1) {
-            progress.error(Constant.messages.getString("automation.error.context.badurl", url));
+            progress.error(Constant.messages.getString("automation.error.context.badurl", urlStr));
             return;
         }
 
         // Request all specified URLs
         for (String u : context.getUrls()) {
-            this.urlRequester.requestUrl(u, progress);
+            urlStr = env.replaceVars(u);
+            progress.info(
+                    Constant.messages.getString("automation.info.requrl", this.getName(), urlStr));
+            this.urlRequester.requestUrl(urlStr, progress);
         }
 
         if (env.isTimeToQuit()) {
@@ -199,7 +203,7 @@ public class SpiderJob extends AutomationJob {
         int numUrlsFound = scan.getNumberOfURIsFound();
         progress.info(
                 Constant.messages.getString(
-                        "automation.info.urlsfound", this.getType(), numUrlsFound));
+                        "automation.info.urlsfound", this.getName(), numUrlsFound));
         Stats.incCounter("automation.spider.urls.added", numUrlsFound);
     }
 

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -291,6 +291,7 @@ automation.info.ascan.setdefstrength = Job {0} set default strength to {1}
 automation.info.ascan.setdefthreshold = Job {0} set default threshold to {1}
 automation.info.pscan.rule.noid = Job {0} ignoring rule with no id 
 automation.info.pscan.rule.setthreshold = Job {0} set rule {1} threshold to {2}
+automation.info.requrl = Job {0} requesting URL {1}
 automation.info.setparam = Job {0} set {1} = {2}
 automation.info.jobstart = Job {0} started
 automation.info.jobend = Job {0} finished

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
@@ -6,7 +6,7 @@ env:                                   # The environment, mandatory
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used throughout the config
+  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
@@ -4,5 +4,5 @@
       - url:                           # String: A mandatory URL of the request to be made
         name:                          # String: Optional name for the request, for documentation only
         method:                        # String: A non-empty request method, default: GET
-        data:                          # String: Optional data to send in the request body
+        data:                          # String: Optional data to send in the request body, supports vars
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/SpiderJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/SpiderJobUnitTest.java
@@ -217,7 +217,7 @@ class SpiderJobUnitTest extends TestUtils {
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
 
-        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        AutomationEnvironment env = new AutomationEnvironment(progress);
 
         // When
         SpiderJob job = new SpiderJob();
@@ -236,7 +236,7 @@ class SpiderJobUnitTest extends TestUtils {
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
 
-        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        AutomationEnvironment env = new AutomationEnvironment(progress);
 
         // When
         SpiderJob job = new SpiderJob();
@@ -308,7 +308,8 @@ class SpiderJobUnitTest extends TestUtils {
         Constant.messages = new I18N(Locale.ENGLISH);
         Context context = mock(Context.class);
         ContextWrapper contextWrapper = new ContextWrapper(context);
-        contextWrapper.addUrl("https://www.example.com");
+        String url = "https://www.example.com";
+        contextWrapper.addUrl(url);
 
         String specifiedUrl = "https://www.example.com/url";
         given(extSpider.startScan(any(), any(), any())).willReturn(1);
@@ -321,6 +322,8 @@ class SpiderJobUnitTest extends TestUtils {
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
+        given(env.replaceVars(specifiedUrl)).willReturn(specifiedUrl);
 
         // When
         SpiderJob job = new SpiderJob();
@@ -412,7 +415,8 @@ class SpiderJobUnitTest extends TestUtils {
         startServer();
         Context context = mock(Context.class);
         ContextWrapper contextWrapper = new ContextWrapper(context);
-        contextWrapper.addUrl("http://localhost:" + nano.getListeningPort() + "/top");
+        String url = "http://localhost:" + nano.getListeningPort() + "/top";
+        contextWrapper.addUrl(url);
 
         given(extSpider.startScan(any(), any(), any())).willReturn(1);
 
@@ -424,6 +428,7 @@ class SpiderJobUnitTest extends TestUtils {
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
 
         SpiderJob job = new SpiderJob();
 
@@ -450,9 +455,12 @@ class SpiderJobUnitTest extends TestUtils {
         startServer();
         Context context = mock(Context.class);
         ContextWrapper contextWrapper = new ContextWrapper(context);
-        contextWrapper.addUrl("http://localhost:" + nano.getListeningPort() + "/1");
-        contextWrapper.addUrl("http://localhost:" + nano.getListeningPort() + "/2");
-        contextWrapper.addUrl("http://localhost:" + nano.getListeningPort() + "/3");
+        String url1 = "http://localhost:" + nano.getListeningPort() + "/1";
+        String url2 = "http://localhost:" + nano.getListeningPort() + "/2";
+        String url3 = "http://localhost:" + nano.getListeningPort() + "/3";
+        contextWrapper.addUrl(url1);
+        contextWrapper.addUrl(url2);
+        contextWrapper.addUrl(url3);
 
         given(extSpider.startScan(any(), any(), any())).willReturn(1);
 
@@ -464,6 +472,9 @@ class SpiderJobUnitTest extends TestUtils {
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url1)).willReturn(url1);
+        given(env.replaceVars(url2)).willReturn(url2);
+        given(env.replaceVars(url3)).willReturn(url3);
 
         SpiderJob job = new SpiderJob();
 
@@ -495,7 +506,8 @@ class SpiderJobUnitTest extends TestUtils {
 
         Context context = mock(Context.class);
         ContextWrapper contextWrapper = new ContextWrapper(context);
-        contextWrapper.addUrl("http://null.example.com/");
+        String url = "http://null.example.com/";
+        contextWrapper.addUrl(url);
 
         given(extSpider.startScan(any(), any(), any())).willReturn(1);
 
@@ -507,6 +519,7 @@ class SpiderJobUnitTest extends TestUtils {
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
 
         SpiderJob job = new SpiderJob();
 
@@ -529,7 +542,8 @@ class SpiderJobUnitTest extends TestUtils {
         startServer();
         Context context = mock(Context.class);
         ContextWrapper contextWrapper = new ContextWrapper(context);
-        contextWrapper.addUrl("http://localhost:" + nano.getListeningPort() + "/top");
+        String url = "http://localhost:" + nano.getListeningPort() + "/top";
+        contextWrapper.addUrl(url);
 
         given(extSpider.startScan(any(), any(), any())).willReturn(1);
 
@@ -541,6 +555,7 @@ class SpiderJobUnitTest extends TestUtils {
 
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
 
         Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
         SpiderJob job = new SpiderJob();

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
@@ -6,7 +6,7 @@ env:                                   # The environment, mandatory
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used throughout the config
+  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -6,7 +6,7 @@ env:                                   # The environment, mandatory
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used throughout the config
+  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
@@ -34,7 +34,7 @@ jobs:
       - url:                           # String: A mandatory URL of the request to be made
         name:                          # String: Optional name for the request, for documentation only
         method:                        # String: A non-empty request method, default: GET
-        data:                          # String: Optional data to send in the request body
+        data:                          # String: Optional data to send in the request body, supports vars
         responseCode:                  # Int: An optional, expected response code against which the actual response code will be matched
   - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
     parameters:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -6,7 +6,7 @@ env:                                   # The environment, mandatory
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
       authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used throughout the config
+  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+ - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
 
 ## [0.4.0] - 2021-08-05
 ### Added

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
@@ -100,22 +100,29 @@ public class GraphQlJob extends AutomationJob {
         }
 
         try {
+            String endpointUrl = env.replaceVars(endpoint);
             GraphQlParser parser =
-                    new GraphQlParser(endpoint, HttpSender.MANUAL_REQUEST_INITIATOR, true);
+                    new GraphQlParser(endpointUrl, HttpSender.MANUAL_REQUEST_INITIATOR, true);
             parser.addRequesterListener(new HistoryPersister());
 
             String schemaFile = this.getParameters().getSchemaFile();
             String schemaUrl = this.getParameters().getSchemaUrl();
 
             if (schemaFile != null && !schemaFile.isEmpty()) {
-                progress.info(Constant.messages.getString("graphql.automation.info.import.file"));
+                progress.info(
+                        Constant.messages.getString(
+                                "graphql.automation.info.import.file", schemaFile, endpointUrl));
                 parser.importFile(schemaFile);
             } else if (schemaUrl != null && !schemaUrl.isEmpty()) {
-                progress.info(Constant.messages.getString("graphql.automation.info.import.url"));
-                parser.importUrl(schemaUrl);
+                String url = env.replaceVars(schemaUrl);
+                progress.info(
+                        Constant.messages.getString(
+                                "graphql.automation.info.import.url", url, endpointUrl));
+                parser.importUrl(url);
             } else {
                 progress.info(
-                        Constant.messages.getString("graphql.automation.info.import.introspect"));
+                        Constant.messages.getString(
+                                "graphql.automation.info.import.introspect", endpointUrl));
                 parser.introspect();
             }
         } catch (IOException e) {

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -33,9 +33,9 @@ graphql.api.view.optionRequestMethod = Returns the current request method.
 graphql.automation.desc = GraphQL Automation Framework Integration
 graphql.automation.name = GraphQL Automation
 graphql.automation.error = Job graphql error: {0}
-graphql.automation.info.import.file = Job graphql importing schema from file
-graphql.automation.info.import.url = Job graphql importing schema from URL
-graphql.automation.info.import.introspect = Job graphql importing schema using introspection
+graphql.automation.info.import.file = Job graphql importing schema from file: {0} target: {1}
+graphql.automation.info.import.url = Job graphql importing schema from URL: {0} target: {1}
+graphql.automation.info.import.introspect = Job graphql importing schema using introspection from: {0}
 
 graphql.automation.dialog.summary = URL: {0}, File: {1}
 graphql.automation.dialog.tab.params = Parameters

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/automation/GraphQlJobUnitTest.java
@@ -154,7 +154,7 @@ class GraphQlJobUnitTest {
     void shouldInfoIfEmptyEndpoint() {
         // Given
         AutomationProgress progress = new AutomationProgress();
-        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        AutomationEnvironment env = new AutomationEnvironment(progress);
 
         // When
         GraphQlJob job = new GraphQlJob();
@@ -176,7 +176,7 @@ class GraphQlJobUnitTest {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
-        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        AutomationEnvironment env = new AutomationEnvironment(progress);
         String yamlStr = "parameters:\n" + "  endpoint: 'invalid url'";
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
@@ -201,7 +201,7 @@ class GraphQlJobUnitTest {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
-        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        AutomationEnvironment env = new AutomationEnvironment(progress);
         String yamlStr =
                 "parameters:\n"
                         + "  endpoint: 'http://example.com/graphql'\n"
@@ -229,7 +229,7 @@ class GraphQlJobUnitTest {
         // Given
         Constant.messages = new I18N(Locale.ENGLISH);
         AutomationProgress progress = new AutomationProgress();
-        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        AutomationEnvironment env = new AutomationEnvironment(progress);
         String yamlStr =
                 "parameters:\n"
                         + "  endpoint: 'http://example.com/graphql'\n"

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+ - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
 
 ## [20] - 2021-08-05
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -94,10 +95,14 @@ public class OpenApiJob extends AutomationJob {
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
 
         String apiFile = this.getParameters().getApiFile();
-        String apiUrl = this.getParameters().getApiUrl();
-        String targetUrl = this.getParameters().getTargetUrl();
+        String apiStr = this.getParameters().getApiUrl();
+        String targetStr = this.getParameters().getTargetUrl();
+        String targetUrl = null;
+        if (!StringUtils.isEmpty(targetStr)) {
+            targetUrl = env.replaceVars(targetStr);
+        }
 
-        if (apiFile != null && apiFile.length() > 0) {
+        if (!StringUtils.isEmpty(apiFile)) {
             File file = new File(apiFile);
             if (file.exists() && file.canRead()) {
                 OpenApiResults results =
@@ -107,7 +112,10 @@ public class OpenApiJob extends AutomationJob {
                     for (String error : errors) {
                         progress.error(
                                 Constant.messages.getString(
-                                        "openapi.automation.error.misc", this.getName(), error));
+                                        "openapi.automation.error.misc",
+                                        this.getName(),
+                                        targetUrl,
+                                        error));
                     }
                 }
                 progress.info(
@@ -118,10 +126,14 @@ public class OpenApiJob extends AutomationJob {
             } else {
                 progress.error(
                         Constant.messages.getString(
-                                "openapi.automation.error.file", this.getName(), apiFile));
+                                "openapi.automation.error.file",
+                                this.getName(),
+                                targetUrl,
+                                apiFile));
             }
         }
-        if (apiUrl != null && apiUrl.length() > 0) {
+        if (!StringUtils.isEmpty(apiStr)) {
+            String apiUrl = env.replaceVars(apiStr);
             try {
                 URI uri = new URI(apiUrl, true);
                 OpenApiResults results =
@@ -131,7 +143,10 @@ public class OpenApiJob extends AutomationJob {
                     for (String error : errors) {
                         progress.error(
                                 Constant.messages.getString(
-                                        "openapi.automation.error.misc", this.getName(), error));
+                                        "openapi.automation.error.misc",
+                                        this.getName(),
+                                        targetUrl,
+                                        error));
                     }
                 }
                 progress.info(
@@ -142,7 +157,7 @@ public class OpenApiJob extends AutomationJob {
             } catch (Exception e) {
                 progress.error(
                         Constant.messages.getString(
-                                "openapi.automation.error.url", this.getName(), apiUrl));
+                                "openapi.automation.error.url", this.getName(), targetUrl, apiUrl));
             }
         }
     }

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -9,8 +9,8 @@ openapi.automation.desc = OpenAPI Automation Framework Integration
 openapi.automation.name = OpenAPI Automation
 openapi.automation.error.nofile = Cannot access file: {0}
 openapi.automation.error.file = Job {0} cannot read file: {1}
-openapi.automation.error.misc = Job {0} error: {1}
-openapi.automation.error.url = Job {0} invalid URL: {1}
+openapi.automation.error.misc = Job {0} target: {1} error: {2}
+openapi.automation.error.url = Job {0} target: {1} invalid API URL: {2}
 openapi.automation.info.urlsadded = Job {0} added {1} URLs
 
 openapi.automation.dialog.summary = URL: {0}, File: {1}

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+ - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
 
 ## [8] - 2021-08-05
 ### Added

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJob.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJob.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
+import org.apache.groovy.parser.antlr4.util.StringUtils;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -91,7 +92,7 @@ public class SoapJob extends AutomationJob {
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {
 
         String wsdlFile = this.getParameters().getWsdlFile();
-        if (wsdlFile != null && !wsdlFile.isEmpty()) {
+        if (!StringUtils.isEmpty(wsdlFile)) {
             File file = new File(wsdlFile);
             if (!file.exists() || !file.canRead()) {
                 progress.error(Constant.messages.getString("soap.automation.error.file", wsdlFile));
@@ -100,8 +101,9 @@ public class SoapJob extends AutomationJob {
             }
         }
 
-        String wsdlUrl = this.getParameters().getWsdlUrl();
-        if (wsdlUrl != null && !wsdlUrl.isEmpty()) {
+        String wsdlStr = this.getParameters().getWsdlUrl();
+        if (!StringUtils.isEmpty(wsdlStr)) {
+            String wsdlUrl = env.replaceVars(wsdlStr);
             try {
                 new URI(wsdlUrl, true);
                 getExtSoap().syncImportWsdlUrl(wsdlUrl);

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
  - Address errors when running the AJAX Spider with Automation Framework.
+ - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
 
 ## [23.4.0] - 2021-08-05
 ### Added

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJob.java
@@ -137,6 +137,7 @@ public class AjaxSpiderJob extends AutomationJob {
         if (uriStr == null) {
             uriStr = context.getUrls().get(0);
         }
+        uriStr = env.replaceVars(uriStr);
         URI uri = null;
         try {
             uri = new URI(uriStr);


### PR DESCRIPTION
Fixes: https://github.com/zaproxy/zaproxy/issues/6726)

Mostly tested manually as automation jobs are hard to unit test :/

Also supports env in requestor data and improved some of the info messages to inc URLs.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>