### PR TITLE
improve: ascanrules: Command Injection scan rule, try basic payload

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Command Injection scan rule will now initially attempt a simple injection without the original parameter value (Issue 6538).
 
 ## [41] - 2021-10-06
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -92,10 +92,13 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
 
     static {
         // No quote payloads
+        NIX_OS_PAYLOADS.put(NIX_TEST_CMD, NIX_CTRL_PATTERN);
         NIX_OS_PAYLOADS.put("&" + NIX_TEST_CMD + "&", NIX_CTRL_PATTERN);
         NIX_OS_PAYLOADS.put(";" + NIX_TEST_CMD + ";", NIX_CTRL_PATTERN);
+        WIN_OS_PAYLOADS.put(WIN_TEST_CMD, WIN_CTRL_PATTERN);
         WIN_OS_PAYLOADS.put("&" + WIN_TEST_CMD, WIN_CTRL_PATTERN);
         WIN_OS_PAYLOADS.put("|" + WIN_TEST_CMD, WIN_CTRL_PATTERN);
+        PS_PAYLOADS.put(PS_TEST_CMD, PS_CTRL_PATTERN);
         PS_PAYLOADS.put(";" + PS_TEST_CMD, PS_CTRL_PATTERN);
 
         // Double quote payloads
@@ -393,23 +396,17 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
 
         switch (this.getAttackStrength()) {
             case LOW:
-                // This works out as a total of 2+2 reqs / param per tech / per interface (i.e.: on
-                // windows we check both commandline and then powershell)
-                // Probably blind should be enabled only starting from MEDIUM (TBE)
-                targetCount = 2;
+                targetCount = 3;
                 blindTargetCount = 2;
                 break;
 
             case MEDIUM:
-                // This works out as a total of 6+6 reqs / param per tech / per interface (i.e.: on
-                // windows we check both commandline and then powershell)
-                targetCount = 6;
+                targetCount = 7;
                 blindTargetCount = 6;
                 break;
 
             case HIGH:
-                // Up to around 24 requests / param / page
-                targetCount = 12;
+                targetCount = 13;
                 blindTargetCount = 12;
                 break;
 
@@ -499,6 +496,7 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
         Iterator<String> it = osPayloads.keySet().iterator();
         List<Long> responseTimes = new ArrayList<>(targetCount);
         long elapsedTime;
+        boolean firstPayload = true;
 
         // -----------------------------------------------
         // Check 1: Feedback based OS Command Injection
@@ -514,7 +512,8 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
             }
 
             HttpMessage msg = getNewMsg();
-            paramValue = value + payload;
+            paramValue = firstPayload ? payload : value + payload;
+            firstPayload = false;
             setParameter(msg, paramName, paramValue);
 
             log.debug("Testing [{}] = [{}]", paramName, paramValue);


### PR DESCRIPTION
- CHANGELOG.md > Added change note.
- CommandInjectionScanRule.java > Tweak payloads and functionality to initially try a simple payload without the original parameter value.
- CommandInjectionScanRuleUnitTest.java > Adjusted to account for additional payloads per OS.

Fixes zaproxy/zaproxy#6538

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>