### PR TITLE
scripts: Mark 'Copy as curl Command' as safe

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update links to zaproxy and community-scripts repo.
 - Maintenance Changes.
 - 'Copy as curl command menu.js' is now preceded by a separator, and the Title Caps of the menu item were fixed (Issue 2000).
+- 'Copy as curl command menu.js' is now available in safe mode.
 
 ## [28] - 2020-12-18
 

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
@@ -11,6 +11,9 @@ var curlmenuitem = new popupmenuitemtype("Copy as curl Command") {
 	},
 	precedeWithSeparator: function() {
 		return true;
+	},
+	isSafe: function() {
+		return true;
 	}
 }
 


### PR DESCRIPTION
Like #3085, make 'Copy as curl Command' also available in safe mode.