### PR TITLE
openapi: fix ClassCastException with nested map properties…

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fixed ClassCastException when using nested map properties with mixed definition styles. 
 
 ## [23] - 2021-10-06
 ### Fixed

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -140,7 +140,13 @@ public class DataGenerator {
                     .generate(name, (ArraySchema) property, "csv", false);
         }
         if (isMap(property)) {
-            return generators.getMapGenerator().generate(TYPES, property);
+            if (property.getAdditionalProperties() instanceof Schema) {
+                return generators.getMapGenerator().generate(TYPES, property);
+            } else if (property.getProperties() != null && !property.getProperties().isEmpty()) {
+                return generators.getBodyGenerator().generate(property);
+            } else {
+                return "";
+            }
         }
         return generateValue(name, property, false);
     }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -728,6 +728,23 @@ class BodyGeneratorUnitTest extends TestUtils {
                 request);
     }
 
+    @Test
+    void shouldGenerateNestedMapProperties() throws IOException {
+        OpenAPI openAPI = parseResource("Schema_with_nested_map_properties.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/v4/endpoint",
+                                        openAPI.getPaths().get("/v4/endpoint").getPost(),
+                                        null),
+                                generators)
+                        .getBody();
+        assertEquals(
+                "[{\"type\":\"John Doe\",\"filtered_keys\":[\"John Doe\"],\"io\":[{\"input\":{\"name\":\"John Doe\",\"desc\":\"John Doe\",\"subthing\":{\"thing1\":\"John Doe\",\"thing2\":\"John Doe\"}},\"output\":{\"name\":\"John Doe\",\"desc\":\"John Doe\"}}]},{\"type\":\"John Doe\",\"filtered_keys\":[\"John Doe\"],\"io\":[{\"input\":{\"name\":\"John Doe\",\"desc\":\"John Doe\",\"subthing\":{\"thing1\":\"John Doe\",\"thing2\":\"John Doe\"}},\"output\":{\"name\":\"John Doe\",\"desc\":\"John Doe\"}}]}]",
+                request);
+    }
+
     private OpenAPI parseResource(String fileName) throws IOException {
         ParseOptions options = new ParseOptions();
         options.setResolveFully(true);

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Schema_with_nested_map_properties.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/Schema_with_nested_map_properties.yaml
@@ -1,0 +1,68 @@
+openapi: 3.0.0
+info:
+  title: Market Data Exporter API
+paths:
+  /v4/endpoint:
+    post:
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/TypeQuery'
+        required: true
+      responses:
+        '400':
+          description: The request was ill-formed
+
+components:
+  schemas:
+    TypeQuery:
+      type: object
+      additionalProperties: true
+      properties:
+        type:
+          type: string
+        filtered_keys:
+          type: array
+          items:
+            $ref: '#/components/schemas/NaturalKey'
+        io:
+          type: object
+          items:
+            $ref: '#/components/schemas/IOType'
+    NaturalKey:
+      type: object
+      additionalProperties:
+        type: string
+    IOType:
+      type: object
+      additionalProperties: true
+      properties:
+        input:
+          $ref: '#/components/schemas/InType'
+        output:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+            desc:
+              type: string
+    InType:
+      type: object
+      additionalProperties: true
+      properties:
+        name:
+          type: string
+        desc:
+          type: string
+        subthing:
+          type: object
+          additionalProperties: true
+          properties:
+            thing1:
+              type: string
+            thing2:
+              type: string


### PR DESCRIPTION
fix ClassCastException with nested map properties that use mixed definition styles

I don't think this is a very common issue but we've seen it once in the wild.

Here is an example of the error...

```
class java.lang.Boolean cannot be cast to class io.swagger.v3.oas.models.media.Schema (java.lang.Boolean is in module java.base of loader 'bootstrap'; io.swagger.v3.oas.models.media.Schema is in unnamed module of loader 'app')
java.lang.ClassCastException: class java.lang.Boolean cannot be cast to class io.swagger.v3.oas.models.media.Schema (java.lang.Boolean is in module java.base of loader 'bootstrap'; io.swagger.v3.oas.models.media.Schema is in unnamed module of loader 'app')
	at org.zaproxy.zap.extension.openapi.generators.MapGenerator.generate(MapGenerator.java:52)
	at org.zaproxy.zap.extension.openapi.generators.DataGenerator.generateBodyValue(DataGenerator.java:144)
	at org.zaproxy.zap.extension.openapi.generators.BodyGenerator.generateFromObjectSchema(BodyGenerator.java:174)
	at org.zaproxy.zap.extension.openapi.generators.BodyGenerator.generate(BodyGenerator.java:113)
	at org.zaproxy.zap.extension.openapi.generators.DataGenerator.generateValue(DataGenerator.java:179)
	at org.zaproxy.zap.extension.openapi.generators.ArrayGenerator.generate(ArrayGenerator.java:59)
	at org.zaproxy.zap.extension.openapi.generators.DataGenerator.generateBodyValue(DataGenerator.java:140)
	at org.zaproxy.zap.extension.openapi.generators.BodyGenerator.generateFromObjectSchema(BodyGenerator.java:174)
	at org.zaproxy.zap.extension.openapi.generators.BodyGenerator.generate(BodyGenerator.java:113)
	at org.zaproxy.zap.extension.openapi.generators.BodyGenerator.generateFromArraySchema(BodyGenerator.java:147)
	at org.zaproxy.zap.extension.openapi.generators.BodyGenerator.generate(BodyGenerator.java:105)
	at org.zaproxy.zap.extension.openapi.generators.BodyGenerator.generate(BodyGenerator.java:94)
	at org.zaproxy.zap.extension.openapi.converter.swagger.RequestModelConverter.generateBody(RequestModelConverter.java:71)
	at org.zaproxy.zap.extension.openapi.converter.swagger.RequestModelConverter.convert(RequestModelConverter.java:47)
	at org.zaproxy.zap.extension.openapi.v3.BodyGeneratorUnitTest.shouldGenerateNestedMapProperties(BodyGeneratorUnitTest.java:736)

```

Signed-off-by: kberg <kc.berg@stackhawk.com>