### PR TITLE
ascanrules: SQLi: add checking for redirection after form input

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - SQL Injection - Hypersonic SQL
   - SQL Injection - MsSQL
   - SQL Injection - MySQL
+- SQL Injection will now be more tolerant to redirects (Issue 6883).
 
 ### Added
 - Help entry for the Spring Actuators scan rule (missed during previous promotion).


### PR DESCRIPTION
In case of redirection after form input, the body may be empty and content comparison won't work. By adding new checking for location header, we may catch potential vulnerability after boolean or arithmetic expression.

Fixes: [#6883](https://github.com/zaproxy/zaproxy/issues/6883)