### PR TITLE
improve: soap: Various User friendliness changes

### DIFF
--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- WSDL File scan rule now includes identification of URLs in the form "example.com/service?wsdl", and specifically excludes 404s and 500s (including support for Custom Pages).
+- `Import a WSDL file from a URL` now logs a more specific message for some exception conditions, or when failing to convert the input 'URL' string into an actual URL to make the WSDL request.
+- The `Import a WSDL file from a URL` dialog now accepts pressing the enter key to activate the import process (instead of having to click the Import button), and the escape key to close/cancel the dialog.
 
 ## [11] - 2021-10-29
 ### Changed

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ImportFromUrlDialog.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ImportFromUrlDialog.java
@@ -31,15 +31,15 @@ import java.awt.event.MouseEvent;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.extension.AbstractDialog;
 
-public class ImportFromUrlDialog extends JDialog implements ActionListener {
+public class ImportFromUrlDialog extends AbstractDialog implements ActionListener {
 
     private static final long serialVersionUID = -7074394202143400215L;
     private static final String MESSAGE_PREFIX = "soap.importfromurldialog.";
@@ -49,7 +49,8 @@ public class ImportFromUrlDialog extends JDialog implements ActionListener {
     private JTextField fieldURL = new JTextField(30);
 
     public ImportFromUrlDialog(JFrame parent, ExtensionImportWSDL caller) {
-        super(parent, Constant.messages.getString(MESSAGE_PREFIX + "actionName"), true);
+        super(parent, true);
+        super.setTitle(Constant.messages.getString(MESSAGE_PREFIX + "actionName"));
         if (caller != null) {
             this.caller = caller;
         }
@@ -67,6 +68,7 @@ public class ImportFromUrlDialog extends JDialog implements ActionListener {
         JButton buttonImport =
                 new JButton(Constant.messages.getString(MESSAGE_PREFIX + "importButton"));
         buttonImport.addActionListener(this);
+        getRootPane().setDefaultButton(buttonImport);
 
         // add components to the frame
         constraints.gridx = 0;

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/WSDLCustomParser.java
@@ -178,7 +178,7 @@ public class WSDLCustomParser {
         } catch (ResourceDownloadException rde) {
             String exMsg =
                     Constant.messages.getString(
-                            "soap.topmenu.tools.importWSDL.fail", file.getAbsolutePath());
+                            "soap.topmenu.import.importWSDL.fail", file.getAbsolutePath());
             LOG.warn(exMsg);
             if (View.isInitialised()) {
                 View.getSingleton().showWarningDialog(exMsg);

--- a/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
+++ b/addOns/soap/src/main/resources/org/zaproxy/zap/extension/soap/resources/Messages.properties
@@ -17,6 +17,7 @@ soap.topmenu.import.importWSDL=Import a WSDL file from local file system
 soap.topmenu.import.importWSDL.tooltip=The file must be a formal described WSDL file.
 soap.topmenu.import.importWSDL.filter.description = WSDL File
 soap.topmenu.import.importWSDL.fail=Unable to access endpoint defined in {0}
+soap.topmenu.import.importWSDL.url.fail=Invalid URL: {0}.\n {1}
 soap.topmenu.import.importRemoteWSDL=Import a WSDL file from a URL
 soap.topmenu.import.importRemoteWSDL.tooltip=The file must be a formal described WSDL file.
 

--- a/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
+++ b/addOns/soap/src/test/java/org/zaproxy/zap/extension/soap/WSDLFilePassiveScanRuleTestCase.java
@@ -19,82 +19,189 @@
  */
 package org.zaproxy.zap.extension.soap;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import org.junit.jupiter.api.BeforeEach;
+import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.PassiveScannerTestUtils;
 
-class WSDLFilePassiveScanRuleTestCase {
-    private HttpMessage wsdlMsg = new HttpMessage();
+class WSDLFilePassiveScanRuleTestCase extends PassiveScannerTestUtils<WSDLFilePassiveScanRule> {
+
+    @Override
+    protected WSDLFilePassiveScanRule createScanner() {
+        return new WSDLFilePassiveScanRule();
+    }
+
+    @Override
+    protected void setUpMessages() {
+        mockMessages(new ExtensionImportWSDL());
+    }
 
     private static void setContentType(HttpMessage msg, String contentType) {
         msg.getResponseHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
     }
 
-    @BeforeEach
-    void setUp() {
-        try {
-            wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
-            wsdlMsg = Sample.setResponseHeaderContent(wsdlMsg);
-            wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
-        } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-    }
-
     @Test
     void isWsdlTest()
             throws NoSuchMethodException, SecurityException, IllegalAccessException,
-                    IllegalArgumentException, InvocationTargetException {
-        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
+                    IllegalArgumentException, InvocationTargetException, IOException {
+
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
+        wsdlMsg = Sample.setResponseHeaderContent(wsdlMsg);
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+
         /* Positive case. */
-        boolean result = scanner.isWsdl(wsdlMsg);
+        boolean result = rule.isWsdl(wsdlMsg);
         assertTrue(result);
 
         /* Negative cases. */
-        result = scanner.isWsdl(null); /* Null response. */
+        result = rule.isWsdl(null); /* Null response. */
         assertFalse(result);
 
-        result = scanner.isWsdl(new HttpMessage()); /* Empty response. */
+        result = rule.isWsdl(new HttpMessage()); /* Empty response. */
         assertFalse(result);
     }
 
     @Test
-    void shouldNotAlertWhenWsdlFileNotFound() throws IOException {
+    void shouldNotIdentifyWsdlWhenWsdlFileNotFound() throws IOException {
+        // Given
         HttpMessage wsdlMsg = new HttpMessage();
         wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
         setContentType(wsdlMsg, "text/xml");
         wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
-        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
-        boolean result = scanner.isWsdl(wsdlMsg);
+        // When
+        boolean result = rule.isWsdl(wsdlMsg);
+        // Then
         assertFalse(result);
     }
 
     @Test
-    void shouldAlertWhenWsdlFileFound() throws IOException {
+    void shouldNotIdentifyWsdlWhenWsdlFileIsHtml() throws IOException {
+        // Given
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
+        setContentType(wsdlMsg, "text/html");
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        // When
+        boolean result = rule.isWsdl(wsdlMsg);
+        // Then
+        assertFalse(result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/xml", "application/wsdl+xml"})
+    void shouldAlertWhenWsdlResponseStatus200(String contentType) throws IOException {
+        // Given
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
+        setContentType(wsdlMsg, contentType);
+        wsdlMsg.getResponseHeader().setStatusCode(200);
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        // When
+        scanHttpResponseReceive(wsdlMsg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(1));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/xml", "application/wsdl+xml"})
+    void shouldNotAlertWhenWsdlResponseStatus500(String contentType) throws IOException {
+        // Given
+        given(passiveScanData.isPage500(any())).willReturn(true);
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
+        setContentType(wsdlMsg, contentType);
+        wsdlMsg.getResponseHeader().setStatusCode(500);
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        // When
+        scanHttpResponseReceive(wsdlMsg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/xml", "application/wsdl+xml"})
+    void shouldNotAlertWhenWsdlResponseStatus404(String contentType) throws IOException {
+        // Given
+        given(passiveScanData.isPage404(any())).willReturn(true);
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
+        setContentType(wsdlMsg, contentType);
+        wsdlMsg.getResponseHeader().setStatusCode(404);
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        // When
+        scanHttpResponseReceive(wsdlMsg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
+    void shouldIdentifyWsdlWhenWsdlFileFound() throws IOException {
+        // Given
         HttpMessage wsdlMsg = new HttpMessage();
         wsdlMsg = Sample.setRequestHeaderContent(wsdlMsg);
         setContentType(wsdlMsg, "text/xml");
         wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
-        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
-        boolean result = scanner.isWsdl(wsdlMsg);
+        // When
+        boolean result = rule.isWsdl(wsdlMsg);
+        // Then
         assertTrue(result);
     }
 
     @Test
-    void shouldAlertWhenWsdlXmlContentTypeFound() throws IOException {
+    void shouldIdentifyWsdlWhenWsdlXmlContentTypeFound() throws IOException {
+        // Given
         HttpMessage wsdlMsg = new HttpMessage();
         wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
         setContentType(wsdlMsg, "application/wsdl+xml");
         wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
-        WSDLFilePassiveScanRule scanner = new WSDLFilePassiveScanRule();
-        boolean result = scanner.isWsdl(wsdlMsg);
+        // When
+        boolean result = rule.isWsdl(wsdlMsg);
+        // Then
         assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"http://example.com/service.asmx?wsdl", "http://example.com/service.wsdl"})
+    void shouldIdentifyWsdlWhenWsdlUrlFoundRegardlessOfContentType(String url) throws IOException {
+        // Given
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
+        setContentType(wsdlMsg, "text/plain");
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        wsdlMsg.getRequestHeader().setURI(new URI(url, true));
+        // When
+        boolean result = rule.isWsdl(wsdlMsg);
+        // Then
+        assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"http://example.com/service.asmx?wsdl", "http://example.com/service.wsdl"})
+    void shouldNotIdentifyWsdlWhenWsdlUrlFoundIfHtmlContentType(String url) throws IOException {
+        // Given
+        HttpMessage wsdlMsg = new HttpMessage();
+        wsdlMsg = Sample.setOriginalRequest(wsdlMsg);
+        setContentType(wsdlMsg, "text/html");
+        wsdlMsg = Sample.setResponseBodyContent(wsdlMsg);
+        wsdlMsg.getRequestHeader().setURI(new URI(url, true));
+        // When
+        boolean result = rule.isWsdl(wsdlMsg);
+        // Then
+        assertFalse(result);
     }
 }


### PR DESCRIPTION
- WSDL File scan rule now includes identification of URLs in the form "example.com/service?wsdl", and specifically excludes 404s and 500s (including support for Custom Pages).
- Import a WSDL file from a URL now logs a more specific message for some exception conditions, or when failing to convert the
input 'URL' string into an actual URL to make the WSDL request.
- The import from URL dialog now accepts pressing the enter key to activate the import process (instead of having to click the Import button), and the escape key to close/cancel the dialog.
- Changed Scan Rule test class to extend PassiveScannerTest, adjusted some test names to be more specific, added tests to assert the new behavior.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>