### PR TITLE
openapi: use path servers

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Use path servers ([Issue #6754](https://github.com/zaproxy/zaproxy/issues/6754)).
 
 ## [22] - 2021-09-16
 ### Changed

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/converter/swagger/openapi_path_servers.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/converter/swagger/openapi_path_servers.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Paths with servers
+  version: 1.0.0
+servers:
+  - url: http://server0.localhost/
+paths:
+  /path/without/servers:
+    get:
+      operationId: path/without/servers
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}
+  /path/with/server:
+    servers:
+      - url: http://server1.localhost/
+    get:
+      operationId: path/with/server
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}
+  /path/with/servers:
+    servers:
+      - url: http://server2.localhost/v1/
+      - url: http://server3.localhost/
+    get:
+      operationId: path/with/servers
+      responses:
+        default:
+          description:
+          content:
+            text/plain: {}


### PR DESCRIPTION
Use path servers when available.

Fix zaproxy/zaproxy#6754.