### PR TITLE
sse: properly close server side connections

### DIFF
--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 
+### Fixed
+ - Properly close the server side connection when no longer in use (Issue 6424).
+
 ## [10] - 2021-10-07
 ### Added
 - Add info and repo URLs.

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamListener.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamListener.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.zaproxy.zap.ZapGetMethod;
 
 public class EventStreamListener implements Runnable {
 
@@ -30,10 +31,12 @@ public class EventStreamListener implements Runnable {
 
     private EventStreamProxy proxy;
     private BufferedReader reader;
+    private ZapGetMethod method;
 
-    public EventStreamListener(EventStreamProxy proxy, BufferedReader reader) {
+    public EventStreamListener(EventStreamProxy proxy, BufferedReader reader, ZapGetMethod method) {
         this.proxy = proxy;
         this.reader = reader;
+        this.method = method;
     }
 
     @Override
@@ -71,6 +74,6 @@ public class EventStreamListener implements Runnable {
     }
 
     public void close() throws IOException {
-        reader.close();
+        method.abort();
     }
 }

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamProxy.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/EventStreamProxy.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.ZapGetMethod;
 import org.zaproxy.zap.extension.sse.db.ServerSentEventStream;
 
 public class EventStreamProxy {
@@ -69,11 +70,15 @@ public class EventStreamProxy {
 
     private ServerSentEventStream dataStreamObject;
 
-    public EventStreamProxy(HttpMessage message, BufferedReader reader, BufferedWriter writer) {
+    public EventStreamProxy(
+            HttpMessage message,
+            BufferedReader reader,
+            BufferedWriter writer,
+            ZapGetMethod method) {
         //		this.message = message;
         this.writer = writer;
 
-        listener = new EventStreamListener(this, reader);
+        listener = new EventStreamListener(this, reader, method);
 
         HttpRequestHeader reqHeader = message.getRequestHeader();
 
@@ -97,7 +102,7 @@ public class EventStreamProxy {
 
     public void start() {
         // TODO use thread pool
-        (new Thread(listener)).start();
+        (new Thread(listener, "ZAP-SSE-Listener")).start();
         notifyStateObservers(State.OPEN);
     }
 

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ExtensionServerSentEvents.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ExtensionServerSentEvents.java
@@ -196,13 +196,17 @@ public class ExtensionServerSentEvents extends ExtensionAdaptor
      * @param msg Contains request & response headers.
      * @param remoteReader Content arrives continuously and is forwarded to local client.
      * @param localWriter Received content is written here.
+     * @param method the method used to establish the connection.
      */
     public void addEventStream(
-            HttpMessage msg, final InputStream remoteReader, final OutputStream localWriter) {
+            HttpMessage msg,
+            final InputStream remoteReader,
+            final OutputStream localWriter,
+            ZapGetMethod method) {
         BufferedReader reader = new BufferedReader(new InputStreamReader(remoteReader, charset));
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(localWriter, charset));
 
-        EventStreamProxy proxy = new EventStreamProxy(msg, reader, writer);
+        EventStreamProxy proxy = new EventStreamProxy(msg, reader, writer, method);
         synchronized (observers) {
             for (EventStreamObserver observer : observers) {
                 proxy.addObserver(observer);
@@ -237,7 +241,7 @@ public class ExtensionServerSentEvents extends ExtensionAdaptor
                     inSocket.setTcpNoDelay(true);
                     inSocket.setKeepAlive(true);
 
-                    addEventStream(httpMessage, inputStream, inSocket.getOutputStream());
+                    addEventStream(httpMessage, inputStream, inSocket.getOutputStream(), method);
                 } catch (IOException e) {
                     logger.warn(e.getMessage(), e);
                     keepSocketOpen = false;

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamListenerUnitTest.java
@@ -38,6 +38,7 @@ import org.mockito.InOrder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
+import org.zaproxy.zap.ZapGetMethod;
 
 /** Unit test for {@link EventStreamListener}. */
 @ExtendWith(MockitoExtension.class)
@@ -51,8 +52,9 @@ class EventStreamListenerUnitTest {
         // When
         BufferedReader readerMock = getReaderMockForStream(prepareEventStreamLines(event1));
         EventStreamProxy proxyMock = mock(EventStreamProxy.class);
+        ZapGetMethod method = mock(ZapGetMethod.class);
 
-        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock);
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, method);
         listener.run();
 
         // Then
@@ -71,8 +73,9 @@ class EventStreamListenerUnitTest {
         BufferedReader readerMock =
                 getReaderMockForStream(prepareEventStreamLines(event1, event2, event3, event4));
         EventStreamProxy proxyMock = mock(EventStreamProxy.class);
+        ZapGetMethod method = mock(ZapGetMethod.class);
 
-        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock);
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, method);
         listener.run();
 
         // Then
@@ -91,8 +94,9 @@ class EventStreamListenerUnitTest {
         // When
         BufferedReader readerMock = getReaderMockForStream(prepareEventStreamLines(event1));
         EventStreamProxy proxyMock = mock(EventStreamProxy.class);
+        ZapGetMethod method = mock(ZapGetMethod.class);
 
-        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock);
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, method);
         listener.run();
 
         // Then
@@ -109,8 +113,9 @@ class EventStreamListenerUnitTest {
         // When
         BufferedReader readerMock = getReaderMockForStream(streamLines);
         EventStreamProxy proxyMock = mock(EventStreamProxy.class);
+        ZapGetMethod method = mock(ZapGetMethod.class);
 
-        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock);
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, method);
         listener.run();
 
         // Then
@@ -126,12 +131,26 @@ class EventStreamListenerUnitTest {
         // When
         BufferedReader readerMock = getReaderMockForStream(streamLines);
         EventStreamProxy proxyMock = mock(EventStreamProxy.class);
+        ZapGetMethod method = mock(ZapGetMethod.class);
 
-        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock);
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, method);
         listener.run();
 
         // Then
         verify(proxyMock, times(1)).processEvent("");
+    }
+
+    @Test
+    void shouldAbortMethodWhenClosing() throws IOException {
+        // Given
+        EventStreamProxy proxyMock = mock(EventStreamProxy.class);
+        BufferedReader readerMock = mock(BufferedReader.class);
+        ZapGetMethod method = mock(ZapGetMethod.class);
+        EventStreamListener listener = new EventStreamListener(proxyMock, readerMock, method);
+        // When
+        listener.close();
+        // Then
+        verify(method).abort();
     }
 
     /**

--- a/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
+++ b/addOns/sse/src/test/java/org/zaproxy/zap/extension/sse/EventStreamProxyUnitTest.java
@@ -54,7 +54,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
     void shouldForwardEventWhenAllObserversReturnTrue() throws IOException {
         // Given
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // create mock observer
         EventStreamObserver mockObserver = mock(EventStreamObserver.class);
@@ -72,7 +72,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
     void shouldNotForwardEventWhenAtLeastOneObserverReturnsFalse() throws IOException {
         // Given
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // create mock observer
         EventStreamObserver mockObserver = mock(EventStreamObserver.class);
@@ -90,7 +90,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
     void shouldForwardEventWithoutObservers() throws IOException {
         // Given
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         proxy.processEvent("data:blub");
@@ -105,7 +105,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         final String data = "blub";
         final String eventStream = "data:" + data;
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -122,7 +122,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "data: YHOO\ndata: +2\ndata: 10";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -136,7 +136,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = ": test stream";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -150,7 +150,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "data: first event\nid: 2";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -166,7 +166,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "data:second event\nid";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -181,7 +181,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "data:  third event";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -195,7 +195,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "data";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -210,7 +210,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "data\ndata";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -225,7 +225,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "event: server-time\ndata: 1357651178";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);
@@ -240,7 +240,7 @@ class EventStreamProxyUnitTest extends BaseEventStreamTest {
         // Given
         final String eventStream = "retry: 10000";
         BufferedWriter writer = mock(BufferedWriter.class);
-        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer);
+        EventStreamProxy proxy = new EventStreamProxy(getMockHttpMessage(), null, writer, null);
 
         // When
         ServerSentEvent event = proxy.processEvent(eventStream);


### PR DESCRIPTION
Use the method to abort the connection instead of closing the stream
directly, the latter might try read more data (and block) when closing.
Name the thread used for listening for events.

Fix zaproxy/zaproxy#6424.