### PR TITLE
improve: exim: Add HAR help, use camelCase for existing API endpoints

### DIFF
--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ImportExportApi.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ImportExportApi.java
@@ -38,15 +38,14 @@ public class ImportExportApi extends ApiImplementor {
 
     private static final Logger LOG = LogManager.getLogger(ImportExportApi.class);
     private static final String PREFIX = "exim";
-    private static final String ACTION_IMPORTHAR = "importhar";
     private static final String PARAM_FILE_PATH = "filePath";
-
-    private static final String ACTION_IMPORTURLS = "importurls";
+    private static final String ACTION_IMPORT_HAR = "importHar";
+    private static final String ACTION_IMPORT_URLS = "importUrls";
 
     public ImportExportApi() {
         super();
-        this.addApiAction(new ApiAction(ACTION_IMPORTHAR, new String[] {PARAM_FILE_PATH}));
-        this.addApiAction(new ApiAction(ACTION_IMPORTURLS, new String[] {PARAM_FILE_PATH}));
+        this.addApiAction(new ApiAction(ACTION_IMPORT_HAR, new String[] {PARAM_FILE_PATH}));
+        this.addApiAction(new ApiAction(ACTION_IMPORT_URLS, new String[] {PARAM_FILE_PATH}));
     }
 
     @Override
@@ -61,11 +60,11 @@ public class ImportExportApi extends ApiImplementor {
         boolean success;
         File file;
         switch (name) {
-            case ACTION_IMPORTHAR:
+            case ACTION_IMPORT_HAR:
                 file = new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH));
                 success = HarImporter.importHarFile(file);
                 return handleFileImportResponse(success, file);
-            case ACTION_IMPORTURLS:
+            case ACTION_IMPORT_URLS:
                 file = new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH));
                 success = UrlsImporter.importUrlFile(file);
                 return handleFileImportResponse(success, file);

--- a/addOns/exim/src/main/javahelp/help/contents/exim.html
+++ b/addOns/exim/src/main/javahelp/help/contents/exim.html
@@ -7,17 +7,29 @@ Import/Export
 </TITLE>
 </HEAD>
 <BODY>
+<H1>Save Selected Entries as HAR (HTTP Archive File)</H1>
+A context menu item to save the selected HTTP messages in HAR format.
+
 <H1>Save Raw Message</H1>
 Provides a context menu to save content of HTTP messages as binary.
 
 <H1>Save XML Message</H1>
 Provides a context menu to save content of HTTP messages as XML.
 
+<H1>Import HAR (HTTP Archive File)</H1>
+An option to import messages from a HTTP Archive (HAR), available via the 'Import' menu.
+
 <H1>Import URLs</H1>
 An option to import a file of URLs is available via the 'Import' menu ('Import a File Containing URLs'). The file must be plain text with one URL per line.
 Blank lines and lines starting with # will be ignored.
+
 </p>
-This add-on also exposes a ZAP API endpoint <tt>/exim/importurls (filePath*)</tt> to facilitate programmatic 
-use of the functionality.
+<H1>ZAP API</H1>
+This add-on also exposes various ZAP API endpoints to facilitate programmatic use of the functionality.
+<ul>
+  <li><code>/exim/importHar (filePath*)</code></li>
+  <li><code>/exim/importUrls (filePath*)</code></li>
+</ul>
+
 </BODY>
 </HTML>

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -22,4 +22,4 @@ exim.savexml.popup.option = Save XML
 
 exim.har.file.description = HTTP Archive File (*.har)
 exim.har.file.save.error = Error saving file to {0}.
-exim.har.popup.option = Save Selected Entries as HAR (HTTP Archive File) 
+exim.har.popup.option = Save Selected Entries as HAR (HTTP Archive File)


### PR DESCRIPTION
- exim.html > Added HAR details, and adjusted API content.
- ImportExportApi.java > Made existing API endpoint names camelCase.
- Messages.properties > Removed spurious trailing space.

Part of zaproxy/zaproxy#6579

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>