### PR TITLE
chore: pscanrules: Update cache-control details to be more lenient

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update Cache-control scan rule name, description, and solution to make it more clear that there are cases in which caching is reasonable. Reduced risk to Info. (Issue 6462)
 
 ## [38] - 2022-01-07
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
@@ -107,7 +107,7 @@ public class CacheControlScanRule extends PluginPassiveScanner {
     }
 
     public int getRisk() {
-        return Alert.RISK_LOW;
+        return Alert.RISK_INFO;
     }
 
     public String getDescription() {

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -155,9 +155,9 @@ pscanrules.applicationerrors.name = Application Error Disclosure
 pscanrules.applicationerrors.desc = This page contains an error/warning message that may disclose sensitive information like the location of the file that produced the unhandled exception. This information can be used to launch further attacks against the web application. The alert could be a false positive if the error message is found inside a documentation page.
 pscanrules.applicationerrors.soln = Review the source code of this page. Implement custom error pages. Consider implementing a mechanism to provide a unique error reference/identifier to the client (browser) while logging the details on the server side and not exposing them to the user.
 
-pscanrules.cachecontrol.name = Incomplete or No Cache-control Header Set
-pscanrules.cachecontrol.desc = The cache-control header has not been set properly or is missing, allowing the browser and proxies to cache content.
-pscanrules.cachecontrol.soln = Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate.
+pscanrules.cachecontrol.name = Re-examine Cache-control Directives
+pscanrules.cachecontrol.desc = The cache-control header has not been set properly or is missing, allowing the browser and proxies to cache content. For static assets like css, js, or image files this might be intended, however, the resources should be reviewed to ensure that no sensitive content will be cached.
+pscanrules.cachecontrol.soln = Whenever possible ensure the cache-control HTTP header is set with "no-cache, no-store, must-revalidate". If an asset should be cached consider setting the directives "public, max-age, immutable".
 pscanrules.cachecontrol.refs = https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#web-content-caching\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 
 pscanrules.contenttypemissing.name = Content-Type Header Missing


### PR DESCRIPTION
- CHANGELOG > Added change note.
- Messages.properties > Update name, description, and solution to be more lenient.

Fixes zaproxy/zaproxy#6462

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>