### PR TITLE
Quickstart: Disable browser launch in containers unless override option enabled

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
 - Generate quickout reports using the reports add-on instead of the core
+- Update minimum ZAP version to 2.11.0.
+- Disable browser launch in containers unless override option enabled
 
 ## [29] - 2020-12-15
 ### Changed

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -5,7 +5,7 @@ description = "Provides a tab which allows you to quickly test a target applicat
 zapAddOn {
     addOnName.set("Quick Start")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")
@@ -62,7 +62,15 @@ zapAddOn {
     }
 }
 
+repositories {
+    maven {
+        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
+}
+
 dependencies {
+    zap("org.zaproxy:zap:2.11.0-20210923.152813-2")
+
     compileOnly(parent!!.childProjects.get("reports")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
     compileOnly(parent!!.childProjects.get("spiderAjax")!!)

--- a/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
+++ b/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
@@ -94,6 +94,9 @@ quickstart.launch.panel.default.message2 = To do this you will need to:
 quickstart.learn.panel.title			= Learn More
 quickstart.learn.panel.message1			= This screen links to local and remote resources that will help you learn more about ZAP.
 
+quickstart.panel.launch.container		= <html><p><b>You appear to be running ZAP in a container, so launching browsers has been disabled as this is unlikely to work.</b></p><p>\
+You will need to use a browser that you don't launch from ZAP, configure it to proxy through ZAP and to import the ZAP root CA certificate.</p><p>\
+If you think ZAP will be able to launch browsers in your environment then you can enable this feature via the Option: Display / Enable app integration in containers.</p><p><p></html>
 quickstart.panel.launch.manual			= <html><p>You can also use browsers that you don't launch from ZAP, but will need to configure them to proxy through ZAP and to import the ZAP root CA certificate.</p><p><p></html>
 
 quickstart.progress.ascan				= Actively scanning (attacking) the URLs discovered by the spider(s)


### PR DESCRIPTION
Screenshot for when the panel is disabled:
<img width="1209" alt="Screenshot 2021-09-24 at 13 44 33" src="https://user-images.githubusercontent.com/1081115/134676872-fda4a0eb-dba7-472b-b169-bf8d8b03a0fc.png">

Signed-off-by: Simon Bennetts <psiinon@gmail.com>