### PR TITLE
Stop using ZAP snapshot

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -117,12 +117,7 @@ subprojects {
         }
     }
 
-    val zapGav = "org.zaproxy:zap:2.11.0-20210929.165234-4"
-    dependencies {
-        "zap"(zapGav)
-    }
-
-    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create(zapGav))
+    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.11.0"))
 
     zapAddOn {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })

--- a/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
+++ b/addOns/reports/src/test/resources/org/zaproxy/addon/reports/resources/basic-traditional-html-plus.html
@@ -269,7 +269,7 @@
 									Host: example.com
 									<br />
 								
-									User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:82.0) Gecko/20100101 Firefox/82.0
+									User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0
 									<br />
 								
 									Pragma: no-cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,9 +17,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-        }
     }
 
     spotless {

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -20,7 +20,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.11.0-20210929.165234-4")
+    compileOnly("org.zaproxy:zap:2.11.0")
 
     api("org.hamcrest:hamcrest-library:1.3")
     api("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")


### PR DESCRIPTION
Use main release, already available.
Use new user-agent version in reports test resource.