### PR TITLE
quickstart: use network add-on to write cert

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -5,7 +5,7 @@ description = "Provides core networking capabilities."
 zapAddOn {
     addOnName.set("Network")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.12.0")
+    zapVersion.set("2.11.0")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Use the Network add-on to export the Root CA certificate.
 
 ## [31] - 2021-11-23
 ### Changed

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -60,6 +60,9 @@ zapAddOn {
                 register("callhome") {
                     version.set(">= 0.0.1")
                 }
+                register("network") {
+                    version.set(">= 0.0.1")
+                }
             }
         }
     }
@@ -67,6 +70,7 @@ zapAddOn {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("callhome")!!)
+    compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("reports")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
     compileOnly(parent!!.childProjects.get("spiderAjax")!!)

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
@@ -24,27 +24,20 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.io.IOException;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.security.KeyStore;
 import java.security.KeyStoreException;
-import java.security.cert.Certificate;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
-import org.bouncycastle.util.io.pem.PemWriter;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.OptionsParam;
-import org.parosproxy.paros.security.SslCertificateService;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.ZAP;
-import org.zaproxy.zap.extension.dynssl.DynSSLParam;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
@@ -160,16 +153,10 @@ public class DefaultExplorePanel extends QuickStartSubPanel {
     }
 
     private void writePubCertificateToFile(File f) throws IOException, KeyStoreException {
-        OptionsParam options = Model.getSingleton().getOptionsParam();
-        DynSSLParam param = options.getParamSet(DynSSLParam.class);
-        KeyStore ks = param.getRootca();
-        if (ks != null) {
-            final Certificate cert = ks.getCertificate(SslCertificateService.ZAPROXY_JKS_ALIAS);
-            try (final Writer w = Files.newBufferedWriter(f.toPath(), StandardCharsets.US_ASCII);
-                    final PemWriter pw = new PemWriter(w)) {
-                pw.writeObject(new JcaMiscPEMGenerator(cert));
-                pw.flush();
-            }
+        ExtensionNetwork extensionNetwork =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionNetwork.class);
+        if (extensionNetwork != null) {
+            extensionNetwork.writeRootCaCertAsPem(f.toPath());
         }
     }
 


### PR DESCRIPTION
Move the write of the root CA certificate to the network add-on to hide
implementation details (network add-on will manage the Root CA cert).
Change Network add-on to target 2.11, to not require existing add-ons
to also target the newer version.

---
WIP pending release of Quick Start add-on with the callhome changes.