### PR TITLE
Reports: Support for custom messages in outputSummary job.

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Support for custom messages in outputSummary job.
+
 ### Fixed
  - Ignore false positives when listing messages in the outputSummary job.
 


### PR DESCRIPTION
As defined on https://www.zaproxy.org/docs/docker/baseline-scan/

> You can add your own messages to each rule by appending them after a tab on each line.

I think this is actually the last java code change required in order to completely support config files in the baseline scan :O
I'll update https://github.com/zaproxy/zaproxy/pull/6781 to use this once it has been merged.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>