### PR TITLE
network: handle cert command line args

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -7,5 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Server certificates management on newer ZAP versions.
+- Handle command line arguments `-certload`, `-certpubdump`, and `-certfulldump` on newer ZAP versions.
 - API endpoints to generate, import, obtain, and to configure the validity of the root CA
 certificate and issued certificates (Issue 4673).

--- a/addOns/network/src/main/javahelp/help/contents/cmdline.html
+++ b/addOns/network/src/main/javahelp/help/contents/cmdline.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Command Line</TITLE>
+</HEAD>
+<BODY>
+	<H1>Command Line</H1>
+	The Network add-on supports the following command line options:
+	<table>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td>-certload</td>
+			<td>Loads the Root CA certificate from the specified file.</td>
+		</tr>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td>-certpubdump</td>
+			<td>Dumps the Root CA certificate into the specified file, this is suitable for importing into browsers.</td>
+		</tr>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td>-certfulldump</td>
+			<td>Dumps the Root CA certificate and the private key into the specified file, this is suitable for importing into ZAP.</td>
+		</tr>
+	</table>
+
+	<H2>See also</H2>
+	<table>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td><a href="network.html">Network</a></td>
+			<td>the introduction to Network add-on</td>
+		</tr>
+	</table>
+
+</BODY>
+</HTML>

--- a/addOns/network/src/main/javahelp/help/index.xml
+++ b/addOns/network/src/main/javahelp/help/index.xml
@@ -6,4 +6,5 @@
 <index version="2.0">
     <indexitem text="Network" target="addon.network" />
     <indexitem text="Network API" target="addon.network.api" />
+    <indexitem text="Network Command Line" target="addon.network.cmdline" />
 </index>

--- a/addOns/network/src/main/javahelp/help/map.jhm
+++ b/addOns/network/src/main/javahelp/help/map.jhm
@@ -7,4 +7,5 @@
     <mapID target="addon.network.icon" url="contents/images/icon.png" />
     <mapID target="addon.network" url="contents/network.html" />
     <mapID target="addon.network.api" url="contents/api.html" />
+    <mapID target="addon.network.cmdline" url="contents/cmdline.html" />
 </map>

--- a/addOns/network/src/main/javahelp/help/toc.xml
+++ b/addOns/network/src/main/javahelp/help/toc.xml
@@ -8,6 +8,7 @@
         <tocitem text="Add Ons" tocid="addons">
             <tocitem text="Network" image="addon.network.icon" target="addon.network">
                 <tocitem text="API" target="addon.network.api" />
+                <tocitem text="Command Line"  target="addon.network.cmdline" />
             </tocitem>
         </tocitem>
     </tocitem>

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -10,6 +10,15 @@ network.api.other.rootCaCert = Gets the Root CA certificate used to issue server
 network.api.view.getRootCaCertValidity = Gets the Root CA certificate validity, in days. Used when generating a new Root CA certificate.
 network.api.view.getServerCertValidity = Gets the server certificate validity, in days. Used when generating server certificates.
 
+network.cmdline.certdump.done = Root CA certificate written to {0}
+network.cmdline.certfulldump = Dumps the Root CA full certificate (including the private key) into the specified file name, this is suitable for importing into ZAP
+network.cmdline.certload = Loads the Root CA certificate from the specified file name
+network.cmdline.certload.done = Root CA certificate loaded from {0}
+network.cmdline.certpubdump = Dumps the Root CA public certificate into the specified file name, this is suitable for importing into browsers
+network.cmdline.error.noread = Cannot read file {0}
+network.cmdline.error.nowrite = Cannot write to file {0}
+network.cmdline.error.write = Error writing Root CA certificate to {0}
+
 network.ext.name = Network Extension
 network.ext.desc = Provides core networking capabilities.
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/cert/CertificateUtilsUnitTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -500,6 +501,23 @@ class CertificateUtilsUnitTest {
         PrivateKey privateKey = CertificateUtils.getPrivateKey(keyStore);
         // Then
         assertThat(privateKey, is(nullValue()));
+    }
+
+    @Test
+    void shouldConvertKeyStoreToCertificateAndPrivateKeyPemFile() throws Exception {
+        // Given
+        KeyStore keyStore =
+                CertificateUtils.stringToKeystore(NetworkTestUtils.FISH_CERT_BASE64_STR);
+        Path file = Files.createTempFile("cert", ".cer");
+        // When
+        CertificateUtils.keyStoreToCertificateAndPrivateKeyPem(keyStore, file);
+        // Then
+        String pem = new String(Files.readAllBytes(file), StandardCharsets.US_ASCII);
+        byte[] certificate = CertificateUtils.extractCertificate(pem);
+        assertThat(certificate.length, is(not(0)));
+        byte[] privateKey = CertificateUtils.extractPrivateKey(pem);
+        assertThat(privateKey.length, is(not(0)));
+        assertThat(CertificateUtils.pemToKeyStore(certificate, privateKey), is(notNullValue()));
     }
 
     private static String contents(Path file) throws IOException {


### PR DESCRIPTION
Handle command line arguments `-certload`, `-certpubdump`, and
`-certfulldump` when the corresponding core extension is deprecated.

Moves core deprecated functionality, zaproxy/zaproxy#6950.