### PR TITLE
fix: Address help URL parsing issue

### DIFF
--- a/addOns/domxss/src/main/javahelp/org/zaproxy/zap/extension/domxss/resources/help/contents/domxss.html
+++ b/addOns/domxss/src/main/javahelp/org/zaproxy/zap/extension/domxss/resources/help/contents/domxss.html
@@ -20,7 +20,7 @@ the rule <code>rules.domxss.browserid</code>, via the Options 'Rule configuratio
 </p>
 <p>
 The following Attack Strengths are supported, and related directly to the number of attack payloads used
-for URL fragment and form input field injections (eg: http://example.com/index.html?foo=bar#injection):
+for URL fragment and form input field injections (eg: <code>http://example.com/index.html?foo=bar#injection</code>):
 <ul>
 <li>LOW: 1 attack payloads 
 <li>MEDIUM: 3 attack payloads 


### PR DESCRIPTION
Wrapped example link in code tags, to address a weird parsing issue on https://www.zaproxy.org/docs/desktop/addons/dom-xss-active-scan-rule/
![image](https://user-images.githubusercontent.com/7570458/133469011-36a48b49-848a-4cb7-b600-10ad0cd5acc7.png)

No changelog entry, leaving this attributed to "maintenance changes".

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>