### PR TITLE
oast: test callback server

### DIFF
--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -81,7 +81,7 @@ public class ExtensionOast extends ExtensionAdaptor {
     @Override
     public void init() {
         boastService = new BoastService();
-        callbackService = new CallbackService();
+        callbackService = new CallbackService(OastRequest::create);
         interactshService = new InteractshService();
     }
 

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.oast.services.callback;
 
 import java.util.Date;
+import java.util.Objects;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -38,9 +39,12 @@ class CallbackProxyListener implements OverrideMessageProxyListener {
     private static final Logger LOGGER = LogManager.getLogger(CallbackProxyListener.class);
 
     private final CallbackService callbackService;
+    private final OastRequestFactory oastRequestFactory;
 
-    public CallbackProxyListener(CallbackService callbackService) {
-        this.callbackService = callbackService;
+    public CallbackProxyListener(
+            CallbackService callbackService, OastRequestFactory oastRequestFactory) {
+        this.callbackService = Objects.requireNonNull(callbackService);
+        this.oastRequestFactory = Objects.requireNonNull(oastRequestFactory);
     }
 
     @Override
@@ -86,7 +90,7 @@ class CallbackProxyListener implements OverrideMessageProxyListener {
     private void callbackReceivedHandler(String handler, HttpMessage httpMessage) {
         try {
             OastRequest request =
-                    OastRequest.create(
+                    oastRequestFactory.create(
                             httpMessage,
                             httpMessage.getRequestHeader().getSenderAddress().getHostAddress(),
                             handler);

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackService.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.oast.services.callback;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,9 +44,12 @@ public class CallbackService extends OastService implements OptionsChangedListen
 
     private static final Logger LOGGER = LogManager.getLogger(CallbackService.class);
 
-    public CallbackService() {
+    public CallbackService(OastRequestFactory oastRequestFactory) {
+        Objects.requireNonNull(oastRequestFactory);
+
         proxyServer = new ProxyServer("ZAP-CallbackService");
-        proxyServer.addOverrideMessageProxyListener(new CallbackProxyListener(this));
+        proxyServer.addOverrideMessageProxyListener(
+                new CallbackProxyListener(this, oastRequestFactory));
     }
 
     @Override

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/OastRequestFactory.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/OastRequestFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.oast.services.callback;
+
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.oast.OastRequest;
+
+public interface OastRequestFactory {
+
+    OastRequest create(HttpMessage httpMessage, String source, String handler)
+            throws HttpMalformedHeaderException, DatabaseException;
+}

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
@@ -1,0 +1,136 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.oast.services.callback;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.oast.ExtensionOast;
+import org.zaproxy.addon.oast.OastRequest;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/* Unit test for {@link CallbackProxyListener}. */
+class CallbackProxyListenerUnitTest extends TestUtils {
+
+    private static final String EXPECTED_RESPONSE_HEADER = "HTTP/1.1 200\r\n\r\n";
+
+    private HttpMessage message;
+    private InetAddress source;
+    private OastRequest oastRequest;
+    private OastRequestFactory oastRequestFactory;
+    private CallbackService callbackService;
+    private CallbackProxyListener listener;
+
+    @BeforeAll
+    static void setupAll() {
+        mockMessages(new ExtensionOast());
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        message = new HttpMessage(new HttpRequestHeader("GET /uuid HTTP/1.1\r\n"));
+        source = InetAddress.getLocalHost();
+        message.getRequestHeader().setSenderAddress(source);
+        oastRequest = mock(OastRequest.class);
+        oastRequestFactory = mock(OastRequestFactory.class, withSettings().lenient());
+        given(oastRequestFactory.create(any(), anyString(), anyString())).willReturn(oastRequest);
+        callbackService = mock(CallbackService.class);
+        listener = new CallbackProxyListener(callbackService, oastRequestFactory);
+    }
+
+    @Test
+    void shouldThrowForNullCallbackService() throws Exception {
+        // Given
+        CallbackService callbackService = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new CallbackProxyListener(callbackService, oastRequestFactory));
+    }
+
+    @Test
+    void shouldThrowForNullOastRequestFactory() throws Exception {
+        // Given
+        OastRequestFactory oastRequestFactory = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new CallbackProxyListener(callbackService, oastRequestFactory));
+    }
+
+    @Test
+    void shouldNotifyOfRequestReceivedForUnknownCallbackHandler() throws Exception {
+        // Given
+        long now = System.currentTimeMillis();
+        // When
+        boolean override = listener.onHttpRequestSend(message);
+        // Then
+        assertThat(override, is(equalTo(true)));
+        assertMessage(now);
+        verifyServiceAndFactory("No callback handler");
+    }
+
+    @Test
+    void shouldNotifyOfRequestReceivedForKnownCallbackHandler() throws Exception {
+        // Given
+        long now = System.currentTimeMillis();
+        String handler = "Known Handler";
+        Map<String, String> handlers = new HashMap<>();
+        handlers.put("uuid", handler);
+        given(callbackService.getHandlers()).willReturn(handlers);
+        // When
+        boolean override = listener.onHttpRequestSend(message);
+        // Then
+        assertThat(override, is(equalTo(true)));
+        assertMessage(now);
+        verifyServiceAndFactory(handler);
+    }
+
+    private void verifyServiceAndFactory(String handler) throws Exception {
+        verify(oastRequestFactory).create(message, source.getHostAddress(), handler);
+        verify(callbackService).handleOastRequest(oastRequest);
+    }
+
+    private void assertMessage(long time) {
+        assertThat(
+                message.getTimeSentMillis(),
+                is(allOf(greaterThanOrEqualTo(time), lessThanOrEqualTo(time + 1000L))));
+        assertThat(message.getResponseHeader().toString(), is(equalTo(EXPECTED_RESPONSE_HEADER)));
+    }
+}

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackServiceUnitTest.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackServiceUnitTest.java
@@ -1,0 +1,147 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.oast.services.callback;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.ConnectionParam;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.oast.ExtensionOast;
+import org.zaproxy.addon.oast.OastRequest;
+import org.zaproxy.addon.oast.OastRequestHandler;
+import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link CallbackService}. */
+class CallbackServiceUnitTest extends TestUtils {
+
+    private int serverPort;
+    private OastRequestHandler oastRequestHandler;
+    private OastRequest oastRequest;
+    private HttpSender httpSender;
+    private CallbackService callbackService;
+
+    @BeforeAll
+    static void setupAll() {
+        mockMessages(new ExtensionOast());
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        httpSender = new HttpSender(new ConnectionParam(), false, 0);
+
+        oastRequest = mock(OastRequest.class);
+        OastRequestFactory oastRequestFactory =
+                mock(OastRequestFactory.class, withSettings().lenient());
+        given(oastRequestFactory.create(any(), anyString(), anyString())).willReturn(oastRequest);
+        oastRequestHandler = mock(OastRequestHandler.class);
+
+        callbackService = new CallbackService(oastRequestFactory);
+        callbackService.getParam().load(new ZapXmlConfiguration());
+        serverPort = getRandomPort();
+        callbackService.getParam().setPort(serverPort);
+        callbackService.addOastRequestHandler(oastRequestHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        this.callbackService.stopService();
+    }
+
+    @Test
+    void shouldThrowForNullOastRequestFactory() throws Exception {
+        // Given
+        OastRequestFactory oastRequestFactory = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new CallbackService(oastRequestFactory));
+    }
+
+    @Test
+    void shouldStartServerOnSpecifiedPort() throws Exception {
+        // Given
+        callbackService.startService();
+        HttpMessage serverRequest = createServerRequest("/");
+        // When
+        httpSender.sendAndReceive(serverRequest);
+        // Then
+        verify(oastRequestHandler).handle(oastRequest);
+    }
+
+    @Test
+    void shouldStartServerOnRandomPort() throws Exception {
+        // Given
+        callbackService.getParam().setPort(0);
+        callbackService.startService();
+        serverPort = callbackService.getPort();
+        HttpMessage serverRequest = createServerRequest("/");
+        // When
+        httpSender.sendAndReceive(serverRequest);
+        // Then
+        verify(oastRequestHandler).handle(oastRequest);
+    }
+
+    @Test
+    void shouldStopServer() throws Exception {
+        // Given
+        callbackService.startService();
+        HttpMessage serverRequest = createServerRequest("/");
+        // When
+        httpSender.sendAndReceive(serverRequest);
+        callbackService.stopService();
+        // Then
+        assertThrows(IOException.class, () -> httpSender.sendAndReceive(serverRequest));
+        verify(oastRequestHandler).handle(oastRequest);
+    }
+
+    @Test
+    void shouldRestartServer() throws Exception {
+        // Given
+        callbackService.startService();
+        HttpMessage serverRequest = createServerRequest("/");
+        // When
+        httpSender.sendAndReceive(serverRequest);
+        callbackService.stopService();
+        assertThrows(IOException.class, () -> httpSender.sendAndReceive(serverRequest));
+        callbackService.startService();
+        httpSender.sendAndReceive(serverRequest);
+        // Then
+        verify(oastRequestHandler, times(2)).handle(oastRequest);
+    }
+
+    private HttpMessage createServerRequest(String path) throws Exception {
+        return new HttpMessage(
+                new HttpRequestHeader(
+                        "GET " + path + " HTTP/1.1\r\nHost: 127.0.0.1:" + serverPort));
+    }
+}

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/TestUtils.java
@@ -168,7 +168,7 @@ public abstract class TestUtils {
         nano.start();
     }
 
-    private static int getRandomPort() throws IOException {
+    protected static int getRandomPort() throws IOException {
         try (ServerSocket server = new ServerSocket(0)) {
             return server.getLocalPort();
         }


### PR DESCRIPTION
Add tests to test the callback server, make it safer to verify the
replacement of the server implementation.