### PR TITLE
chore: pscanrules: Fix CSP false positive on trusted-types directives

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Renamed 'X-Frame-Options Header Not Set' alert to 'Missing Anti-clickjacking Header', and associated scan rule 'X-Frame-Options Header' to 'Anti-clickjacking Header'. The rule already considered Content-Security-Policy 'frame-ancestors' which is a more modern solution to the same concern. Updated associated solution text. (Issue 6937)
+- Content Security Policy scan rule will no longer classify "require-trusted-types-for" or "trusted-types" directives as unknown (Issue 6602).
 
 ## [37] - 2021-12-01
 ### Added


### PR DESCRIPTION
- CHANGELOG > Added change note.
- ContentSecurityPolicyScanRule > Added functionality to skip allowed directives that aren't handled/known to the salvation library.
- ContentSecurityPolicyScanRuleUnitTest > Added a new test to assert the updated behavior.

Fixes zaproxy/zaproxy#6602

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>