### PR TITLE
exim: Mark export HAR as safe

### DIFF
--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
@@ -62,6 +62,11 @@ public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContain
     }
 
     @Override
+    public boolean isSafe() {
+        return true;
+    }
+
+    @Override
     protected void performActions(List<HttpMessage> httpMessages) {
         File file = getOutputFile();
         if (file == null) {


### PR DESCRIPTION
Save raw/XML are currently available in safe mode, but export HAR is not.