### PR TITLE
Automation: enable authentication for jobs

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Delay job
-- Session management support (but not currently exposed - its a stepping stone to full authentication support)
-- User and HTTP authentication support (as above)
-- Authentication verification support (as above)
+- Session management support
+- User and HTTP authentication support
+- Authentication verification support
 - Set ZAP exit code when "-cmd" and "-autorun" options used
+- Requestor, Spider and ActiveScan jobs changed to support an authenticated user
 
 ### Changed
 - Dependency updates.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.automation.gui.EnvironmentDialog;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.users.User;
 
 public class AutomationEnvironment {
 
@@ -101,7 +102,8 @@ public class AutomationEnvironment {
                                 "automation.error.env.badcontext", contextObject));
                 return;
             }
-            this.contexts.add(new ContextWrapper((LinkedHashMap<?, ?>) contextObject, progress));
+            this.contexts.add(
+                    new ContextWrapper((LinkedHashMap<?, ?>) contextObject, this, progress));
         }
     }
 
@@ -215,6 +217,25 @@ public class AutomationEnvironment {
         ContextWrapper wrapper = this.getContextWrapper(name);
         if (wrapper != null) {
             return wrapper.getContext();
+        }
+        return null;
+    }
+
+    public List<String> getAllUserNames() {
+        List<String> userNames = new ArrayList<>();
+        for (ContextWrapper context : contexts) {
+            userNames.addAll(context.getUserNames());
+        }
+
+        return userNames;
+    }
+
+    public User getUser(String name) {
+        for (ContextWrapper context : contexts) {
+            User user = context.getUser(name);
+            if (user != null) {
+                return user;
+            }
         }
         return null;
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
@@ -36,6 +37,7 @@ import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
 import org.zaproxy.addon.automation.tests.AutomationAlertTest;
 import org.zaproxy.addon.automation.tests.AutomationStatisticTest;
 import org.zaproxy.zap.extension.stats.ExtensionStats;
+import org.zaproxy.zap.users.User;
 
 public abstract class AutomationJob implements Comparable<AutomationJob> {
 
@@ -629,5 +631,26 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
         } catch (Exception e) {
             throw new AutomationJobException("Failed to create new job", e);
         }
+    }
+
+    public void verifyUser(String username, AutomationProgress progress) {
+        if (!StringUtils.isEmpty(username) && !this.getEnv().getAllUserNames().contains(username)) {
+            progress.error(
+                    Constant.messages.getString(
+                            "automation.error.job.baduser", this.getName(), username));
+        }
+    }
+
+    public User getUser(String username, AutomationProgress progress) {
+        User user = null;
+        if (!StringUtils.isEmpty(username)) {
+            user = this.getEnv().getUser(username);
+            if (user == null) {
+                progress.error(
+                        Constant.messages.getString(
+                                "automation.error.job.baduser", this.getName(), username));
+            }
+        }
+        return user;
     }
 }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
@@ -55,6 +55,7 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
     private static final String TITLE = "automation.dialog.ascan.title";
     private static final String NAME_PARAM = "automation.dialog.all.name";
     private static final String CONTEXT_PARAM = "automation.dialog.ascan.context";
+    private static final String USER_PARAM = "automation.dialog.all.user";
     private static final String POLICY_PARAM = "automation.dialog.ascan.policy";
     private static final String MAX_RULE_DURATION_PARAM = "automation.dialog.ascan.maxruleduration";
     private static final String MAX_SCAN_DURATION_PARAM = "automation.dialog.ascan.maxscanduration";
@@ -93,6 +94,12 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
         // Add blank option
         contextNames.add(0, "");
         this.addComboField(0, CONTEXT_PARAM, contextNames, this.job.getParameters().getContext());
+
+        List<String> users = job.getEnv().getAllUserNames();
+        // Add blank option
+        users.add(0, "");
+        this.addComboField(0, USER_PARAM, users, this.job.getData().getParameters().getUser());
+
         this.addTextField(0, POLICY_PARAM, this.job.getParameters().getPolicy());
         this.addNumberField(
                 0,
@@ -204,6 +211,7 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
     public void save() {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
         this.job.getParameters().setContext(this.getStringValue(CONTEXT_PARAM));
+        this.job.getParameters().setUser(this.getStringValue(USER_PARAM));
         this.job.getParameters().setPolicy(this.getStringValue(POLICY_PARAM));
         this.job
                 .getParameters()

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
@@ -42,6 +42,7 @@ public class RequestorJobDialog extends StandardFieldsDialog {
 
     private static final String TITLE = "automation.dialog.requestor.title";
     private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String USER_PARAM = "automation.dialog.all.user";
 
     private RequestorJob job;
 
@@ -66,6 +67,12 @@ public class RequestorJobDialog extends StandardFieldsDialog {
         buttons.add(getRemoveButton());
 
         this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+
+        List<String> users = job.getEnv().getAllUserNames();
+        // Add blank option
+        users.add(0, "");
+        this.addComboField(0, USER_PARAM, users, this.job.getData().getParameters().getUser());
+
         this.addPadding(0);
 
         this.addTableField(1, getRulesTable(), buttons);
@@ -74,6 +81,7 @@ public class RequestorJobDialog extends StandardFieldsDialog {
     @Override
     public void save() {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getData().getParameters().setUser(this.getStringValue(USER_PARAM));
         job.getData().setRequests(this.getRulesModel().getRules());
         this.job.setChanged();
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
@@ -50,6 +50,7 @@ public class SpiderJobDialog extends StandardFieldsDialog {
     private static final String TITLE = "automation.dialog.spider.title";
     private static final String NAME_PARAM = "automation.dialog.all.name";
     private static final String CONTEXT_PARAM = "automation.dialog.spider.context";
+    private static final String USER_PARAM = "automation.dialog.all.user";
     private static final String URL_PARAM = "automation.dialog.spider.url";
     private static final String MAX_DURATION_PARAM = "automation.dialog.spider.maxduration";
     private static final String MAX_DEPTH_PARAM = "automation.dialog.spider.maxdepth";
@@ -88,6 +89,12 @@ public class SpiderJobDialog extends StandardFieldsDialog {
         // Add blank option
         contextNames.add(0, "");
         this.addComboField(0, CONTEXT_PARAM, contextNames, this.job.getParameters().getContext());
+
+        List<String> users = job.getEnv().getAllUserNames();
+        // Add blank option
+        users.add(0, "");
+        this.addComboField(0, USER_PARAM, users, this.job.getData().getParameters().getUser());
+
         // Cannot select the node as it might not be present in the Sites tree
         this.addNodeSelectField(0, URL_PARAM, null, true, false);
         Component urlField = this.getField(URL_PARAM);
@@ -250,6 +257,7 @@ public class SpiderJobDialog extends StandardFieldsDialog {
     public void save() {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
         this.job.getParameters().setContext(this.getStringValue(CONTEXT_PARAM));
+        this.job.getParameters().setUser(this.getStringValue(USER_PARAM));
         this.job.getParameters().setUrl(this.getStringValue(URL_PARAM));
         this.job.getParameters().setMaxDuration(this.getIntValue(MAX_DURATION_PARAM));
         this.job.getParameters().setMaxDepth(this.getIntValue(MAX_DEPTH_PARAM));

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -44,6 +44,7 @@ import org.zaproxy.zap.extension.ascan.ActiveScan;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
 import org.zaproxy.zap.model.Target;
+import org.zaproxy.zap.users.User;
 
 public class ActiveScanJob extends AutomationJob {
 
@@ -83,6 +84,8 @@ public class ActiveScanJob extends AutomationJob {
         }
         LinkedHashMap<?, ?> params = (LinkedHashMap<?, ?>) jobData.get("parameters");
         JobUtils.applyParamsToObject(params, this.parameters, this.getName(), null, progress);
+
+        this.verifyUser(this.getParameters().getUser(), progress);
 
         // Parse the policy defn
         Object policyDefn = this.getJobData().get("policyDefinition");
@@ -192,6 +195,7 @@ public class ActiveScanJob extends AutomationJob {
         Target target = new Target(context.getContext());
         target.setRecurse(true);
         List<Object> contextSpecificObjects = new ArrayList<>();
+        User user = this.getUser(this.getParameters().getUser(), progress);
 
         ScanPolicy scanPolicy = null;
         if (!StringUtils.isEmpty(this.getParameters().getPolicy())) {
@@ -210,7 +214,7 @@ public class ActiveScanJob extends AutomationJob {
             contextSpecificObjects.add(scanPolicy);
         }
 
-        int scanId = this.getExtAScan().startScan(target, null, contextSpecificObjects.toArray());
+        int scanId = this.getExtAScan().startScan(target, user, contextSpecificObjects.toArray());
 
         long endTime = Long.MAX_VALUE;
         if (JobUtils.unBox(this.getParameters().getMaxScanDurationInMins()) > 0) {
@@ -509,6 +513,7 @@ public class ActiveScanJob extends AutomationJob {
     public static class Parameters extends AutomationData {
 
         private String context;
+        private String user;
         private String policy;
         private Integer maxRuleDurationInMins;
         private Integer maxScanDurationInMins;
@@ -528,6 +533,14 @@ public class ActiveScanJob extends AutomationJob {
 
         public void setContext(String context) {
             this.context = context;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public void setUser(String user) {
+            this.user = user;
         }
 
         public String getPolicy() {

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/authentication.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/authentication.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<TITLE>
+Automation Framework - authentication
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Automation Framework - authentication</H1>
+The Automation Framework supports a subset of the authentication mechanisms supported by ZAP.
+
+<H2>Environmental Variables</H2>
+
+ZAP supports a set of Authentication Header Environmental Variables - these will be applied by ZAP if they are defined
+however ZAP is run, including via the Automation Framework.
+<p>
+These environmental variables must be defined at the system level - if they are defined in the <a href="environment.html">environment</a> 
+env section then they will be ignored.
+
+<H2>Context Based Authentication</H2>
+
+The Automation Framework supports the following methods of authentication supported by ZAP:
+
+<ul>
+<li>Manual (use this if you are using the Authentication Header Environmental Variable)</li>
+<li>HTTP / NTLM</li>
+</ul>
+
+The remaining mechanisms will be supported soon.
+
+<H2>Authentication Statistics</H2>
+
+ZAP maintains authentication statistics - search for 'auth' in the key field on the 
+<a href="https://www.zaproxy.org/docs/internal-statistics/">ZAP Internal Statistics</a> website page.
+These are ideal to use in <a href="tests.html">tests</a> to make sure the authentication is working as you expect. 
+<p>
+The authentication statistics are maintained for all supported authentication methods (including 'manual')
+but only if you have configured all of the authentication elements correctly.<br>
+You are strongly advised to test this via the ZAP desktop GUI.
+
+<H2>Configuring Authentication</H2>
+
+The recommended way to configure authentication is to do so via the ZAP desktop GUI - 
+this gives you complete control over all aspects and allows you to test it in place.<br>
+Then you can create a new Authentication Framework job using the context(s) you have tested - 
+the authentication elements will be correctly initialised for all aspects supported.
+<p>
+It is worth noting that the authentication elements cannot be edited via the Automation Framework <a href="gui.html">GUI</a>,
+but they will not get lost if you use the GUI as long as you do not use it to delete the contexts.
+<p>
+The GUI will be updated to support all of the authentication elements in due course.
+
+</BODY>
+</HTML>
+

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/automation.html
@@ -36,6 +36,9 @@ In most cases it is recommended to also use the <code>-cmd</code> command line o
 and ZAP exits as soon as it has finished generating or running the jobs defined in the file.
 However you can choose to run Automation Framework jobs using the ZAP desktop to help you debug issues.
 
+<H2>Authentication</H2>
+The Automation Framework supports a subset of the <a href="authentication.html">authentication</a> mechanisms supported by ZAP.
+
 <H2>GUI</H2>
 A <a href="gui.html">GUI</a> is under development and provides an ever increasing set of features.
 

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/environment.html
@@ -9,6 +9,8 @@ Automation Framework - Environment
 <H1>Automation Framework - Environment</H1>
 
 This section of the YAML configuration file defines the applications which the rest of the jobs can act on.
+<p>
+The Automation Framework supports a subset of the <a href="authentication.html">authentication</a> mechanisms supported by ZAP.
 
 <pre>
 env:                                   # The environment, mandatory
@@ -17,14 +19,38 @@ env:                                   # The environment, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
-      authentication:                  # TBA: In time to cover all auth configs
+      authentication:
+        method:                        # String, one of 'manual', 'http' - in time will cover all methods supported by ZAP
+        parameters:
+          hostname:                    # String, only for 'http' method
+          port:                        # Int, only for 'http' method
+          realm:                       # String, only for 'http' method
+        verification:
+          method:                      # String, one of 'response', 'request', 'both', 'poll'
+          loggedInRegex:               # String, regex pattern for determining if logged in
+          loggedOutRegex:              # String, regex pattern for determining if logged out
+          pollFrequency:               # Int, the poll frequency, only for 'poll' verification
+          pollUnits:                   # String, the poll units, one of 'requests', 'seconds', only for 'poll' verification
+          pollUrl:                     # String, the URL to poll, only for 'poll' verification
+          pollPostData:                # String, post dat to include in the poll, only for 'poll' verification
+          pollAdditionalHeaders:       # List of additional headers for poll request, only for 'poll' verification
+          - header:                    # The header name
+            value:                     # The header value
+      sessionManagement:
+        method:                        # String, one of 'cookie', 'http', 'script'
+        script:                        # String, path to script, only for 'script' session management
+        scriptEngine:                  # String, the name of the script engine to use, only for 'script' session management
+      users:                           # List of one or more users to use for authentication
+      - name:                          # String, the name to be used by the jobs
+        username:                      # String, the username to use when authenticating, vars supported
+        password:                      # String, the password to use when authenticating, vars supported
+  vars:                                # List of 0 or more custom variables to be used throughout the config file
+    myVarOne: CustomConfigVarOne       # Can be used as ${myVarOne} anywhere throughout the config
+    myVarTwo: ${myVarOne}.VarTwo       # Can refer other vars    
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
     progressToStdout: true             # If set will write job progress to stdout
-  vars:                                # List of 1 or more custom variables to be used throughout the config file
-    myVarOne: CustomConfigVarOne       # Can be used as ${myVarOne} anywhere throughout the config
-    myVarTwo: ${myVarOne}.VarTwo       # Can refer other vars    
 </pre>
 
 System environment variables can also be used in the config in the same manner as above. In case there are two variables

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-ascan.html
@@ -19,6 +19,7 @@ By default this job will actively scan the first context defined in the <a href=
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
       context:                         # String: Name of the context to attack, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       policy:                          # String: Name of the scan policy to be used, default: Default Policy
       maxRuleDurationInMins:           # Int: The max time in minutes any individual rule will be allowed to run for, default: 0 unlimited
       maxScanDurationInMins:           # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-requestor.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-requestor.html
@@ -16,6 +16,7 @@ an expected response code, against which the actual response is compared, and th
 <pre>
   - type: requestor                    # Used to send specific requests to targets
     parameters:
+      user:                            # String: An optional user to use for authenticated requests, must be defined in the env
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
         method:                        # String: A non-empty request method, default: GET

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-spider.html
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/contents/job-spider.html
@@ -18,6 +18,7 @@ By default this job will spider the first context defined in the <a href="enviro
   - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
     parameters:
       context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       url:                             # String: Url to start spidering from, default: first context URL
       maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
       maxDepth:                        # Int: The maximum tree depth to explore, default 5

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/index.xml
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/index.xml
@@ -8,6 +8,7 @@
 	<indexitem text="automation" target="automation" />
     <indexitem text="automation - gui" target="automation.gui" />
     <indexitem text="automation - environment" target="automation.env" />
+    <indexitem text="automation - authentication" target="automation.auth" />
     <indexitem text="automation - addOns job" target="automation.addons" />
     <indexitem text="automation - passiveScan-config job" target="automation.pscanconf" />
     <indexitem text="automation - passiveScan-wait job" target="automation.pscanwait" />

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/map.jhm
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/map.jhm
@@ -8,6 +8,7 @@
     <mapID target="automation" url="contents/automation.html" />
     <mapID target="automation.gui" url="contents/gui.html" />
     <mapID target="automation.env" url="contents/environment.html" />
+    <mapID target="automation.auth" url="contents/authentication.html" />
     <mapID target="automation.addons" url="contents/job-addons.html" />
     <mapID target="automation.pscanconf" url="contents/job-pscanconf.html" />
     <mapID target="automation.pscanwait" url="contents/job-pscanwait.html" />

--- a/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/toc.xml
+++ b/addOns/automation/src/main/javahelp/org/zaproxy/addon/automation/resources/help/toc.xml
@@ -9,6 +9,7 @@
 			<tocitem text="Automation Framework" image="automation-icon" target="automation">
 				<tocitem text="GUI" target="automation.gui"/>
 				<tocitem text="Environment" target="automation.env"/>
+				<tocitem text="Authentication" target="automation.auth"/>
 				<tocitem text="Job: addOns" target="automation.addons"/>
 				<tocitem text="Job: passiveScanConfig" target="automation.pscanconf"/>
 				<tocitem text="Job: passiveScanWait" target="automation.pscanwait"/>

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -53,6 +53,7 @@ automation.dialog.alerttest.other = Other Info (regex):
 automation.dialog.alerttest.onfail = On Fail:
 
 automation.dialog.all.name = Job Name:
+automation.dialog.all.user = Authenticated User:
 
 automation.dialog.ascan.summary = Context: {0}
 automation.dialog.ascan.title = Active Scan Job
@@ -247,6 +248,7 @@ automation.error.context.badurlslist = Context URLs should be a list: {0}
 automation.error.context.baduserslist = Context users should be a list: {0}
 automation.error.context.baduser = Invalid user in context: {0}
 automation.error.context.badregex = Invalid value for regex: {0} : {1}
+automation.error.context.dupuser = Duplicate user in context {0} : {1}
 automation.error.context.noname = Missing name for context: {0}
 automation.error.context.nourl = Missing URLs for context: {0}
 automation.error.context.unknown = Unrecognised context: {0}
@@ -279,6 +281,7 @@ automation.error.env.verification.logoutregex.bad = Invalid verification loggedO
 automation.error.nofile = Cannot access file: {0}
 automation.error.read = Cannot read file: {0}
 automation.error.write = Cannot write to file: {0}
+automation.error.job.baduser = Job {0} unrecognised user: {1}
 automation.error.job.data = Unsupported job data format: {0}
 automation.error.job.name = Unsupported job name format: {0}
 automation.error.job.unknown = Unrecognised job type: {0}
@@ -304,6 +307,7 @@ automation.error.requestor.badurl = Job {0} has invalid URL {1} for request : {2
 automation.error.requestor.invalidmethod = Job {0} has invalid method {1} for request : {2}
 automation.error.requestor.badcode = Job {0} has invalid response code {1} for request: {2}
 automation.error.requestor.badnetwork = Error sending message {1} in job {0} : {2}
+automation.error.requestor.baduser = Job {0} user {1} not found
 automation.error.requestor.codemismatch = Difference in response code values for message {0} Expected : {1} Received : {2}
 
 automation.error.pscan.rule.unknown = Unrecognised passive scan rule id for job {0} : {1}
@@ -328,6 +332,7 @@ automation.info.delay.timeout = Job {0} ended after specified time {1}
 automation.info.pscan.rule.noid = Job {0} ignoring rule with no id 
 automation.info.pscan.rule.setthreshold = Job {0} set rule {1} threshold to {2}
 automation.info.requrl = Job {0} requesting URL {1}
+automation.info.requrluser = Job {0} requesting URL {1} with user {2}
 automation.info.setparam = Job {0} set {1} = {2}
 automation.info.jobstart = Job {0} started
 automation.info.jobend = Job {0} finished

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-max.yaml
@@ -1,6 +1,7 @@
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
       context:                         # String: Name of the context to attack, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       policy:                          # String: Name of the scan policy to be used, default: Default Policy
       maxRuleDurationInMins:           # Int: The max time in minutes any individual rule will be allowed to run for, default: 0 unlimited
       maxScanDurationInMins:           # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-min.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/activeScan-min.yaml
@@ -1,6 +1,7 @@
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
       context:                         # String: Name of the context to attack, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       policy:                          # String: Name of the scan policy to be used, default: Default Policy
       maxRuleDurationInMins:           # Int: The max time in minutes any individual rule will be allowed to run for, default: 0 unlimited
       maxScanDurationInMins:           # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/env.yaml
@@ -5,8 +5,32 @@ env:                                   # The environment, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
-      authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
+      authentication:
+        method:                        # String, one of 'manual', 'http' - in time will cover all methods supported by ZAP
+        parameters:
+          hostname:                    # String, only for 'http' method
+          port:                        # Int, only for 'http' method
+          realm:                       # String, only for 'http' method
+        verification:
+          method:                      # String, one of 'response', 'request', 'both', 'poll'
+          loggedInRegex:               # String, regex pattern for determining if logged in
+          loggedOutRegex:              # String, regex pattern for determining if logged out
+          pollFrequency:               # Int, the poll frequency, only for 'poll' verification
+          pollUnits:                   # String, the poll units, one of 'requests', 'seconds', only for 'poll' verification
+          pollUrl:                     # String, the URL to poll, only for 'poll' verification
+          pollPostData:                # String, post dat to include in the poll, only for 'poll' verification
+          pollAdditionalHeaders:       # List of additional headers for poll request, only for 'poll' verification
+          - header:                    # The header name
+            value:                     # The header value
+      sessionManagement:
+        method:                        # String, one of 'cookie', 'http', 'script'
+        script:                        # String, path to script, only for 'script' session management
+        scriptEngine:                  # String, the name of the script engine to use, only for 'script' session management
+      users:                           # List of one or more users to use for authentication
+      - name:                          # String, the name to be used by the jobs
+        username:                      # String, the username to use when authenticating, vars supported
+        password:                      # String, the password to use when authenticating, vars supported
+  vars:                                # List of 0 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-max.yaml
@@ -1,5 +1,6 @@
   - type: requestor                    # Used to send specific requests to targets
     parameters:
+      user:                            # String: An optional user to use for authenticated requests, must be defined in the env
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
         name:                          # String: Optional name for the request, for documentation only

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-min.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/requestor-min.yaml
@@ -1,4 +1,5 @@
   - type: requestor                    # Used to send specific requests to targets
     parameters:
+      user:                            # String: An optional user to use for authenticated requests, must be defined in the env
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/spider-max.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/spider-max.yaml
@@ -1,6 +1,7 @@
   - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
     parameters:
       context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       url:                             # String: Url to start spidering from, default: first context URL
       maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
       maxDepth:                        # Int: The maximum tree depth to explore, default 5

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/spider-min.yaml
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/spider-min.yaml
@@ -1,6 +1,7 @@
   - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
     parameters:
       context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       url:                             # String: Url to start spidering from, default: first context URL
       maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
       maxDepth:                        # Int: The maximum tree depth to explore

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
@@ -5,8 +5,32 @@ env:                                   # The environment, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
-      authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
+      authentication:
+        method:                        # String, one of 'manual', 'http' - in time will cover all methods supported by ZAP
+        parameters:
+          hostname:                    # String, only for 'http' method
+          port:                        # Int, only for 'http' method
+          realm:                       # String, only for 'http' method
+        verification:
+          method:                      # String, one of 'response', 'request', 'both', 'poll'
+          loggedInRegex:               # String, regex pattern for determining if logged in
+          loggedOutRegex:              # String, regex pattern for determining if logged out
+          pollFrequency:               # Int, the poll frequency, only for 'poll' verification
+          pollUnits:                   # String, the poll units, one of 'requests', 'seconds', only for 'poll' verification
+          pollUrl:                     # String, the URL to poll, only for 'poll' verification
+          pollPostData:                # String, post dat to include in the poll, only for 'poll' verification
+          pollAdditionalHeaders:       # List of additional headers for poll request, only for 'poll' verification
+          - header:                    # The header name
+            value:                     # The header value
+      sessionManagement:
+        method:                        # String, one of 'cookie', 'http', 'script'
+        script:                        # String, path to script, only for 'script' session management
+        scriptEngine:                  # String, the name of the script engine to use, only for 'script' session management
+      users:                           # List of one or more users to use for authentication
+      - name:                          # String, the name to be used by the jobs
+        username:                      # String, the username to use when authenticating, vars supported
+        password:                      # String, the password to use when authenticating, vars supported
+  vars:                                # List of 0 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-max.yaml
@@ -5,8 +5,32 @@ env:                                   # The environment, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
-      authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
+      authentication:
+        method:                        # String, one of 'manual', 'http' - in time will cover all methods supported by ZAP
+        parameters:
+          hostname:                    # String, only for 'http' method
+          port:                        # Int, only for 'http' method
+          realm:                       # String, only for 'http' method
+        verification:
+          method:                      # String, one of 'response', 'request', 'both', 'poll'
+          loggedInRegex:               # String, regex pattern for determining if logged in
+          loggedOutRegex:              # String, regex pattern for determining if logged out
+          pollFrequency:               # Int, the poll frequency, only for 'poll' verification
+          pollUnits:                   # String, the poll units, one of 'requests', 'seconds', only for 'poll' verification
+          pollUrl:                     # String, the URL to poll, only for 'poll' verification
+          pollPostData:                # String, post dat to include in the poll, only for 'poll' verification
+          pollAdditionalHeaders:       # List of additional headers for poll request, only for 'poll' verification
+          - header:                    # The header name
+            value:                     # The header value
+      sessionManagement:
+        method:                        # String, one of 'cookie', 'http', 'script'
+        script:                        # String, path to script, only for 'script' session management
+        scriptEngine:                  # String, the name of the script engine to use, only for 'script' session management
+      users:                           # List of one or more users to use for authentication
+      - name:                          # String, the name to be used by the jobs
+        username:                      # String, the username to use when authenticating, vars supported
+        password:                      # String, the password to use when authenticating, vars supported
+  vars:                                # List of 0 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
@@ -30,6 +54,7 @@ jobs:
       threshold:                       # String: The Alert Threshold for this rule, one of Off, Low, Medium, High, default: Medium
   - type: requestor                    # Used to send specific requests to targets
     parameters:
+      user:                            # String: An optional user to use for authenticated requests, must be defined in the env
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
         name:                          # String: Optional name for the request, for documentation only
@@ -39,6 +64,7 @@ jobs:
   - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
     parameters:
       context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       url:                             # String: Url to start spidering from, default: first context URL
       maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
       maxDepth:                        # Int: The maximum tree depth to explore, default 5
@@ -90,6 +116,7 @@ jobs:
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
       context:                         # String: Name of the context to attack, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       policy:                          # String: Name of the scan policy to be used, default: Default Policy
       maxRuleDurationInMins:           # Int: The max time in minutes any individual rule will be allowed to run for, default: 0 unlimited
       maxScanDurationInMins:           # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-min.yaml
@@ -5,8 +5,32 @@ env:                                   # The environment, mandatory
       urls:                            # A mandatory list of top level urls, everything under each url will be included
       includePaths:                    # An optional list of regexes to include
       excludePaths:                    # An optional list of regexes to exclude
-      authentication:                  # TBA: In time to cover all auth configs
-  vars:                                # List of 1 or more variables, can be used in urls and selected other parameters
+      authentication:
+        method:                        # String, one of 'manual', 'http' - in time will cover all methods supported by ZAP
+        parameters:
+          hostname:                    # String, only for 'http' method
+          port:                        # Int, only for 'http' method
+          realm:                       # String, only for 'http' method
+        verification:
+          method:                      # String, one of 'response', 'request', 'both', 'poll'
+          loggedInRegex:               # String, regex pattern for determining if logged in
+          loggedOutRegex:              # String, regex pattern for determining if logged out
+          pollFrequency:               # Int, the poll frequency, only for 'poll' verification
+          pollUnits:                   # String, the poll units, one of 'requests', 'seconds', only for 'poll' verification
+          pollUrl:                     # String, the URL to poll, only for 'poll' verification
+          pollPostData:                # String, post dat to include in the poll, only for 'poll' verification
+          pollAdditionalHeaders:       # List of additional headers for poll request, only for 'poll' verification
+          - header:                    # The header name
+            value:                     # The header value
+      sessionManagement:
+        method:                        # String, one of 'cookie', 'http', 'script'
+        script:                        # String, path to script, only for 'script' session management
+        scriptEngine:                  # String, the name of the script engine to use, only for 'script' session management
+      users:                           # List of one or more users to use for authentication
+      - name:                          # String, the name to be used by the jobs
+        username:                      # String, the username to use when authenticating, vars supported
+        password:                      # String, the password to use when authenticating, vars supported
+  vars:                                # List of 0 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
     failOnWarning: false               # If set exit on a warning
@@ -25,11 +49,13 @@ jobs:
       maxBodySizeInBytesToScan:        # Int: Maximum body size to scan, default: 0 - will scan all messages
   - type: requestor                    # Used to send specific requests to targets
     parameters:
+      user:                            # String: An optional user to use for authenticated requests, must be defined in the env
     requests:                          # A list of requests to make
       - url:                           # String: A mandatory URL of the request to be made
   - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
     parameters:
       context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       url:                             # String: Url to start spidering from, default: first context URL
       maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
       maxDepth:                        # Int: The maximum tree depth to explore
@@ -66,6 +92,7 @@ jobs:
   - type: activeScan                   # The active scanner - this actively attacks the target so should only be used with permission
     parameters:
       context:                         # String: Name of the context to attack, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       policy:                          # String: Name of the scan policy to be used, default: Default Policy
       maxRuleDurationInMins:           # Int: The max time in minutes any individual rule will be allowed to run for, default: 0 unlimited
       maxScanDurationInMins:           # Int: The max time in minutes the active scanner will be allowed to run for, default: 0 unlimited


### PR DESCRIPTION
This actually enables limited authentication support, enough (I think) to make it worth releasing.
Initial support is just for manual and http/ntlm auth - the others will be added asap.
The GUI doesnt support most of the auth elements but will create them from an existing context and shouldnt delete those elements unless you delete the context.
The requestor, spider and active scan jobs have all been updated to support auth - the relevant dialogs have an "Authenticated User" pulldown.
I'll submit a separate PR for supporting auth in the Ajax Spider.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>