### PR TITLE
Websockets: Always auto add+enable missing default pscan scripts

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes (some changes impact the visibility of variables and add getters/setters, which may impact third party add-ons or scripts).
 - Update links to repository.
 - Support passive scan alert examples so they can be added to the website
+- Missing default scripts will always be added and enabled on start up.
 
 ## [23] - 2020-12-18
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -466,20 +466,17 @@ public class ExtensionWebSocket extends ExtensionAdaptor
     }
 
     @Override
-    public void postInstall() {
-        super.postInstall();
-
-        if (webSocketPassiveScannerManager != null) {
-            registerDefaultScripts(websocketPassiveScanScriptType);
-        }
-    }
-
-    @Override
     public void postInit() {
         super.postInit();
 
-        if (webSocketPassiveScannerManager != null && !webSocketPassiveScannerManager.hasTable()) {
-            webSocketPassiveScannerManager.setTable(table);
+        if (webSocketPassiveScannerManager != null) {
+            // Always register the built (non template) in scripts, so that they get used from a new
+            // install
+            registerDefaultScripts(websocketPassiveScanScriptType);
+
+            if (!webSocketPassiveScannerManager.hasTable()) {
+                webSocketPassiveScannerManager.setTable(table);
+            }
         }
     }
 

--- a/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/script.html
+++ b/addOns/websocket/src/main/javahelp/org/zaproxy/zap/extension/websocket/resources/help/contents/script.html
@@ -23,7 +23,8 @@ A template script is provided which gives details of the methods and parameters 
 <h2>WebSocket Passive Rules</h2>
 
 WebSocket Passive Scan scripts are called every time a WebSocket message frame is transmitted over a WebSocket connection. Scripts can access WebSocket messages in order to examine the payload and raise an alert.<br>
-They are initially disabled, to enable them right click the relevant script in the Scripts tree and select "enable".<br>
+All of the default scripts are registered and enabled on start up. If you do not want them to run by default then right click the relevant scripts and select 'disable'.
+If you delete them then they will be added and enabled again when you restart ZAP.<br>
 Template scripts are provided which give details of the methods and parameters supported.<br>
 In the <a href="pscanrules.html#scripts">WebSocket Passive Scan Rules</a> section, there are descriptions for scripts which are included by default in the add-on.
 


### PR DESCRIPTION
It worked fine with the previous code when the add-on was installed, but not when its included as standard in ZAP.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>