### PR TITLE
chore: various add-ons: remove use of setParent

### DIFF
--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanConfigJobUnitTest.java
@@ -50,7 +50,6 @@ import org.zaproxy.addon.automation.AutomationJob.Order;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.pscan.PassiveScanParam;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.pscan.scanner.RegexAutoTagScanner;
 import org.zaproxy.zap.utils.I18N;
@@ -431,9 +430,6 @@ class PassiveScanConfigJobUnitTest {
         public int getPluginId() {
             return this.id;
         }
-
-        @Override
-        public void setParent(PassiveScanThread parent) {}
 
         @Override
         public String getName() {

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanJobResultsUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/PassiveScanJobResultsUnitTest.java
@@ -50,7 +50,6 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.alert.AlertNode;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.extension.stats.ExtensionStats;
 import org.zaproxy.zap.extension.stats.InMemoryStats;
@@ -189,9 +188,6 @@ class PassiveScanJobResultsUnitTest {
             this.name = name;
             this.pluginId = pluginId;
         }
-
-        @Override
-        public void setParent(PassiveScanThread parent) {}
 
         @Override
         public String getName() {

--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [3] - 2021-10-07
 ### Added

--- a/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
+++ b/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
@@ -37,7 +37,6 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 import com.veggiespam.imagelocationscanner.ILS;
@@ -62,11 +61,6 @@ public class ImageLocationScanRule extends PluginPassiveScanner {
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
                     CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG);
-	
-    @Override
-    public void setParent(PassiveScanThread parent) {
-        // Nothing to do.
-    }
 
 	@Override
 	public int getPluginId() {

--- a/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
+++ b/addOns/reports/src/test/java/org/zaproxy/addon/reports/automation/OutputSummaryJobUnitTest.java
@@ -56,7 +56,6 @@ import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData;
 import org.zaproxy.addon.automation.jobs.PassiveScanJobResultData.RuleData;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.addon.reports.automation.OutputSummaryJob.Format;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.utils.I18N;
 
@@ -669,9 +668,6 @@ class OutputSummaryJobUnitTest {
             this.id = id;
             this.name = name;
         }
-
-        @Override
-        public void setParent(PassiveScanThread parent) {}
 
         @Override
         public String getName() {

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.9.0] - 2021-10-06
 ### Added

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -33,7 +33,6 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.retire.model.Repo;
-import org.zaproxy.zap.extension.pscan.PassiveScanThread;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
 public class RetireScanRule extends PluginPassiveScanner {
@@ -132,11 +131,6 @@ public class RetireScanRule extends PluginPassiveScanner {
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    @Override
-    public void setParent(PassiveScanThread parent) {
-        // Nothing to do.
     }
 
     private Repo getRepo() {

--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [9] - 2021-10-07
 ### Added

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/SAMLPassiveScanner.java
@@ -63,11 +63,6 @@ public class SAMLPassiveScanner extends PluginPassiveScanner {
     }
 
     @Override
-    public void setParent(PassiveScanThread parent) {
-        this.parent = parent;
-    }
-
-    @Override
     public int getPluginId() {
         return 10070;
     }

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [11] - 2021-10-29
 ### Changed

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRule.java
@@ -78,11 +78,6 @@ public class WSDLFilePassiveScanRule extends PluginPassiveScanner {
     }
 
     @Override
-    public void setParent(PassiveScanThread parent) {
-        this.parent = parent;
-    }
-
-    @Override
     public int getPluginId() {
         return 90030;
     }


### PR DESCRIPTION
In follow-up to: https://github.com/zaproxy/zaproxy/pull/6598

- automation
- imagelocationscanner
- reports
- retire
- saml
- soap

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>