### PR TITLE
oast: Interactsh Options Dialog - 'New Payload' Button use old config

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- OAST Interactsh Options Dialog: If host or token config changed the 'New Payload' Button generates the Payload still with the old config. 
+Button is disabled in that case.
 
 ## [0.7.0] - 2021-12-12
 ### Changed

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
@@ -23,11 +23,15 @@ import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
+import javax.swing.JTextField;
 import javax.swing.border.TitledBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
 import org.apache.commons.lang3.StringUtils;
 import org.jdesktop.swingx.JXTable;
@@ -52,6 +56,8 @@ public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
     private JXTable payloadsTable;
     private PayloadsTableModel payloadsTableModel;
     private JButton newPayloadButton;
+    private String originalServerUrl;
+    private String originalAuthToken;
 
     public InteractshOptionsPanelTab(InteractshService interactshService) {
         super(interactshService.getName());
@@ -103,6 +109,7 @@ public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
     ZapTextField getServerUrl() {
         if (serverUrl == null) {
             serverUrl = new ZapTextField();
+            addChangeListenerToRefreshPayloadButtonEnabledState(serverUrl);
         }
         return serverUrl;
     }
@@ -110,6 +117,7 @@ public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
     ZapTextField getAuthToken() {
         if (authToken == null) {
             authToken = new ZapTextField();
+            addChangeListenerToRefreshPayloadButtonEnabledState(authToken);
         }
         return authToken;
     }
@@ -161,9 +169,34 @@ public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
         }
     }
 
+    private void addChangeListenerToRefreshPayloadButtonEnabledState(JTextField textField) {
+        textField
+                .getDocument()
+                .addDocumentListener(
+                        new DocumentListener() {
+
+                            @Override
+                            public void changedUpdate(DocumentEvent e) {
+                                refreshPayloadButtonEnabledState();
+                            }
+
+                            @Override
+                            public void removeUpdate(DocumentEvent e) {
+                                refreshPayloadButtonEnabledState();
+                            }
+
+                            @Override
+                            public void insertUpdate(DocumentEvent e) {
+                                refreshPayloadButtonEnabledState();
+                            }
+                        });
+    }
+
     @Override
     public void initParam(OptionsParam options) {
         final InteractshParam param = options.getParamSet(InteractshParam.class);
+        this.originalServerUrl = param.getServerUrl();
+        this.originalAuthToken = param.getAuthToken();
         getServerUrl().setText(param.getServerUrl());
         getAuthToken().setText(param.getAuthToken());
         getPollingFrequencySpinner().setValue(param.getPollingFrequency());
@@ -177,6 +210,16 @@ public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
         param.setServerUrl(getServerUrl().getText());
         param.setAuthToken(getAuthToken().getText());
         param.setPollingFrequency(getPollingFrequencySpinner().getValue());
+    }
+
+    private void refreshPayloadButtonEnabledState() {
+        if (newPayloadButton == null) {
+            return;
+        }
+
+        newPayloadButton.setEnabled(
+                Objects.equals(getServerUrl().getText(), originalServerUrl)
+                        && Objects.equals(getAuthToken().getText(), originalAuthToken));
     }
 
     private class PayloadsTableModel extends AbstractTableModel {

--- a/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/interactsh/options.html
+++ b/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/services/interactsh/options.html
@@ -30,7 +30,8 @@
 <h3>Active Payloads</h3>
 
 <p>This table lists all the generated Payloads and corresponding Canary values. An entry is added each time you create a
-    new payload.</p>
+    new payload. The 'New Payload' Button is disabled if you change the Server URL and/or the Authorization Token.
+    To create new payloads in that case either revert the changes or save the settings and reopen the options screen.</p>
 
 <h4>Payload</h4>
 


### PR DESCRIPTION
OAST Interactsh Options Dialog: If host or token config changed the 'New Payload' Button generates the Payload still with the old config.

That is confusing (especially if there were errors in the config). 
As a quick fix I disabled the button if the relevant configs changed

