### PR TITLE
pscanrulesBeta: Fixed false positive in Reverse Tabnabbing

### DIFF
--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Fixed false positive in Reverse Tabnabbing scan rule.
 
 ## [27] - 2021-10-07
 ### Added

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRule.java
@@ -158,23 +158,18 @@ public class LinkTargetScanRule extends PluginPassiveScanner {
             String relAtt = link.getAttributeValue(REL_ATTRIBUTE);
             if (relAtt != null) {
                 relAtt = relAtt.toLowerCase();
-                if (!relAtt.contains(OPENER)) {
-                    // Its ok
-                    return false;
-                } else if (relAtt.contains(NOOPENER)) {
-                    return false;
+                if (relAtt.contains(OPENER) && !relAtt.contains(NOOPENER)) {
+                    newAlert()
+                            .setRisk(Alert.RISK_MEDIUM)
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setDescription(getDescription())
+                            .setSolution(getSolution())
+                            .setReference(getReference())
+                            .setEvidence(link.toString())
+                            .raise();
+                    return true;
                 }
             }
-            // Its bad
-            newAlert()
-                    .setRisk(Alert.RISK_MEDIUM)
-                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                    .setDescription(getDescription())
-                    .setSolution(getSolution())
-                    .setReference(getReference())
-                    .setEvidence(link.toString())
-                    .raise();
-            return true;
         }
         return false;
     }

--- a/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
+++ b/addOns/pscanrulesBeta/src/test/java/org/zaproxy/zap/extension/pscanrulesBeta/LinkTargetScanRuleUnitTest.java
@@ -78,6 +78,20 @@ class LinkTargetScanRuleUnitTest extends PassiveScannerTest<LinkTargetScanRule> 
     }
 
     @Test
+    void dontRaiseIssueWhenOnlyTargetBlank() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader("GET https://www.example.com/test/ HTTP/1.1");
+        // When
+        msg.setResponseBody(
+                "<html><a href=\"http://www.example.com\" target=\"_blank\">link</a></html>");
+        msg.setResponseHeader(getHeader(HTML_CONTENT_TYPE, msg.getResponseBody().length()));
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
     void dontRaiseIssueWhenNoLinks() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = new HttpMessage();


### PR DESCRIPTION
Hi, 

After the release, I found a false positive(false detection) at reverse tabnabbing in the pscanBetaRule. `target=_blank` and `rel=opener` are required to be detection, but they are also detected if there is no rel attribute(when rel is null). I checked the problem in the code and send PR.

![1414](https://user-images.githubusercontent.com/13212227/137670320-7bcd9ef5-aaea-464a-bc44-35a34d5c5d9c.png)

If there's anything lack, please let me know :D
Thank you.