### PR TITLE
Reports: use default report title and description in new report jobs

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Default report title and description to new report jobs.
+
 ### Fixed
 - In risk-confidence-html template, guard against scanJobResultData being null.
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJob.java
@@ -60,6 +60,9 @@ public class ReportJob extends AutomationJob {
         data = new Data(this, this.parameters);
         this.getParameters().setTemplate(ReportParam.DEFAULT_TEMPLATE);
         this.getParameters().setReportDir(System.getProperty("user.home"));
+        this.getParameters().setReportTitle(this.getExtReport().getReportParam().getTitle());
+        this.getParameters()
+                .setReportDescription(this.getExtReport().getReportParam().getDescription());
     }
 
     @Override


### PR DESCRIPTION
Done because:

- Its more friendly
- Otherwise null is set which can cause problems with templates :/

Signed-off-by: Simon Bennetts <psiinon@gmail.com>