### PR TITLE
feat: fuzz: Add result panel context menu item for sending to sites

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- A right click (context menu) item to facilitate adding a fuzz message to the Sites Tree and History panel (Issue 1437).
 
 ## [13.3.0] - 2021-10-06
 ### Fixed

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ExtensionHttpFuzzer.java
@@ -45,6 +45,7 @@ import org.zaproxy.zap.extension.fuzz.httpfuzzer.processors.UserHttpFuzzerMessag
 import org.zaproxy.zap.extension.fuzz.httpfuzzer.processors.tagcreator.HttpFuzzerMessageProcessorTagStateHighlighter;
 import org.zaproxy.zap.extension.fuzz.httpfuzzer.processors.tagcreator.HttpFuzzerMessageProcessorTagUIHandler;
 import org.zaproxy.zap.extension.fuzz.httpfuzzer.ui.HttpFuzzAttackPopupMenuItem;
+import org.zaproxy.zap.extension.fuzz.httpfuzzer.ui.HttpFuzzResultToHistoryPopupMenuItem;
 import org.zaproxy.zap.extension.fuzz.httpfuzzer.ui.HttpFuzzerResultStateHighlighter;
 import org.zaproxy.zap.extension.fuzz.messagelocations.MessageLocationReplacers;
 import org.zaproxy.zap.extension.script.ExtensionScript;
@@ -135,6 +136,9 @@ public class ExtensionHttpFuzzer extends ExtensionAdaptor {
                     .addPopupMenuItem(
                             new HttpFuzzAttackPopupMenuItem(extensionFuzz, httpFuzzerHandler));
 
+            extensionHook
+                    .getHookMenu()
+                    .addPopupMenuItem(new HttpFuzzResultToHistoryPopupMenuItem());
             ExtensionSearch extensionSearch =
                     Control.getSingleton().getExtensionLoader().getExtension(ExtensionSearch.class);
             if (extensionSearch != null) {

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzResultToHistoryPopupMenuItem.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/ui/HttpFuzzResultToHistoryPopupMenuItem.java
@@ -1,0 +1,63 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.fuzz.httpfuzzer.ui;
+
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.SiteMap;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
+import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
+
+public class HttpFuzzResultToHistoryPopupMenuItem extends PopupMenuItemHttpMessageContainer {
+
+    private static final long serialVersionUID = 1692164709968649149L;
+
+    public HttpFuzzResultToHistoryPopupMenuItem() {
+        super(Constant.messages.getString("fuzz.panel.popup.add.site.history.label"), true);
+    }
+
+    @Override
+    protected void performAction(HttpMessage httpMessage) {
+        ExtensionHistory extHistory =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionHistory.class);
+        extHistory.addHistory(httpMessage, HistoryReference.TYPE_ZAP_USER);
+        HistoryReference currentHr = httpMessage.getHistoryRef();
+        currentHr.addTag(Constant.messages.getString("fuzz.panel.popup.add.site.history.tag"));
+        currentHr.setCustomIcon("org/zaproxy/zap/extension/fuzz/resources/icons/fuzzer.png", true);
+
+        SiteMap currentTree = Model.getSingleton().getSession().getSiteTree();
+        currentTree.addPath(currentHr);
+    }
+
+    @Override
+    protected boolean isEnableForInvoker(
+            Invoker invoker, HttpMessageContainer httpMessageContainer) {
+        return invoker == Invoker.FUZZER_PANEL;
+    }
+
+    @Override
+    public boolean isSafe() {
+        return true;
+    }
+}

--- a/addOns/fuzz/src/main/javahelp/org/zaproxy/zap/extension/fuzz/resources/help/contents/tab.html
+++ b/addOns/fuzz/src/main/javahelp/org/zaproxy/zap/extension/fuzz/resources/help/contents/tab.html
@@ -17,7 +17,9 @@
 
 	<H2>Right click menu</H2>
 	Right clicking on a row will bring up a menu which has the same options as the History tab.
-
+	Plus providing an option to add messages from the fuzz results to the Sites Tree and History tab
+	(the messages will be tagged <code>FromFuzzer</code> and initially show a fuzzer icon in the Sites Tree).
+	</p>
 	<H2>See also</H2>
 	<table>
 		<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;</td><td><a href="concepts.html">Fuzzer concepts</a></td></tr>

--- a/addOns/fuzz/src/main/resources/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/addOns/fuzz/src/main/resources/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -4,6 +4,8 @@ fuzz.description = Provides the foundation for concrete message types (for examp
 
 fuzz.panel.mnemonic         = f
 fuzz.panel.title            = Fuzzer
+fuzz.panel.popup.add.site.history.label = Add to Sites Tree & History
+fuzz.panel.popup.add.site.history.tag = FromFuzzer
 
 fuzz.results.error.unknown.source = Unknown
 fuzz.results.error.unknown.message = Unknown error while executing fuzzer task. Log file contains details of the error.


### PR DESCRIPTION
- CHANGELOG > Added note.
- ExtensionHttpFuzzer > Hook the new menu item.
- HttpFuzzREsultsToHistoryPopupMenuItem > The new menu item class.
- Messages.properties > Added supporting key value pair.
- tab.html > Add a line about the new right click functionality.

Fixes zaproxy/zaproxy#1437

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>