### PR TITLE
ascanrules: XSS: try more payloads if outside of HTML tags

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- The XSS scan rule will try several different payloads if the payload is being reflected outside of any HTML tags (for example in a JSON response body).
 
 ## [43] - 2021-12-06
 ### Added


### PR DESCRIPTION
In the XSS addOn, in the case when the payload is reflected outside…f HTML tags, try more payloads.

I made this to catch a potential XSS that I noticed being missed by the active scan in an API that I was scanning. Payload was reflected in a json response.