### PR TITLE
feat: spider: Add spider add-on with SVG href parsing

### DIFF
--- a/addOns/spider/CHANGELOG.md
+++ b/addOns/spider/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this add-on will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+### Added
+- Functionality to parse URLs from href attributes in SVG files (Issue 4984).

--- a/addOns/spider/gradle.properties
+++ b/addOns/spider/gradle.properties
@@ -1,0 +1,2 @@
+version=0.1.0
+release=false

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -1,0 +1,15 @@
+description = "Add supplemental parsing functionality to the spider."
+
+zapAddOn {
+    addOnName.set("Spider")
+    zapVersion.set("2.11.1")
+
+    manifest {
+        author.set("ZAP Dev Team")
+        url.set("https://www.zaproxy.org/docs/desktop/addons/spider/")
+    }
+}
+
+dependencies {
+    testImplementation(project(":testutils"))
+}

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
@@ -1,0 +1,83 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.spider.parser.SpiderParser;
+
+public class ExtensionSpider2 extends ExtensionAdaptor {
+    public static final String NAME = "ExtensionSpider2";
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionSpider2.class);
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(Arrays.asList(ExtensionSpider.class));
+
+    private SpiderParser svgHrefSpider;
+
+    public ExtensionSpider2() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        ExtensionSpider spider = getExtensionSpider();
+        svgHrefSpider = new SvgHrefSpider();
+        spider.addCustomParser(svgHrefSpider);
+        LOGGER.debug("Added custom SVG HREF spider.");
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void unload() {
+        getExtensionSpider().removeCustomParser(svgHrefSpider);
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("spider.addon.desc");
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("spider.addon.name");
+    }
+
+    private ExtensionSpider getExtensionSpider() {
+        return Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
+    }
+}

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SvgHrefSpider.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SvgHrefSpider.java
@@ -1,0 +1,162 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import net.htmlparser.jericho.Source;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXParseException;
+import org.zaproxy.zap.spider.parser.SpiderParser;
+import org.zaproxy.zap.utils.XmlUtils;
+
+public class SvgHrefSpider extends SpiderParser {
+    private static final Logger LOGGER = LogManager.getLogger(SvgHrefSpider.class);
+    private static final Pattern PATTERN_SVG_EXTENSION =
+            Pattern.compile("\\.svg\\z", Pattern.CASE_INSENSITIVE);
+    private static final String HREF_EXPRESSION = "//*[@href or @HREF]";
+    private static final String[] ATTRIBUTE_NAMES = {"href", "HREF", "xlink:href", "XLINK:HREF"};
+
+    private static XPathExpression xpathHrefExpression;
+
+    static {
+        try {
+            XPath xpath = XPathFactory.newInstance().newXPath();
+            xpathHrefExpression = xpath.compile(HREF_EXPRESSION);
+        } catch (XPathExpressionException e) {
+            LOGGER.error(e);
+        }
+    }
+
+    private static DocumentBuilder documentBuilder;
+
+    static {
+        try {
+            documentBuilder = XmlUtils.newXxeDisabledDocumentBuilderFactory().newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            LOGGER.warn("An error occurred while getting the DocumentBuilder", e);
+        }
+    }
+
+    @Override
+    public boolean parseResource(HttpMessage message, Source source, int depth) {
+        String baseUrl = message.getRequestHeader().getURI().toString();
+        LOGGER.debug("SVG Spider attempting to parse {}", baseUrl);
+
+        try {
+            synchronized (documentBuilder) {
+                Document xmldoc =
+                        documentBuilder.parse(
+                                new InputSource(
+                                        new ByteArrayInputStream(
+                                                message.getResponseBody().getBytes())));
+                NodeList hrefNodes =
+                        (NodeList) xpathHrefExpression.evaluate(xmldoc, XPathConstants.NODESET);
+                if (hrefNodes.getLength() > 0) {
+                    processNodeList(hrefNodes, message, depth, baseUrl);
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        } catch (SAXParseException spe) {
+            if (spe.getMessage().contains("DOCTYPE is disallowed")) {
+                LOGGER.debug(
+                        "Skipping {} due to XXE safety and DOCTYPE declaration present.", baseUrl);
+            } else {
+                LOGGER.warn("An error occurred trying to parse {}", baseUrl, spe);
+            }
+            return false;
+        } catch (Exception e) {
+            LOGGER.warn("An error occurred trying to parse {}", baseUrl, e);
+            return false;
+        }
+    }
+
+    private void processNodeList(NodeList nodes, HttpMessage message, int depth, String baseUrl) {
+        LOGGER.debug(
+                "Identified {} nodes with href attribute from: {}", nodes.getLength(), baseUrl);
+        for (int i = 0; i < nodes.getLength(); i++) {
+            String extractedUrl = extractUrl(nodes.item(i));
+            if (!extractedUrl.isEmpty()) {
+                URI newUri = null;
+                try {
+                    newUri = new URI(baseUrl).resolve(extractedUrl);
+                } catch (URISyntaxException e) {
+                    LOGGER.warn(
+                            "Failed to resolve extracted URL: {} against base URL: {})",
+                            extractedUrl,
+                            baseUrl);
+                }
+                LOGGER.debug("Resolved URL: {} from: {}", newUri, baseUrl);
+                if (newUri != null && newUri.isAbsolute()) {
+                    processURL(message, depth, extractedUrl, baseUrl);
+                }
+            }
+        }
+    }
+
+    private String extractUrl(Node node) {
+        String extractedUrl = "";
+        for (String attributeName : ATTRIBUTE_NAMES) {
+            try {
+                extractedUrl = node.getAttributes().getNamedItem(attributeName).getNodeValue();
+                if (!extractedUrl.isEmpty()) {
+                    break;
+                }
+            } catch (NullPointerException npe) {
+                // ignore
+            }
+        }
+        return extractedUrl;
+    }
+
+    @Override
+    public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
+        return isSvg(message);
+    }
+
+    private boolean isSvg(HttpMessage msg) {
+        if (msg.getResponseHeader().hasContentType("svg")) {
+            return true;
+        }
+
+        String path = msg.getRequestHeader().getURI().getEscapedPath();
+        if (path != null) {
+            return PATTERN_SVG_EXTENSION.matcher(path).find();
+        }
+        return false;
+    }
+}

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/intro.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/intro.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>
+Spider
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Spider</H1>
+Spider add-on, which adds parsing functionality to ZAP's spider. Currently this includes:
+
+<ul>
+  <li>URLs from <code>href</code> attributes in SVG files.</li>
+</ul>
+
+</BODY>
+</HTML>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/helpset.hs
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/helpset.hs
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE helpset
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp HelpSet Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/helpset_2_0.dtd">
+<helpset version="2.0" xml:lang="en-GB">
+  <title>Spider Add-On</title>
+
+  <maps>
+     <homeID>spider</homeID>
+     <mapref location="map.jhm"/>
+  </maps>
+
+  <view>
+    <name>TOC</name>
+    <label>Contents</label>
+    <type>org.zaproxy.zap.extension.help.ZapTocView</type>
+    <data>toc.xml</data>
+  </view>
+
+  <view>
+    <name>Index</name>
+    <label>Index</label>
+    <type>javax.help.IndexView</type>
+    <data>index.xml</data>
+  </view>
+
+  <view>
+    <name>Search</name>
+    <label>Search</label>
+    <type>javax.help.SearchView</type>
+    <data engine="com.sun.java.help.search.DefaultSearchEngine">
+      JavaHelpSearch
+    </data>
+  </view>
+
+  <view>
+    <name>Favorites</name>
+    <label>Favorites</label>
+    <type>javax.help.FavoritesView</type>
+  </view>
+</helpset>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/index.xml
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/index.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE index
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Index Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/index_2_0.dtd">
+
+<index version="2.0">
+    <indexitem text="Spider" target="spider" />
+</index>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/map.jhm
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/map.jhm
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE map
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp Map Version 1.0//EN"
+         "http://java.sun.com/products/javahelp/map_1_0.dtd">
+
+<map version="1.0">
+    <mapID target="spider" url="contents/intro.html" />
+</map>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/toc.xml
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/toc.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE toc
+  PUBLIC "-//Sun Microsystems Inc.//DTD JavaHelp TOC Version 2.0//EN"
+         "http://java.sun.com/products/javahelp/toc_2_0.dtd">
+
+<toc version="2.0">
+    <tocitem text="ZAP User Guide" tocid="toplevelitem">
+        <tocitem text="Add Ons" tocid="addons">
+            <tocitem text="Spider" target="spider"/>
+        </tocitem>
+    </tocitem>
+</toc>

--- a/addOns/spider/src/main/resources/org/zaproxy/addon/spider/resources/Messages.properties
+++ b/addOns/spider/src/main/resources/org/zaproxy/addon/spider/resources/Messages.properties
@@ -1,0 +1,2 @@
+spider.addon.name = Spider Extension
+spider.addon.desc = Adds parsing functionality to ZAP's spider, such as URLs from href attributes in SVG files.

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/SvgHrefSpiderUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/SvgHrefSpiderUnitTest.java
@@ -1,0 +1,212 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.htmlparser.jericho.Source;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+
+class SvgHrefSpiderUnitTest {
+
+    private static final String SVG_CONTENT_TYPE = "image/svg+xml";
+    private static final String XML_CONTENT_TYPE = "text/xml";
+
+    SvgHrefSpider shs;
+
+    @BeforeEach
+    void setup() {
+        shs = new SvgHrefSpider();
+    }
+
+    @Test
+    void shouldBeAbleToParseRelevantRequest() {
+        // Given
+        HttpMessage msg = createMessage("test.svg");
+        // When
+        boolean canParse = shs.canParseResource(msg, "", false);
+        // Then
+        assertTrue(canParse);
+    }
+
+    @Test
+    void shouldNotBeAbleToParseIrrelevantRequest() {
+        // Given
+        HttpMessage msg = createMessage("test.test");
+        // When
+        boolean canParse = shs.canParseResource(msg, "", false);
+        // Then
+        assertFalse(canParse);
+    }
+
+    @Test
+    void shouldBeAbleToParseRelevantResponse() {
+        // Given
+        HttpMessage msg = createMessage("svgimage");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, SVG_CONTENT_TYPE);
+        // When
+        boolean canParse = shs.canParseResource(msg, "", false);
+        // Then
+        assertTrue(canParse);
+    }
+
+    @Test
+    void shouldNotBeAbleToParseIrrelevantResponse() {
+        // Given
+        HttpMessage msg = createMessage("test.xml");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, XML_CONTENT_TYPE);
+        // When
+        boolean canParse = shs.canParseResource(msg, "", false);
+        // Then
+        assertFalse(canParse);
+    }
+
+    @Test
+    void shouldNotParseResourceWhenNotSvg() {
+        // Given
+        HttpMessage msg = createMessage("test");
+        msg.setResponseBody("Foo Bar");
+        // When
+        boolean parse = shs.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertFalse(parse);
+    }
+
+    @Test
+    void shouldNotParseResourceWhenNoHrefInSvg() {
+        // Given
+        HttpMessage msg = createMessage("test.svg");
+        msg.setResponseBody(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                        + "<svg width=\"5cm\" height=\"3cm\" viewBox=\"0 0 5 3\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n"
+                        + "  <rect x=\".01\" y=\".01\" width=\"4.98\" height=\"2.98\" fill=\"none\" stroke=\"blue\" stroke-width=\".03\"/>\n"
+                        + "</svg>");
+        // When
+        boolean parse = shs.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertFalse(parse);
+    }
+
+    @Test
+    void shouldNotParseResourceWhenSaxParseExceptionEncountered() {
+        // Given
+        HttpMessage msg = createMessage("test.svg");
+        msg.setResponseBody(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                        + "<svg width=\"5cm\" height=\"3cm\" viewBox=\"0 0 5 3\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n"
+                        + "  <rect x=\".01\" y=\".01\" width=\"4.98\" height=\"2.98\" fill=\"none\" stroke=\"blue\" stroke-width=\".03\"/>\n"
+                        // The following line produces a SAXParseException other than the DOCTYPE
+                        // issue tested elsewhere due to the ampersand outside of a CDATA block
+                        + "<text x=\"20\" y=\"35\" class=\"small\">Test & Text</text>"
+                        + "</svg>");
+        // When
+        boolean parse = shs.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertFalse(parse);
+    }
+
+    @Test
+    void shouldNotParseResourceWithDoctypeDeclaration() {
+        // Given
+        HttpMessage msg = createMessage("test.svg");
+        msg.setResponseBody(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                        + "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n"
+                        + "<svg width=\"5cm\" height=\"3cm\" viewBox=\"0 0 5 3\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n"
+                        + "  <rect x=\".01\" y=\".01\" width=\"4.98\" height=\"2.98\" fill=\"none\" stroke=\"blue\" stroke-width=\".03\"/>\n"
+                        + "  <a HREF=\"http://www.w3.org\">\n"
+                        + "    <ellipse cx=\"2.5\" cy=\"1.5\" rx=\"2\" ry=\"1\" fill=\"red\"/>\n"
+                        + "  </a>"
+                        + "</svg>");
+        // When
+        boolean parse = shs.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertFalse(parse);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"href", "HREF", "xlink:href", "XLINK:HREF"})
+    void shouldParseValidResourceWithHref(String elementName) {
+        // Given
+        HttpMessage msg = createMessage("test.svg");
+        msg.setResponseBody(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                        + "<svg width=\"5cm\" height=\"3cm\" viewBox=\"0 0 5 3\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n"
+                        + "  <rect x=\".01\" y=\".01\" width=\"4.98\" height=\"2.98\" fill=\"none\" stroke=\"blue\" stroke-width=\".03\"/>\n"
+                        + "  <a "
+                        + elementName
+                        + "=\"http://www.w3.org\">\n"
+                        + "    <ellipse cx=\"2.5\" cy=\"1.5\" rx=\"2\" ry=\"1\" fill=\"red\"/>\n"
+                        + "  </a>"
+                        + "</svg>");
+        // When
+        boolean parse = shs.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertTrue(parse);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http://www.w3.org/", "test.html", "test", "/test"})
+    void shouldParseValidResourceWithVariousUrls(String url) {
+        // Given
+        HttpMessage msg = createMessage("test.svg");
+        msg.setResponseBody(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                        + "<svg width=\"5cm\" height=\"3cm\" viewBox=\"0 0 5 3\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\">\n"
+                        + "  <rect x=\".01\" y=\".01\" width=\"4.98\" height=\"2.98\" fill=\"none\" stroke=\"blue\" stroke-width=\".03\"/>\n"
+                        + "  <a href=\""
+                        + url
+                        + "\">\n"
+                        + "    <ellipse cx=\"2.5\" cy=\"1.5\" rx=\"2\" ry=\"1\" fill=\"red\"/>\n"
+                        + "  </a>"
+                        + "</svg>");
+        // When
+        boolean parse = shs.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertTrue(parse);
+    }
+
+    private HttpMessage createMessage(String path) {
+        HttpMessage msg = new HttpMessage();
+        try {
+            msg.setRequestHeader("GET http://www.example.com/" + path + " HTTP/1.1");
+        } catch (HttpMalformedHeaderException e) {
+            // ignore
+        }
+
+        try {
+            msg.setResponseHeader(
+                    "HTTP/1.1 200 OK\r\n"
+                            + "Content-Length: "
+                            + msg.getResponseBody().length()
+                            + "\r\n");
+        } catch (HttpMalformedHeaderException e) {
+            // ignore
+        }
+        return msg;
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -76,6 +76,7 @@ var addOns = listOf(
     "sequence",
     "simpleexample",
     "soap",
+    "spider",
     "spiderAjax",
     "sqliplugin",
     "sse",


### PR DESCRIPTION
Fixes zaproxy/zaproxy#4984

Initial addition of spider add-on with support for parsing HREFs from SVGs.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>