### PR TITLE
network: use core cert service for older versions

### DIFF
--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -166,6 +166,14 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldCreateLegacyCertServiceOnInit() {
+        // Given / When
+        extension.init();
+        // Then
+        assertThat(extension.getSslCertificateService(), is(notNullValue()));
+    }
+
+    @Test
     void shouldAddNetworkApiOnHook() {
         // Given
         ExtensionHook extensionHook = mock(ExtensionHook.class);


### PR DESCRIPTION
Rely on the core cert service if running in older versions.