### PR TITLE
network: make it easier to extend BaseServer

### DIFF
--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
@@ -145,6 +145,35 @@ class BaseServerUnitTest extends TestUtils {
         server = new BaseServer(eventLoopGroup, channelInitialiser);
     }
 
+    @Test
+    void shouldThrowIfNoChannelInitialiserProvided() throws Exception {
+        // Given
+        Consumer<SocketChannel> channelInitialiser = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> server = new BaseServer(eventLoopGroup, channelInitialiser));
+    }
+
+    @Test
+    void shouldThrowIfSettingNullChannelInitialiser() throws Exception {
+        // Given
+        server = new BaseServer(eventLoopGroup);
+        Consumer<SocketChannel> channelInitialiser = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class, () -> server.setChannelInitialiser(channelInitialiser));
+    }
+
+    @Test
+    void shouldFailToStartWithNoChannelInitialiser() throws Exception {
+        // Given
+        server = new BaseServer(eventLoopGroup);
+        int port = getRandomPort();
+        // When / Then
+        assertThrows(IOException.class, () -> server.start(port));
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {-1, Server.MAX_PORT + 1})
     void shouldThrowWhenStartingWithInvalidPort(int port) throws Exception {


### PR DESCRIPTION
Allow to set the channel initialiser after creating the base server to
allow to use the instance's state in the initialiser.