### PR TITLE
oast: Make Interactsh payloads more robust

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - Close callback connections gracefully.
 - Maintenance changes.
+- Make Interactsh payloads more robust by adding a further char with a dot before the actual correlationId (Issue 7003)
 
 ## [0.8.0] - 2022-01-10
 ### Changed

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
@@ -33,7 +33,6 @@ import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.table.AbstractTableModel;
-import org.apache.commons.lang3.StringUtils;
 import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
@@ -262,7 +261,9 @@ public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
                     return payloads.get(rowIndex);
                 case 1:
                     String payload = payloads.get(rowIndex);
-                    return StringUtils.reverse(payload.substring(0, payload.indexOf('.')));
+                    int firstDot = payload.indexOf('.');
+                    int secondDot = payload.indexOf('.', firstDot + 1);
+                    return payload.substring(firstDot + 1, secondDot);
                 default:
                     return "";
             }

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
@@ -293,7 +293,9 @@ public class InteractshService extends OastService implements OptionsChangedList
         if (!isRegistered) {
             register();
         }
-        return correlationId
+        return RandomStringUtils.randomAlphanumeric(1).toLowerCase(Locale.ROOT)
+                + '.'
+                + correlationId
                 + RandomStringUtils.randomAlphanumeric(13).toLowerCase(Locale.ROOT)
                 + '.'
                 + serverUrl.getHost();


### PR DESCRIPTION
Make Interactsh payloads more robust by adding a further char with a dot before the actual correlationId. 
Fixes zaproxy/zaproxy#7003

Signed-off-by: Dennis Kniep <kniepdennis@gmail.com>