### PR TITLE
graphql: Handle NPE during introspection

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- A message is displayed if the "data" object in an introspection response
+  is `null` ([Issue 6890](https://github.com/zaproxy/zaproxy/issues/6890)).
 
 ## [0.6.0] - 2021-10-06
 ### Changed

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -93,9 +93,12 @@ public class GraphQlParser {
                 throw new IOException("The response was empty.");
             }
             @SuppressWarnings("unchecked")
-            Document schema =
-                    new IntrospectionResultToSchema()
-                            .createSchemaDefinition((Map<String, Object>) result.get("data"));
+            Map<String, Object> data = (Map<String, Object>) result.get("data");
+            if (data == null) {
+                throw new IOException(
+                        "The \"data\" object in the introspection response was null.");
+            }
+            Document schema = new IntrospectionResultToSchema().createSchemaDefinition(data);
             String schemaSdl = new SchemaPrinter().print(schema);
             parse(schemaSdl);
         } catch (JsonSyntaxException e) {

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlParserUnitTest.java
@@ -50,7 +50,7 @@ class GraphQlParserUnitTest extends TestUtils {
         nano.addHandler(new StaticContentServerHandler("/", ""));
         GraphQlParser gqp = new GraphQlParser(endpointUrl);
         // When/Then
-        assertThrows(IOException.class, () -> gqp.introspect());
+        assertThrows(IOException.class, gqp::introspect);
     }
 
     @Test
@@ -59,6 +59,15 @@ class GraphQlParserUnitTest extends TestUtils {
         nano.addHandler(new StaticContentServerHandler("/", "not json"));
         GraphQlParser gqp = new GraphQlParser(endpointUrl);
         // When/Then
-        assertThrows(IOException.class, () -> gqp.introspect());
+        assertThrows(IOException.class, gqp::introspect);
+    }
+
+    @Test
+    void shouldFailIntrospectionWhenResponseDataIsNull() throws Exception {
+        // Given
+        nano.addHandler(new StaticContentServerHandler("/", "{\"data\": null}"));
+        GraphQlParser gqp = new GraphQlParser(endpointUrl);
+        // When/Then
+        assertThrows(IOException.class, gqp::introspect);
     }
 }


### PR DESCRIPTION
Add a null check for the value of "data" in the introspection response.
Resolves zaproxy/zaproxy#6890.

Signed-off-by: ricekot <github@ricekot.com>