### PR TITLE
websocket: reset threads' name returned to pool

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Update the reference links used in the Username IDOR passive scan script.
+- Reset the name of the connection threads when not actively used.
 
 ## [24] - 2021-10-06
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketListener.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketListener.java
@@ -89,6 +89,8 @@ public class WebSocketListener implements Runnable {
 
             // close the other listener too
             wsProxy.shutdown();
+
+            Thread.currentThread().setName("ZAP-WS-Listener (pool)");
         }
     }
 


### PR DESCRIPTION
Reset the name of the threads when not actively used, keeping the name
of the closed WebSocket channel is misleading.