### PR TITLE
fix: pscanrulesAlpha: SRI False Positive on link rel=canonical

### DIFF
--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 
+### Fixed
+- False positive condition from Sub Resource Integrity Attribute Missing scan rule when rel=canonical is used (Issue 7040).
+
 ## [35] - 2021-12-01
 ### Changed
 - Maintenance changes.

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRule.java
@@ -168,6 +168,7 @@ public class SubResourceIntegrityAttributeScanRule extends PluginPassiveScanner 
         return element -> {
             Optional<String> maybeHostname = SupportedElements.getHost(element, origin);
             return element.getAttributeValue("integrity") == null
+                    && !"canonical".equalsIgnoreCase(element.getAttributeValue("rel"))
                     && !maybeHostname.map(hostname -> hostname.matches(origin)).orElse(false);
         };
     }

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/SubResourceIntegrityAttributeScanRuleUnitTest.java
@@ -107,6 +107,22 @@ class SubResourceIntegrityAttributeScanRuleUnitTest
     }
 
     @Test
+    void shouldNotRaiseAlertGivenCanonicalAttributeIsPresentInLinkElement()
+            throws HttpMalformedHeaderException {
+        // Given
+        // From https://www.w3.org/TR/SRI/#use-casesexamples
+        HttpMessage msg =
+                buildMessage(
+                        "<html><head><link href=\"https://dev.example.net/style.css\"\n"
+                                + "rel=\"canonical\"\n"
+                                + "      ></head><body></body></html>");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
+    }
+
+    @Test
     void shouldNotRaiseAlertGivenIntegrityAttributeIsPresentInScriptElement()
             throws HttpMalformedHeaderException {
         // Given


### PR DESCRIPTION
- CHANGELOG > Added fix note.
- SubResourceIntegrityAttributeScanRule > Add functionality to skip tags where rel=canonical is set.
- SubResourceIntegrityAttributeScanRuleUnitTest > Add test method to assert the new behavior.

Fixes zaproxy/zaproxy#7040.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>