### PR TITLE
ascanrulesAlpha: Basic Check for Spring Actuators

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Spring Boot Actuator Scan Rule
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -2,7 +2,7 @@ description = "The alpha quality Active Scanner rules"
 
 zapAddOn {
     addOnName.set("Active scanner rules (alpha)")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")
@@ -18,7 +18,14 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.11.0-20210929.165234-4")
     compileOnly(parent!!.childProjects.get("commonlib")!!)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java
@@ -1,0 +1,198 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+
+/**
+ * An active scan rule to test for Spring Actuators revealing too much info. Health might be the
+ * most commonly enabled but if health is enabled, so might be Thread Dump or Heap Dump which could
+ * be serious https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#overview
+ *
+ * @author sgerlach
+ */
+public class SpringActuatorScanRule extends AbstractHostPlugin {
+
+    private static final String MESSAGE_PREFIX = "ascanalpha.springactuator.";
+    private static final int PLUGIN_ID = 40042;
+    private static final Logger LOG = LogManager.getLogger(SpringActuatorScanRule.class);
+    private static final Pattern CONTENT_TYPE =
+            Pattern.compile(
+                    "application\\/vnd\\.spring-boot\\.actuator\\.v[0-9]\\+json|application\\/json",
+                    Pattern.MULTILINE);
+    private static final Pattern JSON_PAYLOAD = Pattern.compile("\\{.*\\:.*\\}", Pattern.MULTILINE);
+
+    @Override
+    public boolean targets(TechSet technologies) {
+        return technologies.includes(Tech.SPRING);
+    }
+
+    @Override
+    public int getId() {
+        return PLUGIN_ID;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "desc");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "refs");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.INFO_GATHER;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(MESSAGE_PREFIX + "soln");
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_MEDIUM;
+    }
+
+    @Override
+    public int getWascId() {
+        return 13;
+    }
+
+    @Override
+    public int getCweId() {
+        return 215;
+    }
+
+    private String getAlertName() {
+        return getName();
+    }
+
+    @Override
+    public void scan() {
+        String[] endpointList = {"actuator/health"};
+        String[] encodingTypes = {null, "application/json"};
+        for (String endpoint : endpointList) {
+            for (String encodingType : encodingTypes) {
+                if (isStop()) {
+                    LOG.debug("Scan rule {} stopping.", getName());
+                    return;
+                }
+                HttpMessage testMsg = sendActuatorRequest(encodingType, endpoint);
+                if (testMsg == null) {
+                    continue;
+                }
+                String contentType = testMsg.getResponseHeader().getNormalisedContentTypeValue();
+                if (isPage200(testMsg)) {
+                    String responseBody = testMsg.getResponseBody().toString();
+                    boolean matches =
+                            CONTENT_TYPE.matcher(contentType).find()
+                                    && JSON_PAYLOAD.matcher(responseBody).find();
+                    if (matches) {
+                        raiseAlert(testMsg, Alert.CONFIDENCE_MEDIUM, getRisk());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private static String generatePath(String baseUriPath, String actuatorEndpoint) {
+        String newPath = "";
+        if (baseUriPath.contains("/")) {
+            if (baseUriPath.endsWith("/")) {
+                newPath = baseUriPath + actuatorEndpoint;
+            } else {
+                newPath =
+                        baseUriPath.substring(0, baseUriPath.lastIndexOf('/'))
+                                + "/"
+                                + actuatorEndpoint;
+            }
+        } else {
+            newPath = baseUriPath + "/" + actuatorEndpoint;
+        }
+        return newPath;
+    }
+
+    private HttpMessage sendActuatorRequest(String encodingType, String actuatorEndpoint) {
+        HttpMessage testMsg = getNewMsg();
+        try {
+            URI baseUri = getBaseMsg().getRequestHeader().getURI();
+            String baseUriPath = baseUri.getPath() == null ? "" : baseUri.getPath();
+            URI testUri =
+                    new URI(
+                            baseUri.getScheme(),
+                            null,
+                            baseUri.getHost(),
+                            baseUri.getPort(),
+                            generatePath(baseUriPath, actuatorEndpoint));
+            testMsg.getRequestHeader().setURI(testUri);
+            testMsg.getRequestHeader().setMethod(HttpRequestHeader.GET);
+            testMsg.getRequestHeader()
+                    .setHeader(HttpHeader.ACCEPT_ENCODING, encodingType); // Set this correctly
+            testMsg.setRequestBody("");
+            sendAndReceive(testMsg);
+            return testMsg;
+        } catch (IOException e) {
+            LOG.warn(
+                    "An error occurred while checking [{}] [{}] for {} Caught {} {}",
+                    testMsg.getRequestHeader().getMethod(),
+                    testMsg.getRequestHeader().getURI(),
+                    getName(),
+                    e.getClass().getName(),
+                    e.getMessage());
+        }
+        return null;
+    }
+
+    private void raiseAlert(HttpMessage msg, int confidence, int risk) {
+        newAlert()
+                .setRisk(risk)
+                .setConfidence(confidence)
+                .setName(getAlertName())
+                .setEvidence(msg.getResponseHeader().getPrimeHeader())
+                .setReference(getReference())
+                .setMessage(msg)
+                .setEvidence(StringUtils.left(msg.getResponseBody().toString(), 100))
+                .raise();
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -46,5 +46,10 @@ This rule attempts to identify Web Cache Deception vulnerabilities. It checks wh
 </ul>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRule.java">WebCacheDeceptionScanRule.java</a>
 
+<H2>Java Spring Actuators</H2>
+This rule attempts to identify if the Spring Actuators are enabled. Tests for the default /actuator/health route in the application.
+
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java">SpringActuatorScanRule.java</a>
+
 </BODY>
 </HTML>

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -44,3 +44,9 @@ ascanalpha.webCacheDeception.desc=Web cache deception may be possible. It may be
 ascanalpha.webCacheDeception.refs=https://blogs.akamai.com/2017/03/on-web-cache-deception-attacks.html\nhttps://www.netsparker.com/web-vulnerability-scanner/vulnerabilities/web-cache-deception/
 ascanalpha.webCacheDeception.soln=It is strongly advised to refrain from classifying file types, such as images or stylesheets solely by their URL and file extension. Instead you should make sure that files are cached based on their Content-Type header.
 ascanalpha.webCacheDeception.otherinfo=Cached Authorised Response and Unauthorised Response are similar.
+
+ascanalpha.springactuator.name=Spring Actuator Information Leak
+ascanalpha.springactuator.desc=Spring Actuator for Health is enabled and may reveal sensitive information about this application. Spring Actuators can be used for real monitoring purposes, but should be used with caution as to not expose too much information about the application or the infrastructure running it.
+ascanalpha.springactuator.soln=Disable the Health Actuators and other actuators, or restrict them to administrative users.
+ascanalpha.springactuator.refs=https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#overview
+

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRuleTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRuleTest.java
@@ -1,0 +1,312 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Unit test for {@link SpringActuatorScanRule}. */
+class SpringActuatorScanRuleUnitTest extends ActiveScannerTest<SpringActuatorScanRule> {
+
+    private static final String ACTUATOR_CONTENT_TYPE =
+            "Content-Type: application/vnd.spring-boot.actuator.v2+json;charset=UTF-8";
+    private static final String RELEVANT_BODY = "{\"status\":\"UP\"}";
+    private static final String IRRELEVANT_BODY = "<body><h1>Howdy></h1></body>";
+    private static final String REQ_PATH = "actuator/health";
+
+    @Override
+    protected SpringActuatorScanRule createScanner() {
+        return new SpringActuatorScanRule();
+    }
+
+    @Test
+    void shouldTargetSpringTech() {
+        // Given
+        TechSet techSet = techSet(Tech.SPRING);
+        // When
+        boolean targets = rule.targets(techSet);
+        // Then
+        assertThat(targets, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotTargetNonSpringTechs() {
+        // Given
+        TechSet techSet = techSetWithout(Tech.SPRING);
+        // When
+        boolean targets = rule.targets(techSet);
+        // Then
+        assertThat(targets, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldBeInfoGatherAlert() {
+        // Given
+        Integer category = Category.INFO_GATHER;
+        // When
+        Integer ruleCategory = rule.getCategory();
+        // Then
+        assertEquals(ruleCategory, category);
+    }
+
+    @Test
+    void shouldScanMessageWithoutPath() throws HttpMalformedHeaderException {
+        // Given
+        String path = "";
+        this.nano.addHandler(
+                new NanoServerHandler(path) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, RELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = getHttpMessage(path);
+        rule.init(msg, parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+        assertThat(httpMessagesSent, hasSize(2));
+    }
+
+    @Test
+    void shouldHandleNetworkErrors() throws HttpMalformedHeaderException {
+        // Given
+        String path = "/";
+        this.nano.addHandler(
+                new NanoServerHandler(path) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, RELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = getHttpMessage(path);
+        rule.init(msg, parent);
+        this.nano.stop();
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+        assertThat(httpMessagesSent, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {ACTUATOR_CONTENT_TYPE, "Content-Type: application/json"})
+    void shouldAlertWhenScanMessageWithoutPathAndRelevantContent(String contentType)
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "";
+        String alertPath = REQ_PATH;
+        this.nano.addHandler(
+                new NanoServerHandler("/" + alertPath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, contentType, RELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = this.getHttpMessage(servePath);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(httpMessagesSent, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_MEDIUM, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_MEDIUM, alert.getConfidence());
+        assertEquals(rule.getName(), alert.getName());
+        assertEquals(rule.getWascId(), alert.getWascId());
+    }
+
+    @Test
+    void shouldSendGetRequestWhenOriginalRequestWasNotGet() throws HttpMalformedHeaderException {
+        // Given
+        String path = "";
+        HttpMessage msg = getHttpMessage(path);
+        msg.getRequestHeader().setMethod(HttpRequestHeader.POST);
+        msg.getRequestHeader().addHeader(HttpHeader.CONTENT_TYPE, ACTUATOR_CONTENT_TYPE);
+        msg.setRequestBody("field1=value1&field2=value2");
+        rule.init(msg, parent);
+
+        // When
+        rule.scan();
+        // Then
+        assertThat(httpMessagesSent, hasSize(2));
+        assertEquals(HttpRequestHeader.GET, httpMessagesSent.get(0).getRequestHeader().getMethod());
+        assertEquals(0, httpMessagesSent.get(0).getRequestBody().length());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {ACTUATOR_CONTENT_TYPE, "Content-Type: application/json"})
+    void shouldAlertIfTestedUrlRespondsOKWithRelevantContent(String contentType)
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/shouldAlert";
+        String alertPath = REQ_PATH;
+        this.nano.addHandler(
+                new NanoServerHandler(servePath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, IRRELEVANT_BODY);
+                    }
+                });
+        this.nano.addHandler(
+                new NanoServerHandler("/" + alertPath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, contentType, RELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = this.getHttpMessage(servePath);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(httpMessagesSent, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_MEDIUM, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_MEDIUM, alert.getConfidence());
+        assertEquals(rule.getName(), alert.getName());
+        assertEquals(rule.getWascId(), alert.getWascId());
+    }
+
+    @Test
+    void shouldNotAlertIfTestedUrlRespondsOKWithIrrelevantContent()
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/randomPath";
+        String alertPath = REQ_PATH;
+        this.nano.addHandler(
+                new NanoServerHandler(servePath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, IRRELEVANT_BODY);
+                    }
+                });
+        this.nano.addHandler(
+                new NanoServerHandler("/" + alertPath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, ACTUATOR_CONTENT_TYPE, IRRELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = this.getHttpMessage(servePath);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+        assertThat(httpMessagesSent, hasSize(2));
+    }
+
+    @Test
+    void shouldNotAlertIfTestedUrlRespondsOKWithIrrelevantHeader()
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/randomPath";
+        String alertPath = REQ_PATH;
+        this.nano.addHandler(
+                new NanoServerHandler(servePath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, IRRELEVANT_BODY);
+                    }
+                });
+        this.nano.addHandler(
+                new NanoServerHandler("/" + alertPath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, RELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = this.getHttpMessage(servePath);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+        assertThat(httpMessagesSent, hasSize(2));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {ACTUATOR_CONTENT_TYPE, "Content-Type: application/json"})
+    void shouldAlertIfTestedNestedUrlRespondsOKWithRelevantHeader(String contentType)
+            throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "/shouldAlert/";
+        String alertPath = REQ_PATH;
+        String deepPath = servePath + alertPath;
+        this.nano.addHandler(
+                new NanoServerHandler(deepPath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, contentType, RELEVANT_BODY);
+                    }
+                });
+        this.nano.addHandler(
+                new NanoServerHandler(servePath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(
+                                Response.Status.OK, NanoHTTPD.MIME_HTML, IRRELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = this.getHttpMessage(servePath);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+        assertThat(httpMessagesSent, hasSize(1));
+        Alert alert = alertsRaised.get(0);
+        assertEquals(Alert.RISK_MEDIUM, alert.getRisk());
+        assertEquals(Alert.CONFIDENCE_MEDIUM, alert.getConfidence());
+    }
+}


### PR DESCRIPTION
Resolves zaproxy/zaproxy#6777 Adds a basic check for Spring Boot Actuators, specifically the health check.

Also, my first cut at adding a new rule so thanks for the help.

Signed-off-by: Scott Gerlach <scott.gerlach@stackhawk.com>