### PR TITLE
chore: websockets: Replace old OWASP mediawiki links

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Update the reference links used in the Username IDOR passive scan script.
 
 ## [24] - 2021-10-06
 ### Changed

--- a/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Username Idor Scanner.js
+++ b/addOns/websocket/src/main/zapHomeFiles/scripts/templates/websocketpassive/Username Idor Scanner.js
@@ -56,8 +56,8 @@ function createAlertBuilder(helper, evidence, username, contextname, hashType){
         .setSolution("Use per user or session indirect object references (create a temporary mapping at time of use)."
                      + " Or, ensure that each use of a direct object reference is tied to an authorization check to ensure the"
                      + " user is authorized for the requested object.")
-        .setReference("https://www.owasp.org/index.php/Top_10_2013-A4-Insecure_Direct_Object_References\n"
-                      + "https://www.owasp.org/index.php/Testing_for_Insecure_Direct_Object_References_(OTG-AUTHZ-004)")
+        .setReference("https://cheatsheetseries.owasp.org/cheatsheets/Insecure_Direct_Object_Reference_Prevention_Cheat_Sheet.html\n"
+                      + "https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References")
         .setEvidence(evidence)
         .setCweId(284) // CWE-284: Improper Access Control
         .setWascId(2); // WASC-2: Insufficient Authorization


### PR DESCRIPTION
- Updated the references in the script.
- Added change not to CHANGELOG.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>