### PR TITLE
chore: various add-ons: leverage new commonlib unified isImage method

### DIFF
--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
@@ -44,7 +44,7 @@ public class CacheControlScanRule extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (msg.getRequestHeader().isSecure()
                 && msg.getResponseBody().length() > 0
-                && !msg.getResponseHeader().isImage()) {
+                && !ResourceIdentificationUtils.isImage(msg)) {
 
             if (!AlertThreshold.LOW.equals(this.getAlertThreshold())
                     && (HttpStatusCode.isRedirection(msg.getResponseHeader().getStatusCode())

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/SourceCodeDisclosureScanRule.java
@@ -652,8 +652,7 @@ public class SourceCodeDisclosureScanRule extends PluginPassiveScanner {
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
         if (ResourceIdentificationUtils.isCss(msg)
                 || ResourceIdentificationUtils.isJavaScript(msg)
-                || msg.getRequestHeader().isImage()
-                || msg.getResponseHeader().isImage()
+                || ResourceIdentificationUtils.isImage(msg)
                 || ResourceIdentificationUtils.isFont(msg)) {
             return;
         }

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/PiiScanRule.java
@@ -88,9 +88,7 @@ public class PiiScanRule extends PluginPassiveScanner {
 
     @Override
     public void scanHttpResponseReceive(HttpMessage msg, int id, Source source) {
-        if (ResourceIdentificationUtils.isCss(msg)
-                || msg.getRequestHeader().isImage()
-                || msg.getResponseHeader().isImage()) {
+        if (ResourceIdentificationUtils.isCss(msg) || ResourceIdentificationUtils.isImage(msg)) {
             return;
         }
 

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -64,7 +64,7 @@ public class RetireScanRule extends PluginPassiveScanner {
             return;
         }
         String uri = msg.getRequestHeader().getURI().toString();
-        if (!msg.getResponseHeader().isImage() && !ResourceIdentificationUtils.isCss(msg)) {
+        if (!ResourceIdentificationUtils.isImage(msg) && !ResourceIdentificationUtils.isCss(msg)) {
             Repo scanRepo = getRepo();
             if (scanRepo == null) {
                 LOGGER.error("\tThe Retire.js repository was null.");


### PR DESCRIPTION
- Updated various passive scan rules replacing request/response isImage calls with unified commonlib isImage call.
- All relevant add-on CHANGELOGs already contain maintenance notes.

Related to: https://github.com/zaproxy/zap-extensions/pull/3506

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>