### PR TITLE
Update ZAP and dependency

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [7] - 2021-10-07
 ### Changed

--- a/addOns/accessControl/accessControl.gradle.kts
+++ b/addOns/accessControl/accessControl.gradle.kts
@@ -2,7 +2,7 @@ description = "Adds a set of tools for testing access control in web application
 
 zapAddOn {
     addOnName.set("Access Control Testing")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -122,7 +122,7 @@ subprojects {
         }
     }
 
-    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.11.0"))
+    val apiGenClasspath = configurations.detachedConfiguration(dependencies.create("org.zaproxy:zap:2.11.1"))
 
     zapAddOn {
         releaseLink.set(project.provider { "https://github.com/zaproxy/zap-extensions/releases/${zapAddOn.addOnId.get()}-v@CURRENT_VERSION@" })

--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [13] - 2021-10-06
 ### Added

--- a/addOns/alertFilters/alertFilters.gradle.kts
+++ b/addOns/alertFilters/alertFilters.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows you to automate the changing of alert risk levels."
 zapAddOn {
     addOnName.set("Alert Filters")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/allinonenotes/CHANGELOG.md
+++ b/addOns/allinonenotes/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/allinonenotes/allinonenotes.gradle.kts
+++ b/addOns/allinonenotes/allinonenotes.gradle.kts
@@ -2,7 +2,7 @@ description = "A simple extension to view all notes in one pane."
 
 zapAddOn {
     addOnName.set("All In One Notes")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("David Vassallo")

--- a/addOns/amf/CHANGELOG.md
+++ b/addOns/amf/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [3] - 2021-10-07
 ### Added

--- a/addOns/amf/amf.gradle.kts
+++ b/addOns/amf/amf.gradle.kts
@@ -6,7 +6,7 @@ repositories {
 
 zapAddOn {
     addOnName.set("AMF Support")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [43] - 2021-12-06
 ### Added

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -5,7 +5,7 @@ description = "The release quality Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [33] - 2021-12-06
 ### Changed

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -2,7 +2,7 @@ description = "The alpha quality Active Scanner rules"
 
 zapAddOn {
     addOnName.set("Active scanner rules (alpha)")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
 
 ## [38] - 2021-12-06

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -5,7 +5,7 @@ description = "The beta quality Active Scanner rules"
 zapAddOn {
     addOnName.set("Active scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/authstats/CHANGELOG.md
+++ b/addOns/authstats/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/authstats/authstats.gradle.kts
+++ b/addOns/authstats/authstats.gradle.kts
@@ -2,7 +2,7 @@ description = "Records logged in/out statistics for all contexts in scope."
 
 zapAddOn {
     addOnName.set("Authentication Statistics")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.9.0] - 2021-12-06
 

--- a/addOns/automation/automation.gradle.kts
+++ b/addOns/automation/automation.gradle.kts
@@ -2,7 +2,7 @@ description = "Automation Framework."
 
 zapAddOn {
     addOnName.set("Automation Framework")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Dependency updates.
 
 ## [7] - 2021-10-07

--- a/addOns/beanshell/beanshell.gradle.kts
+++ b/addOns/beanshell/beanshell.gradle.kts
@@ -5,7 +5,7 @@ description = "Provides a BeanShell Console"
 zapAddOn {
     addOnName.set("BeanShell Console")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/browserView/CHANGELOG.md
+++ b/addOns/browserView/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add info and repo URLs.
 
 ### Changed
-- Update minimum ZAP version to 2.11.0.
+- Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
 - Make missing JavaFX logging less verbose in regular use.
 

--- a/addOns/browserView/browserView.gradle.kts
+++ b/addOns/browserView/browserView.gradle.kts
@@ -26,7 +26,7 @@ if (JavaVersion.current() <= JavaVersion.VERSION_1_10) {
 
 zapAddOn {
     addOnName.set("Browser View")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [11] - 2021-10-06
 ### Changed

--- a/addOns/bruteforce/bruteforce.gradle.kts
+++ b/addOns/bruteforce/bruteforce.gradle.kts
@@ -5,7 +5,7 @@ description = "Forced browsing of files and directories using code from the OWAS
 zapAddOn {
     addOnName.set("Forced Browse")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Dependency updates.
 
 ## [3] - 2021-10-07

--- a/addOns/bugtracker/bugtracker.gradle.kts
+++ b/addOns/bugtracker/bugtracker.gradle.kts
@@ -6,7 +6,7 @@ tasks.withType<JavaCompile> {
 
 zapAddOn {
     addOnName.set("Bug Tracker")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/callgraph/CHANGELOG.md
+++ b/addOns/callgraph/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [5] - 2021-10-07
 ### Added

--- a/addOns/callgraph/callgraph.gradle.kts
+++ b/addOns/callgraph/callgraph.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows the user to view a call graph of the selected resources"
 
 zapAddOn {
     addOnName.set("Call Graph")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Colm O'Flaherty")

--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.0.3] - 2021-11-23
 ### Fixed

--- a/addOns/callhome/callhome.gradle.kts
+++ b/addOns/callhome/callhome.gradle.kts
@@ -2,7 +2,7 @@ description = "Handles all of the calls to ZAP services."
 
 zapAddOn {
     addOnName.set("Call Home")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/codedx/CHANGELOG.md
+++ b/addOns/codedx/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Dependency updates.
 
 ## [9] - 2021-10-07

--- a/addOns/codedx/codedx.gradle.kts
+++ b/addOns/codedx/codedx.gradle.kts
@@ -2,7 +2,7 @@ description = "Includes request and response data in XML reports and provides th
 
 zapAddOn {
     addOnName.set("Code Dx Extension")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Code Dx, Inc.")

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [1.6.0] - 2021-12-01
 ### Changed

--- a/addOns/commonlib/commonlib.gradle.kts
+++ b/addOns/commonlib/commonlib.gradle.kts
@@ -15,7 +15,7 @@ description = "A common library, for use by other add-ons."
 zapAddOn {
     addOnName.set("Common Library")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/coreLang/CHANGELOG.md
+++ b/addOns/coreLang/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [14] - 2021-11-02
 ### Changed

--- a/addOns/coreLang/coreLang.gradle.kts
+++ b/addOns/coreLang/coreLang.gradle.kts
@@ -5,7 +5,7 @@ description = "Translations of the core language files"
 zapAddOn {
     addOnName.set("Core Language Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.11.0] - 2021-10-07
 ### Changed

--- a/addOns/custompayloads/custompayloads.gradle.kts
+++ b/addOns/custompayloads/custompayloads.gradle.kts
@@ -2,7 +2,7 @@ description = "Ability to add, edit or remove payloads that are used i.e. by act
 
 zapAddOn {
     addOnName.set("Custom Payloads")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/diff/CHANGELOG.md
+++ b/addOns/diff/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [11] - 2021-10-06
 ### Changed

--- a/addOns/diff/diff.gradle.kts
+++ b/addOns/diff/diff.gradle.kts
@@ -5,7 +5,7 @@ description = "Displays a dialog showing the differences between 2 requests or r
 zapAddOn {
     addOnName.set("Diff")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv1/CHANGELOG.md
+++ b/addOns/directorylistv1/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [5] - 2021-10-06
 ### Changed

--- a/addOns/directorylistv1/directorylistv1.gradle.kts
+++ b/addOns/directorylistv1/directorylistv1.gradle.kts
@@ -5,7 +5,7 @@ description = "List of directory names to be used with Forced Browse or Fuzzer a
 zapAddOn {
     addOnName.set("Directory List v1.0")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3/CHANGELOG.md
+++ b/addOns/directorylistv2_3/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
+++ b/addOns/directorylistv2_3/directorylistv2_3.gradle.kts
@@ -5,7 +5,7 @@ description = "Lists of directory names to be used with Forced Browse or Fuzzer 
 zapAddOn {
     addOnName.set("Directory List v2.3")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/directorylistv2_3_lc/CHANGELOG.md
+++ b/addOns/directorylistv2_3_lc/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
+++ b/addOns/directorylistv2_3_lc/directorylistv2_3_lc.gradle.kts
@@ -5,7 +5,7 @@ description = "Lists of lower case directory names to be used with Forced Browse
 zapAddOn {
     addOnName.set("Directory List v2.3 LC")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - OWASP Web Security Testing Guide v4.2 mappings.
 
+### Changed
+- Update minimum ZAP version to 2.11.1.
+
 ## [12] - 2021-12-06
 ### Changed
 - Dependency updates.

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -5,7 +5,7 @@ description = "DOM XSS Active scanner rule"
 zapAddOn {
     addOnName.set("DOM XSS Active scanner rule")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Aabha Biyani, ZAP Dev Team")

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.6.0] - 2021-10-06
 ### Changed

--- a/addOns/encoder/encoder.gradle.kts
+++ b/addOns/encoder/encoder.gradle.kts
@@ -5,7 +5,7 @@ description = "Adds encode/decode/hash dialog and support for scripted processor
 zapAddOn {
     addOnName.set("Encoder")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/evalvillain/CHANGELOG.md
+++ b/addOns/evalvillain/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Link to the blog post in the help.
 
+### Changed
+- Update minimum ZAP version to 2.11.1.
+
 ## [0.0.1] - 2021-12-01
 
 - First version.

--- a/addOns/evalvillain/evalvillain.gradle.kts
+++ b/addOns/evalvillain/evalvillain.gradle.kts
@@ -2,7 +2,7 @@ description = "Adds the Eval Villain extension to Firefox when launched from ZAP
 
 zapAddOn {
     addOnName.set("Eval Villain")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Dennis Goodlett and the ZAP Dev Team")

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -5,7 +5,7 @@ description = "Import and Export functionality"
 zapAddOn {
     addOnName.set("Import/Export")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team & thatsn0tmysite")

--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [4] - 2021-10-06
 ### Changed

--- a/addOns/formhandler/formhandler.gradle.kts
+++ b/addOns/formhandler/formhandler.gradle.kts
@@ -5,7 +5,7 @@ description = "This Form Handler Add-on allows a user to define field names and 
 zapAddOn {
     addOnName.set("Form Handler")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/frontendscanner/frontendscanner.gradle.kts
+++ b/addOns/frontendscanner/frontendscanner.gradle.kts
@@ -2,7 +2,7 @@ description = "Scan modern web applications relying heavily on Javascript."
 
 zapAddOn {
     addOnName.set("Front-end Scanner")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [13.5.0] - 2021-11-04
 ### Changed

--- a/addOns/fuzz/fuzz.gradle.kts
+++ b/addOns/fuzz/fuzz.gradle.kts
@@ -16,7 +16,7 @@ tasks.withType<JavaCompile> {
 zapAddOn {
     addOnName.set("Fuzzer")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/fuzzdb/CHANGELOG.md
+++ b/addOns/fuzzdb/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [8] - 2021-10-07
 ### Changed

--- a/addOns/fuzzdb/fuzzdb.gradle.kts
+++ b/addOns/fuzzdb/fuzzdb.gradle.kts
@@ -16,7 +16,7 @@ description = "FuzzDB files which can be used with the ZAP fuzzer"
 zapAddOn {
     addOnName.set("FuzzDB Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/gettingStarted/CHANGELOG.md
+++ b/addOns/gettingStarted/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [13] - 2021-10-06
 ### Changed

--- a/addOns/gettingStarted/gettingStarted.gradle.kts
+++ b/addOns/gettingStarted/gettingStarted.gradle.kts
@@ -5,7 +5,7 @@ description = "A short Getting Started with ZAP Guide"
 zapAddOn {
     addOnName.set("Getting Started with ZAP Guide")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.2.0] - 2021-10-06
 ### Added

--- a/addOns/graaljs/graaljs.gradle.kts
+++ b/addOns/graaljs/graaljs.gradle.kts
@@ -5,7 +5,7 @@ description = "Provides the GraalVM JavaScript engine for ZAP scripting."
 zapAddOn {
     addOnName.set("GraalVM JavaScript")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.7.0] - 2021-11-01
 ### Fixed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -2,7 +2,7 @@ description = "Inspect and attack GraphQL endpoints."
 
 zapAddOn {
     addOnName.set("GraphQL Support")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/groovy/CHANGELOG.md
+++ b/addOns/groovy/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Dependency updates.
 
 ## [3.1.0] - 2021-10-07

--- a/addOns/groovy/groovy.gradle.kts
+++ b/addOns/groovy/groovy.gradle.kts
@@ -5,7 +5,7 @@ description = "Adds Groovy support to ZAP"
 zapAddOn {
     addOnName.set("Groovy Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/highlighter/CHANGELOG.md
+++ b/addOns/highlighter/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/highlighter/highlighter.gradle.kts
+++ b/addOns/highlighter/highlighter.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to highlight strings in the request and response tabs.
 
 zapAddOn {
     addOnName.set("Highlighter")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/imagelocationscanner/CHANGELOG.md
+++ b/addOns/imagelocationscanner/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
 
 ### Added

--- a/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
+++ b/addOns/imagelocationscanner/imagelocationscanner.gradle.kts
@@ -5,7 +5,7 @@ description = "Image Location and Privacy Passive Scanner"
 zapAddOn {
     addOnName.set("Image Location and Privacy Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Jay Ball (veggiespam) and the ZAP Dev Team")

--- a/addOns/importLogFiles/CHANGELOG.md
+++ b/addOns/importLogFiles/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [5] - 2021-10-07
 ### Added

--- a/addOns/importLogFiles/importLogFiles.gradle.kts
+++ b/addOns/importLogFiles/importLogFiles.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to import log files from ModSecurity and files previou
 
 zapAddOn {
     addOnName.set("Log File Importer")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Joseph Kirwin, ZAP Dev Team")

--- a/addOns/importurls/CHANGELOG.md
+++ b/addOns/importurls/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [8] - 2021-10-06
 ### Changed

--- a/addOns/importurls/importurls.gradle.kts
+++ b/addOns/importurls/importurls.gradle.kts
@@ -5,7 +5,7 @@ description = "Adds an option to import a file of URLs. The file must be plain t
 zapAddOn {
     addOnName.set("Import files containing URLs")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [11] - 2021-10-06
 ### Changed

--- a/addOns/invoke/invoke.gradle.kts
+++ b/addOns/invoke/invoke.gradle.kts
@@ -5,7 +5,7 @@ description = "Invoke external applications passing context related information 
 zapAddOn {
     addOnName.set("Invoke Applications")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jruby/CHANGELOG.md
+++ b/addOns/jruby/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [8] - 2021-10-07
 ### Changed

--- a/addOns/jruby/jruby.gradle.kts
+++ b/addOns/jruby/jruby.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows Ruby to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Ruby Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/jsonview/CHANGELOG.md
+++ b/addOns/jsonview/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/jsonview/jsonview.gradle.kts
+++ b/addOns/jsonview/jsonview.gradle.kts
@@ -2,7 +2,7 @@ description = "Adds a view that shows JSON messages nicely formatted"
 
 zapAddOn {
     addOnName.set("JSON View")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Juha Kivekäs")

--- a/addOns/jython/CHANGELOG.md
+++ b/addOns/jython/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [12] - 2021-10-07
 ### Added

--- a/addOns/jython/jython.gradle.kts
+++ b/addOns/jython/jython.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows Python to be used for ZAP scripting - templates included"
 zapAddOn {
     addOnName.set("Python Scripting")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/kotlin/CHANGELOG.md
+++ b/addOns/kotlin/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [1.1.0] - 2021-10-07
 ### Changed

--- a/addOns/kotlin/kotlin.gradle.kts
+++ b/addOns/kotlin/kotlin.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows Kotlin to be used for ZAP scripting"
 zapAddOn {
     addOnName.set("Kotlin Support")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("StackHawk Engineering")

--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.0.1] - 2021-12-03
 ### Added

--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -8,7 +8,7 @@ configurations.api { extendsFrom(bouncyCastle) }
 zapAddOn {
     addOnName.set("Network")
     addOnStatus.set(AddOnStatus.ALPHA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")
@@ -38,8 +38,6 @@ crowdin {
 }
 
 dependencies {
-    zap("org.zaproxy:zap:2.11.0")
-
     val nettyVersion = "4.1.70.Final"
     implementation("io.netty:netty-codec:$nettyVersion")
 
@@ -49,5 +47,5 @@ dependencies {
     bouncyCastle("org.bouncycastle:bcpkix-jdk15on:$bcVersion")
 
     testImplementation(project(":testutils"))
-    testImplementation("org.apache.logging.log4j:log4j-core:2.14.1")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.15.0")
 }

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
 - Add a link to the OAST help in the alert tag value.
 

--- a/addOns/oast/oast.gradle.kts
+++ b/addOns/oast/oast.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to exploit out-of-band vulnerabilities"
 
 zapAddOn {
     addOnName.set("OAST Support")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/onlineMenu/CHANGELOG.md
+++ b/addOns/onlineMenu/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [9] - 2021-10-06
 ### Changed

--- a/addOns/onlineMenu/onlineMenu.gradle.kts
+++ b/addOns/onlineMenu/onlineMenu.gradle.kts
@@ -5,7 +5,7 @@ description = "ZAP Online menu items"
 zapAddOn {
     addOnName.set("Online menus")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
+- Dependency updates.
 
 ## [24] - 2021-12-06
 ### Changed

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -5,7 +5,7 @@ description = "Imports and spiders OpenAPI definitions."
 zapAddOn {
     addOnName.set("OpenAPI Support")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team plus Joanna Bona, Nathalie Bouchahine, Artur Grzesica, Mohammad Kamar, Markus Kiss, Michal Materniak, Marcin Spiewak, and SDA SE Open Industry Solutions")
@@ -48,12 +48,12 @@ dependencies {
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0") {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")
     }
 
-    testImplementation("org.apache.logging.log4j:log4j-core:2.14.1")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.15.0")
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [12] - 2021-10-07
 ### Added

--- a/addOns/plugnhack/plugnhack.gradle.kts
+++ b/addOns/plugnhack/plugnhack.gradle.kts
@@ -5,7 +5,7 @@ description = "Supports the Mozilla Plug-n-Hack standard: https://developer.mozi
 zapAddOn {
     addOnName.set("Plug-n-Hack Configuration")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [9] - 2021-10-07
 ### Added

--- a/addOns/portscan/portscan.gradle.kts
+++ b/addOns/portscan/portscan.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows to port scan a target server"
 zapAddOn {
     addOnName.set("Port Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Renamed 'X-Frame-Options Header Not Set' alert to 'Missing Anti-clickjacking Header', and associated scan rule 'X-Frame-Options Header' to 'Anti-clickjacking Header'. The rule already considered Content-Security-Policy 'frame-ancestors' which is a more modern solution to the same concern. Updated associated solution text. (Issue 6937)
 
 ## [37] - 2021-12-01

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -5,7 +5,7 @@ description = "The release quality Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [35] - 2021-12-01
 ### Changed

--- a/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
+++ b/addOns/pscanrulesAlpha/pscanrulesAlpha.gradle.kts
@@ -2,7 +2,7 @@ description = "The alpha quality Passive Scanner rules"
 
 zapAddOn {
     addOnName.set("Passive scanner rules (alpha)")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/pscanrulesBeta/CHANGELOG.md
+++ b/addOns/pscanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [28] - 2021-12-01
 ### Fixed

--- a/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
+++ b/addOns/pscanrulesBeta/pscanrulesBeta.gradle.kts
@@ -5,7 +5,7 @@ description = "The beta quality Passive Scanner rules"
 zapAddOn {
     addOnName.set("Passive scanner rules (beta)")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [32] - 2021-12-06
 ### Changed

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -5,7 +5,7 @@ description = "Provides a tab which allows you to quickly test a target applicat
 zapAddOn {
     addOnName.set("Quick Start")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/regextester/regextester.gradle.kts
+++ b/addOns/regextester/regextester.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows to test Regular Expressions"
 
 zapAddOn {
     addOnName.set("Regular Expression Tester")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [9] - 2021-10-06
 ### Changed

--- a/addOns/replacer/replacer.gradle.kts
+++ b/addOns/replacer/replacer.gradle.kts
@@ -5,7 +5,7 @@ description = "Easy way to replace strings in requests and responses."
 zapAddOn {
     addOnName.set("Replacer")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
+- Dependency updates.
 
 ## [0.10.0] - 2021-12-06
 ### Changed

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -10,7 +10,7 @@ description = "Official ZAP Reports."
 zapAddOn {
     addOnName.set("Report Generation")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")
@@ -52,7 +52,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.0")
     implementation("org.snakeyaml:snakeyaml-engine:2.3")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0") {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")
     }

--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [5] - 2021-10-07
 ### Changed

--- a/addOns/requester/requester.gradle.kts
+++ b/addOns/requester/requester.gradle.kts
@@ -2,7 +2,7 @@ description = "Request numbered panel."
 
 zapAddOn {
     addOnName.set("Requester")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Surikato")

--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [0.2.0] - 2021-10-06
 ### Changed

--- a/addOns/retest/retest.gradle.kts
+++ b/addOns/retest/retest.gradle.kts
@@ -2,7 +2,7 @@ description = "An add-on to retest for presence/absence of previously generated 
 
 zapAddOn {
     addOnName.set("Retest")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
 
 ## [0.9.0] - 2021-10-06

--- a/addOns/retire/retire.gradle.kts
+++ b/addOns/retire/retire.gradle.kts
@@ -5,7 +5,7 @@ description = "Retire.js"
 zapAddOn {
     addOnName.set("Retire.js")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Nikita Mundhada and the ZAP Dev Team")

--- a/addOns/reveal/CHANGELOG.md
+++ b/addOns/reveal/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [4] - 2021-10-06
 ### Changed

--- a/addOns/reveal/reveal.gradle.kts
+++ b/addOns/reveal/reveal.gradle.kts
@@ -5,7 +5,7 @@ description = "Show hidden fields and enable disabled fields"
 zapAddOn {
     addOnName.set("Reveal")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/revisit/revisit.gradle.kts
+++ b/addOns/revisit/revisit.gradle.kts
@@ -2,7 +2,7 @@ description = "Revisit a site at any time in the past using the session history"
 
 zapAddOn {
     addOnName.set("Revisit")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/saml/CHANGELOG.md
+++ b/addOns/saml/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
 
 ## [9] - 2021-10-07

--- a/addOns/saml/saml.gradle.kts
+++ b/addOns/saml/saml.gradle.kts
@@ -2,7 +2,7 @@ description = "Detect, Show, Edit, Fuzz SAML requests"
 
 zapAddOn {
     addOnName.set("SAML Support")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/saverawmessage/saverawmessage.gradle.kts
+++ b/addOns/saverawmessage/saverawmessage.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows to save content of HTTP messages as binary"
 zapAddOn {
     addOnName.set("Save Raw Message")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/savexmlmessage/savexmlmessage.gradle.kts
+++ b/addOns/savexmlmessage/savexmlmessage.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows to save content of HTTP messages as XML"
 
 zapAddOn {
     addOnName.set("Save XML Message")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("thatsn0tmysite")

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [29] - 2021-10-06
 ### Added

--- a/addOns/scripts/scripts.gradle.kts
+++ b/addOns/scripts/scripts.gradle.kts
@@ -5,7 +5,7 @@ description = "Supports all JSR 223 scripting languages"
 zapAddOn {
     addOnName.set("Script Console")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [15.5.1] - 2021-11-28
 ### Fixed

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -5,7 +5,7 @@ description = "WebDriver provider and includes HtmlUnit browser"
 zapAddOn {
     addOnName.set("Selenium")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [6] - 2021-10-07
 ### Added

--- a/addOns/sequence/sequence.gradle.kts
+++ b/addOns/sequence/sequence.gradle.kts
@@ -2,7 +2,7 @@ description = "Gives the possibility of defining a sequence of requests to be sc
 
 zapAddOn {
     addOnName.set("Sequence")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/simpleexample/simpleexample.gradle.kts
+++ b/addOns/simpleexample/simpleexample.gradle.kts
@@ -2,7 +2,7 @@ description = "A simple extension example."
 
 zapAddOn {
     addOnName.set("Simple Example")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
+- Dependency updates.
 
 ## [12] - 2021-11-29
 ### Changed

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -2,7 +2,7 @@ description = "Imports and scans WSDL files containing SOAP endpoints."
 
 zapAddOn {
     addOnName.set("SOAP Support")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Alberto (albertov91) + ZAP Dev Team")
@@ -44,7 +44,7 @@ dependencies {
     implementation("com.predic8:soa-model-core:1.6.3")
     implementation("com.sun.xml.messaging.saaj:saaj-impl:2.0.1")
     implementation("jakarta.xml.soap:jakarta.xml.soap-api:2.0.1")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0") {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")
     }

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [23.7.0] - 2021-11-02
 ### Added

--- a/addOns/spiderAjax/spiderAjax.gradle.kts
+++ b/addOns/spiderAjax/spiderAjax.gradle.kts
@@ -2,7 +2,7 @@ import org.zaproxy.gradle.addon.AddOnStatus
 
 description = "Allows you to spider sites that make heavy use of JavaScript using Crawljax"
 
-val minimumZapVersion = "2.11.0"
+val minimumZapVersion = "2.11.1"
 
 zapAddOn {
     addOnName.set("Ajax Spider")

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [15] - 2021-10-20
 ### Fixed

--- a/addOns/sqliplugin/sqliplugin.gradle.kts
+++ b/addOns/sqliplugin/sqliplugin.gradle.kts
@@ -5,7 +5,7 @@ description = "An advanced active injection bundle for SQLi (derived by SQLMap)"
 zapAddOn {
     addOnName.set("Advanced SQLInjection Scanner")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Andrea Pompili (Yhawke)")

--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [10] - 2021-10-07
 ### Added

--- a/addOns/sse/sse.gradle.kts
+++ b/addOns/sse/sse.gradle.kts
@@ -2,7 +2,7 @@ description = "Allows you to view Server-Sent Events (SSE) communication."
 
 zapAddOn {
     addOnName.set("Server-Sent Events")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/svndigger/CHANGELOG.md
+++ b/addOns/svndigger/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [4] - 2021-10-07
 ### Added

--- a/addOns/svndigger/svndigger.gradle.kts
+++ b/addOns/svndigger/svndigger.gradle.kts
@@ -11,7 +11,7 @@ val processFiles by tasks.registering(ProcessSvnDiggerFiles::class) {
 zapAddOn {
     addOnName.set("SVN Digger Files")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [9] - 2021-10-06
 ### Changed

--- a/addOns/tips/tips.gradle.kts
+++ b/addOns/tips/tips.gradle.kts
@@ -5,7 +5,7 @@ description = "Display ZAP Tips and Tricks"
 zapAddOn {
     addOnName.set("Tips and Tricks")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/todo/todo.gradle.kts
+++ b/addOns/todo/todo.gradle.kts
@@ -2,7 +2,7 @@ description = "Provides a tab which allows you to view the list of test cases"
 
 zapAddOn {
     addOnName.set("ToDo-List")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("vishesh, ZAP Dev Team")

--- a/addOns/tokengen/CHANGELOG.md
+++ b/addOns/tokengen/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [15] - 2021-10-07
 ### Changed

--- a/addOns/tokengen/tokengen.gradle.kts
+++ b/addOns/tokengen/tokengen.gradle.kts
@@ -9,7 +9,7 @@ tasks.withType<JavaCompile> {
 zapAddOn {
     addOnName.set("Token Generation and Analysis")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/treetools/CHANGELOG.md
+++ b/addOns/treetools/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [8] - 2021-10-07
 ### Added

--- a/addOns/treetools/treetools.gradle.kts
+++ b/addOns/treetools/treetools.gradle.kts
@@ -5,7 +5,7 @@ description = "Tools to add functionality to the tree view."
 zapAddOn {
     addOnName.set("TreeTools")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Carl Sampson")

--- a/addOns/viewstate/CHANGELOG.md
+++ b/addOns/viewstate/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [3] - 2021-10-07
 ### Changed

--- a/addOns/viewstate/viewstate.gradle.kts
+++ b/addOns/viewstate/viewstate.gradle.kts
@@ -2,7 +2,7 @@ description = "ASP/JSF ViewState Decoder and Editor"
 
 zapAddOn {
     addOnName.set("ViewState")
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("Calum Hutton")

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [21.6.0] - 2021-12-07
 ### Changed

--- a/addOns/wappalyzer/wappalyzer.gradle.kts
+++ b/addOns/wappalyzer/wappalyzer.gradle.kts
@@ -5,7 +5,7 @@ description = "Technology detection using Wappalyzer: wappalyzer.com"
 zapAddOn {
     addOnName.set("Wappalyzer - Technology Detection")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [33] - 2021-10-26
 ### Changed

--- a/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
+++ b/addOns/webdrivers/webdriverlinux/webdriverlinux.gradle.kts
@@ -8,7 +8,7 @@ extra["targetOs"] = DownloadWebDriver.OS.LINUX
 zapAddOn {
     addOnName.set("Linux WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [33] - 2021-10-26
 ### Changed

--- a/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
+++ b/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
@@ -8,7 +8,7 @@ extra["targetOs"] = DownloadWebDriver.OS.MAC
 zapAddOn {
     addOnName.set("MacOS WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [33] - 2021-10-26
 ### Changed

--- a/addOns/webdrivers/webdriverwindows/webdriverwindows.gradle.kts
+++ b/addOns/webdrivers/webdriverwindows/webdriverwindows.gradle.kts
@@ -8,7 +8,7 @@ extra["targetOs"] = DownloadWebDriver.OS.WIN
 zapAddOn {
     addOnName.set("Windows WebDrivers")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [24] - 2021-10-06
 ### Changed

--- a/addOns/websocket/websocket.gradle.kts
+++ b/addOns/websocket/websocket.gradle.kts
@@ -5,7 +5,7 @@ description = "Allows you to inspect WebSocket communication."
 zapAddOn {
     addOnName.set("WebSockets")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update minimum ZAP version to 2.11.1.
 
 ## [35] - 2021-10-06
 ### Changed

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -16,7 +16,7 @@ description = "A graphical security scripting language, ZAPs macro language on s
 zapAddOn {
     addOnName.set("Zest - Graphical Security Scripting Language")
     addOnStatus.set(AddOnStatus.BETA)
-    zapVersion.set("2.11.0")
+    zapVersion.set("2.11.1")
 
     manifest {
         author.set("ZAP Dev Team")

--- a/testutils/testutils.gradle.kts
+++ b/testutils/testutils.gradle.kts
@@ -20,7 +20,7 @@ configurations {
 }
 
 dependencies {
-    compileOnly("org.zaproxy:zap:2.11.0")
+    compileOnly("org.zaproxy:zap:2.11.1")
 
     api("org.hamcrest:hamcrest-library:2.2")
     api("org.junit.jupiter:junit-jupiter-api:$jupiterVersion")


### PR DESCRIPTION
Update ZAP to 2.11.1.
Update Log4j to latest version, 2.15.0.
Update changelogs where needed.

---
Just to stop using the older version, the vulnerability does not have impact on the add-ons (core Log4j lib is not bundled).