### PR TITLE
network: tweak exception handler

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.timeout.ReadTimeoutException;
+import java.io.IOException;
 import javax.net.ssl.SSLHandshakeException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -74,14 +75,19 @@ public class ServerExceptionHandler extends ChannelInboundHandlerAdapter {
             return;
         }
 
+        if (cause instanceof IOException) {
+            LOGGER.debug(cause, cause);
+            return;
+        }
+
         if (!(cause instanceof DecoderException)) {
-            LOGGER.error(cause);
+            LOGGER.error(cause, cause);
             return;
         }
 
         Throwable nestedCause = cause.getCause();
         if (nestedCause == null) {
-            LOGGER.error(cause);
+            LOGGER.error(cause, cause);
             return;
         }
 
@@ -98,6 +104,6 @@ public class ServerExceptionHandler extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        LOGGER.error(nestedCause);
+        LOGGER.error(nestedCause, nestedCause);
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.timeout.ReadTimeoutException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLHandshakeException;
@@ -171,6 +172,18 @@ class ServerExceptionHandlerUnitTest {
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
         assertThat(logEvents, contains(startsWith("WARN Received malformed header: Missing xyz")));
+    }
+
+    @Test
+    void shouldLogIoExceptionAsDebug() throws Exception {
+        // Given
+        Exception exception = new IOException("Connection reset by peer");
+        // When
+        serverExceptionHandler.exceptionCaught(ctx, exception);
+        // Then
+        assertThat(
+                logEvents,
+                contains(startsWith("DEBUG java.io.IOException: Connection reset by peer")));
     }
 
     @Test


### PR DESCRIPTION
Handle `IOException` and log them as debug, these are expected to
happen.
Include the stack trace when logging errors.