### PR TITLE
network: add API to manage root CA certificate

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -25,7 +25,8 @@ plugins {
 description = "Common configuration of the add-ons."
 
 val mandatoryAddOns = listOf(
-    "callhome"
+    "callhome",
+    "network"
 )
 
 val parentProjects = listOf(

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,5 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- API endpoints to generate, import, and obtain the root CA certificate.
 

--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -16,6 +16,11 @@ zapAddOn {
             localeToken.set("%LC%")
         }
     }
+
+    apiClientGen {
+        api.set("org.zaproxy.addon.network.NetworkApi")
+        messages.set(file("src/main/resources/org/zaproxy/addon/network/resources/Messages.properties"))
+    }
 }
 
 crowdin {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/NetworkApi.java
@@ -1,0 +1,145 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.Arrays;
+import net.sf.json.JSONObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.security.SslCertificateService;
+import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.ApiAction;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiOther;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+
+public class NetworkApi extends ApiImplementor {
+
+    private static final Logger LOGGER = LogManager.getLogger(NetworkApi.class);
+
+    private static final String PREFIX = "network";
+
+    private static final String ACTION_GENERATE_ROOT_CA_CERT = "generateRootCaCert";
+    private static final String ACTION_IMPORT_ROOT_CA_CERT = "importRootCaCert";
+
+    private static final String OTHER_ROOT_CA_CERT = "rootCaCert";
+
+    private static final String PARAM_FILE_PATH = "filePath";
+
+    private final ExtensionNetwork extensionNetwork;
+
+    public NetworkApi() {
+        this(null);
+    }
+
+    public NetworkApi(ExtensionNetwork extensionNetwork) {
+        this.extensionNetwork = extensionNetwork;
+
+        this.addApiAction(new ApiAction(ACTION_GENERATE_ROOT_CA_CERT));
+        this.addApiAction(
+                new ApiAction(ACTION_IMPORT_ROOT_CA_CERT, Arrays.asList(PARAM_FILE_PATH)));
+
+        this.addApiOthers(new ApiOther(OTHER_ROOT_CA_CERT, false));
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+        switch (name) {
+            case ACTION_GENERATE_ROOT_CA_CERT:
+                if (extensionNetwork.generateRootCaCert()) {
+                    return ApiResponseElement.OK;
+                }
+                return ApiResponseElement.FAIL;
+
+            case ACTION_IMPORT_ROOT_CA_CERT:
+                Path file = Paths.get(params.getString(PARAM_FILE_PATH));
+                String errorMessage = extensionNetwork.importRootCaCert(file);
+                if (errorMessage == null) {
+                    return ApiResponseElement.OK;
+                }
+                throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, errorMessage);
+
+            default:
+                throw new ApiException(ApiException.Type.BAD_ACTION);
+        }
+    }
+
+    @Override
+    public HttpMessage handleApiOther(HttpMessage msg, String name, JSONObject params)
+            throws ApiException {
+        switch (name) {
+            case OTHER_ROOT_CA_CERT:
+                KeyStore keyStore = extensionNetwork.getRootCaKeyStore();
+                if (keyStore == null) {
+                    throw new ApiException(ApiException.Type.DOES_NOT_EXIST);
+                }
+
+                String pem = keyStoreToPublicPem(keyStore);
+                if (pem.isEmpty()) {
+                    throw new ApiException(ApiException.Type.INTERNAL_ERROR);
+                }
+
+                try {
+                    msg.setResponseHeader(
+                            API.getDefaultResponseHeader("application/pkix-cert;", pem.length())
+                                    + "Content-Disposition: attachment; filename=\"ZAPCACert.cer\"\r\n");
+                } catch (HttpMalformedHeaderException e) {
+                    LOGGER.error(e.getMessage(), e);
+                    throw new ApiException(ApiException.Type.INTERNAL_ERROR);
+                }
+
+                msg.setResponseBody(pem);
+                return msg;
+
+            default:
+                throw new ApiException(ApiException.Type.BAD_OTHER);
+        }
+    }
+
+    private static String keyStoreToPublicPem(KeyStore keyStore) {
+        StringWriter sw = new StringWriter();
+        try {
+            Certificate cert = keyStore.getCertificate(SslCertificateService.ZAPROXY_JKS_ALIAS);
+            try (PemWriter pw = new PemWriter(sw)) {
+                pw.writeObject(new JcaMiscPEMGenerator(cert));
+                pw.flush();
+            }
+        } catch (Exception e) {
+            LOGGER.error("An error occurred while converting KeyStore to public PEM:", e);
+        }
+        return sw.toString();
+    }
+}

--- a/addOns/network/src/main/javahelp/help/contents/api.html
+++ b/addOns/network/src/main/javahelp/help/contents/api.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Network API</TITLE>
+</HEAD>
+<BODY>
+	<H1>Network API</H1>
+	The following operations are added to the API:
+
+	<h3>Actions</h3>
+	<ul>
+		<li>generateRootCaCert: Generates a new Root CA certificate, used to issue server certificates.</li>
+		<li>importRootCaCert (filePath*): Imports a Root CA certificate to be used to issue server certificates.
+			<ul>
+				<li>filePath: The file system path to the PEM file, containing the certificate and private key.</li>
+			</ul>
+		</li>
+	</ul>
+
+	<h3>Other</h3>
+	<ul>
+		<li>rootCaCert: Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).</li>
+	</ul>
+
+</BODY>
+</HTML>

--- a/addOns/network/src/main/javahelp/help/contents/network.html
+++ b/addOns/network/src/main/javahelp/help/contents/network.html
@@ -10,5 +10,14 @@ Network Add-on
 <H1>Network Add-on</H1>
 An add-on that provides core networking capabilities.
 
+
+<H2>See also</H2>
+<table>
+	<tr>
+		<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+		<td><a href="api.html">Network API</a></td>
+		<td>for more details about the Network API</td>
+	</tr>
+</table>
 </BODY>
 </HTML>

--- a/addOns/network/src/main/javahelp/help/index.xml
+++ b/addOns/network/src/main/javahelp/help/index.xml
@@ -5,4 +5,5 @@
 
 <index version="2.0">
     <indexitem text="Network" target="addon.network" />
+    <indexitem text="Network API" target="addon.network.api" />
 </index>

--- a/addOns/network/src/main/javahelp/help/map.jhm
+++ b/addOns/network/src/main/javahelp/help/map.jhm
@@ -6,4 +6,5 @@
 <map version="1.0">
     <mapID target="addon.network.icon" url="contents/images/icon.png" />
     <mapID target="addon.network" url="contents/network.html" />
+    <mapID target="addon.network.api" url="contents/api.html" />
 </map>

--- a/addOns/network/src/main/javahelp/help/toc.xml
+++ b/addOns/network/src/main/javahelp/help/toc.xml
@@ -6,7 +6,9 @@
 <toc version="2.0">
     <tocitem text="ZAP User Guide" tocid="toplevelitem">
         <tocitem text="Add Ons" tocid="addons">
-            <tocitem text="Network" image="addon.network.icon" target="addon.network" />
+            <tocitem text="Network" image="addon.network.icon" target="addon.network">
+                <tocitem text="API" target="addon.network.api" />
+            </tocitem>
         </tocitem>
     </tocitem>
 </toc>

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -1,2 +1,8 @@
+network.api.desc = Allows to access and configure core networking capabilities.
+network.api.action.generateRootCaCert = Generates a new Root CA certificate, used to issue server certificates.
+network.api.action.importRootCaCert = Imports a Root CA certificate to be used to issue server certificates.
+network.api.action.importRootCaCert.param.filePath = The file system path to the PEM file, containing the certificate and private key.
+network.api.other.rootCaCert = Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).
+
 network.ext.name = Network Extension
 network.ext.desc = Provides core networking capabilities.

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -20,27 +20,60 @@
 package org.zaproxy.addon.network;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.model.OptionsParam;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.dynssl.DynSSLParam;
+import org.zaproxy.zap.extension.dynssl.ExtensionDynSSL;
+import org.zaproxy.zap.extension.dynssl.SslCertificateUtils;
 import org.zaproxy.zap.testutils.TestUtils;
 
 /** Unit test for {@link ExtensionNetwork}. */
 class ExtensionNetworkUnitTest extends TestUtils {
 
+    private Model model;
+    private OptionsParam optionsParam;
+    private ExtensionLoader extensionLoader;
     private ExtensionNetwork extension;
 
     @BeforeEach
     void setUp() {
         extension = new ExtensionNetwork();
         mockMessages(extension);
+        model = mock(Model.class, withSettings().lenient());
+        Model.setSingletonForTesting(model);
+        optionsParam = mock(OptionsParam.class, withSettings().lenient());
+        given(model.getOptionsParam()).willReturn(optionsParam);
+
+        extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        Control.initSingletonForTesting(model, extensionLoader);
     }
 
     @Test
@@ -59,6 +92,18 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldAddNetworkApiOnHook() {
+        // Given
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        // When
+        extension.hook(extensionHook);
+        // Then
+        ArgumentCaptor<ApiImplementor> argument = ArgumentCaptor.forClass(ApiImplementor.class);
+        verify(extensionHook).addApiImplementor(argument.capture());
+        assertThat(argument.getAllValues(), contains(instanceOf(NetworkApi.class)));
+    }
+
+    @Test
     void shouldBeUnloadable() {
         assertThat(extension.canUnload(), is(true));
     }
@@ -68,5 +113,107 @@ class ExtensionNetworkUnitTest extends TestUtils {
     @ValueSource(strings = {"db1", "db2"})
     void shouldSupportAllDbs(String name) {
         assertThat(extension.supportsDb(name), is(true));
+    }
+
+    @Test
+    void shouldWriteRootCaCertAsPem() throws Exception {
+        // Given
+        Path file = Files.createTempFile("rootca", ".cer");
+        mockRootCaKeyStore();
+        // When
+        extension.writeRootCaCertAsPem(file);
+        // Then
+        String contents = new String(Files.readAllBytes(file), StandardCharsets.US_ASCII);
+        assertThat(
+                contents,
+                allOf(
+                        containsString(SslCertificateUtils.BEGIN_CERTIFICATE_TOKEN),
+                        containsString(
+                                "MIIC9TCCAl6gAwIBAgIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAMFsxGDAWBgNV\n"),
+                        containsString(SslCertificateUtils.END_CERTIFICATE_TOKEN),
+                        not(containsString(SslCertificateUtils.BEGIN_PRIVATE_KEY_TOKEN))));
+    }
+
+    @Test
+    void shouldNotWriteRootCaCertAsPemIfRootCaKeyStoreMissing() throws Exception {
+        // Given
+        Path file = Files.createTempFile("rootca", ".cer");
+        // When
+        extension.writeRootCaCertAsPem(file);
+        // Then
+        String contents = new String(Files.readAllBytes(file), StandardCharsets.US_ASCII);
+        assertThat(contents, not(containsString(SslCertificateUtils.BEGIN_CERTIFICATE_TOKEN)));
+    }
+
+    @Test
+    void shouldGetRootCaKeyStoreFromDynSslParam() throws Exception {
+        // Given
+        mockRootCaKeyStore();
+        // When
+        KeyStore keyStore = extension.getRootCaKeyStore();
+        // Then
+        assertThat(keyStore, is(not(nullValue())));
+    }
+
+    @Test
+    void shouldNotGetRootCaKeyStoreFromDynSslParamIfNotAvailable() throws Exception {
+        // Given / When
+        KeyStore keyStore = extension.getRootCaKeyStore();
+        // Then
+        assertThat(keyStore, is(nullValue()));
+    }
+
+    @Test
+    void shouldGenerateRootCaCertWithExtensionDynSsl() throws Exception {
+        // Given
+        ExtensionDynSSL extensionDynSsl = mock(ExtensionDynSSL.class);
+        given(extensionLoader.getExtension(ExtensionDynSSL.class)).willReturn(extensionDynSsl);
+        // When
+        boolean generated = extension.generateRootCaCert();
+        // Then
+        assertThat(generated, is(equalTo(true)));
+        verify(extensionDynSsl).createNewRootCa();
+    }
+
+    @Test
+    void shouldNotGenerateRootCaCertWithExtensionDynSslIfNotAvailable() throws Exception {
+        // Given
+        given(extensionLoader.getExtension(ExtensionDynSSL.class)).willReturn(null);
+        // When
+        boolean generated = extension.generateRootCaCert();
+        // Then
+        assertThat(generated, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldImportRootCaCertWithExtensionDynSsl() throws Exception {
+        // Given
+        Path file = Files.createTempFile("rootca", ".cer");
+        ExtensionDynSSL extensionDynSsl = mock(ExtensionDynSSL.class);
+        given(extensionLoader.getExtension(ExtensionDynSSL.class)).willReturn(extensionDynSsl);
+        // When
+        String result = extension.importRootCaCert(file);
+        // Then
+        assertThat(result, is(nullValue()));
+        verify(extensionDynSsl).importRootCaCertificate(file.toFile());
+    }
+
+    @Test
+    void shouldNotImportRootCaCertWithExtensionDynSslIfNotAvailable() throws Exception {
+        // Given
+        Path file = Files.createTempFile("rootca", ".cer");
+        given(extensionLoader.getExtension(ExtensionDynSSL.class)).willReturn(null);
+        // When
+        String result = extension.importRootCaCert(file);
+        // Then
+        assertThat(result, is(equalTo("")));
+    }
+
+    private void mockRootCaKeyStore() throws Exception {
+        KeyStore keyStore =
+                SslCertificateUtils.string2Keystore(NetworkTestUtils.FISH_CERT_BASE64_STR);
+        DynSSLParam dynSslParam = mock(DynSSLParam.class);
+        given(optionsParam.getParamSet(DynSSLParam.class)).willReturn(dynSslParam);
+        given(dynSslParam.getRootca()).willReturn(keyStore);
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkApiUnitTest.java
@@ -1,0 +1,266 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.API.RequestType;
+import org.zaproxy.zap.extension.api.ApiElement;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiParameter;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+import org.zaproxy.zap.extension.dynssl.SslCertificateUtils;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link NetworkApi}. */
+class NetworkApiUnitTest extends TestUtils {
+
+    private NetworkApi networkApi;
+    private ExtensionNetwork extensionNetwork;
+
+    @BeforeEach
+    void setUp() {
+        mockMessages(new ExtensionNetwork());
+        extensionNetwork = mock(ExtensionNetwork.class);
+        networkApi = new NetworkApi(extensionNetwork);
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        Constant.messages = null;
+    }
+
+    @Test
+    void shouldHavePrefix() throws Exception {
+        // Given / When
+        String prefix = networkApi.getPrefix();
+        // Then
+        assertThat(prefix, is(equalTo("network")));
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownAction(String name) throws Exception {
+        // Given
+        JSONObject params = new JSONObject();
+        // When
+        ApiException exception =
+                assertThrows(ApiException.class, () -> networkApi.handleApiAction(name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_ACTION)));
+    }
+
+    @Test
+    void shouldReturnOkForGeneratedRootCaCert() throws Exception {
+        // Given
+        String name = "generateRootCaCert";
+        JSONObject params = new JSONObject();
+        given(extensionNetwork.generateRootCaCert()).willReturn(true);
+        // When
+        ApiResponse response = networkApi.handleApiAction(name, params);
+        // Then
+        assertThat(response, is(equalTo(ApiResponseElement.OK)));
+    }
+
+    @Test
+    void shouldReturnFailForNonGeneratedRootCaCert() throws Exception {
+        // Given
+        String name = "generateRootCaCert";
+        JSONObject params = new JSONObject();
+        given(extensionNetwork.generateRootCaCert()).willReturn(false);
+        // When
+        ApiResponse response = networkApi.handleApiAction(name, params);
+        // Then
+        assertThat(response, is(equalTo(ApiResponseElement.FAIL)));
+    }
+
+    @Test
+    void shouldReturnOkForImportedRootCaCert() throws Exception {
+        // Given
+        String name = "importRootCaCert";
+        JSONObject params = new JSONObject();
+        Path file = Paths.get("/dir/cert.pem");
+        params.put("filePath", file.toString());
+        given(extensionNetwork.importRootCaCert(file)).willReturn(null);
+        // When
+        ApiResponse response = networkApi.handleApiAction(name, params);
+        // Then
+        assertThat(response, is(equalTo(ApiResponseElement.OK)));
+        verify(extensionNetwork).importRootCaCert(file);
+    }
+
+    @Test
+    void shouldThrowApiExceptionForNonImportedRootCaCert() throws Exception {
+        // Given
+        String name = "importRootCaCert";
+        JSONObject params = new JSONObject();
+        Path file = Paths.get("/dir/cert.pem");
+        params.put("filePath", file.toString());
+        given(extensionNetwork.importRootCaCert(file)).willReturn("Missing private key.");
+        // When
+        ApiException exception =
+                assertThrows(ApiException.class, () -> networkApi.handleApiAction(name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.ILLEGAL_PARAMETER)));
+        assertThat(exception.toString(true), containsString("Missing private key."));
+        verify(extensionNetwork).importRootCaCert(file);
+    }
+
+    @ParameterizedTest
+    @EmptySource
+    @ValueSource(strings = {"unknown", "something"})
+    void shouldThrowApiExceptionForUnknownOther(String name) throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        JSONObject params = new JSONObject();
+        // When
+        ApiException exception =
+                assertThrows(
+                        ApiException.class, () -> networkApi.handleApiOther(message, name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.BAD_OTHER)));
+    }
+
+    @Test
+    void shouldReturnPemForExistingRootCaCert() throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        String name = "rootCaCert";
+        JSONObject params = new JSONObject();
+        KeyStore keyStore =
+                SslCertificateUtils.string2Keystore(NetworkTestUtils.FISH_CERT_BASE64_STR);
+        given(extensionNetwork.getRootCaKeyStore()).willReturn(keyStore);
+        // When
+        HttpMessage apiMessage = networkApi.handleApiOther(message, name, params);
+        // Then
+        assertThat(apiMessage, is(sameInstance(message)));
+        assertThat(
+                apiMessage.getResponseHeader().toString(),
+                allOf(
+                        containsString("Content-Type: application/pkix-cert;"),
+                        containsString(
+                                "Content-Disposition: attachment; filename=\"ZAPCACert.cer\"\r\n")));
+        assertThat(
+                apiMessage.getResponseBody().toString(),
+                allOf(
+                        containsString(SslCertificateUtils.BEGIN_CERTIFICATE_TOKEN),
+                        containsString(
+                                "MIIC9TCCAl6gAwIBAgIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAMFsxGDAWBgNV\n"),
+                        containsString(SslCertificateUtils.END_CERTIFICATE_TOKEN),
+                        not(containsString(SslCertificateUtils.BEGIN_PRIVATE_KEY_TOKEN))));
+        assertThat(apiMessage, is(sameInstance(message)));
+    }
+
+    @Test
+    void shouldThrowExceptionForMissingRootCaCert() throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        String name = "rootCaCert";
+        JSONObject params = new JSONObject();
+        given(extensionNetwork.getRootCaKeyStore()).willReturn(null);
+        // When
+        ApiException exception =
+                assertThrows(
+                        ApiException.class, () -> networkApi.handleApiOther(message, name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.DOES_NOT_EXIST)));
+    }
+
+    @Test
+    void shouldThrowExceptionForIncorrectRootCaCert() throws Exception {
+        // Given
+        HttpMessage message = new HttpMessage();
+        String name = "rootCaCert";
+        JSONObject params = new JSONObject();
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        given(extensionNetwork.getRootCaKeyStore()).willReturn(keyStore);
+        // When
+        ApiException exception =
+                assertThrows(
+                        ApiException.class, () -> networkApi.handleApiOther(message, name, params));
+        // Then
+        assertThat(exception.getType(), is(equalTo(ApiException.Type.INTERNAL_ERROR)));
+    }
+
+    @Test
+    void shouldHaveDescriptionsForAllApiElements() {
+        List<String> missingKeys = new ArrayList<>();
+        checkKey(networkApi.getDescriptionKey(), missingKeys);
+        checkApiElements(
+                networkApi, networkApi.getApiActions(), API.RequestType.action, missingKeys);
+        checkApiElements(networkApi, networkApi.getApiOthers(), API.RequestType.other, missingKeys);
+        checkApiElements(networkApi, networkApi.getApiViews(), API.RequestType.view, missingKeys);
+        assertThat(missingKeys, is(empty()));
+    }
+
+    private static void checkApiElements(
+            ApiImplementor api,
+            List<? extends ApiElement> elements,
+            RequestType type,
+            List<String> missingKeys) {
+        elements.sort((a, b) -> a.getName().compareTo(b.getName()));
+        for (ApiElement element : elements) {
+            assertThat(
+                    "API element: " + api.getPrefix() + "/" + element.getName(),
+                    element.getDescriptionTag(),
+                    is(not(emptyString())));
+            checkKey(element.getDescriptionTag(), missingKeys);
+            element.getParameters().stream()
+                    .map(ApiParameter::getDescriptionKey)
+                    .forEach(key -> checkKey(key, missingKeys));
+        }
+    }
+
+    private static void checkKey(String key, List<String> missingKeys) {
+        if (!Constant.messages.containsKey(key)) {
+            missingKeys.add(key);
+        }
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkTestUtils.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/NetworkTestUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+/** Utilities to help with network tests. */
+public final class NetworkTestUtils {
+
+    public static final String FISH_CERT_BASE64 =
+            "MIIC9TCCAl6gAwIBAgIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAMFsxGDAWBgNV\n"
+                    + "BAoTD1N1cGVyZmlzaCwgSW5jLjELMAkGA1UEBxMCU0YxCzAJBgNVBAgTAkNBMQsw\n"
+                    + "CQYDVQQGEwJVUzEYMBYGA1UEAxMPU3VwZXJmaXNoLCBJbmMuMB4XDTE0MDUxMjE2\n"
+                    + "MjUyNloXDTM0MDUwNzE2MjUyNlowWzEYMBYGA1UEChMPU3VwZXJmaXNoLCBJbmMu\n"
+                    + "MQswCQYDVQQHEwJTRjELMAkGA1UECBMCQ0ExCzAJBgNVBAYTAlVTMRgwFgYDVQQD\n"
+                    + "Ew9TdXBlcmZpc2gsIEluYy4wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOjz\n"
+                    + "Shh2Xxk/sc9Y6X9DBwmVgDXFD/5xMSeBmRImIKXfj2r8QlU57gk4idngNsSsAYJb\n"
+                    + "1Tnm+Y8HiN/+7vahFM6pdEXY/fAXVyqC4XouEpNarIrXFWPRt5tVgA9YvBxJ7SBi\n"
+                    + "3bZMpTrrHD2g/3pxptMQeDOuS8Ic/ZJKocPnQaQtAgMBAAGjgcAwgb0wDAYDVR0T\n"
+                    + "BAUwAwEB/zAdBgNVHQ4EFgQU+5izU38URC7o7tUJml4OVoaoNYgwgY0GA1UdIwSB\n"
+                    + "hTCBgoAU+5izU38URC7o7tUJml4OVoaoNYihX6RdMFsxGDAWBgNVBAoTD1N1cGVy\n"
+                    + "ZmlzaCwgSW5jLjELMAkGA1UEBxMCU0YxCzAJBgNVBAgTAkNBMQswCQYDVQQGEwJV\n"
+                    + "UzEYMBYGA1UEAxMPU3VwZXJmaXNoLCBJbmMuggkA0vwTh6lE3OcwDQYJKoZIhvcN\n"
+                    + "AQEFBQADgYEApHyg7ApKx3DEcWjzOyLi3JyN0JL+c35yK1VEmxu0Qusfr76645Oj\n"
+                    + "1IsYwpTws6a9ZTRMzST4GQvFFQra81eLqYbPbMPuhC+FCxkUF5i0DNSWi+kczJXJ\n"
+                    + "TtCqSwGl9t9JEoFqvtW+znZ9TqyLiOMw7TGEUI+88VAqW0qmXnwPcfo=\n";
+
+    public static final String FISH_PRIV_KEY_BASE64 =
+            "MIICXgIBAAKBgQDo80oYdl8ZP7HPWOl/QwcJlYA1xQ/+cTEngZkSJiCl349q/EJV\n"
+                    + "Oe4JOInZ4DbErAGCW9U55vmPB4jf/u72oRTOqXRF2P3wF1cqguF6LhKTWqyK1xVj\n"
+                    + "0bebVYAPWLwcSe0gYt22TKU66xw9oP96cabTEHgzrkvCHP2SSqHD50GkLQIDAQAB\n"
+                    + "AoGBAKepW14J7F5e0ppa8wvOcUU7neCVafKHA4rcoxBF8t+P7UhiMVfn7uQiFk2D\n"
+                    + "K8gXyKpLcEdRb7K7CI+3i8RkoXTRDEZU5XPMJnZsE5LWgNQ+pi3HwMEdR0vD2Iyv\n"
+                    + "vIH3tq6mNKgDu+vozm8DWsEP96jrhVbo1U1rzyEtX46afo79AkEA/VXanGaqj4ua\n"
+                    + "EsqfY6n/7+MTm4iPOM7qfoyI4EppJXZklc/FbcV2lAjY2Jl9U6X7WnqCPn+/zg44\n"
+                    + "6lKWTnhAawJBAOtmi6nw8WjY6uyXZosE/0r4SkSSo20EJbBCJcgdofKT+VCGB4hp\n"
+                    + "h6XwGdls0ca+qa5ZE1a196dpwwVre0hm88cCQQDrUm3QbHmw/39uRzOJs6dfYPKc\n"
+                    + "vlwz69jdFpQqrFRBjVlf4/FDx3IfjpxHj0RgiEUUxcnoXmh/8qwh1fdzCrbjAkB4\n"
+                    + "afg/chTLQUrKw5ecvW2p9+Blu20Fsv1kcDHLb/0LjU4XNrhbuz+8TlmqstOMCrPZ\n"
+                    + "j48o5+RLKvqrpxNlMeS5AkEA6qIdW/yp5N8b1j2OxYZ9u5O//BvspwRITGM60Cps\n"
+                    + "yemZE/ua8wm34SKvDHf5uxcmofShW17PLICrsLJ7P35y/A==\n";
+
+    public static final String FISH_CERT_BASE64_STR =
+            "_u3-7QAAAAIAAAACAAAAAgAKY2VydC1hbGlhcwAAAWB_rTdKAAVYLjUwOQAAAvkwggL1MIICXqADAgECAgkA0vwTh6lE3OcwDQYJKoZIhvcNAQEFBQAwWzEYMBYGA1UEChMPU3VwZXJmaXNoLCBJbmMuMQswCQYDVQQHEwJTRjELMAkGA1UECBMCQ0ExCzAJBgNVBAYTAlVTMRgwFgYDVQQDEw9TdXBlcmZpc2gsIEluYy4wHhcNMTQwNTEyMTYyNTI2WhcNMzQwNTA3MTYyNTI2WjBbMRgwFgYDVQQKEw9TdXBlcmZpc2gsIEluYy4xCzAJBgNVBAcTAlNGMQswCQYDVQQIEwJDQTELMAkGA1UEBhMCVVMxGDAWBgNVBAMTD1N1cGVyZmlzaCwgSW5jLjCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA6PNKGHZfGT-xz1jpf0MHCZWANcUP_nExJ4GZEiYgpd-PavxCVTnuCTiJ2eA2xKwBglvVOeb5jweI3_7u9qEUzql0Rdj98BdXKoLhei4Sk1qsitcVY9G3m1WAD1i8HEntIGLdtkylOuscPaD_enGm0xB4M65Lwhz9kkqhw-dBpC0CAwEAAaOBwDCBvTAMBgNVHRMEBTADAQH_MB0GA1UdDgQWBBT7mLNTfxRELuju1QmaXg5Whqg1iDCBjQYDVR0jBIGFMIGCgBT7mLNTfxRELuju1QmaXg5Whqg1iKFfpF0wWzEYMBYGA1UEChMPU3VwZXJmaXNoLCBJbmMuMQswCQYDVQQHEwJTRjELMAkGA1UECBMCQ0ExCzAJBgNVBAYTAlVTMRgwFgYDVQQDEw9TdXBlcmZpc2gsIEluYy6CCQDS_BOHqUTc5zANBgkqhkiG9w0BAQUFAAOBgQCkfKDsCkrHcMRxaPM7IuLcnI3Qkv5zfnIrVUSbG7RC6x-vvrrjk6PUixjClPCzpr1lNEzNJPgZC8UVCtrzV4uphs9sw-6EL4ULGRQXmLQM1JaL6RzMlclO0KpLAaX230kSgWq-1b7Odn1OrIuI4zDtMYRQj7zxUCpbSqZefA9x-gAAAAEAEW93YXNwX3phcF9yb290X2NhAAABYH-tN0oAAAK8MIICuDAOBgorBgEEASoCEQEBBQAEggKkpEg-GU1c0LSAqPTCS8ZthP0BRqVvB14nWLF8jJohHp2xHy3mOckHPsO8ecYB2NBeMvmq2QP3NpQZAmQ1pDo2pi4Dk4lCbBmfp7E6_jKWhxeI2JhhTLlIkaCymQ6H8I2MY2gEXLikMU_Q6zTFqnL1Qw0M04Xkhy0PV9reb2qM2D9B2p3YwKFrDgUk4oAH_3vvqD56v-KdyO6b0CkzpR5e9sQsjq5odRvErgKmHTgUZ1kNMVacEojrFYVdqaBPR8jreGxQJMsCuFG6ZfMMS1R9Xt1iR5O_dtWvtlpt8RBoBgLVKQLTbjBuJe6pJ9wL9gkQYSolx0naqLAJpHirkGaEmQjnGq0DdwpnMvNlgBMl4sz7U_1eD0_j_D_h-BZud5fx2WkBwBVJvl6oirrg_YMQ6q5xxqhHp3BXwYMZktIuhWKK_ESiu4tqtc3_K8bzStuvORUzjOlZuT6XuR0d57wtt5nlf8NeQGXVJFCA0b1EZivtcPDCpAm8qW4IuTVtmV7aS7q5zPSmXFvNpJ_GrOWoErCmYSn0_7dtKjObCs3l3iglr2syvE7QPwdJHSBdurg6MBaMnmFQUuWax-318T-prQxvJ7uBEY1q6dHHlDUmUaRZ3-CHRVGrFtuXanOYSLCZwZAvz4yrR7qU2ct6HJVMfd7-obhHtptlzSJdlBT-ssvuKoNApvo06VTNUB3TAXwED6T5JZciUSD3iA0T4qkzgyRSAnru9zAsinfKyONZPJIvk2z-h0FljdtaqSJJT4wz0-ASKbPzMfMLNOhtU2p2DB4Tbc9X63COU2VwyC4iDasPTg1AralosvKUMje4sPcJBwoaBHsJmHd0xQowfQa0mIpZGPe-HnXesGSNH_PFNlykzKxD4aIcx4syqIFedT1il0FNiwAAAAEABVguNTA5AAAC-TCCAvUwggJeoAMCAQICCQDS_BOHqUTc5zANBgkqhkiG9w0BAQUFADBbMRgwFgYDVQQKEw9TdXBlcmZpc2gsIEluYy4xCzAJBgNVBAcTAlNGMQswCQYDVQQIEwJDQTELMAkGA1UEBhMCVVMxGDAWBgNVBAMTD1N1cGVyZmlzaCwgSW5jLjAeFw0xNDA1MTIxNjI1MjZaFw0zNDA1MDcxNjI1MjZaMFsxGDAWBgNVBAoTD1N1cGVyZmlzaCwgSW5jLjELMAkGA1UEBxMCU0YxCzAJBgNVBAgTAkNBMQswCQYDVQQGEwJVUzEYMBYGA1UEAxMPU3VwZXJmaXNoLCBJbmMuMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDo80oYdl8ZP7HPWOl_QwcJlYA1xQ_-cTEngZkSJiCl349q_EJVOe4JOInZ4DbErAGCW9U55vmPB4jf_u72oRTOqXRF2P3wF1cqguF6LhKTWqyK1xVj0bebVYAPWLwcSe0gYt22TKU66xw9oP96cabTEHgzrkvCHP2SSqHD50GkLQIDAQABo4HAMIG9MAwGA1UdEwQFMAMBAf8wHQYDVR0OBBYEFPuYs1N_FEQu6O7VCZpeDlaGqDWIMIGNBgNVHSMEgYUwgYKAFPuYs1N_FEQu6O7VCZpeDlaGqDWIoV-kXTBbMRgwFgYDVQQKEw9TdXBlcmZpc2gsIEluYy4xCzAJBgNVBAcTAlNGMQswCQYDVQQIEwJDQTELMAkGA1UEBhMCVVMxGDAWBgNVBAMTD1N1cGVyZmlzaCwgSW5jLoIJANL8E4epRNznMA0GCSqGSIb3DQEBBQUAA4GBAKR8oOwKSsdwxHFo8zsi4tycjdCS_nN-citVRJsbtELrH6--uuOTo9SLGMKU8LOmvWU0TM0k-BkLxRUK2vNXi6mGz2zD7oQvhQsZFBeYtAzUlovpHMyVyU7QqksBpfbfSRKBar7Vvs52fU6si4jjMO0xhFCPvPFQKltKpl58D3H6JOMFodMMw2IeCb55eEfrh6zCSzM=";
+
+    private NetworkTestUtils() {}
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -531,6 +531,17 @@ public abstract class TestUtils {
                             // Return an empty string for non extension's messages.
                             return "";
                         });
+
+        when(i18n.containsKey(anyString()))
+                .thenAnswer(
+                        invocation -> {
+                            String key = (String) invocation.getArguments()[0];
+                            if (key.startsWith(prefix)) {
+                                return extensionResourceBundle.containsKey(key);
+                            }
+                            // Return true for non extension's messages.
+                            return true;
+                        });
     }
 
     private static ResourceBundle getExtensionResourceBundle(String baseName) {


### PR DESCRIPTION
Add API to generate, import, and obtain the root CA certificate,
replaces core endpoints `generateRootCA` and `rootcert`.
Add network add-on to the list of mandatory add-ons.

Fix zaproxy/zaproxy#2280.
Related to zaproxy/zaproxy#6949.