### PR TITLE
Callhome: Add telemetry

### DIFF
--- a/addOns/callhome/callhome.gradle.kts
+++ b/addOns/callhome/callhome.gradle.kts
@@ -10,6 +10,10 @@ zapAddOn {
     }
 }
 
+dependencies {
+    testImplementation(project(":testutils"))
+}
+
 crowdin {
     configuration {
         val resourcesPath = "org/zaproxy/addon/${zapAddOn.addOnId.get()}/resources/"

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/CallHomeParam.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/CallHomeParam.java
@@ -1,0 +1,77 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.callhome;
+
+import java.util.UUID;
+import org.zaproxy.zap.common.VersionedAbstractParam;
+
+public class CallHomeParam extends VersionedAbstractParam {
+
+    private static final int PARAM_CURRENT_VERSION = 1;
+    private static final String CALL_HOME_KEY = "callhome";
+
+    private static final String TEL_UUID_KEY = CALL_HOME_KEY + ".tel.uuid";
+    private static final String TEL_ENABLED_KEY = CALL_HOME_KEY + ".tel.enabled";
+
+    private String telUuid;
+    private boolean telEnabled = true;
+
+    public CallHomeParam() {
+        // Nothing to do
+    }
+
+    public String getTelemetryUuid() {
+        return telUuid;
+    }
+
+    public boolean isTelemetryEnabled() {
+        return telEnabled;
+    }
+
+    public void setTelemetryEnabled(boolean enabled) {
+        this.telEnabled = enabled;
+        getConfig().setProperty(TEL_ENABLED_KEY, this.telEnabled);
+    }
+
+    @Override
+    protected void parseImpl() {
+        this.telUuid = this.getString(TEL_UUID_KEY, null);
+        if (this.telUuid == null) {
+            this.telUuid = UUID.randomUUID().toString();
+            getConfig().setProperty(TEL_UUID_KEY, this.telUuid);
+        }
+        this.telEnabled = getBoolean(TEL_ENABLED_KEY, true);
+    }
+
+    @Override
+    protected String getConfigVersionKey() {
+        return CALL_HOME_KEY + VERSION_ATTRIBUTE;
+    }
+
+    @Override
+    protected int getCurrentVersion() {
+        return PARAM_CURRENT_VERSION;
+    }
+
+    @Override
+    protected void updateConfigsImpl(int fileVersion) {
+        // Nothing to do
+    }
+}

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/OptionsCallHomePanel.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/OptionsCallHomePanel.java
@@ -1,0 +1,123 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.callhome;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ScrollPaneConstants;
+import javax.swing.border.EmptyBorder;
+import net.sf.json.JSONObject;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.zap.utils.ZapTextArea;
+import org.zaproxy.zap.view.LayoutHelper;
+
+public class OptionsCallHomePanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = -7541236934312940852L;
+
+    private static final String NAME = Constant.messages.getString("callhome.optionspanel.name");
+
+    private ExtensionCallHome ext;
+    private JCheckBox telemetryEnabledBox;
+    private ZapTextArea lastTelemetryDataBox;
+
+    public OptionsCallHomePanel(ExtensionCallHome ext) {
+        super();
+        setName(NAME);
+        this.ext = ext;
+
+        setLayout(new GridBagLayout());
+
+        JPanel panel = new JPanel(new GridBagLayout());
+        panel.setBorder(new EmptyBorder(2, 2, 2, 2));
+
+        int y = 0;
+        panel.add(
+                getTelemetryEnabledBox(),
+                LayoutHelper.getGBC(0, y++, 1, 1.0, new Insets(2, 2, 2, 2)));
+
+        JLabel lastTelemetryDataLabel =
+                new JLabel(Constant.messages.getString("callhome.optionspanel.label.tellastdata"));
+        lastTelemetryDataLabel.setLabelFor(getLastTelemetryDataBox());
+        panel.add(
+                lastTelemetryDataLabel,
+                LayoutHelper.getGBC(0, y++, 1, 1.0, new Insets(2, 2, 2, 2)));
+
+        JScrollPane scrollPane = new JScrollPane(getLastTelemetryDataBox());
+        scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
+        scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+        panel.add(
+                scrollPane,
+                LayoutHelper.getGBC(0, y++, 1, 1.0, 1.0, GridBagConstraints.BOTH, getInsets()));
+
+        add(panel, LayoutHelper.getGBC(0, 0, 1, 1.0, 1.0));
+    }
+
+    private JCheckBox getTelemetryEnabledBox() {
+        if (telemetryEnabledBox == null) {
+            telemetryEnabledBox = new JCheckBox();
+            telemetryEnabledBox.setText(
+                    Constant.messages.getString("callhome.optionspanel.label.telenabled"));
+        }
+        return telemetryEnabledBox;
+    }
+
+    private ZapTextArea getLastTelemetryDataBox() {
+        if (lastTelemetryDataBox == null) {
+            lastTelemetryDataBox = new ZapTextArea();
+            lastTelemetryDataBox.setEditable(false);
+        }
+        return lastTelemetryDataBox;
+    }
+
+    @Override
+    public void initParam(Object obj) {
+        final OptionsParam options = (OptionsParam) obj;
+        final CallHomeParam param = options.getParamSet(CallHomeParam.class);
+
+        getTelemetryEnabledBox().setSelected(param.isTelemetryEnabled());
+        JSONObject data = ext.getLastTelemetryData();
+        if (data == null) {
+            getLastTelemetryDataBox().setText("");
+        } else {
+            getLastTelemetryDataBox().setText(data.toString(4));
+        }
+    }
+
+    @Override
+    public void saveParam(Object obj) throws Exception {
+        final OptionsParam options = (OptionsParam) obj;
+        final CallHomeParam param = options.getParamSet(CallHomeParam.class);
+
+        param.setTelemetryEnabled(getTelemetryEnabledBox().isSelected());
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "callhome";
+    }
+}

--- a/addOns/callhome/src/main/javahelp/org/zaproxy/addon/callhome/resources/help/contents/callhome.html
+++ b/addOns/callhome/src/main/javahelp/org/zaproxy/addon/callhome/resources/help/contents/callhome.html
@@ -7,7 +7,7 @@ Call Home
 </HEAD>
 <BODY>
 <H1>Call Home</H1>
-This add-on will be used for all "calls home". It does not currently provide any UI.
+This add-on will be used for all "calls home". 
 <p>
 It currently supports:
 
@@ -18,5 +18,20 @@ It is a mandatory add-on from ZAP 2.12.0 as this feature is used by the ZAP core
 <H2>News</H2>
 The News call is used to find out the latest news item about ZAP - this is displayed in the ZAP desktop Quick Start panel. 
 
+<H2>Telemetry</H2>
+The Telemetry call reports the add-ons being used and some of the ZAP internal statistics.
+It will never collect details of the sites ZAP is being used on, details of the vulnerabilities or any personal identifiable information (PII).
+<p>
+For more background see the blog post <a href="https://www.zaproxy.org/blog/2021-10-25-zap-telemetry-plans/">ZAP Telemetry Plans</a>.
+
+<H2>Command Line option: -notel</H2>
+If <code>-notel</code> is specified on the command line then no telemetry calls will be made. The other calls will not be affected.
+Telemetry calls will also not be made if the standard <code>-silent</code> ZAP command line option is used.
+
+<H2>Call Home Options Panel</H2>
+This panel allows you to turn telemetry support on and off.
+<p>
+It also displays the last set of telemetry data transmitted. 
+The telemetry data is also logged at DEBUG level in the ZAP log file.
 </BODY>
 </HTML>

--- a/addOns/callhome/src/main/resources/org/zaproxy/addon/callhome/resources/Messages.properties
+++ b/addOns/callhome/src/main/resources/org/zaproxy/addon/callhome/resources/Messages.properties
@@ -1,1 +1,5 @@
 callhome.desc = Handles all of the calls to ZAP services
+callhome.cmdline.notel.help = Turns off telemetry calls
+callhome.optionspanel.name = Call Home
+callhome.optionspanel.label.telenabled = Telemetry Enabled
+callhome.optionspanel.label.tellastdata = Last Telemetry Data Sent:

--- a/addOns/callhome/src/test/java/org/zaproxy/addon/callhome/ExtensionCallHomeUnitTest.java
+++ b/addOns/callhome/src/test/java/org/zaproxy/addon/callhome/ExtensionCallHomeUnitTest.java
@@ -1,0 +1,77 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.callhome;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.extension.stats.InMemoryStats;
+
+class ExtensionCallHomeUnitTest {
+
+    @Test
+    void shouldAddFilteredGlobalStats() {
+        // Given
+        ExtensionCallHome ext = new ExtensionCallHome();
+        InMemoryStats stats = new InMemoryStats();
+        stats.counterInc("stats.ascan.one", 1);
+        stats.counterInc("stats.ascan.two", 2);
+        stats.counterInc("stats.ascan.three", 3);
+        stats.counterInc("stats.ignore", 4);
+        JSONObject data = new JSONObject();
+
+        // When
+        ext.addStatistics(data, stats);
+
+        // Then
+        assertThat(data.size(), is(equalTo(3)));
+        assertThat(data.get("stats.ascan.one"), is(equalTo(1)));
+        assertThat(data.get("stats.ascan.two"), is(equalTo(2)));
+        assertThat(data.get("stats.ascan.three"), is(equalTo(3)));
+        assertThat(data.get("stats.ignore"), is(nullValue()));
+    }
+
+    @Test
+    void shouldMergeFilteredSiteStats() {
+        // Given
+        ExtensionCallHome ext = new ExtensionCallHome();
+        InMemoryStats stats = new InMemoryStats();
+        stats.counterInc("https://www.example.com", "stats.code.one", 1);
+        stats.counterInc("https://www.example.com", "stats.code.two", 2);
+
+        stats.counterInc("https://www.example.com", "stats.code.two", 2);
+        stats.counterInc("https://www.example.org", "stats.code.three", 3);
+        stats.counterInc("https://www.example.org", "stats.blah", 4);
+
+        JSONObject data = new JSONObject();
+        // When
+        ext.addStatistics(data, stats);
+
+        // Then
+        assertThat(data.size(), is(equalTo(3)));
+        assertThat(data.get("stats.code.one"), is(equalTo(1)));
+        assertThat(data.get("stats.code.two"), is(equalTo(4)));
+        assertThat(data.get("stats.code.three"), is(equalTo(3)));
+    }
+}


### PR DESCRIPTION
Adds support for the telemetry service.
Telemetry calls are made on startup (reporting the add-ons and versions) and when the session changes (including when ZAP is stopped) (reporting stats that shouldnt leak any sensitive info).
The new `-notel` command line option turns off telemetry and theres a new Options / Call Home screen which allows you to switch telemetry on and off and shows the last telemetry data sent.
The telemetry data sent is also logged at debug level.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>