### PR TITLE
fix: fuzz: Ensure 'Follow Redirects' is displayed

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Enhanced the help entry for the Options tab in the main fuzz dialog.
 
+### Fixed
+- Ensure the "Follow Redirects" option is displayed.
+
 ## [13.4.0] - 2021-10-14
 ### Added
 - A right click (context menu) item to facilitate adding a fuzz message to the Sites Tree and History panel (Issue 1437).

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerOptionsPanel.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerOptionsPanel.java
@@ -210,7 +210,10 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
                         .addGroup(
                                 layout.createSequentialGroup()
                                         .addComponent(defaultFuzzDelayLabel)
-                                        .addComponent(defaultFuzzDelayInMsSpinner)));
+                                        .addComponent(defaultFuzzDelayInMsSpinner))
+                        .addGroup(
+                                layout.createSequentialGroup()
+                                        .addComponent(fuzzerHandlerOptions.getPanel())));
 
         layout.setVerticalGroup(
                 layout.createSequentialGroup()
@@ -245,7 +248,10 @@ public class FuzzerOptionsPanel<FO extends FuzzerOptions> extends JPanel {
                         .addGroup(
                                 layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                         .addComponent(defaultFuzzDelayLabel)
-                                        .addComponent(defaultFuzzDelayInMsSpinner)));
+                                        .addComponent(defaultFuzzDelayInMsSpinner))
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(fuzzerHandlerOptions.getPanel())));
 
         JScrollPane scrollPane = new JScrollPane();
         scrollPane.setViewportView(innerPanel);


### PR DESCRIPTION
- CHANGELOG.md > Added fix note.
- FuzerOptionsPanel.java > Ensure the panel from the received fuzzerHandlerOptions parameter is actually displayed/used.

I did test this with a 301 and once displayed the option does seem to be handled as expected.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>