### PR TITLE
network: manage pass-through authorities

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
@@ -1,0 +1,218 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zaproxy.addon.network.internal.server.http.PassThrough;
+import org.zaproxy.zap.common.VersionedAbstractParam;
+
+/** The options related to local servers/proxies. */
+public class LocalServersOptions extends VersionedAbstractParam {
+
+    private static final Logger LOGGER = LogManager.getLogger(LocalServersOptions.class);
+    /**
+     * The current version of the configurations. Used to keep track of configuration changes
+     * between releases, in case changes/updates are needed.
+     *
+     * <p>It only needs to be incremented for configuration changes (not releases of the add-on).
+     *
+     * @see #CONFIG_VERSION_KEY
+     * @see #updateConfigsImpl(int)
+     */
+    private static final int CURRENT_CONFIG_VERSION = 1;
+
+    private static final String BASE_KEY = "network.localServers";
+
+    /**
+     * The configuration key for the version of the configurations.
+     *
+     * @see #CURRENT_CONFIG_VERSION
+     */
+    private static final String CONFIG_VERSION_KEY = BASE_KEY + VERSION_ATTRIBUTE;
+
+    private static final String PASS_THROUGHS_BASE_KEY = BASE_KEY + ".passThroughs";
+    private static final String ALL_PASS_THROUGHS_KEY = PASS_THROUGHS_BASE_KEY + ".passThrough";
+    private static final String PASS_THROUGH_ENABLED = "enabled";
+    private static final String PASS_THROUGH_AUTHORITY = "authority";
+    private static final String CONFIRM_REMOVE_PASS_THROUGH =
+            PASS_THROUGHS_BASE_KEY + ".confirmRemove";
+
+    private List<PassThrough> passThroughs = new ArrayList<>();
+    private boolean confirmRemovePassThrough = true;
+
+    @Override
+    protected int getCurrentVersion() {
+        return CURRENT_CONFIG_VERSION;
+    }
+
+    @Override
+    protected String getConfigVersionKey() {
+        return CONFIG_VERSION_KEY;
+    }
+
+    @Override
+    protected void updateConfigsImpl(int fileVersion) {
+        // Nothing to do.
+    }
+
+    @Override
+    protected void parseImpl() {
+        List<HierarchicalConfiguration> fields =
+                ((HierarchicalConfiguration) getConfig()).configurationsAt(ALL_PASS_THROUGHS_KEY);
+        passThroughs = new ArrayList<>(fields.size());
+        for (HierarchicalConfiguration sub : fields) {
+            try {
+                String value = sub.getString(PASS_THROUGH_AUTHORITY, "");
+                Pattern pattern = createPassThroughPattern(value);
+                if (pattern != null) {
+                    boolean enabled = sub.getBoolean(PASS_THROUGH_ENABLED, true);
+                    passThroughs.add(new PassThrough(pattern, enabled));
+                }
+            } catch (ConversionException e) {
+                LOGGER.warn("An error occurred while reading a pass-through:", e);
+            }
+        }
+        confirmRemovePassThrough = getBoolean(CONFIRM_REMOVE_PASS_THROUGH, true);
+    }
+
+    /**
+     * Adds the given pass-through.
+     *
+     * @param passThrough the pass-through.
+     * @throws NullPointerException if the given pass-through is {@code null}.
+     */
+    public void addPassThrough(PassThrough passThrough) {
+        Objects.requireNonNull(passThrough);
+        passThroughs.add(passThrough);
+        persistPassThroughs();
+    }
+
+    private void persistPassThroughs() {
+        ((HierarchicalConfiguration) getConfig()).clearTree(ALL_PASS_THROUGHS_KEY);
+
+        for (int i = 0, size = passThroughs.size(); i < size; ++i) {
+            String elementBaseKey = ALL_PASS_THROUGHS_KEY + "(" + i + ").";
+            PassThrough passThrough = passThroughs.get(i);
+
+            getConfig()
+                    .setProperty(
+                            elementBaseKey + PASS_THROUGH_AUTHORITY,
+                            passThrough.getAuthority().pattern());
+            getConfig().setProperty(elementBaseKey + PASS_THROUGH_ENABLED, passThrough.isEnabled());
+        }
+    }
+
+    /**
+     * Sets whether or not the pass-through with the given authority should be enabled.
+     *
+     * @param authority the value of the authority.
+     * @param enabled {@code true} if the pass-through should be enabled, {@code false} otherwise.
+     * @return {@code true} if the pass-through was changed, {@code false} otherwise.
+     * @throws NullPointerException if the given authority is {@code null}.
+     */
+    public boolean setPassThroughEnabled(String authority, boolean enabled) {
+        Objects.requireNonNull(authority);
+        for (Iterator<PassThrough> it = passThroughs.iterator(); it.hasNext(); ) {
+            PassThrough passThrough = it.next();
+            if (authority.equals(passThrough.getAuthority().pattern())) {
+                passThrough.setEnabled(enabled);
+                persistPassThroughs();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes a pass-through.
+     *
+     * @param authority the value of the authority.
+     * @return {@code true} if the pass-through was removed, {@code false} otherwise.
+     */
+    public boolean removePassThrough(String authority) {
+        Objects.requireNonNull(authority);
+        for (Iterator<PassThrough> it = passThroughs.iterator(); it.hasNext(); ) {
+            if (authority.equals(it.next().getAuthority().pattern())) {
+                it.remove();
+                persistPassThroughs();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Sets the pass-through.
+     *
+     * @param passThroughs the pass-through.
+     * @throws NullPointerException if the given list is {@code null}.
+     */
+    public void setPassThroughs(List<PassThrough> passThroughs) {
+        this.passThroughs = Objects.requireNonNull(passThroughs);
+
+        this.passThroughs = new ArrayList<>(passThroughs);
+        persistPassThroughs();
+    }
+
+    /**
+     * Gets all the pass-throughs.
+     *
+     * @return the list of pass-throughs, never {@code null}.
+     */
+    public List<PassThrough> getPassThroughs() {
+        return passThroughs;
+    }
+
+    /**
+     * Sets whether or not the removal of a pass-through needs confirmation.
+     *
+     * @param confirmRemove {@code true} if the removal needs confirmation, {@code false} otherwise.
+     */
+    public void setConfirmRemovePassThrough(boolean confirmRemove) {
+        this.confirmRemovePassThrough = confirmRemove;
+        getConfig().setProperty(CONFIRM_REMOVE_PASS_THROUGH, confirmRemovePassThrough);
+    }
+
+    /**
+     * Tells whether or not the removal of a pass-through needs confirmation.
+     *
+     * @return {@code true} if the removal needs confirmation, {@code false} otherwise.
+     */
+    public boolean isConfirmRemovePassThrough() {
+        return confirmRemovePassThrough;
+    }
+
+    private static Pattern createPassThroughPattern(String value) {
+        try {
+            return PassThrough.createAuthorityPattern(value);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Ignoring invalid pass-through pattern:", e);
+            return null;
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
@@ -1,0 +1,114 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import javax.swing.GroupLayout;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.addon.network.internal.ui.PassThroughTableModel;
+import org.zaproxy.addon.network.internal.ui.PassThroughTablePanel;
+
+class LocalServersOptionsPanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final PassThroughPanel passThroughPanel;
+
+    public LocalServersOptionsPanel(ExtensionNetwork extensionNetwork) {
+        passThroughPanel = new PassThroughPanel();
+
+        setName(Constant.messages.getString("network.ui.options.localservers.name"));
+
+        JTabbedPane tabbedPane = new JTabbedPane();
+        tabbedPane.add(
+                Constant.messages.getString("network.ui.options.passthrough.tab"),
+                passThroughPanel.getPanel());
+
+        GroupLayout mainLayout = new GroupLayout(this);
+        setLayout(mainLayout);
+        mainLayout.setAutoCreateGaps(true);
+        mainLayout.setAutoCreateContainerGaps(true);
+
+        mainLayout.setHorizontalGroup(mainLayout.createParallelGroup().addComponent(tabbedPane));
+        mainLayout.setVerticalGroup(mainLayout.createSequentialGroup().addComponent(tabbedPane));
+    }
+
+    @Override
+    public void initParam(Object mainOptions) {
+        LocalServersOptions options = getLocalServersOptions(mainOptions);
+
+        passThroughPanel.init(options);
+    }
+
+    private static LocalServersOptions getLocalServersOptions(Object mainOptions) {
+        return ((OptionsParam) mainOptions).getParamSet(LocalServersOptions.class);
+    }
+
+    @Override
+    public void saveParam(Object mainOptions) throws Exception {
+        LocalServersOptions options = getLocalServersOptions(mainOptions);
+
+        passThroughPanel.save(options);
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "addon.network.options.localservers";
+    }
+
+    private static class PassThroughPanel {
+
+        private final PassThroughTableModel tableModel;
+        private final PassThroughTablePanel tablePanel;
+        private final JPanel panel;
+
+        PassThroughPanel() {
+            tableModel = new PassThroughTableModel();
+            tablePanel = new PassThroughTablePanel(tableModel);
+
+            panel = new JPanel();
+            GroupLayout layout = new GroupLayout(panel);
+            panel.setLayout(layout);
+            layout.setAutoCreateGaps(true);
+            layout.setAutoCreateContainerGaps(true);
+
+            layout.setHorizontalGroup(layout.createParallelGroup().addComponent(tablePanel));
+
+            layout.setVerticalGroup(layout.createSequentialGroup().addComponent(tablePanel));
+        }
+
+        JPanel getPanel() {
+            return panel;
+        }
+
+        void init(LocalServersOptions options) {
+            tableModel.setPassThroughs(options.getPassThroughs());
+            tablePanel.setRemoveWithoutConfirmation(!options.isConfirmRemovePassThrough());
+        }
+
+        void save(LocalServersOptions options) {
+            options.setPassThroughs(tableModel.getElements());
+            options.setConfirmRemovePassThrough(!tablePanel.isRemoveWithoutConfirmation());
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ChannelAttributes.java
@@ -50,9 +50,9 @@ public final class ChannelAttributes {
     public static final AttributeKey<Boolean> TLS_UPGRADED =
             AttributeKey.newInstance("zap.tls-upgraded");
 
-    /** The attribute that indicates if a channel is set to passthrough the data. */
-    public static final AttributeKey<Boolean> PASSTHROUGH =
-            AttributeKey.newInstance("zap.passthrough");
+    /** The attribute that indicates if a channel is set to pass-through the data. */
+    public static final AttributeKey<Boolean> PASS_THROUGH =
+            AttributeKey.newInstance("zap.pass-through");
 
     /** The attribute that indicates if a message is still being processed. */
     public static final AttributeKey<Boolean> PROCESSING_MESSAGE =

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainProxyHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/MainProxyHandler.java
@@ -58,19 +58,19 @@ public class MainProxyHandler extends MainServerHandler {
             return false;
         }
 
-        LegacySocketAdapter passthroughAdapter = new LegacySocketAdapter(ctx.channel());
+        LegacySocketAdapter passThroughAdapter = new LegacySocketAdapter(ctx.channel());
         ZapGetMethod method = (ZapGetMethod) msg.getUserObject();
         if (method == null) {
             method = new ZapGetMethod();
-            method.setUpgradedSocket(passthroughAdapter.getSocket());
+            method.setUpgradedSocket(passThroughAdapter.getSocket());
             try {
-                method.setUpgradedInputStream(passthroughAdapter.getSocket().getInputStream());
+                method.setUpgradedInputStream(passThroughAdapter.getSocket().getInputStream());
             } catch (IOException ignore) {
             }
         }
         boolean keepConnectionOpen =
                 legacyHandler.notifyPersistentConnectionListener(
-                        msg, passthroughAdapter.getSocket(), method);
+                        msg, passThroughAdapter.getSocket(), method);
         if (keepConnectionOpen) {
             return true;
         }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/PassThrough.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/PassThrough.java
@@ -1,0 +1,122 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.zap.utils.Enableable;
+
+/** The pass-through condition of a HTTPS connection. */
+public class PassThrough extends Enableable implements Predicate<HttpRequestHeader> {
+
+    private Pattern authority;
+
+    /**
+     * Constructs a {@code PassThrough} with the given values.
+     *
+     * @param authority the authority pattern.
+     * @param enabled {@code true} if enabled, {@code false} otherwise.
+     * @throws NullPointerException if the given authority is {@code null}.
+     */
+    public PassThrough(Pattern authority, boolean enabled) {
+        super(enabled);
+        setAuthority(authority);
+    }
+
+    /**
+     * Constructs a {@code PassThrough} from the given instance.
+     *
+     * @param other the other instance.
+     * @throws NullPointerException if the given value is {@code null}.
+     */
+    public PassThrough(PassThrough other) {
+        super(Objects.requireNonNull(other).isEnabled());
+
+        this.authority = other.authority;
+    }
+
+    /**
+     * Gets the authority pattern.
+     *
+     * @return the authority.
+     */
+    public Pattern getAuthority() {
+        return authority;
+    }
+
+    /**
+     * Sets the authority pattern.
+     *
+     * @param authority the authority
+     * @throws NullPointerException if the given authority is {@code null}.
+     */
+    public void setAuthority(Pattern authority) {
+        this.authority = Objects.requireNonNull(authority);
+    }
+
+    @Override
+    public boolean test(HttpRequestHeader requestHeader) {
+        if (!isEnabled()) {
+            return false;
+        }
+
+        String requestedAuthority = requestHeader.getURI().getEscapedAuthority();
+        return authority.matcher(requestedAuthority).find();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(authority.pattern());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (!(obj instanceof PassThrough)) {
+            return false;
+        }
+        PassThrough other = (PassThrough) obj;
+        return Objects.equals(authority.pattern(), other.authority.pattern());
+    }
+
+    /**
+     * Creates the authority pattern.
+     *
+     * @param value the value of the authority.
+     * @return the pattern or {@code null} if the given value is {@code null} or empty.
+     * @throws IllegalArgumentException if the given value is not a valid pattern.
+     */
+    public static Pattern createAuthorityPattern(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return Pattern.compile(value);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddPassThroughDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddPassThroughDialog.java
@@ -1,0 +1,174 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import java.awt.Dialog;
+import javax.swing.GroupLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.server.http.PassThrough;
+import org.zaproxy.zap.utils.ZapTextField;
+import org.zaproxy.zap.view.AbstractFormDialog;
+
+public class AddPassThroughDialog extends AbstractFormDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final JPanel fieldsPanel;
+    protected final ZapTextField authorityTextField;
+    protected final JCheckBox enabledCheckBox;
+
+    protected PassThrough passThrough;
+
+    public AddPassThroughDialog(Dialog owner) {
+        this(owner, Constant.messages.getString("network.ui.options.passthrough.add.title"));
+    }
+
+    protected AddPassThroughDialog(Dialog owner, String title) {
+        super(owner, title, false);
+
+        fieldsPanel = new JPanel();
+
+        GroupLayout layout = new GroupLayout(fieldsPanel);
+        fieldsPanel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        JLabel authorityLabel =
+                new JLabel(
+                        Constant.messages.getString(
+                                "network.ui.options.passthrough.add.field.authority"));
+        authorityTextField = new ZapTextField(25);
+        authorityTextField.getDocument().addDocumentListener(new EnableButtonDocumentListener());
+        authorityLabel.setLabelFor(authorityTextField);
+
+        JLabel enabledLabel =
+                new JLabel(
+                        Constant.messages.getString(
+                                "network.ui.options.passthrough.add.field.enabled"));
+        enabledCheckBox = new JCheckBox();
+        enabledLabel.setLabelFor(enabledCheckBox);
+
+        layout.setHorizontalGroup(
+                layout.createSequentialGroup()
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+                                        .addComponent(authorityLabel)
+                                        .addComponent(enabledLabel))
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                        .addComponent(authorityTextField)
+                                        .addComponent(enabledCheckBox)));
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(authorityLabel)
+                                        .addComponent(authorityTextField))
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(enabledLabel)
+                                        .addComponent(enabledCheckBox)));
+
+        initView();
+    }
+
+    @Override
+    protected JPanel getFieldsPanel() {
+        return fieldsPanel;
+    }
+
+    @Override
+    protected String getConfirmButtonLabel() {
+        return Constant.messages.getString("network.ui.options.passthrough.add.button");
+    }
+
+    @Override
+    protected void init() {
+        authorityTextField.setText("");
+        authorityTextField.discardAllEdits();
+        enabledCheckBox.setSelected(true);
+        passThrough = null;
+    }
+
+    @Override
+    protected boolean validateFields() {
+        String value = authorityTextField.getText();
+
+        try {
+            PassThrough.createAuthorityPattern(value);
+        } catch (IllegalArgumentException e) {
+            JOptionPane.showMessageDialog(
+                    this,
+                    Constant.messages.getString(
+                            "network.ui.options.passthrough.warn.invalidregex.message",
+                            e.getMessage()),
+                    Constant.messages.getString(
+                            "network.ui.options.passthrough.warn.invalidregex.title"),
+                    JOptionPane.INFORMATION_MESSAGE);
+            authorityTextField.requestFocusInWindow();
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    protected void performAction() {
+        String value = authorityTextField.getText();
+        passThrough =
+                new PassThrough(
+                        PassThrough.createAuthorityPattern(value), enabledCheckBox.isSelected());
+    }
+
+    public PassThrough getPassThrough() {
+        PassThrough passThrough = this.passThrough;
+        this.passThrough = null;
+        return passThrough;
+    }
+
+    private class EnableButtonDocumentListener implements DocumentListener {
+
+        @Override
+        public void removeUpdate(DocumentEvent e) {
+            checkAndEnableConfirmButton(e);
+        }
+
+        @Override
+        public void insertUpdate(DocumentEvent e) {
+            checkAndEnableConfirmButton(e);
+        }
+
+        @Override
+        public void changedUpdate(DocumentEvent e) {
+            checkAndEnableConfirmButton(e);
+        }
+
+        private void checkAndEnableConfirmButton(DocumentEvent e) {
+            setConfirmButtonEnabled(e.getDocument().getLength() > 0);
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/ModifyPassThroughDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/ModifyPassThroughDialog.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import java.awt.Dialog;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.server.http.PassThrough;
+
+public class ModifyPassThroughDialog extends AddPassThroughDialog {
+
+    private static final long serialVersionUID = -4031122965844883255L;
+
+    public ModifyPassThroughDialog(Dialog owner) {
+        super(owner, Constant.messages.getString("network.ui.options.passthrough.modify.title"));
+    }
+
+    @Override
+    protected String getConfirmButtonLabel() {
+        return Constant.messages.getString("network.ui.options.passthrough.modify.button");
+    }
+
+    public void setPassThrough(PassThrough passThrough) {
+        this.passThrough = passThrough;
+    }
+
+    @Override
+    protected void init() {
+        authorityTextField.setText(passThrough.getAuthority().pattern());
+        authorityTextField.discardAllEdits();
+        enabledCheckBox.setSelected(passThrough.isEnabled());
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PassThroughTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PassThroughTableModel.java
@@ -1,0 +1,107 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.server.http.PassThrough;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
+
+public class PassThroughTableModel extends AbstractMultipleOptionsTableModel<PassThrough> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] COLUMN_NAMES = {
+        Constant.messages.getString("network.ui.options.passthrough.table.header.enabled"),
+        Constant.messages.getString("network.ui.options.passthrough.table.header.authority")
+    };
+
+    private static final int COLUMN_COUNT = COLUMN_NAMES.length;
+
+    private List<PassThrough> passThroughs;
+
+    public PassThroughTableModel() {
+        super();
+
+        passThroughs = Collections.emptyList();
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return COLUMN_NAMES[col];
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COLUMN_COUNT;
+    }
+
+    @Override
+    public int getRowCount() {
+        return passThroughs.size();
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return columnIndex == 0;
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        switch (columnIndex) {
+            case 0:
+                return getElement(rowIndex).isEnabled();
+            case 1:
+                return getElement(rowIndex).getAuthority().pattern();
+        }
+        return null;
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+        if (columnIndex == 0 && aValue instanceof Boolean) {
+            passThroughs.get(rowIndex).setEnabled((Boolean) aValue);
+            fireTableCellUpdated(rowIndex, columnIndex);
+        }
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        if (c == 0) {
+            return Boolean.class;
+        }
+        return String.class;
+    }
+
+    public void setPassThroughs(List<PassThrough> passThroughs) {
+        this.passThroughs = new ArrayList<>(passThroughs.size());
+        for (PassThrough passThrough : passThroughs) {
+            this.passThroughs.add(new PassThrough(passThrough));
+        }
+        fireTableDataChanged();
+    }
+
+    @Override
+    public List<PassThrough> getElements() {
+        return passThroughs;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PassThroughTablePanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PassThroughTablePanel.java
@@ -1,0 +1,109 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import javax.swing.JCheckBox;
+import javax.swing.JOptionPane;
+import javax.swing.SortOrder;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.network.internal.server.http.PassThrough;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
+
+public class PassThroughTablePanel extends AbstractMultipleOptionsTablePanel<PassThrough> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String REMOVE_DIALOG_TITLE =
+            Constant.messages.getString("network.ui.options.passthrough.remove.title");
+    private static final String REMOVE_DIALOG_TEXT =
+            Constant.messages.getString("network.ui.options.passthrough.remove.text");
+
+    private static final String REMOVE_DIALOG_CONFIRM_BUTTON_LABEL =
+            Constant.messages.getString("network.ui.options.passthrough.remove.button.confirm");
+    private static final String REMOVE_DIALOG_CANCEL_BUTTON_LABEL =
+            Constant.messages.getString("network.ui.options.passthrough.remove.button.cancel");
+
+    private static final String REMOVE_DIALOG_CHECKBOX_LABEL =
+            Constant.messages.getString("network.ui.options.passthrough.remove.checkbox.label");
+
+    private AddPassThroughDialog addDialog;
+    private ModifyPassThroughDialog modifyDialog;
+
+    public PassThroughTablePanel(PassThroughTableModel model) {
+        super(model);
+
+        getTable().setSortOrder(1, SortOrder.ASCENDING);
+    }
+
+    @Override
+    public PassThrough showAddDialogue() {
+        if (addDialog == null) {
+            addDialog = new AddPassThroughDialog(View.getSingleton().getOptionsDialog(null));
+            addDialog.pack();
+        }
+        addDialog.setVisible(true);
+        return addDialog.getPassThrough();
+    }
+
+    @Override
+    public PassThrough showModifyDialogue(PassThrough e) {
+        if (modifyDialog == null) {
+            modifyDialog = new ModifyPassThroughDialog(View.getSingleton().getOptionsDialog(null));
+            modifyDialog.pack();
+        }
+        modifyDialog.setPassThrough(e);
+        modifyDialog.setVisible(true);
+
+        PassThrough passThrough = modifyDialog.getPassThrough();
+
+        if (!passThrough.equals(e)) {
+            return passThrough;
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean showRemoveDialogue(PassThrough e) {
+        JCheckBox removeWithoutConfirmationCheckBox = new JCheckBox(REMOVE_DIALOG_CHECKBOX_LABEL);
+        Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};
+        int option =
+                JOptionPane.showOptionDialog(
+                        View.getSingleton().getMainFrame(),
+                        messages,
+                        REMOVE_DIALOG_TITLE,
+                        JOptionPane.OK_CANCEL_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        new String[] {
+                            REMOVE_DIALOG_CONFIRM_BUTTON_LABEL, REMOVE_DIALOG_CANCEL_BUTTON_LABEL
+                        },
+                        null);
+
+        if (option == JOptionPane.OK_OPTION) {
+            setRemoveWithoutConfirmation(removeWithoutConfirmationCheckBox.isSelected());
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/addOns/network/src/main/javahelp/help/contents/api.html
+++ b/addOns/network/src/main/javahelp/help/contents/api.html
@@ -10,10 +10,36 @@
 
 	<h3>Actions</h3>
 	<ul>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			addPassThrough (authority* enabled): Adds an authority to pass-through the local proxies.
+			<ul>
+				<li>authority: The value of the authority, can be a regular expression.</li>
+				<li>enabled: The enabled state, true or false.</li>
+			</ul>
+		</li>
 		<li>generateRootCaCert: Generates a new Root CA certificate, used to issue server certificates.</li>
 		<li>importRootCaCert (filePath*): Imports a Root CA certificate to be used to issue server certificates.
 			<ul>
 				<li>filePath: The file system path to the PEM file, containing the certificate and private key.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			removePassThrough (authority*):  Removes a pass-through.
+			<ul>
+				<li>authority: The value of the authority.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setPassThroughEnabled (authority* enabled): Sets whether or not a pass-through is enabled.
+			<ul>
+				<li>authority: The value of the authority.</li>
+				<li>enabled: The enabled state, true or false.</li>
 			</ul>
 		</li>
 		<li>
@@ -37,6 +63,7 @@
 	<h3>Views</h3>
 	<strong>Note:</strong> These endpoints are only available in weekly releases and versions after 2.11.
 	<ul>
+		<li>getPassThroughs: Gets the authorities that will pass-through the local proxies.</li>
 		<li>getRootCaCertValidity: Gets the Root CA certificate validity, in days. Used when generating a new Root CA certificate.</li>
 		<li>getServerCertValidity:  Gets the server certificate validity, in days. Used when generating server certificates.</li>
 	</ul>

--- a/addOns/network/src/main/javahelp/help/contents/options/localservers.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/localservers.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Local Servers/Proxies</TITLE>
+</HEAD>
+<BODY>
+	<H1>Local Servers/Proxies</H1>
+	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
+	<br>
+
+	<H2>Pass-through</H2>
+	Allows to configure the authorities (domain/address and port) that will pass-through ZAP, thus sending the data without being decrypted/encrypted.
+	This is useful when a client has certificate pinning for certain hosts or the domain/data is irrelevant to the target being tested.
+	<p>Requires that the client sends a CONNECT request with the required authority. The <code>authority</code> is interpreted as a regular expression and
+	needs to be present in the requested authority.
+	<br>For example, to pass-through all connections to <code>example.org</code> it can be specified just <code>example.org</code>, therefore matching any port.
+	<p>Using pass-through is more efficient than using excludes (e.g. Exclude from Proxy, Global Exclude URL) when all the traffic for the host is not relevant
+	to the tests.
+
+	<H2>See also</H2>
+	<table>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td><a href="../network.html">Network</a></td>
+			<td>the introduction to Network add-on</td>
+		</tr>
+	</table>
+
+</BODY>
+</HTML>

--- a/addOns/network/src/main/javahelp/help/contents/options/options.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/options.html
@@ -12,6 +12,13 @@
 	<table>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td><a href="localservers.html">Local Servers/Proxies</a></td>
+			<td>Allows to manage and configure the local servers/proxies.</td>
+		</tr>
+	</table>
+	<table>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 			<td><a href="servercertificates.html">Server Certificates</a></td>
 			<td>Allows to manage and configure the root CA certificate and issued certificates.</td>
 		</tr>

--- a/addOns/network/src/main/javahelp/help/map.jhm
+++ b/addOns/network/src/main/javahelp/help/map.jhm
@@ -10,4 +10,5 @@
     <mapID target="addon.network.cmdline" url="contents/cmdline.html" />
     <mapID target="addon.network.options" url="contents/options/options.html" />
     <mapID target="addon.network.options.servercertificates" url="contents/options/servercertificates.html" />
+    <mapID target="addon.network.options.localservers" url="contents/options/localservers.html" />
 </map>

--- a/addOns/network/src/main/javahelp/help/toc.xml
+++ b/addOns/network/src/main/javahelp/help/toc.xml
@@ -10,6 +10,7 @@
                 <tocitem text="API" target="addon.network.api" />
                 <tocitem text="Command Line"  target="addon.network.cmdline" />
                 <tocitem text="Options" target="addon.network.options">
+                    <tocitem text="Local Servers/Proxies" target="addon.network.options.localservers" />
                     <tocitem text="Server Certificates" target="addon.network.options.servercertificates" />
                 </tocitem>
             </tocitem>

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -1,12 +1,21 @@
 network.api.desc = Allows to access and configure core networking capabilities.
+network.api.action.addPassThrough = Adds an authority to pass-through the local proxies.
+network.api.action.addPassThrough.param.authority = The value of the authority, can be a regular expression.
+network.api.action.addPassThrough.param.enabled = The enabled state, true or false.
 network.api.action.generateRootCaCert = Generates a new Root CA certificate, used to issue server certificates.
 network.api.action.importRootCaCert = Imports a Root CA certificate to be used to issue server certificates.
 network.api.action.importRootCaCert.param.filePath = The file system path to the PEM file, containing the certificate and private key.
+network.api.action.removePassThrough = Removes a pass-through.
+network.api.action.removePassThrough.param.authority = The value of the authority.
+network.api.action.setPassThroughEnabled = Sets whether or not a pass-through is enabled.
+network.api.action.setPassThroughEnabled.param.authority = The value of the authority.
+network.api.action.setPassThroughEnabled.param.enabled = The enabled state, true or false.
 network.api.action.setRootCaCertValidity = Sets the Root CA certificate validity. Used when generating a new Root CA certificate.
 network.api.action.setRootCaCertValidity.param.validity = The number of days that the generated Root CA certificate will be valid for.
 network.api.action.setServerCertValidity = Sets the server certificate validity. Used when generating server certificates.
 network.api.action.setServerCertValidity.param.validity = The number of days that the generated server certificates will be valid for.
 network.api.other.rootCaCert = Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).
+network.api.view.getPassThroughs = Gets the authorities that will pass-through the local proxies.
 network.api.view.getRootCaCertValidity = Gets the Root CA certificate validity, in days. Used when generating a new Root CA certificate.
 network.api.view.getServerCertValidity = Gets the server certificate validity, in days. Used when generating server certificates.
 
@@ -39,6 +48,26 @@ network.httpsender.ssl.error.help = The following document may be of assistance 
 network.httpsender.ssl.error.help.url = https://www.zaproxy.org/faq/how-to-connect-to-an-https-site-that-reports-a-handshake-failure/
 
 network.ui.options.name = Network
+
+network.ui.options.localservers.name = Local Servers/Proxies
+
+network.ui.options.passthrough.tab = Pass-through
+network.ui.options.passthrough.add.title = Add Pass-through Condition
+network.ui.options.passthrough.add.field.authority = Authority:
+network.ui.options.passthrough.add.field.enabled = Enabled:
+network.ui.options.passthrough.add.button = Add
+network.ui.options.passthrough.table.header.enabled = Enabled
+network.ui.options.passthrough.table.header.authority = Authority
+network.ui.options.passthrough.modify.title = Modify Pass-through Condition
+network.ui.options.passthrough.modify.button = Modify
+network.ui.options.passthrough.remove.title = Remove Pass-through Condition
+network.ui.options.passthrough.remove.text = Are you sure you want to remove the selected pass-through condition?
+network.ui.options.passthrough.remove.button.cancel = Cancel
+network.ui.options.passthrough.remove.button.confirm = Remove
+network.ui.options.passthrough.remove.checkbox.label = Do not show this message again
+network.ui.options.passthrough.warn.invalidregex.message = The provided regular expression is not valid:\n{0}
+network.ui.options.passthrough.warn.invalidregex.title = Invalid Regular Expression
+
 network.ui.options.servercertificates.name = Server Certificates
 network.ui.options.servercertificates.button.generate = Generate
 network.ui.options.servercertificates.button.import = Import

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -264,6 +265,60 @@ class ExtensionNetworkUnitTest extends TestUtils {
         assertThat(
                 extension.getLegacyProxyListenerHandler(),
                 is(equalTo(argument.getAllValues().get(0))));
+    }
+
+    @Test
+    void shouldAddLocalServersOptionsOnHookIfHandlingLocalServers() {
+        // Given
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        extension.handleServerCerts = true;
+        extension.handleLocalServers = true;
+        // When
+        extension.hook(extensionHook);
+        // Then
+        ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
+        verify(extensionHook, times(2)).addOptionsParamSet(argument.capture());
+        assertThat(argument.getAllValues(), hasItem(instanceOf(LocalServersOptions.class)));
+        assertThat(extension.getLocalServersOptions(), is(equalTo(argument.getAllValues().get(1))));
+    }
+
+    @Test
+    void shouldNotAddLocalServersOptionsOnHookIfNotHandlingLocalServers() {
+        // Given
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        extension.handleServerCerts = true;
+        extension.handleLocalServers = false;
+        // When
+        extension.hook(extensionHook);
+        // Then
+        ArgumentCaptor<AbstractParam> argument = ArgumentCaptor.forClass(AbstractParam.class);
+        verify(extensionHook).addOptionsParamSet(argument.capture());
+        assertThat(argument.getAllValues(), not(contains(instanceOf(LocalServersOptions.class))));
+        assertThat(extension.getLocalServersOptions(), is(nullValue()));
+    }
+
+    @Test
+    void shouldCreatePassThroughHandlerOnHookIfHandlingLocalServers() {
+        // Given
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        extension.handleServerCerts = true;
+        extension.handleLocalServers = true;
+        // When
+        extension.hook(extensionHook);
+        // Then
+        assertThat(extension.getPassThroughHandler(), is(notNullValue()));
+    }
+
+    @Test
+    void shouldNotCreatePassThroughHandlerOnHookIfNotHandlingLocalServers() {
+        // Given
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        extension.handleServerCerts = true;
+        extension.handleLocalServers = false;
+        // When
+        extension.hook(extensionHook);
+        // Then
+        assertThat(extension.getPassThroughHandler(), is(nullValue()));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
@@ -1,0 +1,372 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.addon.network.internal.server.http.PassThrough;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link LocalServersOptions}. */
+class LocalServersOptionsUnitTest {
+
+    private static final String PASS_THROUGH_KEY = "network.localServers.passThroughs.passThrough";
+
+    private LocalServersOptions options;
+
+    @BeforeEach
+    void setUp() {
+        options = new LocalServersOptions();
+    }
+
+    @Test
+    void shouldHaveConfigVersionKey() {
+        assertThat(options.getConfigVersionKey(), is(equalTo("network.localServers[@version]")));
+    }
+
+    @Test
+    void shouldHaveDefaultValues() {
+        assertThat(options.getPassThroughs(), is(empty()));
+        assertThat(options.isConfirmRemovePassThrough(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldLoadEmptyConfig() {
+        // Given
+        ZapXmlConfiguration emptyConfig = new ZapXmlConfiguration();
+        // When
+        options.load(emptyConfig);
+        // Then
+        assertThat(options.getPassThroughs(), is(empty()));
+        assertThat(options.isConfirmRemovePassThrough(), is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithConfirmRemovePassThrough(boolean value) {
+        // Given
+        ZapXmlConfiguration config =
+                configWith(
+                        "<network>\n"
+                                + "  <localServers version=\"1\">\n"
+                                + "    <passThroughs>\n"
+                                + "      <confirmRemove>"
+                                + value
+                                + "</confirmRemove>\n"
+                                + "    </passThroughs>\n"
+                                + "  </localServers>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isConfirmRemovePassThrough(), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldLoadConfigWithInvalidConfirmRemovePassThrough() {
+        // Given
+        ZapXmlConfiguration config =
+                configWith(
+                        "<network>\n"
+                                + "  <localServers version=\"1\">\n"
+                                + "    <passThroughs>\n"
+                                + "      <confirmRemove>not boolean</confirmRemove>\n"
+                                + "    </passThroughs>\n"
+                                + "  </localServers>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isConfirmRemovePassThrough(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldAddPassThrough() {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        options.load(config);
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), true);
+        // When
+        options.addPassThrough(passThrough);
+        // Then
+        assertThat(options.getPassThroughs(), hasSize(1));
+
+        assertThat(config.getProperty(PASS_THROUGH_KEY + ".authority"), is(equalTo("example.org")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + ".enabled"), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldThrowIfAddingNullPassThrough() {
+        // Given
+        PassThrough passThrough = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> options.addPassThrough(passThrough));
+        assertThat(options.getPassThroughs(), hasSize(0));
+    }
+
+    @Test
+    void shouldSetPassThroughEnabled() {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        options.load(config);
+        options.addPassThrough(new PassThrough(Pattern.compile("example.org"), true));
+        options.addPassThrough(new PassThrough(Pattern.compile("example.com"), true));
+        // When
+        boolean removed = options.setPassThroughEnabled("example.org", false);
+        // Then
+        assertThat(removed, is(equalTo(true)));
+        assertThat(options.getPassThroughs(), hasSize(2));
+        assertThat(
+                config.getProperty(PASS_THROUGH_KEY + "(0).authority"), is(equalTo("example.org")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(0).enabled"), is(equalTo(false)));
+        assertThat(
+                config.getProperty(PASS_THROUGH_KEY + "(1).authority"), is(equalTo("example.com")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(1).enabled"), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldReturnFalseIfPassThroughNotChanged() {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        options.load(config);
+        options.addPassThrough(new PassThrough(Pattern.compile("example.org"), true));
+        options.addPassThrough(new PassThrough(Pattern.compile("example.com"), true));
+        // When
+        boolean removed = options.setPassThroughEnabled("other.example.org", false);
+        // Then
+        assertThat(removed, is(equalTo(false)));
+        assertThat(options.getPassThroughs(), hasSize(2));
+        assertThat(
+                config.getProperty(PASS_THROUGH_KEY + "(0).authority"), is(equalTo("example.org")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(0).enabled"), is(equalTo(true)));
+        assertThat(
+                config.getProperty(PASS_THROUGH_KEY + "(1).authority"), is(equalTo("example.com")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(1).enabled"), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldThrowIfSettingNullAuthorityEnabled() {
+        // Given
+        String authority = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class, () -> options.setPassThroughEnabled(authority, true));
+        assertThat(options.getPassThroughs(), hasSize(0));
+    }
+
+    @Test
+    void shouldRemovePassThrough() {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        options.load(config);
+        options.addPassThrough(new PassThrough(Pattern.compile("example.org"), true));
+        options.addPassThrough(new PassThrough(Pattern.compile("example.com"), true));
+        // When
+        boolean removed = options.removePassThrough("example.org");
+        // Then
+        assertThat(removed, is(equalTo(true)));
+        assertThat(options.getPassThroughs(), hasSize(1));
+        assertThat(
+                config.getProperty(PASS_THROUGH_KEY + "(0).authority"), is(equalTo("example.com")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(0).enabled"), is(equalTo(true)));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(1).authority"), is(nullValue()));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(1).enabled"), is(nullValue()));
+    }
+
+    @Test
+    void shouldReturnFalseIfPassThroughNotRemoved() {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        options.load(config);
+        options.addPassThrough(new PassThrough(Pattern.compile("example.org"), true));
+        options.addPassThrough(new PassThrough(Pattern.compile("example.com"), true));
+        // When
+        boolean removed = options.removePassThrough("other.example.org");
+        // Then
+        assertThat(removed, is(equalTo(false)));
+        assertThat(options.getPassThroughs(), hasSize(2));
+        assertThat(
+                config.getProperty(PASS_THROUGH_KEY + "(0).authority"), is(equalTo("example.org")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(0).enabled"), is(equalTo(true)));
+        assertThat(
+                config.getProperty(PASS_THROUGH_KEY + "(1).authority"), is(equalTo("example.com")));
+        assertThat(config.getProperty(PASS_THROUGH_KEY + "(1).enabled"), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldThrowIfRemovingNullAuthority() {
+        // Given
+        String authority = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> options.removePassThrough(authority));
+        assertThat(options.getPassThroughs(), hasSize(0));
+    }
+
+    @Test
+    void shouldSetAndPersistConfirmRemovePassThrough() throws Exception {
+        // Given
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        options.load(config);
+        // When
+        options.setConfirmRemovePassThrough(false);
+        // Then
+        assertThat(options.isConfirmRemovePassThrough(), is(equalTo(false)));
+        assertThat(
+                config.getBoolean("network.localServers.passThroughs.confirmRemove"),
+                is(equalTo(false)));
+    }
+
+    @Test
+    void shouldLoadConfigWithPassThroughs() {
+        // Given
+        ZapXmlConfiguration config =
+                configWith(
+                        "<network>\n"
+                                + "  <localServers version=\"1\">\n"
+                                + "    <passThroughs>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority>example.org</authority>\n"
+                                + "        <enabled>true</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority>example.com</authority>\n"
+                                + "        <enabled>false</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "    </passThroughs>\n"
+                                + "  </localServers>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getPassThroughs(), hasSize(2));
+        assertThat(
+                options.getPassThroughs().get(0).getAuthority().pattern(),
+                is(equalTo("example.org")));
+        assertThat(options.getPassThroughs().get(0).isEnabled(), is(equalTo(true)));
+        assertThat(
+                options.getPassThroughs().get(1).getAuthority().pattern(),
+                is(equalTo("example.com")));
+        assertThat(options.getPassThroughs().get(1).isEnabled(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldSetAndPersistPassThroughs() {
+        // Given
+        ZapXmlConfiguration config =
+                configWith(
+                        "<network>\n"
+                                + "  <localServers version=\"1\">\n"
+                                + "    <passThroughs>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority>example.org</authority>\n"
+                                + "        <enabled>true</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority>example.com</authority>\n"
+                                + "        <enabled>false</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "    </passThroughs>\n"
+                                + "  </localServers>\n"
+                                + "</network>");
+        options.load(config);
+        List<PassThrough> passThroughs = options.getPassThroughs();
+        options.load(new ZapXmlConfiguration());
+        // When
+        options.setPassThroughs(passThroughs);
+        // Then
+        assertThat(options.getPassThroughs(), hasSize(2));
+        assertThat(
+                options.getPassThroughs().get(0).getAuthority().pattern(),
+                is(equalTo("example.org")));
+        assertThat(options.getPassThroughs().get(0).isEnabled(), is(equalTo(true)));
+        assertThat(
+                options.getPassThroughs().get(1).getAuthority().pattern(),
+                is(equalTo("example.com")));
+        assertThat(options.getPassThroughs().get(1).isEnabled(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldLoadConfigWhileIgnoringInvalidPassThroughs() {
+        // Given
+        ZapXmlConfiguration config =
+                configWith(
+                        "<network>\n"
+                                + "  <localServers version=\"1\">\n"
+                                + "    <passThroughs>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority></authority>\n"
+                                + "        <enabled>true</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "      <passThrough>\n"
+                                + "        <enabled>false</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority>*</authority>\n"
+                                + "        <enabled>false</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority>example.com</authority>\n"
+                                + "        <enabled>not a boolean</enabled>\n"
+                                + "      </passThrough>\n"
+                                + "      <passThrough>\n"
+                                + "        <authority>valid.example.com</authority>\n"
+                                + "      </passThrough>\n"
+                                + "    </passThroughs>\n"
+                                + "  </localServers>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getPassThroughs(), hasSize(1));
+        assertThat(
+                options.getPassThroughs().get(0).getAuthority().pattern(),
+                is(equalTo("valid.example.com")));
+        assertThat(options.getPassThroughs().get(0).isEnabled(), is(equalTo(true)));
+    }
+
+    private static ZapXmlConfiguration configWith(String value) {
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        String contents =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                        + "<config>\n"
+                        + value
+                        + "\n</config>";
+        try {
+            config.load(new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return config;
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/PassThroughHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/PassThroughHandlerUnitTest.java
@@ -58,8 +58,8 @@ import org.zaproxy.addon.network.server.Server;
 import org.zaproxy.addon.network.testutils.TestClient;
 import org.zaproxy.addon.network.testutils.TextTestClient;
 
-/** Unit test for {@link PassthroughHandler}. */
-class PassthroughHandlerUnitTest {
+/** Unit test for {@link PassThroughHandler}. */
+class PassThroughHandlerUnitTest {
 
     private static final String CLIENT_CODEC_NAME = "http.client";
 
@@ -81,7 +81,7 @@ class PassthroughHandlerUnitTest {
         eventLoopGroup =
                 new NioEventLoopGroup(
                         NettyRuntime.availableProcessors(),
-                        new DefaultThreadFactory("ZAP-PassthroughHandlerUnitTest"));
+                        new DefaultThreadFactory("ZAP-PassThroughHandlerUnitTest"));
 
         client =
                 new TextTestClient(
@@ -124,13 +124,13 @@ class PassthroughHandlerUnitTest {
         }
     }
 
-    private BaseServer createProxy(Predicate<HttpRequestHeader> passthroughCondition) {
-        proxy = new BaseServer(eventLoopGroup, ch -> initProxyChannel(ch, passthroughCondition));
+    private BaseServer createProxy(Predicate<HttpRequestHeader> passThroughCondition) {
+        proxy = new BaseServer(eventLoopGroup, ch -> initProxyChannel(ch, passThroughCondition));
         return proxy;
     }
 
     private void initProxyChannel(
-            SocketChannel ch, Predicate<HttpRequestHeader> passthroughCondition) {
+            SocketChannel ch, Predicate<HttpRequestHeader> passThroughCondition) {
         ch.pipeline()
                 .addLast(new HttpRequestDecoder())
                 .addLast(HttpResponseEncoder.getInstance())
@@ -144,7 +144,7 @@ class PassthroughHandlerUnitTest {
                                 ctx.fireChannelRead(msg);
                             }
                         })
-                .addLast(new PassthroughHandler(passthroughCondition))
+                .addLast(new PassThroughHandler(passThroughCondition))
                 .addLast(
                         new SimpleChannelInboundHandler<HttpMessage>() {
 
@@ -207,7 +207,7 @@ class PassthroughHandlerUnitTest {
     }
 
     @Test
-    void shouldNotPassthroughIfDisabled() throws Exception {
+    void shouldNotPassThroughIfDisabled() throws Exception {
         // Given
         int serverPort = startServer();
         int proxyPort = createProxy(NO_PASSTHROUGH).start(Server.ANY_PORT);
@@ -218,7 +218,7 @@ class PassthroughHandlerUnitTest {
         clientChannel.writeAndFlush(request).sync();
         HttpMessage response = (HttpMessage) TextTestClient.waitForResponse(clientChannel);
         // Then
-        assertTrue(Boolean.FALSE.equals(proxyChannel.attr(ChannelAttributes.PASSTHROUGH).get()));
+        assertTrue(Boolean.FALSE.equals(proxyChannel.attr(ChannelAttributes.PASS_THROUGH).get()));
         assertThat(proxyMessagesProcessed, hasSize(1));
         assertThat(serverMessagesReceived, hasSize(0));
         assertThat(
@@ -227,7 +227,7 @@ class PassthroughHandlerUnitTest {
     }
 
     @Test
-    void shouldNotPassthroughIfNotConnect() throws Exception {
+    void shouldNotPassThroughIfNotConnect() throws Exception {
         // Given
         int serverPort = startServer();
         int proxyPort = createProxy(PASSTHROUGH_ALL).start(Server.ANY_PORT);
@@ -237,7 +237,7 @@ class PassthroughHandlerUnitTest {
         clientChannel.writeAndFlush(request).sync();
         HttpMessage response = (HttpMessage) TextTestClient.waitForResponse(clientChannel);
         // Then
-        assertTrue(Boolean.FALSE.equals(proxyChannel.attr(ChannelAttributes.PASSTHROUGH).get()));
+        assertTrue(Boolean.FALSE.equals(proxyChannel.attr(ChannelAttributes.PASS_THROUGH).get()));
         assertThat(proxyMessagesProcessed, hasSize(1));
         assertThat(serverMessagesReceived, hasSize(0));
         assertThat(
@@ -246,7 +246,7 @@ class PassthroughHandlerUnitTest {
     }
 
     @Test
-    void shouldNotPassthroughIfNotAllowedConnect() throws Exception {
+    void shouldNotPassThroughIfNotAllowedConnect() throws Exception {
         // Given
         int serverPort = startServer();
         int proxyPort =
@@ -258,7 +258,7 @@ class PassthroughHandlerUnitTest {
         clientChannel.writeAndFlush(request).sync();
         HttpMessage response = (HttpMessage) TextTestClient.waitForResponse(clientChannel);
         // Then
-        assertTrue(Boolean.FALSE.equals(proxyChannel.attr(ChannelAttributes.PASSTHROUGH).get()));
+        assertTrue(Boolean.FALSE.equals(proxyChannel.attr(ChannelAttributes.PASS_THROUGH).get()));
         assertThat(proxyMessagesProcessed, hasSize(1));
         assertThat(serverMessagesReceived, hasSize(0));
         assertThat(
@@ -267,7 +267,7 @@ class PassthroughHandlerUnitTest {
     }
 
     @Test
-    void shouldPassthroughIfAllowedConnect() throws Exception {
+    void shouldPassThroughIfAllowedConnect() throws Exception {
         // Given
         int serverPort = startServer();
         int proxyPort =
@@ -283,15 +283,15 @@ class PassthroughHandlerUnitTest {
                 is(equalTo("HTTP/1.1 200 Connection established\r\n\r\n")));
         clientChannel.pipeline().remove(CLIENT_CODEC_NAME);
         clientChannel.writeAndFlush("Message 1\n").sync();
-        String passthroughResponse1 = (String) TextTestClient.waitForResponse(clientChannel);
+        String passThroughResponse1 = (String) TextTestClient.waitForResponse(clientChannel);
         clientChannel.writeAndFlush("Message 2\n").sync();
-        String passthroughResponse2 = (String) TextTestClient.waitForResponse(clientChannel);
+        String passThroughResponse2 = (String) TextTestClient.waitForResponse(clientChannel);
         // Then
-        assertTrue(Boolean.TRUE.equals(proxyChannel.attr(ChannelAttributes.PASSTHROUGH).get()));
+        assertTrue(Boolean.TRUE.equals(proxyChannel.attr(ChannelAttributes.PASS_THROUGH).get()));
         assertThat(proxyMessagesProcessed, hasSize(0));
         assertThat(serverMessagesReceived, contains("Message 1", "Message 2"));
-        assertThat(passthroughResponse1, is(equalTo("Received: Message 1")));
-        assertThat(passthroughResponse2, is(equalTo("Received: Message 2")));
+        assertThat(passThroughResponse1, is(equalTo("Received: Message 1")));
+        assertThat(passThroughResponse2, is(equalTo("Received: Message 2")));
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/PassThroughUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/PassThroughUnitTest.java
@@ -1,0 +1,278 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.server.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.apache.commons.httpclient.URI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpRequestHeader;
+
+/** Unit test for {@link PassThrough}. */
+class PassThroughUnitTest {
+
+    @Test
+    void shouldCreateWithGivenValues() {
+        // Given
+        Pattern authority = Pattern.compile("example.org");
+        boolean enabled = false;
+        // When
+        PassThrough passThrough = new PassThrough(authority, enabled);
+        // Then
+        assertThat(passThrough.getAuthority(), is(equalTo(authority)));
+        assertThat(passThrough.isEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldThrowWhenCreatingWithNullAuthority() {
+        // Given
+        Pattern authority = null;
+        boolean enabled = false;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new PassThrough(authority, enabled));
+    }
+
+    @Test
+    void shouldCreateWithOtherInstance() {
+        // Given
+        Pattern authority = Pattern.compile("example.org");
+        boolean enabled = false;
+        PassThrough other = new PassThrough(authority, enabled);
+        // When
+        PassThrough passThrough = new PassThrough(other);
+        // Then
+        assertThat(passThrough.getAuthority(), is(equalTo(authority)));
+        assertThat(passThrough.isEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldThrowWhenCreatingWithNullOtherInstance() {
+        // Given
+        PassThrough other = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new PassThrough(other));
+    }
+
+    @Test
+    void shouldSetEnabledState() {
+        // Given
+        Pattern authority = Pattern.compile("example.org");
+        PassThrough passThrough = new PassThrough(authority, true);
+        boolean enabled = false;
+        // When
+        passThrough.setEnabled(enabled);
+        // Then
+        assertThat(passThrough.isEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldSetAuthority() {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), true);
+        Pattern authority = Pattern.compile("example.com");
+        // When
+        passThrough.setAuthority(authority);
+        // Then
+        assertThat(passThrough.getAuthority(), is(equalTo(authority)));
+    }
+
+    @Test
+    void shouldThrowWhenSettingNullAuthority() {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), true);
+        Pattern authority = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> passThrough.setAuthority(authority));
+    }
+
+    @Test
+    void shouldProduceConsistentHashCodes() {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), false);
+        // When
+        int hashCode = passThrough.hashCode();
+        // Then
+        assertThat(hashCode, is(equalTo(-1943962101)));
+    }
+
+    @Test
+    void shouldBeEqualToItself() {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), false);
+        // When
+        boolean equals = passThrough.equals(passThrough);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    static Stream<Arguments> constructorArgsProvider() {
+        return Stream.of(
+                arguments(Pattern.compile("example.org"), false),
+                arguments(Pattern.compile("example.com"), true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("constructorArgsProvider")
+    void shouldBeEqualToDifferentPassThroughWithSameContents(Pattern authority, boolean enabled) {
+        // Given
+        PassThrough passThrough = new PassThrough(authority, enabled);
+        PassThrough otherEqualPassThrough = new PassThrough(authority, enabled);
+        // When
+        boolean equals = passThrough.equals(otherEqualPassThrough);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotBeEqualToNull() {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), false);
+        // When
+        boolean equals = passThrough.equals(null);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    static Stream<Arguments> differencesProvider() {
+        Pattern authority = Pattern.compile("example.org");
+        Pattern otherAuthority = Pattern.compile("example.com");
+        return Stream.of(
+                arguments(authority, false, authority, true),
+                arguments(authority, true, authority, false),
+                arguments(authority, true, otherAuthority, true),
+                arguments(otherAuthority, true, authority, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("differencesProvider")
+    void shouldNotBeEqualToPassThroughWithDifferentValues(
+            Pattern authority, boolean enabled, Pattern otherAuthority, boolean otherEnabled) {
+        // Given
+        PassThrough passThrough = new PassThrough(authority, enabled);
+        PassThrough otherPassThrough = new PassThrough(otherAuthority, otherEnabled);
+        // When
+        boolean equals = passThrough.equals(otherPassThrough);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToExtendedPassThrough() {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), false);
+        PassThrough otherPassThrough = new PassThrough(Pattern.compile("example.org"), false) {
+                    // Anonymous PassThrough
+                };
+        // When
+        boolean equals = passThrough.equals(otherPassThrough);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "example.org",
+                "subdomain.example.org",
+                "example.org:443",
+                "example.org:8080"
+            })
+    void shouldReturnTrueWhenTestingWithMatchingAuthority(String authority) {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), true);
+        // When
+        boolean result = passThrough.test(requestWithAuthority(authority));
+        // Then
+        assertThat(result, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldReturnFalseWhenTestingWithMatchingAuthorityButNotEnabled() {
+        // Given
+        boolean enabled = false;
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), enabled);
+        // When
+        boolean result = passThrough.test(requestWithAuthority("subdomain.example.org"));
+        // Then
+        assertThat(result, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldReturnFalseWhenTestingWithNonMatchingAuthority() {
+        // Given
+        PassThrough passThrough = new PassThrough(Pattern.compile("example.org"), true);
+        // When
+        boolean result = passThrough.test(requestWithAuthority("example.com"));
+        // Then
+        assertThat(result, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldCreateAuthorityPattern() {
+        // Given
+        String value = "example.org";
+        // When
+        Pattern authority = PassThrough.createAuthorityPattern(value);
+        // Then
+        assertThat(authority, is(notNullValue()));
+        assertThat(authority.pattern(), is(equalTo(value)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldReturnNullForEmptyAndNullAuthorityPattern(String value) {
+        // Given / When
+        Pattern authority = PassThrough.createAuthorityPattern(value);
+        // Then
+        assertThat(authority, is(nullValue()));
+    }
+
+    @Test
+    void shouldThrowWhenCreatingWithInvalidAuthorityPattern() {
+        // Given
+        String value = "[";
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> PassThrough.createAuthorityPattern(value));
+    }
+
+    private static HttpRequestHeader requestWithAuthority(String authority) {
+        HttpRequestHeader requestHeader = mock(HttpRequestHeader.class);
+        URI uri = mock(URI.class);
+        given(requestHeader.getURI()).willReturn(uri);
+        given(uri.getEscapedAuthority()).willReturn(authority);
+        return requestHeader;
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ui/PassThroughTableModelUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ui/PassThroughTableModelUnitTest.java
@@ -1,0 +1,61 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.server.http.PassThrough;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link PassThroughTableModel}. */
+class PassThroughTableModelUnitTest {
+
+    @BeforeAll
+    static void setUpAll() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @Test
+    void shouldCreateCopyOfCollectionAndValues() {
+        // Given
+        PassThroughTableModel model = new PassThroughTableModel();
+        List<PassThrough> passThroughs = new ArrayList<>();
+        PassThrough original = new PassThrough(Pattern.compile("X"), false);
+        passThroughs.add(original);
+        // When
+        model.setPassThroughs(passThroughs);
+        model.setAllEnabled(true);
+        passThroughs.clear();
+        // Then
+        assertThat(original.isEnabled(), is(equalTo(false)));
+        assertThat(model.getElements(), hasSize(1));
+        assertThat(model.getElements().get(0).isEnabled(), is(equalTo(true)));
+    }
+}


### PR DESCRIPTION
Allow to manage pass-through authorities with the UI and API.
Set `PassThroughHandler` as sharable to reuse the same handler in
several proxies.
Correct pass-through word everywhere.

Part of zaproxy/zaproxy#6832.