### PR TITLE
network: add encoders for HttpMessage

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -28,5 +28,8 @@ crowdin {
 dependencies {
     zap("org.zaproxy:zap:2.11.0")
 
+    val nettyVersion = "4.1.70.Final"
+    implementation("io.netty:netty-codec:$nettyVersion")
+
     testImplementation(project(":testutils"))
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoder.java
@@ -1,0 +1,70 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Encodes the header and body contained in a {@link HttpMessage}. */
+@Sharable
+abstract class HttpMessageEncoder extends MessageToByteEncoder<HttpMessage> {
+
+    private static final int CRLF = '\r' << 8 | '\n';
+
+    private final Function<HttpMessage, HttpHeader> headerProvider;
+    private final Function<HttpMessage, HttpBody> bodyProvider;
+
+    HttpMessageEncoder(
+            Function<HttpMessage, HttpHeader> headerProvider,
+            Function<HttpMessage, HttpBody> bodyProvider) {
+        super(HttpMessage.class);
+        this.headerProvider = headerProvider;
+        this.bodyProvider = bodyProvider;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, HttpMessage msg, ByteBuf out) {
+        HttpHeader header = headerProvider.apply(msg);
+
+        out.writeCharSequence(header.getPrimeHeader(), StandardCharsets.US_ASCII);
+        ByteBufUtil.writeShortBE(out, CRLF);
+
+        out.writeCharSequence(header.getHeadersAsString(), StandardCharsets.US_ASCII);
+        ByteBufUtil.writeShortBE(out, CRLF);
+
+        HttpBody body = bodyProvider.apply(msg);
+        if (body.length() != 0) {
+            out.writeBytes(body.getBytes());
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpRequestEncoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpRequestEncoder.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Encodes the request contained in a {@link HttpMessage}.
+ *
+ * @see #getInstance()
+ */
+@Sharable
+public class HttpRequestEncoder extends HttpMessageEncoder {
+
+    private static final HttpRequestEncoder INSTANCE = new HttpRequestEncoder();
+
+    HttpRequestEncoder() {
+        super(HttpMessage::getRequestHeader, HttpMessage::getRequestBody);
+    }
+
+    /**
+     * Gets the instance of the encoder.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static HttpRequestEncoder getInstance() {
+        return INSTANCE;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpResponseEncoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpResponseEncoder.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import org.parosproxy.paros.network.HttpMessage;
+
+/**
+ * Encodes the response contained in a {@link HttpMessage}.
+ *
+ * @see #getInstance()
+ */
+@Sharable
+public class HttpResponseEncoder extends HttpMessageEncoder {
+
+    private static final HttpResponseEncoder INSTANCE = new HttpResponseEncoder();
+
+    HttpResponseEncoder() {
+        super(HttpMessage::getResponseHeader, HttpMessage::getResponseBody);
+    }
+
+    /**
+     * Gets the instance of the encoder.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static HttpResponseEncoder getInstance() {
+        return INSTANCE;
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoderUnitTest.java
@@ -1,0 +1,144 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.EncoderException;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Unit test for {@link HttpMessageEncoder}. */
+class HttpMessageEncoderUnitTest {
+
+    private HttpHeader header;
+    private HttpBody body;
+    private HttpMessageEncoder encoder;
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        header = mock(HttpHeader.class);
+        given(header.getPrimeHeader()).willReturn("Prime Header");
+        given(header.getHeadersAsString()).willReturn("Headers");
+        body = mock(HttpBody.class);
+        encoder = new HttpMessageEncoderImpl(msg -> header, msg -> body);
+        channel = new EmbeddedChannel(encoder);
+    }
+
+    @Test
+    void shouldBeSharable() {
+        assertThat(encoder.isSharable(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldEncodeHeaderAndBodyInHttpMessage() throws Exception {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        given(body.length()).willReturn(4);
+        given(body.getBytes()).willReturn("Body".getBytes(StandardCharsets.US_ASCII));
+        // When
+        boolean written = channel.writeOutbound(httpMessage);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        ByteBuf encoded = channel.readOutbound();
+        assertNotNull(encoded);
+        assertThat(
+                encoded.toString(StandardCharsets.US_ASCII),
+                is(equalTo("Prime Header\r\nHeaders\r\nBody")));
+        encoded.release();
+        assertChannelStateEnd();
+    }
+
+    @Test
+    void shouldNotGetBodyBytesIfBodyEmpty() throws Exception {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        given(body.length()).willReturn(0);
+        // When
+        boolean written = channel.writeOutbound(httpMessage);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        ByteBuf encoded = channel.readOutbound();
+        assertNotNull(encoded);
+        assertThat(
+                encoded.toString(StandardCharsets.US_ASCII),
+                is(equalTo("Prime Header\r\nHeaders\r\n")));
+        encoded.release();
+        assertChannelStateEnd();
+        verify(body, times(0)).getBytes();
+    }
+
+    @Test
+    void shouldThrowExceptionIfEncodingNullHeader() {
+        // Given
+        encoder = new HttpMessageEncoderImpl(msg -> null, msg -> body);
+        channel = new EmbeddedChannel(encoder);
+        // When / Then
+        EncoderException exception =
+                assertThrows(
+                        EncoderException.class, () -> channel.writeOutbound(new HttpMessage()));
+        assertThat(exception.getCause(), is(instanceOf(NullPointerException.class)));
+    }
+
+    @Test
+    void shouldThrowExceptionIfEncodingNullBody() {
+        // Given
+        encoder = new HttpMessageEncoderImpl(msg -> header, msg -> null);
+        channel = new EmbeddedChannel(encoder);
+        // When / Then
+        EncoderException exception =
+                assertThrows(
+                        EncoderException.class, () -> channel.writeOutbound(new HttpMessage()));
+        assertThat(exception.getCause(), is(instanceOf(NullPointerException.class)));
+    }
+
+    private void assertChannelStateEnd() {
+        assertFalse(channel.finish());
+        assertNull(channel.readInbound());
+    }
+
+    private static class HttpMessageEncoderImpl extends HttpMessageEncoder {
+
+        HttpMessageEncoderImpl(
+                Function<HttpMessage, HttpHeader> headerProvider,
+                Function<HttpMessage, HttpBody> bodyProvider) {
+            super(headerProvider, bodyProvider);
+        }
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestEncoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestEncoderUnitTest.java
@@ -1,0 +1,118 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.network.HttpRequestBody;
+
+/** Unit test for {@link HttpRequestEncoder}. */
+class HttpRequestEncoderUnitTest {
+
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        channel = new EmbeddedChannel(HttpRequestEncoder.getInstance());
+    }
+
+    @Test
+    void shouldBeSharable() {
+        assertThat(HttpRequestEncoder.getInstance().isSharable(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldEncodeRequestInHttpMessage() throws Exception {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        httpMessage.setRequestHeader("POST http://127.0.0.1/ HTTP/1.1\r\nHost: 127.0.0.1");
+        httpMessage.setRequestBody("123");
+        // When
+        boolean written = channel.writeOutbound(httpMessage);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        ByteBuf encoded = channel.readOutbound();
+        assertNotNull(encoded);
+        assertThat(
+                encoded.toString(StandardCharsets.US_ASCII),
+                is(equalTo("POST http://127.0.0.1/ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n123")));
+        encoded.release();
+        assertChannelStateEnd();
+    }
+
+    @Test
+    void shouldEncodeRequestWithEmptyBodyInHttpMessage() throws Exception {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        httpMessage.setRequestHeader("POST http://127.0.0.1/ HTTP/1.1\r\nHost: 127.0.0.1");
+        httpMessage.setRequestBody("");
+        // When
+        boolean written = channel.writeOutbound(httpMessage);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        ByteBuf encoded = channel.readOutbound();
+        assertNotNull(encoded);
+        assertThat(
+                encoded.toString(StandardCharsets.US_ASCII),
+                is(equalTo("POST http://127.0.0.1/ HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")));
+        encoded.release();
+        assertChannelStateEnd();
+    }
+
+    @Test
+    void shouldNotEncodeDirectHttpRequestHeader() throws Exception {
+        HttpRequestHeader header = new HttpRequestHeader("GET / HTTP/1.1\r\nHost: 127.0.0.1");
+        // When
+        boolean written = channel.writeOutbound(header);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        assertSame(header, channel.readOutbound());
+        assertChannelStateEnd();
+    }
+
+    @Test
+    void shouldNotEncodeDirectHttpRequestBody() {
+        HttpRequestBody body = new HttpRequestBody("123");
+        // When
+        boolean written = channel.writeOutbound(body);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        assertSame(body, channel.readOutbound());
+        assertChannelStateEnd();
+    }
+
+    private void assertChannelStateEnd() {
+        assertFalse(channel.finish());
+        assertNull(channel.readInbound());
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpResponseEncoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpResponseEncoderUnitTest.java
@@ -1,0 +1,118 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+/** Unit test for {@link HttpResponseEncoder}. */
+class HttpResponseEncoderUnitTest {
+
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        channel = new EmbeddedChannel(HttpResponseEncoder.getInstance());
+    }
+
+    @Test
+    void shouldBeSharable() {
+        assertThat(HttpResponseEncoder.getInstance().isSharable(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldEncodeResponseInHttpMessage() throws Exception {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        httpMessage.setResponseHeader("HTTP/1.1 200 OK");
+        httpMessage.setResponseBody("123");
+        // When
+        boolean written = channel.writeOutbound(httpMessage);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        ByteBuf encoded = channel.readOutbound();
+        assertNotNull(encoded);
+        assertThat(
+                encoded.toString(StandardCharsets.US_ASCII),
+                is(equalTo("HTTP/1.1 200 OK\r\n\r\n123")));
+        encoded.release();
+        assertChannelStateEnd();
+    }
+
+    @Test
+    void shouldEncodeResponseWithEmptyBodyInHttpMessage() throws Exception {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        httpMessage.setResponseHeader("HTTP/1.1 200 OK");
+        httpMessage.setResponseBody("");
+        // When
+        boolean written = channel.writeOutbound(httpMessage);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        ByteBuf encoded = channel.readOutbound();
+        assertNotNull(encoded);
+        assertThat(
+                encoded.toString(StandardCharsets.US_ASCII),
+                is(equalTo("HTTP/1.1 200 OK\r\n\r\n")));
+        encoded.release();
+        assertChannelStateEnd();
+    }
+
+    @Test
+    void shouldNotEncodeDirectHttpResponseHeader() throws Exception {
+        HttpResponseHeader header = new HttpResponseHeader("HTTP/1.1 200 OK");
+        // When
+        boolean written = channel.writeOutbound(header);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        assertSame(header, channel.readOutbound());
+        assertChannelStateEnd();
+    }
+
+    @Test
+    void shouldNotEncodeDirectHttpResponseBody() {
+        HttpResponseBody body = new HttpResponseBody("123");
+        // When
+        boolean written = channel.writeOutbound(body);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        assertSame(body, channel.readOutbound());
+        assertChannelStateEnd();
+    }
+
+    private void assertChannelStateEnd() {
+        assertFalse(channel.finish());
+        assertNull(channel.readInbound());
+    }
+}


### PR DESCRIPTION
Allow to encode the request and response of a `HttpMessage`.