### PR TITLE
feat: wappalyzer: Handle simple DOM selectors

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - API help content.
 - Maintenance changes.
 
+### Changed
+- Further support for DOM selector patterns (Issue 6607).
+
 ## [21.7.0] - 2022-01-03
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/Application.java
@@ -38,6 +38,7 @@ public class Application {
     private List<AppPattern> html = new ArrayList<>();
     private List<Map<String, AppPattern>> metas;
     private List<Map<String, Map<String, Map<String, AppPattern>>>> dom;
+    private List<String> simpleDom;
     private List<AppPattern> css = new ArrayList<>();
     private List<AppPattern> script = new ArrayList<>();
 
@@ -109,6 +110,14 @@ public class Application {
 
     public void setDom(List<Map<String, Map<String, Map<String, AppPattern>>>> dom) {
         this.dom = dom;
+    }
+
+    void setSimpleDom(List<String> simpleDom) {
+        this.simpleDom = simpleDom;
+    }
+
+    List<String> getSimpleDom() {
+        return simpleDom;
     }
 
     public void setScript(List<AppPattern> script) {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -143,6 +143,7 @@ public class WappalyzerJsonParser {
                     app.setMetas(this.jsonToAppPatternMapList("META", appData.get("meta")));
                     app.setCss(this.jsonToPatternList("CSS", appData.get("css")));
                     app.setDom(this.jsonToAppPatternNestedMapList("DOM", appData.get("dom")));
+                    app.setSimpleDom(this.jsonToDomStringList(appData.get("dom")));
                     app.setImplies(this.jsonToStringList(appData.get("implies")));
                     app.setCpe(appData.optString("cpe"));
 
@@ -227,6 +228,26 @@ public class WappalyzerJsonParser {
         svgIcon.paint(g2d);
         g2d.dispose();
         return new ImageIcon(image);
+    }
+
+    private List<String> jsonToDomStringList(Object json) {
+        if (json instanceof JSONObject) {
+            // Objects are handled elsewhere
+            return Collections.emptyList();
+        }
+        List<String> list = new ArrayList<>();
+        if (json instanceof JSONArray) {
+            for (Object obj : (JSONArray) json) {
+                if (isValidQuery(obj.toString())) {
+                    list.add(obj.toString());
+                }
+            }
+        } else if (json != null) {
+            if (isValidQuery(json.toString())) {
+                list.add(json.toString());
+            }
+        }
+        return list;
     }
 
     private List<String> jsonToStringList(Object json) {

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScanner.java
@@ -123,6 +123,7 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
         checkMetaElementsMatches(source);
         checkScriptElementsMatches(source);
         checkCssElementsMatches(msg, source);
+        checkSimpleDomMatches(msg);
         checkDomElementMatches(msg);
     }
 
@@ -197,6 +198,13 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
         }
     }
 
+    private void checkSimpleDomMatches(HttpMessage msg) {
+        String body = msg.getResponseBody().toString();
+        for (String selector : currentApp.getSimpleDom()) {
+            addIfDomMatches(selector, body);
+        }
+    }
+
     private void checkBodyMatches(HttpMessage msg) {
         String body = msg.getResponseBody().toString();
         for (AppPattern p : currentApp.getHtml()) {
@@ -233,6 +241,14 @@ public class WappalyzerPassiveScanner implements PassiveScanner {
         String url = msg.getRequestHeader().getURI().toString();
         for (AppPattern p : currentApp.getUrl()) {
             addIfMatches(p, url);
+        }
+    }
+
+    private void addIfDomMatches(String selector, String content) {
+        Document doc = Jsoup.parse(content);
+        Elements elements = doc.select(selector);
+        if (!elements.isEmpty()) {
+            this.appMatch = getAppMatch();
         }
     }
 

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParserUnitTest.java
@@ -40,7 +40,7 @@ class WappalyzerJsonParserUnitTest {
         List<Application> apps = wappData.getApplications();
         Application app = apps.get(0);
         // Then
-        assertEquals(5, apps.size());
+        assertEquals(6, apps.size());
         assertEquals("Test Entry", app.getName());
         assertEquals("Test Entry is a test entry for UnitTests", app.getDescription());
         assertEquals("https://www.example.com/testentry", app.getWebsite());
@@ -53,9 +53,12 @@ class WappalyzerJsonParserUnitTest {
         assertEquals(0, app.getImplies().size());
         assertEquals(2, app.getDom().size());
         assertEquals("", app.getCpe());
+
+        app = apps.get(1);
+        assertEquals(1, app.getSimpleDom().size());
         // Ignore Icon
 
-        app = apps.get(2);
+        app = apps.get(3);
         assertEquals("Apache", app.getName());
         assertEquals(1, app.getMetas().size());
     }

--- a/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
+++ b/addOns/wappalyzer/src/test/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerPassiveScannerUnitTest.java
@@ -173,6 +173,18 @@ class WappalyzerPassiveScannerUnitTest extends PassiveScannerTestUtils<Wappalyze
     }
 
     @Test
+    void shouldMatchSimpleDomPattern() throws HttpMalformedHeaderException {
+        // Given
+        HttpMessage msg = makeHttpMessage();
+        msg.setResponseBody("<html><body><script src=\"sites/g/files\"></script></body></html>");
+        // When
+        scan(msg);
+        // Then
+        assertFoundAppCount("https://www.example.com", 1);
+        assertFoundApp("https://www.example.com", "Test Entry2");
+    }
+
+    @Test
     void shouldNotMatchDomElementIfNoContentMatches() throws HttpMalformedHeaderException {
         // Given
         HttpMessage msg = makeHttpMessage();

--- a/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
+++ b/addOns/wappalyzer/src/test/resources/org/zaproxy/zap/extension/wappalyzer/apps.json
@@ -45,6 +45,15 @@
       "url": "^https?://test\\.example\\.com",
       "website": "https://www.example.com/testentry"
     },
+     "Test Entry2": {
+      "cats": [
+        36
+      ],
+      "dom": "script[src*='sites/g/files']",
+      "description": "Test Entry2 is a test entry for UnitTests",
+      "url": "^https?://test\\.example\\.com",
+      "website": "https://www.example.com/testentry2"
+    },
      "1C-Bitrix": {
       "cats": [
         1,


### PR DESCRIPTION
Fixes zaproxy/zaproxy#6607

- Application.java > Add new field, setter, and getter.
- apps.json > Add new simple test entry.
- CHANGELOG.md > Added change note.
- WappalyzerJsonParser.java > Add handling for building/using a simple string list with DOM selector patterns.
- WappalyzerJsonParserUnitTest.java > Updated test assertions.
- WappalyzerPassiveScanner.java > Updated to handle the new simple DOM selector patterns/functionality.
- WappalyzerPassiveScannerUnitTest.java > Added a test method to test the new simple DOM selector functionality.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>