### PR TITLE
openapi: use examples in parameters

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Use examples defined in parameters ([Issue #6870](https://github.com/zaproxy/zaproxy/issues/6870)).
+
 ### Fixed
 - Fixed ClassCastException when using nested map properties with mixed definition styles. 
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.zap.extension.openapi.generators;
 
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.DateSchema;
@@ -30,10 +31,13 @@ import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 public class DataGenerator {
 
@@ -78,10 +82,21 @@ public class DataGenerator {
         if (value != null) {
             return value;
         }
-        if (parameter.getExample() != null) {
-            return parameter.getExample().toString();
+        String example = extractExample(parameter);
+        if (example != null) {
+            return example;
         }
         return "";
+    }
+
+    private static String extractExample(Parameter parameter) {
+        return Optional.ofNullable(parameter.getExamples())
+                .map(Map::values)
+                .map(Collection::stream)
+                .map(stream -> stream.map(Example::getValue).filter(Objects::nonNull).findFirst())
+                .orElse(Optional.ofNullable(parameter.getExample()))
+                .map(Object::toString)
+                .orElse(null);
     }
 
     private static String getDefaultValue(Schema<?> schema) {

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/PathGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/PathGeneratorUnitTest.java
@@ -1,0 +1,106 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.generators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+import org.zaproxy.zap.extension.openapi.converter.swagger.OperationModel;
+import org.zaproxy.zap.extension.openapi.converter.swagger.RequestModelConverter;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class PathGeneratorUnitTest extends TestUtils {
+    Generators generators;
+
+    @BeforeAll
+    static void setUp() {
+        mockMessages(new ExtensionOpenApi());
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        Constant.messages = null;
+    }
+
+    @BeforeEach
+    void init() {
+        generators = new Generators(null);
+    }
+
+    @Test
+    void shouldUseExampleInQueryParameters() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/query-parameter-with-example",
+                                        openAPI.getPaths()
+                                                .get("/query-parameter-with-example")
+                                                .getGet(),
+                                        null),
+                                generators)
+                        .getUrl();
+
+        assertEquals("/query-parameter-with-example?petId=42", request);
+    }
+
+    @Test
+    void shouldUseExamplesInQueryParameters() throws IOException {
+        OpenAPI openAPI = parseResource("OpenApi_defn_examples.yaml");
+        String request =
+                new RequestModelConverter()
+                        .convert(
+                                new OperationModel(
+                                        "/query-parameter-with-examples",
+                                        openAPI.getPaths()
+                                                .get("/query-parameter-with-examples")
+                                                .getGet(),
+                                        null),
+                                generators)
+                        .getUrl();
+
+        assertEquals("/query-parameter-with-examples?petId=42", request);
+    }
+
+    private OpenAPI parseResource(String fileName) throws IOException {
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+        String defn =
+                IOUtils.toString(
+                        this.getClass()
+                                .getResourceAsStream(
+                                        "/org/zaproxy/zap/extension/openapi/v3/" + fileName),
+                        StandardCharsets.UTF_8);
+        return new OpenAPIV3Parser().readContents(defn, new ArrayList<>(), options).getOpenAPI();
+    }
+}

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_examples.yaml
@@ -11,6 +11,36 @@ components:
           type: string
           example: Fluffy
 paths:
+  /query-parameter-with-example:
+    get:
+      parameters:
+        - name: petId
+          in: query
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+          example: 42
+      responses:
+        '201':
+          description: Created
+  /query-parameter-with-examples:
+    get:
+      parameters:
+        - name: petId
+          in: query
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+          examples:
+            petId:
+              value: 42
+      responses:
+        '201':
+          description: Created
   # Using Example defined in a references schema
   /pets-with-example:
     post:


### PR DESCRIPTION
Use also `examples` in parameters, not just the `example` field.

Fix zaproxy/zaproxy#6870.