### PR TITLE
oast: Updates

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- The add-on did not stop when ZAP did, which led to ZAP hanging.
 
+### Changed
+- Minor script and help updates.
 
 ## [0.2.1] - 2021-08-19
 ### Changed

--- a/addOns/oast/gradle.properties
+++ b/addOns/oast/gradle.properties
@@ -1,2 +1,2 @@
-version=0.3.0
+version=0.2.2
 release=false

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -167,8 +167,14 @@ public class ExtensionOast extends ExtensionAdaptor {
         return true;
     }
 
+    // TODO: Remove once targeting >= 2.11, refer to issue 6536.
     @Override
     public void unload() {
+        stop();
+    }
+
+    @Override
+    public void stop() {
         boastService.stopService();
         callbackService.stopService();
         unregisterOastService(boastService);

--- a/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/boast/options.html
+++ b/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/boast/options.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
-    <title>BOAST</title>
+    <title>BOAST Options</title>
 </head>
 <body>
 <h1>BOAST Options</h1>
@@ -26,7 +26,7 @@
 <h3>Active Servers</h3>
 
 <p>This table lists the Payloads and Canary values of all registered BOAST Servers. An entry is added each time you
-    click on Register.</p>
+    register a new BOAST server.</p>
 
 <h4>Payload</h4>
 

--- a/addOns/oast/src/main/zapHomeFiles/scripts/templates/standalone/OAST Register Request Handler.js
+++ b/addOns/oast/src/main/zapHomeFiles/scripts/templates/standalone/OAST Register Request Handler.js
@@ -12,5 +12,5 @@ function requestHandler(request) {
     print()
 }
 
-boast.addOastRequestHandler(function(req) { requestHandler(req) })
+boast.addOastRequestHandler(requestHandler)
 print("OAST Request handler registered.")


### PR DESCRIPTION
- Fix zaproxy/zaproxy#6765: The add-on did not stop when ZAP did, which led to ZAP hanging.
- Change: Minor script and help updates.

Signed-off-by: ricekot <ricekot@gmail.com>