### PR TITLE
fix: pscanrulesAlpha: Source Code Disclosure image false positive

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Ignore CSS, JavaScript, or font files when scanning for source code disclosures (Issues: 6595 & 6795).
+- Ignore CSS, JavaScript, images, or font files when scanning for source code disclosures (Issues: 6595, 6795, & 6820).
 
 ## [33] - 2021-07-07
 ### Fixed

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
@@ -650,6 +650,8 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
         if (msg.getResponseHeader().isCss()
                 || msg.getResponseHeader().isJavaScript()
                 || msg.getRequestHeader().isCss()
+                || msg.getRequestHeader().isImage()
+                || msg.getResponseHeader().isImage()
                 || msg.getResponseHeader().hasContentType("font")
                 || isFontRequest(msg)) {
             return;

--- a/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
+++ b/addOns/pscanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/pscanrulesAlpha/resources/help/contents/pscanalpha.html
@@ -109,7 +109,7 @@ Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns
 
 <H2>Source Code Disclosure</H2>
 Application Source Code was disclosed by the web server.<br>
-NOTE: Ignores CSS and JavaScript files.
+NOTE: Ignores CSS, JavaScript, images, and font files.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java">SourceCodeDisclosureScanRule.java</a>
 

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRuleUnitTest.java
@@ -161,6 +161,18 @@ class SourceCodeDisclosureScanRuleUnitTest
         assertEquals(0, alertsRaised.size());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"image.gif", "image.jpg", "image.png", "image.bmp"})
+    void shouldNotRaiseAlertOnValidPhpInImageRequest(String fileName) throws Exception {
+        // Given
+        msg.setResponseBody(wrapWithHTML(CODE_PHP2));
+        msg.getRequestHeader().setURI(new URI("http://example.com/" + fileName, false));
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
+    }
+
     @Test
     void patternFontExtensionShouldNotFindSubString() {
         // Given / When
@@ -173,6 +185,18 @@ class SourceCodeDisclosureScanRuleUnitTest
     @ParameterizedTest
     @ValueSource(strings = {"font/ttf", "font/otf", "font/woff", "font/woff2"})
     void shouldNotRaiseAlertOnValidPhpWhenInFontResponse(String type) throws Exception {
+        // Given
+        msg.setResponseBody(wrapWithHTML(CODE_PHP2));
+        msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, type);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"image/gif", "image/jpeg", "image/png", "image/bmp"})
+    void shouldNotRaiseAlertOnValidPhpWhenInImageResponse(String type) throws Exception {
         // Given
         msg.setResponseBody(wrapWithHTML(CODE_PHP2));
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, type);


### PR DESCRIPTION
- CHANGELOG.md > Updated change note.
- pscanalpha.html > Tweaked help note.
- SourceCodeDisclosureScanRule.java > Added image to request/response exclusions.
- SourceCodeDisclosureScanRuleUnitTest.java > Added test methods to assert the image related behavior.

Fixes zaproxy/zaproxy#6820

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>