### PR TITLE
Updating Hidden File detector for SVN

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Hidden File Finder scan rule, content checking has been added for .svn/entries as well as detection for wc.db.
 
 ## [39] - 2021-12-13
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/zapHomeFiles/json/hidden_files.json
+++ b/addOns/ascanrulesBeta/src/main/zapHomeFiles/json/hidden_files.json
@@ -35,6 +35,14 @@
     },
     {
       "path":".svn/entries",
+      "content":["FILE","DIR"],
+      "links":["https://www.oreilly.com/library/view/version-control-with/9780596510336/ch08s02s01.html"],
+      "type":"svn_dir",
+      "source":"snallygaster"
+    },
+    {
+      "path":".svn/wc.db",
+      "content":["SQLite"],
       "links":["https://www.oreilly.com/library/view/version-control-with/9780596510336/ch08s02s01.html"],
       "type":"svn_dir",
       "source":"snallygaster"


### PR DESCRIPTION
Signed-off-by: Scott Gerlach <scott.gerlach@stackhawk.com>

Resolved some false positives for the .svn/entries detector triggering on HTML content AND adds the new wc.db file for newer versions of SVN.