### PR TITLE
Correct output dir of localized resources

### DIFF
--- a/gradle/crowdin-help-only.yml
+++ b/gradle/crowdin-help-only.yml
@@ -2,7 +2,7 @@ projects:
   - id: 32705
     sources:
       - dir: "src/main/javahelp/%helpPath%help"
-        outputDir: "src/main/javahelp/%helpPath%resources"
+        outputDir: "src/main/javahelp/%helpPath%"
         crowdinPath:
           dir: "/addons/%addOnId%"
           filename: "%file_pathname%"


### PR DESCRIPTION
Remove incorrect suffix in the output dir path of help resources.