### PR TITLE
domxss: use the proxy from the network add-on

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Use Network add-on to proxy browser requests.
 
 ## [12] - 2021-12-06
 ### Changed

--- a/addOns/domxss/domxss.gradle.kts
+++ b/addOns/domxss/domxss.gradle.kts
@@ -18,6 +18,9 @@ zapAddOn {
         }
         dependencies {
             addOns {
+                register("network") {
+                    version.set(">=0.1.0")
+                }
                 register("selenium") {
                     version.set("15.*")
                 }
@@ -31,8 +34,10 @@ zapAddOn {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("commonlib")!!)
+    compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
     testImplementation(parent!!.childProjects.get("commonlib")!!)
+    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("selenium")!!)
     testImplementation("io.github.bonigarcia:webdrivermanager:5.0.3")
     testImplementation(project(":testutils"))


### PR DESCRIPTION
Replace the usage of core `ProxyServer` and related classes with the
proxy provided by the add-on.