### PR TITLE
feat: domxss & ILS: Add WSTG v4.2 alert mappings

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Added
+- OWASP Web Security Testing Guide v4.2 mappings.
 
 ## [12] - 2021-12-06
 ### Changed

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -22,7 +22,7 @@ zapAddOn {
                     version.set("15.*")
                 }
                 register("commonlib") {
-                    version.set(">= 1.5.0 & < 2.0.0")
+                    version.set(">= 1.6.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/DomXssScanRule.java
@@ -116,7 +116,9 @@ public class DomXssScanRule extends AbstractAppParamPlugin {
     private static final Browser DEFAULT_BROWSER = Browser.FIREFOX_HEADLESS;
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
-                    CommonAlertTag.OWASP_2021_A03_INJECTION, CommonAlertTag.OWASP_2017_A07_XSS);
+                    CommonAlertTag.OWASP_2021_A03_INJECTION,
+                    CommonAlertTag.OWASP_2017_A07_XSS,
+                    CommonAlertTag.WSTG_V42_CLNT_01_DOM_XSS);
     private static Map<Browser, Stack<WebDriverWrapper>> freeDrivers = new HashMap<>();
     private static List<WebDriverWrapper> takenDrivers = new ArrayList<>();
 

--- a/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
+++ b/addOns/domxss/src/test/java/org/zaproxy/zap/extension/domxss/DomXssScanRuleUnitTest.java
@@ -394,17 +394,23 @@ class DomXssScanRuleUnitTest extends ActiveScannerTestUtils<DomXssScanRule> {
         Map<String, String> tags = rule.getAlertTags();
         // Then
         assertThat(cwe, is(equalTo(79)));
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(true)));
         assertThat(tags.containsKey(CommonAlertTag.OWASP_2017_A07_XSS.getTag()), is(equalTo(true)));
+        assertThat(
+                tags.containsKey(CommonAlertTag.WSTG_V42_CLNT_01_DOM_XSS.getTag()),
+                is(equalTo(true)));
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2021_A03_INJECTION.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2021_A03_INJECTION.getValue())));
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A07_XSS.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A07_XSS.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.WSTG_V42_CLNT_01_DOM_XSS.getTag()),
+                is(equalTo(CommonAlertTag.WSTG_V42_CLNT_01_DOM_XSS.getValue())));
     }
 
     private class TestNanoServerHandler extends NanoServerHandler {

--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Added
+- OWASP Web Security Testing Guide v4.2 mappings.
+
 ## [3] - 2021-10-07
 ### Added
 - OWASP Top Ten 2021/2017 mappings.

--- a/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
+++ b/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.5.0 & < 2.0.0")
+                    version.set(">= 1.6.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
+++ b/addOns/imagelocationscanner/src/main/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRule.java
@@ -60,7 +60,8 @@ public class ImageLocationScanRule extends PluginPassiveScanner {
     private static final Map<String, String> ALERT_TAGS =
             CommonAlertTag.toMap(
                     CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
-                    CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG);
+                    CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG,
+                    CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK);
 
 	@Override
 	public int getPluginId() {

--- a/addOns/imagelocationscanner/src/test/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRuleUnitTest.java
+++ b/addOns/imagelocationscanner/src/test/java/org/zaproxy/zap/extension/imagelocationscanner/ImageLocationScanRuleUnitTest.java
@@ -124,7 +124,7 @@ class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<ImageLocatio
         // Given / When
         Map<String, String> tags = rule.getAlertTags();
         // Then
-        assertThat(tags.size(), is(equalTo(2)));
+        assertThat(tags.size(), is(equalTo(3)));
         assertThat(
                 tags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),
                 is(equalTo(true)));
@@ -132,11 +132,17 @@ class ImageLocationScanRuleUnitTest extends PassiveScannerTestUtils<ImageLocatio
                 tags.containsKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
                 is(equalTo(true)));
         assertThat(
+                tags.containsKey(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()),
+                is(equalTo(true)));
+        assertThat(
                 tags.get(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getValue())));
         assertThat(
                 tags.get(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()),
                 is(equalTo(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getValue())));
+        assertThat(
+                tags.get(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getTag()),
+                is(equalTo(CommonAlertTag.WSTG_V42_INFO_05_CONTENT_LEAK.getValue())));
     }
 
     private static void validateAlert(Alert alert) {


### PR DESCRIPTION
- Added alert mappings to scan rules.
- Updated UnitTests.
- Added change note.
- Update build file to depend on commonlib 1.6.0 or newer.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>