### PR TITLE
oast: use server provided by the Network add-on

### DIFF
--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     compileOnly(parent!!.childProjects.get("oast")!!)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)
+    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Use Network add-on to serve callback requests.
 
 ## [0.9.0] - 2022-01-31
 ### Added

--- a/addOns/oast/oast.gradle.kts
+++ b/addOns/oast/oast.gradle.kts
@@ -10,7 +10,9 @@ zapAddOn {
 
         dependencies {
             addOns {
-                register("network")
+                register("network") {
+                    version.set(">= 0.1.0")
+                }
             }
         }
 
@@ -48,4 +50,5 @@ dependencies {
     compileOnly(parent!!.childProjects["network"]!!)
 
     testImplementation(project(":testutils"))
+    testImplementation(parent!!.childProjects["network"]!!)
 }

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.oast;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
@@ -39,6 +41,7 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.oast.services.boast.BoastOptionsPanelTab;
 import org.zaproxy.addon.oast.services.boast.BoastService;
 import org.zaproxy.addon.oast.services.callback.CallbackOptionsPanelTab;
@@ -65,6 +68,9 @@ public class ExtensionOast extends ExtensionAdaptor {
     private static final Logger LOGGER = LogManager.getLogger(ExtensionOast.class);
     static final int HISTORY_TYPE_OAST = HistoryReference.TYPE_OAST;
 
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(Arrays.asList(ExtensionNetwork.class));
+
     private final Map<String, OastService> services = new HashMap<>();
     private final ReferenceMap alertCache =
             new ReferenceMap(AbstractReferenceMap.HARD, AbstractReferenceMap.SOFT);
@@ -80,9 +86,19 @@ public class ExtensionOast extends ExtensionAdaptor {
     }
 
     @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
     public void init() {
         boastService = new BoastService();
-        callbackService = new CallbackService(OastRequest::create);
+        callbackService =
+                new CallbackService(
+                        OastRequest::create,
+                        Control.getSingleton()
+                                .getExtensionLoader()
+                                .getExtension(ExtensionNetwork.class));
         interactshService = new InteractshService();
     }
 


### PR DESCRIPTION
Replace the usage of core `ProxyServer` and related classes with the
`Server` provided by the add-on.