### PR TITLE
graphql: reduce error messages in input vector

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Reduce printed errors messages in the script Input Vector.
 
 ## [0.7.0] - 2021-11-01
 ### Fixed

--- a/addOns/graphql/src/main/zapHomeFiles/scripts/scripts/variant/GraphQL Support.js
+++ b/addOns/graphql/src/main/zapHomeFiles/scripts/scripts/variant/GraphQL Support.js
@@ -11,13 +11,15 @@ function getQuery(msg){
 	
 	if (header.getMethod() == "POST") {
 		var contentTypeHeader = header.getHeader("Content-Type");
-		if (contentTypeHeader == null || contentTypeHeader.contains("application/json")) {
+		if (!body.isEmpty() && contentTypeHeader == null || contentTypeHeader.contains("application/json")) {
 			try{
 				var json = JSON.parse(body);
 				query = json.query;
 			}
 			catch(err){
-				print("Parsing message body failed: " + err.message);
+				if (contentTypeHeader != null) {
+					print("Parsing message body failed: " + err.message);
+				}
 				return null;
 			}
 		} else if (contentTypeHeader.contains("application/graphql")) {
@@ -39,7 +41,7 @@ function setQuery(msg, query){
 	
 	if (header.getMethod() == "POST") {
 		var contentTypeHeader = header.getHeader("Content-Type");
-		if (contentTypeHeader == null || contentTypeHeader.contains("application/json")) {
+		if (!body.isEmpty() && contentTypeHeader == null || contentTypeHeader.contains("application/json")) {
 			try{
 				var json = JSON.parse(body);
 				json.query = query;
@@ -47,7 +49,9 @@ function setQuery(msg, query){
 				msg.getRequestHeader().setContentLength(msg.getRequestBody().length());
 			}
 			catch(err){
-				print("Parsing message body failed: " + err.message);
+				if (contentTypeHeader != null) {
+					print("Parsing message body failed: " + err.message);
+				}
 			}
 		} else if (contentTypeHeader.contains("application/graphql")) {
 			msg.setRequestBody(query);


### PR DESCRIPTION
Do not attempt to parse empty content as JSON and do not print an error
message for unknown content type.

---
From OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/ZBMWInpSH94/m/qsck-NU2AwAJ