### PR TITLE
Fuzz: Add edit option

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- An option to edit the selected message - note this will clear any defined fuzz locations
+
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandler.java
@@ -128,7 +128,7 @@ public class HttpFuzzerHandler implements FuzzerHandler<HttpMessage, HttpFuzzer>
         fuzzDialogue.dispose();
 
         return createFuzzer(
-                message,
+                (HttpMessage) fuzzDialogue.getMessage(),
                 fuzzDialogue.getFuzzLocations(),
                 fuzzDialogue.getFuzzerOptions(),
                 fuzzDialogue.getFuzzerMessageProcessors());

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzMessagePanel.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzMessagePanel.java
@@ -19,13 +19,64 @@
  */
 package org.zaproxy.zap.extension.fuzz.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JButton;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.view.messagelocation.MessageLocationProducerFocusListener;
 import org.zaproxy.zap.view.messagelocation.SelectMessageLocationsPanel;
 
 public class FuzzMessagePanel extends SelectMessageLocationsPanel {
 
     private static final long serialVersionUID = -1511437565770653938L;
 
-    public FuzzMessagePanel() {
+    // Maintain a local copy of these so we can remove them when editing - this will prevent users
+    // from adding more fuzzer locations
+    private List<MessageLocationProducerFocusListener> focusListeners = new ArrayList<>();
+
+    public FuzzMessagePanel(FuzzerDialog<?, ?, ?> fuzzerDialog) {
         super();
+
+        JButton editButton =
+                new JButton(Constant.messages.getString("fuzz.fuzzer.dialog.button.edit"));
+        editButton.setToolTipText(
+                Constant.messages.getString("fuzz.fuzzer.dialog.button.edit.tooltip"));
+
+        editButton.addActionListener(
+                e -> {
+                    fuzzerDialog.setMessageEditable(!fuzzerDialog.isEditable());
+                    if (fuzzerDialog.isEditable()) {
+                        editButton.setText(
+                                Constant.messages.getString("fuzz.fuzzer.dialog.button.save"));
+                        editButton.setToolTipText(
+                                Constant.messages.getString(
+                                        "fuzz.fuzzer.dialog.button.save.tooltip"));
+                        for (MessageLocationProducerFocusListener fl : focusListeners) {
+                            super.removeFocusListener(fl);
+                        }
+                    } else {
+                        editButton.setText(
+                                Constant.messages.getString("fuzz.fuzzer.dialog.button.edit"));
+                        editButton.setToolTipText(
+                                Constant.messages.getString(
+                                        "fuzz.fuzzer.dialog.button.edit.tooltip"));
+                        for (MessageLocationProducerFocusListener fl : focusListeners) {
+                            super.addFocusListener(fl);
+                        }
+                    }
+                });
+        this.addOptions(editButton, OptionsLocation.END);
+    }
+
+    @Override
+    public void addFocusListener(MessageLocationProducerFocusListener fl) {
+        focusListeners.add(fl);
+        super.addFocusListener(fl);
+    }
+
+    @Override
+    public void removeFocusListener(MessageLocationProducerFocusListener fl) {
+        focusListeners.remove(fl);
+        super.removeFocusListener(fl);
     }
 }

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerDialog.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/impl/FuzzerDialog.java
@@ -34,6 +34,7 @@ import javax.swing.JSplitPane;
 import javax.swing.border.EtchedBorder;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.fuzz.ExtensionFuzz;
 import org.zaproxy.zap.extension.fuzz.FuzzerMessageProcessor;
 import org.zaproxy.zap.extension.fuzz.FuzzerOptions;
@@ -68,6 +69,8 @@ public class FuzzerDialog<
     private List<PayloadGeneratorMessageLocation<?>> fuzzLocations;
     private FuzzerMessageProcessorsTablePanel<M, FMP> fuzzerMessageProcessorsTablePanel;
 
+    private boolean isEditable;
+
     public FuzzerDialog(
             Frame owner,
             FuzzerOptions defaultOptions,
@@ -99,7 +102,8 @@ public class FuzzerDialog<
                                 .getNameDefaultPayloadGenerator());
 
         outgoingMessage = outgoing;
-        this.fuzzMessagePanel = new FuzzMessagePanel();
+        this.fuzzMessagePanel = new FuzzMessagePanel(this);
+
         if (outgoingMessage) {
             fuzzMessagePanel.addComponent(new RequestSplitComponent<>(), new ZapXmlConfiguration());
             HttpPanelManager.getInstance().addRequestPanel(fuzzMessagePanel);
@@ -131,6 +135,32 @@ public class FuzzerDialog<
                     new FuzzerMessageProcessorsTablePanel<>(this, message, fuzzerMessageProcessors);
             this.setCustomTabPanel(2, fuzzerMessageProcessorsTablePanel);
         }
+    }
+
+    protected boolean isEditable() {
+        return isEditable;
+    }
+
+    protected void setMessageEditable(boolean editable) {
+        isEditable = editable;
+        try {
+            if (editable) {
+                fuzzLocationsPanel.reset();
+            } else {
+                fuzzMessagePanel.saveData();
+            }
+            this.fuzzMessagePanel.setEditable(editable);
+
+        } catch (Exception e) {
+            View.getSingleton()
+                    .showWarningDialog(
+                            this,
+                            Constant.messages.getString("fuzz.fuzzer.dialog.warn.badmessage"));
+        }
+    }
+
+    public Message getMessage() {
+        return fuzzMessagePanel.getMessage();
     }
 
     private static void withExtensionFuzz(Consumer<ExtensionFuzz> consumer) {
@@ -253,6 +283,9 @@ public class FuzzerDialog<
 
     @Override
     public String validateFields() {
+        if (this.isEditable) {
+            return Constant.messages.getString("fuzz.fuzzer.dialog.warn.editMode");
+        }
         if (!fuzzLocationsPanel.hasLocations()) {
             return Constant.messages.getString("fuzz.fuzzer.dialog.warn.noFuzzLocations");
         }

--- a/addOns/fuzz/src/main/javahelp/org/zaproxy/zap/extension/fuzz/resources/help/contents/dialogue.html
+++ b/addOns/fuzz/src/main/javahelp/org/zaproxy/zap/extension/fuzz/resources/help/contents/dialogue.html
@@ -21,6 +21,11 @@ To configure the fuzzing:<br/>
 <li>The results will then be listed in the <a href="tab.html">Fuzzer tab</a> select them to see the full requests and responses.</li>
 </ul>
 You can also search for strings in the fuzz results using the 'Search tab'.
+<p>
+Click on the 'Edit' button to edit the message you have selected for fuzzing.
+Note that this will remove all of the fuzz locations that you have defined.
+<p>
+You will need to 'Save' the message before you can define new fuzz locations.
 
 <H3>Options tab</H3>
 This tab allows you to configure the options to be used when fuzzing. See the main <a href="options.html">options help</a> for more details.

--- a/addOns/fuzz/src/main/resources/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
+++ b/addOns/fuzz/src/main/resources/org/zaproxy/zap/extension/fuzz/resources/Messages.properties
@@ -84,7 +84,13 @@ fuzz.select.message.dialog.message.type.label = Message Type:
 
 fuzz.fuzzer.dialog.button.start = Start Fuzzer
 fuzz.fuzzer.dialog.button.reset = Reset
+fuzz.fuzzer.dialog.button.edit = Edit
+fuzz.fuzzer.dialog.button.edit.tooltip = Note that this will clear all of the fuzzer locations
+fuzz.fuzzer.dialog.button.save = Save
+fuzz.fuzzer.dialog.button.save.tooltip = You will need to Save before you can define any fuzzer locations
 
+fuzz.fuzzer.dialog.warn.badmessage = A valid message is required for fuzzing
+fuzz.fuzzer.dialog.warn.editMode = You must Save your message before fuzzing.\nYou will also need to define at least one new fuzz location.
 fuzz.fuzzer.dialog.warn.noFuzzLocations = No fuzz locations, at least one fuzz location must be added to start the fuzzer.
 fuzz.fuzzer.dialog.warn.noPayloadsSomeLocations = Some fuzz locations do not have any payload set.\nAt least one payload must be added to start the fuzzer.
 


### PR DESCRIPTION
Fixes https://github.com/zaproxy/zaproxy/issues/2315

This adds a new 'Edit' button to the Fuzz Dialog.
When clicked this changes to 'Save', makes the message editable and clears all fuzz locations. It also disabled the 'Add...' button so people cant add new fuzz locations in 'edit mode'.

<img width="968" alt="Screenshot 2022-01-14 at 12 23 04" src="https://user-images.githubusercontent.com/1081115/149516939-ba420aaf-f8fa-4a9c-8627-f39e2eb1db56.png">

It seems to work well with HTTP messages and WebSocket ones (although I've done less testing with those).

It would be better if we didnt have to remove the fuzz locations but in order to handle them we'd need to get edit events from the relevant text areas - this will be _very_ tricky without core changes.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>