### PR TITLE
ascanrulesBeta: change rule to use network server

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Hidden File Finder scan rule, content checking has been added for .svn/entries as well as detection for wc.db.
+- Use Network add-on to detect/serve HttPoxy scan rule requests.
 
 ### Fixed
 - Adapted Cloud Metadata Attack scan rule to use Custom Pages and active scan analyzer to help reduce false positives in certain cases (Issue 7033).

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -16,6 +16,9 @@ zapAddOn {
                 register("commonlib") {
                     version.set(">= 1.6.0 & < 2.0.0")
                 }
+                register("network") {
+                    version.set(">= 0.1.0")
+                }
                 register("oast") {
                     version.set(">= 0.7.0")
                 }
@@ -42,6 +45,7 @@ zapAddOn {
 dependencies {
     compileOnly(parent!!.childProjects.get("commonlib")!!)
     compileOnly(parent!!.childProjects.get("custompayloads")!!)
+    compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("oast")!!)
 
     implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
@@ -50,6 +54,7 @@ dependencies {
     testImplementation(parent!!.childProjects.get("commonlib")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(parent!!.childProjects.get("custompayloads")!!)
+    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))
     testImplementation("org.apache.commons:commons-lang3:3.12")

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -94,6 +94,7 @@ This may allow attackers to:\n\
 ascanbeta.httpoxy.otherinfo = An outgoing message to {0} was proxied via the host and port that ZAP injected into the HTTP Proxy header.
 ascanbeta.httpoxy.soln = The best immediate mitigation is to block Proxy request headers as early as possible, and before they hit your application.
 ascanbeta.httpoxy.refs = https://httpoxy.org/
+ascanbeta.httpoxy.skipped = the Network extension is disabled
 
 ascanbeta.httpsashttp.name = HTTPS Content Available via HTTP
 ascanbeta.httpsashttp.desc = Content which was initially accessed via HTTPS (i.e.: using SSL/TLS encryption) is also accessible via HTTP (without encryption). 


### PR DESCRIPTION
Change `HttPoxyScanRule` to use the server provided by the network
add-on.