### PR TITLE
network: correct exception handler's assertions

### DIFF
--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandlerUnitTest.java
@@ -22,7 +22,7 @@ package org.zaproxy.addon.network.internal.handlers;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -48,11 +48,6 @@ import org.zaproxy.addon.network.internal.cert.GenerationException;
 
 /** Unit test for {@link ServerExceptionHandler}. */
 class ServerExceptionHandlerUnitTest {
-
-    static {
-        // Force initialisation of Netty classes to have clean log events later.
-        ReadTimeoutException.INSTANCE.getCause();
-    }
 
     private ChannelHandlerContext ctx;
     private List<String> logEvents;
@@ -91,7 +86,7 @@ class ServerExceptionHandlerUnitTest {
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
-        assertThat(logEvents, contains(startsWith("DEBUG Timed out while reading")));
+        assertThat(logEvents, hasItem(startsWith("DEBUG Timed out while reading")));
     }
 
     @Test
@@ -104,7 +99,7 @@ class ServerExceptionHandlerUnitTest {
         // Then
         assertThat(
                 logEvents,
-                contains(
+                hasItem(
                         startsWith(
                                 "WARN Failed while establishing secure connection, cause: missing protocol")));
     }
@@ -119,7 +114,7 @@ class ServerExceptionHandlerUnitTest {
         // Then
         assertThat(
                 logEvents,
-                contains(
+                hasItem(
                         startsWith(
                                 "WARN Failed while creating certificate, cause: java.lang.Exception: Cause")));
     }
@@ -134,7 +129,7 @@ class ServerExceptionHandlerUnitTest {
         // Then
         assertThat(
                 logEvents,
-                contains(
+                hasItem(
                         startsWith(
                                 "WARN Failed while creating certificate, cause: No Root CA cert")));
     }
@@ -148,7 +143,7 @@ class ServerExceptionHandlerUnitTest {
         // Then
         assertThat(
                 logEvents,
-                contains(
+                hasItem(
                         startsWith(
                                 "ERROR io.netty.handler.codec.DecoderException: Decoder Exception")));
     }
@@ -161,7 +156,7 @@ class ServerExceptionHandlerUnitTest {
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
-        assertThat(logEvents, contains(startsWith("ERROR java.lang.Exception: Unknown Cause")));
+        assertThat(logEvents, hasItem(startsWith("ERROR java.lang.Exception: Unknown Cause")));
     }
 
     @Test
@@ -171,7 +166,7 @@ class ServerExceptionHandlerUnitTest {
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
-        assertThat(logEvents, contains(startsWith("WARN Received malformed header: Missing xyz")));
+        assertThat(logEvents, hasItem(startsWith("WARN Received malformed header: Missing xyz")));
     }
 
     @Test
@@ -183,7 +178,7 @@ class ServerExceptionHandlerUnitTest {
         // Then
         assertThat(
                 logEvents,
-                contains(startsWith("DEBUG java.io.IOException: Connection reset by peer")));
+                hasItem(startsWith("DEBUG java.io.IOException: Connection reset by peer")));
     }
 
     @Test
@@ -193,7 +188,7 @@ class ServerExceptionHandlerUnitTest {
         // When
         serverExceptionHandler.exceptionCaught(ctx, exception);
         // Then
-        assertThat(logEvents, contains(startsWith("ERROR java.lang.Exception")));
+        assertThat(logEvents, hasItem(startsWith("ERROR java.lang.Exception")));
     }
 
     private static List<String> registerLogEvents() {


### PR DESCRIPTION
Check that the log message is present instead of requiring that's the
only one logged, other classes might log as well which would make the
assertion fail even if the message was actually logged.
Remove workaround.