### PR TITLE
automation: bugfixes: DelayJob and apply job changes

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- When the automation Job is edited via UI Dialog then the status will be set to Not started
 
 ## [13] - 2021-10-06
 ### Added

--- a/addOns/alertFilters/alertFilters.gradle.kts
+++ b/addOns/alertFilters/alertFilters.gradle.kts
@@ -18,7 +18,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.6.0")
+                            version.set(">=0.12.0")
                         }
                     }
                 }

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJobDialog.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJobDialog.java
@@ -84,7 +84,7 @@ public class AlertFilterJobDialog extends StandardFieldsDialog {
                 .getParameters()
                 .setDeleteGlobalAlerts(this.getBoolValue(DELETE_GLOBAL_PARAM));
         this.job.getData().setAlertFilters(this.getAlertFilterModel().getAlertFilters());
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- When a Job is loaded via yaml and edited via UI Dialog then the saved changes will be applied on the next job run
+- DelayJob will be verified on yaml load
 
+### Changed
+- When a Job is edited via UI Dialog then the status will be set to Not started
 
 ## [0.11.0] - 2022-01-19
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/AutomationJob.java
@@ -187,6 +187,11 @@ public abstract class AutomationJob implements Comparable<AutomationJob> {
         return plan;
     }
 
+    public void resetAndSetChanged() {
+        reset();
+        setChanged();
+    }
+
     public void setChanged() {
         AutomationEventPublisher.publishEvent(AutomationEventPublisher.JOB_CHANGED, this, null);
         this.plan.setChanged();

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
@@ -253,7 +253,7 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
             this.job.getParameters().setScanHeadersAllRequests(null);
         }
         this.job.getData().getPolicyDefinition().setRules(this.getRulesModel().getRules());
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
@@ -205,7 +205,7 @@ public class AddOnJobDialog extends StandardFieldsDialog {
         } else {
             this.job.getData().setUninstall(addOns);
         }
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
@@ -594,6 +594,7 @@ public class AutomationPanel extends AbstractPanel implements EventConsumer {
                                 if (userObj instanceof AutomationEnvironment) {
                                     ((AutomationEnvironment) userObj).showDialog();
                                 } else if (userObj instanceof AutomationJob) {
+                                    ((AutomationJob) userObj).setJobData(null);
                                     ((AutomationJob) userObj).showDialog();
                                 } else if (userObj instanceof AbstractAutomationTest) {
                                     ((AbstractAutomationTest) userObj).showDialog();

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/DelayJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/DelayJobDialog.java
@@ -53,7 +53,7 @@ public class DelayJobDialog extends StandardFieldsDialog {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
         this.job.getParameters().setTime(this.getStringValue(TIME_PARAM));
         this.job.getParameters().setFileName(this.getStringValue(FILENAME_PARAM));
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
@@ -104,7 +104,7 @@ public class PassiveScanConfigJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setMaxBodySizeInBytesToScan(this.getIntValue(MAX_BODY_SIZE_PARAM));
         this.job.getParameters().setEnableTags(this.getBoolValue(ENABLE_TAGS_PARAM));
         this.job.getData().setRules(this.getRulesModel().getRules());
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanWaitJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanWaitJobDialog.java
@@ -52,7 +52,7 @@ public class PassiveScanWaitJobDialog extends StandardFieldsDialog {
     public void save() {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
         this.job.getParameters().setMaxDuration(this.getIntValue(MAX_DURATION_PARAM));
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
@@ -83,7 +83,7 @@ public class RequestorJobDialog extends StandardFieldsDialog {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
         this.job.getData().getParameters().setUser(this.getStringValue(USER_PARAM));
         job.getData().setRequests(this.getRulesModel().getRules());
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
@@ -303,7 +303,7 @@ public class SpiderJobDialog extends StandardFieldsDialog {
             this.job.getParameters().setUserAgent(null);
             this.job.getParameters().setHandleParameters(null);
         }
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/DelayJob.java
@@ -46,6 +46,16 @@ public class DelayJob extends AutomationJob {
 
     @Override
     public void verifyParameters(AutomationProgress progress) {
+        Map<?, ?> jobData = this.getJobData();
+        if (jobData != null) {
+            JobUtils.applyParamsToObject(
+                    (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                    this.parameters,
+                    this.getName(),
+                    null,
+                    progress);
+        }
+
         String timeStr = this.getParameters().getTime();
         try {
             new HhMmSs(timeStr);
@@ -55,18 +65,7 @@ public class DelayJob extends AutomationJob {
     }
 
     @Override
-    public void applyParameters(AutomationProgress progress) {
-        Map<?, ?> jobData = this.getJobData();
-        if (jobData == null) {
-            return;
-        }
-        JobUtils.applyParamsToObject(
-                (LinkedHashMap<?, ?>) jobData.get("parameters"),
-                this.parameters,
-                this.getName(),
-                null,
-                progress);
-    }
+    public void applyParameters(AutomationProgress progress) {}
 
     @Override
     public void runJob(AutomationEnvironment env, AutomationProgress progress) {

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Reduce printed errors messages in the script Input Vector.
+- When the automation Job is edited via UI Dialog then the status will be set to Not started
 
 ## [0.7.0] - 2021-11-01
 ### Fixed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -15,7 +15,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.6.0")
+                            version.set(">=0.12.0")
                         }
                     }
                 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
@@ -331,7 +331,7 @@ public class GraphQlJobDialog extends StandardFieldsDialog {
             this.job.getParameters().setQuerySplitType(null);
             this.job.getParameters().setRequestMethod(null);
         }
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Dependency updates.
+- When the automation Job is edited via UI Dialog then the status will be set to Not started
 
 ### Fixed
 - Parameter examples specified as part of the schema were not being used.

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -18,7 +18,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.6.0")
+                            version.set(">=0.12.0")
                         }
                     }
                 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
@@ -71,7 +71,7 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setApiFile(this.getStringValue(API_FILE_PARAM));
         this.job.getParameters().setApiUrl(this.getStringValue(API_URL_PARAM));
         this.job.getParameters().setTargetUrl(this.getStringValue(TARGET_URL_PARAM));
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Dependency updates.
+- When the automation Job is edited via UI Dialog then the status will be set to Not started
 
 ## [0.10.0] - 2021-12-06
 ### Changed

--- a/addOns/reports/reports.gradle.kts
+++ b/addOns/reports/reports.gradle.kts
@@ -23,7 +23,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.6.0")
+                            version.set(">=0.12.0")
                         }
                     }
                 }

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
@@ -305,7 +305,7 @@ public class ReportJobDialog extends StandardFieldsDialog {
         } else {
             job.getData().setConfidences(confs);
         }
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     private File getReportFile() {

--- a/addOns/soap/CHANGELOG.md
+++ b/addOns/soap/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Dependency updates.
+- When the automation Job is edited via UI Dialog then the status will be set to Not started
 
 ## [12] - 2021-11-29
 ### Changed

--- a/addOns/soap/soap.gradle.kts
+++ b/addOns/soap/soap.gradle.kts
@@ -24,7 +24,7 @@ zapAddOn {
                 dependencies {
                     addOns {
                         register("automation") {
-                            version.set(">=0.6.0")
+                            version.set(">=0.12.0")
                         }
                     }
                 }

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
@@ -63,7 +63,7 @@ public class SoapJobDialog extends StandardFieldsDialog {
         this.job.getData().setName(this.getStringValue(NAME_PARAM));
         this.job.getParameters().setWsdlFile(this.getStringValue(WSDL_FILE_PARAM));
         this.job.getParameters().setWsdlUrl(this.getStringValue(WSDL_URL_PARAM));
-        this.job.setChanged();
+        this.job.resetAndSetChanged();
     }
 
     @Override


### PR DESCRIPTION
* **When a Job is loaded via yaml and edited via Ui Dialog then the saved changes will be applied on the next job run**
Before running the job there is always an `applyParameters()` which overwrites the fresh changes from the UI Dialog with the yaml input hashmap!

* **DelayJob will be verified on yaml load**
The verification logic used the parameters member, which was not set yet

* **When a Job is edited via Ui Dialog then the status will be set to NOT_STARTED** 
Because the parameters are changed now and the job was running with other parameters before. Therefore the Job Status message includes the old parameters, which is confusing. Would be more clear to the user, that the summary is displayed with the new parameter

Signed-off-by: Dennis Kniep <kniepdennis@gmail.com>