### PR TITLE
oast: Update default Interactsh server URL

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Updated the default Interactsh server URL to https://interactsh.com.
 
 ## [0.4.0] - 2021-09-22
 ### Added

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshParam.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshParam.java
@@ -51,7 +51,7 @@ public class InteractshParam extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
-        serverUrl = getString(PARAM_SERVER_URL, "https://interact.sh");
+        serverUrl = getString(PARAM_SERVER_URL, "https://interactsh.com");
         setPollingFrequency(getInt(PARAM_POLLING_FREQUENCY, 60));
         authToken = getString(PARAM_AUTH_TOKEN, "");
     }


### PR DESCRIPTION
See https://github.com/projectdiscovery/interactsh/issues/99.

Signed-off-by: Akshath Kothari <ricekot@gmail.com>