### PR TITLE
Updating PathTraversal error checking to be case-insensitive

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed 
+- Path Traversal scan rule, updated the regex for case 5 to be case-insensitive when searching for Error or Exception in content body.
 
 
 ## [44] - 2022-01-13

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -473,7 +473,7 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                 }
 
                 // do some pattern matching on the results.
-                Pattern errorPattern = Pattern.compile("Exception|Error");
+                Pattern errorPattern = Pattern.compile("Exception|Error", Pattern.CASE_INSENSITIVE);
                 Matcher errorMatcher = errorPattern.matcher(msg.getResponseBody().toString());
 
                 String urlfilename = msg.getRequestHeader().getURI().getName();

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRuleUnitTest.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
@@ -274,14 +275,15 @@ class PathTraversalScanRuleUnitTest extends ActiveScannerTest<PathTraversalScanR
         assertThat(alertsRaised, hasSize(0));
     }
 
-    @Test
-    void shouldNotAlertOnCheckFiveAtLowThresholdUnderInvalidConditions()
+    @ParameterizedTest
+    @ValueSource(strings = {"error", "Error"})
+    void shouldNotAlertOnCheckFiveAtLowThresholdUnderInvalidConditions(String errorText)
             throws HttpMalformedHeaderException {
         // Given
         String path = "/file.ext";
         HttpMessage msg = getHttpMessage(path + "?p=a");
         rule.init(msg, parent);
-        nano.addHandler(new Check5Handler(path, "p", "Error", true));
+        nano.addHandler(new Check5Handler(path, "p", errorText, true));
         rule.setAlertThreshold(AlertThreshold.LOW);
         // When
         rule.scan();


### PR DESCRIPTION
Resolves false positive cases where "error" or "exception" appears in the content body and is not detected because of case sensitivity in the RegEx. Case-insensitive search for error messages.

Signed-off-by: Scott Gerlach <scott.gerlach@stackhawk.com>