### PR TITLE
Update Gradle Crowdin plugin

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     eclipse
     jacoco
     id("org.zaproxy.add-on") version "0.7.0" apply false
-    id("org.zaproxy.crowdin") version "0.2.0" apply false
+    id("org.zaproxy.crowdin") version "0.2.1" apply false
 }
 
 description = "Common configuration of the add-ons."


### PR DESCRIPTION
Update plugin to latest version to fix the issue when copying
translations that have a common prefix in the export path.