### PR TITLE
graaljs: revert dependency update

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -4,8 +4,6 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-### Changed
-- Dependency updates.
 
 ## [0.2.0] - 2021-10-06
 ### Added

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -28,7 +28,7 @@ crowdin {
 }
 
 dependencies {
-    val graalJsVersion = "21.3.0"
+    val graalJsVersion = "20.2.0"
     implementation("org.graalvm.js:js:$graalJsVersion")
     implementation("org.graalvm.js:js-scriptengine:$graalJsVersion")
     implementation("org.javadelight:delight-graaljs-sandbox:0.1.2")


### PR DESCRIPTION
Use the previous version of the Graal JavaScript library, the newer
version is causing problems in the live Docker image.
Remove change from changelog.

---
Per OWASP ZAP User Group thread: https://groups.google.com/g/zaproxy-users/c/fbrYAVKKu9Y/m/DvARO3c2CwAJ