### PR TITLE
network: provide localProxies endpoints

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -333,6 +333,8 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                             requestHeader ->
                                     localServersOptions.getPassThroughs().stream()
                                             .anyMatch(e -> e.test(requestHeader)));
+
+            extensionHook.addApiImplementor(new LegacyProxiesApi(this));
         }
 
         if (hasView()) {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LegacyProxiesApi.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LegacyProxiesApi.java
@@ -1,0 +1,139 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import java.util.HashMap;
+import java.util.Map;
+import net.sf.json.JSONObject;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.server.http.LocalServerConfig;
+import org.zaproxy.zap.extension.api.API;
+import org.zaproxy.zap.extension.api.ApiAction;
+import org.zaproxy.zap.extension.api.ApiElement;
+import org.zaproxy.zap.extension.api.ApiException;
+import org.zaproxy.zap.extension.api.ApiImplementor;
+import org.zaproxy.zap.extension.api.ApiResponse;
+import org.zaproxy.zap.extension.api.ApiResponseElement;
+import org.zaproxy.zap.extension.api.ApiResponseList;
+import org.zaproxy.zap.extension.api.ApiResponseSet;
+import org.zaproxy.zap.extension.api.ApiView;
+
+class LegacyProxiesApi extends ApiImplementor {
+
+    private static final String PREFIX = "localProxies";
+
+    private static final String VIEW_ADDITIONAL_PROXIES = "additionalProxies";
+    private static final String ACTION_ADD_PROXY = "addAdditionalProxy";
+    private static final String ACTION_REMOVE_PROXY = "removeAdditionalProxy";
+    private static final String PARAM_ADDRESS = "address";
+    private static final String PARAM_PORT = "port";
+    private static final String PARAM_BEHIND_NAT = "behindNat";
+    private static final String PARAM_DECODE_ZIP = "alwaysDecodeZip";
+    private static final String PARAM_REM_UNSUPPORTED_ENC = "removeUnsupportedEncodings";
+
+    private final ExtensionNetwork extensionNetwork;
+
+    public LegacyProxiesApi(ExtensionNetwork extensionNetwork) {
+        this.extensionNetwork = extensionNetwork;
+
+        this.addApiView(deprecate(new ApiView(VIEW_ADDITIONAL_PROXIES)));
+        this.addApiAction(
+                deprecate(
+                        new ApiAction(
+                                ACTION_ADD_PROXY,
+                                new String[] {PARAM_ADDRESS, PARAM_PORT},
+                                new String[] {
+                                    PARAM_BEHIND_NAT, PARAM_DECODE_ZIP, PARAM_REM_UNSUPPORTED_ENC
+                                })));
+        this.addApiAction(
+                deprecate(
+                        new ApiAction(
+                                ACTION_REMOVE_PROXY, new String[] {PARAM_ADDRESS, PARAM_PORT})));
+    }
+
+    private static <T extends ApiElement> T deprecate(T element) {
+        element.setDeprecated(true);
+        element.setDeprecatedDescription(
+                Constant.messages.getString("network.api.legacy.deprecated.network"));
+        return element;
+    }
+
+    @Override
+    protected String getI18nPrefix() {
+        return "network.api.legacy";
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public ApiResponse handleApiView(String name, JSONObject params) throws ApiException {
+        if (VIEW_ADDITIONAL_PROXIES.equals(name)) {
+            ApiResponseList response = new ApiResponseList(name);
+
+            for (LocalServerConfig p : extensionNetwork.getLocalServersOptions().getServers()) {
+                Map<String, String> map = new HashMap<>();
+                map.put("address", p.getAddress());
+                map.put("port", Integer.toString(p.getPort()));
+                map.put("enabled", Boolean.toString(p.isEnabled()));
+                map.put("behindNat", Boolean.toString(p.isBehindNat()));
+                map.put("alwaysDecodeZip", Boolean.toString(p.isDecodeResponse()));
+                map.put("removeUnsupportedEncodings", Boolean.toString(p.isRemoveAcceptEncoding()));
+                response.addItem(new ApiResponseSet<>("proxy", map));
+            }
+
+            return response;
+        }
+
+        throw new ApiException(ApiException.Type.BAD_VIEW, name);
+    }
+
+    @Override
+    public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
+        if (ACTION_ADD_PROXY.equals(name)) {
+            params.put(
+                    "removeAcceptEncoding", params.optString(PARAM_REM_UNSUPPORTED_ENC, "false"));
+            params.put("decodeResponse", params.optString(PARAM_DECODE_ZIP, "false"));
+            getNetworkImplementor().handleApiAction("addLocalServer", params);
+            return ApiResponseElement.OK;
+        }
+
+        if (ACTION_REMOVE_PROXY.equals(name)) {
+            try {
+                getNetworkImplementor().handleApiAction("removeLocalServer", params);
+                return ApiResponseElement.OK;
+            } catch (ApiException e) {
+                String address = params.getString(PARAM_ADDRESS);
+                int port = params.getInt(PARAM_PORT);
+                throw new ApiException(
+                        ApiException.Type.ILLEGAL_PARAMETER,
+                        "Proxy not found: " + address + ":" + port);
+            }
+        }
+
+        throw new ApiException(ApiException.Type.BAD_ACTION, name);
+    }
+
+    private static ApiImplementor getNetworkImplementor() {
+        return API.getInstance().getImplementors().get("network");
+    }
+}

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -40,6 +40,11 @@ network.api.view.getPassThroughs = Gets the authorities that will pass-through t
 network.api.view.getRootCaCertValidity = Gets the Root CA certificate validity, in days. Used when generating a new Root CA certificate.
 network.api.view.getServerCertValidity = Gets the server certificate validity, in days. Used when generating server certificates.
 
+network.api.legacy.api.action.addAdditionalProxy = Adds a new proxy using the details supplied.
+network.api.legacy.api.action.removeAdditionalProxy = Removes the additional proxy with the specified address and port.
+network.api.legacy.api.view.additionalProxies = Gets all of the additional proxies that have been configured.
+network.api.legacy.deprecated.network = Use the API endpoints in the 'network' component instead.
+
 network.cmdline.certdump.done = Root CA certificate written to {0}
 network.cmdline.certfulldump = Dumps the Root CA full certificate (including the private key) into the specified file name, this is suitable for importing into ZAP
 network.cmdline.certload = Loads the Root CA certificate from the specified file name

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -189,6 +189,20 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldAddLegacyProxiesApiOnHookIfHandlingLocalServers() {
+        // Given
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        extension.handleServerCerts = true;
+        extension.handleLocalServers = true;
+        // When
+        extension.hook(extensionHook);
+        // Then
+        ArgumentCaptor<LegacyProxiesApi> argument = ArgumentCaptor.forClass(LegacyProxiesApi.class);
+        verify(extensionHook, times(2)).addApiImplementor(argument.capture());
+        assertThat(argument.getAllValues(), hasItem(instanceOf(LegacyProxiesApi.class)));
+    }
+
+    @Test
     void shouldNotAddServerCertificatesOptionsOnHookIfNotHandlingServerCerts() throws Exception {
         // Given
         ExtensionHook extensionHook = mock(ExtensionHook.class);


### PR DESCRIPTION
Provide the deprecated `localProxies` endpoints with the add-on to
completely disable the corresponding extension in core.