### PR TITLE
oast: Do not load script templates twice

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Script templates were being loaded twice, resulting in a warning.
 
 ## [0.2.0] - 2021-08-17
 ### Added

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/scripts/ExtensionOastScripts.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/scripts/ExtensionOastScripts.java
@@ -20,9 +20,7 @@
 package org.zaproxy.addon.oast.scripts;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
-import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -79,6 +77,11 @@ public class ExtensionOastScripts extends ExtensionAdaptor {
     }
 
     @Override
+    public void postInstall() {
+        addTemplates();
+    }
+
+    @Override
     public boolean canUnload() {
         return true;
     }
@@ -88,12 +91,15 @@ public class ExtensionOastScripts extends ExtensionAdaptor {
         removeScripts();
     }
 
-    private void addScripts() {
+    private void addTemplates() {
         addScript(
                 TEMPLATE_REGISTER_REQUEST_HANDLER,
                 Constant.messages.getString("oast.scripts.requestHandler.desc"),
                 extScript.getScriptType(ExtensionScript.TYPE_STANDALONE),
                 true);
+    }
+
+    private void addScripts() {
         addScript(
                 SCRIPT_GET_BOAST_SERVERS,
                 Constant.messages.getString("oast.scripts.getBoastServers.desc"),
@@ -137,10 +143,10 @@ public class ExtensionOastScripts extends ExtensionAdaptor {
             } else {
                 extScript.addScript(script, false);
             }
-        } catch (IOException e) {
-            LOGGER.warn(Constant.messages.getString("oast.scripts.warn.couldNotAddScripts"));
-        } catch (InvalidParameterException e) {
-            LOGGER.warn(Constant.messages.getString("oast.scripts.warn.couldNotFindGraaljs"));
+        } catch (Exception e) {
+            LOGGER.warn(
+                    Constant.messages.getString(
+                            "oast.scripts.warn.couldNotAddScripts", e.getLocalizedMessage()));
         }
     }
 

--- a/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
+++ b/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
@@ -33,7 +33,6 @@ oast.boast.param.info.minPollingFrequency=The polling frequency ({0} seconds) is
 oast.options.title=OAST
 
 oast.scripts.desc=Adds OAST scripts.
-oast.scripts.warn.couldNotAddScripts=Could not add OAST scripts.
-oast.scripts.warn.couldNotFindGraaljs=The Graal.js engine was not found, OAST scripts will not be added.
+oast.scripts.warn.couldNotAddScripts=Could not add OAST scripts: {0}.
 oast.scripts.requestHandler.desc=This script registers an OAST message handler. Change it to do whatever you want to do.
 oast.scripts.getBoastServers.desc=This script lists the details of all registered BOAST Servers.


### PR DESCRIPTION
Script templates already loaded by core were being loaded again by the
add-on, resulting in a warning.

Signed-off-by: ricekot <ricekot@gmail.com>