### PR TITLE
fix: fuzz: Delay can now be set in main fuzz dialog (opt not overridden)

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - A right click (context menu) item to facilitate adding a fuzz message to the Sites Tree and History panel (Issue 1437).
 
+### Fixed
+- The 'Delay when Fuzzing (in milliseconds)' value can now also properly be controlled from the main fuzz window, and the options value won't be overridden (Issue 6651).
+
 ## [13.3.0] - 2021-10-06
 ### Fixed
 - The Numberzz payload generator should not set the increment to zero when creating subsequent payloads.

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptions.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptions.java
@@ -33,7 +33,7 @@ public class FuzzOptions extends VersionedAbstractParam {
     public static final int DEFAULT_THREADS_PER_FUZZER = 5;
 
     public static final int DEFAULT_FUZZ_DELAY_IN_MS = 0;
-
+    public static final int MAX_DELAY_IN_MS = 3600000;
     public static final int DEFAULT_RETRIES_ON_IO_ERROR = 3;
 
     public static final int DEFAULT_MAX_ERRORS_ALLOWED = 1000;

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/FuzzOptionsPanel.java
@@ -56,8 +56,6 @@ public class FuzzOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 4273217959656622745L;
 
-    private static final int MAX_DELAY_IN_MS = 3600000;
-
     private final CustomFileFuzzerAddedListener customFileFuzzerAddedListener;
 
     private final String customCategoryName;
@@ -126,7 +124,8 @@ public class FuzzOptionsPanel extends AbstractParamPanel {
                 Integer.toString(FuzzOptions.DEFAULT_THREADS_PER_FUZZER));
 
         defaultFuzzDelayInMsSpinner =
-                new ZapNumberSpinner(0, FuzzOptions.DEFAULT_FUZZ_DELAY_IN_MS, MAX_DELAY_IN_MS);
+                new ZapNumberSpinner(
+                        0, FuzzOptions.DEFAULT_FUZZ_DELAY_IN_MS, FuzzOptions.MAX_DELAY_IN_MS);
         JLabel defaultFuzzDelayLabel =
                 new JLabel(resourceBundle.getString("fuzz.options.label.delayInMs"));
         defaultFuzzDelayLabel.setLabelFor(defaultFuzzDelayInMsSpinner);

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerOptionsPanel.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerOptionsPanel.java
@@ -50,7 +50,7 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
     private final JRadioButton depthFirstPayloadReplacementStrategyRadioButton;
     private final JRadioButton breadthFirstPayloadReplacementStrategyRadioButton;
     private final JSlider defaultThreadsPerFuzzerSlider;
-    private final JSlider defaultFuzzDelayInMsSlider;
+    private final ZapNumberSpinner defaultFuzzDelayInMsSpinner;
 
     private final FuzzerHandlerOptionsPanel<FO> fuzzerHandlerOptions;
 
@@ -100,17 +100,12 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
         currentDefaultThreadsPerFuzzerLabel.setText(
                 Integer.toString(defaultOptions.getThreadCount()));
 
-        JLabel currentDefaultFuzzDelayLabel = new JLabel();
-        defaultFuzzDelayInMsSlider =
-                createDefaultFuzzDelayInMsSlider(
-                        (int) defaultOptions.getSendMessageDelay(),
-                        1000,
-                        currentDefaultFuzzDelayLabel);
+        defaultFuzzDelayInMsSpinner =
+                new ZapNumberSpinner(
+                        0, (int) defaultOptions.getSendMessageDelay(), FuzzOptions.MAX_DELAY_IN_MS);
         JLabel defaultFuzzDelayLabel =
                 new JLabel(resourceBundle.getString("fuzz.options.label.delayInMs"));
-        defaultFuzzDelayLabel.setLabelFor(defaultFuzzDelayInMsSlider);
-        currentDefaultFuzzDelayLabel.setText(
-                Integer.toString((int) defaultOptions.getSendMessageDelay()));
+        defaultFuzzDelayLabel.setLabelFor(defaultFuzzDelayInMsSpinner);
 
         ButtonGroup replacementStrategyButtonGroup = new ButtonGroup();
         depthFirstPayloadReplacementStrategyRadioButton =
@@ -213,13 +208,9 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
                                                                 currentDefaultThreadsPerFuzzerLabel))
                                         .addComponent(defaultThreadsPerFuzzerSlider))
                         .addGroup(
-                                layout.createParallelGroup()
-                                        .addGroup(
-                                                layout.createSequentialGroup()
-                                                        .addComponent(defaultFuzzDelayLabel)
-                                                        .addComponent(currentDefaultFuzzDelayLabel))
-                                        .addComponent(defaultFuzzDelayInMsSlider))
-                        .addComponent(this.fuzzerHandlerOptions.getPanel()));
+                                layout.createSequentialGroup()
+                                        .addComponent(defaultFuzzDelayLabel)
+                                        .addComponent(defaultFuzzDelayInMsSpinner)));
 
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
@@ -252,13 +243,9 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
                                                                 currentDefaultThreadsPerFuzzerLabel))
                                         .addComponent(defaultThreadsPerFuzzerSlider))
                         .addGroup(
-                                layout.createSequentialGroup()
-                                        .addGroup(
-                                                layout.createParallelGroup()
-                                                        .addComponent(defaultFuzzDelayLabel)
-                                                        .addComponent(currentDefaultFuzzDelayLabel))
-                                        .addComponent(defaultFuzzDelayInMsSlider))
-                        .addComponent(this.fuzzerHandlerOptions.getPanel()));
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(defaultFuzzDelayLabel)
+                                        .addComponent(defaultFuzzDelayInMsSpinner)));
 
         JScrollPane scrollPane = new JScrollPane();
         scrollPane.setViewportView(innerPanel);
@@ -275,28 +262,13 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
         return threadsSlider;
     }
 
-    private static JSlider createDefaultFuzzDelayInMsSlider(
-            int delayInMs, int maxDelayInMs, final JLabel currentValueFeedbackLabel) {
-        final JSlider delaySlider = new JSlider();
-        delaySlider.setMinimum(0);
-        delaySlider.setValue(delayInMs);
-        delaySlider.setMaximum(maxDelayInMs);
-        delaySlider.setMinorTickSpacing(25);
-        delaySlider.setMajorTickSpacing(100);
-        delaySlider.setPaintTicks(true);
-        delaySlider.setPaintLabels(true);
-        delaySlider.addChangeListener(
-                e -> currentValueFeedbackLabel.setText(Integer.toString(delaySlider.getValue())));
-        return delaySlider;
-    }
-
     public boolean validateFields() {
         FuzzerOptions baseOptions =
                 new FuzzerOptions(
                         defaultThreadsPerFuzzerSlider.getValue(),
                         retriesOnIOErrorNumberSpinner.getValue().intValue(),
                         getMaxErrorsAllowed(),
-                        defaultFuzzDelayInMsSlider.getValue(),
+                        defaultFuzzDelayInMsSpinner.getValue(),
                         TimeUnit.MILLISECONDS,
                         getSelectedStrategy());
 
@@ -326,7 +298,7 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
                         defaultThreadsPerFuzzerSlider.getValue(),
                         retriesOnIOErrorNumberSpinner.getValue().intValue(),
                         getMaxErrorsAllowed(),
-                        defaultFuzzDelayInMsSlider.getValue(),
+                        defaultFuzzDelayInMsSpinner.getValue(),
                         TimeUnit.MILLISECONDS,
                         getSelectedStrategy());
 
@@ -338,7 +310,7 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
         retriesOnIOErrorNumberSpinner.setValue(defaultOptions.getRetriesOnIOError());
         maxErrorsAllowedEnabledCheckBox.setSelected(true);
         maxErrorsAllowedNumberSpinner.setValue(defaultOptions.getMaxErrorsAllowed());
-        defaultFuzzDelayInMsSlider.setValue((int) defaultOptions.getSendMessageDelay());
+        defaultFuzzDelayInMsSpinner.setValue((int) defaultOptions.getSendMessageDelay());
         depthFirstPayloadReplacementStrategyRadioButton.setSelected(
                 MessageLocationsReplacementStrategy.DEPTH_FIRST
                         == defaultOptions.getPayloadsReplacementStrategy());


### PR DESCRIPTION
- CHANGELOG > Added fix note.
- impl/FuzzerOptionsPanel > Switched to spinner control (from slider).
- FuzzOptions > Added Max Delay constant.
- FuzzOptionsPanel > User new constant when creating spinner.

Fixes zaproxy/zaproxy#6651

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>