### PR TITLE
fix: domxss: Check alert dialog content to reduce false positives

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- False Positives caused by un-related alerts or Basic auth prompts (Issue 6484).
+
 ### Changed
 - Update links to repository.
 - Maintenance changes.

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomAlertInfo.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomAlertInfo.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.domxss;
 
-public class DomAlertException extends Exception {
+public class DomAlertInfo {
 
     private static final long serialVersionUID = 1L;
     private String url;
@@ -28,7 +28,7 @@ public class DomAlertException extends Exception {
     private String attributeId;
     private String attributeName;
 
-    public DomAlertException(
+    public DomAlertInfo(
             String url, String attack, String tagName, String attributeId, String attributeName) {
         super();
         this.url = url;
@@ -38,7 +38,7 @@ public class DomAlertException extends Exception {
         this.attributeName = attributeName;
     }
 
-    public DomAlertException(String url, String attack) {
+    public DomAlertInfo(String url, String attack) {
         super();
         this.url = url;
         this.attack = attack;

--- a/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
+++ b/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
@@ -41,7 +41,6 @@ import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 
-@Disabled
 class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
 
     @BeforeAll
@@ -105,6 +104,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
     }
 
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/assign */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInLocationHashAssign(String browser)
@@ -137,10 +137,11 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
                         equalTo(DomXssScanRule.HASH_JAVASCRIPT_ALERT),
                         equalTo(DomXssScanRule.QUERY_HASH_IMG_ALERT)));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
     }
 
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/eval */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInLocationHashEval(String browser)
@@ -162,6 +163,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
     }
 
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/replace */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInLocationHashReplace(String browser)
@@ -182,7 +184,27 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
         assertAlertsRaised();
     }
 
+    @ParameterizedTest
+    @MethodSource("testBrowsers")
+    void shouldNotReportXssWhenRandomAlertEncountered(String browser)
+            throws NullPointerException, IOException {
+        // Given
+        String test = "/shouldNotReportXssWhenRandomAlertEncountered/";
+        this.nano.addHandler(new TestNanoServerHandler(test, "RandomAlert.html"));
+
+        HttpMessage msg = this.getHttpMessage(test);
+        this.rule.getConfig().setProperty("rules.domxss.browserid", browser);
+        this.rule.init(msg, this.parent);
+
+        // When
+        this.rule.scan();
+
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/setTimeout */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInLocationHashSetTimeout(String browser)
@@ -204,6 +226,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
     }
 
     /** Test to trigger XSS after cancel button is clicked */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssWhenCancelButtonIsClicked(String browser)
@@ -226,6 +249,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
     }
 
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/function */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInLocationHashFunction(String browser)
@@ -247,6 +271,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
     }
 
     /** Test based on http://public-firing-range.appspot.com/address/location.hash/jshref */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInLocationHashInlineEvent(String browser)
@@ -293,6 +318,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
      * http://public-firing-range.appspot.com/dom/eventtriggering/document/formSubmission/innerHtml
      * Note that this only works in Firefox, not Chrome.
      */
+    @Disabled
     @Test
     void shouldReportXssInEventInnerHtmlFirefox() throws NullPointerException, IOException {
         // Given
@@ -317,6 +343,7 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
      * Test based on
      * http://public-firing-range.appspot.com/dom/eventtriggering/document/inputTyping/innerHtml
      */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInTypingInnerHtml(String browser) throws NullPointerException, IOException {
@@ -336,10 +363,8 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
         assertAlertsRaised();
     }
 
-    /**
-     * Test based on
-     * http://public-firing-range.appspot.com/dom/eventtriggering/document/inputTyping/innerHtml
-     */
+    /** Test based on http://public-firing-range.appspot.com/dom/dompropagation/ */
+    @Disabled
     @ParameterizedTest
     @MethodSource("testBrowsers")
     void shouldReportXssInDomPropagation(String browser) throws NullPointerException, IOException {

--- a/addOns/domxss/src/test/resources/org/zaproxy/zap/extension/domxss/RandomAlert.html
+++ b/addOns/domxss/src/test/resources/org/zaproxy/zap/extension/domxss/RandomAlert.html
@@ -1,0 +1,8 @@
+<html>
+  <head><title>Random Alert</title></head>
+  <body>
+    <script>
+      alert("FooBar");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
- DomXssScanRule > Now gets the alert dialog's content before catching UnhandledAlertException then compares it to ensure the dialog is likely to be one ZAP caused. Increased confidence to HIGH.
- DomXswsScanRuleUnitTest > Added a single method to test an unrelated alert dialog condition. (Ex: When an alert shouldn't pop.) Adjusted to accommodate new HIGH confidence. Corrected one documentation URL.
- DomAlertException > Renamed to DomAlertInfo, and changed control away from Throwing a custom exception to checking if the return is null or not.
- DomXswsScanRuleUnitTest > Added a single method to test an unrelated alert dialog condition. (Ex: When an alert shouldn't pop.) Adjusted to accommodate new HIGH confidence.
- ExtensionSelenium > Added a utility method to accept a capabilities consumer to be passed. In the case of the domxss add-on this sets the unhandled dialog behavior to IGNORE (vs the seeming default of ACCEPT).
- RandomAlert.html > Supports the added unit test.
- CHANGELOG.md > Added fix note.

Fixes zaproxy/zaproxy#6484

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>