### PR TITLE
improve: pscanrules: Timestamp Disclosure ignore Expect-CT

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - OWASP Top Ten 2021/2017 mappings for Insecure Authentication scan rule.
 
+### Changed
+- Timestamp Disclosure scan rule now excludes values in "Expect-CT" headers (Issue 6725).
+
 ## [36] - 2021-10-06
 ### Added
 - OWASP Top Ten 2021/2017 mappings.

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -84,7 +84,8 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
         "Age",
         "Strict-Transport-Security",
         "Report-To",
-        "NEL"
+        "NEL",
+        "Expect-CT"
     };
 
     static final Pattern PATTERN_FONT_EXTENSIONS =


### PR DESCRIPTION
- CHANGELOG > Added change note.
- TimeStampDisclosureScanRule > Added Expect-CT to ignored headers.
- TimeStampDisclosureScanRuleUnitTest > Beefed up coverage for excluded header tests.

Fixes zaproxy/zaproxy#6725

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>