### PR TITLE
network: add recursive handler

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -47,6 +47,11 @@ dependencies {
     bouncyCastle("org.bouncycastle:bcprov-jdk15on:$bcVersion")
     bouncyCastle("org.bouncycastle:bcpkix-jdk15on:$bcVersion")
 
+    implementation("org.jitsi:ice4j:3.0-24-g34c2ce5") {
+        // Don't need its dependencies, for now.
+        setTransitive(false)
+    }
+
     testImplementation(project(":testutils"))
     testImplementation("org.apache.logging.log4j:log4j-core:2.17.1")
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
@@ -23,6 +23,7 @@ import io.netty.util.AttributeKey;
 import java.net.InetSocketAddress;
 import org.parosproxy.paros.security.SslCertificateService;
 import org.zaproxy.addon.network.internal.handlers.TlsConfig;
+import org.zaproxy.addon.network.internal.server.ServerConfig;
 
 /** Common attributes for a channel. */
 public final class ChannelAttributes {
@@ -56,4 +57,15 @@ public final class ChannelAttributes {
     /** The attribute that indicates if a message is still being processed. */
     public static final AttributeKey<Boolean> PROCESSING_MESSAGE =
             AttributeKey.newInstance("zap.processing-message");
+
+    /**
+     * The attribute that indicates if a message is for the server itself, thus recursive if
+     * forwarded.
+     */
+    public static final AttributeKey<Boolean> RECURSIVE_MESSAGE =
+            AttributeKey.newInstance("zap.recursive-message");
+
+    /** The attribute that contains the server configuration that the channel belongs to. */
+    public static final AttributeKey<ServerConfig> SERVER_CONFIG =
+            AttributeKey.newInstance("zap.server-config");
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/RecursiveRequestHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/RecursiveRequestHandler.java
@@ -1,0 +1,243 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Arrays;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.ice4j.TransportAddress;
+import org.ice4j.ice.harvest.AwsCandidateHarvester;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.network.internal.ChannelAttributes;
+import org.zaproxy.addon.network.internal.server.ServerConfig;
+
+/**
+ * A handler that checks if a HTTP request is a request to the server itself, thus recursive if
+ * forwarded.
+ *
+ * <p>Sets the attribute {@link ChannelAttributes#RECURSIVE_MESSAGE} accordingly.
+ *
+ * @see #getInstance()
+ */
+@Sharable
+public class RecursiveRequestHandler extends SimpleChannelInboundHandler<HttpMessage> {
+
+    private static final Logger LOGGER = LogManager.getLogger(RecursiveRequestHandler.class);
+
+    private static final RecursiveRequestHandler INSTANCE = new RecursiveRequestHandler();
+
+    /**
+     * Gets the instance of this handler.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static RecursiveRequestHandler getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Used to obtain the public address of an AWS EC2 instance.
+     *
+     * <p>Lazily initialised.
+     *
+     * @see #getAwsCandidateHarvester()
+     * @see #isOwnPublicAddress(ServerConfig, InetAddress)
+     */
+    private static AwsCandidateHarvester awsCandidateHarvester;
+
+    @Override
+    public boolean isSharable() {
+        return true;
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, HttpMessage msg) throws Exception {
+        if (msg.getUserObject() instanceof Exception) {
+            throw (Exception) msg.getUserObject();
+        }
+
+        Channel channel = ctx.channel();
+        boolean recursive = false;
+        if (!HttpRequestHeader.CONNECT.equals(msg.getRequestHeader().getMethod())) {
+            ServerConfig serverConfig = channel.attr(ChannelAttributes.SERVER_CONFIG).get();
+            InetSocketAddress localInetAddress =
+                    channel.attr(ChannelAttributes.LOCAL_ADDRESS).get();
+            recursive = isRecursive(serverConfig, localInetAddress, msg.getRequestHeader());
+        }
+        channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).set(recursive);
+
+        ctx.fireChannelRead(msg);
+    }
+
+    /**
+     * Tells whether or not the given {@code header} has a request to the server itself.
+     *
+     * <p>The request is to the server itself if one of the following conditions are met:
+     *
+     * <ol>
+     *   <li>The requested domain is one of the server aliases, regardless of the port.
+     *   <li>The requested address and port are the ones that the server is bound to.
+     * </ol>
+     *
+     * @param serverConfig the server configuration.
+     * @param localInetAddress the address of the server.
+     * @param header the request that will be checked.
+     * @return {@code true} if it is a request to the server itself, {@code false} otherwise.
+     * @see #isProxyAddress(InetAddress)
+     */
+    private static boolean isRecursive(
+            ServerConfig serverConfig,
+            InetSocketAddress localInetAddress,
+            HttpRequestHeader header) {
+        try {
+            String targetDomain = header.getHostName();
+            if (serverConfig.getAliases().contains(targetDomain)) {
+                return true;
+            }
+
+            if (header.getHostPort() == localInetAddress.getPort()
+                    && isServerAddress(
+                            InetAddress.getByName(targetDomain),
+                            serverConfig,
+                            localInetAddress.getAddress())) {
+                return true;
+            }
+        } catch (Exception e) {
+            LOGGER.warn(e.getMessage(), e);
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given {@code address} is one of address(es) the server is bound to.
+     *
+     * <p>If the server is bound to any address it checks whether the given {@code address} is a
+     * local address or if it belongs to a network interface. If not bound to any address, it checks
+     * if it's the one it is bound to.
+     *
+     * @param address the address that will be checked.
+     * @param serverConfig the server configuration.
+     * @param serverAddress the address of the server.
+     * @return {@code true} if it is one of the addresses the srever is bound to, {@code false}
+     *     otherwise.
+     * @see #isLocalAddress(InetAddress)
+     * @see #isNetworkInterfaceAddress(InetAddress)
+     */
+    private static boolean isServerAddress(
+            InetAddress address, ServerConfig serverConfig, InetAddress serverAddress) {
+        if (serverConfig.isAnyLocalAddress()) {
+            if (isLocalAddress(address)
+                    || isNetworkInterfaceAddress(address)
+                    || isOwnPublicAddress(serverConfig, address)) {
+                return true;
+            }
+        } else if (address.equals(serverAddress)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given {@code address} is a loopback, a site local, or any local
+     * address.
+     *
+     * @param address the address that will be checked
+     * @return {@code true} if the address is loopback, site local, or any local address, {@code
+     *     false} otherwise.
+     * @see InetAddress#isLoopbackAddress()
+     * @see InetAddress#isSiteLocalAddress()
+     * @see InetAddress#isAnyLocalAddress()
+     */
+    private static boolean isLocalAddress(InetAddress address) {
+        return address.isLoopbackAddress()
+                || address.isSiteLocalAddress()
+                || address.isAnyLocalAddress();
+    }
+
+    /**
+     * Tells whether or not the given {@code address} belongs to any of the network interfaces.
+     *
+     * @param address the address that will be checked.
+     * @return {@code true} if the address belongs to any of the network interfaces, {@code false}
+     *     otherwise.
+     * @see NetworkInterface#getByInetAddress(InetAddress)
+     */
+    private static boolean isNetworkInterfaceAddress(InetAddress address) {
+        try {
+            if (NetworkInterface.getByInetAddress(address) != null) {
+                return true;
+            }
+        } catch (SocketException e) {
+            LOGGER.warn("Failed to check if an address is from a network interface:", e);
+        }
+        return false;
+    }
+
+    /**
+     * Tells whether or not the given {@code address} is a public address of the host, when behind
+     * NAT.
+     *
+     * <p>Returns {@code false} if the server is not behind NAT.
+     *
+     * <p><strong>Implementation Note:</strong> Only AWS EC2 NAT detection is supported, by
+     * requesting the public IP address from <a href=
+     * "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#working-with-ip-addresses">
+     * AWS EC2 instance's metadata</a>.
+     *
+     * @param serverConfig the server configuration.
+     * @param address the address that will be checked.
+     * @return {@code true} if the address is public address of the host, {@code false} otherwise.
+     * @see ServerConfig#isBehindNat()
+     */
+    private static boolean isOwnPublicAddress(ServerConfig serverConfig, InetAddress address) {
+        if (!serverConfig.isBehindNat()) {
+            return false;
+        }
+
+        // Support just AWS for now.
+        TransportAddress publicAddress = getAwsCandidateHarvester().getMask();
+        if (publicAddress == null) {
+            return false;
+        }
+        return Arrays.equals(address.getAddress(), publicAddress.getAddress().getAddress());
+    }
+
+    private static AwsCandidateHarvester getAwsCandidateHarvester() {
+        if (awsCandidateHarvester == null) {
+            createAwsCandidateHarvester();
+        }
+        return awsCandidateHarvester;
+    }
+
+    private static synchronized void createAwsCandidateHarvester() {
+        if (awsCandidateHarvester == null) {
+            awsCandidateHarvester = new AwsCandidateHarvester();
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
@@ -51,7 +51,8 @@ import org.zaproxy.addon.network.server.Server;
  *   <li>{@link ChannelAttributes#LOCAL_ADDRESS};
  *   <li>{@link ChannelAttributes#REMOTE_ADDRESS};
  *   <li>{@link ChannelAttributes#TLS_UPGRADED} (always {@code false});
- *   <li>{@link ChannelAttributes#PROCESSING_MESSAGE} (always {@code false}).
+ *   <li>{@link ChannelAttributes#PROCESSING_MESSAGE} (always {@code false});
+ *   <li>{@link ChannelAttributes#RECURSIVE_MESSAGE} (always {@code false}).
  * </ul>
  */
 public class BaseServer implements Server {
@@ -148,6 +149,7 @@ public class BaseServer implements Server {
             ch.attr(ChannelAttributes.REMOTE_ADDRESS).set(ch.remoteAddress());
             ch.attr(ChannelAttributes.TLS_UPGRADED).set(Boolean.FALSE);
             ch.attr(ChannelAttributes.PROCESSING_MESSAGE).set(Boolean.FALSE);
+            ch.attr(ChannelAttributes.RECURSIVE_MESSAGE).set(Boolean.FALSE);
 
             ch.pipeline().addLast(new ChannelGroupHandler(allChannels));
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/ServerConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/ServerConfig.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server;
+
+import java.util.Set;
+
+/** The configuration of a server. */
+public interface ServerConfig {
+
+    /**
+     * Tells whether or not the server is bound to any local address.
+     *
+     * @return {@code true} if the server is bound to any local address, {@code false} otherwise.
+     */
+    boolean isAnyLocalAddress();
+
+    /**
+     * Tells whether or not the server is behind NAT.
+     *
+     * <p>When behind NAT the server will attempt to discover its public address, to correctly serve
+     * requests to itself.
+     *
+     * @return {@code true} if the server is behind NAT, {@code false} otherwise.
+     */
+    boolean isBehindNat();
+
+    /**
+     * Gets the aliases of the server.
+     *
+     * <p>Allows to identify the server with different addresses/domains to serve those requests
+     * itself. For example, the {@code zap} domain.
+     *
+     * @return the aliases, never {@code null}.
+     */
+    Set<String> getAliases();
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/RecursiveRequestHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/RecursiveRequestHandlerUnitTest.java
@@ -1,0 +1,287 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.handlers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.internal.ChannelAttributes;
+import org.zaproxy.addon.network.internal.codec.HttpRequestDecoder;
+import org.zaproxy.addon.network.internal.server.ServerConfig;
+
+/** Unit test for {@link RecursiveRequestHandler}. */
+class RecursiveRequestHandlerUnitTest {
+
+    private static final InetSocketAddress SENDER_ADDRESS =
+            new InetSocketAddress("127.0.0.1", 1234);
+
+    private static final int LOCAL_PORT = 8080;
+    private static final InetSocketAddress LOCAL_ADDRESS =
+            new InetSocketAddress("127.0.0.1", LOCAL_PORT);
+
+    private List<HttpMessage> messagesReceived;
+    private List<HttpMessage> messagesProcessed;
+    private List<Throwable> exceptionsThrown;
+
+    private ServerConfig serverConfig;
+    private EmbeddedChannel channel;
+
+    @BeforeEach
+    void setUp() {
+        serverConfig = mock(ServerConfig.class);
+        messagesReceived = new ArrayList<>();
+        messagesProcessed = new ArrayList<>();
+        exceptionsThrown = new ArrayList<>();
+
+        channel =
+                new EmbeddedChannel(
+                        new HttpRequestDecoder(),
+                        new SimpleChannelInboundHandler<HttpMessage>() {
+
+                            @Override
+                            protected void channelRead0(ChannelHandlerContext ctx, HttpMessage msg)
+                                    throws Exception {
+                                messagesReceived.add(msg);
+                                ctx.fireChannelRead(msg);
+                            }
+                        },
+                        RecursiveRequestHandler.getInstance(),
+                        new SimpleChannelInboundHandler<HttpMessage>() {
+
+                            @Override
+                            protected void channelRead0(ChannelHandlerContext ctx, HttpMessage msg)
+                                    throws Exception {
+                                messagesProcessed.add(msg);
+                            }
+
+                            @Override
+                            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+                                    throws Exception {
+                                exceptionsThrown.add(cause);
+                            }
+                        });
+
+        channel.attr(ChannelAttributes.TLS_UPGRADED).set(Boolean.FALSE);
+        channel.attr(ChannelAttributes.REMOTE_ADDRESS).set(SENDER_ADDRESS);
+        channel.attr(ChannelAttributes.SERVER_CONFIG).set(serverConfig);
+        channel.attr(ChannelAttributes.LOCAL_ADDRESS).set(LOCAL_ADDRESS);
+    }
+
+    @Test
+    void shouldBeSharable() {
+        assertThat(new RecursiveRequestHandler().isSharable(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldThrowIfServerConfigAttributeNotPresent() throws Exception {
+        // Given
+        channel =
+                new EmbeddedChannel(
+                        new HttpRequestDecoder(), RecursiveRequestHandler.getInstance());
+        channel.attr(ChannelAttributes.SERVER_CONFIG).set(null);
+        String request = "GET / HTTP/1.1\r\n\r\n";
+        // When /Then
+        assertThrows(NullPointerException.class, () -> written(request));
+    }
+
+    @Test
+    void shouldThrowIfLocalAddressAttributeNotPresent() throws Exception {
+        // Given
+        channel =
+                new EmbeddedChannel(
+                        new HttpRequestDecoder(), RecursiveRequestHandler.getInstance());
+        channel.attr(ChannelAttributes.LOCAL_ADDRESS).set(null);
+        String request = "GET / HTTP/1.1\r\n\r\n";
+        // When /Then
+        assertThrows(NullPointerException.class, () -> written(request));
+    }
+
+    @Test
+    void shouldThrowExceptionInDecodedHttpMessage() throws Exception {
+        // Given
+        String request = "MalformedRequest HTTP/1.1\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(0));
+        assertThat(exceptionsThrown, hasSize(1));
+        Object exception = messagesReceived.get(0).getUserObject();
+        assertThat(exceptionsThrown.get(0), is(sameInstance(exception)));
+    }
+
+    @Test
+    void shouldKeepItselAfterCheckingMessage() throws Exception {
+        // Given
+        String request = "GET / HTTP/1.1\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        ChannelPipeline pipeline = channel.pipeline();
+        assertThat(pipeline.get(RecursiveRequestHandler.class), is(notNullValue()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @Test
+    void shouldNotBeRecursiveIfNotRequestToItself() throws Exception {
+        // Given
+        String request = "GET / HTTP/1.1\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.FALSE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @Test
+    void shouldNotBeRecursiveIfConnectRequestToItself() throws Exception {
+        // Given
+        String request = "CONNECT 127.0.0.1:" + LOCAL_PORT + " HTTP/1.1\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.FALSE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @Test
+    void shouldNotBeRecursiveIfSameAddressButNotSamePort() throws Exception {
+        // Given
+        String request = "GET / HTTP/1.1\r\nHost: 127.0.0.1:" + (LOCAL_PORT + 1) + "\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.FALSE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @Test
+    void shouldNotBeRecursiveIfSamePortButNotSameAddress() throws Exception {
+        // Given
+        String request = "GET / HTTP/1.1\r\nHost: 127.0.0.2:" + LOCAL_PORT + "\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.FALSE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @Test
+    void shouldNotBeRecursiveIfAnyLocalAddressWithSamePortButNotSameAddress() throws Exception {
+        // Given
+        given(serverConfig.isAnyLocalAddress()).willReturn(true);
+        String request = "GET / HTTP/1.1\r\nHost: example.com:" + LOCAL_PORT + "\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.FALSE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"example.com", "zap", "zap:1234"})
+    void shouldBeRecursiveIfAnAlias(String domain) throws Exception {
+        // Given
+        given(serverConfig.getAliases()).willReturn(aliases(domain));
+        String request = "GET / HTTP/1.1\r\nHost: " + domain + "\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.TRUE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @Test
+    void shouldBeRecursiveIfSameAddressAndPort() throws Exception {
+        // Given
+        String request = "GET / HTTP/1.1\r\nHost: 127.0.0.1:" + LOCAL_PORT + "\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.TRUE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    @Test
+    void shouldBeRecursiveIfAnyLocalAddressAndLocalAddressAndPort() throws Exception {
+        // Given
+        given(serverConfig.isAnyLocalAddress()).willReturn(true);
+        String request = "GET / HTTP/1.1\r\nHost: localhost:" + LOCAL_PORT + "\r\n\r\n";
+        // When
+        written(request);
+        // Then
+        assertTrue(Boolean.TRUE.equals(channel.attr(ChannelAttributes.RECURSIVE_MESSAGE).get()));
+        assertThat(messagesReceived, hasSize(1));
+        assertThat(messagesProcessed, hasSize(1));
+        assertThat(exceptionsThrown, hasSize(0));
+    }
+
+    private void written(String content) {
+        ByteBuf buf = Unpooled.copiedBuffer(content, StandardCharsets.US_ASCII);
+        assertThat(channel.writeInbound(buf), is(equalTo(false)));
+    }
+
+    private static Set<String> aliases(String domain) {
+        Set<String> aliases = new HashSet<>();
+        aliases.add(domain.split(":")[0]);
+        return aliases;
+    }
+}


### PR DESCRIPTION
Add handler that checks if a message is a request to the server itself,
to prevent forwarding recursive requests.
Change the base server to set the corresponding attribute.