### PR TITLE
retest: specify location of files for Crowdin

### DIFF
--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -22,6 +22,14 @@ zapAddOn {
     }
 }
 
+crowdin {
+    configuration {
+        val resourcesPath = "org/zaproxy/addon/${zapAddOn.addOnId.get()}/resources/"
+        tokens.put("%messagesPath%", resourcesPath)
+        tokens.put("%helpPath%", resourcesPath)
+    }
+}
+
 dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
     testImplementation(parent!!.childProjects.get("automation")!!)


### PR DESCRIPTION
Override the default location so the source files that require
localization are found.