### PR TITLE
automation: Add delay job

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- Delay job
 
 ## [0.7.0] - 2021-10-06
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationAPI.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationAPI.java
@@ -26,6 +26,7 @@ import net.sf.json.JSONObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.DelayJob;
 import org.zaproxy.zap.extension.api.ApiAction;
 import org.zaproxy.zap.extension.api.ApiException;
 import org.zaproxy.zap.extension.api.ApiException.Type;
@@ -44,6 +45,7 @@ public class AutomationAPI extends ApiImplementor {
     private static final String PREFIX = "automation";
 
     private static final String ACTION_RUN_PLAN = "runPlan";
+    private static final String ACTION_END_DELAY_JOB = "endDelayJob";
     private static final String VIEW_PLAN_PROGRESS = "planProgress";
 
     private static final String PARAM_FILE_PATH = "filePath";
@@ -64,6 +66,7 @@ public class AutomationAPI extends ApiImplementor {
         super();
         this.extension = extension;
         this.addApiAction(new ApiAction(ACTION_RUN_PLAN, new String[] {PARAM_FILE_PATH}));
+        this.addApiAction(new ApiAction(ACTION_END_DELAY_JOB));
         this.addApiView(new ApiView(VIEW_PLAN_PROGRESS, new String[] {PARAM_PLAN_ID}));
     }
 
@@ -92,6 +95,9 @@ public class AutomationAPI extends ApiImplementor {
             } catch (IOException | ApiException e) {
                 throw new ApiException(Type.DOES_NOT_EXIST, e.getMessage());
             }
+        } else if (name.equals(ACTION_END_DELAY_JOB)) {
+            DelayJob.setEndJob(true);
+            return ApiResponseElement.OK;
         }
         throw new ApiException(Type.BAD_ACTION);
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -50,6 +50,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.zaproxy.addon.automation.gui.AutomationPanel;
 import org.zaproxy.addon.automation.jobs.ActiveScanJob;
 import org.zaproxy.addon.automation.jobs.AddOnJob;
+import org.zaproxy.addon.automation.jobs.DelayJob;
 import org.zaproxy.addon.automation.jobs.ParamsJob;
 import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
 import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
@@ -97,6 +98,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         this.registerAutomationJob(new RequestorJob());
         this.registerAutomationJob(new PassiveScanWaitJob());
         this.registerAutomationJob(new SpiderJob());
+        this.registerAutomationJob(new DelayJob());
         this.registerAutomationJob(new ActiveScanJob());
         this.registerAutomationJob(new ParamsJob());
         // Instantiate early so its visible to potential consumers
@@ -116,9 +118,6 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
             extensionHook.getHookView().addStatusPanel(getAutomationPanel());
         }
     }
-
-    @Override
-    public void optionsLoaded() {}
 
     @Override
     public boolean canUnload() {

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/HhMmSs.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/HhMmSs.java
@@ -1,0 +1,66 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation;
+
+import java.text.ParseException;
+import java.util.concurrent.TimeUnit;
+
+public class HhMmSs {
+
+    private long timeInMs;
+    private static final String SEPARATOR = ":";
+
+    public HhMmSs(String timeStr) throws ParseException, NumberFormatException {
+        if (timeStr == null) {
+            // Cope with no string - default to 0
+            return;
+        }
+        int minusIndex = timeStr.indexOf("-");
+        if (minusIndex >= 0) {
+            throw new ParseException(timeStr, minusIndex);
+        }
+
+        String[] units = timeStr.split(SEPARATOR);
+        int offset = 0;
+        if (units.length > 3) {
+            throw new ParseException(timeStr, timeStr.lastIndexOf(SEPARATOR));
+        }
+        if (units.length == 3) {
+            timeInMs = TimeUnit.HOURS.toMillis(parse(units[offset]));
+            offset++;
+        }
+        if (units.length >= 2) {
+            timeInMs += TimeUnit.MINUTES.toMillis(parse(units[offset]));
+            offset++;
+        }
+        timeInMs += TimeUnit.SECONDS.toMillis(parse(units[offset]));
+    }
+
+    private static long parse(String str) {
+        if (str.isEmpty()) {
+            return 0;
+        }
+        return Integer.parseInt(str);
+    }
+
+    public long getTimeInMs() {
+        return timeInMs;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/DelayJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/DelayJobDialog.java
@@ -1,0 +1,68 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.text.ParseException;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.HhMmSs;
+import org.zaproxy.addon.automation.jobs.DelayJob;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class DelayJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.delay.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String TIME_PARAM = "automation.dialog.delay.time";
+    private static final String FILENAME_PARAM = "automation.dialog.delay.fileName";
+
+    private DelayJob job;
+
+    public DelayJobDialog(DelayJob job) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(300, 200));
+        this.job = job;
+
+        this.addTextField(NAME_PARAM, this.job.getData().getName());
+        this.addTextField(TIME_PARAM, this.job.getData().getParameters().getTime());
+        this.addTextField(FILENAME_PARAM, this.job.getData().getParameters().getFileName());
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setTime(this.getStringValue(TIME_PARAM));
+        this.job.getParameters().setFileName(this.getStringValue(FILENAME_PARAM));
+        this.job.setChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        try {
+            new HhMmSs(this.getStringValue(TIME_PARAM));
+        } catch (ParseException | NumberFormatException e) {
+            return Constant.messages.getString("automation.dialog.delay.error.time");
+        }
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
@@ -1,0 +1,182 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.jobs;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.AutomationData;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.HhMmSs;
+import org.zaproxy.addon.automation.gui.DelayJobDialog;
+
+public class DelayJob extends AutomationJob {
+
+    public static final String JOB_NAME = "delay";
+
+    private Data data;
+    private Parameters parameters = new Parameters();
+    private static boolean endJob;
+
+    public DelayJob() {
+        this.data = new Data(this, parameters);
+    }
+
+    @Override
+    public void verifyParameters(AutomationProgress progress) {
+        String timeStr = this.getParameters().getTime();
+        try {
+            new HhMmSs(timeStr);
+        } catch (Exception e) {
+            progress.error(Constant.messages.getString("automation.error.delay.badtime", timeStr));
+        }
+    }
+
+    @Override
+    public void runJob(AutomationEnvironment env, AutomationProgress progress) {
+        setEndJob(false);
+        HhMmSs hhmmss;
+        File file = null;
+        try {
+            hhmmss = new HhMmSs(this.getParameters().getTime());
+        } catch (Exception e) {
+            // Will have warned the user during the verify
+            return;
+        }
+        if (!StringUtils.isEmpty(this.getParameters().getFileName())) {
+            file = new File(this.getParameters().getFileName());
+        }
+        long end = System.currentTimeMillis() + hhmmss.getTimeInMs();
+        try {
+            while (System.currentTimeMillis() < end
+                    && !endJob
+                    && !(file != null && file.exists())) {
+                Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            }
+            if (endJob) {
+                progress.info(
+                        Constant.messages.getString(
+                                "automation.info.delay.endjob", this.getName()));
+            } else if (file != null && file.exists()) {
+                progress.info(
+                        Constant.messages.getString(
+                                "automation.info.delay.filecreated",
+                                this.getName(),
+                                file.getAbsolutePath()));
+            } else {
+                progress.info(
+                        Constant.messages.getString(
+                                "automation.info.delay.timeout",
+                                this.getName(),
+                                this.getParameters().getTime()));
+            }
+        } catch (InterruptedException e) {
+            // Looks like something really does want us to stop
+            Thread.currentThread().interrupt();
+            progress.info(
+                    Constant.messages.getString(
+                            "automation.info.delay.interrupted", this.getName()));
+        }
+    }
+
+    public static void setEndJob(boolean bool) {
+        endJob = bool;
+    }
+
+    @Override
+    public String getType() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public Order getOrder() {
+        return Order.AFTER_EXPLORE;
+    }
+
+    @Override
+    public Object getParamMethodObject() {
+        return null;
+    }
+
+    @Override
+    public String getParamMethodName() {
+        return null;
+    }
+
+    @Override
+    public void showDialog() {
+        new DelayJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "automation.dialog.delay.summary",
+                this.getData().getParameters().getTime(),
+                this.getData().getParameters().getFileName());
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return this.parameters;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private String time;
+        private String fileName;
+
+        public String getTime() {
+            return time;
+        }
+
+        public void setTime(String time) {
+            this.time = time;
+        }
+
+        public String getFileName() {
+            return fileName;
+        }
+
+        public void setFileName(String fileName) {
+            this.fileName = fileName;
+        }
+    }
+}

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
@@ -46,6 +46,7 @@ The <a href="environment.html">environment</a> section of the file defines the a
 The following automation jobs are supported by this add-on:
 <ul>
 <li><a href="job-addons.html">addOns</a> - add-on management</li>
+<li><a href="job-delay.html">delay</a> - pauses the plan for a specified period of time or a specific condition is met</li>
 <li><a href="job-pscanconf.html">passiveScan-config</a> - passive scan configuration</li>
 <li><a href="job-pscanwait.html">passiveScan-wait</a> - waits for the passive scanner to finish processing the current queue</li>
 <li><a href="job-requestor.html">requestor</a> - crafts specific requests to send to the corresponding targets</li>

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-delay.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-delay.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<TITLE>
+Automation Framework - delay Job
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Automation Framework - delay Job</H1>
+
+This job waits for a specified time unless one of a specific set of conditions are met.<br>
+It can be used to wait for regression tests being proxied through ZAP in order to explore your application more thoroughly.
+<p>
+The time parameter supports the formats <code>hh:mm:ss</code>, <code>mm:ss</code> and <code>ss</code>, so "5" is 5 seconds, 
+"1:30" is one minute and 30 seconds and "2:20:30" is 2 hours, 20 minutes and 30 seconds.
+<p>
+The conditions supported are:
+<ul>
+<li>The creation of the file given by the optional fileName parameter
+<li>Calling the static method: <code>org.zaproxy.addon.automation.jobs.DelayJob.setEndJob(true);</code>
+<li>Calling the API end point: <code>authentication / action / endDelayJob</code>
+</ul>
+
+<H2>YAML</H2>
+
+<pre>
+  - type: delay                        # Pause the plan for a set period of time or event (file created, static method called, API end point called)
+    parameters:
+      time:                            # String: The time to wait, format any of ['hh:mm:ss', 'mm:ss', 'ss'], default: 0
+      fileName:                        # String: Name of a file which will cause the job to end early if created, default: empty
+</pre>
+
+</BODY>
+</HTML>

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -104,6 +104,12 @@ automation.dialog.context.error.nourls = You must specify at least one URL
 
 automation.dialog.default = Default
 
+automation.dialog.delay.error.time = Invalid time: must be of the format hh:mm:ss, mm:ss or ss
+automation.dialog.delay.fileName = File Name: 
+automation.dialog.delay.summary = Time: {0} file name: {1}
+automation.dialog.delay.time = Time:
+automation.dialog.delay.title = Delay Job
+
 automation.dialog.env.failonerror = Fail On Error:
 automation.dialog.env.failonwarning = Fail On Warning:
 automation.dialog.env.progresstostdout = Progresss To Stdout:
@@ -244,6 +250,8 @@ automation.error.context.nourl = Missing URLs for context: {0}
 automation.error.context.unknown = Unrecognised context: {0}
 automation.error.context.url.deprecated = The context 'url' field has been replaced with a 'urls' list field
 
+automation.error.delay.badtime = Invalid time: {0}
+
 automation.error.env.missing = Missing environment: {0}
 automation.error.env.nocontexts = Missing contexts in environment: {0}
 automation.error.env.badcontext = Invalid context in environment: {0}
@@ -292,6 +300,12 @@ automation.info.ascan.rule.setstrength = Job {0} set rule {1} strength to {2}
 automation.info.ascan.rule.setthreshold = Job {0} set rule {1} threshold to {2}
 automation.info.ascan.setdefstrength = Job {0} set default strength to {1}
 automation.info.ascan.setdefthreshold = Job {0} set default threshold to {1}
+
+automation.info.delay.endjob = Job {0} ended by programmatic or API call
+automation.info.delay.filecreated = Job {0} ended by creation of file {1}
+automation.info.delay.interrupted = Job {0} interrupted
+automation.info.delay.timeout = Job {0} ended after specified time {1}
+
 automation.info.pscan.rule.noid = Job {0} ignoring rule with no id 
 automation.info.pscan.rule.setthreshold = Job {0} set rule {1} threshold to {2}
 automation.info.requrl = Job {0} requesting URL {1}

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/delay-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/delay-max.yaml
@@ -1,0 +1,4 @@
+  - type: delay                        # Pause the plan for a set period of time or event (file created, programmatic method called, API endpoint called)
+    parameters:
+      time:                            # String: The time to wait, format any of ['hh:mm:ss', 'mm:ss', 'ss'], default: 0
+      fileName:                        # String: Name of a file which will cause the job to end early if created, default: empty

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/delay-min.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/delay-min.yaml
@@ -1,0 +1,4 @@
+  - type: delay                        # Pause the plan for a set period of time or event (file created, programmatic method called, API endpoint called)
+    parameters:
+      time:                            # String: The time to wait, format any of ['hh:mm:ss', 'mm:ss', 'ss'], default: 0
+      fileName:                        # String: Name of a file which will cause the job to end early if created, default: empty

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -51,6 +51,7 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.automation.jobs.ActiveScanJob;
 import org.zaproxy.addon.automation.jobs.AddOnJob;
+import org.zaproxy.addon.automation.jobs.DelayJob;
 import org.zaproxy.addon.automation.jobs.ParamsJob;
 import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
 import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
@@ -107,11 +108,12 @@ class ExtentionAutomationUnitTest extends TestUtils {
         Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
 
         // Then
-        assertThat(jobs.size(), is(equalTo(7)));
+        assertThat(jobs.size(), is(equalTo(8)));
         assertThat(jobs.containsKey(AddOnJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(PassiveScanConfigJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(PassiveScanWaitJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(SpiderJob.JOB_NAME), is(equalTo(true)));
+        assertThat(jobs.containsKey(DelayJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(ActiveScanJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(ParamsJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(RequestorJob.JOB_NAME), is(equalTo(true)));
@@ -141,7 +143,7 @@ class ExtentionAutomationUnitTest extends TestUtils {
         Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
 
         // Then
-        assertThat(jobs.size(), is(equalTo(8)));
+        assertThat(jobs.size(), is(equalTo(9)));
         assertThat(jobs.containsKey(jobName), is(equalTo(true)));
     }
 

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/HhMmSsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/HhMmSsUnitTest.java
@@ -1,0 +1,112 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.text.ParseException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HhMmSsUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-1", "-1:10", "-1:20:20", "10:-2:20", "-1:-2:-3", "10:20:-30"})
+    void shouldRejectNegativeValues(String hhmmss) {
+        ParseException exception = assertThrows(ParseException.class, () -> new HhMmSs(hhmmss));
+        assertThat(exception.getErrorOffset(), is(equalTo(hhmmss.indexOf('-'))));
+    }
+
+    @Test
+    void shouldRejectTooManyColons() {
+        String str = "1:2:3:4";
+        ParseException exception = assertThrows(ParseException.class, () -> new HhMmSs(str));
+        assertThat(exception.getErrorOffset(), is(equalTo(str.lastIndexOf(":"))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 20, 100, 10000})
+    void shouldParseSs(int timeInSecs) throws ParseException {
+        // Given
+        HhMmSs hhmmss = new HhMmSs(Integer.toString(timeInSecs));
+
+        // When
+        long time = hhmmss.getTimeInMs();
+
+        // Then
+        assertThat(time, is(equalTo(TimeUnit.SECONDS.toMillis(timeInSecs))));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"0,0", "0,1", "10,00", "100,100"})
+    void shouldParseMmSs(String mmStr, String ssStr) throws ParseException {
+        // Given
+        HhMmSs hhmmss = new HhMmSs(mmStr + ":" + ssStr);
+
+        // When
+        long time = hhmmss.getTimeInMs();
+
+        // Then
+        assertThat(
+                time,
+                is(
+                        equalTo(
+                                TimeUnit.MINUTES.toMillis(Integer.parseInt(mmStr))
+                                        + TimeUnit.SECONDS.toMillis(Integer.parseInt(ssStr)))));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"0,0,0", "0,0,1", "0,10,00", "10,0,0", "1000,1000,1000"})
+    void shouldParseHhMmSs(String hhStr, String mmStr, String ssStr) throws ParseException {
+        // Given
+        HhMmSs hhmmss = new HhMmSs(hhStr + ":" + mmStr + ":" + ssStr);
+
+        // When
+        long time = hhmmss.getTimeInMs();
+
+        // Then
+        assertThat(
+                time,
+                is(
+                        equalTo(
+                                TimeUnit.HOURS.toMillis(Integer.parseInt(hhStr))
+                                        + TimeUnit.MINUTES.toMillis(Integer.parseInt(mmStr))
+                                        + TimeUnit.SECONDS.toMillis(Integer.parseInt(ssStr)))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "0:", ":0", ":0:0", "0::", "::0"})
+    void shouldHandleEmptyValues(String hhMmSsStr) throws ParseException {
+        // Given
+        HhMmSs hhmmss = new HhMmSs(hhMmSsStr);
+
+        // When
+        long time = hhmmss.getTimeInMs();
+
+        // Then
+        assertThat(time, is(equalTo(0L)));
+    }
+}

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/DelayJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/DelayJobUnitTest.java
@@ -1,0 +1,214 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.jobs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.zap.utils.I18N;
+
+class DelayJobUnitTest {
+
+    @BeforeAll
+    static void setUp() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @Test
+    void shouldNotFailIfNoConfigs() {
+        // Given
+        DelayJob job = new DelayJob();
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+
+        // When
+        job.applyParameters(progress);
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-", "1.1", " ", "test", "1:2:3:4"})
+    void shouldFailOnInvalidTimes(String hHmMsS) {
+        // Given
+        DelayJob job = new DelayJob();
+        AutomationProgress progress = new AutomationProgress();
+
+        // When
+        job.getParameters().setTime(hHmMsS);
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "0:", ":0", ":0:0", "0::", "::0"})
+    void shouldNotSleepIfZeroSeconds(String hHmMsS) {
+        // Given
+        DelayJob job = new DelayJob();
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+
+        // When
+        job.getParameters().setTime(hHmMsS);
+        job.applyParameters(progress);
+        long startTime = System.currentTimeMillis();
+        job.runJob(env, progress);
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(TimeUnit.MILLISECONDS.toSeconds(endTime - startTime), is(equalTo(0L)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1", ":1", ":0:1", "::1"})
+    void shouldSleepForGivenSeconds(String hHmMsS) {
+        // Given
+        DelayJob job = new DelayJob();
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+
+        // When
+        job.getParameters().setTime(hHmMsS);
+        job.applyParameters(progress);
+        long startTime = System.currentTimeMillis();
+        job.runJob(env, progress);
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(TimeUnit.MILLISECONDS.toSeconds(endTime - startTime), is(equalTo(1L)));
+    }
+
+    @Test
+    void shouldInterruptWhenMethodCalled() {
+        // Given
+        DelayJob job = new DelayJob();
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+        long sleepSeconds = 2;
+
+        // When
+        job.getParameters().setTime("1:0");
+        job.applyParameters(progress);
+
+        new Thread(
+                        () -> {
+                            try {
+                                TimeUnit.SECONDS.sleep(sleepSeconds);
+                            } catch (InterruptedException e) {
+                            }
+                            DelayJob.setEndJob(true);
+                        })
+                .start();
+
+        long startTime = System.currentTimeMillis();
+        job.runJob(env, progress);
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertTrue(TimeUnit.MILLISECONDS.toSeconds(endTime - startTime) < 4);
+    }
+
+    @Test
+    void shouldNotSleepIfFileExists() throws IOException {
+        // Given
+        DelayJob job = new DelayJob();
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+
+        // When
+        Path path = Files.createTempFile("delay-test1", ".txt");
+        File file = path.toFile();
+        job.getParameters().setTime("1:0");
+        job.getParameters().setFileName(file.getAbsolutePath());
+        job.applyParameters(progress);
+
+        long startTime = System.currentTimeMillis();
+        job.runJob(env, progress);
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(TimeUnit.MILLISECONDS.toSeconds(endTime - startTime), is(equalTo(0L)));
+    }
+
+    @Test
+    void shouldInterruptWhenFileCreated() throws IOException {
+        // Given
+        DelayJob job = new DelayJob();
+        AutomationProgress progress = new AutomationProgress();
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+
+        // When
+        Path path = Files.createTempFile("delay-test2", ".txt");
+        File file1 = path.toFile();
+        File file2 = new File(file1.getAbsoluteFile() + "2");
+        file1.renameTo(file2);
+
+        job.getParameters().setTime("1:0");
+        job.getParameters().setFileName(file1.getAbsolutePath());
+        job.applyParameters(progress);
+
+        new Thread(
+                        () -> {
+                            try {
+                                TimeUnit.SECONDS.sleep(2);
+                            } catch (InterruptedException e) {
+                            }
+                            file2.renameTo(file1);
+                        })
+                .start();
+
+        long startTime = System.currentTimeMillis();
+        job.runJob(env, progress);
+        long endTime = System.currentTimeMillis();
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertTrue(TimeUnit.MILLISECONDS.toSeconds(endTime - startTime) < 4);
+    }
+}

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
@@ -37,6 +37,10 @@ jobs:
       context: 
       url: 
 
+  - type: delay
+    name: delay
+    parameters:
+
   - type: passiveScan-wait
     name: passiveScan-wait
     parameters:

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -65,6 +65,10 @@ jobs:
         operator: '>='                                  # String ['==', '!=', '>=', '>', '<', '<=']: Operator used for testing
         value: 100                                      # Int: Change this to the number of URLs you expect to find
         onFail: 'info'                                  # String: One of 'warn', 'error', 'info', mandatory
+  - type: delay                        # Pause the plan for a set period of time or event (file created, programmatic method called, API endpoint called)
+    parameters:
+      time:                            # String: The time to wait, format any of ['hh:mm:ss', 'mm:ss', 'ss'], default: 0
+      fileName:                        # String: Name of a file which will cause the job to end early if created, default: empty
   - type: passiveScan-wait             # Passive scan wait for the passive scanner to finish
     parameters:
       maxDuration: 5                   # Int: The max time to wait for the passive scanner, default: 0 unlimited

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -41,6 +41,10 @@ jobs:
         operator: '>='                                  # String ['==', '!=', '>=', '>', '<', '<=']: Operator used for testing
         value: 100                                      # Int: Change this to the number of URLs you expect to find
         onFail: 'info'                                  # String: One of 'warn', 'error', 'info', mandatory
+  - type: delay                        # Pause the plan for a set period of time or event (file created, programmatic method called, API endpoint called)
+    parameters:
+      time:                            # String: The time to wait, format any of ['hh:mm:ss', 'mm:ss', 'ss'], default: 0
+      fileName:                        # String: Name of a file which will cause the job to end early if created, default: empty
   - type: passiveScan-wait             # Passive scan wait for the passive scanner to finish
     parameters:
       maxDuration: 5                   # Int: The max time to wait for the passive scanner, default: 0 unlimited


### PR DESCRIPTION
Needed for the packaged scans and also generally useful for pausing a plan while (for example) regression tests are proxied through ZAP.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>