### PR TITLE
openapi: utilize media type examples if available

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
  - Import file definition even if it has issues ([Issue #6758](https://github.com/zaproxy/zaproxy/issues/6758)).
 
+### Changed
+- Use `application/json` media type examples when available.
+
 ## [20] - 2021-08-05
 ### Added
 - Automation Framework GUI

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/RequestModelConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/RequestModelConverter.java
@@ -64,8 +64,7 @@ public class RequestModelConverter {
             Schema<?> schema;
 
             if (content.containsKey("application/json")) {
-                schema = content.get("application/json").getSchema();
-                return generators.getBodyGenerator().generate(schema);
+                return generators.getBodyGenerator().generate(content.get("application/json"));
             }
             if (content.containsKey("application/octet-stream")) {
                 schema = content.get("application/octet-stream").getSchema();

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -567,6 +567,42 @@ class BodyGeneratorUnitTest {
     }
 
     @Test
+    void shouldUseJsonMediaTypeExamples() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/pets-with-examples",
+                                        openAPI.getPaths()
+                                                .get("/pets-with-json-media-type-examples")
+                                                .getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+
+        assertEquals("{\"age\":6,\"name\":\"Big Fluffy\"}", request);
+    }
+
+    @Test
+    void shouldUseJsonMediaTypeExample() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/pets-with-examples",
+                                        openAPI.getPaths()
+                                                .get("/pets-with-json-media-type-example")
+                                                .getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+
+        assertEquals("{\"age\":1,\"name\":\"Small Fluffy\"}", request);
+    }
+
+    @Test
     void shouldGenerateArraysFromExamples() throws IOException {
         OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
         String request =

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
@@ -11,7 +11,7 @@ components:
           type: string
           example: Fluffy
 paths:
-  # Using Examples defined in a references schema
+  # Using Example defined in a references schema
   /pets-with-example:
     post:
       requestBody:
@@ -19,6 +19,41 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Pet'
+      responses:
+        '201':
+          description: Created
+  # Using Examples defined in a json request body
+  /pets-with-json-media-type-examples:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+            examples:
+              fluffy-example:
+                description: a pet called Big Fluffy
+                value:
+                  age: 6
+                  name: Big Fluffy
+              fawkes-example:
+                description: a pet called Small Fawkes
+                value:
+                  age: 1
+                  name: Small Fawkes
+      responses:
+        '201':
+          description: Created
+  /pets-with-json-media-type-example:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+            example:
+              age: 1
+              name: Small Fluffy
       responses:
         '201':
           description: Created
@@ -42,7 +77,7 @@ paths:
       responses:
         '201':
           description: Created
-  # Using an Array has a example formatted as string
+  # Using an Array has an example formatted as string
   /pets-with-array-full-example-string:
     post:
       requestBody:


### PR DESCRIPTION
What do think about if we support OpenAPI examples as a generated request body if it's available ?