### PR TITLE
Automation: Fix add-ons UI bug

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Issue when adding or removing add-ons via the UI (Issue 7075)
 
 ## [0.12.0] - 2022-02-01
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAddOnsDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAddOnsDialog.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.automation.gui;
 
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
@@ -47,6 +48,9 @@ public class AddAddOnsDialog extends StandardFieldsDialog {
 
     @Override
     public String validateFields() {
+        if (this.isEmptyField(ADDON_ID_PARAM)) {
+            return Constant.messages.getString("automation.dialog.addon.error.noname");
+        }
         // Nothing to do
         return null;
     }

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
@@ -161,7 +161,7 @@ public class AddOnJobDialog extends StandardFieldsDialog {
     private AddOnsTableModel getAddOnsInstallModel() {
         if (addOnsInstallModel == null) {
             addOnsInstallModel = new AddOnsTableModel();
-            addOnsInstallModel.setAddOns(job.getData().getInstall());
+            addOnsInstallModel.setAddOns(new ArrayList<>(job.getData().getInstall()));
         }
         return addOnsInstallModel;
     }
@@ -183,7 +183,7 @@ public class AddOnJobDialog extends StandardFieldsDialog {
     private AddOnsTableModel getAddOnsUninstallModel() {
         if (addOnsUninstallModel == null) {
             addOnsUninstallModel = new AddOnsTableModel();
-            addOnsUninstallModel.setAddOns(job.getData().getUninstall());
+            addOnsUninstallModel.setAddOns(new ArrayList<>(job.getData().getUninstall()));
         }
         return addOnsUninstallModel;
     }

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -21,6 +21,7 @@ automation.dialog.addon.updateaddons = Update Add-Ons:
 automation.dialog.addon.installaddons = Install Add-Ons:
 automation.dialog.addon.uninstalladdons = Uninstall Add-Ons:
 automation.dialog.addon.table.header.addons = AddOns
+automation.dialog.addon.error.noname = You must specify an Add-On Id
 
 automation.dialog.addreq.title = Request
 automation.dialog.addreq.url = URL:


### PR DESCRIPTION
Fixes https://github.com/zaproxy/zaproxy/issues/7075

The problem was that when adding the addons job from the UI the add-ons to add/remove default to `Collections.emptyList()`.
This was then used as is - but the collection is immutable and therefore we got an exception when we tried to add to it.
The fix is to always copy the relevant lists.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>