### PR TITLE
Update codebase to ZAP 2.11

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Don't set the font color for inherited entries (Issue 6397).
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes (some changes impact the visibility of variables and add getters/setters, which may impact third party add-ons or scripts).
 - Change to no longer rely on core report classes, which are going to be deleted.
 

--- a/addOns/accessControl/accessControl.gradle.kts
+++ b/addOns/accessControl/accessControl.gradle.kts
@@ -2,7 +2,7 @@ description = "Adds a set of tools for testing access control in web application
 
 zapAddOn {
     addOnName.set("Access Control Testing")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -117,7 +117,12 @@ subprojects {
         }
     }
 
-    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.10.0"))
+    val zapGav = "org.zaproxy:zap:2.11.0-20210929.165234-4"
+    dependencies {
+        "zap"(zapGav)
+    }
+
+    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create(zapGav))
 
     zapAddOn {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })

--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Stats for alerts changed
 
+### Changed
+- Update minimum ZAP version to 2.11.0.
+
 ### Fixed
 - Dialogs being shown under the owning dialog / frame.
 

--- a/addOns/alertFilters/alertFilters.gradle.kts
+++ b/addOns/alertFilters/alertFilters.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows you to automate the changing of alert risk levels."
 zapAddOn {
     addOnName.set("Alert Filters")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/allinonenotes/CHANGELOG.md
+++ b/addOns/allinonenotes/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Update link to repository.
 - Maintenance changes.
 

--- a/addOns/allinonenotes/allinonenotes.gradle.kts
+++ b/addOns/allinonenotes/allinonenotes.gradle.kts
@@ -2,7 +2,7 @@ description = "A simple extension to view all notes in one pane."
 
 zapAddOn {
     addOnName.set("All In One Notes")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("David Vassallo")

--- a/addOns/amf/CHANGELOG.md
+++ b/addOns/amf/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 
 ## 2 - 2017-05-26
 

--- a/addOns/amf/amf.gradle.kts
+++ b/addOns/amf/amf.gradle.kts
@@ -6,7 +6,7 @@ repositories {
 
 zapAddOn {
     addOnName.set("AMF Support")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Added OWASP Top Ten 2021/2017 mappings.
+- Update minimum ZAP version to 2.11.0.
 
 ## [40] - 2021-06-17
 ### Changed

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -5,7 +5,7 @@ description = "The release quality Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/BufferOverflowScanRule.java
@@ -155,6 +155,7 @@ public class BufferOverflowScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
@@ -117,6 +117,7 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -326,6 +326,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrlfInjectionScanRule.java
@@ -144,6 +144,7 @@ public class CrlfInjectionScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -745,6 +745,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_HIGH;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/DirectoryBrowsingScanRule.java
@@ -156,6 +156,7 @@ public class DirectoryBrowsingScanRule extends AbstractAppPlugin {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ElmahScanRule.java
@@ -64,6 +64,7 @@ public class ElmahScanRule extends AbstractHostFilePlugin {
         return PLUGIN_ID;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExternalRedirectScanRule.java
@@ -467,6 +467,7 @@ public class ExternalRedirectScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_HIGH;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
@@ -287,6 +287,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HtAccessScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/HtAccessScanRule.java
@@ -82,6 +82,7 @@ public class HtAccessScanRule extends AbstractAppFilePlugin {
         return false;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
@@ -229,6 +229,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -652,6 +652,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_HIGH;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
@@ -684,6 +684,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_HIGH;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
@@ -264,6 +264,7 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_HIGH;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ServerSideIncludeScanRule.java
@@ -187,6 +187,7 @@ public class ServerSideIncludeScanRule extends AbstractAppParamPlugin {
         return Alert.RISK_HIGH;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SourceCodeDisclosureWebInfScanRule.java
@@ -336,6 +336,7 @@ public class SourceCodeDisclosureWebInfScanRule extends AbstractHostPlugin {
         return Alert.RISK_HIGH;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -1971,6 +1971,7 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
         return result;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [31] - 2021-06-17
 ### Changed

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -18,14 +18,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.11.0-20210929.165234-4")
     compileOnly(parent!!.childProjects.get("commonlib")!!)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -39,14 +39,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.11.0-20210929.165234-4")
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
     compileOnly(parent!!.childProjects.get("oast")!!)

--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Dynamically unload the add-on.
 - Change info URL to link to the site.
 

--- a/addOns/authstats/authstats.gradle.kts
+++ b/addOns/authstats/authstats.gradle.kts
@@ -2,7 +2,7 @@ description = "Records logged in/out statistics for all contexts in scope."
 
 zapAddOn {
     addOnName.set("Authentication Statistics")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  - API support: runplan action and planprogress view.
 ### Changed
  - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
+
 ### Fixed
  - "Unexpected obj object java.lang.String" error shown during initialization
 

--- a/addOns/automation/automation.gradle.kts
+++ b/addOns/automation/automation.gradle.kts
@@ -2,7 +2,7 @@ description = "Automation Framework."
 
 zapAddOn {
     addOnName.set("Automation Framework")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -187,7 +187,7 @@ class ActiveScanJobUnitTest {
                 job.getConfigParameters(new ScannerParamWrapper(), job.getParamMethodName());
 
         // Then
-        assertThat(params.size(), is(equalTo(9)));
+        assertThat(params.size(), is(equalTo(10)));
 
         assertThat(params.containsKey("addQueryParam"), is(equalTo(true)));
         assertThat(params.containsKey("defaultPolicy"), is(equalTo(true)));
@@ -198,6 +198,7 @@ class ActiveScanJobUnitTest {
         assertThat(params.containsKey("maxScanDurationInMins"), is(equalTo(true)));
         assertThat(params.containsKey("scanHeadersAllRequests"), is(equalTo(true)));
         assertThat(params.containsKey("threadPerHost"), is(equalTo(true)));
+        assertThat(params.containsKey("scanNullJsonValues"), is(equalTo(true)));
     }
 
     private static class ScannerParamWrapper {

--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 - Improve permissions and space handling when saving.
 

--- a/addOns/beanshell/beanshell.gradle.kts
+++ b/addOns/beanshell/beanshell.gradle.kts
@@ -5,7 +5,7 @@ description = "Provides a BeanShell Console"
 zapAddOn {
     addOnName.set("BeanShell Console")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 - Make missing JavaFX logging less verbose in regular use.
 

--- a/addOns/browserView/browserView.gradle.kts
+++ b/addOns/browserView/browserView.gradle.kts
@@ -26,7 +26,7 @@ if (JavaVersion.current() <= JavaVersion.VERSION_1_10) {
 
 zapAddOn {
     addOnName.set("Browser View")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Send HTTP messages with ZAP, making use of all its features (e.g. user authentication, custom user-agent, HTTP Sender scripts) (Issues 173 and 3060).
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [10] - 2020-12-15
 

--- a/addOns/bruteforce/bruteforce.gradle.kts
+++ b/addOns/bruteforce/bruteforce.gradle.kts
@@ -5,7 +5,7 @@ description = "Forced browsing of files and directories using code from the OWAS
 zapAddOn {
     addOnName.set("Forced Browse")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 - Remove broken link from the user guide.
 

--- a/addOns/bugtracker/bugtracker.gradle.kts
+++ b/addOns/bugtracker/bugtracker.gradle.kts
@@ -6,7 +6,7 @@ tasks.withType<JavaCompile> {
 
 zapAddOn {
     addOnName.set("Bug Tracker")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/callgraph/CHANGELOG.md
+++ b/addOns/callgraph/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## 4 - 2017-11-24

--- a/addOns/callgraph/callgraph.gradle.kts
+++ b/addOns/callgraph/callgraph.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows the user to view a call graph of the selected resources"
 
 zapAddOn {
     addOnName.set("Call Graph")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Colm O'Flaherty")

--- a/addOns/codedx/CHANGELOG.md
+++ b/addOns/codedx/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Change info URL to link to the site.
 - Maintenance changes.
 - Change to no longer rely on core report classes, which are going to be deleted.

--- a/addOns/codedx/codedx.gradle.kts
+++ b/addOns/codedx/codedx.gradle.kts
@@ -2,7 +2,7 @@ description = "Includes request and response data in XML reports and provides th
 
 zapAddOn {
     addOnName.set("Code Dx Extension")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Code Dx, Inc.")

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Common alert tags for OWASP Top Ten 2021 and 2017.
 
+### Changed
+- Update minimum ZAP version to 2.11.0.
+
 ## [1.4.0] - 2021-06-23
 ### Added
 - An HTTP date parser/formatter.

--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -15,7 +15,7 @@ description = "A common library, for use by other add-ons."
 zapAddOn {
     addOnName.set("Common Library")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/coreLang/CHANGELOG.md
+++ b/addOns/coreLang/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Added more people to the credits.
 
 ## 13 - 2018-01-15

--- a/addOns/coreLang/coreLang.gradle.kts
+++ b/addOns/coreLang/coreLang.gradle.kts
@@ -5,7 +5,7 @@ description = "Translations of the core language files"
 zapAddOn {
     addOnName.set("Core Language Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [0.10.0] - 2021-06-17
 ### Added

--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -2,7 +2,7 @@ description = "Ability to add, edit or remove payloads that are used i.e. by act
 
 zapAddOn {
     addOnName.set("Custom Payloads")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/diff/CHANGELOG.md
+++ b/addOns/diff/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 - Updated menu items to use title caps (Issue 2000).
 

--- a/addOns/diff/diff.gradle.kts
+++ b/addOns/diff/diff.gradle.kts
@@ -5,7 +5,7 @@ description = "Displays a dialog showing the differences between 2 requests or r
 zapAddOn {
     addOnName.set("Diff")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv1/CHANGELOG.md
+++ b/addOns/directorylistv1/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 
 ## [4] - 2020-01-17
 ### Added

--- a/addOns/directorylistv1/directorylistv1.gradle.kts
+++ b/addOns/directorylistv1/directorylistv1.gradle.kts
@@ -5,7 +5,7 @@ description = "List of directory names to be used with Forced Browse or Fuzzer a
 zapAddOn {
     addOnName.set("Directory List v1.0")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3/CHANGELOG.md
+++ b/addOns/directorylistv2_3/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Change info URL to link to the site.
 
 ## 3 - 2015-12-04

--- a/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
+++ b/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
@@ -5,7 +5,7 @@ description = "Lists of directory names to be used with Forced Browse or Fuzzer 
 zapAddOn {
     addOnName.set("Directory List v2.3")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3_lc/CHANGELOG.md
+++ b/addOns/directorylistv2_3_lc/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Change info URL to link to the site.
 
 ## 3 - 2015-12-04

--- a/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
+++ b/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
@@ -5,7 +5,7 @@ description = "Lists of lower case directory names to be used with Forced Browse
 zapAddOn {
     addOnName.set("Directory List v2.3 LC")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update links to repository.
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [10] - 2020-12-15
 ### Added

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -5,7 +5,7 @@ description = "DOM XSS Active scanner rule"
 zapAddOn {
     addOnName.set("DOM XSS Active scanner rule")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Aabha Biyani, ZAP Dev Team")

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -702,6 +702,7 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
         return 8;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ### Removed
 - Groovy default template moved to Groovy add-on.

--- a/addOns/encoder/encoder.gradle.kts
+++ b/addOns/encoder/encoder.gradle.kts
@@ -5,7 +5,7 @@ description = "Adds encode/decode/hash dialog and support for scripted processor
 zapAddOn {
     addOnName.set("Encoder")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -5,7 +5,7 @@ description = "Import and Export functionality"
 zapAddOn {
     addOnName.set("Import/Export")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team & thatsn0tmysite")

--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [3] - 2020-12-15
 ### Added

--- a/addOns/formhandler/formhandler.gradle.kts
+++ b/addOns/formhandler/formhandler.gradle.kts
@@ -5,7 +5,7 @@ description = "This Form Handler Add-on allows a user to define field names and 
 zapAddOn {
     addOnName.set("Form Handler")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/frontendscanner/frontendscanner.gradle.kts
+++ b/addOns/frontendscanner/frontendscanner.gradle.kts
@@ -2,7 +2,7 @@ description = "Scan modern web applications relying heavily on Javascript."
 
 zapAddOn {
     addOnName.set("Front-end Scanner")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The 'Delay when Fuzzing (in milliseconds)' value can now be up to an hour (3,600,000ms), and the control was changed from a slider to a spinner (Issue 6651).
 - Updated the fuzzer options documentation (Issue 6791).
 - Fixed title caps on items in the Fuzzer options panel (Issue 2000).
+- Update minimum ZAP version to 2.11.0.
 
 ## [13.2.0] - 2021-06-01
 ### Changed

--- a/addOns/fuzz/fuzz.gradle.kts
+++ b/addOns/fuzz/fuzz.gradle.kts
@@ -16,7 +16,7 @@ tasks.withType<JavaCompile> {
 zapAddOn {
     addOnName.set("Fuzzer")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/fuzzdb/CHANGELOG.md
+++ b/addOns/fuzzdb/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 
 ### Fixed
  - Terminology

--- a/addOns/fuzzdb/fuzzdb.gradle.kts
+++ b/addOns/fuzzdb/fuzzdb.gradle.kts
@@ -16,7 +16,7 @@ description = "FuzzDB files which can be used with the ZAP fuzzer"
 zapAddOn {
     addOnName.set("FuzzDB Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/gettingStarted/CHANGELOG.md
+++ b/addOns/gettingStarted/CHANGELOG.md
@@ -11,11 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [12] - 2020-12-15
 ### Changed
 - Update link to OWASP ZAP homepage.
-- Updated for 2.10.0
 - Update minimum ZAP version to 2.10.0.
-
-### Changed
-- Update minimum ZAP version to 2.9.0.
 
 ## [11] - 2020-01-17
 ### Added

--- a/addOns/gettingStarted/gettingStarted.gradle.kts
+++ b/addOns/gettingStarted/gettingStarted.gradle.kts
@@ -5,7 +5,7 @@ description = "A short Getting Started with ZAP Guide"
 zapAddOn {
     addOnName.set("Getting Started with ZAP Guide")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - encode-decode Default and rot13 templates.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Update links to zaproxy repo.
 
 ## [0.1.0] - 2020-11-17

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -5,7 +5,7 @@ description = "Provides the GraalVM JavaScript engine for ZAP scripting."
 zapAddOn {
     addOnName.set("GraalVM JavaScript")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [0.5.0] - 2021-09-16
 ### Fixed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -2,7 +2,7 @@ description = "Inspect and attack GraphQL endpoints."
 
 zapAddOn {
     addOnName.set("GraphQL Support")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update links to zaproxy and zap-extensions repos.
+- Update minimum ZAP version to 2.11.0.
 
 ## [3.0.0] - 2020-12-15
 ### Added

--- a/addOns/groovy/groovy.gradle.kts
+++ b/addOns/groovy/groovy.gradle.kts
@@ -5,7 +5,7 @@ description = "Adds Groovy support to ZAP"
 zapAddOn {
     addOnName.set("Groovy Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/highlighter/CHANGELOG.md
+++ b/addOns/highlighter/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 
 ## 7 - 2018-05-30
 

--- a/addOns/highlighter/highlighter.gradle.kts
+++ b/addOns/highlighter/highlighter.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to highlight strings in the request and response tabs.
 
 zapAddOn {
     addOnName.set("Highlighter")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/httpsInfo/CHANGELOG.md
+++ b/addOns/httpsInfo/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show usage info in the HTTPS Info panel (Issue 6113).
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Updated owasp.org references (Issue 5962).
 - Maintenance changes.
 

--- a/addOns/httpsInfo/httpsInfo.gradle.kts
+++ b/addOns/httpsInfo/httpsInfo.gradle.kts
@@ -2,7 +2,7 @@ description = "Displays HTTPS configuration information."
 
 zapAddOn {
     addOnName.set("HttpsInfo")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update link to repository.
-- Minimum ZAP version is now 2.10.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## [2] - 2020-07-03

--- a/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
+++ b/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
@@ -5,7 +5,7 @@ description = "Image Location and Privacy Passive Scanner"
 zapAddOn {
     addOnName.set("Image Location and Privacy Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Jay Ball (veggiespam) and the ZAP Dev Team")

--- a/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
+++ b/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
@@ -184,6 +184,7 @@ public class ImageLocationScanRule extends PluginPassiveScanner {
         return alerts;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/importLogFiles/CHANGELOG.md
+++ b/addOns/importLogFiles/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Internationalise some strings.
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Add import menu to (new) top level Import menu instead of Analyse menu.
 - Change info URL to link to the site.
 - Maintenance changes.

--- a/addOns/importLogFiles/importLogFiles.gradle.kts
+++ b/addOns/importLogFiles/importLogFiles.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to import log files from ModSecurity and files previou
 
 zapAddOn {
     addOnName.set("Log File Importer")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Joseph Kirwin, ZAP Dev Team")

--- a/addOns/importurls/CHANGELOG.md
+++ b/addOns/importurls/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## [7] - 2020-01-17

--- a/addOns/importurls/importurls.gradle.kts
+++ b/addOns/importurls/importurls.gradle.kts
@@ -5,7 +5,7 @@ description = "Adds an option to import a file of URLs. The file must be plain t
 zapAddOn {
     addOnName.set("Import files containing URLs")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## [10] - 2020-01-17

--- a/addOns/invoke/invoke.gradle.kts
+++ b/addOns/invoke/invoke.gradle.kts
@@ -5,7 +5,7 @@ description = "Invoke external applications passing context related information 
 zapAddOn {
     addOnName.set("Invoke Applications")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update links to zaproxy repo.
 - Rename reliability to confidence in active/passive templates.
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [7] - 2020-12-15
 ### Added

--- a/addOns/jruby/jruby.gradle.kts
+++ b/addOns/jruby/jruby.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows Ruby to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Ruby Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jsonview/CHANGELOG.md
+++ b/addOns/jsonview/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Capitalize the view dropdown menu entry (related to Issue 2000).
 
 ## 1 - 2018-02-08

--- a/addOns/jsonview/jsonview.gradle.kts
+++ b/addOns/jsonview/jsonview.gradle.kts
@@ -2,7 +2,7 @@ description = "Adds a view that shows JSON messages nicely formatted"
 
 zapAddOn {
     addOnName.set("JSON View")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Juha Kivekäs")

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update links to zaproxy repo.
 - Rename reliability to confidence in active/passive templates.
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [11] - 2020-12-15
 ### Added

--- a/addOns/jython/jython.gradle.kts
+++ b/addOns/jython/jython.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows Python to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Python Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Use appropriate syntax style for highlighting of code (requires newer ZAP version).
-- Update minimum ZAP version to 2.10.0.
+- Use appropriate syntax style for highlighting of code.
+- Update minimum ZAP version to 2.11.0.
 
 ## [1.0.0] - 2020-09-14
 

--- a/addOns/kotlin/kotlin.gradle.kts
+++ b/addOns/kotlin/kotlin.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows Kotlin to be used for ZAP scripting"
 zapAddOn {
     addOnName.set("Kotlin Support")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("StackHawk Engineering")

--- a/addOns/kotlin/src/main/java/org/zaproxy/addon/kotlin/KotlinEngineWrapper.java
+++ b/addOns/kotlin/src/main/java/org/zaproxy/addon/kotlin/KotlinEngineWrapper.java
@@ -27,6 +27,7 @@ import javax.script.ScriptException;
 import javax.swing.ImageIcon;
 import kotlin.script.experimental.jsr223.KotlinJsr223DefaultScriptEngineFactory;
 import kotlin.script.experimental.jsr223.KotlinJsr223DefaultScriptEngineFactoryKt;
+import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.script.DefaultEngineWrapper;
 
@@ -57,8 +58,7 @@ public class KotlinEngineWrapper extends DefaultEngineWrapper {
 
     @Override
     public String getSyntaxStyle() {
-        // TODO Use constant when available: SyntaxConstants.SYNTAX_STYLE_KOTLIN
-        return "text/kotlin";
+        return SyntaxConstants.SYNTAX_STYLE_KOTLIN;
     }
 
     @Override

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 ### Changed
 - Updated the default Interactsh server URL to https://interactsh.com.
+- Update minimum ZAP version to 2.11.0.
 
 ## [0.4.0] - 2021-09-22
 ### Added

--- a/addOns/oast/oast.gradle.kts
+++ b/addOns/oast/oast.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to exploit out-of-band vulnerabilities"
 
 zapAddOn {
     addOnName.set("OAST Support")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -48,7 +48,7 @@ public class ExtensionOast extends ExtensionAdaptor {
 
     private static final String NAME = ExtensionOast.class.getSimpleName();
     private static final Logger LOGGER = LogManager.getLogger(ExtensionOast.class);
-    static final int HISTORY_TYPE_OAST = 22; // Equal to HistoryReference.TYPE_OAST
+    static final int HISTORY_TYPE_OAST = HistoryReference.TYPE_OAST;
 
     private final Map<String, OastService> services = new HashMap<>();
     private OastOptionsPanel oastOptionsPanel;
@@ -183,12 +183,6 @@ public class ExtensionOast extends ExtensionAdaptor {
     @Override
     public boolean canUnload() {
         return true;
-    }
-
-    // TODO: Remove once targeting >= 2.11, refer to issue 6536.
-    @Override
-    public void unload() {
-        stop();
     }
 
     @Override

--- a/addOns/onlineMenu/CHANGELOG.md
+++ b/addOns/onlineMenu/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [8] - 2020-12-15
 ### Added

--- a/addOns/onlineMenu/onlineMenu.gradle.kts
+++ b/addOns/onlineMenu/onlineMenu.gradle.kts
@@ -5,7 +5,7 @@ description = "ZAP Online menu items"
 zapAddOn {
     addOnName.set("Online menus")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Warn when request has content `application/xml`, not supported (Related to [Issue #6767](https://github.com/zaproxy/zaproxy/issues/6767)).
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [22] - 2021-09-16
 ### Changed

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -5,7 +5,7 @@ description = "Imports and spiders OpenAPI definitions."
 zapAddOn {
     addOnName.set("OpenAPI Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak, Marcin Spiewak, and SDA SE Open Industry Solutions")

--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Issue 2000 - Updated strings shown in context menu with title caps.
 - Change info URL to link to the site.
 - Maintenance changes.

--- a/addOns/plugnhack/plugnhack.gradle.kts
+++ b/addOns/plugnhack/plugnhack.gradle.kts
@@ -5,7 +5,7 @@ description = "Supports the Mozilla Plug-n-Hack standard: https://developer.mozi
 zapAddOn {
     addOnName.set("Plug-n-Hack Configuration")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Update default values in the options to match the ones in the default configuration file.
 - Maintenance changes.
 

--- a/addOns/portscan/portscan.gradle.kts
+++ b/addOns/portscan/portscan.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows to port scan a target server"
 zapAddOn {
     addOnName.set("Port Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - OWASP Top Ten 2021/2017 mappings.
 
+### Changed
+- Update minimum ZAP version to 2.11.0.
+
 ### Fixed
 - Fixed reference URL on CORS misconfiguration.
 - Reduce false positives from Private IP Disclosure scan rule (Issue 6749).

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -5,7 +5,7 @@ description = "The release quality Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -132,6 +132,7 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -401,6 +401,7 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentTypeMissingScanRule.java
@@ -101,6 +101,7 @@ public class ContentTypeMissingScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRule.java
@@ -123,6 +123,7 @@ public class CookieHttpOnlyScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieLooselyScopedScanRule.java
@@ -210,6 +210,7 @@ public class CookieLooselyScopedScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSameSiteScanRule.java
@@ -146,6 +146,7 @@ public class CookieSameSiteScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRule.java
@@ -132,6 +132,7 @@ public class CookieSecureFlagScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainMisconfigurationScanRule.java
@@ -161,6 +161,7 @@ public class CrossDomainMisconfigurationScanRule extends PluginPassiveScanner {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CrossDomainScriptInclusionScanRule.java
@@ -118,6 +118,7 @@ public class CrossDomainScriptInclusionScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -287,6 +287,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
         return "Failed to load vulnerability reference from file";
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoPrivateAddressDisclosureScanRule.java
@@ -145,6 +145,7 @@ public class InfoPrivateAddressDisclosureScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InfoSessionIdUrlScanRule.java
@@ -119,6 +119,7 @@ public class InfoSessionIdUrlScanRule extends PluginPassiveScanner {
         return Alert.RISK_MEDIUM;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureDebugErrorsScanRule.java
@@ -154,6 +154,7 @@ public class InformationDisclosureDebugErrorsScanRule extends PluginPassiveScann
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureInUrlScanRule.java
@@ -182,6 +182,7 @@ public class InformationDisclosureInUrlScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureReferrerScanRule.java
@@ -244,6 +244,7 @@ public class InformationDisclosureReferrerScanRule extends PluginPassiveScanner 
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InformationDisclosureSuspiciousCommentsScanRule.java
@@ -244,6 +244,7 @@ public class InformationDisclosureSuspiciousCommentsScanRule extends PluginPassi
         return Constant.messages.getString(MESSAGE_PREFIX + "desc");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/InsecureJsfViewStatePassiveScanRule.java
@@ -247,6 +247,7 @@ public class InsecureJsfViewStatePassiveScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/MixedContentScanRule.java
@@ -160,6 +160,7 @@ public class MixedContentScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -265,6 +265,7 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", evidence, formattedDate);
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
@@ -157,6 +157,7 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "otherinfo", hashType, hashValue);
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
@@ -185,6 +185,7 @@ public class ViewstateScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "soln");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XAspNetVersionScanRule.java
@@ -95,6 +95,7 @@ public class XAspNetVersionScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XContentTypeOptionsScanRule.java
@@ -132,6 +132,7 @@ public class XContentTypeOptionsScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XDebugTokenScanRule.java
@@ -154,6 +154,7 @@ public class XDebugTokenScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XFrameOptionScanRule.java
@@ -152,6 +152,7 @@ public class XFrameOptionScanRule extends PluginPassiveScanner {
         return PLUGIN_ID;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/XPoweredByHeaderInfoLeakScanRule.java
@@ -158,6 +158,7 @@ public class XPoweredByHeaderInfoLeakScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Ignore CSS, JavaScript, images, or font files when scanning for source code disclosures (Issues: 6595, 6795, & 6820).
+- Update minimum ZAP version to 2.11.0.
 
 ## [33] - 2021-07-07
 ### Fixed

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -2,7 +2,7 @@ description = "The alpha quality Passive Scanner rules"
 
 zapAddOn {
     addOnName.set("Passive scanner rules (alpha)")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/Base64Disclosure.java
@@ -369,6 +369,7 @@ public class Base64Disclosure extends PluginPassiveScanner {
         return 10094;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/InPageBannerInfoLeakScanRule.java
@@ -86,6 +86,7 @@ public class InPageBannerInfoLeakScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
@@ -201,6 +201,7 @@ public class JsFunctionScanRule extends PluginPassiveScanner {
         return PLUGIN_ID;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsoScanRule.java
@@ -158,6 +158,7 @@ public class JsoScanRule extends PluginPassiveScanner {
         return 90002;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/PermissionsPolicyScanRule.java
@@ -116,6 +116,7 @@ public class PermissionsPolicyScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SiteIsolationScanRule.java
@@ -110,6 +110,7 @@ public class SiteIsolationScanRule extends PluginPassiveScanner {
         return PLUGIN_ID;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
@@ -719,6 +719,7 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
         return 10099;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
@@ -145,6 +145,7 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner 
         return 90003;
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Reverse Tabnabbing Scan Rule will now alert when the 'opener' keyword is present.
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [26] - 2021-07-29
 ### Fixed

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -5,7 +5,7 @@ description = "The beta quality Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/BigRedirectsScanRule.java
@@ -137,6 +137,7 @@ public class BigRedirectsScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ContentSecurityPolicyMissingScanRule.java
@@ -160,6 +160,7 @@ public class ContentSecurityPolicyMissingScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + key);
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/DirectoryBrowsingScanRule.java
@@ -179,6 +179,7 @@ public class DirectoryBrowsingScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HashDisclosureScanRule.java
@@ -293,6 +293,7 @@ public class HashDisclosureScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", arg0);
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/HeartBleedScanRule.java
@@ -148,6 +148,7 @@ public class HeartBleedScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "extrainfo", opensslVersion);
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormLoadScanRule.java
@@ -139,6 +139,7 @@ public class InsecureFormLoadScanRule extends PluginPassiveScanner {
                 formElement.toString());
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/InsecureFormPostScanRule.java
@@ -139,6 +139,7 @@ public class InsecureFormPostScanRule extends PluginPassiveScanner {
                 formElement.toString());
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
@@ -227,6 +227,7 @@ public class LinkTargetScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
@@ -243,6 +243,7 @@ public class PiiScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "name");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServerHeaderInfoLeakScanRule.java
@@ -108,6 +108,7 @@ public class ServerHeaderInfoLeakScanRule extends PluginPassiveScanner {
         return Constant.messages.getString("pscanbeta.serverheader.rule.name");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ServletParameterPollutionScanRule.java
@@ -122,6 +122,7 @@ public class ServletParameterPollutionScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/StrictTransportSecurityScanRule.java
@@ -185,6 +185,7 @@ public class StrictTransportSecurityScanRule extends PluginPassiveScanner {
         return Constant.messages.getString(MESSAGE_PREFIX + "rule.name");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
@@ -215,6 +215,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner {
         // Nothing to do.
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCookieScanRule.java
@@ -174,6 +174,7 @@ public class UserControlledCookieScanRule extends PluginPassiveScanner {
         // Nothing to do.
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
@@ -266,6 +266,7 @@ public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner {
         // Nothing to do.
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
@@ -196,6 +196,7 @@ public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner 
         // Nothing to do.
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledOpenRedirectScanRule.java
@@ -154,6 +154,7 @@ public class UserControlledOpenRedirectScanRule extends PluginPassiveScanner {
         // Nothing to do.
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XBackendServerInformationLeakScanRule.java
@@ -100,6 +100,7 @@ public class XBackendServerInformationLeakScanRule extends PluginPassiveScanner 
         return Constant.messages.getString(MESSAGE_PREFIX + "refs");
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/XChromeLoggerDataInfoLeakScanRule.java
@@ -126,6 +126,7 @@ public class XChromeLoggerDataInfoLeakScanRule extends PluginPassiveScanner {
         }
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -62,15 +62,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.11.0-20210923.152813-2")
-
     compileOnly(parent!!.childProjects.get("reports")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
     compileOnly(parent!!.childProjects.get("spiderAjax")!!)

--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 
 ### Fixed
  - Close dialogues when the add-on is uninstalled.

--- a/addOns/regextester/regextester.gradle.kts
+++ b/addOns/regextester/regextester.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows to test Regular Expressions"
 
 zapAddOn {
     addOnName.set("Regular Expression Tester")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Update links to zaproxy repo.
 - Maintenance changes.
 

--- a/addOns/replacer/replacer.gradle.kts
+++ b/addOns/replacer/replacer.gradle.kts
@@ -5,7 +5,7 @@ description = "Easy way to replace strings in requests and responses."
 zapAddOn {
     addOnName.set("Replacer")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -45,14 +45,7 @@ crowdin {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.11.0-20210929.093237-3")
     compileOnly(parent!!.childProjects.get("automation")!!)
     implementation("org.thymeleaf:thymeleaf:3.0.12.RELEASE")
     implementation("org.xhtmlrenderer:flying-saucer-pdf:9.1.20")

--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Warn when unable to save (malformed) HTTP message (Issue 4235).
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 - Add button to automatically update content length (Issue 6254).
 

--- a/addOns/requester/requester.gradle.kts
+++ b/addOns/requester/requester.gradle.kts
@@ -2,7 +2,7 @@ description = "Request numbered panel."
 
 zapAddOn {
     addOnName.set("Requester")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Surikato")

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [0.1.0] - 2021-09-16
 ### Changed

--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -2,7 +2,7 @@ description = "An add-on to retest for presence/absence of previously generated 
 
 zapAddOn {
     addOnName.set("Retest")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [0.8.0] - 2021-08-25
 ### Changed

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -5,7 +5,7 @@ description = "Retire.js"
 zapAddOn {
     addOnName.set("Retire.js")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Nikita Mundhada and the ZAP Dev Team")

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -129,6 +129,7 @@ public class RetireScanRule extends PluginPassiveScanner {
         return sb.toString();
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/reveal/CHANGELOG.md
+++ b/addOns/reveal/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## [3] - 2020-01-17

--- a/addOns/reveal/reveal.gradle.kts
+++ b/addOns/reveal/reveal.gradle.kts
@@ -5,7 +5,7 @@ description = "Show hidden fields and enable disabled fields"
 zapAddOn {
     addOnName.set("Reveal")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## 3 - 2017-11-28

--- a/addOns/revisit/revisit.gradle.kts
+++ b/addOns/revisit/revisit.gradle.kts
@@ -2,7 +2,7 @@ description = "Revisit a site at any time in the past using the session history"
 
 zapAddOn {
     addOnName.set("Revisit")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## [8] - 2019-08-30

--- a/addOns/saml/saml.gradle.kts
+++ b/addOns/saml/saml.gradle.kts
@@ -2,7 +2,7 @@ description = "Detect, Show, Edit, Fuzz SAML requests"
 
 zapAddOn {
     addOnName.set("SAML Support")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java
@@ -45,13 +45,9 @@ public class SAMLPassiveScanner extends PluginPassiveScanner {
     private void scanMessage(HttpMessage msg, int id) {
         SAMLInspectionResult samlInspectionResult = SAMLUtils.inspectMessage(msg);
         if (samlInspectionResult.hasSAMLMessage()) {
-            addTag(id);
+            parent.addTag("SAML");
             raiseAlert(samlInspectionResult);
         }
-    }
-
-    private void addTag(int id) {
-        parent.addTag(id, "SAML");
     }
 
     private void raiseAlert(SAMLInspectionResult samlInspectionResult) {

--- a/addOns/saverawmessage/CHANGELOG.md
+++ b/addOns/saverawmessage/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 
 ## [5] - 2020-01-17
 ### Added

--- a/addOns/saverawmessage/saverawmessage.gradle.kts
+++ b/addOns/saverawmessage/saverawmessage.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows to save content of HTTP messages as binary"
 zapAddOn {
     addOnName.set("Save Raw Message")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/savexmlmessage/CHANGELOG.md
+++ b/addOns/savexmlmessage/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 
 ## [0.1.0] - 2020-01-17
 ### Added

--- a/addOns/savexmlmessage/savexmlmessage.gradle.kts
+++ b/addOns/savexmlmessage/savexmlmessage.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows to save content of HTTP messages as XML"
 
 zapAddOn {
     addOnName.set("Save XML Message")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("thatsn0tmysite")

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Allow to choose Kotlin for syntax highlighting (requires newer ZAP version).
+- Allow to choose Kotlin for syntax highlighting.
 
 ### Changed
 - Do not show `Null` script engine in Edit Script dialogue.
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance Changes.
 - 'Copy as curl command menu.js' is now preceded by a separator, and the Title Caps of the menu item were fixed (Issue 2000).
 - 'Copy as curl command menu.js' is now available in safe mode.
+- Update minimum ZAP version to 2.11.0.
 
 ## [28] - 2020-12-18
 

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -5,7 +5,7 @@ description = "Supports all JSR 223 scripting languages"
 zapAddOn {
     addOnName.set("Script Console")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -508,11 +508,11 @@ public class ConsolePanel extends AbstractPanel implements Tab {
      * @see #getStopButton()
      * @see #setButtonsAllowRunScript(boolean)
      * @see #updateButtonsStateScriptRunning()
-     * @see ScriptWrapper#isRunableStandalone()
+     * @see ScriptWrapper#isRunnableStandalone()
      */
     private void updateButtonsState() {
         // The only type that can be run directly from the console
-        if (script == null || !script.isRunableStandalone()) {
+        if (script == null || !script.isRunnableStandalone()) {
             setButtonsAllowRunScript(false);
             return;
         }

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxHighlightTextArea.java
@@ -22,7 +22,6 @@ package org.zaproxy.zap.extension.scripts;
 import java.awt.Component;
 import java.awt.Font;
 import java.io.IOException;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Vector;
 import javax.swing.Action;
@@ -79,8 +78,6 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
     private static final String RESOURCE_DARK = "/org/fife/ui/rsyntaxtextarea/themes/dark.xml";
     private static final String RESOURCE_LIGHT = "/org/fife/ui/rsyntaxtextarea/themes/default.xml";
 
-    private Boolean supportsDarkLaF;
-    private Method isDarkLookAndFeelMethod;
     private Boolean darkLaF;
 
     public SyntaxHighlightTextArea() {
@@ -96,8 +93,7 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
         addSyntaxStyle(SCALA_SYNTAX_LABEL, SyntaxConstants.SYNTAX_STYLE_SCALA);
         addSyntaxStyle(HTML_SYNTAX_LABEL, SyntaxConstants.SYNTAX_STYLE_HTML);
         addSyntaxStyle(CSS_SYNTAX_LABEL, SyntaxConstants.SYNTAX_STYLE_CSS);
-        // TODO Use constant when available: SyntaxConstants.SYNTAX_STYLE_KOTLIN
-        addSyntaxStyle(KOTLIN_SYNTAX_LABEL, "text/kotlin");
+        addSyntaxStyle(KOTLIN_SYNTAX_LABEL, SyntaxConstants.SYNTAX_STYLE_KOTLIN);
 
         initActions();
 
@@ -136,7 +132,7 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
         }
         this.setFont(font);
 
-        if (isDarkLaF()) {
+        if (DisplayUtils.isDarkLookAndFeel()) {
             darkLaF = true;
             setLookAndFeel(true);
         } else {
@@ -201,39 +197,11 @@ public class SyntaxHighlightTextArea extends RSyntaxTextArea {
         }
     }
 
-    private boolean isDarkLaF() {
-        // TODO Update to calling the DisplayUtils.isDarkLookAndFeel() method directly once it is
-        // available
-        if (supportsDarkLaF == null) {
-            supportsDarkLaF = false;
-            try {
-                Class<DisplayUtils> cls = DisplayUtils.class;
-                isDarkLookAndFeelMethod = cls.getMethod("isDarkLookAndFeel");
-                if (isDarkLookAndFeelMethod != null) {
-                    supportsDarkLaF = true;
-                }
-            } catch (Exception e) {
-                // Ignore
-            }
-        }
-        if (isDarkLookAndFeelMethod != null) {
-            try {
-                Object obj = isDarkLookAndFeelMethod.invoke(null);
-                if (obj instanceof Boolean) {
-                    return (Boolean) obj;
-                }
-            } catch (Exception e) {
-                // Ignore
-            }
-        }
-        return false;
-    }
-
     @Override
     public void updateUI() {
         super.updateUI();
-        if (darkLaF != null && darkLaF != isDarkLaF()) {
-            if (isDarkLaF()) {
+        if (darkLaF != null && darkLaF != DisplayUtils.isDarkLookAndFeel()) {
+            if (DisplayUtils.isDarkLookAndFeel()) {
                 darkLaF = true;
             } else {
                 darkLaF = false;

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -19,15 +19,7 @@ zapAddOn {
     }
 }
 
-repositories {
-    maven {
-        url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-    }
-}
-
 dependencies {
-    zap("org.zaproxy:zap:2.11.0-20210923.152813-2")
-
     api("org.seleniumhq.selenium:selenium-server:3.141.59")
     api("org.seleniumhq.selenium:htmlunit-driver:2.36.0")
     api("com.codeborne:phantomjsdriver:1.4.4")

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Issue 2000 - Updated strings shown in active scan dialog with title caps.
 - Enable help button in Sequence tab of Active Scan dialog.
 - Maintenance changes.

--- a/addOns/sequence/sequence.gradle.kts
+++ b/addOns/sequence/sequence.gradle.kts
@@ -2,7 +2,7 @@ description = "Gives the possibility of defining a sequence of requests to be sc
 
 zapAddOn {
     addOnName.set("Sequence")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/simpleexample/simpleexample.gradle.kts
+++ b/addOns/simpleexample/simpleexample.gradle.kts
@@ -2,7 +2,7 @@ description = "A simple extension example."
 
 zapAddOn {
     addOnName.set("Simple Example")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [9] - 2021-09-16
 ### Changed

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -2,7 +2,7 @@ description = "Imports and scans WSDL files containing SOAP endpoints."
 
 zapAddOn {
     addOnName.set("SOAP Support")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Alberto (albertov91) + ZAP Dev Team")

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [23.5.0] - 2021-09-16
 ### Added

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -2,7 +2,7 @@ import org.zaproxy.gradle.addon.AddOnStatus
 
 description = "Allows you to spider sites that make heavy use of JavaScript using Crawljax"
 
-val minimumZapVersion = "2.10.0"
+val minimumZapVersion = "2.11.0"
 
 zapAddOn {
     addOnName.set("Ajax Spider")

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  - Terminology
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 - Updated owasp.org references (Issue 5962).
 

--- a/addOns/sqliplugin/sqliplugin.gradle.kts
+++ b/addOns/sqliplugin/sqliplugin.gradle.kts
@@ -5,7 +5,7 @@ description = "An advanced active injection bundle for SQLi (derived by SQLMap)"
 zapAddOn {
     addOnName.set("Advanced SQLInjection Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Andrea Pompili (Yhawke)")

--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
@@ -1092,6 +1092,7 @@ public class SQLInjectionScanRule extends AbstractAppParamPlugin {
                 .raise();
     }
 
+    @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
     }

--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  - Terminology
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Adjust log levels to be less verbose.
 - Maintenance changes.
 

--- a/addOns/sse/sse.gradle.kts
+++ b/addOns/sse/sse.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to view Server-Sent Events (SSE) communication."
 
 zapAddOn {
     addOnName.set("Server-Sent Events")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/svndigger/CHANGELOG.md
+++ b/addOns/svndigger/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add repo URL.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Promote to release status.
 - Change info URL to link to the site.
 

--- a/addOns/svndigger/svndigger.gradle.kts
+++ b/addOns/svndigger/svndigger.gradle.kts
@@ -11,7 +11,7 @@ val processFiles by tasks.registering(ProcessSvnDiggerFiles::class) {
 zapAddOn {
     addOnName.set("SVN Digger Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [8] - 2021-05-28
 ### Changed

--- a/addOns/tips/tips.gradle.kts
+++ b/addOns/tips/tips.gradle.kts
@@ -5,7 +5,7 @@ description = "Display ZAP Tips and Tricks"
 zapAddOn {
     addOnName.set("Tips and Tricks")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/tlsdebug/CHANGELOG.md
+++ b/addOns/tlsdebug/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [4] - 2020-12-15
 ### Added

--- a/addOns/tlsdebug/tlsdebug.gradle.kts
+++ b/addOns/tlsdebug/tlsdebug.gradle.kts
@@ -2,7 +2,7 @@ description = "Provides a tab which allows to quickly debug a TLS/SSL connection
 
 zapAddOn {
     addOnName.set("TLS Debug")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("P.M.J. Roth")

--- a/addOns/todo/todo.gradle.kts
+++ b/addOns/todo/todo.gradle.kts
@@ -2,7 +2,7 @@ description = "Provides a tab which allows you to view the list of test cases"
 
 zapAddOn {
     addOnName.set("ToDo-List")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("vishesh, ZAP Dev Team")

--- a/addOns/tokengen/CHANGELOG.md
+++ b/addOns/tokengen/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [14] - 2020-12-15
 ### Added

--- a/addOns/tokengen/tokengen.gradle.kts
+++ b/addOns/tokengen/tokengen.gradle.kts
@@ -9,7 +9,7 @@ tasks.withType<JavaCompile> {
 zapAddOn {
     addOnName.set("Token Generation and Analysis")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/treetools/CHANGELOG.md
+++ b/addOns/treetools/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## 7 - 2017-11-27

--- a/addOns/treetools/treetools.gradle.kts
+++ b/addOns/treetools/treetools.gradle.kts
@@ -5,7 +5,7 @@ description = "Tools to add functionality to the tree view."
 zapAddOn {
     addOnName.set("TreeTools")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Carl Sampson")

--- a/addOns/viewstate/CHANGELOG.md
+++ b/addOns/viewstate/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update minimum ZAP version to 2.10.0.
+- Update minimum ZAP version to 2.11.0.
 - Maintenance changes.
 
 ## [2] - 2020-07-07

--- a/addOns/viewstate/viewstate.gradle.kts
+++ b/addOns/viewstate/viewstate.gradle.kts
@@ -2,7 +2,7 @@ description = "ASP/JSF ViewState Decoder and Editor"
 
 zapAddOn {
     addOnName.set("ViewState")
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("Calum Hutton")

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.
 - Updated to handle upstream Wappalyzer data file changes (Issue 6784).
+- Update minimum ZAP version to 2.11.0.
 
 ## [21.3.0] - 2021-08-25
 ### Changed

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -5,7 +5,7 @@ description = "Technology detection using Wappalyzer: wappalyzer.com"
 zapAddOn {
     addOnName.set("Wappalyzer - Technology Detection")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [31] - 2021-09-17
 ### Changed

--- a/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
+++ b/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
@@ -8,7 +8,7 @@ extra["targetOs"] = DownloadWebDriver.OS.LINUX
 zapAddOn {
     addOnName.set("Linux WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [31] - 2021-09-17
 ### Changed

--- a/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
+++ b/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
@@ -8,7 +8,7 @@ extra["targetOs"] = DownloadWebDriver.OS.MAC
 zapAddOn {
     addOnName.set("MacOS WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.0.
 
 ## [31] - 2021-09-17
 ### Changed

--- a/addOns/webdrivers/webdriverwindows/webdriverwindows.gradle.kts
+++ b/addOns/webdrivers/webdriverwindows/webdriverwindows.gradle.kts
@@ -8,7 +8,7 @@ extra["targetOs"] = DownloadWebDriver.OS.WIN
 zapAddOn {
     addOnName.set("Windows WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update links to repository.
 - Support passive scan alert examples so they can be added to the website
 - Missing default scripts will always be added and enabled on start up.
+- Update minimum ZAP version to 2.11.0.
 
 ## [23] - 2020-12-18
 ### Changed

--- a/addOns/websocket/websocket.gradle.kts
+++ b/addOns/websocket/websocket.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows you to inspect WebSocket communication."
 zapAddOn {
     addOnName.set("WebSockets")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Update minimum ZAP version to 2.11.0.
 
 ## [34] - 2021-04-22
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -210,7 +210,7 @@ public class ZestScriptWrapper extends ScriptWrapper {
     }
 
     @Override
-    public boolean isRunableStandalone() {
+    public boolean isRunnableStandalone() {
         // We can always prompt for parameters :)
         return true;
     }

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -16,7 +16,7 @@ description = "A graphical security scripting language, ZAPs macro language on s
 zapAddOn {
     addOnName.set("Zest - Graphical Security Scripting Language")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.10.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,9 @@ allprojects {
 
     repositories {
         mavenCentral()
+        maven {
+            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -20,7 +20,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.10.0")
+    compileOnly("org.zaproxy:zap:2.11.0-20210929.165234-4")
 
     api("org.hamcrest:hamcrest-library:1.3")
     api("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")


### PR DESCRIPTION
Change all add-ons and `testutils` to use 2.11 (SNAPSHOT).
Update code accordingly (e.g. add annotations, address deprecations).