### PR TITLE
ascanalpha: Log4Shell: Added detection for CVE-2021-45046

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Log4Shell: Fixed the RMI Payloads (Issue 7002).
 - Log4Shell: Continue with further payloads if one payload throws an error
 
+### Changed
+- Log4Shell: Added detection for CVE-2021-45046
+
 ## [34] - 2021-12-12
 ### Added
 - Log4Shell (CVE-2021-44228) Scan Rule.

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -51,8 +51,8 @@ This rule attempts to identify if the Spring Actuators are enabled. Tests for th
 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java">SpringActuatorScanRule.java</a>
 
-<H2>Log4Shell (CVE-2021-44228)</H2>
-This rule attempts to discover the Log4Shell (<a href="https://www.cve.org/CVERecord?id=CVE-2021-44228">CVE-2021-44228</a>) vulnerability.
+<H2>Log4Shell (CVE-2021-44228 and CVE-2021-45046)</H2>
+This rule attempts to discover the Log4Shell (<a href="https://www.cve.org/CVERecord?id=CVE-2021-44228">CVE-2021-44228</a> and <a href="https://www.cve.org/CVERecord?id=CVE-2021-45046">CVE-2021-45046</a>) vulnerabilities.
 It relies on the OAST add-on to generate out-of-band payloads and verify DNS interactions.
 We recommend that this scan rule is used with header injection enabled for maximum coverage.
 

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -50,8 +50,16 @@ ascanalpha.springactuator.desc=Spring Actuator for Health is enabled and may rev
 ascanalpha.springactuator.soln=Disable the Health Actuators and other actuators, or restrict them to administrative users.
 ascanalpha.springactuator.refs=https://docs.spring.io/spring-boot/docs/current/actuator-api/htmlsingle/#overview
 
-ascanalpha.log4shell.name=Log4Shell (CVE-2021-44228)
-ascanalpha.log4shell.desc=Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default.
-ascanalpha.log4shell.soln=Upgrade Log4j2 to version 2.15.0 or newer. In previous releases (>2.10) this behavior can be mitigated by setting system property "log4j2.formatMsgNoLookups" to "true" or by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class). Java 8u121 (see https://www.oracle.com/java/technologies/javase/8u121-relnotes.html) protects against remote code execution by defaulting "com.sun.jndi.rmi.object.trustURLCodebase" and "com.sun.jndi.cosnaming.object.trustURLCodebase" to "false".
-ascanalpha.log4shell.refs=https://www.cve.org/CVERecord?id=CVE-2021-44228\nhttps://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-44228
+ascanalpha.log4shell.name=Log4Shell
 ascanalpha.log4shell.skipped=no Active Scan OAST service is selected.
+
+ascanalpha.log4shell.cve44228.name=Log4Shell (CVE-2021-44228)
+ascanalpha.log4shell.cve44228.desc=Apache Log4j2 <=2.14.1 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints. An attacker who can control log messages or log message parameters can execute arbitrary code loaded from LDAP servers when message lookup substitution is enabled. From log4j 2.15.0, this behavior has been disabled by default.
+ascanalpha.log4shell.cve44228.soln=Upgrade Log4j2 to version 2.17.1 or newer. In previous releases (>2.10) this behavior can be mitigated by setting system property "log4j2.formatMsgNoLookups" to "true" or by removing the JndiLookup class from the classpath (example: zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class). Java 8u121 (see https://www.oracle.com/java/technologies/javase/8u121-relnotes.html) protects against remote code execution by defaulting "com.sun.jndi.rmi.object.trustURLCodebase" and "com.sun.jndi.cosnaming.object.trustURLCodebase" to "false".
+ascanalpha.log4shell.cve44228.refs=https://www.cve.org/CVERecord?id=CVE-2021-44228\nhttps://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-44228
+
+ascanalpha.log4shell.cve45046.name=Log4Shell (CVE-2021-45046)
+ascanalpha.log4shell.cve45046.desc=It was found that the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allow attackers to craft malicious input data using a JNDI Lookup pattern resulting in an information leak and remote code execution in some environments.
+ascanalpha.log4shell.cve45046.soln=Upgrade Log4j2 to version 2.17.1 or newer.
+ascanalpha.log4shell.cve45046.refs=https://www.cve.org/CVERecord?id=CVE-2021-45046\nhttps://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-45046
+


### PR DESCRIPTION
Was a bit tricky to find out why the original payload does not trigger:
`"${jndi:ldap://127.0.0.1#{0}/abc}"`
Turns out it was due to how interactsh parses the correlationId. It needs a dot between arbitrary characters and the correlationId.
Fixed it in that case with `a.` in front of the canary token:
`"${jndi:ldap://127.0.0.1#a.{0}/abc}"`

I will create a ticket if we should handle that more generally in the `getNewPayload()` Method

This CVE Detection can be reproduced with this vuln app:
`sudo docker run -p 8000:8080 --rm ghcr.io/denniskniep/vulnerable-app-log4shell-2.15.0:latest`
Can be found here: https://github.com/denniskniep/log4shell-vulnerable-app


Signed-off-by: Dennis Kniep <kniepdennis@gmail.com>