### PR TITLE
oast: Updates

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- An option to allow changing the polling frequency of BOAST servers.
+- A table that lists the payloads and canary values of all registered BOAST servers.
 
+### Removed
+- The _ID_ and the _Canary Value_ fields, in favour of the _Active Servers_ table in the BOAST options window.
 
 ## [0.1.1] - 2021-08-04
 ### Fixed

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastService.java
@@ -44,4 +44,8 @@ public abstract class OastService {
             handler.handle(oastRequest);
         }
     }
+
+    public void clearOastRequestHandlers() {
+        oastRequestHandlerList.clear();
+    }
 }

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastParam.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastParam.java
@@ -19,20 +19,29 @@
  */
 package org.zaproxy.addon.oast.services.boast;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.common.VersionedAbstractParam;
 
 public class BoastParam extends VersionedAbstractParam {
 
     private static final int PARAM_CURRENT_VERSION = 1;
+    private static final Logger LOGGER = LogManager.getLogger(BoastParam.class);
 
     private static final String PARAM_BASE_KEY = "oast.boast";
-    private static final String PARAM_BOAST_URI = PARAM_BASE_KEY + ".uri";
+    static final String PARAM_BOAST_URI = PARAM_BASE_KEY + ".uri";
+    static final String PARAM_POLLING_FREQUENCY = PARAM_BASE_KEY + ".pollingFrequency";
+
+    static final int MINIMUM_POLLING_FREQUENCY = 10;
 
     private String boastUri;
+    private int pollingFrequency;
 
     @Override
     protected void parseImpl() {
         boastUri = getString(PARAM_BOAST_URI, "https://odiss.eu:1337/events");
+        setPollingFrequency(getInt(PARAM_POLLING_FREQUENCY, 60));
     }
 
     public String getBoastUri() {
@@ -42,6 +51,21 @@ public class BoastParam extends VersionedAbstractParam {
     public void setBoastUri(String boastUri) {
         this.boastUri = boastUri;
         getConfig().setProperty(PARAM_BOAST_URI, boastUri);
+    }
+
+    public int getPollingFrequency() {
+        return pollingFrequency;
+    }
+
+    public void setPollingFrequency(int pollingFrequency) {
+        if (pollingFrequency < MINIMUM_POLLING_FREQUENCY) {
+            LOGGER.info(
+                    Constant.messages.getString(
+                            "oast.boast.param.info.minPollingFrequency", pollingFrequency));
+            pollingFrequency = MINIMUM_POLLING_FREQUENCY;
+        }
+        this.pollingFrequency = pollingFrequency;
+        getConfig().setProperty(PARAM_POLLING_FREQUENCY, pollingFrequency);
     }
 
     @Override

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastServer.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastServer.java
@@ -29,6 +29,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -90,6 +91,17 @@ public class BoastServer {
 
     public URI getUri() {
         return uri;
+    }
+
+    public String getPayload() {
+        try {
+            return id + "." + uri.getHost();
+        } catch (URIException e) {
+            LOGGER.warn(
+                    Constant.messages.getString(
+                            "oast.boast.error.payload", e.getLocalizedMessage()));
+            return "";
+        }
     }
 
     public String getId() {

--- a/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/boast/options.html
+++ b/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/boast/options.html
@@ -17,27 +17,27 @@
     running a working instance of BOAST.</p>
 <p>An example of a valid URI is: <code>https://example.com:1337/events</code>.</p>
 
-<h3>ID</h3>
+<h3>Polling Frequency</h3>
 
-<p>A non-editable field that is filled in when you register with a BOAST instance.</p>
-<p>This ID can be used to craft an address that can be specified in relevant attacks.</p>
-<p>For example, if an ID is <code>cxcjyaf5wahkidrp2zvhxe6ola</code>, and the Server URI host is <code>example.com</code>,
-    then the payload URI host will be <code>cxcjyaf5wahkidrp2zvhxe6ola.example.com</code>.</p>
+<p>This option allows you to change the frequency of polling the registered BOAST servers. It takes values in
+    seconds. The minimum allowed value is 10 seconds and there is no maximum allowed value. The default value is 60
+    seconds.</p>
 
-<h3>Canary</h3>
+<h3>Active Servers</h3>
+
+<p>This table lists the Payloads and Canary values of all registered BOAST Servers. An entry is added each time you
+    click on Register.</p>
+
+<h4>Payload</h4>
+
+<p>The Payload is the address of an active BOAST server that can be used in out-of-bound attacks.</p>
+
+<h4>Canary</h4>
 
 <p>The Canary value is a random string that is returned to the target web application when it makes a request to the
-    registered BOAST server.</p>
+    corresponding Payload address.</p>
 <p>Consider an example of how this value could be used: if the target web application ends up using the canary value
-    somewhere, then it may be vulnerable to out of band injection attacks. </p>
-
-<h3>Other Configuration Options</h3>
-
-<p>By default, ZAP polls all the registered BOAST servers once per minute. This setting will be made configurable in
-    future versions of this add-on.</p>
-<p>Along with the <em>Polling Frequency</em> setting, there is also a plan to introduce a <em>Registered Servers</em>
-    panel that will display all registered BOAST servers.</p>
-<p></p>
+    somewhere, then it may be vulnerable to out-of-band injection attacks. </p>
 
 
 <H2>See also</H2>

--- a/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
+++ b/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
@@ -18,11 +18,16 @@ oast.callback.handler.test.name=Test Handler
 
 oast.boast.name=BOAST
 oast.boast.options.label.uri=Server URI:
-oast.boast.options.label.id=ID:
-oast.boast.options.label.canary=Canary Value:
+oast.boast.options.label.pollingFrequency=Polling Frequency (in seconds):
+oast.boast.options.label.activeServers=Active Servers
 oast.boast.options.button.register=Register
+oast.boast.options.activeServers.payload=Payload
+oast.boast.options.activeServers.canary=Canary
+oast.boast.error.payload=Could not create payload [{0}]
 oast.boast.error.poll=Could not poll BOAST server {0} [{1}]
 oast.boast.error.persist=Failed to persist boast event
 oast.boast.event.badMsgDump=Malformed HTTP Message: Dumping entire message in request body
+oast.boast.param.info.minPollingFrequency=The polling frequency ({0} seconds) is less than the minimum permissible \
+  value (10 seconds). The polling frequency will be set to 10 seconds.
 
 oast.options.title=OAST

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/boast/BoastParamUnitTests.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/boast/BoastParamUnitTests.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.oast.services.boast;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.utils.I18N;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+class BoastParamUnitTests {
+
+    @BeforeEach
+    void setUp() {
+        Constant.messages = new I18N(Locale.ROOT);
+    }
+
+    @Test
+    void shouldNotReturnPollingFrequencyLessThanMinimum() {
+        // Given
+        BoastParam param = spy(new BoastParam());
+        when(param.getConfig()).thenReturn(new ZapXmlConfiguration());
+
+        // When
+        param.setPollingFrequency(BoastParam.MINIMUM_POLLING_FREQUENCY - 1);
+
+        // Then
+        assertThat(param.getPollingFrequency(), is(BoastParam.MINIMUM_POLLING_FREQUENCY));
+        assertThat(
+                param.getConfig().getInt(BoastParam.PARAM_POLLING_FREQUENCY),
+                is(BoastParam.MINIMUM_POLLING_FREQUENCY));
+    }
+}


### PR DESCRIPTION
- Added an option to allow changing the polling frequency of BOAST servers.
- Added a table that lists the payloads and canary values of all registered BOAST servers.
- Removed the _ID_ and the _Canary Value_ fields, in favour of the _Active Servers_ table in the BOAST options window.

<details><summary>Before and After Options Window Screenshots</summary>
<img src="https://user-images.githubusercontent.com/16446369/128868563-7c093896-fa86-41b3-aabc-032bb42272a1.png">
</details>

Signed-off-by: ricekot <ricekot@gmail.com>