### PR TITLE
network: correct handlers result

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandler.java
@@ -77,7 +77,7 @@ public class HttpSenderHandler implements HttpMessageHandler {
 
     @Override
     public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
-        if (!ctx.isFromClient()) {
+        if (!ctx.isFromClient() || !msg.getResponseHeader().isEmpty()) {
             return;
         }
 
@@ -174,8 +174,6 @@ public class HttpSenderHandler implements HttpMessageHandler {
             int statusCode,
             String reasonPhrase,
             String message) {
-        ctx.overridden();
-
         HttpResponseHeader responseHeader = new HttpResponseHeader();
         responseHeader.setVersion(HttpHeader.HTTP11);
         responseHeader.setStatusCode(statusCode);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/LegacyProxyListenerHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/LegacyProxyListenerHandler.java
@@ -177,12 +177,6 @@ public class LegacyProxyListenerHandler extends ProxyServer implements HttpMessa
                 }
             }
         }
-
-        if (request) {
-            if (!message.getResponseHeader().isEmpty()) {
-                ctx.overridden();
-            }
-        }
     }
 
     private static <T> T handleErrors(Callable<T> runnable, T fallbackValue) {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/server/HttpMessageHandlerContext.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/server/HttpMessageHandlerContext.java
@@ -52,9 +52,17 @@ public interface HttpMessageHandlerContext {
      */
     boolean isFromClient();
 
-    /** Indicates that the message contents were overridden and should be forwarded as is. */
+    /**
+     * Indicates that the message contents were overridden and should be forwarded as is.
+     *
+     * <p>No other handlers will be notified.
+     */
     void overridden();
 
-    /** Indicates that the connection should be closed without forwarding the message. */
+    /**
+     * Indicates that the connection should be closed without forwarding the message.
+     *
+     * <p>No other handlers will be notified.
+     */
     void close();
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/MainServerHandlerUnitTest.java
@@ -65,9 +65,7 @@ class MainServerHandlerUnitTest {
     void setUp() {
         exceptionsThrown = new ArrayList<>();
 
-        ;
         handler1 = new TestHttpMessageHandler();
-        ;
         handler2 = new TestHttpMessageHandler();
         channel =
                 new EmbeddedChannel(
@@ -175,7 +173,7 @@ class MainServerHandlerUnitTest {
     }
 
     @Test
-    void shouldNotNotifyFollowingHandlerOfRequestIfOverridden() {
+    void shouldNotNotifyFollowingHandlersOfRequestIfOverridden() {
         // Given
         String request = "GET / HTTP/1.1\r\n\r\n";
         handler1.addAction(0, (ctx, msg) -> ctx.overridden());
@@ -183,13 +181,12 @@ class MainServerHandlerUnitTest {
         written(request);
         // Then
         assertThat(exceptionsThrown, hasSize(0));
-        handler1.assertCalled(2);
-        handler2.assertCalled(1);
-        handler2.assertFromClient(0, false);
+        handler1.assertCalled(1);
+        handler2.assertCalled(0);
     }
 
     @Test
-    void shouldNotNotifyFollowingHandlerOfResponseIfOverridden() {
+    void shouldNotNotifyFollowingHandlersOfResponseIfOverridden() {
         // Given
         String request = "GET / HTTP/1.1\r\n\r\n";
         handler1.addAction(1, (ctx, msg) -> ctx.overridden());
@@ -203,7 +200,7 @@ class MainServerHandlerUnitTest {
     }
 
     @Test
-    void shouldNotNotifyFollowingHandlerIfClose() {
+    void shouldNotNotifyFollowingHandlersOfRequestIfClose() {
         // Given
         String request = "GET / HTTP/1.1\r\n\r\n";
         handler1.addAction(0, (ctx, msg) -> ctx.close());
@@ -217,10 +214,9 @@ class MainServerHandlerUnitTest {
     }
 
     @Test
-    void shouldNotNotifyFollowingHandlerIfOverriddenAndClose() {
+    void shouldNotNotifyFollowingHandlersOfResponseIfClose() {
         // Given
         String request = "GET / HTTP/1.1\r\n\r\n";
-        handler1.addAction(0, (ctx, msg) -> ctx.overridden());
         handler1.addAction(1, (ctx, msg) -> ctx.close());
         // When
         written(request);
@@ -228,7 +224,8 @@ class MainServerHandlerUnitTest {
         assertThat(exceptionsThrown, hasSize(0));
         assertChannelActive(false);
         handler1.assertCalled(2);
-        handler2.assertCalled(0);
+        handler2.assertCalled(1);
+        handler2.assertFromClient(0, true);
     }
 
     @Test
@@ -262,8 +259,8 @@ class MainServerHandlerUnitTest {
         written(request);
         // Then
         assertThat(exceptionsThrown, hasSize(0));
-        handler1.assertCalled(2);
-        handler2.assertCalled(1);
+        handler1.assertCalled(1);
+        handler2.assertCalled(0);
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpSenderHandlerUnitTest.java
@@ -235,7 +235,8 @@ class HttpSenderHandlerUnitTest extends TestUtils {
         handler.handleMessage(ctx, message);
         // Then
         assertThat(messagesReceived, hasSize(1));
-        verify(ctx).overridden();
+        verify(ctx, times(0)).overridden();
+        verify(ctx, times(0)).close();
         assertThat(
                 message.getResponseHeader().toString(), startsWith("HTTP/1.1 504 Gateway Timeout"));
         assertThat(
@@ -255,7 +256,8 @@ class HttpSenderHandlerUnitTest extends TestUtils {
         handler.handleMessage(ctx, message);
         // Then
         assertThat(messagesReceived, hasSize(1));
-        verify(ctx).overridden();
+        verify(ctx, times(0)).overridden();
+        verify(ctx, times(0)).close();
         assertThat(
                 message.getResponseHeader().toString(), startsWith("HTTP/1.1 504 Gateway Timeout"));
         assertThat(message.getResponseBody().toString(), is(equalTo("")));
@@ -271,7 +273,8 @@ class HttpSenderHandlerUnitTest extends TestUtils {
         handler.handleMessage(ctx, message);
         // Then
         assertThat(messagesReceived, hasSize(greaterThan(1)));
-        verify(ctx).overridden();
+        verify(ctx, times(0)).overridden();
+        verify(ctx, times(0)).close();
         assertThat(message.getResponseHeader().toString(), startsWith("HTTP/1.1 502 Bad Gateway"));
         assertThat(
                 message.getResponseBody().toString(),

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/LegacyProxyListenerHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/LegacyProxyListenerHandlerUnitTest.java
@@ -359,7 +359,7 @@ class LegacyProxyListenerHandlerUnitTest {
     }
 
     @Test
-    void shouldOverrideResponseIfNotEmptyAfterOverrideMessageProxyListeners() {
+    void shouldNotOverrideNorCloseIfResponseNotEmptyAfterOverrideMessageProxyListeners() {
         // Given
         OverrideMessageProxyListener listener1 = mock(OverrideMessageProxyListener.class);
         given(listener1.getArrangeableListenerOrder()).willReturn(1);
@@ -374,7 +374,7 @@ class LegacyProxyListenerHandlerUnitTest {
         InOrder inOrder = inOrder(listener1, listener2);
         inOrder.verify(listener1).onHttpRequestSend(message);
         inOrder.verify(listener2).onHttpRequestSend(message);
-        assertContext(1, 0);
+        assertContext(0, 0);
     }
 
     @Test
@@ -566,7 +566,7 @@ class LegacyProxyListenerHandlerUnitTest {
     }
 
     @Test
-    void shouldOverrideResponseIfNotEmptyAfterProxyListeners() {
+    void shouldNotOverrideNorCloseIfResponseNotEmptyAfterProxyListeners() {
         // Given
         ProxyListener listener1 = mock(ProxyListener.class);
         given(listener1.getArrangeableListenerOrder()).willReturn(1);
@@ -583,7 +583,7 @@ class LegacyProxyListenerHandlerUnitTest {
         InOrder inOrder = inOrder(listener1, listener2);
         inOrder.verify(listener1).onHttpRequestSend(message);
         inOrder.verify(listener2).onHttpRequestSend(message);
-        assertContext(1, 0);
+        assertContext(0, 0);
     }
 
     @Test


### PR DESCRIPTION
Return immediately if a handler overrides the message.
Do not override when setting an error response nor if legacy listeners
set a response to allow other handlers to be notified.
Do not send a message if it already has a response.
Be more clear of the outcome of override and close in the JavaDoc.