### PR TITLE
ascanalpha: Log4Shell: Continue with further payloads if one payload throws an error

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Log4Shell: Continue with further payloads if one payload throws an error
 
 ## [34] - 2021-12-12
 ### Added

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRuleUnitTest.java
@@ -19,19 +19,48 @@
  */
 package org.zaproxy.zap.extension.ascanrulesAlpha;
 
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import fi.iki.elonen.NanoHTTPD;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.oast.ExtensionOast;
 import org.zaproxy.zap.model.Tech;
 import org.zaproxy.zap.model.TechSet;
+import org.zaproxy.zap.testutils.NanoServerHandler;
 
 class Log4ShellScanRuleUnitTest extends ActiveScannerTest<Log4ShellScanRule> {
+
+    private ExtensionOast extensionOast;
 
     @Override
     protected Log4ShellScanRule createScanner() {
         return new Log4ShellScanRule();
+    }
+
+    @BeforeEach
+    void init() throws Exception {
+        nano.addHandler(new Log4ShellServerHandler("/abc"));
+        HttpMessage httpMessageToTest = getHttpMessage("/abc?test=123");
+
+        extensionOast = mock(ExtensionOast.class);
+        Control.initSingletonForTesting(Model.getSingleton(), mock(ExtensionLoader.class));
+        when(Control.getSingleton().getExtensionLoader().getExtension(ExtensionOast.class))
+                .thenReturn(extensionOast);
+
+        rule.init(httpMessageToTest, parent);
     }
 
     @Test
@@ -40,5 +69,59 @@ class Log4ShellScanRuleUnitTest extends ActiveScannerTest<Log4ShellScanRule> {
         TechSet techSet = techSet(Tech.JAVA);
         // Then
         assertThat(rule.targets(techSet), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldSendHttpMessageForEachPayload() throws Exception {
+        // Given
+        when(extensionOast.registerAlertAndGetPayload(any())).thenReturn("PAYLOAD");
+
+        // When
+        rule.scan();
+
+        // Then
+        assertThat(httpMessagesSent, hasSize(Log4ShellScanRule.ATTACK_PATTERN_COUNT));
+    }
+
+    @Test
+    void shouldSendAllPayloadsEvenInCaseOfIoException() throws Exception {
+        // Given
+        when(extensionOast.registerAlertAndGetPayload(any()))
+                .thenReturn("PAYLOAD1")
+                .thenThrow(IOException.class)
+                .thenReturn("PAYLOAD");
+
+        // When
+        rule.scan();
+
+        // Then
+        assertThat(httpMessagesSent, hasSize(Log4ShellScanRule.ATTACK_PATTERN_COUNT - 1));
+    }
+
+    @Test
+    void shouldStopSendingPayloadsOnNonIoException() throws Exception {
+        // Given
+        when(extensionOast.registerAlertAndGetPayload(any()))
+                .thenReturn("PAYLOAD1")
+                .thenThrow(NullPointerException.class)
+                .thenReturn("PAYLOAD");
+
+        // When
+        rule.scan();
+
+        // Then
+        assertThat(httpMessagesSent, hasSize(1));
+    }
+
+    private static class Log4ShellServerHandler extends NanoServerHandler {
+        public Log4ShellServerHandler(String path) {
+            super(path);
+        }
+
+        @Override
+        protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
+            return newFixedLengthResponse(
+                    NanoHTTPD.Response.Status.OK, NanoHTTPD.MIME_PLAINTEXT, "Log4Shell");
+        }
     }
 }


### PR DESCRIPTION
ascanalpha: Log4Shell: Continue with further payloads if one payload throws an error

I observed this behavior especially on the vulnerable docker container `ghcr.io/christophetd/log4shell-vulnerable-app` which returns an read timeout if the vuln is triggered! This results in an exception for the specific payload and no further payload is tested.

Signed-off-by: Dennis Kniep <kniepdennis@gmail.com>