### PR TITLE
websocket: address exception on manual reconnect

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update the reference links used in the Username IDOR passive scan script.
 - Reset the name of the connection threads when not actively used.
 
+### Fixed
+- Fix exception when manually reconnecting to the server.
+
 ## [24] - 2021-10-06
 ### Changed
 - Now using 2.10 logging infrastructure (Log4j 2.x).

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketEventPublisher.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/WebSocketEventPublisher.java
@@ -77,7 +77,7 @@ public final class WebSocketEventPublisher implements EventPublisher, WebSocketS
     @Override
     public void onMessageFrame(int channelId, WebSocketMessage message, Initiator initiator) {
         WebSocketProxy proxy = extension.getWebSocketProxy(channelId);
-        if (proxy.isAllowAPI()) {
+        if (proxy != null && proxy.isAllowAPI()) {
             // Sending an event on an API message will cause an infinite loop
             return;
         }


### PR DESCRIPTION
Check if the proxy exists when checking if it serves the API, it might
not exist if manually reconnecting to the server.