### PR TITLE
fix: pscanrules: Timestamp Disclosure shouldn't alert on percentages

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
-- Update Cache-control scan rule name, description, and solution to make it more clear that there are cases in which caching is reasonable. Reduced risk to Info. (Issue 6462)
+- Address false positive condition for Timestamp Disclosure scan rule when values are percentages (Issue 7057).
+- Update Cache-control scan rule name, description, and solution to make it more clear that there are cases in which caching is reasonable. Reduced risk to Info (Issue 6462).
 - Maintenance changes.
 
 ## [38] - 2022-01-07

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRule.java
@@ -60,7 +60,7 @@ public class TimestampDisclosureScanRule extends PluginPassiveScanner {
         // as well as all of the current Unix time value (beyond the range for a valid Unix time, in
         // fact)
         timestampPatterns.put(
-                Pattern.compile("\\b[0-9]{8,10}\\b", Pattern.CASE_INSENSITIVE), "Unix");
+                Pattern.compile("\\b[0-9]{8,10}\\b(?!%)", Pattern.CASE_INSENSITIVE), "Unix");
     }
 
     private static Logger log = LogManager.getLogger(TimestampDisclosureScanRule.class);

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/TimestampDisclosureScanRuleUnitTest.java
@@ -115,6 +115,24 @@ class TimestampDisclosureScanRuleUnitTest extends PassiveScannerTest<TimestampDi
         assertEquals(0, alertsRaised.size());
     }
 
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "0.33333333%",
+                "0.33333333em",
+                "0.33333333rem",
+                "1.1592500000000001",
+                "000000000000000000000000000000001"
+            })
+    void shouldNotRaiseAlertOnUnlikelyValues(String value) throws Exception {
+        // Given
+        HttpMessage msg = createMessage(value);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertEquals(0, alertsRaised.size());
+    }
+
     @Test
     void shouldRaiseAlertOnValidCurrentTimestamp() throws Exception {
         // Given


### PR DESCRIPTION
- CHANGELOG > Added change note.
- TimestampDisclosureScanRule > Slight adjustment to regex to prevent matching of percentage values.
- TimestampDisclosureScanRuleUnitTest > Add additional test to assert the updated behavior.

Fixes zaproxy/zaproxy#7057

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>