### PR TITLE
Fix 6731 - replaced dead CORS misconfiguration reference URL

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fixed reference URL on CORS misconfiguration.
 
 ## [35] - 2021-07-06
 ### Changed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -39,7 +39,7 @@ pscanrules.cookiesamesite.refs=https://tools.ietf.org/html/draft-ietf-httpbis-co
 pscanrules.crossdomain.name=Cross-Domain Misconfiguration
 pscanrules.crossdomain.desc=Web browser data loading may be possible, due to a Cross Origin Resource Sharing (CORS) misconfiguration on the web server
 pscanrules.crossdomain.soln=Ensure that sensitive data is not available in an unauthenticated manner (using IP address white-listing, for instance).\nConfigure the "Access-Control-Allow-Origin" HTTP header to a more restrictive set of domains, or remove all CORS headers entirely, to allow the web browser to enforce the Same Origin Policy (SOP) in a more restrictive manner.
-pscanrules.crossdomain.refs=http://www.hpenterprisesecurity.com/vulncat/en/vulncat/vb/html5_overly_permissive_cors_policy.html
+pscanrules.crossdomain.refs=https://vulncat.fortify.com/en/detail?id=desc.config.dotnet.html5_overly_permissive_cors_policy
 pscanrules.crossdomain.extrainfo=The CORS misconfiguration on the web server permits cross-domain read requests from arbitrary third party domains, using unauthenticated APIs on this domain. Web browser implementations do not permit arbitrary third parties to read the response from authenticated APIs, however. This reduces the risk somewhat. This misconfiguration could be used by an attacker to access data that is available in an unauthenticated manner, but which uses some other form of security, such as IP address white-listing.
 
 pscanrules.cookielooselyscoped.name=Loosely Scoped Cookie


### PR DESCRIPTION
Replaced the dead URL in Cross-Domain misconfiguration with correct updated URL:

https://vulncat.fortify.com/en/detail?id=desc.config.dotnet.html5_overly_permissive_cors_policy

Fix zaproxy/zaproxy#6731.