### PR TITLE
feat: commonlib: Add unified isImage method

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+
 ### Added
 - Maintenance changes (Issue 6810).
 

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ResourceIdentificationUtils.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ResourceIdentificationUtils.java
@@ -78,6 +78,18 @@ public final class ResourceIdentificationUtils {
     }
 
     /**
+     * Returns whether or not the given {@link HttpMessage} has an image content type in its
+     * response or request URL path.
+     *
+     * @param msg the {@link HttpMessage} to check
+     * @return {@code true} if the given {@link HttpMessage} has an image content type in its
+     *     response or request URL path, {@code false} otherwise.
+     */
+    public static boolean isImage(HttpMessage msg) {
+        return msg.getResponseHeader().isImage() || msg.getRequestHeader().isImage();
+    }
+
+    /**
      * Returns whether or not the given {@link HttpMessage} has a CSS content type in its response
      * or request URL path.
      *

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/ResourceIdentificationUtilsUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/ResourceIdentificationUtilsUnitTest.java
@@ -98,6 +98,53 @@ public class ResourceIdentificationUtilsUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldReturnTrueWhenRequestUrlSeemsToBeAnImageFile()
+            throws HttpMalformedHeaderException, URIException, NullPointerException {
+        // Given
+        msg.getRequestHeader().setURI(new URI("http://example.com/something.jpg", false));
+        // When
+        boolean result = ResourceIdentificationUtils.isImage(msg);
+        // Then
+        assertThat(result, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldReturnFalseWhenRequestUrlDoesNotSeemToBeAnImageFile()
+            throws HttpMalformedHeaderException, URIException, NullPointerException {
+        // Given
+        HttpMessage msg = new HttpMessage();
+        msg.getRequestHeader().setURI(new URI("http://example.com/any.xml", false));
+        // When
+        boolean result = ResourceIdentificationUtils.isImage(msg);
+        // Then
+        assertThat(result, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldReturnTrueWhenResponseSeemsToBeAnImageFile()
+            throws HttpMalformedHeaderException, URIException, NullPointerException {
+        // Given
+        msg.getRequestHeader().setURI(new URI("http://example.com/logo", true));
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "image/jpg");
+        // When
+        boolean result = ResourceIdentificationUtils.isImage(msg);
+        // Then
+        assertThat(result, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldReturnFalseWhenResponseDoesNotSeemsToBeAnImageFile()
+            throws HttpMalformedHeaderException, URIException, NullPointerException {
+        // Given
+        msg.getRequestHeader().setURI(new URI("http://example.com/logo", true));
+        msg.getResponseHeader().setHeader(HttpResponseHeader.CONTENT_TYPE, "text/html");
+        // When
+        boolean result = ResourceIdentificationUtils.isImage(msg);
+        // Then
+        assertThat(result, is(equalTo(false)));
+    }
+
+    @Test
     void shouldReturnTrueWhenRequestUrlSeemsToBeACssFile()
             throws HttpMalformedHeaderException, URIException, NullPointerException {
         // Given


### PR DESCRIPTION
- CHANGELOG > Fixed spacing, didn't add note, attributing this to existing 6810 note.
- ResourceIdentificaitonUtils > Added new method that combines request/response check from core for isImage.
- ResourceIdentificationUtilsUnitTest > Added new test methods to assert the new behavior.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>