### PR TITLE
Automation and retest addon tweaks

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
  - Always enable the Save button on changes and prompt user when opening a plan if the current one has changes.
 
+### Changed
+ - Changes to support the Retest add-on.
+
 ## [0.4.1] - 2021-08-07
 ### Added
 - Missing icons

--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -10,7 +10,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("automation") {
-                    version.set(">=0.4.0")
+                    version.set(">=0.5.0")
                 }
             }
         }


### PR DESCRIPTION
- Bumped the minimum required version of the automation addon required by the retest addon to 0.5.0
- Updated the changelog of the automation addon.