### PR TITLE
network: add handlers for proxy

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandler.java
@@ -1,0 +1,51 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/**
+ * A {@link HttpRequestHandler} that {@link HttpMessageHandlerContext#close closes} if a recursive
+ * request.
+ *
+ * @see #getInstance()
+ */
+public class CloseOnRecursiveRequestHandler extends HttpRequestHandler {
+
+    private static final CloseOnRecursiveRequestHandler INSTANCE =
+            new CloseOnRecursiveRequestHandler();
+
+    /**
+     * Gets the instance.
+     *
+     * @return the instance, never {@code null}.
+     */
+    public static CloseOnRecursiveRequestHandler getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected void handleRequest(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (ctx.isRecursive()) {
+            ctx.close();
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/DecodeResponseHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/DecodeResponseHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import java.util.Collections;
+import java.util.Objects;
+import org.parosproxy.paros.network.HttpBody;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/**
+ * A {@link HttpResponseHandler} that decodes a response.
+ *
+ * @see #getEnabledInstance()
+ */
+public class DecodeResponseHandler extends HttpResponseHandler {
+
+    private static final DecodeResponseHandler ALWAYS_ENABLED =
+            new DecodeResponseHandler(() -> true);
+
+    /**
+     * Gets the handler that always decodes the response.
+     *
+     * @return the handler, never {@code null}.
+     */
+    public static DecodeResponseHandler getEnabledInstance() {
+        return ALWAYS_ENABLED;
+    }
+
+    private HandlerState state;
+
+    /**
+     * Constructs a {@code DecodeResponseHandler} with the given state provider.
+     *
+     * @param state the state provider.
+     * @throws NullPointerException if the given state provider is {@code null}.
+     */
+    public DecodeResponseHandler(HandlerState state) {
+        this.state = Objects.requireNonNull(state);
+    }
+
+    @Override
+    public void handleResponse(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (!state.isEnabled()) {
+            return;
+        }
+
+        HttpBody body = msg.getResponseBody();
+        if (body.getContentEncodings().isEmpty() || body.hasContentEncodingErrors()) {
+            return;
+        }
+
+        body.setBody(body.getContent());
+        body.setContentEncodings(Collections.emptyList());
+        HttpHeader header = msg.getResponseHeader();
+        header.setHeader(HttpHeader.CONTENT_ENCODING, null);
+        if (header.getHeader(HttpHeader.CONTENT_LENGTH) != null) {
+            header.setContentLength(body.length());
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HandlerState.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HandlerState.java
@@ -1,0 +1,31 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+/** Interface that allows to provide the enabled state for a handler. */
+public interface HandlerState {
+
+    /**
+     * Tells whether or not the handler should be enabled.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise.
+     */
+    boolean isEnabled();
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpIncludedMessageHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpIncludedMessageHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandler;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** A {@link HttpMessageHandler} that's interested only in non-excluded HTTP messages. */
+public abstract class HttpIncludedMessageHandler implements HttpMessageHandler {
+
+    @Override
+    public final void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (!ctx.isExcluded()) {
+            handleMessage0(ctx, msg);
+        }
+    }
+
+    /**
+     * Handles the given non-excluded HTTP message.
+     *
+     * @param ctx the current handling context.
+     * @param msg the message received.
+     */
+    protected abstract void handleMessage0(HttpMessageHandlerContext ctx, HttpMessage msg);
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpRequestHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpRequestHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandler;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** A {@link HttpMessageHandler} that's interested only in HTTP requests. */
+public abstract class HttpRequestHandler extends HttpIncludedMessageHandler {
+
+    @Override
+    public final void handleMessage0(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (ctx.isFromClient()) {
+            handleRequest(ctx, msg);
+        }
+    }
+
+    /**
+     * Handles the given HTTP request.
+     *
+     * @param ctx the current handling context.
+     * @param msg the HTTP request received.
+     */
+    protected abstract void handleRequest(HttpMessageHandlerContext ctx, HttpMessage msg);
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpResponseHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpResponseHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandler;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** A {@link HttpMessageHandler} that's interested only in HTTP responses. */
+public abstract class HttpResponseHandler extends HttpIncludedMessageHandler {
+
+    @Override
+    protected final void handleMessage0(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (!ctx.isFromClient()) {
+            handleResponse(ctx, msg);
+        }
+    }
+
+    /**
+     * Handles the given HTTP response.
+     *
+     * @param ctx the current handling context.
+     * @param msg the HTTP response received.
+     */
+    protected abstract void handleResponse(HttpMessageHandlerContext ctx, HttpMessage msg);
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/RemoveAcceptEncodingHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/RemoveAcceptEncodingHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import java.util.Objects;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/**
+ * A {@link HttpRequestHandler} that removes the {@code Accept-Encoding} header.
+ *
+ * @see #getEnabledInstance()
+ */
+public class RemoveAcceptEncodingHandler extends HttpRequestHandler {
+
+    private static final RemoveAcceptEncodingHandler ALWAYS_ENABLED =
+            new RemoveAcceptEncodingHandler(() -> true);
+
+    /**
+     * Gets the handler that always removes the header.
+     *
+     * @return the handler, never {@code null}.
+     */
+    public static RemoveAcceptEncodingHandler getEnabledInstance() {
+        return ALWAYS_ENABLED;
+    }
+
+    private HandlerState status;
+
+    /**
+     * Constructs a {@code RemoveAcceptEncodingHandler} with the given state provider.
+     *
+     * @param state the state provider.
+     * @throws NullPointerException if the given state provider is {@code null}.
+     */
+    public RemoveAcceptEncodingHandler(HandlerState state) {
+        this.status = Objects.requireNonNull(state);
+    }
+
+    @Override
+    protected void handleRequest(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (!status.isEnabled()) {
+            return;
+        }
+
+        String encoding = msg.getRequestHeader().getHeader(HttpHeader.ACCEPT_ENCODING);
+        if (encoding == null) {
+            return;
+        }
+
+        msg.getRequestHeader().setHeader(HttpHeader.ACCEPT_ENCODING, null);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandlerUnitTest.java
@@ -1,0 +1,88 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** Unit test for {@link CloseOnRecursiveRequestHandler}. */
+class CloseOnRecursiveRequestHandlerUnitTest {
+
+    private HttpMessageHandlerContext ctx;
+    private HttpMessage message;
+    private CloseOnRecursiveRequestHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(HttpMessageHandlerContext.class);
+        given(ctx.isFromClient()).willReturn(true);
+        message = mock(HttpMessage.class);
+        handler = CloseOnRecursiveRequestHandler.getInstance();
+    }
+
+    @Test
+    void shouldNotHandleExcludedMessage() throws Exception {
+        // Given
+        given(ctx.isRecursive()).willReturn(true);
+        given(ctx.isExcluded()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(ctx, times(0)).close();
+    }
+
+    @Test
+    void shouldNotHandleResponse() throws Exception {
+        // Given
+        given(ctx.isRecursive()).willReturn(true);
+        given(ctx.isFromClient()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(ctx, times(0)).close();
+    }
+
+    @Test
+    void shouldNotCloseIfNotRecursive() throws Exception {
+        // Given
+        given(ctx.isRecursive()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(ctx, times(0)).close();
+    }
+
+    @Test
+    void shouldCloseIfRecursiveRequest() throws Exception {
+        // Given
+        given(ctx.isRecursive()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(ctx).close();
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/DecodeResponseHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/DecodeResponseHandlerUnitTest.java
@@ -1,0 +1,179 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+import org.zaproxy.zap.network.HttpEncoding;
+import org.zaproxy.zap.network.HttpResponseBody;
+
+/** Unit test for {@link DecodeResponseHandler}. */
+class DecodeResponseHandlerUnitTest {
+
+    private HttpMessageHandlerContext ctx;
+    private HttpResponseHeader responseHeader;
+    private HttpResponseBody responseBody;
+    private HttpMessage message;
+    private HandlerState state;
+    private DecodeResponseHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(HttpMessageHandlerContext.class);
+        responseBody = mock(HttpResponseBody.class);
+        message = mock(HttpMessage.class);
+        given(message.getResponseBody()).willReturn(responseBody);
+        responseHeader = mock(HttpResponseHeader.class);
+        given(message.getResponseHeader()).willReturn(responseHeader);
+        state = mock(HandlerState.class);
+        given(state.isEnabled()).willReturn(true);
+        handler = new DecodeResponseHandler(state);
+    }
+
+    @Test
+    void shouldNotHandleExcludedMessage() throws Exception {
+        // Given
+        given(ctx.isExcluded()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(message, times(0)).getResponseBody();
+    }
+
+    @Test
+    void shouldNotHandleRequest() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(message, times(0)).getResponseBody();
+    }
+
+    @Test
+    void shouldNotDecodeResponseIfNotEncoded() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings()).willReturn(Collections.emptyList());
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseBody, times(0)).setBody(any(byte[].class));
+    }
+
+    @Test
+    void shouldNotDecodeResponseIfHasEncodingErrors() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings())
+                .willReturn(Arrays.asList(mock(HttpEncoding.class)));
+        given(responseBody.hasContentEncodingErrors()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseBody, times(0)).setBody(any(byte[].class));
+    }
+
+    @Test
+    void shouldDecodeResponseWithResponseContent() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings())
+                .willReturn(Arrays.asList(mock(HttpEncoding.class)));
+        byte[] content = {};
+        given(responseBody.getContent()).willReturn(content);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseBody).setBody(content);
+    }
+
+    @Test
+    void shouldClearContentEncodingsInResponseAfterDecode() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings())
+                .willReturn(Arrays.asList(mock(HttpEncoding.class)));
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseBody).setContentEncodings(Collections.emptyList());
+    }
+
+    @Test
+    void shouldRemoveContentEncodingHeaderAfterDecode() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings())
+                .willReturn(Arrays.asList(mock(HttpEncoding.class)));
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseHeader).setHeader(HttpHeader.CONTENT_ENCODING, null);
+    }
+
+    @Test
+    void shouldUpdateContentLengthIfPresentAfterDecode() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings())
+                .willReturn(Arrays.asList(mock(HttpEncoding.class)));
+        given(responseHeader.getHeader(HttpHeader.CONTENT_LENGTH)).willReturn("5");
+        given(responseBody.length()).willReturn(10);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseHeader).setContentLength(10);
+    }
+
+    @Test
+    void shouldDecodeResponseWithAlwaysEnabledInstance() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings())
+                .willReturn(Arrays.asList(mock(HttpEncoding.class)));
+        byte[] content = {};
+        given(responseBody.getContent()).willReturn(content);
+        handler = DecodeResponseHandler.getEnabledInstance();
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseBody).setBody(content);
+    }
+
+    @Test
+    void shouldNotDecodeResponseIfDisabled() throws Exception {
+        // Given
+        given(responseBody.getContentEncodings())
+                .willReturn(Arrays.asList(mock(HttpEncoding.class)));
+        byte[] content = {};
+        given(responseBody.getContent()).willReturn(content);
+        given(state.isEnabled()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(responseBody, times(0)).setBody(content);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpIncludedMessageHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpIncludedMessageHandlerUnitTest.java
@@ -1,0 +1,95 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** Unit test for {@link HttpIncludedMessageHandler}. */
+class HttpIncludedMessageHandlerUnitTest {
+
+    private HttpMessageHandlerContext ctx;
+    private HttpMessage message;
+    private HttpIncludedMessageHandlerImpl handler;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(HttpMessageHandlerContext.class);
+        message = mock(HttpMessage.class);
+        handler = new HttpIncludedMessageHandlerImpl();
+    }
+
+    @Test
+    void shouldNotHandleExcludedMessage() throws Exception {
+        // Given
+        given(ctx.isExcluded()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        assertThat(handler.isCalled(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldHandleIncludedMessage() throws Exception {
+        // Given
+        given(ctx.isExcluded()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        assertThat(handler.isCalled(), is(equalTo(true)));
+        assertThat(handler.ctx(), is(sameInstance(ctx)));
+        assertThat(handler.msg(), is(sameInstance(message)));
+    }
+
+    private static class HttpIncludedMessageHandlerImpl extends HttpIncludedMessageHandler {
+
+        private boolean called;
+        private HttpMessageHandlerContext ctx;
+        private HttpMessage msg;
+
+        @Override
+        protected void handleMessage0(HttpMessageHandlerContext ctx, HttpMessage msg) {
+            called = true;
+            this.ctx = ctx;
+            this.msg = msg;
+        }
+
+        boolean isCalled() {
+            return called;
+        }
+
+        public HttpMessageHandlerContext ctx() {
+            return ctx;
+        }
+
+        public HttpMessage msg() {
+            return msg;
+        }
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpRequestHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpRequestHandlerUnitTest.java
@@ -1,0 +1,95 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** Unit test for {@link HttpRequestHandler}. */
+class HttpRequestHandlerUnitTest {
+
+    private HttpMessageHandlerContext ctx;
+    private HttpMessage message;
+    private HttpRequestHandlerImpl handler;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(HttpMessageHandlerContext.class);
+        message = mock(HttpMessage.class);
+        handler = new HttpRequestHandlerImpl();
+    }
+
+    @Test
+    void shouldNotHandleResponse() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        assertThat(handler.isCalled(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldHandleRequest() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        assertThat(handler.isCalled(), is(equalTo(true)));
+        assertThat(handler.ctx(), is(sameInstance(ctx)));
+        assertThat(handler.msg(), is(sameInstance(message)));
+    }
+
+    private static class HttpRequestHandlerImpl extends HttpRequestHandler {
+
+        private boolean called;
+        private HttpMessageHandlerContext ctx;
+        private HttpMessage msg;
+
+        @Override
+        protected void handleRequest(HttpMessageHandlerContext ctx, HttpMessage msg) {
+            called = true;
+            this.ctx = ctx;
+            this.msg = msg;
+        }
+
+        boolean isCalled() {
+            return called;
+        }
+
+        public HttpMessageHandlerContext ctx() {
+            return ctx;
+        }
+
+        public HttpMessage msg() {
+            return msg;
+        }
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpResponseHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpResponseHandlerUnitTest.java
@@ -1,0 +1,95 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** Unit test for {@link HttpResponseHandler}. */
+class HttpResponseHandlerUnitTest {
+
+    private HttpMessageHandlerContext ctx;
+    private HttpMessage message;
+    private HttpResponseHandlerImpl handler;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(HttpMessageHandlerContext.class);
+        message = mock(HttpMessage.class);
+        handler = new HttpResponseHandlerImpl();
+    }
+
+    @Test
+    void shouldNotHandleRequest() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        assertThat(handler.isCalled(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldHandleResponse() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        assertThat(handler.isCalled(), is(equalTo(true)));
+        assertThat(handler.ctx(), is(sameInstance(ctx)));
+        assertThat(handler.msg(), is(sameInstance(message)));
+    }
+
+    private static class HttpResponseHandlerImpl extends HttpResponseHandler {
+
+        private boolean called;
+        private HttpMessageHandlerContext ctx;
+        private HttpMessage msg;
+
+        @Override
+        protected void handleResponse(HttpMessageHandlerContext ctx, HttpMessage msg) {
+            called = true;
+            this.ctx = ctx;
+            this.msg = msg;
+        }
+
+        boolean isCalled() {
+            return called;
+        }
+
+        public HttpMessageHandlerContext ctx() {
+            return ctx;
+        }
+
+        public HttpMessage msg() {
+            return msg;
+        }
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/RemoveAcceptEncodingHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/RemoveAcceptEncodingHandlerUnitTest.java
@@ -1,0 +1,117 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http.handlers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** Unit test for {@link RemoveAcceptEncodingHandler}. */
+class RemoveAcceptEncodingHandlerUnitTest {
+
+    private HttpMessageHandlerContext ctx;
+    private HttpRequestHeader requestHeader;
+    private HttpMessage message;
+    private HandlerState state;
+    private RemoveAcceptEncodingHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        ctx = mock(HttpMessageHandlerContext.class);
+        given(ctx.isFromClient()).willReturn(true);
+        message = mock(HttpMessage.class);
+        requestHeader = mock(HttpRequestHeader.class);
+        given(message.getRequestHeader()).willReturn(requestHeader);
+        state = mock(HandlerState.class);
+        given(state.isEnabled()).willReturn(true);
+        handler = new RemoveAcceptEncodingHandler(state);
+    }
+
+    @Test
+    void shouldNotHandleExcludedMessage() throws Exception {
+        // Given
+        given(ctx.isExcluded()).willReturn(true);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(message, times(0)).getRequestHeader();
+    }
+
+    @Test
+    void shouldNotHandleResponse() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(message, times(0)).getRequestHeader();
+    }
+
+    @Test
+    void shouldNotRemoveHeaderIfNotPresent() throws Exception {
+        // Given
+        given(requestHeader.getHeader(HttpHeader.ACCEPT_ENCODING)).willReturn(null);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(requestHeader, times(0)).setHeader(any(), any());
+    }
+
+    @Test
+    void shouldRemoveHeaderIfPresent() throws Exception {
+        // Given
+        given(requestHeader.getHeader(HttpHeader.ACCEPT_ENCODING)).willReturn("gzip");
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(requestHeader).setHeader(HttpHeader.ACCEPT_ENCODING, null);
+    }
+
+    @Test
+    void shouldRemoveHeaderWithAlwaysEnabledInstance() throws Exception {
+        // Given
+        given(requestHeader.getHeader(HttpHeader.ACCEPT_ENCODING)).willReturn("gzip");
+        handler = RemoveAcceptEncodingHandler.getEnabledInstance();
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(requestHeader).setHeader(HttpHeader.ACCEPT_ENCODING, null);
+    }
+
+    @Test
+    void shouldNotRemoveHeaderIfDisabled() throws Exception {
+        // Given
+        given(requestHeader.getHeader(HttpHeader.ACCEPT_ENCODING)).willReturn(null);
+        given(state.isEnabled()).willReturn(false);
+        // When
+        handler.handleMessage(ctx, message);
+        // Then
+        verify(requestHeader, times(0)).setHeader(any(), any());
+    }
+}


### PR DESCRIPTION
Add handlers to:
 - Close connection if recursive request;
 - Remove Accept-Encoding request header;
 - Decode the response.

Add helper handlers for common behaviour, e.g. act only on request,
response, and ignore excluded messages.