### PR TITLE
selenium: address exception when saving options

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Address exception when saving the options (Issue 6951).
 
 ## [15.5.0] - 2021-11-25
 ### Added

--- a/addOns/selenium/gradle.properties
+++ b/addOns/selenium/gradle.properties
@@ -1,2 +1,2 @@
-version=15.6.0
+version=15.5.1
 release=false

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptions.java
@@ -67,6 +67,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
 
     private static final File EXTENSIONS_DIR =
             new File(Constant.getZapHome() + "/selenium/extensions/");
+    private static final File[] NO_FILES = {};
 
     private static final Logger LOGGER = LogManager.getLogger(SeleniumOptions.class);
 
@@ -137,6 +138,12 @@ public class SeleniumOptions extends VersionedAbstractParam {
 
     @Override
     protected void parseImpl() {
+        try {
+            Files.createDirectories(EXTENSIONS_DIR.toPath());
+        } catch (IOException e) {
+            LOGGER.error("Failed to create the extensions directory:", e);
+        }
+
         chromeDriverPath =
                 getWebDriverPath(Browser.CHROME, CHROME_DRIVER_SYSTEM_PROPERTY, CHROME_DRIVER_KEY);
         firefoxBinaryPath =
@@ -388,7 +395,7 @@ public class SeleniumOptions extends VersionedAbstractParam {
     public void setBrowserExtensions(List<BrowserExtension> exts) {
         this.disabledExtensions.clear();
         // Delete any that are not in the list
-        for (File file : EXTENSIONS_DIR.listFiles()) {
+        for (File file : getFiles(EXTENSIONS_DIR)) {
             Path path = file.toPath();
             if (BrowserExtension.isBrowserExtension(path)) {
                 boolean found = false;
@@ -428,6 +435,14 @@ public class SeleniumOptions extends VersionedAbstractParam {
             }
         }
         this.getConfig().setProperty(DISABLED_EXTENSIONS_KEY, this.disabledExtensions);
+    }
+
+    private static File[] getFiles(File file) {
+        File[] files = file.listFiles();
+        if (files != null) {
+            return files;
+        }
+        return NO_FILES;
     }
 
     public String getLastDirectory() {

--- a/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsUnitTest.java
+++ b/addOns/selenium/src/test/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsUnitTest.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.selenium;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link SeleniumOptions}. */
+class SeleniumOptionsUnitTest extends TestUtils {
+
+    private Path seleniumExtensionsDir;
+    private SeleniumOptions options;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        setUpZap();
+        seleniumExtensionsDir = Paths.get(Constant.getZapHome(), "selenium", "extensions");
+
+        options = new SeleniumOptions();
+    }
+
+    @Test
+    void shouldCreateSeleniumExtensionsDirOnLoad() {
+        // Given / When
+        options.load(new ZapXmlConfiguration());
+        // Then
+        assertThat(Files.isDirectory(seleniumExtensionsDir), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotFailToSetBrowserExtensionsIfExtensionsDirDoesNotExist() throws Exception {
+        // Given
+        options.load(new ZapXmlConfiguration());
+        Files.deleteIfExists(seleniumExtensionsDir);
+        // When / Then
+        assertDoesNotThrow(() -> options.setBrowserExtensions(Collections.emptyList()));
+    }
+}


### PR DESCRIPTION
Check if files were returned from the extensions directory to prevent a
NullPointerException.
Create the extensions directory for proper enumeration of the files and
for the user to not need to create it manually.

Fix zaproxy/zaproxy#6951.