### PR TITLE
openapi: import from file even if it has issues

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
  - Fixed var support in URLs ([Issue #6726](https://github.com/zaproxy/zaproxy/issues/6726))
+ - Import file definition even if it has issues ([Issue #6758](https://github.com/zaproxy/zaproxy/issues/6758)).
 
 ## [20] - 2021-08-05
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -312,7 +312,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             OpenAPI openApi = swaggerParseResult.getOpenAPI();
 
             List<String> errors;
-            if (openApi == null || !swaggerParseResult.getMessages().isEmpty()) {
+            if (openApi == null) {
                 errors = swaggerParseResult.getMessages();
             } else {
                 errors =

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -402,18 +402,18 @@ public class SwaggerConverter implements Converter {
         parseOptions.setResolve(true);
         parseOptions.setResolveFully(true);
 
-        SwaggerParseResult swaggerParseResult = new SwaggerParseResult();
         List<String> errors = new ArrayList<>();
         for (SwaggerParserExtension ex : OpenAPIV3Parser.getExtensions()) {
-            swaggerParseResult = ex.readLocation(file.getAbsolutePath(), null, parseOptions);
-            OpenAPI openAPI = swaggerParseResult.getOpenAPI();
-            if (openAPI != null && swaggerParseResult.getMessages().isEmpty()) {
+            SwaggerParseResult swaggerParseResult =
+                    ex.readLocation(file.getAbsolutePath(), null, parseOptions);
+            if (swaggerParseResult.getOpenAPI() != null) {
                 return swaggerParseResult;
             } else {
                 errors.addAll(swaggerParseResult.getMessages());
             }
         }
 
+        SwaggerParseResult swaggerParseResult = new SwaggerParseResult();
         swaggerParseResult.setMessages(errors);
         return swaggerParseResult;
     }

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/defn-with-warns.yml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/defn-with-warns.yml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+info:
+  title: "Definition with warning (missing version)."
+servers:
+  - url: http://localhost:@@@PORT@@@/
+paths:
+  /pet:
+    get:
+      responses:
+        '200':
+          description: OK
+


### PR DESCRIPTION
Change `SwaggerConverter` to return as soon as it's able to parse the
definition, even if it has issues.
Change `ExtensionOpenApi` to not skip the parsed file definition when it
has issues, still try to import what was parsed.
Restore behaviour of previous versions and match the behaviour when
importing from URL.

Fix zaproxy/zaproxy#6758.