### PR TITLE
Updated Fuzzer Options Documentation

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - The 'Delay when fuzzing (in milliseconds)' value can now be up to an hour (3,600,000ms), and the control was changed from a slider to a spinner (Issue 6651).
+- Updated the fuzzer options documentation (Issue 6791).
 
 ## [13.2.0] - 2021-06-01
 ### Changed

--- a/addOns/fuzz/src/main/javahelp/org/zaproxy/zap/extension/fuzz/resources/help/contents/options.html
+++ b/addOns/fuzz/src/main/javahelp/org/zaproxy/zap/extension/fuzz/resources/help/contents/options.html
@@ -11,17 +11,34 @@ Options Fuzz screen
 <p>
 This screen allows you to configure the <a href="concepts.html">fuzzing</a> options:
 
-<H3>Default category</H3>
-The category that will be initially selected shown when the <a href="dialogue.html">Fuzz dialog</a> is displayed. 
+<H3>Default Category</H3>
+The category that will initially be selected when the <a href="dialogue.html">Fuzz dialog</a> is displayed.
 
-<H3>Concurrent scanning threads per host</H3>
-The number of threads the scanner will use per host.<br>
-Increasing the number of threads will speed up the scan but may put extra strain on the computer ZAP is running on and the target host.
-
-<H3>Add custom Fuzz file</H3>
+<H3>Add Custom Fuzz File</H3>
 Allows you to add your own files to be used when fuzzing.<br>
-These should be text files with one attack per line.<br>
+These should be text files with one payload per line.<br>
 Files are added to the 'fuzzers' directory underneath the ZAP home directory.
+
+<H3>Finished Fuzzers in UI</H3>
+It defines the numbers of fuzzers (that have completed their execution)
+visible in the fuzzer tab.
+
+<H3>Retries on IO Error</H3>
+The number of retries when an input/output error occurs sending a request to the target.
+
+<H3>Max. Errors Allowed</H3>
+If the number of errors exceed this limit, fuzzer will stop its execution.
+
+<H3>Payload Replacement Strategy</H3>
+Rules defined to control the order that multiple payload lists are iterated.
+
+<H3>Concurrent Scanning Threads per Scan</H3>
+The number of threads the fuzzer will use per scan.<br>
+Increasing the number of threads will speed up the scan but may put extra strain on the computer ZAP is running on as well as the target.
+
+<H3>Delay when Fuzzing (in milliseconds)</H3>
+The number of milliseconds between requests by the fuzzer to the target host, usually done to
+avoid getting blocked by the target or if the target implements some sort of throttling requirement.
 
 <H2>See also</H2>
 <table>


### PR DESCRIPTION
I have added the missing definitions to the documentation of fuzzer options screen.

It resolves zaproxy/zaproxy#6791