### PR TITLE
chore: importLogFIles & importUrls: Hollow & Retire

### DIFF
--- a/addOns/importLogFiles/importLogFiles.gradle.kts
+++ b/addOns/importLogFiles/importLogFiles.gradle.kts
@@ -12,6 +12,12 @@ zapAddOn {
             baseName.set("help%LC%.helpset")
             localeToken.set("%LC%")
         }
+
+        dependencies {
+            addOns {
+                register("exim")
+            }
+        }
     }
 
     apiClientGen {

--- a/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
+++ b/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ExtensionImportLogFiles.java
@@ -34,11 +34,6 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import javax.swing.filechooser.FileFilter;
-import javax.swing.filechooser.FileNameExtensionFilter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jwall.web.audit.AuditEvent;
@@ -58,7 +53,6 @@ import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.network.HttpResponseBody;
-import org.zaproxy.zap.view.ZapMenuItem;
 
 public class ExtensionImportLogFiles extends ExtensionAdaptor {
 
@@ -79,7 +73,10 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
         }
     }
 
-    private ZapMenuItem menuExample = null;
+    public static final String RETIRE_MESSAGE =
+            "The Import Log Files add-on has been retired. This functionality is now provided by the Import/Export add-on.\n\n"
+                    + "NOTE: The Web API for this functionality has been simplified in the Import/Export add-on, you will likely "
+                    + "have to update your usage to adapt the new endpoints.";
 
     private static Logger log = LogManager.getLogger(ExtensionImportLogFiles.class);
 
@@ -95,55 +92,11 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
         super.hook(extensionHook);
         importLogAPI = new ImportLogAPI(null);
         extensionHook.addApiImplementor(importLogAPI);
-        if (getView() != null) {
-            extensionHook.getHookMenu().addImportMenuItem(getImportOption());
-        }
     }
 
     @Override
     public boolean canUnload() {
         return true;
-    }
-
-    private ZapMenuItem getImportOption() {
-        if (menuExample == null) {
-            menuExample = new ZapMenuItem("importLogFiles.import.importLOG");
-
-            menuExample.addActionListener(
-                    e -> {
-                        View view = View.getSingleton();
-                        JFrame main = view.getMainFrame();
-                        JFileChooser fc = new JFileChooser();
-                        fc.setAcceptAllFileFilterUsed(false);
-                        FileFilter filter =
-                                new FileNameExtensionFilter(
-                                        getMessageString(
-                                                "importLogFiles.choosefile.filter.description"),
-                                        "txt");
-                        fc.addChoosableFileFilter(filter);
-
-                        LogType logChoice =
-                                (LogType)
-                                        JOptionPane.showInputDialog(
-                                                main,
-                                                getMessageString(
-                                                        "importLogFiles.choosefile.message"),
-                                                getMessageString("importLogFiles.choosefile.title"),
-                                                JOptionPane.QUESTION_MESSAGE,
-                                                null,
-                                                LogType.values(),
-                                                LogType.ZAP);
-
-                        if (logChoice != null) {
-                            int openChoice = fc.showOpenDialog(main);
-                            if (openChoice == JFileChooser.APPROVE_OPTION) {
-                                File newFile = fc.getSelectedFile();
-                                processInput(newFile, logChoice);
-                            }
-                        }
-                    });
-        }
-        return menuExample;
     }
 
     public List<HttpMessage> ReadModSecAuditEvent(InputStream stream) {
@@ -413,6 +366,14 @@ public class ExtensionImportLogFiles extends ExtensionAdaptor {
                     "https://github.com/zaproxy/zaproxy/wiki/MozillaMentorship_ImportingModSecurityLogs");
         } catch (MalformedURLException e) {
             return null;
+        }
+    }
+
+    @Override
+    public void postInstall() {
+        log.warn(RETIRE_MESSAGE);
+        if (View.isInitialised()) {
+            View.getSingleton().showWarningDialog(RETIRE_MESSAGE);
         }
     }
 }

--- a/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
+++ b/addOns/importLogFiles/src/main/java/org/zaproxy/zap/extension/importLogFiles/ImportLogAPI.java
@@ -183,6 +183,8 @@ public class ImportLogAPI extends ApiImplementor {
 
     @Override
     public HttpMessage handleApiOther(HttpMessage msg, String name, JSONObject params) {
+        log.warn(ExtensionImportLogFiles.RETIRE_MESSAGE);
+
         ExtensionImportLogFiles importer = new ExtensionImportLogFiles();
         if (OtherPOST_ModSec_AuditEvent.equals(name)) {
             String trimmed =
@@ -203,6 +205,8 @@ public class ImportLogAPI extends ApiImplementor {
 
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+        log.warn(ExtensionImportLogFiles.RETIRE_MESSAGE);
+
         ExtensionImportLogFiles importer = new ExtensionImportLogFiles();
         if (Import_Zap_Log_From_File.equals(name))
             return processLogsFromFile(params.getString(PARAM_FILE), importer, LogType.ZAP);

--- a/addOns/importLogFiles/src/main/resources/org/zaproxy/zap/extension/importLogFiles/resources/Messages.properties
+++ b/addOns/importLogFiles/src/main/resources/org/zaproxy/zap/extension/importLogFiles/resources/Messages.properties
@@ -1,10 +1,2 @@
 importLogFiles.desc=Example extension which provides the import option in the analyse section
 importLogFiles.import.importLOG=Import Logs into Zap Site Tree...
-importLogFiles.msg.placeholder=Placeholder message for future functionality
-
-importLogFiles.choosefile.filter.description = TEXT File
-importLogFiles.choosefile.message = Log type:
-importLogFiles.choosefile.title = Select Log Type
-
-importLogFiles.log.type.zap = ZAP Logs
-importLogFiles.log.type.modsec2 = ModSecurity2 Logs

--- a/addOns/importurls/CHANGELOG.md
+++ b/addOns/importurls/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Retired
+- This add-on has been retired, and its functionality has been replaced by the Import/Export Add-on.
+
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 

--- a/addOns/importurls/importurls.gradle.kts
+++ b/addOns/importurls/importurls.gradle.kts
@@ -10,6 +10,12 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/import-urls/")
+
+        dependencies {
+            addOns {
+                register("exim")
+            }
+        }
     }
 
     apiClientGen {

--- a/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
+++ b/addOns/importurls/src/main/java/org/zaproxy/zap/extension/importurls/ImportUrlsAPI.java
@@ -63,12 +63,13 @@ public class ImportUrlsAPI extends ApiImplementor {
     @Override
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
         LOG.debug("handleApiAction {} {}", name, params.toString());
+        LOG.warn(ExtensionImportUrls.RETIRE_MESSAGE);
 
         switch (name) {
             case ACTION_IMPORTURLS:
                 extension.importUrlFile(
                         new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH)));
-                return ApiResponseElement.OK;
+                return new ApiResponseElement("Retired", ExtensionImportUrls.RETIRE_MESSAGE);
             default:
                 throw new ApiException(Type.BAD_ACTION);
         }

--- a/addOns/importurls/src/main/resources/org/zaproxy/zap/extension/importurls/resources/Messages.properties
+++ b/addOns/importurls/src/main/resources/org/zaproxy/zap/extension/importurls/resources/Messages.properties
@@ -1,5 +1,2 @@
 importurls.api.action.importurls = Imports URLs (one per line) from the file with the given file system path.
 importurls.desc	= Allows you to import a file containing URLs which ZAP will access, adding them to the Sites tree
-importurls.topmenu.import.importurls = Import a File Containing URLs
-importurls.topmenu.import.importurls.tooltip = The file must be plain text with one URL per line\nBlank lines and lines starting with a # are ignored
-


### PR DESCRIPTION
- Add Retire entry to CHANGELOGs.
- Add exim dependency to build files.
- Display a warning dialog and log a warning message in `postInstall()`.
- Log a warning message on API use.

Part of zaproxy/zaproxy#6579

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>