### PR TITLE
zest: use the proxy from network add-on

### DIFF
--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Use Network add-on to proxy client authentication requests.
 
 ## [35] - 2021-10-06
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -58,6 +59,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.control.AddOn;
 import org.zaproxy.zap.extension.anticsrf.AntiCsrfToken;
 import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
@@ -118,7 +120,9 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
 
     private static final Logger logger = LogManager.getLogger(ExtensionZest.class);
 
-    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES;
+    private static final List<Class<? extends Extension>> EXTENSION_DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionScript.class, ExtensionNetwork.class));
 
     private ZestParam param = null;
     private OptionsZestPanel optionsZestPanel = null;
@@ -150,12 +154,6 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     private String startRecordingUrl = null;
     private int recordingWinId = 0;
     private ScriptNode recordingNode = null;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionScript.class);
-        EXTENSION_DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
 
     public ExtensionZest() {
         super(NAME);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestAuthenticationRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestAuthenticationRunner.java
@@ -20,18 +20,19 @@
 package org.zaproxy.zap.extension.zest;
 
 import java.io.IOException;
-import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.script.ScriptException;
 import org.apache.commons.httpclient.URI;
-import org.parosproxy.paros.core.proxy.ProxyListener;
-import org.parosproxy.paros.core.proxy.ProxyServer;
-import org.parosproxy.paros.core.proxy.ProxyThread;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
-import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.ExtensionNetwork;
+import org.zaproxy.addon.network.server.HttpMessageHandler;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+import org.zaproxy.addon.network.server.Server;
 import org.zaproxy.zap.authentication.AuthenticationHelper;
 import org.zaproxy.zap.authentication.GenericAuthenticationCredentials;
 import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType.AuthenticationScript;
@@ -44,6 +45,8 @@ import org.zaproxy.zest.impl.ZestBasicRunner;
 
 public class ZestAuthenticationRunner extends ZestZapRunner implements AuthenticationScript {
 
+    private static final Logger LOGGER = LogManager.getLogger(ZestAuthenticationRunner.class);
+
     private static final String PROXY_ADDRESS = "127.0.0.1";
 
     private static final String USERNAME = "Username";
@@ -51,10 +54,13 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
 
     private ZestScriptWrapper script = null;
     private AuthenticationHelper helper;
+    private final ExtensionNetwork extensionNetwork;
 
-    public ZestAuthenticationRunner(ExtensionZest extension, ZestScriptWrapper script) {
+    public ZestAuthenticationRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper script) {
         super(extension, script);
         this.script = script;
+        this.extensionNetwork = extensionNetwork;
     }
 
     @Override
@@ -99,11 +105,13 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
 
         this.helper = helper;
 
-        ProxyServer proxyServer = null;
+        Server proxyServer = null;
         try {
             if (hasClientStatements()) {
-                proxyServer = new ZestProxyServer(this, helper);
-                int port = proxyServer.startServer(PROXY_ADDRESS, 0, true);
+                proxyServer =
+                        extensionNetwork.createHttpProxy(
+                                helper.getHttpSender(), new ZestMessageHandler(this, helper));
+                int port = proxyServer.start(PROXY_ADDRESS, Server.ANY_PORT);
                 this.setProxy(PROXY_ADDRESS, port);
             }
 
@@ -135,7 +143,11 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
             throw new ScriptException(e);
         } finally {
             if (proxyServer != null) {
-                proxyServer.stopServer();
+                try {
+                    proxyServer.close();
+                } catch (IOException e) {
+                    LOGGER.debug("An error occurred while stopping the proxy.", e);
+                }
             }
         }
     }
@@ -159,63 +171,34 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
         return ZestZapUtils.toZestResponse(msg);
     }
 
-    private static class ZestProxyServer extends ProxyServer {
+    private static class ZestMessageHandler implements HttpMessageHandler {
 
-        private final HttpSender httpSender;
+        private final ZestBasicRunner runner;
+        private final AuthenticationHelper helper;
 
-        ZestProxyServer(ZestBasicRunner runner, AuthenticationHelper helper) {
-            this.httpSender = helper.getHttpSender();
-            addProxyListener(
-                    new ProxyListener() {
-
-                        @Override
-                        public int getArrangeableListenerOrder() {
-                            return 0;
-                        }
-
-                        @Override
-                        public boolean onHttpRequestSend(HttpMessage msg) {
-                            msg.setRequestingUser(helper.getRequestingUser());
-                            return true;
-                        }
-
-                        @Override
-                        public boolean onHttpResponseReceive(HttpMessage msg) {
-                            runner.setVariable(
-                                    ZestVariables.REQUEST_URL,
-                                    msg.getRequestHeader().getURI().toString());
-                            runner.setVariable(
-                                    ZestVariables.REQUEST_HEADER,
-                                    msg.getRequestHeader().getHeadersAsString());
-                            runner.setVariable(
-                                    ZestVariables.REQUEST_METHOD,
-                                    msg.getRequestHeader().getMethod());
-                            runner.setVariable(
-                                    ZestVariables.REQUEST_BODY, msg.getRequestBody().toString());
-
-                            runner.setVariable(
-                                    ZestVariables.RESPONSE_URL,
-                                    msg.getRequestHeader().getURI().toString());
-                            runner.setVariable(
-                                    ZestVariables.RESPONSE_HEADER,
-                                    msg.getResponseHeader().toString());
-                            runner.setVariable(
-                                    ZestVariables.RESPONSE_BODY, msg.getResponseBody().toString());
-                            return true;
-                        }
-                    });
+        private ZestMessageHandler(ZestBasicRunner runner, AuthenticationHelper helper) {
+            this.runner = runner;
+            this.helper = helper;
         }
 
         @Override
-        protected ProxyThread createProxyProcess(Socket clientSocket) {
-            return new ZestProxyThread(this, clientSocket, httpSender);
-        }
-
-        private static class ZestProxyThread extends ProxyThread {
-
-            ZestProxyThread(ProxyServer server, Socket socket, HttpSender sender) {
-                super(server, socket, sender);
+        public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+            if (ctx.isFromClient()) {
+                msg.setRequestingUser(helper.getRequestingUser());
+                return;
             }
+
+            runner.setVariable(
+                    ZestVariables.REQUEST_URL, msg.getRequestHeader().getURI().toString());
+            runner.setVariable(
+                    ZestVariables.REQUEST_HEADER, msg.getRequestHeader().getHeadersAsString());
+            runner.setVariable(ZestVariables.REQUEST_METHOD, msg.getRequestHeader().getMethod());
+            runner.setVariable(ZestVariables.REQUEST_BODY, msg.getRequestBody().toString());
+
+            runner.setVariable(
+                    ZestVariables.RESPONSE_URL, msg.getRequestHeader().getURI().toString());
+            runner.setVariable(ZestVariables.RESPONSE_HEADER, msg.getResponseHeader().toString());
+            runner.setVariable(ZestVariables.RESPONSE_BODY, msg.getResponseBody().toString());
         }
     }
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.zest;
 import java.io.IOException;
 import javax.script.ScriptException;
 import org.parosproxy.paros.control.Control;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.authentication.ScriptBasedAuthenticationMethodType;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
@@ -41,6 +42,7 @@ public class ZestScriptWrapper extends ScriptWrapper {
     private int lengthApprox = 1;
     private ZestScript zestScript = null;
     private ExtensionZest extension = null;
+    private ExtensionNetwork extensionNetwork;
     private ScriptWrapper original = null;
     private boolean debug = false;
     private boolean recording = false;
@@ -136,7 +138,9 @@ public class ZestScriptWrapper extends ScriptWrapper {
             return (T) new ZestProxyRunner(this.getExtension(), this.clone());
 
         } else if (class1.isAssignableFrom(ZestAuthenticationRunner.class)) {
-            return (T) new ZestAuthenticationRunner(this.getExtension(), this.clone());
+            return (T)
+                    new ZestAuthenticationRunner(
+                            this.getExtension(), getExtensionNetwork(), this.clone());
         } else if (class1.isAssignableFrom(ZestSequenceRunner.class)) {
             return (T) new ZestSequenceRunner(this.getExtension(), this.clone());
         }
@@ -152,6 +156,16 @@ public class ZestScriptWrapper extends ScriptWrapper {
                                     .getExtension(ExtensionZest.NAME);
         }
         return extension;
+    }
+
+    private ExtensionNetwork getExtensionNetwork() {
+        if (extensionNetwork == null) {
+            extensionNetwork =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionNetwork.class);
+        }
+        return extensionNetwork;
     }
 
     @Override

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -23,6 +23,9 @@ zapAddOn {
         url.set("https://www.zaproxy.org/docs/desktop/addons/zest/")
         dependencies {
             addOns {
+                register("network") {
+                    version.set(">=0.1.0")
+                }
                 register("selenium") {
                     version.set("15.*")
                 }
@@ -33,6 +36,7 @@ zapAddOn {
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
     implementation("org.zaproxy:zest:0.15.0") {
         // Provided by Selenium add-on.
@@ -47,5 +51,6 @@ dependencies {
     }
 
     testImplementation(project(":testutils"))
+    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("selenium")!!)
 }


### PR DESCRIPTION
Replace the usage of core `ProxyServer` and related classes with the
proxy provided by the add-on for client authentication requests.