### PR TITLE
ascanrulesAlpha: Update OOB XSS Rule

### DIFF
--- a/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
+++ b/addOns/ascanrulesAlpha/src/main/resources/org/zaproxy/zap/extension/ascanrulesAlpha/resources/Messages.properties
@@ -63,4 +63,5 @@ ascanalpha.log4shell.cve45046.desc=It was found that the fix to address CVE-2021
 ascanalpha.log4shell.cve45046.soln=Upgrade Log4j2 to version 2.17.1 or newer.
 ascanalpha.log4shell.cve45046.refs=https://www.cve.org/CVERecord?id=CVE-2021-45046\nhttps://www.lunasec.io/docs/blog/log4j-zero-day/\nhttps://nvd.nist.gov/vuln/detail/CVE-2021-45046
 
-ascanalpha.oobxss.name = Out of Band XSS
+ascanalpha.oobxss.name=Out of Band XSS
+ascanalpha.oobxss.skipped=no Active Scan OAST service is selected.


### PR DESCRIPTION
As discussed on IRC,
- Skip the rule if oast is not available or no active scan
  oast service is selected.
- Catch IO Exceptions in loops so that all attacks are made.

Signed-off-by: ricekot <github@ricekot.com>