### PR TITLE
Automation: Fix setting the delay params via the cmdline

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 
+### Fixed
+- Setting delay job parameters from the commandline
+
 ## [0.9.0] - 2021-12-06
 
 ### Changed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
@@ -20,6 +20,8 @@
 package org.zaproxy.addon.automation.jobs;
 
 import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.Constant;
@@ -50,6 +52,20 @@ public class DelayJob extends AutomationJob {
         } catch (Exception e) {
             progress.error(Constant.messages.getString("automation.error.delay.badtime", timeStr));
         }
+    }
+
+    @Override
+    public void applyParameters(AutomationProgress progress) {
+        Map<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
+        }
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
     }
 
     @Override


### PR DESCRIPTION
It works fine when creating the job from the desktop as the parameters are set directly.
But if you load the job from a file or run it on the command line then the parameters are not applied.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>