### PR TITLE
feat: requester: Save view option when changed

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- The Request/Response view option will now be saved each time it is changed (Issue 6985).
 - Update minimum ZAP version to 2.11.1.
 
 ## [5] - 2021-10-07

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
@@ -553,6 +553,7 @@ public class ManualHttpRequestEditorPanel extends ManualRequestEditorPanel {
 
                 this.validate();
                 this.repaint();
+                this.saveConfig();
             }
         }
 


### PR DESCRIPTION
- CHANGELOG > Added change note.
- ManualHttpRequestEditorPanel > Added call to `saveConfig` in `changedView` method.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>