### PR TITLE
fix: ascanrulesBeta: Cloud Metadata scan rule address possible FPs

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Hidden File Finder scan rule, content checking has been added for .svn/entries as well as detection for wc.db.
 
+### Fixed
+- Adapted Cloud Metadata Attack scan rule to use Custom Pages and active scan analyzer to help reduce false positives in certain cases (Issue 7033).
+
 ## [39] - 2021-12-13
 ### Changed
 - Update minimum ZAP version to 2.11.1.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
@@ -40,7 +40,6 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpMethodHelper;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
-import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.ZapGetMethod;
 import org.zaproxy.zap.users.User;
@@ -119,8 +118,7 @@ public class CloudMetadataScanRule extends AbstractHostPlugin {
         try {
             newRequest.getRequestHeader().getURI().setPath(METADATA_PATH);
             this.sendMessageWithCustomHostHeader(newRequest, METADATA_HOST);
-            if (HttpStatusCode.isSuccess(newRequest.getResponseHeader().getStatusCode())
-                    && newRequest.getResponseBody().length() > 0) {
+            if (isSuccess(newRequest) && newRequest.getResponseBody().length() > 0) {
                 this.raiseAlert(newRequest);
             }
         } catch (Exception e) {


### PR DESCRIPTION
- CHANGELOG > Added change note.
- CloudMetadataScanRule > Switched from status code attack to checking
the whole message for success state which includes (Custom Pages, Analyser, etc).

Fixes zaproxy/zaproxy#7033.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>