### PR TITLE
automation: ensure env vars take precedence

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Ensure system environment variables take precedence over configuration variables (Issue 7000).
 
 ## [0.10.0] - 2021-12-13
 ### Changed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationEnvironment.java
@@ -144,8 +144,8 @@ public class AutomationEnvironment {
             return null;
         }
         if (this.combinedVars == null) {
-            this.combinedVars = new HashMap<>(System.getenv());
-            this.combinedVars.putAll(this.getData().getVars());
+            this.combinedVars = new HashMap<>(this.getData().getVars());
+            this.combinedVars.putAll(System.getenv());
         }
         String text = value.toString();
         Matcher matcher = varPattern.matcher(text);


### PR DESCRIPTION
Reorder the variables to ensure that the system env vars take
precedence when replacing them.

Fix zaproxy/zaproxy#7000.