### PR TITLE
retest: fix about help page

### DIFF
--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+ - Show about help page.
 
 ## [0.0.1] - 2021-08-23
 

--- a/addOns/retest/src/main/javahelp/org/zaproxy/addon/retest/resources/help/map.jhm
+++ b/addOns/retest/src/main/javahelp/org/zaproxy/addon/retest/resources/help/map.jhm
@@ -5,4 +5,5 @@
 
 <map version="1.0">
     <mapID target="retest" url="contents/retest.html" />
+    <mapID target="retest.about" url="contents/about.html" />
 </map>

--- a/addOns/retest/src/main/javahelp/org/zaproxy/addon/retest/resources/help/toc.xml
+++ b/addOns/retest/src/main/javahelp/org/zaproxy/addon/retest/resources/help/toc.xml
@@ -6,7 +6,7 @@
 <toc version="2.0">
 	<tocitem text="ZAP User Guide" tocid="toplevelitem">
 		<tocitem text="Add Ons" tocid="addons">
-			<tocitem text="Retest" image="retest-icon" target="retest">
+			<tocitem text="Retest" target="retest">
 				<tocitem text="About" target="retest.about"/>
 			</tocitem>
 		</tocitem>


### PR DESCRIPTION
Add missing mapping for the about help page.
Remove image attribute from main TOC item, the image does not exist.