### PR TITLE
oast: close callback connections gracefully

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Close callback connections gracefully.
+- Maintenance changes.
 
 ## [0.8.0] - 2022-01-10
 ### Changed

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
@@ -19,7 +19,6 @@
  */
 package org.zaproxy.addon.oast.services.callback;
 
-import java.util.Date;
 import java.util.Objects;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
@@ -37,6 +36,11 @@ import org.zaproxy.zap.utils.ThreadUtils;
 class CallbackProxyListener implements OverrideMessageProxyListener {
 
     private static final Logger LOGGER = LogManager.getLogger(CallbackProxyListener.class);
+    private static final String RESPONSE_HEADER =
+            HttpHeader.HTTP11
+                    + " "
+                    + HttpStatusCode.OK
+                    + "\r\nContent-Length: 0\r\nConnection: close";
 
     private final CallbackService callbackService;
     private final OastRequestFactory oastRequestFactory;
@@ -60,15 +64,14 @@ class CallbackProxyListener implements OverrideMessageProxyListener {
     @Override
     public boolean onHttpRequestSend(HttpMessage msg) {
         try {
-            msg.setTimeSentMillis(new Date().getTime());
-            String url = msg.getRequestHeader().getURI().toString();
+            msg.setTimeSentMillis(System.currentTimeMillis());
             String path = msg.getRequestHeader().getURI().getPath();
             LOGGER.debug(
                     "Callback received for URL : {} path : {} from {}",
-                    url,
+                    msg.getRequestHeader().getURI(),
                     path,
                     msg.getRequestHeader().getSenderAddress());
-            msg.setResponseHeader(HttpHeader.HTTP11 + " " + HttpStatusCode.OK);
+            msg.setResponseHeader(RESPONSE_HEADER);
             String uuid = path.substring(1);
             String handler = callbackService.getHandlers().get(uuid);
             if (handler != null) {

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
@@ -48,7 +48,8 @@ import org.zaproxy.zap.testutils.TestUtils;
 /* Unit test for {@link CallbackProxyListener}. */
 class CallbackProxyListenerUnitTest extends TestUtils {
 
-    private static final String EXPECTED_RESPONSE_HEADER = "HTTP/1.1 200\r\n\r\n";
+    private static final String EXPECTED_RESPONSE_HEADER =
+            "HTTP/1.1 200\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
 
     private HttpMessage message;
     private InetAddress source;


### PR DESCRIPTION
Change the response to indicate that it contains an empty body and that
the connection will be closed, instead of waiting for a timeout.

Minor tweaks:
 - Extract a constant for the response header;
 - Do not use a Date to get the current time in milliseconds;
 - Let the URI be converted to string when logging.

Update the expected response header in the tests.