### PR TITLE
improve:exim: Add importUrls functionality

### DIFF
--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
@@ -23,6 +23,7 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.zaproxy.addon.exim.har.MenuImportHar;
 import org.zaproxy.addon.exim.har.PopupMenuItemSaveHarMessage;
+import org.zaproxy.addon.exim.urls.MenuItemImportUrls;
 
 public class ExtensionExim extends ExtensionAdaptor {
 
@@ -42,6 +43,7 @@ public class ExtensionExim extends ExtensionAdaptor {
             extensionHook.getHookMenu().addPopupMenuItem(new PopupMenuItemSaveHarMessage());
 
             extensionHook.getHookMenu().addImportMenuItem(new MenuImportHar());
+            extensionHook.getHookMenu().addImportMenuItem(new MenuItemImportUrls());
         }
         extensionHook.addApiImplementor(new ImportExportApi());
     }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/MenuItemImportUrls.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/MenuItemImportUrls.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2014 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim.urls;
+
+import java.awt.event.KeyEvent;
+import javax.swing.JFileChooser;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.view.ZapMenuItem;
+
+public class MenuItemImportUrls extends ZapMenuItem {
+
+    private static final long serialVersionUID = 2617077109056192411L;
+    private static final String THREAD_PREFIX = "ZAP-Exim-Import-Urls-";
+
+    private int threadId = 1;
+
+    public MenuItemImportUrls() {
+        super(
+                "exim.importurls.topmenu.import",
+                View.getSingleton().getMenuShortcutKeyStroke(KeyEvent.VK_I, 0, false));
+        this.setToolTipText(Constant.messages.getString("exim.importurls.topmenu.import.tooltip"));
+        this.addActionListener(
+                e -> {
+                    JFileChooser chooser =
+                            new JFileChooser(
+                                    Model.getSingleton().getOptionsParam().getUserDirectory());
+                    int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
+                    if (rc == JFileChooser.APPROVE_OPTION) {
+
+                        new Thread(
+                                        () -> UrlsImporter.importUrlFile(chooser.getSelectedFile()),
+                                        THREAD_PREFIX + threadId++)
+                                .start();
+                    }
+                });
+    }
+}

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
@@ -1,0 +1,124 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim.urls;
+
+import java.awt.EventQueue;
+import java.io.BufferedReader;
+import java.io.File;
+import java.nio.file.Files;
+import org.apache.commons.httpclient.URI;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpSender;
+import org.parosproxy.paros.view.View;
+
+public final class UrlsImporter {
+
+    private static final Logger LOG = LogManager.getLogger(UrlsImporter.class);
+
+    private UrlsImporter() {}
+
+    public static boolean importUrlFile(File file) {
+        if (file == null) {
+            return false;
+        }
+        try (BufferedReader in = Files.newBufferedReader(file.toPath())) {
+            if (View.isInitialised()) {
+                View.getSingleton().getOutputPanel().setTabFocus();
+            }
+
+            HttpSender sender =
+                    new HttpSender(
+                            Model.getSingleton().getOptionsParam().getConnectionParam(),
+                            true,
+                            HttpSender.MANUAL_REQUEST_INITIATOR);
+
+            String line;
+            StringBuilder outputLine = new StringBuilder();
+            while ((line = in.readLine()) != null) {
+                if (!line.startsWith("#") && line.trim().length() > 0) {
+                    try {
+                        outputLine
+                                .append(HttpRequestHeader.GET)
+                                .append('\t')
+                                .append(line)
+                                .append('\t');
+                        HttpMessage msg = new HttpMessage(new URI(line, false));
+                        sender.sendAndReceive(msg, true);
+                        persistMessage(msg);
+
+                        outputLine.append(msg.getResponseHeader().getStatusCode());
+
+                    } catch (Exception e) {
+                        outputLine.append(e.getMessage());
+                    }
+                    outputLine.append('\n');
+                    if (View.isInitialised()) {
+                        EventQueue.invokeLater(
+                                () -> {
+                                    View.getSingleton()
+                                            .getOutputPanel()
+                                            .append(outputLine.toString());
+                                    outputLine.delete(0, outputLine.length());
+                                });
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            return false;
+        }
+        return true;
+    }
+
+    private static void persistMessage(HttpMessage message) {
+        HistoryReference historyRef;
+
+        try {
+            historyRef =
+                    new HistoryReference(
+                            Model.getSingleton().getSession(),
+                            HistoryReference.TYPE_ZAP_USER,
+                            message);
+        } catch (Exception e) {
+            LOG.warn(e.getMessage(), e);
+            return;
+        }
+
+        ExtensionHistory extHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+        if (extHistory != null) {
+            EventQueue.invokeLater(
+                    () -> {
+                        extHistory.addHistory(historyRef);
+                        Model.getSingleton()
+                                .getSession()
+                                .getSiteTree()
+                                .addPath(historyRef, message);
+                    });
+        }
+    }
+}

--- a/addOns/exim/src/main/javahelp/help/contents/exim.html
+++ b/addOns/exim/src/main/javahelp/help/contents/exim.html
@@ -13,5 +13,11 @@ Provides a context menu to save content of HTTP messages as binary.
 <H1>Save XML Message</H1>
 Provides a context menu to save content of HTTP messages as XML.
 
+<H1>Import URLs</H1>
+An option to import a file of URLs is available via the 'Import' menu ('Import a File Containing URLs'). The file must be plain text with one URL per line.
+Blank lines and lines starting with # will be ignored.
+</p>
+This add-on also exposes a ZAP API endpoint <tt>/exim/importurls (filePath*)</tt> to facilitate programmatic 
+use of the functionality.
 </BODY>
 </HTML>

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -4,6 +4,10 @@ exim.har.file.import.error = Could not import the file {0}
 exim.har.topmenu.import.importhar = Import HAR (HTTP Archive File)
 exim.har.topmenu.import.importhar.tooltip = Import a HTTP Archive File and add the messages to the sites tree and history panel.
 
+exim.api.action.importurls = Imports URLs (one per line) from the file with the given file system path.
+exim.importurls.topmenu.import = Import a File Containing URLs
+exim.importurls.topmenu.import.tooltip = The file must be plain text with one URL per line.\nBlank lines and lines starting with a # are ignored.
+
 exim.popup.option.all = All
 exim.popup.option.body = Body
 exim.popup.option.header = Header


### PR DESCRIPTION
- ExtensionExim > Updated to hook the new menu item.
- ImportExportApi > Updated to include the importUrls endpoint.
- MenuItemImportUrls > Extracted from the original add-on.
- UrlsImporter > Utility class with static work methods.
- Messages.properties > Added necessary resource key value pairs.
- exim.html > Added help info for this functionality.

Part of: zaproxy/zaproxy#6579

Didn't include any CHANGELOG entry as the add-on has not yet been released.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>