### PR TITLE
Automation: Set ZAP exit status

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Session management support (but not currently exposed - its a stepping stone to full authentication support)
 - User and HTTP authentication support (as above)
 - Authentication verification support (as above)
+- Set ZAP exit code when "-cmd" and "-autorun" options used
 
 ### Fixed
 - Plans saved without default ".yaml" extension.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -57,6 +57,7 @@ import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
 import org.zaproxy.addon.automation.jobs.RequestorJob;
 import org.zaproxy.addon.automation.jobs.SpiderJob;
 import org.zaproxy.zap.ZAP;
+import org.zaproxy.zap.ZAP.ProcessType;
 import org.zaproxy.zap.eventBus.Event;
 import org.zaproxy.zap.extension.stats.ExtensionStats;
 
@@ -513,7 +514,21 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
     @Override
     public void execute(CommandLineArgument[] args) {
         if (arguments[ARG_AUTO_RUN_IDX].isEnabled()) {
-            runAutomationFile(arguments[ARG_AUTO_RUN_IDX].getArguments().firstElement());
+            AutomationProgress progress =
+                    runAutomationFile(arguments[ARG_AUTO_RUN_IDX].getArguments().firstElement());
+            if (ProcessType.cmdline.equals(ZAP.getProcessType())) {
+                if (progress.hasErrors()) {
+                    Control.getSingleton()
+                            .setExitStatus(
+                                    1,
+                                    "Automation Framework setting exit status to due to plan errors");
+                } else if (progress.hasWarnings()) {
+                    Control.getSingleton()
+                            .setExitStatus(
+                                    2,
+                                    "Automation Framework setting exit status to due to plan warnings");
+                }
+            }
         }
         if (arguments[ARG_AUTO_GEN_MIN_IDX].isEnabled()) {
             generateTemplateFile(

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
@@ -17,6 +17,14 @@ It provides the following command line options:
 <li>-autogenconf &lt;filename&gt;	Generate template automation file using the current configuration.
 </ul>
 
+If the <code>-autorun</code> option is used with the ZAP <code>-cmd</code> option then the ZAP exit value will be set as follows: 
+<ul>
+<li>0 - The plan completed successfully with no errors or warnings
+<li>1 - The plan reported one or more errors
+<li>2 - The plan reported no errors but one or more warnings
+</ul>
+Whether the plan completed after encountering errors or warnings will depend on the settings used in the <a href="environment.html">environment</a>.
+<p>
 To use the automation framework:
 <ol>
 <li>Generate a template automation file using one of the <code>-autogen*</code> command line options
@@ -29,7 +37,7 @@ and ZAP exits as soon as it has finished generating or running the jobs defined 
 However you can choose to run Automation Framework jobs using the ZAP desktop to help you debug issues.
 
 <H2>GUI</H2>
-A <a href="gui.html">GUI</a> is under development and currently provides a limited set of functionality.
+A <a href="gui.html">GUI</a> is under development and provides an ever increasing set of features.
 
 <H2>API</H2>
 The following API endpoints are provided by this add-on:


### PR DESCRIPTION
Only when both -cmd and -autorun options used together.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>