### PR TITLE
network: init legacy listeners handler always

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -246,6 +246,9 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
     public void hook(ExtensionHook extensionHook) {
         extensionHook.addApiImplementor(new NetworkApi(this));
 
+        legacyProxyListenerHandler = new LegacyProxyListenerHandler();
+        Control.getSingleton().getExtensionLoader().addProxyServer(legacyProxyListenerHandler);
+
         if (!handleServerCerts) {
             return;
         }
@@ -256,11 +259,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
         serverCertificatesOptions = new ServerCertificatesOptions();
         extensionHook.addOptionsParamSet(serverCertificatesOptions);
-
-        if (handleLocalServers) {
-            legacyProxyListenerHandler = new LegacyProxyListenerHandler();
-            Control.getSingleton().getExtensionLoader().addProxyServer(legacyProxyListenerHandler);
-        }
 
         if (hasView()) {
             OptionsDialog optionsDialog = View.getSingleton().getOptionsDialog("");
@@ -509,6 +507,9 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
     @Override
     public void unload() {
+        Control.getSingleton().getExtensionLoader().removeProxyServer(legacyProxyListenerHandler);
+        legacyProxyListenerHandler = null;
+
         if (!handleServerCerts) {
             return;
         }
@@ -519,13 +520,6 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
         if (hasView()) {
             OptionsDialog optionsDialog = View.getSingleton().getOptionsDialog("");
             optionsDialog.removeParamPanel(serverCertificatesOptionsPanel);
-        }
-
-        if (handleLocalServers) {
-            Control.getSingleton()
-                    .getExtensionLoader()
-                    .removeProxyServer(legacyProxyListenerHandler);
-            legacyProxyListenerHandler = null;
         }
     }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -250,24 +250,9 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldNotAddLegacyProxyListenerHandlerOnHookIfNotHandlingLocalServers() throws Exception {
+    void shouldAddLegacyProxyListenerHandlerOnHookAlways() {
         // Given
         ExtensionHook extensionHook = mock(ExtensionHook.class);
-        extension.handleServerCerts = true;
-        extension.handleLocalServers = false;
-        // When
-        extension.hook(extensionHook);
-        // Then
-        verify(extensionLoader, times(0)).addProxyServer(any());
-        assertThat(extension.getLegacyProxyListenerHandler(), is(nullValue()));
-    }
-
-    @Test
-    void shouldAddLegacyProxyListenerHandlerOnHookIfHandlingLocalServers() {
-        // Given
-        ExtensionHook extensionHook = mock(ExtensionHook.class);
-        extension.handleServerCerts = true;
-        extension.handleLocalServers = true;
         // When
         extension.hook(extensionHook);
         // Then
@@ -542,18 +527,6 @@ class ExtensionNetworkUnitTest extends TestUtils {
         // Then
         verify(extension.setSslCertificateService, times(0)).accept(any());
         assertThat(Security.getProvider(BouncyCastleProvider.PROVIDER_NAME), is(notNullValue()));
-        verify(extensionLoader, times(0)).removeProxyServer(any());
-    }
-
-    @Test
-    void shouldNotUnloadProxyListenerHandlerIfNotHandlingLocalServers() {
-        // Given
-        extension.handleServerCerts = true;
-        extension.handleLocalServers = false;
-        // When
-        extension.unload();
-        // Then
-        verify(extensionLoader, times(0)).removeProxyServer(any());
     }
 
     @Test
@@ -568,10 +541,8 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldUnloadLegacyProxyListenerHandlerIfHandlingLocalServers() {
+    void shouldUnloadLegacyProxyListenerHandlerAlways() {
         // Given
-        extension.handleServerCerts = true;
-        extension.handleLocalServers = true;
         extension.hook(mock(ExtensionHook.class));
         LegacyProxyListenerHandler handler = extension.getLegacyProxyListenerHandler();
         // When


### PR DESCRIPTION
Initialise the `LegacyProxyListenerHandler` always, needed for all
proxies (e.g. AJAX Spider) not just the ones in the add-on itself to
support other protocols than HTTP (e.g. WebSocket).