### PR TITLE
ascanrulesAlpha: Fix typo in payload in ForbiddenBypassScanRule

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Fixed typo in payload in Forbidden (403) Bypass scan rule.
 
 ## [32] - 2021-10-07
 ### Added

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ForbiddenBypassScanRule.java
@@ -128,7 +128,7 @@ public class ForbiddenBypassScanRule extends AbstractAppPlugin {
             "X-Remote-IP: 127.0.0.1",
             "X-Client-IP: 127.0.0.1",
             "X-Host: 127.0.0.1",
-            "X-Forwared-Host: 127.0.0.1"
+            "X-Forwarded-Host: 127.0.0.1"
         };
 
         for (String header : headerPayloads) {


### PR DESCRIPTION
Signed-off-by: Karthik UJ <karthikuj2001@gmail.com>

**Summary**
- There was an error in one of the payloads in ForbiddedBypassScanRule.java
- X-Forwared-Host (incorrect)
- X-Forwarded-Host (correct)