### PR TITLE
network: add helper handlers

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -38,8 +38,9 @@ crowdin {
 }
 
 dependencies {
-    val nettyVersion = "4.1.70.Final"
+    val nettyVersion = "4.1.73.Final"
     implementation("io.netty:netty-codec:$nettyVersion")
+    implementation("io.netty:netty-handler:$nettyVersion")
 
     val bcVersion = "1.69"
     bouncyCastle("org.bouncycastle:bcmail-jdk15on:$bcVersion")

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ChannelGroupHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ChannelGroupHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.group.ChannelGroup;
+import java.util.Objects;
+
+/**
+ * A handler that adds an activated channel to a {@link ChannelGroup}.
+ *
+ * <p>The handler removes itself after adding the channel.
+ */
+public class ChannelGroupHandler extends ChannelInboundHandlerAdapter {
+
+    private final ChannelGroup channelGroup;
+
+    /**
+     * Constructs a {@code ChannelGroupHandler} with the given channel group.
+     *
+     * @param channelGroup the channel group to where to add the activated channels.
+     * @throws NullPointerException if the given {@code channelGroup} is {@code null}.
+     */
+    public ChannelGroupHandler(ChannelGroup channelGroup) {
+        this.channelGroup = Objects.requireNonNull(channelGroup);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        channelGroup.add(ctx.channel());
+        super.channelActive(ctx);
+        ctx.pipeline().remove(ctx.name());
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ReadTimeoutHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ReadTimeoutHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.handler.timeout.ReadTimeoutException;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Handles read timeouts.
+ *
+ * <p>Fires a {@link ReadTimeoutException} when a timeout occurs.
+ */
+public class ReadTimeoutHandler extends IdleStateHandler {
+
+    /**
+     * Constructs a {@code ReadTimeoutHandler} with the given timeout and unit.
+     *
+     * @param timeout the value to timeout.
+     * @param unit the time unit.
+     * @throws IllegalArgumentException if the timeout is less or equal to zero.
+     * @throws NullPointerException if the given {@code unit} is {@code null}.
+     */
+    public ReadTimeoutHandler(int timeout, TimeUnit unit) {
+        super(validate(timeout), 0, 0, Objects.requireNonNull(unit));
+    }
+
+    private static int validate(int timeout) {
+        if (timeout <= 0) {
+            throw new IllegalArgumentException("The timeout value must be greater than 0.");
+        }
+        return timeout;
+    }
+
+    @Override
+    protected final void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt)
+            throws Exception {
+        ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
@@ -1,0 +1,103 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.timeout.ReadTimeoutException;
+import javax.net.ssl.SSLHandshakeException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.security.MissingRootCertificateException;
+import org.zaproxy.addon.network.internal.cert.GenerationException;
+
+/**
+ * Handles exceptions caught in the pipeline.
+ *
+ * <p>Logs the cause appropriately and closes the connection.
+ */
+@Sharable
+public class ServerExceptionHandler extends ChannelInboundHandlerAdapter {
+
+    private static final Logger LOGGER = LogManager.getLogger(ServerExceptionHandler.class);
+
+    private static final ServerExceptionHandler INSTANCE = new ServerExceptionHandler();
+
+    /**
+     * Gets the instance of this handler.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static ServerExceptionHandler getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+        logCause(cause);
+        ctx.close();
+    }
+
+    private static void logCause(Throwable cause) {
+        if (cause instanceof ReadTimeoutException) {
+            LOGGER.debug("Timed out while reading message.");
+            return;
+        }
+
+        if (cause instanceof HttpMalformedHeaderException) {
+            LOGGER.warn("Received malformed header: {}", cause.getMessage());
+            return;
+        }
+
+        if (!(cause instanceof DecoderException)) {
+            LOGGER.error(cause);
+            return;
+        }
+
+        Throwable nestedCause = cause.getCause();
+        if (nestedCause == null) {
+            LOGGER.error(cause);
+            return;
+        }
+
+        if (nestedCause instanceof SSLHandshakeException) {
+            LOGGER.warn(
+                    "Failed while establishing secure connection, cause: {}",
+                    cause.getCause().getMessage());
+            return;
+        }
+
+        if (nestedCause instanceof GenerationException
+                || nestedCause instanceof MissingRootCertificateException) {
+            LOGGER.warn("Failed while creating certificate, cause: {}", nestedCause.getMessage());
+            return;
+        }
+
+        LOGGER.error(nestedCause);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/TestLogAppender.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/TestLogAppender.java
@@ -34,14 +34,18 @@ public class TestLogAppender extends AbstractAppender {
 
     private final Consumer<String> logConsumer;
 
-    TestLogAppender(Consumer<String> logConsumer) {
+    public TestLogAppender(Consumer<String> logConsumer) {
+        this("%m%n", logConsumer);
+    }
+
+    public TestLogAppender(String pattern, Consumer<String> logConsumer) {
         super(
                 "TestLogAppender",
                 null,
                 PatternLayout.newBuilder()
                         .withDisableAnsi(true)
                         .withCharset(StandardCharsets.UTF_8)
-                        .withPattern("%m%n")
+                        .withPattern(pattern)
                         .build(),
                 true,
                 NO_PROPERTIES);

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ChannelGroupHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ChannelGroupHandlerUnitTest.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.group.ChannelGroup;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link ChannelGroupHandler}. */
+class ChannelGroupHandlerUnitTest {
+
+    private ChannelGroup channelGroup;
+
+    @BeforeEach
+    void setUp() {
+        channelGroup = mock(ChannelGroup.class);
+    }
+
+    @Test
+    void shouldThrowIfChannelGroupIsNull() throws Exception {
+        // Given
+        ChannelGroup channelGroup = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new ChannelGroupHandler(channelGroup));
+    }
+
+    @Test
+    void shouldAddActivatedChannelToGroup() throws Exception {
+        // Given
+        ChannelGroupHandler channelGroupHandler = new ChannelGroupHandler(channelGroup);
+        // When
+        EmbeddedChannel channel = new EmbeddedChannel(channelGroupHandler);
+        // Then
+        verify(channelGroup).add(channel);
+    }
+
+    @Test
+    void shouldRemoveItselfFromPipeline() throws Exception {
+        // Given
+        ChannelGroupHandler channelGroupHandler = new ChannelGroupHandler(channelGroup);
+        // When
+        EmbeddedChannel channel = new EmbeddedChannel(channelGroupHandler);
+        // Then
+        assertThat(channel.pipeline().get(ChannelGroupHandler.class), is(nullValue()));
+    }
+
+    @Test
+    void shouldNotifyNextHandlerChannelActivated() throws Exception {
+        // Given
+        ChannelGroupHandler channelGroupHandler = new ChannelGroupHandler(channelGroup);
+        ChannelInboundHandler nextHandler = mock(ChannelInboundHandler.class);
+        // When
+        new EmbeddedChannel(channelGroupHandler, nextHandler);
+        // Then
+        verify(nextHandler).channelActive(any());
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ReadTimeoutHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ReadTimeoutHandlerUnitTest.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.timeout.ReadTimeoutException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit test for {@link ReadTimeoutHandler}. */
+class ReadTimeoutHandlerUnitTest {
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0})
+    void shouldThrowIfInvalidTimeout(int timeout) throws Exception {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new ReadTimeoutHandler(timeout, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void shouldThrowIfUnitIsNull() throws Exception {
+        // Given
+        TimeUnit unit = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new ReadTimeoutHandler(1, unit));
+    }
+
+    @Test
+    void shouldTimeoutAfterSpecifiedValue() throws Exception {
+        // Given
+        int millis = 250;
+        ReadTimeoutHandler readTimeoutHandler =
+                new ReadTimeoutHandler(millis, TimeUnit.MILLISECONDS);
+        ChannelInboundHandler nextHandler = mock(ChannelInboundHandler.class);
+        // When
+        EmbeddedChannel channel = new EmbeddedChannel(readTimeoutHandler, nextHandler);
+        Thread.sleep(millis * 2);
+        channel.runPendingTasks();
+        // Then
+        verify(nextHandler).exceptionCaught(any(), eq(ReadTimeoutException.INSTANCE));
+    }
+
+    @Test
+    void shouldKeepInPipelineAfterTimeout() throws Exception {
+        // Given
+        int millis = 250;
+        ReadTimeoutHandler readTimeoutHandler =
+                new ReadTimeoutHandler(millis, TimeUnit.MILLISECONDS);
+        ChannelInboundHandler nextHandler = mock(ChannelInboundHandler.class);
+        // When
+        EmbeddedChannel channel = new EmbeddedChannel(readTimeoutHandler, nextHandler);
+        Thread.sleep(millis * 2);
+        channel.runPendingTasks();
+        // Then
+        assertThat(channel.pipeline().get(ReadTimeoutHandler.class), is(notNullValue()));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
@@ -1,0 +1,197 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.timeout.ReadTimeoutException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.net.ssl.SSLHandshakeException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.security.MissingRootCertificateException;
+import org.zaproxy.addon.network.TestLogAppender;
+import org.zaproxy.addon.network.internal.cert.GenerationException;
+
+/** Unit test for {@link ServerExceptionHandler}. */
+class ServerExceptionHandlerUnitTest {
+
+    static {
+        // Force initialisation of Netty classes to have clean log events later.
+        ReadTimeoutException.INSTANCE.getCause();
+    }
+
+    private ChannelHandlerContext ctx;
+    private List<String> logEvents;
+    private ServerExceptionHandler serverExceptionHandler = ServerExceptionHandler.getInstance();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ctx = mock(ChannelHandlerContext.class);
+        logEvents = registerLogEvents();
+    }
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        Configurator.reconfigure(getClass().getResource("/log4j2-test.properties").toURI());
+    }
+
+    @Test
+    void shouldBeSharable() {
+        assertThat(serverExceptionHandler.isSharable(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldCloseChannelOnCaughtException() throws Exception {
+        // Given
+        Exception exception = new Exception();
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        verify(ctx).close();
+    }
+
+    @Test
+    void shouldLogReadTimeoutAsDebug() throws Exception {
+        // Given
+        Exception exception = ReadTimeoutException.INSTANCE;
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(logEvents, contains(startsWith("DEBUG Timed out while reading")));
+    }
+
+    @Test
+    void shouldLogSslHandshakeExceptionAsWarn() throws Exception {
+        // Given
+        Exception cause = new SSLHandshakeException("missing protocol");
+        Exception exception = new DecoderException(cause);
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                contains(
+                        startsWith(
+                                "WARN Failed while establishing secure connection, cause: missing protocol")));
+    }
+
+    @Test
+    void shouldLogGenerationExceptionAsWarn() throws Exception {
+        // Given
+        Exception cause = new GenerationException(new Exception("Cause"));
+        Exception exception = new DecoderException(cause);
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                contains(
+                        startsWith(
+                                "WARN Failed while creating certificate, cause: java.lang.Exception: Cause")));
+    }
+
+    @Test
+    void shouldLogMissingRootCertificateExceptionAsWarn() throws Exception {
+        // Given
+        Exception cause = new MissingRootCertificateException("No Root CA cert");
+        Exception exception = new DecoderException(cause);
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                contains(
+                        startsWith(
+                                "WARN Failed while creating certificate, cause: No Root CA cert")));
+    }
+
+    @Test
+    void shouldLogGenericDecoderExceptionAsError() throws Exception {
+        // Given
+        Exception exception = new DecoderException("Decoder Exception");
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                contains(
+                        startsWith(
+                                "ERROR io.netty.handler.codec.DecoderException: Decoder Exception")));
+    }
+
+    @Test
+    void shouldLogUnknownDecoderExceptionCauseAsError() throws Exception {
+        // Given
+        Exception cause = new Exception("Unknown Cause");
+        Exception exception = new DecoderException(cause);
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(logEvents, contains(startsWith("ERROR java.lang.Exception: Unknown Cause")));
+    }
+
+    @Test
+    void shouldLogHttpMalformedHeaderExceptionAsWarn() throws Exception {
+        // Given
+        Exception exception = new HttpMalformedHeaderException("Missing xyz");
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(logEvents, contains(startsWith("WARN Received malformed header: Missing xyz")));
+    }
+
+    @Test
+    void shouldLogGenericExceptionAsError() throws Exception {
+        // Given
+        Exception exception = new Exception();
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(logEvents, contains(startsWith("ERROR java.lang.Exception")));
+    }
+
+    private static List<String> registerLogEvents() {
+        List<String> logEvents = new ArrayList<>();
+        TestLogAppender logAppender = new TestLogAppender("%p %m%n", logEvents::add);
+        LoggerContext context = LoggerContext.getContext();
+        LoggerConfig rootLoggerconfig = context.getConfiguration().getRootLogger();
+        rootLoggerconfig.getAppenders().values().forEach(context.getRootLogger()::removeAppender);
+        rootLoggerconfig.addAppender(logAppender, null, null);
+        rootLoggerconfig.setLevel(Level.ALL);
+        context.updateLoggers();
+        return logEvents;
+    }
+}


### PR DESCRIPTION
Add handlers to:
 - Keep track of activated channels;
 - Produce read timeouts;
 - Handle exceptions in the pipeline.

Update Netty and add required dependency.