### PR TITLE
fix: retire: Version Extraction Pattern False Positives

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Version extraction pattern was fixed to reduce false positives (Issue 6818).
 
 ## [0.8.0] - 2021-08-25
 ### Changed

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -100,7 +100,7 @@ public class RetireScanRule extends PluginPassiveScanner {
                 .setOtherInfo(otherInfo)
                 .setReference(getDetails(Result.INFO, result.getInfo()))
                 .setSolution(Constant.messages.getString("retire.rule.soln", result.getFilename()))
-                .setEvidence(result.getEvidence())
+                .setEvidence(result.getEvidence().trim())
                 .setCweId(829); // CWE-829: Inclusion of Functionality from Untrusted Control Sphere
     }
 

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/ExtractorsTypeAdapter.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/ExtractorsTypeAdapter.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class ExtractorsTypeAdapter extends TypeAdapter<Extractors> {
 
     private static final String VERSION_TOKEN = "§§version§§";
-    private static final String VERSION_SUB_PATTERN = "[0-9][0-9.a-z_\\\\\\\\-]+";
+    private static final String VERSION_SUB_PATTERN = "[0-9][0-9a-z._\\-]+?";
 
     @Override
     public Extractors read(JsonReader in) throws IOException {
@@ -110,7 +110,7 @@ public class ExtractorsTypeAdapter extends TypeAdapter<Extractors> {
         return extractors;
     }
 
-    private String fixPattern(String inPattern) {
+    static String fixPattern(String inPattern) {
         String goodPattern;
         goodPattern = inPattern.replace(VERSION_TOKEN, VERSION_SUB_PATTERN);
         if (goodPattern.contains("{")) {
@@ -118,6 +118,11 @@ public class ExtractorsTypeAdapter extends TypeAdapter<Extractors> {
                     goodPattern.replaceAll(
                             "\\{\\}", "\\\\{\\\\}"); // PatternSyntaxException: {} is treated
             // as an empty number of chars definition ex: [a-z]{8}
+        }
+        if (goodPattern.endsWith(VERSION_SUB_PATTERN + ")")) {
+            // If the pattern ends with a version sub pattern, then artificially bound it with a
+            // whitespace check
+            goodPattern = goodPattern + "\\s";
         }
         return goodPattern;
     }

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
@@ -110,17 +112,17 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
                 alertsRaised.get(0).getReference());
     }
 
-    @Test
-    void shouldRaiseAlertOnVulnerableFilename() {
+    @ParameterizedTest
+    @ValueSource(strings = {"jquery-3.1.1.min.js", "jquery-3_1_1.min.js", "jquery-3-1-1.min.js"})
+    void shouldRaiseAlertOnVulnerableFilename(String fileName) {
         // Given
-        HttpMessage msg =
-                createMessage("http://example.com/CommonElements/js/jquery-3.1.1.min.js", null);
+        HttpMessage msg = createMessage("http://example.com/CommonElements/js/" + fileName, null);
         given(passiveScanData.isPage200(any())).willReturn(true);
         // When
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertEquals("jquery-3.1.1.min.js", alertsRaised.get(0).getEvidence());
+        assertEquals(fileName, alertsRaised.get(0).getEvidence());
         assertEquals(
                 "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/\n",
                 alertsRaised.get(0).getReference());

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/model/VersionPatternUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/model/VersionPatternUnitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.retire.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class VersionPatternUnitTest {
+
+    private static Stream<Arguments> getFilenameTestValuesAndExpectedVersions() {
+        return Stream.of(
+                Arguments.of("bootstrap-3.1.1.min.js", "3.1.1"),
+                Arguments.of("bootstrap-3_1_1.min.js", "3_1_1"),
+                Arguments.of("bootstrap-3-1-1.min.js", "3-1-1"),
+                Arguments.of("bootstrap-3.1.1.js", "3.1.1"),
+                Arguments.of("bootstrap-3.1.1-alpha.js", "3.1.1-alpha"),
+                Arguments.of("bootstrap-3.1.1-beta1.js", "3.1.1-beta1"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getFilenameTestValuesAndExpectedVersions")
+    void shouldMatchExpectedVersionStringInFilenames(String input, String expected) {
+        // Given
+        String pattern = "bootstrap-(§§version§§)(\\.min)?\\.js";
+        // When
+        String goodPattern = ExtractorsTypeAdapter.fixPattern(pattern);
+        Pattern patternToTest = Pattern.compile(goodPattern);
+        Matcher matcher = patternToTest.matcher(input);
+        boolean matched = matcher.find();
+        String matchedVersion = matcher.group(1);
+        // Then
+        assertTrue(matched);
+        assertEquals(expected, matchedVersion);
+    }
+
+    private static Stream<Arguments> getContentTestValuesAndExpectedVersions() {
+        return Stream.of(
+                Arguments.of("/* Bootstrap v3.1.1-beta1 (foobar)", "3.1.1-beta1"),
+                Arguments.of("/* Bootstrap v3.1.1-beta1\n", "3.1.1-beta1"),
+                Arguments.of("/* Bootstrap v3.1.1\r\n", "3.1.1"),
+                Arguments.of("/* Bootstrap v3.1.1\t(foorbar)", "3.1.1"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getContentTestValuesAndExpectedVersions")
+    void shouldMatchExpectedVersionStringInContent(String input, String expected) {
+        // Given
+        String pattern = "/\\*!? Bootstrap v(§§version§§)";
+        // When
+        String goodPattern = ExtractorsTypeAdapter.fixPattern(pattern);
+        Pattern patternToTest = Pattern.compile(goodPattern);
+        Matcher matcher = patternToTest.matcher(input);
+        boolean matched = matcher.find();
+        String matchedVersion = matcher.group(1);
+        // Then
+        assertTrue(matched);
+        assertEquals(expected, matchedVersion);
+    }
+}


### PR DESCRIPTION
- CHANGELOG > Added fix note.
- ExtracrotsTypeAdapter > Fixed version extraction regex and fixPattern method.
- RetireScanRule.java > Added trim on evidence (whitespace doesn't need to be included).
- RetireSccanRuleUnitTest > Parameterized an existing  test method to more completely test this condition, and added VersionPatternUnitTest to further ensure things behave as expected.

Fixes zaproxy/zaproxy#6818

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>