### PR TITLE
chore: Leverage isEmpty vs size equality zero checks

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed 
 - Remote OS Command Injection rule now has more information in the Other Info field to differentiate feedback-based or time-based tests
 - Path Traversal scan rule, updated the regex for case 5 to be case-insensitive when searching for Error or Exception in content body.
-
+- Maintenance changes.
 
 ## [44] - 2022-01-13
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -238,15 +238,15 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
             HtmlContextAnalyser hca = new HtmlContextAnalyser(msg2);
             List<HtmlContext> contexts = hca.getHtmlContexts(Constant.getEyeCatcher(), null, 0);
-            if (contexts.size() == 0) {
+            if (contexts.isEmpty()) {
                 // Lower case?
                 contexts = hca.getHtmlContexts(Constant.getEyeCatcher().toLowerCase(), null, 0);
             }
-            if (contexts.size() == 0) {
+            if (contexts.isEmpty()) {
                 // Upper case?
                 contexts = hca.getHtmlContexts(Constant.getEyeCatcher().toUpperCase(), null, 0);
             }
-            if (contexts.size() == 0) {
+            if (contexts.isEmpty()) {
                 // No luck - try again, appending the eyecatcher to the original
                 // value
                 msg2 = getNewMsg();
@@ -264,7 +264,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 hca = new HtmlContextAnalyser(msg2);
                 contexts = hca.getHtmlContexts(value + Constant.getEyeCatcher(), null, 0);
             }
-            if (contexts.size() == 0) {
+            if (contexts.isEmpty()) {
                 // No luck - lets just try a direct attack
                 for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
                     List<HtmlContext> contexts2 =

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SessionFixationScanRule.java
@@ -1314,7 +1314,7 @@ public class SessionFixationScanRule extends AbstractAppPlugin {
      */
     private HtmlParameter getResponseCookie(HttpMessage message, String cookieName) {
         TreeSet<HtmlParameter> cookieBackParams = message.getResponseHeader().getCookieParams();
-        if (cookieBackParams.size() == 0) {
+        if (cookieBackParams.isEmpty()) {
             // no cookies
             return null;
         }

--- a/addOns/bruteforce/CHANGELOG.md
+++ b/addOns/bruteforce/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Maintenance changes.
 
 ## [11] - 2021-10-06
 ### Changed

--- a/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
+++ b/addOns/bruteforce/src/main/java/com/sittinglittleduck/DirBuster/GenBaseCase.java
@@ -135,7 +135,7 @@ public class GenBaseCase {
                 if (!baseResponce1.equalsIgnoreCase(baseResponce2)
                         || !baseResponce1.equalsIgnoreCase(baseResponce3)
                         || !baseResponce2.equalsIgnoreCase(baseResponce3)) {
-                    if (manager.getFailCaseRegexes().size() != 0) {
+                    if (!manager.getFailCaseRegexes().isEmpty()) {
 
                         /*
                          * for each saved regex see if it will work, if it does then use that one

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/ExtensionBruteForce.java
@@ -312,7 +312,7 @@ public class ExtensionBruteForce extends ExtensionAdaptor
         }
         // Allow 2 secs for the threads to stop - if we wait 'for ever' then we can get deadlocks
         for (int i = 0; i < 20; i++) {
-            if (activeScans.size() == 0) {
+            if (activeScans.isEmpty()) {
                 break;
             }
             try {

--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Dependency updates.
+- Maintenance changes.
 
 ## [3] - 2021-10-07
 ### Added

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzillaParam.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerBugzillaParam.java
@@ -45,7 +45,6 @@ public class BugTrackerBugzillaParam extends AbstractParam {
             GITHUB_BASE_KEY + ".confirmRemoveConfig";
 
     private List<BugTrackerBugzillaConfigParams> configs = null;
-    // private List<String> enabledConfigsNames = null;
 
     private boolean confirmRemoveConfig = true;
 
@@ -57,7 +56,7 @@ public class BugTrackerBugzillaParam extends AbstractParam {
             List<HierarchicalConfiguration> fields =
                     ((HierarchicalConfiguration) getConfig()).configurationsAt(ALL_CONFIGS_KEY);
             this.configs = new ArrayList<>(fields.size());
-            // enabledConfigsNames = new ArrayList<>(fields.size());
+
             List<String> tempConfigsNames = new ArrayList<>(fields.size());
             for (HierarchicalConfiguration sub : fields) {
                 String name = sub.getString(CONFIG_NAME_KEY, "");
@@ -67,23 +66,11 @@ public class BugTrackerBugzillaParam extends AbstractParam {
                     this.configs.add(
                             new BugTrackerBugzillaConfigParams(name, password, bugzillaUrl));
                     tempConfigsNames.add(name);
-                    // if (enabled) {
-                    //     enabledConfigsNames.add(name);
-                    // }
                 }
             }
         } catch (ConversionException e) {
             logger.error("Error while loading bugzilla configs: {}", e.getMessage(), e);
-            // this.configs = new ArrayList<>(DEFAULT_CONFIGS_NAMES.length);
-            // this.enabledConfigsNames = new ArrayList<>(DEFAULT_CONFIGS_NAMES.length);
         }
-
-        // if (this.configs.size() == 0) {
-        //     for (String configName : DEFAULT_CONFIGS_NAMES) {
-        //         this.configs.add(new BugTrackerBugzillaConfigParams(configName));
-        //         this.enabledConfigsNames.add(configName);
-        //     }
-        // }
 
         try {
             this.confirmRemoveConfig = getConfig().getBoolean(CONFIRM_REMOVE_CONFIG_KEY, true);
@@ -104,7 +91,6 @@ public class BugTrackerBugzillaParam extends AbstractParam {
 
         ((HierarchicalConfiguration) getConfig()).clearTree(ALL_CONFIGS_KEY);
 
-        // ArrayList<String> enabledConfigs = new ArrayList<>(configs.size());
         for (int i = 0, size = configs.size(); i < size; ++i) {
             String elementBaseKey = ALL_CONFIGS_KEY + "(" + i + ").";
             BugTrackerBugzillaConfigParams config = configs.get(i);
@@ -113,16 +99,7 @@ public class BugTrackerBugzillaParam extends AbstractParam {
             getConfig().setProperty(elementBaseKey + CONFIG_PASSWORD_KEY, config.getPassword());
             getConfig()
                     .setProperty(elementBaseKey + CONFIG_BUGZILLA_URL_KEY, config.getBugzillaUrl());
-            // getConfig().setProperty(elementBaseKey + CONFIG_ENABLED_KEY,
-            // Boolean.valueOf(config.isEnabled()));
-
-            // if (config.isEnabled()) {
-            //     enabledConfigs.add(config.getName());
-            // }
         }
-
-        // enabledConfigs.trimToSize();
-        // this.enabledConfigsNames = enabledConfigs;
     }
 
     /**
@@ -145,8 +122,6 @@ public class BugTrackerBugzillaParam extends AbstractParam {
         }
 
         this.configs.add(new BugTrackerBugzillaConfigParams(name, password, bugzillaUrl));
-
-        // this.enabledConfigsNames.add(name);
     }
 
     /**
@@ -166,17 +141,10 @@ public class BugTrackerBugzillaParam extends AbstractParam {
             BugTrackerBugzillaConfigParams config = it.next();
             if (name.equals(config.getName())) {
                 it.remove();
-                // if (config.isEnabled()) {
-                //     this.enabledConfigsNames.remove(name);
-                // }
                 break;
             }
         }
     }
-
-    // public List<String> getConfigsNames() {
-    //     return enabledConfigsNames;
-    // }
 
     @ZapApiIgnore
     public boolean isConfirmRemoveConfig() {

--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Maintenance changes.
 
 ## [4] - 2021-10-06
 ### Changed

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerParam.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerParam.java
@@ -87,7 +87,7 @@ public class FormHandlerParam extends AbstractParam {
             this.enabledFieldsNames = new ArrayList<>(DEFAULT_KEY_VALUE_PAIRS.size());
         }
 
-        if (this.fields.size() == 0) {
+        if (this.fields.isEmpty()) {
             // Grab the entry for every set in the map
             for (Map.Entry<String, String> entry : DEFAULT_KEY_VALUE_PAIRS.entrySet()) {
                 // Store the key and value of that entry in variables

--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [13.6.0] - 2022-01-14
 ### Added

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/ExtensionFuzz.java
@@ -553,7 +553,7 @@ public class ExtensionFuzz extends ExtensionAdaptor {
     }
 
     private static String createSubCategoryFullName(List<String> categories) {
-        if (categories == null || categories.size() == 0) {
+        if (categories == null || categories.isEmpty()) {
             return "";
         }
         if (categories.size() == 1) {

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/payloads/generator/CompositePayloadGenerator.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/payloads/generator/CompositePayloadGenerator.java
@@ -57,7 +57,7 @@ public class CompositePayloadGenerator<E extends Payload> implements PayloadGene
 
     @Override
     public ResettableAutoCloseableIterator<E> iterator() {
-        if (payloadGenerators.size() == 0) {
+        if (payloadGenerators.isEmpty()) {
             return EmptyResettableAutoCloseableIterator.emptyIterator();
         }
         return new CompositeIterator<>(payloadGenerators);

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/ModernAppDetectionScanRule.java
@@ -48,7 +48,7 @@ public class ModernAppDetectionScanRule extends PluginPassiveScanner {
         String otherInfo = null;
 
         List<Element> links = source.getAllElements(HTMLElementName.A);
-        if (links.size() == 0) {
+        if (links.isEmpty()) {
             // if no links but there are scripts then thats another indication
             List<Element> scripts = source.getAllElements(HTMLElementName.SCRIPT);
             if (scripts.size() > 0) {

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledCharsetScanRule.java
@@ -68,7 +68,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner {
 
         Set<HtmlParameter> params = new TreeSet<>(msg.getFormParams());
         params.addAll(msg.getUrlParams());
-        if (params.size() == 0) {
+        if (params.isEmpty()) {
             return;
         }
 
@@ -88,7 +88,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner {
     private void checkMetaContentCharset(
             HttpMessage msg, int id, Source source, Set<HtmlParameter> params) {
         List<Element> metaElements = source.getAllElements(HTMLElementName.META);
-        if (metaElements == null || metaElements.size() == 0) {
+        if (metaElements == null || metaElements.isEmpty()) {
             return;
         }
 
@@ -137,7 +137,7 @@ public class UserControlledCharsetScanRule extends PluginPassiveScanner {
     private void checkXmlEncodingCharset(
             HttpMessage msg, int id, Source source, Set<HtmlParameter> params) {
         List<StartTag> xmlDeclarationTags = source.getAllStartTags(StartTagType.XML_DECLARATION);
-        if (xmlDeclarationTags.size() == 0) {
+        if (xmlDeclarationTags.isEmpty()) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledHTMLAttributesScanRule.java
@@ -64,13 +64,13 @@ public class UserControlledHTMLAttributesScanRule extends PluginPassiveScanner {
         }
 
         List<Element> htmlElements = source.getAllElements();
-        if (htmlElements.size() == 0) {
+        if (htmlElements.isEmpty()) {
             return;
         }
 
         Set<HtmlParameter> params = new TreeSet<>(msg.getFormParams());
         params.addAll(msg.getUrlParams());
-        if (params.size() == 0) {
+        if (params.isEmpty()) {
             return;
         }
 

--- a/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
+++ b/addOns/pscanrulesBeta/src/main/java/org/zaproxy/zap/extension/pscanrulesBeta/UserControlledJavascriptEventScanRule.java
@@ -109,7 +109,7 @@ public class UserControlledJavascriptEventScanRule extends PluginPassiveScanner 
 
         Set<HtmlParameter> params = new TreeSet<>(msg.getFormParams());
         params.addAll(msg.getUrlParams());
-        if (params.size() == 0) {
+        if (params.isEmpty()) {
             return;
         }
 

--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Maintenance changes.
 
 ## [9] - 2021-10-06
 ### Changed

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
@@ -154,7 +154,7 @@ public class ReplacerParam extends AbstractParam {
             this.rules = new ArrayList<>(defaultList.size());
         }
 
-        if (this.rules.size() == 0) {
+        if (this.rules.isEmpty()) {
             for (ReplacerParamRule geu : defaultList) {
                 this.rules.add(new ReplacerParamRule(geu));
             }

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.11.0] - 2022-02-08
 ### Added

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -307,7 +307,7 @@ public class ReportDialog extends StandardFieldsDialog {
 
             List<String> sections = template.getSections();
             sectionsMap = new HashMap<>();
-            if (sections.size() == 0) {
+            if (sections.isEmpty()) {
                 sectionPanel.add(
                         new JLabel(
                                 Constant.messages.getString("reports.dialog.field.sections.none")));
@@ -321,7 +321,7 @@ public class ReportDialog extends StandardFieldsDialog {
                                             "report.template.section." + section, null));
                     cb.setSelected(
                             sectionList == null
-                                    || sectionList.size() == 0
+                                    || sectionList.isEmpty()
                                     || sectionList.contains(section));
                     sectionsMap.put(section, cb);
                     sectionPanel.add(cb);
@@ -545,7 +545,7 @@ public class ReportDialog extends StandardFieldsDialog {
         if (root.getChildCount() == 0 && !this.getBoolValue(FIELD_GENERATE_ANYWAY)) {
             return Constant.messages.getString("reports.dialog.error.noalerts");
         }
-        if (sectionsMap.size() > 0 && reportData.getSections().size() == 0) {
+        if (sectionsMap.size() > 0 && reportData.getSections().isEmpty()) {
             return Constant.messages.getString("reports.dialog.error.nosections");
         }
 

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Maintenance changes.
 
 ## [29] - 2021-10-06
 ### Added

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -148,7 +148,7 @@ public class NewScriptDialog extends StandardFieldsDialog {
 
     private void resetTemplates() {
         List<String> templates = getTemplates();
-        if (templates.size() == 0) {
+        if (templates.isEmpty()) {
             // None to select :(
             setComboFields(FIELD_TEMPLATE, templates, "");
         } else if (!this.isEmptyField(FIELD_TEMPLATE)

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Use Network add-on to proxy Crawljax/browser requests.
+- Maintenance changes.
 
 ## [23.7.0] - 2021-11-02
 ### Added

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderParam.java
@@ -256,7 +256,7 @@ public class AjaxSpiderParam extends VersionedAbstractParam {
             this.enabledElemsNames = new ArrayList<>(DEFAULT_ELEMS_NAMES.length);
         }
 
-        if (this.elems.size() == 0) {
+        if (this.elems.isEmpty()) {
             for (String elemName : DEFAULT_ELEMS_NAMES) {
                 this.elems.add(new AjaxSpiderParamElem(elemName));
                 this.enabledElemsNames.add(elemName);

--- a/addOns/tips/CHANGELOG.md
+++ b/addOns/tips/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Maintenance changes.
 
 ## [9] - 2021-10-06
 ### Changed

--- a/addOns/tips/src/main/java/org/zaproxy/zap/extension/tips/ExtensionTipsAndTricks.java
+++ b/addOns/tips/src/main/java/org/zaproxy/zap/extension/tips/ExtensionTipsAndTricks.java
@@ -96,7 +96,7 @@ public class ExtensionTipsAndTricks extends ExtensionAdaptor {
                 }
             }
 
-            if (tipsAndTricks.size() == 0) {
+            if (tipsAndTricks.isEmpty()) {
                 this.getMenuTipsAndTricks().setEnabled(false);
             }
         }

--- a/addOns/zest/CHANGELOG.md
+++ b/addOns/zest/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Use Network add-on to proxy client authentication requests.
+- Maintenance changes.
 
 ## [35] - 2021-10-06
 ### Changed

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestParam.java
@@ -110,7 +110,7 @@ public class ZestParam extends AbstractParam {
 
             this.ignoredHeaders.clear();
             List<Object> ignoreList = getConfig().getList(IGNORE_HEADERS_KEY);
-            if (ignoreList == null || ignoreList.size() == 0) {
+            if (ignoreList == null || ignoreList.isEmpty()) {
                 // Use the defaults
                 for (String header : DEFAULT_IGNORED_HEADERS) {
                     this.ignoredHeaders.add(header);

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -327,7 +327,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 
             lastResult = zrw;
 
-            if (request.getAssertions().size() == 0) {
+            if (request.getAssertions().isEmpty()) {
                 zrw.setPassed(true);
             } else {
                 for (ZestAssertion za : request.getAssertions()) {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddClientPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddClientPopupMenu.java
@@ -88,7 +88,7 @@ public abstract class ZestAddClientPopupMenu extends ExtensionPopupMenuItem {
                     // Launching a Window isnt passive, and it will just go down hill from there ;)
                     return false;
                 }
-                if (this.requiresHandle && script.getClientWindowHandles().size() == 0) {
+                if (this.requiresHandle && script.getClientWindowHandles().isEmpty()) {
                     // This type of popup requires a window handle, and there arent any in this
                     // script
                     this.setEnabled(false);


### PR DESCRIPTION
- Use isEmpty() instead, as pointed out by SAST (SonarLint)
- Skipped occurrence in importLogFiles as it's going to be removed.
- Updated CHANGELOGs with maintenance note where add-ons didn't already have one.
- BugTrackerBugZillaParam > Remove blocks of commented code.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>