### PR TITLE
Fix dialogs being shown under owning frame/dialog

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Stats for alerts changed
 
+### Fixed
+- Dialogs being shown under the owning dialog / frame.
+
 ## [12] - 2021-09-16
 ### Added
 - Support for the Automation Framework

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFiltersMultipleOptionsPanel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFiltersMultipleOptionsPanel.java
@@ -20,11 +20,11 @@
 package org.zaproxy.zap.extension.alertFilters;
 
 import java.awt.Component;
+import java.awt.Window;
 import javax.swing.JCheckBox;
 import javax.swing.JOptionPane;
 import javax.swing.SortOrder;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
@@ -50,11 +50,13 @@ public class AlertFiltersMultipleOptionsPanel
     private DialogAddAlertFilter addDialog = null;
     private DialogModifyAlertFilter modifyDialog = null;
     private Context uiSharedContext;
+    private Window owner;
 
     public AlertFiltersMultipleOptionsPanel(
-            ExtensionAlertFilters extension, AlertFilterTableModel model) {
+            ExtensionAlertFilters extension, Window owner, AlertFilterTableModel model) {
         super(model);
         this.extension = extension;
+        this.owner = owner;
 
         Component rendererComponent;
         if (getTable().getColumnExt(0).getHeaderRenderer()
@@ -97,16 +99,14 @@ public class AlertFiltersMultipleOptionsPanel
     public AlertFilter showAddDialogue(AlertFilter alertFilter) {
 
         if (addDialog == null) {
-            addDialog =
-                    new DialogAddAlertFilter(
-                            this.extension, View.getSingleton().getOptionsDialog(null));
+            addDialog = new DialogAddAlertFilter(this.extension, owner);
             addDialog.pack();
         }
+        addDialog.clearFields();
         addDialog.setWorkingContext(this.uiSharedContext);
         addDialog.setCanChangeContext(alertFilter != null);
         addDialog.setAlertFilter(alertFilter);
         addDialog.setVisible(true);
-        addDialog.clearFields();
 
         return addDialog.getAlertFilter();
     }
@@ -118,16 +118,14 @@ public class AlertFiltersMultipleOptionsPanel
 
     public AlertFilter showModifyDialogue(AlertFilter alertFilter, boolean canChangeContext) {
         if (modifyDialog == null) {
-            modifyDialog =
-                    new DialogModifyAlertFilter(
-                            this.extension, View.getSingleton().getOptionsDialog(null));
+            modifyDialog = new DialogModifyAlertFilter(this.extension, owner);
             modifyDialog.pack();
         }
+        modifyDialog.clearFields();
         modifyDialog.setWorkingContext(this.uiSharedContext);
         modifyDialog.setAlertFilter(alertFilter);
         modifyDialog.setCanChangeContext(canChangeContext);
         modifyDialog.setVisible(true);
-        modifyDialog.clearFields();
 
         return modifyDialog.getAlertFilter();
     }
@@ -138,7 +136,7 @@ public class AlertFiltersMultipleOptionsPanel
         Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};
         int option =
                 JOptionPane.showOptionDialog(
-                        View.getSingleton().getMainFrame(),
+                        this,
                         messages,
                         REMOVE_DIALOG_TITLE,
                         JOptionPane.OK_CANCEL_OPTION,

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterPanel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterPanel.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.alertFilters;
 
 import java.awt.CardLayout;
 import java.awt.GridBagLayout;
+import java.awt.Window;
 import javax.swing.JLabel;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Session;
@@ -34,6 +35,7 @@ public class ContextAlertFilterPanel extends AbstractContextPropertiesPanel {
     private ContextAlertFilterManager contextManager;
     private AlertFilterTableModel alertFilterTableModel;
     private ExtensionAlertFilters extension;
+    private Window owner;
 
     /** The Constant serialVersionUID. */
     private static final long serialVersionUID = -3920598166129639573L;
@@ -41,9 +43,10 @@ public class ContextAlertFilterPanel extends AbstractContextPropertiesPanel {
     private static final String PANEL_NAME =
             Constant.messages.getString("alertFilters.panel.title");
 
-    public ContextAlertFilterPanel(ExtensionAlertFilters extension, int contextId) {
+    public ContextAlertFilterPanel(ExtensionAlertFilters extension, Window owner, int contextId) {
         super(contextId);
         this.extension = extension;
+        this.owner = owner;
         this.contextManager = extension.getContextAlertFilterManager(contextId);
         initialize();
     }
@@ -64,7 +67,7 @@ public class ContextAlertFilterPanel extends AbstractContextPropertiesPanel {
 
         alertFilterTableModel = new AlertFilterTableModel();
         alertFilterOptionsPanel =
-                new AlertFiltersMultipleOptionsPanel(extension, alertFilterTableModel);
+                new AlertFiltersMultipleOptionsPanel(extension, this.owner, alertFilterTableModel);
         this.add(alertFilterOptionsPanel, LayoutHelper.getGBC(0, 1, 1, 1.0d, 1.0d));
     }
 

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
@@ -20,9 +20,9 @@
 package org.zaproxy.zap.extension.alertFilters;
 
 import java.awt.Component;
-import java.awt.Dialog;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.awt.Window;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.swing.BorderFactory;
@@ -91,7 +91,7 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
      *
      * @param owner the owner
      */
-    public DialogAddAlertFilter(ExtensionAlertFilters extension, Dialog owner) {
+    public DialogAddAlertFilter(ExtensionAlertFilters extension, Window owner) {
         this(extension, owner, DIALOG_TITLE);
     }
 
@@ -101,7 +101,7 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
      * @param owner the owner
      * @param title the title
      */
-    public DialogAddAlertFilter(ExtensionAlertFilters extension, Dialog owner, String title) {
+    public DialogAddAlertFilter(ExtensionAlertFilters extension, Window owner, String title) {
         super(owner, title);
         this.extension = extension;
     }

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogModifyAlertFilter.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogModifyAlertFilter.java
@@ -19,7 +19,7 @@
  */
 package org.zaproxy.zap.extension.alertFilters;
 
-import java.awt.Dialog;
+import java.awt.Window;
 import org.parosproxy.paros.Constant;
 
 public class DialogModifyAlertFilter extends DialogAddAlertFilter {
@@ -28,13 +28,8 @@ public class DialogModifyAlertFilter extends DialogAddAlertFilter {
     private static final String DIALOG_TITLE =
             Constant.messages.getString("alertFilters.dialog.modify.title");
 
-    public DialogModifyAlertFilter(ExtensionAlertFilters extension, Dialog owner) {
+    public DialogModifyAlertFilter(ExtensionAlertFilters extension, Window owner) {
         super(extension, owner, DIALOG_TITLE);
-    }
-
-    @Override
-    public void setAlertFilter(AlertFilter alertFilter) {
-        super.setAlertFilter(alertFilter);
     }
 
     @Override

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -45,6 +45,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.Session.OnContextsChangedListener;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.control.CoreFunctionality;
 import org.zaproxy.zap.control.ExtensionFactory;
@@ -109,6 +110,7 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
     private Logger log = LogManager.getLogger(this.getClass());
 
     private OnContextsChangedListenerImpl contextsChangedListener;
+    private DialogAddAlertFilter addDialog = null;
 
     public ExtensionAlertFilters() {
         super(NAME);
@@ -210,9 +212,8 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
 
                                 @Override
                                 protected void performAction(Alert alert) {
-                                    AlertFilter af =
-                                            getOptionGlobalAlertFilterPanel()
-                                                    .showAddDialogue(new AlertFilter(-1, alert));
+                                    DialogAddAlertFilter dialog = showAddDialog(alert);
+                                    AlertFilter af = dialog.getAlertFilter();
                                     if (af != null) {
                                         if (af.getContextId() >= 0) {
                                             getContextAlertFilterManager(af.getContextId())
@@ -233,9 +234,23 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
         extensionHook.addApiImplementor(api);
     }
 
+    private DialogAddAlertFilter showAddDialog(Alert alert) {
+        if (addDialog == null) {
+            addDialog = new DialogAddAlertFilter(this, View.getSingleton().getMainFrame());
+            addDialog.pack();
+        }
+        addDialog.clearFields();
+        addDialog.setCanChangeContext(true);
+        addDialog.setAlertFilter(new AlertFilter(-1, alert));
+        addDialog.setVisible(true);
+        return addDialog;
+    }
+
     private OptionsGlobalAlertFilterPanel getOptionGlobalAlertFilterPanel() {
         if (optionsGlobalAlertFilterPanel == null) {
-            optionsGlobalAlertFilterPanel = new OptionsGlobalAlertFilterPanel(this);
+            optionsGlobalAlertFilterPanel =
+                    new OptionsGlobalAlertFilterPanel(
+                            this, View.getSingleton().getOptionsDialog(null));
         }
         return optionsGlobalAlertFilterPanel;
     }
@@ -339,7 +354,9 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
     private ContextAlertFilterPanel getContextPanel(int contextId) {
         ContextAlertFilterPanel panel = this.alertFilterPanelsMap.get(contextId);
         if (panel == null) {
-            panel = new ContextAlertFilterPanel(this, contextId);
+            panel =
+                    new ContextAlertFilterPanel(
+                            this, View.getSingleton().getSessionDialog(), contextId);
             this.alertFilterPanelsMap.put(contextId, panel);
         }
         return panel;

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/OptionsGlobalAlertFilterPanel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/OptionsGlobalAlertFilterPanel.java
@@ -20,6 +20,7 @@
 package org.zaproxy.zap.extension.alertFilters;
 
 import java.awt.BorderLayout;
+import java.awt.Window;
 import java.util.ArrayList;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
@@ -32,11 +33,12 @@ public class OptionsGlobalAlertFilterPanel extends AbstractParamPanel {
     private final AlertFilterTableModel alertFilterModel = new AlertFilterTableModel();
     private final AlertFiltersMultipleOptionsPanel alertFilterOptionsPanel;
 
-    public OptionsGlobalAlertFilterPanel(ExtensionAlertFilters extension) {
+    public OptionsGlobalAlertFilterPanel(ExtensionAlertFilters extension, Window owner) {
         super();
         this.setName(Constant.messages.getString("alertFilters.global.options.title"));
         this.setLayout(new BorderLayout());
-        alertFilterOptionsPanel = new AlertFiltersMultipleOptionsPanel(extension, alertFilterModel);
+        alertFilterOptionsPanel =
+                new AlertFiltersMultipleOptionsPanel(extension, owner, alertFilterModel);
         this.add(alertFilterOptionsPanel);
     }
 


### PR DESCRIPTION
The alert filter dialog can be accessed via the global options, contexts and right clicking alerts.
Previously is assumed the parent was always the same which meant that in many cases it appeared under the main frame.
This change associates the parent with the dialog so that we can always display it correctly.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>