### PR TITLE
chore: Upgrade Log4j to 2.17.1

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -47,5 +47,5 @@ dependencies {
     bouncyCastle("org.bouncycastle:bcpkix-jdk15on:$bcVersion")
 
     testImplementation(project(":testutils"))
-    testImplementation("org.apache.logging.log4j:log4j-core:2.17.0")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.17.1")
 }

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -48,12 +48,12 @@ dependencies {
         exclude(group = "com.github.java-json-tools", module = "json-schema-validator")
         exclude(group = "org.apache.httpcomponents", module = "httpclient")
     }
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1") {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")
     }
 
-    testImplementation("org.apache.logging.log4j:log4j-core:2.17.0")
+    testImplementation("org.apache.logging.log4j:log4j-core:2.17.1")
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.13.0")
     implementation("org.snakeyaml:snakeyaml-engine:2.3")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1") {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")
     }

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("com.predic8:soa-model-core:1.6.3")
     implementation("com.sun.xml.messaging.saaj:saaj-impl:2.0.1")
     implementation("jakarta.xml.soap:jakarta.xml.soap-api:2.0.1")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.0") {
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1") {
         // Provided by ZAP.
         exclude(group = "org.apache.logging.log4j")
     }


### PR DESCRIPTION
Updated build files.

Related to zaproxy/zaproxy#6980

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>