### PR TITLE
network: process args -host and -port

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/server/Server.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/server/Server.java
@@ -84,11 +84,13 @@ public interface Server extends Closeable {
      * Validates that the given port is within the allowed range.
      *
      * @param port the port to validate
+     * @return the valid port.
      * @throws IllegalArgumentException if the port is invalid.
      */
-    static void validatePort(int port) {
+    static int validatePort(int port) {
         if (port < ANY_PORT || port > MAX_PORT) {
             throw new IllegalArgumentException("Invalid port: " + port);
         }
+        return port;
     }
 }

--- a/addOns/network/src/main/javahelp/help/contents/cmdline.html
+++ b/addOns/network/src/main/javahelp/help/contents/cmdline.html
@@ -25,7 +25,21 @@
 			<td>-certfulldump</td>
 			<td>Dumps the Root CA certificate and the private key into the specified file, this is suitable for importing into ZAP.</td>
 		</tr>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td>-host</td>
+			<td>Overrides the host used for proxying specified in the configuration file.</td>
+		</tr>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td>-port</td>
+			<td>Overrides the port used for proxying specified in the configuration file.</td>
+		</tr>
 	</table>
+
+	<H3>Local Servers/Proxies</H3>
+	The local servers/proxies are not started when ZAP is running in command line mode (i.e. <code>-cmd</code>). If unable to start the main
+	proxy in daemon mode (i.e. <code>-daemon</code>) ZAP is terminated, when running with GUI an appropriate warning is shown instead.
 
 	<H2>See also</H2>
 	<table>

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -48,6 +48,10 @@ network.cmdline.certpubdump = Dumps the Root CA public certificate into the spec
 network.cmdline.error.noread = Cannot read file {0}
 network.cmdline.error.nowrite = Cannot write to file {0}
 network.cmdline.error.write = Error writing Root CA certificate to {0}
+network.cmdline.proxy.host = Overrides the host used for proxying specified in the configuration file
+network.cmdline.proxy.port = Overrides the port used for proxying specified in the configuration file
+network.cmdline.proxy.port.invalid.title = Invalid Port Number
+network.cmdline.proxy.port.invalid.message = Unable to start the main proxy, -port value is not a valid port number:\n{0}
 
 network.ext.name = Network Extension
 network.ext.desc = Provides core networking capabilities.

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -253,6 +253,28 @@ class ExtensionNetworkUnitTest extends TestUtils {
     }
 
     @Test
+    void shouldAddHostAndPortCommandLineArgsOnHookIfHandlingLocalServerServers() throws Exception {
+        // Given
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        extension.handleServerCerts = true;
+        extension.handleLocalServers = true;
+        // When
+        extension.hook(extensionHook);
+        // Then
+        ArgumentCaptor<CommandLineArgument[]> argument =
+                ArgumentCaptor.forClass(CommandLineArgument[].class);
+        verify(extensionHook).addCommandLine(argument.capture());
+        CommandLineArgument[] args = argument.getAllValues().get(0);
+        assertThat(args, arrayWithSize(5));
+        assertThat(args[3].getName(), is(equalTo("-host")));
+        assertThat(args[3].getNumOfArguments(), is(equalTo(1)));
+        assertThat(args[3].getHelpMessage(), is(not(emptyString())));
+        assertThat(args[4].getName(), is(equalTo("-port")));
+        assertThat(args[4].getNumOfArguments(), is(equalTo(1)));
+        assertThat(args[4].getHelpMessage(), is(not(emptyString())));
+    }
+
+    @Test
     void shouldAddLegacyProxyListenerHandlerOnHookAlways() {
         // Given
         ExtensionHook extensionHook = mock(ExtensionHook.class);


### PR DESCRIPTION
Process the command line arguments `-host` and `-port`, they will be
removed from core.