### PR TITLE
network: bundle Bouncy Castle library

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -2,6 +2,9 @@ import org.zaproxy.gradle.addon.AddOnStatus
 
 description = "Provides core networking capabilities."
 
+val bouncyCastle by configurations.creating
+configurations.api { extendsFrom(bouncyCastle) }
+
 zapAddOn {
     addOnName.set("Network")
     addOnStatus.set(AddOnStatus.ALPHA)
@@ -14,6 +17,10 @@ zapAddOn {
         helpSet {
             baseName.set("help%LC%.helpset")
             localeToken.set("%LC%")
+        }
+
+        bundledLibs {
+            libs.from(bouncyCastle)
         }
     }
 
@@ -35,6 +42,11 @@ dependencies {
 
     val nettyVersion = "4.1.70.Final"
     implementation("io.netty:netty-codec:$nettyVersion")
+
+    val bcVersion = "1.69"
+    bouncyCastle("org.bouncycastle:bcmail-jdk15on:$bcVersion")
+    bouncyCastle("org.bouncycastle:bcprov-jdk15on:$bcVersion")
+    bouncyCastle("org.bouncycastle:bcpkix-jdk15on:$bcVersion")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Depend on Network add-on.
 
 ## [0.5.0] - 2021-10-06
 ### Changed

--- a/addOns/oast/oast.gradle.kts
+++ b/addOns/oast/oast.gradle.kts
@@ -8,6 +8,12 @@ zapAddOn {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/oast-support/")
 
+        dependencies {
+            addOns {
+                register("network")
+            }
+        }
+
         extensions {
             register("org.zaproxy.addon.oast.scripts.ExtensionOastScripts") {
                 classnames {
@@ -39,6 +45,7 @@ crowdin {
 
 dependencies {
     compileOnly(parent!!.childProjects["graaljs"]!!)
+    compileOnly(parent!!.childProjects["network"]!!)
 
     testImplementation(project(":testutils"))
 }


### PR DESCRIPTION
Bundle the Bouncy Castle library to no longer rely on core to create
the server certificates, core will no longer need it.
Change OAST add-on to depend on Network add-on, which also uses Bouncy
Castle library, it will also use other network features (e.g. server
for callbacks).