### PR TITLE
improve: pscanrules: Timestamp Disclosure scan rule ignore zero strings

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - OWASP Top Ten 2021/2017 mappings for Insecure Authentication scan rule.
 
 ### Changed
-- Timestamp Disclosure scan rule now excludes values in "Expect-CT" headers (Issue 6725).
+- Timestamp Disclosure scan rule now excludes values in "Expect-CT" headers (Issue 6725), as well as zero strings (Issue 6761).
 
 ## [36] - 2021-10-06
 ### Added

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -51,6 +51,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
  */
 public class TimestampDisclosureScanRule extends PluginPassiveScanner {
 
+    private static final Date EPOCH_START = new Date(0L);
     /** a map of a regular expression pattern to details of the timestamp type found */
     static Map<Pattern, String> timestampPatterns = new HashMap<>();
 
@@ -151,12 +152,15 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
                 Matcher matcher = timestampPattern.matcher(haystack);
                 while (matcher.find()) {
                     String evidence = matcher.group();
-                    java.util.Date timestamp = null;
+                    Date timestamp = null;
                     try {
                         // parse the number as a Unix timestamp
-                        timestamp = new java.util.Date((long) Integer.parseInt(evidence) * 1000);
+                        timestamp = new Date((long) Integer.parseInt(evidence) * 1000);
                     } catch (NumberFormatException nfe) {
                         // the number is not formatted correctly to be a timestamp. Skip it.
+                        continue;
+                    }
+                    if (EPOCH_START.equals(timestamp)) {
                         continue;
                     }
                     log.debug("Found a match for timestamp type {}:{}", timestampType, evidence);

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -104,6 +104,17 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
         assertEquals(0, alertsRaised.size());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"00000000", "000000000", "0000000000"})
+    void shouldNotRaiseAlertOnZeroValues(String value) throws Exception {
+        // Given
+        HttpMessage msg = createMessage(value);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
+    }
+
     @Test
     void shouldRaiseAlertOnValidCurrentTimestamp() throws Exception {
         // Given


### PR DESCRIPTION
- CHANGELOG.md > Add change note.
- TimestampDisclosureScanRule.java > Add check and early skip for zero strings. Remove unnecessary use of qualified classes when instantiating new Date objects.
- TimestampDisclosureScanRuleUnitTest.java > Add unit test to assert the new behavior.

Fixes zaproxy/zaproxy#6761

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>