### PR TITLE
fix: ascanrulesBeta: Use assumed minimum length for parent folder names

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Use OAST Callbacks for the XXE Scan Rule.
+- Backup File Disclosure Scan Rule: When checkout a parent folder for 404 behavior assume a minimum folder name length of four to further eliminate chance of collision on short folder names (Issue 5330).
 
 ## [36] - 2021-09-17
 ### Removed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/BackupFileDisclosureScanRule.java
@@ -422,7 +422,7 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
 
             String randomfilename =
                     RandomStringUtils.random(
-                            filename.length(), "abcdefghijklmoopqrstuvwxyz9123456789");
+                            filename.length(), "abcdefghijklmnopqrstuvwxyz0123456789");
             String randomfilepath = temppath.substring(0, slashposition) + "/" + randomfilename;
 
             log.debug("Trying non-existent file: {}", randomfilepath);
@@ -459,9 +459,13 @@ public class BackupFileDisclosureScanRule extends AbstractAppPlugin {
                 // a parent folder to mess with)
                 String[] temppathbreak = pathbreak;
                 String parentfoldername = pathbreak[pathbreak.length - 2];
+                // If the parent folder name is really short a collision is likely
+                // Default to a reasonable length, which may have the inverse effect but we'll
+                // chance it
                 String randomparentfoldername =
                         RandomStringUtils.random(
-                                parentfoldername.length(), "abcdefghijklmoopqrstuvwxyz9123456789");
+                                Math.max(parentfoldername.length(), 4),
+                                "abcdefghijklmnopqrstuvwxyz0123456789");
 
                 // replace the parent folder name with the random one, and build it back into a
                 // string


### PR DESCRIPTION
- Backup File Disclosure Scan Rule: When checking a parent folder for 404 behavior assume a minimum folder name length of four to further eliminate chance of collision on short folder names (Issue 5330). Also fix 'alphabet' used for random name generation (missing zero, had two nines & missing n, had two o's).
- CHANGELOG: Add change note.

Fixes zaproxy/zaproxy#5330

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>