### PR TITLE
fix: commonlib: 2017 A10 naming consistency

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Dependency updates.
 
+### Fixed
+- Adjusted the tag of "OWASP_A10_LOGGING_FAIL" to match other alert tags for 2017/2021.
+
 ## [1.5.0] - 2021-10-06
 ### Added
 - Common alert tags for OWASP Top Ten 2021 and 2017.

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
@@ -79,7 +79,7 @@ public enum CommonAlertTag {
             "OWASP_2017_A09",
             "https://owasp.org/www-project-top-ten/2017/A9_2017-Using_Components_with_Known_Vulnerabilities.html"),
     OWASP_2017_A10_LOGGING_FAIL(
-            "OWASP_2017_A10_LOGGING_FAIL",
+            "OWASP_2017_A10",
             "https://owasp.org/www-project-top-ten/2017/A10_2017-Insufficient_Logging%2526Monitoring.html");
 
     private String tag;


### PR DESCRIPTION
- CommonAlertTag > Adjusted the tag of "OWASP_A10_LOGGING_FAIL" to match other alert tags for 2017/2021.
- CHANGELOG > Added maintenance note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>