### PR TITLE
fix: ascanrulesBeta & pscanrules: CSRF alerts Medium Risk

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Hidden File Finder scan rule, content checking has been added for .svn/entries as well as detection for wc.db.
 - Use Network add-on to detect/serve HttPoxy scan rule requests.
 - Maintenance changes.
+- The CSRF Token scan rule will now raise alerts as Medium risk (Issue 7021).
 
 ### Fixed
 - Adapted Cloud Metadata Attack scan rule to use Custom Pages and active scan analyzer to help reduce false positives in certain cases (Issue 7033).

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CsrfTokenScanRule.java
@@ -226,7 +226,7 @@ public class CsrfTokenScanRule extends AbstractAppPlugin {
                     }
                     // If vulnerable, generates the alert
                     if (vuln) {
-                        int risk = Alert.RISK_HIGH;
+                        int risk = Alert.RISK_MEDIUM;
                         String evidence = formElement.getFirstElement().getStartTag().toString();
                         String otherInfo = "";
 
@@ -300,7 +300,7 @@ public class CsrfTokenScanRule extends AbstractAppPlugin {
 
     @Override
     public int getRisk() {
-        return Alert.RISK_HIGH;
+        return Alert.RISK_MEDIUM;
     }
 
     @Override

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Address false positive condition for Timestamp Disclosure scan rule when values are percentages (Issue 7057).
 - Update Cache-control scan rule name, description, and solution to make it more clear that there are cases in which caching is reasonable. Reduced risk to Info (Issue 6462).
 - Maintenance changes.
+- The CSRF Token scan rule will now raise alerts as Medium risk and Low confidence (Issue 7021).
 
 ## [38] - 2022-01-07
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRule.java
@@ -202,7 +202,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
                 String formDetails = sbForm.toString();
                 String tokenNamesFlattened = tokenNames.toString();
 
-                int risk = Alert.RISK_LOW;
+                int risk = Alert.RISK_MEDIUM;
                 String desc = Constant.messages.getString("pscanrules.noanticsrftokens.desc");
                 String extraInfo =
                         Constant.messages.getString(
@@ -218,7 +218,7 @@ public class CsrfCountermeasuresScanRule extends PluginPassiveScanner {
 
                 newAlert()
                         .setRisk(risk)
-                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setConfidence(Alert.CONFIDENCE_LOW)
                         .setDescription(desc + "\n" + getDescription())
                         .setOtherInfo(extraInfo)
                         .setSolution(getSolution())

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CsrfCountermeasuresScanRuleUnitTest.java
@@ -346,7 +346,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
     }
 
     @Test
-    void shouldRaiseLowAlertWhenFormAttributeAndRuleConfigMismatch() {
+    void shouldRaiseMediumAlertWhenFormAttributeAndRuleConfigMismatch() {
         // Given
         rule.setCSRFIgnoreAttName("ignore");
 
@@ -358,7 +358,7 @@ class CsrfCountermeasuresScanRuleUnitTest extends PassiveScannerTest<CsrfCounter
         scanHttpResponseReceive(msg);
         // Then
         assertEquals(1, alertsRaised.size());
-        assertEquals(Alert.RISK_LOW, alertsRaised.get(0).getRisk());
+        assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
     }
 
     @Test


### PR DESCRIPTION
- Standardize the risk of CSRF alerts.
- Reduce confidence of pscan alert.
- Add change note to CHANGELOGs.
- Tweak scan rule unit tests where necessary.

Fixes zaproxy/zaproxy#7021

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>