### PR TITLE
improve: pscanrulesAlpha: Source Code Disclosure no longer check fonts

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Ignore CSS or JavaScript files when scanning for source code disclosures (Issue 6595).
+- Ignore CSS, JavaScript, or font files when scanning for source code disclosures (Issues: 6595 & 6795).
 
 ## [33] - 2021-07-07
 ### Fixed


### PR DESCRIPTION
- CHANGELOG.md > Added change note.
- SourceCodeDisclosureScanRule > Added check for font request/response to early return conditional.
- SourceCodeDisclosureScanRule > Added unit tests to assert the new behavior, and extended coverage on one existing test.

Closes zaproxy/zaproxy#6795

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>