### PR TITLE
network: add decoders for HttpMessage

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoder.java
@@ -1,0 +1,493 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.util.ByteProcessor;
+import io.netty.util.internal.AppendableCharSequence;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.commons.lang3.StringUtils;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpStatusCode;
+
+/**
+ * Decodes a HTTP message, request or response into a {@link HttpMessage}.
+ *
+ * <p>Based on Netty's {@code HttpObjectDecoder}.
+ */
+public abstract class HttpMessageDecoder extends ByteToMessageDecoder {
+
+    private static final HttpMalformedHeaderException MISSING_FULL_BODY =
+            new HttpMalformedHeaderException("Connection closed before receiving full body.");
+
+    private static final Exception MISSING_FULL_HEADER =
+            new HttpMalformedHeaderException("Connection closed before receiving full header.");
+
+    private static final int DEFAULT_INITIAL_BUFFER_SIZE = 128;
+
+    private static final byte LF = 10;
+    private static final byte CR = 13;
+
+    static final int MAX_CHUNK_SIZE = 80;
+
+    private final HeaderParser headerParser;
+    private final LineParser lineParser;
+    private final boolean decodingRequest;
+    private final Function<HttpMessage, HttpHeader> headerProvider;
+    private final Function<HttpMessage, HttpBody> bodyProvider;
+
+    private HttpMessage message;
+    private HttpHeader header;
+    private HttpBody body;
+    private byte[] chunkBuffer;
+
+    private long chunkSize;
+
+    private enum State {
+        READ_HEADER,
+        HANDLE_CONTENT,
+        READ_VARIABLE_LENGTH_CONTENT,
+        READ_FIXED_LENGTH_CONTENT,
+        READ_CHUNK_SIZE,
+        READ_CHUNKED_CONTENT,
+        READ_CHUNK_DELIMITER,
+        READ_CHUNK_FOOTER,
+        BAD_MESSAGE,
+        UPGRADED
+    }
+
+    private State currentState = State.READ_HEADER;
+
+    protected HttpMessageDecoder(
+            boolean decodingRequest,
+            Function<HttpMessage, HttpHeader> headerProvider,
+            Function<HttpMessage, HttpBody> bodyProvider) {
+        AppendableCharSequence seq = new AppendableCharSequence(DEFAULT_INITIAL_BUFFER_SIZE);
+        headerParser = new HeaderParser(seq);
+        lineParser = new LineParser(seq);
+
+        this.decodingRequest = decodingRequest;
+        this.headerProvider = headerProvider;
+        this.bodyProvider = bodyProvider;
+        chunkBuffer = new byte[MAX_CHUNK_SIZE];
+    }
+
+    @Override
+    @SuppressWarnings("fallthrough")
+    protected void decode(ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out)
+            throws Exception {
+
+        switch (currentState) {
+            case READ_HEADER:
+                AppendableCharSequence headerContent = headerParser.parse(buffer);
+                if (headerContent == null) {
+                    return;
+                }
+
+                headerParser.reset();
+                try {
+                    message = new HttpMessage();
+                    header = headerProvider.apply(message);
+                    header.setMessage(headerContent.toString());
+                    body = bodyProvider.apply(message);
+                    body.setLength(0);
+
+                    HttpMessage.setContentEncodings(header, body);
+
+                    currentState = State.HANDLE_CONTENT;
+                } catch (Exception e) {
+                    out.add(invalidMessage(buffer, e));
+                    return;
+                }
+            case HANDLE_CONTENT:
+                if (isContentAlwaysEmpty(message)) {
+                    out.add(message);
+                    resetNow();
+                    return;
+                }
+
+                if (isTransferEncodingChunked()) {
+                    currentState = State.READ_CHUNK_SIZE;
+                    return;
+                }
+
+                int contentLength = header.getContentLength();
+                if (contentLength == 0) {
+                    out.add(message);
+                    resetNow();
+                    return;
+                }
+
+                currentState =
+                        contentLength > 0
+                                ? State.READ_FIXED_LENGTH_CONTENT
+                                : State.READ_VARIABLE_LENGTH_CONTENT;
+                if (currentState == State.READ_FIXED_LENGTH_CONTENT) {
+                    chunkSize = contentLength;
+                }
+
+                return;
+            case READ_VARIABLE_LENGTH_CONTENT:
+                {
+                    int toRead = Math.min(buffer.readableBytes(), MAX_CHUNK_SIZE);
+                    if (toRead > 0) {
+                        appendToBody(buffer, toRead);
+                    }
+                    return;
+                }
+            case READ_FIXED_LENGTH_CONTENT:
+                {
+                    int toRead = Math.min(buffer.readableBytes(), MAX_CHUNK_SIZE);
+                    if (toRead > chunkSize) {
+                        toRead = (int) chunkSize;
+                    }
+
+                    chunkSize -= toRead;
+                    appendToBody(buffer, toRead);
+
+                    if (chunkSize == 0) {
+                        out.add(message);
+                        resetNow();
+                    }
+                    return;
+                }
+
+            case READ_CHUNK_SIZE:
+                try {
+                    AppendableCharSequence line = lineParser.parse(buffer);
+                    if (line == null) {
+                        return;
+                    }
+                    int chunkSize = getChunkSize(line.toString());
+                    if (chunkSize < 0) {
+                        throw new NumberFormatException("Invalid chunk size: " + chunkSize);
+                    }
+
+                    this.chunkSize = chunkSize;
+                    if (chunkSize == 0) {
+                        currentState = State.READ_CHUNK_FOOTER;
+                        return;
+                    }
+                    currentState = State.READ_CHUNKED_CONTENT;
+                } catch (Exception e) {
+                    out.add(invalidMessage(buffer, e));
+                    return;
+                }
+            case READ_CHUNKED_CONTENT:
+                {
+                    int toRead = Math.min((int) chunkSize, MAX_CHUNK_SIZE);
+                    toRead = Math.min(toRead, buffer.readableBytes());
+                    if (toRead == 0) {
+                        return;
+                    }
+
+                    chunkSize -= toRead;
+                    appendToBody(buffer, toRead);
+
+                    if (chunkSize != 0) {
+                        return;
+                    }
+                    currentState = State.READ_CHUNK_DELIMITER;
+                }
+            case READ_CHUNK_DELIMITER:
+                {
+                    final int wIdx = buffer.writerIndex();
+                    int rIdx = buffer.readerIndex();
+                    while (wIdx > rIdx) {
+                        byte next = buffer.getByte(rIdx++);
+                        if (next == LF) {
+                            currentState = State.READ_CHUNK_SIZE;
+                            break;
+                        }
+                    }
+                    buffer.readerIndex(rIdx);
+                    return;
+                }
+            case READ_CHUNK_FOOTER:
+                try {
+                    boolean done = readTrailingHeaders(buffer);
+                    if (!done) {
+                        return;
+                    }
+
+                    header.setHeader(HttpHeader.TRANSFER_ENCODING, null);
+                    header.setContentLength(body.length());
+                    out.add(message);
+                    resetNow();
+                    return;
+                } catch (Exception e) {
+                    out.add(invalidMessage(buffer, e));
+                    return;
+                }
+
+            case BAD_MESSAGE:
+                buffer.skipBytes(buffer.readableBytes());
+                break;
+
+            case UPGRADED:
+                int readableBytes = buffer.readableBytes();
+                if (readableBytes > 0) {
+                    out.add(buffer.readBytes(readableBytes));
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    private void appendToBody(ByteBuf buffer, int length) {
+        buffer.readBytes(chunkBuffer, 0, length);
+        body.append(chunkBuffer, length);
+    }
+
+    private boolean isTransferEncodingChunked() {
+        for (String transferEncoding : header.getHeaderValues(HttpHeader.TRANSFER_ENCODING)) {
+            if (StringUtils.containsIgnoreCase(transferEncoding, HttpHeader._CHUNKED)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    protected void decodeLast(ChannelHandlerContext ctx, ByteBuf in, List<Object> out)
+            throws Exception {
+        super.decodeLast(ctx, in, out);
+
+        if (message == null) {
+            if (headerParser.getSize() != 0) {
+                out.add(invalidMessage(Unpooled.EMPTY_BUFFER, MISSING_FULL_HEADER));
+            }
+            resetNow();
+            return;
+        }
+
+        boolean chunked = isTransferEncodingChunked();
+        if (currentState == State.READ_VARIABLE_LENGTH_CONTENT && !in.isReadable() && !chunked) {
+            out.add(message);
+            resetNow();
+            return;
+        }
+
+        boolean prematureClosure;
+        if (decodingRequest || chunked) {
+            prematureClosure = true;
+        } else {
+            prematureClosure = header.getContentLength() > 0;
+        }
+
+        if (prematureClosure) {
+            message.setUserObject(MISSING_FULL_BODY);
+        }
+        out.add(message);
+        resetNow();
+    }
+
+    protected boolean isContentAlwaysEmpty(HttpMessage msg) {
+        if (decodingRequest) {
+            return false;
+        }
+
+        int code = msg.getResponseHeader().getStatusCode();
+        if (HttpStatusCode.isInformational(code) || code == 204 || code == 304) {
+            return true;
+        }
+        return false;
+    }
+
+    private void resetNow() {
+        message = null;
+        HttpHeader header = this.header;
+        this.header = null;
+        body = null;
+
+        headerParser.reset();
+        lineParser.reset();
+
+        if (!decodingRequest
+                && header != null
+                && isSwitchingToNonHttp1Protocol((HttpResponseHeader) header)) {
+            currentState = State.UPGRADED;
+            return;
+        }
+
+        currentState = State.READ_HEADER;
+    }
+
+    private static boolean isSwitchingToNonHttp1Protocol(HttpResponseHeader header) {
+        if (header.getStatusCode() != HttpStatusCode.SWITCHING_Protocols) {
+            return false;
+        }
+        String newProtocol = header.getHeader("Upgrade");
+        return newProtocol != null
+                && !newProtocol.contains(HttpHeader.HTTP10)
+                && !newProtocol.contains(HttpHeader.HTTP11);
+    }
+
+    private HttpMessage invalidMessage(ByteBuf in, Exception cause) {
+        currentState = State.BAD_MESSAGE;
+        in.skipBytes(in.readableBytes());
+
+        if (message == null) {
+            message = new HttpMessage();
+        }
+        message.setUserObject(cause);
+
+        HttpMessage ret = message;
+        message = null;
+        return ret;
+    }
+
+    private boolean readTrailingHeaders(ByteBuf buffer) throws HttpMalformedHeaderException {
+        AppendableCharSequence line = lineParser.parse(buffer);
+        if (line == null) {
+            return false;
+        }
+        if (line.length() == 0) {
+            return true;
+        }
+
+        int pos = -1;
+        while (line.length() > 0) {
+            String headerField = line.toString();
+            if ((pos = headerField.indexOf(':')) < 0) {
+                throw new HttpMalformedHeaderException(
+                        "Missing name/value separator in header field: " + headerField);
+            }
+
+            String name = headerField.substring(0, pos).trim();
+            String value = headerField.substring(pos + 1).trim();
+            header.addHeader(name, value);
+
+            line = lineParser.parse(buffer);
+            if (line == null) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int getChunkSize(String hex) {
+        hex = hex.trim();
+        for (int i = 0; i < hex.length(); i++) {
+            char c = hex.charAt(i);
+            if (c == ';' || Character.isWhitespace(c) || Character.isISOControl(c)) {
+                hex = hex.substring(0, i);
+                break;
+            }
+        }
+
+        return Integer.parseInt(hex, 16);
+    }
+
+    private static class HeaderParser implements ByteProcessor {
+        protected final AppendableCharSequence seq;
+        private int size;
+
+        HeaderParser(AppendableCharSequence seq) {
+            this.seq = seq;
+        }
+
+        public AppendableCharSequence parse(ByteBuf buffer) {
+            seq.reset();
+            int i = buffer.forEachByte(this);
+            if (i == -1) {
+                return null;
+            }
+            buffer.readerIndex(i + 1);
+            return seq;
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        public void reset() {
+            size = 0;
+        }
+
+        @Override
+        public boolean process(byte value) throws Exception {
+            char currentByte = (char) (value & 0xFF);
+            boolean headerEnd = isHeaderEnd(currentByte);
+            seq.append(currentByte);
+            size++;
+            return !headerEnd;
+        }
+
+        private boolean isHeaderEnd(char currentByte) {
+            if (currentByte != LF) {
+                return false;
+            }
+
+            int len = seq.length();
+            if (len < 1) {
+                return false;
+            }
+
+            char lastChar = seq.charAtUnsafe(len - 1);
+            if (lastChar == LF) {
+                return true;
+            }
+
+            if (lastChar != CR || len < 2) {
+                return false;
+            }
+
+            char previousChar = seq.charAtUnsafe(len - 2);
+            if (previousChar == LF) {
+                return true;
+            }
+            return false;
+        }
+    }
+
+    private static class LineParser extends HeaderParser {
+
+        LineParser(AppendableCharSequence seq) {
+            super(seq);
+        }
+
+        @Override
+        public boolean process(byte value) throws Exception {
+            char nextByte = (char) (value & 0xFF);
+            if (nextByte == LF) {
+                int len = seq.length();
+                if (len >= 1 && seq.charAtUnsafe(len - 1) == CR) {
+                    seq.setLength(len - 1);
+                }
+                return false;
+            }
+
+            seq.append(nextByte);
+            return true;
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoder.java
@@ -1,0 +1,31 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Decodes HTTP request into a {@link HttpMessage}. */
+public class HttpRequestDecoder extends HttpMessageDecoder {
+
+    /** Constructs a {@code HttpRequestDecoder}. */
+    public HttpRequestDecoder() {
+        super(true, HttpMessage::getRequestHeader, HttpMessage::getRequestBody);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoder.java
@@ -1,0 +1,31 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Decodes HTTP response into a {@link HttpMessage}. */
+public class HttpResponseDecoder extends HttpMessageDecoder {
+
+    /** Constructs a {@code HttpResponseDecoder}. */
+    public HttpResponseDecoder() {
+        super(false, HttpMessage::getResponseHeader, HttpMessage::getResponseBody);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageDecoderUnitTest.java
@@ -1,0 +1,404 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpHeaderField;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Unit test for {@link HttpMessageDecoder}. */
+abstract class HttpMessageDecoderUnitTest {
+
+    protected static final int MAX_CHUNK_SIZE = HttpMessageDecoder.MAX_CHUNK_SIZE;
+
+    protected EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        channel = new EmbeddedChannel(createDecoder());
+    }
+
+    protected abstract HttpMessageDecoder createDecoder();
+
+    protected abstract HttpHeader extractHeader(HttpMessage message);
+
+    protected abstract HttpBody extractBody(HttpMessage message);
+
+    protected abstract String getPrimeHeader();
+
+    protected abstract String getMalformedPrimeHeader();
+
+    @Test
+    void shouldNotProduceMessageWithNoInput() {
+        // Given / When
+        channel.close();
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(nullValue()));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @MethodSource("unterminatedHeaders")
+    void shouldProduceMessageWithExceptionForUnterminatedHeader(String content) {
+        // Given
+        written(content, false);
+        // When
+        channel.close();
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(HttpMalformedHeaderException.class)));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidHeaders")
+    void shouldProduceMessageWithExceptionForInvalidHeader(String content) {
+        // Given /When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(HttpMalformedHeaderException.class)));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @MethodSource("headersDifferentSeparators")
+    void shouldReadHeaderWithDifferentSeparators(String content) {
+        // Given / When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(2));
+        checkHeader(header, 0, "Content-Length", "0");
+        checkHeader(header, 1, "Y", "x");
+        assertThat(extractBody(message).toString(), is(equalTo("")));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldReadFixedLengthBody() {
+        // Given
+        String body = "0123456789012345";
+        String content = getPrimeHeader() + "Content-Length: 16\r\n\r\n" + body;
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(1));
+        checkHeader(header, 0, "Content-Length", "16");
+        assertThat(extractBody(message).toString(), is(equalTo(body)));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldReadConsecutiveFixedLengthBodyMessages() {
+        // Given
+        int numberOfRequests = 2;
+        String content =
+                StringUtils.repeat(
+                        getPrimeHeader() + "Content-Length: 1\r\n\r\nA", numberOfRequests);
+        // When
+        written(content, true);
+        // Then
+        for (int i = 0; i < numberOfRequests; i++) {
+            HttpMessage message = channel.readInbound();
+            assertThat(message, is(notNullValue()));
+            HttpHeader header = extractHeader(message);
+            checkHeader(header, 0, "Content-Length", "1");
+            assertThat(extractBody(message).toString(), is(equalTo("A")));
+        }
+        assertChannelState();
+    }
+
+    @Test
+    void shouldProduceMessageWithExceptionIfChannelClosedBeforeSendingFullFixedLengthBody() {
+        // Given / When
+        written(getPrimeHeader() + "Content-Length: 5\r\n\r\n123", false);
+        channel.close();
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(HttpMalformedHeaderException.class)));
+        assertThat(extractBody(message).toString(), is(equalTo("123")));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldReadBodyUsingLastContentLengthHeader() {
+        // Given
+        String body = "0123456789012345";
+        String content =
+                getPrimeHeader() + "Content-Length: 4\r\nContent-Length: 16\r\n\r\n" + body;
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(2));
+        checkHeader(header, 0, "Content-Length", "4", "16");
+        assertThat(extractBody(message).toString(), is(equalTo(body)));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"3\r\nAbc\r\n4\r\nwxyz\r\n0\r\n\r\n", "7\nAbcwxyz\n0\n\n"})
+    void shouldReadChunkedBody(String chunkedBody) {
+        // Given
+        String content = getPrimeHeader() + "Transfer-Encoding: chunked\r\n\r\n" + chunkedBody;
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(1));
+        checkHeader(header, 0, "Content-Length", "7");
+        assertThat(extractBody(message).toString(), is(equalTo("Abcwxyz")));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldReadChunkedBodyIgnoringAndUpdatingExistingContentLength() {
+        // Given
+        String content =
+                getPrimeHeader()
+                        + "Content-Length: 1\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nAbc\r\n4\r\nwxyz\r\n0\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(1));
+        checkHeader(header, 0, "Content-Length", "7");
+        assertThat(extractBody(message).toString(), is(equalTo("Abcwxyz")));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {" ", ";", " ;", "\b ;"})
+    void shouldReadChunkedBodySizeWithSurroundingChars(String chunkSizeChars) {
+        // Given
+        String content =
+                getPrimeHeader()
+                        + "Transfer-Encoding: chunked\r\n\r\n 3"
+                        + chunkSizeChars
+                        + "\r\nAbc\r\n0\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(1));
+        checkHeader(header, 0, "Content-Length", "3");
+        assertThat(extractBody(message).toString(), is(equalTo("Abc")));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldProduceMessageWithExceptionIfChannelClosedBeforeSendingFullChunkedBody() {
+        // Given / When
+        written(getPrimeHeader() + "Transfer-Encoding: chunked\r\n\r\n3\r\nAbc\r\n", false);
+        channel.close();
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(HttpMalformedHeaderException.class)));
+        assertThat(extractBody(message).toString(), is(equalTo("Abc")));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldReadChunkedBodyIgnoringOtherTransferEncodings() {
+        // Given
+        String content =
+                getPrimeHeader()
+                        + "Transfer-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nAbc\r\n4\r\nwxyz\r\n0\r\n\r\n";
+        written(content, true);
+        // When
+        HttpMessage message = channel.readInbound();
+        // Then
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(1));
+        checkHeader(header, 0, "Content-Length", "7");
+        assertThat(extractBody(message).toString(), is(equalTo("Abcwxyz")));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-\r\n", "-1\r\n", "G\r\n"})
+    void shouldProduceMessageWithExceptionForInvalidChunkSize(String chunkedBody) {
+        // Given
+        String content = getPrimeHeader() + "Transfer-Encoding: chunked\r\n\r\n" + chunkedBody;
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(Exception.class)));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldReadTrailingHeaders() {
+        // Given
+        String content =
+                getPrimeHeader() + "Transfer-Encoding: chunked\r\n\r\n0\r\nA: b\r\nX: y\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        HttpHeader header = extractHeader(message);
+        assertThat(header.getHeaders(), hasSize(3));
+        checkHeader(header, 0, "A", "b");
+        checkHeader(header, 1, "X", "y");
+        checkHeader(header, 2, "Content-Length", "0");
+        assertThat(extractBody(message).toString(), is(equalTo("")));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, MAX_CHUNK_SIZE - 1, MAX_CHUNK_SIZE, MAX_CHUNK_SIZE + 1})
+    void shouldReadChunkedBodyIncrementally(int batchSize) {
+        // Given
+        String body = StringUtils.repeat("A", batchSize);
+        String chunkLength = Integer.toHexString(batchSize);
+        String chunkedBody = chunkLength + "\r\n" + body + "\r\n0\r\nA: b\r\nX: y\r\n\r\n";
+        written(getPrimeHeader() + "Transfer-Encoding: chunked\r\n\r\n", false);
+        // When
+        writtenIncrementally(chunkedBody, batchSize);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo(body)));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"X\n", "X y"})
+    void shouldProduceMessageWithExceptionForInvalidTrailingHeader(String header) {
+        // Given
+        String content =
+                getPrimeHeader() + "Transfer-Encoding: chunked\r\n\r\n0\r\n" + header + "\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(HttpMalformedHeaderException.class)));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldConsumeAllInputAfterBadMessage() {
+        // Given
+        written(getMalformedPrimeHeader() + "\r\n", true);
+        channel.readInbound();
+        // When / Then
+        written(getPrimeHeader() + "\r\n", false);
+        assertChannelState();
+    }
+
+    @Test
+    void shouldSetContentEncodings() {
+        // Given
+        String content = getPrimeHeader() + "Content-Encoding: gzip\r\nContent-Length: 1\r\n\r\nA";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).getContentEncodings(), is(not(empty())));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldNotSetContentEncodingsIfNone() {
+        // Given
+        String content = getPrimeHeader() + "Content-Length: 1\r\n\r\nA";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).getContentEncodings(), is(empty()));
+        assertChannelState();
+    }
+
+    protected void assertChannelState() {
+        assertThat(channel.finish(), is(equalTo(false)));
+        assertThat(channel.readInbound(), is(nullValue()));
+    }
+
+    protected void writtenIncrementally(String request, int amount) {
+        for (int i = 0, len = request.length(); i < len; ) {
+            int nextPos = Math.min(i + amount, len);
+            written(request.substring(i, nextPos), nextPos == len);
+            i = nextPos;
+        }
+    }
+
+    protected void written(String content, boolean written) {
+        byte[] bytes = content.getBytes(StandardCharsets.US_ASCII);
+        assertThat(channel.writeInbound(Unpooled.copiedBuffer(bytes)), is(equalTo(written)));
+    }
+
+    protected static void checkHeader(HttpHeader header, int pos, String name, String... value) {
+        List<String> headerValues = header.getHeaderValues(name);
+        assertThat(headerValues, contains(value));
+        HttpHeaderField headerField = header.getHeaders().get(pos);
+        assertThat(headerField.getName(), is(equalTo(name)));
+        assertThat(headerField.getValue(), is(equalTo(value[0])));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
@@ -1,0 +1,103 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Unit test for {@link HttpRequestDecoder}. */
+class HttpRequestDecoderUnitTest extends HttpMessageDecoderUnitTest {
+
+    @Override
+    protected HttpRequestDecoder createDecoder() {
+        return new HttpRequestDecoder();
+    }
+
+    @Override
+    protected HttpHeader extractHeader(HttpMessage message) {
+        return message.getRequestHeader();
+    }
+
+    @Override
+    protected HttpBody extractBody(HttpMessage message) {
+        return message.getRequestBody();
+    }
+
+    @Override
+    protected String getPrimeHeader() {
+        return "POST / HTTP/1.1\r\n";
+    }
+
+    @Override
+    protected String getMalformedPrimeHeader() {
+        return "GET / \r\n";
+    }
+
+    static Stream<String> unterminatedHeaders() {
+        return Stream.of(
+                "\n",
+                "\r\n",
+                "GET / HTTP/1.1\r\r\n",
+                "GET",
+                "GET /",
+                "GET / HTTP/1.1",
+                "GET / HTTP/1.1\r\n",
+                "GET / HTTP/1.1\r\nX: y\r\n",
+                "GET / HTTP/1.1\nX: y\n");
+    }
+
+    static Stream<String> invalidHeaders() {
+        return Stream.of(
+                "GET\r\n\r\nMore Data",
+                "GET /\r\n\r\nMore Data",
+                "GET / HTTP/\r\n\r\nMore Data",
+                "GET / HTTP/\n\nMore Data");
+    }
+
+    static Stream<String> headersDifferentSeparators() {
+        return Stream.of(
+                "GET / HTTP/1.1\r\nContent-Length: 0\r\nY: x\r\n\r\n",
+                "GET / HTTP/1.1\nContent-Length: 0\nY: x\n\n",
+                "GET / HTTP/1.1\nContent-Length: 0\r\nY: x\r\n\n");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "\r\nContent-Length: 0"})
+    void shouldReadEmptyBody(String contentLength) {
+        // Given
+        String content = "POST / HTTP/1.1" + contentLength + "\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo("")));
+        assertChannelState();
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoderUnitTest.java
@@ -1,0 +1,159 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.codec;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+
+/** Unit test for {@link HttpResponseDecoder}. */
+class HttpResponseDecoderUnitTest extends HttpMessageDecoderUnitTest {
+
+    @Override
+    protected HttpResponseDecoder createDecoder() {
+        return new HttpResponseDecoder();
+    }
+
+    @Override
+    protected HttpHeader extractHeader(HttpMessage message) {
+        return message.getResponseHeader();
+    }
+
+    @Override
+    protected HttpBody extractBody(HttpMessage message) {
+        return message.getResponseBody();
+    }
+
+    @Override
+    protected String getPrimeHeader() {
+        return "HTTP/1.1 200 OK\r\n";
+    }
+
+    @Override
+    protected String getMalformedPrimeHeader() {
+        return "HTTP \r\n";
+    }
+
+    static Stream<String> unterminatedHeaders() {
+        return Stream.of(
+                "\n",
+                "\r\n",
+                "HTTP/1.1 200 OK\r\r\n",
+                "HTTP",
+                "HTTP/",
+                "HTTP/1.1 200 OK",
+                "HTTP/1.1 200 OK\r\n",
+                "HTTP/1.1 200 OK\r\nX: y\r\n",
+                "HTTP/1.1 200 OK\nX: y\n");
+    }
+
+    static Stream<String> invalidHeaders() {
+        return Stream.of("HTTP\r\n\r\nMore Data", "HTTP/\r\n\r\nMore Data");
+    }
+
+    static Stream<String> headersDifferentSeparators() {
+        return Stream.of(
+                "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nY: x\r\n\r\n",
+                "HTTP/1.1 200 OK\nContent-Length: 0\nY: x\n\n",
+                "HTTP/1.1 200 OK\nContent-Length: 0\r\nY: x\r\n\n");
+    }
+
+    @Test
+    void shouldReadBodyToConnectionEnd() {
+        // Given
+        String content = "HTTP/1.1 200 OK\r\n\r\nABC";
+        // When
+        written(content, false);
+        channel.close();
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo("ABC")));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {100, 101, 150, 199, 204, 304})
+    void shouldNotReadContentAsBodyIfNoneExpected(int statusCode) {
+        // Given
+        String content =
+                "HTTP/1.1 "
+                        + statusCode
+                        + "\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nABC";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo("")));
+        message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo("ABC")));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldNotConsumeContentAsHttpAfterNonHttp1Upgrade() {
+        // Given
+        String content = "HTTP/1.1 101\r\nUpgrade: websocket\r\n\r\nHTTP/1.1 200 OK\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo("")));
+        ByteBuf data = channel.readInbound();
+        assertThat(data, is(notNullValue()));
+        assertThat(
+                data.toString(StandardCharsets.US_ASCII), is(equalTo("HTTP/1.1 200 OK\r\n\r\n")));
+        assertChannelState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {HttpHeader.HTTP10, HttpHeader.HTTP11})
+    void shouldConsumeContentAsHttpAfterHttp1Upgrade(String httpVersion) {
+        // Given
+        String content =
+                "HTTP/1.1 101\r\nUpgrade: "
+                        + httpVersion
+                        + "\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nABC";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo("")));
+        message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(extractBody(message).toString(), is(equalTo("ABC")));
+        assertChannelState();
+    }
+}


### PR DESCRIPTION
Allow to decode the request and response into a `HttpMessage`.