### PR TITLE
fix: fuzz: Numberzz payload generator properly reset the increment field

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- The Numberzz payload generator should not set the increment to zero when creating subsequent payloads.
 
+### Changed
+- Maintenance changes.
 
 ## [13.2.0] - 2021-06-01
 ### Changed

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/payloads/generator/NumberPayloadGenerator.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/payloads/generator/NumberPayloadGenerator.java
@@ -48,10 +48,9 @@ public class NumberPayloadGenerator
 
     @Override
     public long getNumberOfPayloads() {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Number of payloads = {}", (toNo - fromNo) / steps);
-        }
-        return (toNo - fromNo) / steps;
+        int payloadCount = (toNo - fromNo) / steps;
+        LOGGER.debug("Number of payloads = {}", payloadCount);
+        return payloadCount;
     }
 
     @Override

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/NumberPayloadGeneratorAdapterUIHandler.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/payloads/ui/impl/NumberPayloadGeneratorAdapterUIHandler.java
@@ -52,6 +52,7 @@ public class NumberPayloadGeneratorAdapterUIHandler
             Constant.messages.getString("fuzz.payloads.generator.numbers.name");
     private static final String PAYLOAD_GENERATOR_DESC =
             Constant.messages.getString("fuzz.payloads.generator.numbers.description");
+    private static final int DEFAULT_STEP = 1;
 
     @Override
     public String getName() {
@@ -166,7 +167,7 @@ public class NumberPayloadGeneratorAdapterUIHandler
 
             fromField = new ZapNumberSpinner(Integer.MIN_VALUE, 0, Integer.MAX_VALUE);
             toField = new ZapNumberSpinner(Integer.MIN_VALUE, 0, Integer.MAX_VALUE);
-            stepField = new ZapNumberSpinner(Integer.MIN_VALUE, 1, Integer.MAX_VALUE);
+            stepField = new ZapNumberSpinner(Integer.MIN_VALUE, DEFAULT_STEP, Integer.MAX_VALUE);
 
             JLabel fromLabel = new JLabel(PAYLOADS_FROM_LABEL);
             fromLabel.setLabelFor(fromField);
@@ -267,7 +268,7 @@ public class NumberPayloadGeneratorAdapterUIHandler
             getPayloadsPreviewTextArea().setText("");
             fromField.setValue(0);
             toField.setValue(0);
-            stepField.setValue(0);
+            stepField.setValue(DEFAULT_STEP);
         }
 
         @Override


### PR DESCRIPTION
- CHANGELOG > Added Fix & change entry.
- NumberPayloadGenerator > Remove spurious isDebug check missing in 2.10 logging infrastructure changes.
- NumberPayloadGeneratorAdapterUIHandler > The clear() method now properly resets increment to 1 (which is the initial default used elsewhere) instead of zero.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>