### PR TITLE
ascanalpha: Log4Shell: remove limit for technology java

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Log4Shell: remove limit for technology java
 
 
 ## [34] - 2021-12-12

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRule.java
@@ -31,8 +31,6 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.oast.ExtensionOast;
-import org.zaproxy.zap.model.Tech;
-import org.zaproxy.zap.model.TechSet;
 
 public class Log4ShellScanRule extends AbstractAppParamPlugin {
 
@@ -59,11 +57,6 @@ public class Log4ShellScanRule extends AbstractAppParamPlugin {
     @Override
     public String getName() {
         return Constant.messages.getString(PREFIX + "name");
-    }
-
-    @Override
-    public boolean targets(TechSet technologies) {
-        return technologies.includesAny(Tech.JAVA);
     }
 
     @Override


### PR DESCRIPTION
Removing the limitation for technology java, because it can also affect deep backend system. 

The Pentester might specify that the system under test is **not** java. But used backend systems by the system under test could be java based. And log4shell is also an attack vector for such deep backend systems.


Signed-off-by: Dennis Kniep <kniepdennis@gmail.com>