### PR TITLE
network: do not timeout while processing message

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
@@ -52,4 +52,8 @@ public final class ChannelAttributes {
     /** The attribute that indicates if a channel is set to passthrough the data. */
     public static final AttributeKey<Boolean> PASSTHROUGH =
             AttributeKey.newInstance("zap.passthrough");
+
+    /** The attribute that indicates if a message is still being processed. */
+    public static final AttributeKey<Boolean> PROCESSING_MESSAGE =
+            AttributeKey.newInstance("zap.processing-message");
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ReadTimeoutHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ReadTimeoutHandler.java
@@ -25,11 +25,13 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.timeout.ReadTimeoutException;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import org.zaproxy.addon.network.internal.ChannelAttributes;
 
 /**
  * Handles read timeouts.
  *
- * <p>Fires a {@link ReadTimeoutException} when a timeout occurs.
+ * <p>Fires a {@link ReadTimeoutException} when a timeout occurs and if no message is being
+ * processed, as indicated by {@link ChannelAttributes#PROCESSING_MESSAGE}.
  */
 public class ReadTimeoutHandler extends IdleStateHandler {
 
@@ -55,6 +57,8 @@ public class ReadTimeoutHandler extends IdleStateHandler {
     @Override
     protected final void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt)
             throws Exception {
-        ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+        if (!ctx.channel().attr(ChannelAttributes.PROCESSING_MESSAGE).get()) {
+            ctx.fireExceptionCaught(ReadTimeoutException.INSTANCE);
+        }
     }
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
@@ -43,9 +43,16 @@ import org.zaproxy.addon.network.server.Server;
  * The base server.
  *
  * <p>Provides basic functionality, allows to be started and stopped, and initialise the child
- * channels. It also adds the following channel attributes: {@link ChannelAttributes#LOCAL_ADDRESS},
- * {@link ChannelAttributes#REMOTE_ADDRESS}, and {@link ChannelAttributes#TLS_UPGRADED} (always
- * {@code false}).
+ * channels.
+ *
+ * <p>It also adds the following channel attributes:
+ *
+ * <ul>
+ *   <li>{@link ChannelAttributes#LOCAL_ADDRESS};
+ *   <li>{@link ChannelAttributes#REMOTE_ADDRESS};
+ *   <li>{@link ChannelAttributes#TLS_UPGRADED} (always {@code false});
+ *   <li>{@link ChannelAttributes#PROCESSING_MESSAGE} (always {@code false}).
+ * </ul>
  */
 public class BaseServer implements Server {
 
@@ -135,6 +142,7 @@ public class BaseServer implements Server {
             ch.attr(ChannelAttributes.LOCAL_ADDRESS).set(ch.localAddress());
             ch.attr(ChannelAttributes.REMOTE_ADDRESS).set(ch.remoteAddress());
             ch.attr(ChannelAttributes.TLS_UPGRADED).set(Boolean.FALSE);
+            ch.attr(ChannelAttributes.PROCESSING_MESSAGE).set(Boolean.FALSE);
 
             ch.pipeline().addLast(new ChannelGroupHandler(allChannels));
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
@@ -247,6 +247,20 @@ class BaseServerUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldAddProcessingMessageAttributeToChannel() throws Exception {
+        // Given
+        createServer(
+                ch -> {
+                    assertChannelAttribute(ch, ChannelAttributes.PROCESSING_MESSAGE, Boolean.FALSE);
+                    initDefaultChannel(ch);
+                });
+        int port = getRandomPort();
+        server.start(port);
+        // When / Then
+        client.send(port, "Message");
+    }
+
+    @Test
     void shouldStartServerOnSpecifiedPort() throws Exception {
         // Given
         int port = getRandomPort();


### PR DESCRIPTION
Add attribute to indicate if a message is still being processed to
ignore the timeouts and update timeout handler accordingly.
Change the base server to set the attribute.