### PR TITLE
network: set request attributes when decoding

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal;
+
+import io.netty.util.AttributeKey;
+import java.net.InetSocketAddress;
+
+/** Common attributes for a channel. */
+public final class ChannelAttributes {
+
+    private ChannelAttributes() {}
+
+    /** The attribute that contains the remote address. */
+    public static final AttributeKey<InetSocketAddress> REMOTE_ADDRESS =
+            AttributeKey.newInstance("zap.remote-address");
+
+    /** The attribute that indicates if a channel was upgraded to use the SSL/TLS protocol. */
+    public static final AttributeKey<Boolean> TLS_UPGRADED =
+            AttributeKey.newInstance("zap.tls-upgraded");
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpResponseDecoder.java
@@ -20,12 +20,20 @@
 package org.zaproxy.addon.network.internal.codec;
 
 import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
 
 /** Decodes HTTP response into a {@link HttpMessage}. */
 public class HttpResponseDecoder extends HttpMessageDecoder {
 
     /** Constructs a {@code HttpResponseDecoder}. */
     public HttpResponseDecoder() {
-        super(false, HttpMessage::getResponseHeader, HttpMessage::getResponseBody);
+        super(
+                false,
+                (ctx, msg, content) -> {
+                    HttpResponseHeader header = msg.getResponseHeader();
+                    header.setMessage(content);
+                    return header;
+                },
+                HttpMessage::getResponseBody);
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpRequestDecoderUnitTest.java
@@ -20,19 +20,33 @@
 package org.zaproxy.addon.network.internal.codec;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.net.InetSocketAddress;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.network.HttpBody;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.internal.ChannelAttributes;
 
 /** Unit test for {@link HttpRequestDecoder}. */
 class HttpRequestDecoderUnitTest extends HttpMessageDecoderUnitTest {
+
+    private static final InetSocketAddress SENDER_ADDRESS =
+            new InetSocketAddress("127.0.0.1", 1234);
+
+    @BeforeEach
+    void setUpAttributes() {
+        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(SENDER_ADDRESS);
+        channel.attr(ChannelAttributes.TLS_UPGRADED).set(Boolean.FALSE);
+    }
 
     @Override
     protected HttpRequestDecoder createDecoder() {
@@ -98,6 +112,79 @@ class HttpRequestDecoderUnitTest extends HttpMessageDecoderUnitTest {
         HttpMessage message = channel.readInbound();
         assertThat(message, is(notNullValue()));
         assertThat(extractBody(message).toString(), is(equalTo("")));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldBeSecureIfTlsUpgraded() {
+        // Given
+        channel.attr(ChannelAttributes.TLS_UPGRADED).set(Boolean.TRUE);
+        String content = "GET / HTTP/1.1\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getRequestHeader().isSecure(), is(equalTo(true)));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldNotBeSecureIfNotTlsUpgraded() {
+        // Given
+        channel.attr(ChannelAttributes.TLS_UPGRADED).set(Boolean.FALSE);
+        String content = "GET / HTTP/1.1\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getRequestHeader().isSecure(), is(equalTo(false)));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldProduceMessageWithExceptionForNullTlsUpgraded() {
+        // Given
+        channel.attr(ChannelAttributes.TLS_UPGRADED).set(null);
+        String content = "GET / HTTP/1.1\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(NullPointerException.class)));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldHaveSenderAddress() {
+        // Given
+        InetSocketAddress senderAddress = new InetSocketAddress("127.0.0.3", 1234);
+        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(senderAddress);
+        String content = "GET / HTTP/1.1\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(
+                message.getRequestHeader().getSenderAddress(),
+                is(equalTo(senderAddress.getAddress())));
+        assertChannelState();
+    }
+
+    @Test
+    void shouldProduceMessageWithExceptionForNullRemoteAddress() {
+        // Given
+        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(null);
+        String content = "GET / HTTP/1.1\r\n\r\n";
+        // When
+        written(content, true);
+        // Then
+        HttpMessage message = channel.readInbound();
+        assertThat(message, is(notNullValue()));
+        assertThat(message.getUserObject(), is(instanceOf(NullPointerException.class)));
         assertChannelState();
     }
 }


### PR DESCRIPTION
Set the sender address and if it is secure (using TLS) when decoding
the request, using attributes set on the channel.