### PR TITLE
improve: domxss,sqliplugin, ascanrules: Add/update Top10 Mappings

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -52,8 +52,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
-                    CommonAlertTag.OWASP_2021_A03_INJECTION,
-                    CommonAlertTag.OWASP_2017_A01_INJECTION);
+                    CommonAlertTag.OWASP_2021_A03_INJECTION, CommonAlertTag.OWASP_2017_A07_XSS);
 
     private static final String GENERIC_SCRIPT_ALERT = "<script>alert(1);</script>";
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
@@ -48,8 +48,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
 
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
-                    CommonAlertTag.OWASP_2021_A03_INJECTION,
-                    CommonAlertTag.OWASP_2017_A01_INJECTION);
+                    CommonAlertTag.OWASP_2021_A03_INJECTION, CommonAlertTag.OWASP_2017_A07_XSS);
 
     private static final String GENERIC_SCRIPT_ALERT = "<script>alert(1);</script>";
     private static final List<Integer> GET_POST_TYPES =

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
@@ -69,15 +69,13 @@ class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScri
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(true)));
-        assertThat(
-                tags.containsKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
-                is(equalTo(true)));
+        assertThat(tags.containsKey(CommonAlertTag.OWASP_2017_A07_XSS.getTag()), is(equalTo(true)));
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));
         assertThat(
-                tags.get(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
-                is(equalTo(CommonAlertTag.OWASP_2017_A01_INJECTION.getValue())));
+                tags.get(CommonAlertTag.OWASP_2017_A07_XSS.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2017_A07_XSS.getValue())));
     }
 
     @Test

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRuleUnitTest.java
@@ -48,14 +48,12 @@ class PersistentXssScanRuleUnitTest extends ActiveScannerTest<PersistentXssScanR
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(true)));
-        assertThat(
-                tags.containsKey(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
-                is(equalTo(true)));
+        assertThat(tags.containsKey(CommonAlertTag.OWASP_2017_A07_XSS.getTag()), is(equalTo(true)));
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));
         assertThat(
-                tags.get(CommonAlertTag.OWASP_2017_A01_INJECTION.getTag()),
-                is(equalTo(CommonAlertTag.OWASP_2017_A01_INJECTION.getValue())));
+                tags.get(CommonAlertTag.OWASP_2017_A07_XSS.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2017_A07_XSS.getValue())));
     }
 }

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- OWASP Top Ten 2021/2017 mappings.
+
 ### Fixed
 - False Positives caused by un-related alerts or Basic auth prompts (Issue 6484).
 

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -21,13 +21,18 @@ zapAddOn {
                 register("selenium") {
                     version.set("15.*")
                 }
+                register("commonlib") {
+                    version.set(">= 1.5.0 & < 2.0.0")
+                }
             }
         }
     }
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
+    testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("selenium")!!)
     testImplementation("io.github.bonigarcia:webdrivermanager:4.2.2")
     testImplementation(project(":testutils"))

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -55,6 +55,7 @@ import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HtmlParameter;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.extension.selenium.ExtensionSelenium;
 import org.zaproxy.zap.model.Vulnerabilities;
@@ -112,7 +113,9 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
     private static final String RULE_BROWSER_ID = "rules.domxss.browserid";
 
     private static final Browser DEFAULT_BROWSER = Browser.FIREFOX_HEADLESS;
-
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A03_INJECTION, CommonAlertTag.OWASP_2017_A07_XSS);
     private static Map<Browser, Stack<WebDriverWrapper>> freeDrivers = new HashMap<>();
     private static List<WebDriverWrapper> takenDrivers = new ArrayList<>();
 
@@ -697,6 +700,10 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
     @Override
     public int getWascId() {
         return 8;
+    }
+
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
     }
 
     @Override

--- a/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
+++ b/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
@@ -22,11 +22,13 @@ package org.zaproxy.zap.extension.domxss;
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 import fi.iki.elonen.NanoHTTPD.IHTTPSession;
 import fi.iki.elonen.NanoHTTPD.Response;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import java.io.IOException;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -37,6 +39,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.selenium.Browser;
 import org.zaproxy.zap.testutils.ActiveScannerTestUtils;
 import org.zaproxy.zap.testutils.NanoServerHandler;
@@ -382,6 +385,26 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
 
         // Then
         assertAlertsRaised();
+    }
+
+    @Test
+    void shouldReturnExpectedMappings() {
+        // Given / When
+        int cwe = rule.getCweId();
+        Map<String, String> tags = rule.getAlertTags();
+        // Then
+        assertThat(cwe, is(equalTo(79)));
+        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(
+                tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(true)));
+        assertThat(tags.containsKey(CommonAlertTag.OWASP_2017_A07_XSS.getTag()), is(equalTo(true)));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.OWASP_2017_A07_XSS.getTag()),
+                is(equalTo(CommonAlertTag.OWASP_2017_A07_XSS.getValue())));
     }
 
     private class TestNanoServerHandler extends NanoServerHandler {

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add help and link to the code.
 - Add info and repo URLs.
+- OWASP Top Ten 2021/2017 mappings.
 
 ### Fixed
  - Terminology

--- a/addOns/sqliplugin/sqliplugin.gradle.kts
+++ b/addOns/sqliplugin/sqliplugin.gradle.kts
@@ -15,6 +15,14 @@ zapAddOn {
             baseName.set("help%LC%.helpset")
             localeToken.set("%LC%")
         }
+
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">= 1.5.0 & < 2.0.0")
+                }
+            }
+        }
     }
 }
 
@@ -25,6 +33,8 @@ crowdin {
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("commonlib")!!)
+
     implementation("org.jdom:jdom:2.0.2")
 }
 

--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,6 +38,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
 
@@ -63,7 +65,10 @@ public class SQLInjectionScanRule extends AbstractAppParamPlugin {
     // Payload used for checking of existence of IDS/WAF (dummier the better)
     // IDS_WAF_CHECK_PAYLOAD = "AND 1=1 UNION ALL SELECT 1,2,3,table_name FROM
     // information_schema.tables"
-
+    private static final Map<String, String> ALERT_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A03_INJECTION,
+                    CommonAlertTag.OWASP_2017_A01_INJECTION);
     // ------------------------------------------------------------------
     // Configuration properties
     // ------------------------------------------------------------------
@@ -1085,6 +1090,10 @@ public class SQLInjectionScanRule extends AbstractAppParamPlugin {
                 .setOtherInfo(otherInfo)
                 .setMessage(message)
                 .raise();
+    }
+
+    public Map<String, String> getAlertTags() {
+        return ALERT_TAGS;
     }
 
     /**


### PR DESCRIPTION
ascanrules
- Update XSS rules to use the XSS mapping for 2017.

domxss & sqliplugin
- Updated scan rules and unit tests (some unit test classes added).
- Fixed naming (and help link) for MySql scan rule and unit test.
- Update build files to depend on commonlib.
- Added note to CHANGELOG.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>