### PR TITLE
[WIP] Automation Framework: Initial Implementation of Automation Job API

### DIFF
--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -50,6 +50,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.zaproxy.addon.automation.gui.AutomationPanel;
 import org.zaproxy.addon.automation.jobs.ActiveScanJob;
 import org.zaproxy.addon.automation.jobs.AddOnJob;
+import org.zaproxy.addon.automation.jobs.ApiJob;
 import org.zaproxy.addon.automation.jobs.DelayJob;
 import org.zaproxy.addon.automation.jobs.ParamsJob;
 import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
@@ -102,6 +103,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         this.registerAutomationJob(new DelayJob());
         this.registerAutomationJob(new ActiveScanJob());
         this.registerAutomationJob(new ParamsJob());
+        this.registerAutomationJob(new ApiJob());
         // Instantiate early so its visible to potential consumers
         AutomationEventPublisher.getPublisher();
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddApiParameterDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddApiParameterDialog.java
@@ -1,0 +1,86 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.ApiJob;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class AddApiParameterDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.api.apiparameter.title";
+    private static final String NAME_PARAM = "automation.dialog.api.apiparameter.title.name";
+    private static final String VALUE_PARAM = "automation.dialog.api.apiparameter.title.value";
+
+    private ApiJob.ApiParameter apiParameter;
+    private int tableIndex;
+    private ApiParameterTableModel model;
+
+    public AddApiParameterDialog(ApiParameterTableModel model) {
+        this(model, null, -1);
+    }
+
+    public AddApiParameterDialog(
+            ApiParameterTableModel model, ApiJob.ApiParameter apiParameter, int tableIndex) {
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(400, 200));
+        this.apiParameter = apiParameter;
+        this.model = model;
+        this.tableIndex = tableIndex;
+
+        String name = "";
+        if (apiParameter != null) {
+            name = apiParameter.getName();
+        }
+        this.addTextField(NAME_PARAM, name);
+
+        String value = "";
+        if (apiParameter != null) {
+            value = apiParameter.getValue();
+        }
+        this.addTextField(VALUE_PARAM, value);
+
+        this.addPadding();
+    }
+
+    @Override
+    public void save() {
+        String name = getStringValue(NAME_PARAM);
+        String value = getStringValue(VALUE_PARAM);
+        if (apiParameter == null) {
+            apiParameter = new ApiJob.ApiParameter();
+            apiParameter.setName(name);
+            apiParameter.setValue(value);
+            this.model.add(apiParameter);
+        } else {
+            apiParameter.setName(name);
+            apiParameter.setValue(value);
+            this.model.update(tableIndex, apiParameter);
+        }
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do
+        return null;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ApiJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ApiJobDialog.java
@@ -1,0 +1,345 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.swing.JButton;
+import javax.swing.JOptionPane;
+import javax.swing.JTable;
+import org.apache.commons.lang.StringUtils;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.ApiJob;
+import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.ApiElement;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+public class ApiJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TITLE = "automation.dialog.api.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String API_KEY_PARAM = "automation.dialog.api.apiKey";
+    private static final String API_NAME_PARAM = "automation.dialog.api.apiName";
+    private static final String API_PREFIX_PARAM = "automation.dialog.api.apiPrefix";
+    private static final String API_REQUEST_TYPE_PARAM = "automation.dialog.api.apiRequestType";
+    private static final String OUTPUT_FORMAT_PARAM = "automation.dialog.api.outputFormat";
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.tab.params", "automation.dialog.api.tab.apiParameters"
+    };
+
+    private JTable apiParametersTable = null;
+    private ApiParameterTableModel apiParametersModel = null;
+
+    private JButton addButton = null;
+    private JButton modifyButton = null;
+    private JButton removeButton = null;
+
+    private ApiJob job;
+
+    public ApiJobDialog(ApiJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 300),
+                TAB_LABELS);
+        this.job = job;
+
+        this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+        this.addTextField(0, API_KEY_PARAM, this.job.getData().getParameters().getApiKey());
+        this.addComboField(
+                0,
+                API_PREFIX_PARAM,
+                getPossibleApiPrefixes(),
+                this.job.getData().getParameters().getApiPrefix(),
+                false);
+        this.addFieldListener(API_PREFIX_PARAM, e -> onApiPrefixOrRequestTypeChanged());
+        this.addComboField(
+                0,
+                API_REQUEST_TYPE_PARAM,
+                getPossibleApiRequestTypes(),
+                this.job.getData().getParameters().getApiRequestType(),
+                false);
+        this.addFieldListener(API_REQUEST_TYPE_PARAM, e -> onApiPrefixOrRequestTypeChanged());
+        this.addComboField(
+                0,
+                API_NAME_PARAM,
+                new ArrayList<>(),
+                this.job.getData().getParameters().getApiName(),
+                false);
+        this.addFieldListener(API_NAME_PARAM, e -> onApiNameChanged());
+        this.addComboField(
+                0,
+                OUTPUT_FORMAT_PARAM,
+                getPossibleApiOutputFormats(),
+                this.job.getData().getParameters().getApiOutputFormat(),
+                false);
+
+        this.addPadding(0);
+
+        List<JButton> buttons = new ArrayList<>();
+        buttons.add(getAddButton());
+        buttons.add(getModifyButton());
+        buttons.add(getRemoveButton());
+
+        this.addTableField(1, getApiParameterTable(), buttons);
+
+        onApiPrefixOrRequestTypeChanged();
+        onApiNameChanged();
+    }
+
+    private static List<String> getPossibleApiOutputFormats() {
+        return EnumSet.allOf(API.Format.class).stream()
+                .map(e -> e.name())
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> getPossibleApiRequestTypes() {
+        return EnumSet.allOf(API.RequestType.class).stream()
+                .map(e -> e.name())
+                .collect(Collectors.toList());
+    }
+
+    private static String[] getPossibleApiPrefixes() {
+        return API.getInstance().getImplementors().keySet().toArray(new String[] {});
+    }
+
+    private void onApiPrefixOrRequestTypeChanged() {
+        List<String> apiNames =
+                getPossibleApiElements().stream()
+                        .map(e -> e.getName())
+                        .collect(Collectors.toList());
+        this.setComboFields(
+                API_NAME_PARAM, apiNames, this.job.getData().getParameters().getApiName());
+    }
+
+    private List<ApiElement> getPossibleApiElements() {
+        String prefix = getStringValue(API_PREFIX_PARAM);
+
+        if (StringUtils.isEmpty(prefix)) {
+            return new ArrayList<>();
+        }
+
+        ApiImplementor apiImplementor = API.getInstance().getImplementors().get(prefix);
+        if (apiImplementor == null) {
+            return new ArrayList<>();
+        }
+
+        API.RequestType requestType =
+                API.RequestType.valueOf(getStringValue(API_REQUEST_TYPE_PARAM));
+        if (requestType == null) {
+            return new ArrayList<>();
+        }
+
+        return getPossibleApiElements(apiImplementor, requestType);
+    }
+
+    private void onApiNameChanged() {
+        List<ApiJob.ApiParameter> apiParameters = new ArrayList<>();
+        for (String possibleApiParameters : getPossibleApiParameters()) {
+            Optional<ApiJob.ApiParameter> existingApiParameter =
+                    this.job.getData().getApiParameters().stream()
+                            .filter(p -> Objects.equals(p.getName(), possibleApiParameters))
+                            .findFirst();
+            String value = "";
+            if (existingApiParameter.isPresent()) {
+                value = existingApiParameter.get().getValue();
+            }
+            apiParameters.add(new ApiJob.ApiParameter(possibleApiParameters, value));
+        }
+        this.getApiParameterTableModel().setApiParameters(apiParameters);
+    }
+
+    private List<String> getPossibleApiParameters() {
+        List<ApiElement> apiElements = getPossibleApiElements();
+        String name = getStringValue(API_NAME_PARAM);
+
+        if (StringUtils.isEmpty(name)) {
+            return new ArrayList<>();
+        }
+        Optional<ApiElement> apiElement =
+                apiElements.stream().filter(e -> Objects.equals(e.getName(), name)).findFirst();
+        if (!apiElement.isPresent()) {
+            return new ArrayList<>();
+        }
+
+        return apiElement.get().getParameters().stream()
+                .map(p -> p.getName())
+                .collect(Collectors.toList());
+    }
+
+    private List<ApiElement> getPossibleApiElements(
+            ApiImplementor apiImplementor, API.RequestType requestType) {
+        List<ApiElement> apiElements = new ArrayList<>();
+        switch (requestType) {
+            case action:
+                apiElements = apiImplementor.getApiActions().stream().collect(Collectors.toList());
+                break;
+            case view:
+                apiElements = apiImplementor.getApiViews().stream().collect(Collectors.toList());
+                break;
+            case other:
+                apiElements = apiImplementor.getApiOthers().stream().collect(Collectors.toList());
+                break;
+            case pconn:
+                apiElements =
+                        apiImplementor.getApiPersistentConnections().stream()
+                                .collect(Collectors.toList());
+                break;
+        }
+        return apiElements;
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getData().setApiParameters(this.getApiParameterTableModel().getApiParameters());
+
+        this.job.getParameters().setApiPrefix(this.getStringValue(API_PREFIX_PARAM));
+        this.job.getParameters().setApiKey(this.getStringValue(API_KEY_PARAM));
+        this.job.getParameters().setApiRequestType(this.getStringValue(API_REQUEST_TYPE_PARAM));
+        this.job.getParameters().setApiName(this.getStringValue(API_NAME_PARAM));
+        this.job.getParameters().setApiOutputFormat(this.getStringValue(OUTPUT_FORMAT_PARAM));
+        this.job.setChanged();
+        this.job.reset();
+        this.job.setJobData(new LinkedHashMap<>());
+    }
+
+    @Override
+    public String validateFields() {
+        return null;
+    }
+
+    private JButton getAddButton() {
+        if (this.addButton == null) {
+            this.addButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.add"));
+            this.addButton.addActionListener(
+                    e -> {
+                        AddApiParameterDialog dialog =
+                                new AddApiParameterDialog(getApiParameterTableModel());
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.addButton;
+    }
+
+    private JButton getModifyButton() {
+        if (this.modifyButton == null) {
+            this.modifyButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            this.modifyButton.addActionListener(
+                    e -> {
+                        int row = getApiParameterTable().getSelectedRow();
+                        AddApiParameterDialog dialog =
+                                new AddApiParameterDialog(
+                                        getApiParameterTableModel(),
+                                        getApiParameterTableModel().getApiParameters().get(row),
+                                        row);
+                        dialog.setVisible(true);
+                    });
+        }
+        return this.modifyButton;
+    }
+
+    private JButton getRemoveButton() {
+        if (this.removeButton == null) {
+            this.removeButton =
+                    new JButton(Constant.messages.getString("automation.dialog.button.remove"));
+            this.removeButton.setEnabled(false);
+            final ApiJobDialog parent = this;
+            this.removeButton.addActionListener(
+                    e -> {
+                        if (JOptionPane.OK_OPTION
+                                == View.getSingleton()
+                                        .showConfirmDialog(
+                                                parent,
+                                                Constant.messages.getString(
+                                                        "automation.dialog.pscanconfig.remove.confirm"))) {
+                            getApiParameterTableModel()
+                                    .remove(getApiParameterTable().getSelectedRow());
+                        }
+                    });
+        }
+        return this.removeButton;
+    }
+
+    private JTable getApiParameterTable() {
+        if (apiParametersTable == null) {
+            apiParametersTable = new JTable();
+            apiParametersTable.setModel(getApiParameterTableModel());
+            apiParametersTable
+                    .getColumnModel()
+                    .getColumn(0)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(100));
+            apiParametersTable
+                    .getColumnModel()
+                    .getColumn(1)
+                    .setPreferredWidth(DisplayUtils.getScaledSize(290));
+            apiParametersTable
+                    .getSelectionModel()
+                    .addListSelectionListener(
+                            e -> {
+                                boolean singleRowSelected =
+                                        getApiParameterTable().getSelectedRowCount() == 1;
+                                modifyButton.setEnabled(singleRowSelected);
+                                removeButton.setEnabled(singleRowSelected);
+                            });
+            apiParametersTable.addMouseListener(
+                    new MouseAdapter() {
+                        @Override
+                        public void mouseClicked(MouseEvent me) {
+                            if (me.getClickCount() == 2) {
+                                int row = getApiParameterTable().getSelectedRow();
+                                AddApiParameterDialog dialog =
+                                        new AddApiParameterDialog(
+                                                getApiParameterTableModel(),
+                                                getApiParameterTableModel()
+                                                        .getApiParameters()
+                                                        .get(row),
+                                                row);
+                                dialog.setVisible(true);
+                            }
+                        }
+                    });
+        }
+        return apiParametersTable;
+    }
+
+    private ApiParameterTableModel getApiParameterTableModel() {
+        if (apiParametersModel == null) {
+            apiParametersModel = new ApiParameterTableModel();
+            apiParametersModel.setApiParameters(job.getData().getApiParameters());
+        }
+        return apiParametersModel;
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ApiParameterTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ApiParameterTableModel.java
@@ -1,0 +1,116 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.automation.jobs.ApiJob;
+
+public class ApiParameterTableModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] columnNames = {
+        Constant.messages.getString("automation.dialog.api.table.header.name"),
+        Constant.messages.getString("automation.dialog.api.table.header.value")
+    };
+
+    private List<ApiJob.ApiParameter> apiParameters = new ArrayList<>();
+
+    public ApiParameterTableModel() {
+        super();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public int getRowCount() {
+        return apiParameters.size();
+    }
+
+    @Override
+    public Object getValueAt(int row, int col) {
+        ApiJob.ApiParameter apiParameter = this.apiParameters.get(row);
+        if (apiParameter != null) {
+            switch (col) {
+                case 0:
+                    return apiParameter.getName();
+                case 1:
+                    return apiParameter.getValue();
+                default:
+                    return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return columnNames[col];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        return String.class;
+    }
+
+    public List<ApiJob.ApiParameter> getApiParameters() {
+        return apiParameters;
+    }
+
+    public void setApiParameters(List<ApiJob.ApiParameter> apiParameters) {
+        if (apiParameters == null) {
+            this.apiParameters = new ArrayList<>();
+        } else {
+            this.apiParameters = apiParameters;
+        }
+    }
+
+    public void clear() {
+        this.apiParameters.clear();
+    }
+
+    public void add(ApiJob.ApiParameter apiParameter) {
+        this.apiParameters.add(apiParameter);
+        this.fireTableRowsInserted(this.apiParameters.size() - 1, this.apiParameters.size() - 1);
+    }
+
+    public void update(int tableIndex, ApiJob.ApiParameter apiParameter) {
+        this.apiParameters.set(tableIndex, apiParameter);
+        this.fireTableRowsUpdated(tableIndex, tableIndex);
+    }
+
+    public void remove(int index) {
+        if (index < this.apiParameters.size()) {
+            this.apiParameters.remove(index);
+            this.fireTableRowsDeleted(index, index);
+        }
+    }
+}

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ApiJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ApiJob.java
@@ -1,0 +1,297 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.jobs;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import org.apache.commons.httpclient.URI;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HtmlParameter;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.automation.AutomationData;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.gui.ApiJobDialog;
+import org.zaproxy.zap.extension.api.API;
+
+public class ApiJob extends AutomationJob {
+
+    public static final String JOB_NAME = "api";
+    private final Logger LOGGER = LogManager.getLogger(this.getClass());
+    private Data data;
+    private Parameters parameters = new Parameters();
+    private HttpSender httpSender;
+
+    public ApiJob() {
+        this.data = new Data(this, parameters);
+
+        this.httpSender =
+                new HttpSender(
+                        Model.getSingleton().getOptionsParam().getConnectionParam(),
+                        true,
+                        HttpSender.MANUAL_REQUEST_INITIATOR);
+    }
+
+    @Override
+    public void verifyParameters(AutomationProgress progress) {
+        applyParameters(progress);
+    }
+
+    @Override
+    public void applyParameters(AutomationProgress progress) {
+        Map<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
+        }
+
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
+
+        this.data.apiParameters.clear();
+
+        if (jobData.get("apiParameters") == null) {
+            return;
+        }
+
+        ArrayList<?> apiParameterObjects = (ArrayList<?>) jobData.get("apiParameters");
+        for (Object apiParameterObject : apiParameterObjects) {
+            ApiParameter apiParameter = new ApiParameter();
+            JobUtils.applyParamsToObject(
+                    (LinkedHashMap<?, ?>) apiParameterObject,
+                    apiParameter,
+                    this.getName(),
+                    null,
+                    progress);
+            this.data.apiParameters.add(apiParameter);
+        }
+    }
+
+    @Override
+    public void runJob(AutomationEnvironment env, AutomationProgress progress) {
+        try {
+            URI uri = new URI(getApiUrl(), true);
+            HttpRequestHeader reqHeader =
+                    new HttpRequestHeader(HttpRequestHeader.GET, uri, HttpHeader.HTTP11);
+            HttpMessage apiMsg = new HttpMessage(reqHeader);
+            TreeSet<HtmlParameter> queryParams = new TreeSet<>();
+            for (ApiParameter apiParameter : data.getApiParameters()) {
+                queryParams.add(
+                        new HtmlParameter(
+                                HtmlParameter.Type.url,
+                                apiParameter.getName(),
+                                apiParameter.getValue()));
+            }
+            apiMsg.setGetParams(queryParams);
+            progress.info("Send API request");
+            progress.info(apiMsg.getRequestHeader().getURI().toString());
+
+            queryParams.add(
+                    new HtmlParameter(HtmlParameter.Type.url, "apikey", parameters.getApiKey()));
+            apiMsg.setGetParams(queryParams);
+
+            // ToDo: Maybe possible with handleApiRequest to circumvent network stack?
+            this.httpSender.sendAndReceive(apiMsg);
+            progress.info("Received API response");
+            progress.info(apiMsg.getResponseBody().toString());
+        } catch (Exception e) {
+            LOGGER.error(e);
+            progress.error(e.toString());
+        }
+    }
+
+    private String getApiUrl() {
+        API.Format format = API.Format.JSON;
+        if (parameters.getApiOutputFormat() != null) {
+            format = API.Format.valueOf(parameters.getApiOutputFormat());
+        }
+
+        API.RequestType requestType = API.RequestType.view;
+        if (parameters.getApiRequestType() != null) {
+            requestType = API.RequestType.valueOf(parameters.getApiRequestType());
+        }
+
+        return API.getInstance()
+                .getBaseURL(
+                        format,
+                        parameters.getApiPrefix(),
+                        requestType,
+                        parameters.getApiName(),
+                        false);
+    }
+
+    @Override
+    public String getType() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public Order getOrder() {
+        return Order.CONFIGS;
+    }
+
+    @Override
+    public Object getParamMethodObject() {
+        return null;
+    }
+
+    @Override
+    public String getParamMethodName() {
+        return null;
+    }
+
+    @Override
+    public void showDialog() {
+        new ApiJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        return Constant.messages.getString(
+                "automation.dialog.api.summary",
+                getApiUrl(),
+                this.getData().getApiParameters().size());
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return this.parameters;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+        private List<ApiParameter> apiParameters = new ArrayList<>();
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+
+        public List<ApiParameter> getApiParameters() {
+            return apiParameters;
+        }
+
+        public void setApiParameters(List<ApiParameter> apiParameters) {
+            this.apiParameters = apiParameters;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private String apiOutputFormat = API.Format.JSON.toString();
+        private String apiPrefix;
+        private String apiRequestType = API.RequestType.view.toString();
+        private String apiName;
+        private String apiKey;
+
+        public String getApiOutputFormat() {
+            return apiOutputFormat;
+        }
+
+        public void setApiOutputFormat(String apiOutputFormat) {
+            this.apiOutputFormat = apiOutputFormat;
+        }
+
+        public String getApiPrefix() {
+            return apiPrefix;
+        }
+
+        public void setApiPrefix(String apiPrefix) {
+            this.apiPrefix = apiPrefix;
+        }
+
+        public String getApiRequestType() {
+            return apiRequestType;
+        }
+
+        public void setApiRequestType(String apiRequestType) {
+            this.apiRequestType = apiRequestType;
+        }
+
+        public String getApiName() {
+            return apiName;
+        }
+
+        public void setApiName(String apiName) {
+            this.apiName = apiName;
+        }
+
+        public String getApiKey() {
+            return apiKey;
+        }
+
+        public void setApiKey(String apiKey) {
+            this.apiKey = apiKey;
+        }
+    }
+
+    public static class ApiParameter extends AutomationData {
+        private String name;
+        private String value;
+
+        public ApiParameter() {}
+
+        public ApiParameter(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public ApiParameter copy() {
+            return new ApiParameter(name, value);
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -111,6 +111,20 @@ automation.dialog.delay.summary = Time: {0} file name: {1}
 automation.dialog.delay.time = Time:
 automation.dialog.delay.title = Delay Job
 
+automation.dialog.api.summary = ApiUrl: {0}, ApiParameter Count: {1}
+automation.dialog.api.apiKey = ApiKey:
+automation.dialog.api.apiName = ApiName:
+automation.dialog.api.apiRequestType = ApiRequestType:
+automation.dialog.api.apiPrefix = ApiPrefix:
+automation.dialog.api.outputFormat = Output Format:
+automation.dialog.api.title = Api Job
+automation.dialog.api.table.header.name = Name
+automation.dialog.api.table.header.value = Value
+automation.dialog.api.tab.apiParameters = ApiParameters
+automation.dialog.api.apiparameter.title = Api Parameter
+automation.dialog.api.apiparameter.title.name = Name:
+automation.dialog.api.apiparameter.title.value = Value:
+
 automation.dialog.env.failonerror = Fail On Error:
 automation.dialog.env.failonwarning = Fail On Warning:
 automation.dialog.env.progresstostdout = Progresss To Stdout:

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -108,7 +108,7 @@ class ExtentionAutomationUnitTest extends TestUtils {
         Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
 
         // Then
-        assertThat(jobs.size(), is(equalTo(8)));
+        assertThat(jobs.size(), is(equalTo(9)));
         assertThat(jobs.containsKey(AddOnJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(PassiveScanConfigJob.JOB_NAME), is(equalTo(true)));
         assertThat(jobs.containsKey(PassiveScanWaitJob.JOB_NAME), is(equalTo(true)));
@@ -143,7 +143,7 @@ class ExtentionAutomationUnitTest extends TestUtils {
         Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
 
         // Then
-        assertThat(jobs.size(), is(equalTo(9)));
+        assertThat(jobs.size(), is(equalTo(10)));
         assertThat(jobs.containsKey(jobName), is(equalTo(true)));
     }
 

--- a/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
+++ b/addOns/automation/src/test/resources/org/zaproxy/addon/automation/resources/template-config.yaml
@@ -20,16 +20,16 @@ env:                                   # The environment, mandatory
           pollUrl:                     # String, the URL to poll, only for 'poll' verification
           pollPostData:                # String, post dat to include in the poll, only for 'poll' verification
           pollAdditionalHeaders:       # List of additional headers for poll request, only for 'poll' verification
-          - header:                    # The header name
-            value:                     # The header value
+            - header:                    # The header name
+              value:                     # The header value
       sessionManagement:
         method:                        # String, one of 'cookie', 'http', 'script'
         script:                        # String, path to script, only for 'script' session management
         scriptEngine:                  # String, the name of the script engine to use, only for 'script' session management
       users:                           # List of one or more users to use for authentication
-      - name:                          # String, the name to be used by the jobs
-        username:                      # String, the username to use when authenticating, vars supported
-        password:                      # String, the password to use when authenticating, vars supported
+        - name:                          # String, the name to be used by the jobs
+          username:                      # String, the username to use when authenticating, vars supported
+          password:                      # String, the password to use when authenticating, vars supported
   vars:                                # List of 0 or more variables, can be used in urls and selected other parameters
   parameters:
     failOnError: true                  # If set exit on an error         
@@ -43,6 +43,10 @@ jobs:
       updateAddOns: true
     install:                           # A list of non standard add-ons to install from the ZAP Marketplace
     uninstall:                         # A list of standard add-ons to uninstall
+
+  - type: api
+    name: api
+    parameters:
 
   - type: passiveScan-config
     name: passiveScan-config
@@ -58,8 +62,8 @@ jobs:
   - type: spider
     name: spider
     parameters:
-      context: 
-      url: 
+      context:
+      url:
 
   - type: delay
     name: delay


### PR DESCRIPTION
I added a POC implementation of an APIJob which integrates into the Automation Framework addon.
![image](https://user-images.githubusercontent.com/3629463/148132606-b9b2a011-42eb-4838-a198-560a1169c94b.png)
![image](https://user-images.githubusercontent.com/3629463/148132634-32df9b2a-3d6f-4118-b9ba-e31137a17da8.png)

At least the following ToDos are open:
- [ ] Verification (Parameters with APIImplementor)
- [ ] Display Description and Required/NotRequired in ParameterTable
- [ ] Export result as file option 
- [ ] Parameter which defines order (Because api requests could be useful at any stage).
- [ ] API Key can be obtained internally and doesn't need to be specified
- [ ] Maybe possible to send API Requests with handleApiRequest to circumvent network stack?
- [ ] Is it necessary to execute after UiDialog save the following methods: `this.job.reset();` and  `this.job.setJobData(new LinkedHashMap<>());`
- [ ] Return Output from Standalone Script into API Response

Maybe we can solve following usecases with that:
- [ ] Extract SiteTree (via Standalone Script?)
- [ ] Extract sent messages during activescan (scanId from ActiveScanJob Result -> ascan/view/messagesIds/ -> core/view/messagesById/) How can we chain these requests and use the output as input on the next task?
- [ ] Extract OAST pingbacks

Feedback is welcome

Signed-off-by: Dennis Kniep <kniepdennis@gmail.com>