### PR TITLE
improve: retire: Address SAST (sonar) Items

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Version extraction pattern was fixed to reduce false positives (Issue 6818).
 
+### Changed
+- Maintenance changes.
+
 ## [0.8.0] - 2021-08-25
 ### Changed
 - Updated with upstream retire.js pattern changes.

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
@@ -27,7 +27,7 @@ public class Result {
     public static final String INFO = "info";
     public static final String CVE = "CVE";
 
-    Map<String, Set<String>> info = new HashMap<>();
+    Map<String, Set<String>> information = new HashMap<>();
     String version;
     String filename;
     String evidence;
@@ -40,12 +40,12 @@ public class Result {
             String evidence) {
         this.filename = filename;
         this.version = version;
-        this.info = info;
+        this.information = info;
         this.evidence = evidence;
     }
 
-    public Map<String, Set<String>> getInfo() {
-        return info;
+    public Map<String, Set<String>> getInformation() {
+        return information;
     }
 
     public String getVersion() {

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -62,12 +62,12 @@ public class RetireScanRule extends PluginPassiveScanner {
         if (!msg.getResponseHeader().isImage()
                 && !msg.getRequestHeader().isCss()
                 && !msg.getResponseHeader().isCss()) {
-            Repo repo = getRepo();
-            if (repo == null) {
+            Repo scanRepo = getRepo();
+            if (scanRepo == null) {
                 LOGGER.error("\tThe Retire.js repository was null.");
                 return;
             }
-            Result result = repo.scanJS(msg);
+            Result result = scanRepo.scanJS(msg);
             if (result == null) {
                 LOGGER.debug("\tNo vulnerabilities found in record {} with URL {}", id, uri);
             } else {
@@ -77,9 +77,9 @@ public class RetireScanRule extends PluginPassiveScanner {
                         uri,
                         (result.getFilename() == null) ? "" : result.getFilename(),
                         result.getVersion(),
-                        result.getInfo());
+                        result.getInformation());
 
-                String otherInfo = getDetails(Result.CVE, result.getInfo());
+                String otherInfo = getDetails(Result.CVE, result.getInformation());
 
                 if (result.hasOtherInfo()) {
                     otherInfo = otherInfo + result.getOtherinfo();
@@ -98,7 +98,7 @@ public class RetireScanRule extends PluginPassiveScanner {
                         Constant.messages.getString(
                                 "retire.rule.desc", result.getFilename(), result.getVersion()))
                 .setOtherInfo(otherInfo)
-                .setReference(getDetails(Result.INFO, result.getInfo()))
+                .setReference(getDetails(Result.INFO, result.getInformation()))
                 .setSolution(Constant.messages.getString("retire.rule.soln", result.getFilename()))
                 .setEvidence(result.getEvidence().trim())
                 .setCweId(829); // CWE-829: Inclusion of Functionality from Untrusted Control Sphere

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireUtil.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireUtil.java
@@ -27,9 +27,13 @@ import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class RetireUtil {
+public final class RetireUtil {
 
     private static final Logger LOGGER = LogManager.getLogger(RetireUtil.class);
+
+    private RetireUtil() {
+        // Utility class
+    }
 
     /*
      * This utility function computes the SHA 1 hash input string
@@ -79,26 +83,26 @@ public class RetireUtil {
         String[] v2 = version2.split("[\\.-]");
         int l = v1.length > v2.length ? v1.length : v2.length;
         for (int i = 0; i < l; i++) {
-            String v1_part = v1.length > i ? v1[i] : "0";
-            String v2_part = v2.length > i ? v2[i] : "0";
-            boolean v1_isnumber = isNumber(v1_part);
-            boolean v2_isnumber = isNumber(v2_part);
+            String v1Part = v1.length > i ? v1[i] : "0";
+            String v2part = v2.length > i ? v2[i] : "0";
+            boolean v1IsNumber = isNumber(v1Part);
+            boolean v2IsNumber = isNumber(v2part);
 
             // if either of v1 or v2 is string
-            if (v1_isnumber != v2_isnumber) {
-                return v1_isnumber;
+            if (v1IsNumber != v2IsNumber) {
+                return v1IsNumber;
             }
 
             // if both v1 and v2 are strings
-            if (!v1_isnumber && !v2_isnumber) {
-                return v1_part.compareTo(v2_part) > 0;
+            if (!v1IsNumber && !v2IsNumber) {
+                return v1Part.compareTo(v2part) > 0;
             }
 
             // if both are numbers
-            if (Integer.parseInt(v1_part) < Integer.parseInt(v2_part)) {
+            if (Integer.parseInt(v1Part) < Integer.parseInt(v2part)) {
                 return false;
             }
-            if (Integer.parseInt(v1_part) > Integer.parseInt(v2_part)) {
+            if (Integer.parseInt(v1Part) > Integer.parseInt(v2part)) {
                 return true;
             }
         }

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/model/Repo.java
@@ -99,7 +99,7 @@ public class Repo {
         HashMap<String, String> msginfo = new HashMap<>();
         msginfo.put(Extractors.TYPE_URI, uri);
         if (fileName != null) {
-            msginfo.put(Extractors.TYPE_FILENAME, fileName.toString());
+            msginfo.put(Extractors.TYPE_FILENAME, fileName);
         }
         msginfo.put(Extractors.TYPE_FILECONTENT, content);
 
@@ -136,7 +136,6 @@ public class Repo {
      */
     private Result scanHash(String hash) {
         // Testable URL: https://ajax.googleapis.com/ajax/libs/dojo/1.1.1/dojo/dojo.js
-        Map<String, Set<String>> results = new HashMap<>();
         for (Map.Entry<String, RepoEntry> repoEntry : entries.entrySet()) {
             Map<String, String> hashes = repoEntry.getValue().getExtractors().getHashes();
 
@@ -146,7 +145,8 @@ public class Repo {
                     List<Vulnerability> vulnerabilities = repoEntry.getValue().getVulnerabilities();
 
                     if (hash.equalsIgnoreCase(hashEntry.getKey())) {
-                        results = isVersionVulnerable(vulnerabilities, hashEntry.getValue());
+                        Map<String, Set<String>> results =
+                                isVersionVulnerable(vulnerabilities, hashEntry.getValue());
                         Result result =
                                 new Result(repoEntry.getKey(), hashEntry.getValue(), results, "");
                         result.setOtherinfo(
@@ -166,7 +166,6 @@ public class Repo {
      * FileName OR FileURL OR FileContent
      */
     private Result scan(String extractorType, String input) {
-        Map<String, Set<String>> results = new HashMap<>();
         // reading each entry for JS libraries in repo
         for (Map.Entry<String, RepoEntry> repoEntry : entries.entrySet()) {
             List<String> extractors = repoEntry.getValue().getExtractors().get(extractorType);
@@ -187,7 +186,8 @@ public class Repo {
                             // Now try to determine if this version is vulnerable
                             List<Vulnerability> vulnerabilities =
                                     repoEntry.getValue().getVulnerabilities();
-                            results = isVersionVulnerable(vulnerabilities, versionString);
+                            Map<String, Set<String>> results =
+                                    isVersionVulnerable(vulnerabilities, versionString);
                             if (!results.isEmpty()) {
                                 return new Result(
                                         repoEntry.getKey(),
@@ -214,15 +214,15 @@ public class Repo {
         Extractors extractors = dc.getExtractors();
 
         // iterating over extractors
-        for (String criterion : msginfo.keySet()) {
-            matches = extractors.get(criterion);
+        for (Entry<String, String> criterion : msginfo.entrySet()) {
+            matches = extractors.get(criterion.getKey());
             if (matches != null && !matches.isEmpty()) {
                 Iterator<String> iterator = matches.iterator();
                 while (iterator.hasNext()) {
                     String next = iterator.next();
                     if (next != null) {
                         Pattern p = Pattern.compile(next);
-                        Matcher m = p.matcher(msginfo.get(criterion));
+                        Matcher m = p.matcher(criterion.getValue());
                         // doing a match for each filename regex
                         if (m.find()) {
                             return true;


### PR DESCRIPTION
- CHANGELOG.md added maintenance note.
- Repo.java removed unnecessary toString. Remove unnecessary hashmap assignments. Use entrySet vs keySet.
- Result.java rename info field to information so that it doesn't hide or conflict with the INFO constant.
- ReiteScanRule.java rename local variable to not hide class field.
- RetireUtil.java add private constructor to hide implicit public constructor. Corrected naming of some local variables.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>