### PR TITLE
openapi: tweak error message

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Use examples defined in parameters ([Issue #6870](https://github.com/zaproxy/zaproxy/issues/6870)).
+- Tweak error message shown when content type is not supported.
 
 ### Fixed
 - Fixed ClassCastException when using nested map properties with mixed definition styles. 
@@ -18,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use path and operation servers ([Issue #6754](https://github.com/zaproxy/zaproxy/issues/6754)).
 
 ### Changed
-- Warn when request has content `application/xml`, not supported (Related to [Issue #6767](https://github.com/zaproxy/zaproxy/issues/6767)).
+- Warn when request has content type `application/xml`, not supported (Related to [Issue #6767](https://github.com/zaproxy/zaproxy/issues/6767)).
 - Maintenance changes.
 - Update minimum ZAP version to 2.11.0.
 

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -79,4 +79,4 @@ openapi.swaggerconverter.targeturl.invalid = Failed to create/normalise the targ
 openapi.swaggerconverter.targeturl.missingcomponents = The target URL does not have the scheme or authority component:\n{0}
 
 openapi.unsupportedscheme = The scheme of the URL is not HTTP or HTTPS:\n{0}
-openapi.unsupportedcontent = Not generating request body for operation {0}, the content {1} is not supported.
+openapi.unsupportedcontent = Not generating request body for operation {0}, the content type {1} is not supported.

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/BodyGeneratorUnitTest.java
@@ -705,7 +705,7 @@ class BodyGeneratorUnitTest extends TestUtils {
         assertThat(
                 generators.getErrorMessages(),
                 contains(
-                        "Not generating request body for operation xml, the content application/xml is not supported."));
+                        "Not generating request body for operation xml, the content type application/xml is not supported."));
     }
 
     @Test


### PR DESCRIPTION
Make it clear that it is the content type that's not supported.
Tweak also changelog entry.