### PR TITLE
exim: Add import and save stats

### DIFF
--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
@@ -28,6 +28,7 @@ import org.zaproxy.addon.exim.urls.MenuItemImportUrls;
 
 public class ExtensionExim extends ExtensionAdaptor {
 
+    public static final String STATS_PREFIX = "stats.exim.";
     private static final String NAME = "ExtensionExim";
 
     public ExtensionExim() {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveRawMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveRawMessage.java
@@ -29,11 +29,13 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.utils.Stats;
 
 public class PopupMenuSaveRawMessage extends AbstractPopupMenuSaveMessage {
     private static final long serialVersionUID = -7217818541206464572L;
     private static final Logger LOG = LogManager.getLogger(PopupMenuSaveRawMessage.class);
-
+    private static final String STATS_RAW_FILE_MSG = "save.raw.file.msg";
+    private static final String STATS_RAW_FILE_MSG_ERROR = "save.raw.file.msg.errors";
     private static final String MESSAGE_PREFIX = "exim.saveraw.";
     private static final String RAW_FILE_EXTENSION = ".raw";
 
@@ -76,18 +78,28 @@ public class PopupMenuSaveRawMessage extends AbstractPopupMenuSaveMessage {
                 System.arraycopy(bytesBody, 0, bytes, bytesHeader.length, bytesBody.length);
                 break;
         }
-        writeToFile(file, bytes);
+        writeToFile(file, bytes, messageComponent);
     }
 
-    private static void writeToFile(File file, byte[] bytes) {
+    private static void writeToFile(File file, byte[] bytes, MessageComponent messageComponent) {
         try (OutputStream fw = new BufferedOutputStream(new FileOutputStream(file))) {
             fw.write(bytes);
+            Stats.incCounter(
+                    ExtensionExim.STATS_PREFIX
+                            + STATS_RAW_FILE_MSG
+                            + "."
+                            + messageComponent.name());
         } catch (IOException e) {
             View.getSingleton()
                     .showWarningDialog(
                             Constant.messages.getString(
                                     "exim.file.save.error", file.getAbsolutePath()));
             LOG.error(e.getMessage(), e);
+            Stats.incCounter(
+                    ExtensionExim.STATS_PREFIX
+                            + STATS_RAW_FILE_MSG_ERROR
+                            + "."
+                            + messageComponent.name());
         }
     }
 }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveXmlMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuSaveXmlMessage.java
@@ -34,13 +34,15 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.XmlUtils;
 
 public class PopupMenuSaveXmlMessage extends AbstractPopupMenuSaveMessage {
 
     private static final long serialVersionUID = -7217818541206464572L;
     private static final Logger LOG = LogManager.getLogger(PopupMenuSaveXmlMessage.class);
-
+    private static final String STATS_XML_FILE_MSG = "save.xml.file.msg";
+    private static final String STATS_XML_FILE_MSG_ERROR = "save.xml.file.msg.errors";
     private static final String MESSAGE_PREFIX = "exim.savexml.";
     private static final String XML_FILE_EXTENSION = ".xml";
 
@@ -81,10 +83,14 @@ public class PopupMenuSaveXmlMessage extends AbstractPopupMenuSaveMessage {
                 break;
         }
 
-        writeToFile(file, bytesHeader, bytesBody);
+        writeToFile(file, bytesHeader, bytesBody, messageComponent);
     }
 
-    private static void writeToFile(File file, byte[] headersContent, byte[] bodyContent) {
+    private static void writeToFile(
+            File file,
+            byte[] headersContent,
+            byte[] bodyContent,
+            MessageComponent messageComponent) {
         try {
 
             DocumentBuilder docBuilder =
@@ -119,13 +125,22 @@ public class PopupMenuSaveXmlMessage extends AbstractPopupMenuSaveMessage {
             DOMSource source = new DOMSource(doc);
             StreamResult result = new StreamResult(file);
             transformer.transform(source, result);
-
+            Stats.incCounter(
+                    ExtensionExim.STATS_PREFIX
+                            + STATS_XML_FILE_MSG
+                            + "."
+                            + messageComponent.name());
         } catch (Exception e) {
             View.getSingleton()
                     .showWarningDialog(
                             Constant.messages.getString(
                                     "exim.file.save.error", file.getAbsolutePath()));
             LOG.error(e.getMessage(), e);
+            Stats.incCounter(
+                    ExtensionExim.STATS_PREFIX
+                            + STATS_XML_FILE_MSG_ERROR
+                            + "."
+                            + messageComponent.name());
         }
     }
 }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -39,13 +39,19 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.addon.exim.ExtensionExim;
 import org.zaproxy.zap.network.HttpResponseBody;
 import org.zaproxy.zap.utils.HarUtils;
+import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.ThreadUtils;
 
 public final class HarImporter {
 
     private static final Logger LOG = LogManager.getLogger(HarImporter.class);
+    private static final String STATS_HAR_FILE = "import.har.file";
+    private static final String STATS_HAR_FILE_ERROR = "import.har.file.errors";
+    private static final String STATS_HAR_FILE_MSG = "import.har.file.message";
+    private static final String STATS_HAR_FILE_MSG_ERROR = "import.har.file.message.errors";
 
     private static ExtensionHistory extHistory;
 
@@ -104,9 +110,11 @@ public final class HarImporter {
     public static boolean importHarFile(File file) {
         try {
             processMessages(file);
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE);
             return true;
         } catch (IOException e) {
             LOG.error(e);
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_ERROR);
             return false;
         }
     }
@@ -126,8 +134,10 @@ public final class HarImporter {
                             Model.getSingleton().getSession(),
                             HistoryReference.TYPE_ZAP_USER,
                             message);
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_MSG);
         } catch (Exception e) {
             LOG.warn(e.getMessage(), e);
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_MSG_ERROR);
             return;
         }
 

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/PopupMenuItemSaveHarMessage.java
@@ -35,7 +35,9 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.exim.EximFileChooser;
+import org.zaproxy.addon.exim.ExtensionExim;
 import org.zaproxy.zap.utils.HarUtils;
+import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
 public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContainer {
@@ -43,7 +45,9 @@ public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContain
     private static final long serialVersionUID = -7217818541206464572L;
 
     private static final Logger LOG = LogManager.getLogger(PopupMenuItemSaveHarMessage.class);
-
+    private static final String STATS_SAVE_HAR_FILE = "save.har.file";
+    private static final String STATS_SAVE_HAR_FILE_ERROR = "save.har.file.error";
+    private static final String STATS_SAVE_HAR_FILE_MSG = "save.har.file.message";
     private static final String POPUP_MENU_LABEL =
             Constant.messages.getString("exim.har.popup.option");
     private static final String HAR_FILE_EXTENSION = ".har";
@@ -74,10 +78,12 @@ public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContain
         }
         try (OutputStream os = new BufferedOutputStream(new FileOutputStream(file))) {
             os.write(packRequestInHarArchive(httpMessages));
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_SAVE_HAR_FILE);
         } catch (IOException e) {
             View.getSingleton()
                     .showWarningDialog(MessageFormat.format(ERROR_SAVE, file.getAbsolutePath()));
             LOG.error(e.getMessage(), e);
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_SAVE_HAR_FILE_ERROR);
         }
     }
 
@@ -101,6 +107,7 @@ public class PopupMenuItemSaveHarMessage extends PopupMenuItemHttpMessageContain
                                         httpMessage.getHistoryRef().getHistoryType(),
                                         httpMessage));
                     }
+                    Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_SAVE_HAR_FILE_MSG);
                 });
         harLog.setEntries(entries);
         return HarUtils.harLogToByteArray(harLog);

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -19,6 +19,10 @@ exim.importLogFiles.choosefile.title = Select Input Type
 exim.importLogFiles.log.type.zap = ZAP Messages
 exim.importLogFiles.log.type.modsec2 = ModSecurity2 Logs
 
+exim.output.start = Importing {0}
+exim.output.end = Done importing {0}
+exim.output.error = Error importing {0}
+
 exim.popup.option.all = All
 exim.popup.option.body = Body
 exim.popup.option.header = Header


### PR DESCRIPTION
Part of zaproxy/zaproxy#6579

Add stats for importing and saving files, individual URLs/messages, and errors.
Add output panel messages for starting and finishing files. (Can be handy for example when importing a file of URLs and encountering timeouts.)

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>