### PR TITLE
network: move the started state to the server

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.swing.JOptionPane;
@@ -68,6 +69,7 @@ import org.zaproxy.addon.network.internal.cert.GenerationException;
 import org.zaproxy.addon.network.internal.cert.ServerCertificateGenerator;
 import org.zaproxy.addon.network.internal.handlers.PassThroughHandler;
 import org.zaproxy.addon.network.internal.server.http.HttpServer;
+import org.zaproxy.addon.network.internal.server.http.LocalServerConfig;
 import org.zaproxy.addon.network.internal.server.http.MainProxyHandler;
 import org.zaproxy.addon.network.internal.server.http.MainServerHandler;
 import org.zaproxy.addon.network.internal.server.http.handlers.CloseOnRecursiveRequestHandler;
@@ -376,6 +378,13 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
     }
 
     private void startLocalServers(String mainProxyAddress, int mainProxyPort) {}
+
+    /**
+     * Removes the configurations of the started local servers.
+     *
+     * @param serverConfigs the server configurations to filter.
+     */
+    void removeStartedLocalServers(Set<LocalServerConfig> serverConfigs) {}
 
     LegacyProxyListenerHandler getLegacyProxyListenerHandler() {
         return legacyProxyListenerHandler;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
@@ -57,7 +57,7 @@ class LocalServersOptionsPanel extends AbstractParamPanel {
     private final PassThroughPanel passThroughPanel;
 
     public LocalServersOptionsPanel(ExtensionNetwork extensionNetwork) {
-        serversPanel = new ServersPanel();
+        serversPanel = new ServersPanel(extensionNetwork);
         aliasPanel = new AliasPanel();
         passThroughPanel = new PassThroughPanel();
 
@@ -118,12 +118,15 @@ class LocalServersOptionsPanel extends AbstractParamPanel {
 
     private static class ServersPanel {
 
+        private final ExtensionNetwork extensionNetwork;
         private final MainProxyPanel mainProxyPanel;
         private final LocalServersTablePanel localServersTablePanel;
         private final LocalServersTableModel localServersTableModel;
         private final JPanel panel;
 
-        ServersPanel() {
+        ServersPanel(ExtensionNetwork extensionNetwork) {
+            this.extensionNetwork = extensionNetwork;
+
             ZapLabel labelDesc =
                     new ZapLabel(
                             Constant.messages.getString("network.ui.options.localservers.desc"));
@@ -240,13 +243,7 @@ class LocalServersOptionsPanel extends AbstractParamPanel {
                 }
             }
 
-            LocalServerConfig mainProxy = options.getMainProxy();
-            if (mainProxy.isStarted()) {
-                requiredConfigs.remove(mainProxy);
-            }
-            options.getServers().stream()
-                    .filter(LocalServerConfig::isStarted)
-                    .forEach(requiredConfigs::remove);
+            extensionNetwork.removeStartedLocalServers(requiredConfigs);
 
             Set<ListeningAddress> listeningAddresses = new HashSet<>();
             for (LocalServerConfig requiredConfig : requiredConfigs) {

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/BaseServer.java
@@ -106,6 +106,15 @@ public class BaseServer implements Server {
         this.channelInitialiser = Objects.requireNonNull(channelInitialiser);
     }
 
+    /**
+     * Tells whether or not the server is started.
+     *
+     * @return {@code true} if the server is started, {@code false} otherwise.
+     */
+    public boolean isStarted() {
+        return serverChannel != null;
+    }
+
     @Override
     public int start(String address, int port) throws IOException {
         Server.validatePort(port);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerConfig.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/LocalServerConfig.java
@@ -79,7 +79,6 @@ public class LocalServerConfig extends Enableable implements ServerConfig {
         }
     }
 
-    private boolean started;
     private ServerMode mode;
     private String address;
     private boolean anyLocalAddress;
@@ -146,19 +145,6 @@ public class LocalServerConfig extends Enableable implements ServerConfig {
         removeAcceptEncoding = other.removeAcceptEncoding;
         decodeResponse = other.decodeResponse;
         return requiresRestart;
-    }
-
-    /**
-     * Tells whether or not the server is started.
-     *
-     * @return {@code true} if the server is started, {@code false} otherwise.
-     */
-    public boolean isStarted() {
-        return started;
-    }
-
-    void setStarted(boolean started) {
-        this.started = started;
     }
 
     /**

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
@@ -299,6 +299,7 @@ class BaseServerUnitTest extends TestUtils {
         client.send(port, message);
         // Then
         assertThat(messagesReceived, contains(message));
+        assertThat(server.isStarted(), is(equalTo(true)));
     }
 
     @Test
@@ -309,6 +310,7 @@ class BaseServerUnitTest extends TestUtils {
         client.send(port, message);
         // Then
         assertThat(messagesReceived, contains(message));
+        assertThat(server.isStarted(), is(equalTo(true)));
     }
 
     @Test
@@ -321,6 +323,7 @@ class BaseServerUnitTest extends TestUtils {
         client.send(port, message);
         // Then
         assertThat(messagesReceived, contains(message));
+        assertThat(server.isStarted(), is(equalTo(true)));
     }
 
     @Test
@@ -334,6 +337,7 @@ class BaseServerUnitTest extends TestUtils {
         // Then
         assertThrows(IOException.class, () -> client.send(port, "Message 2"));
         assertThat(messagesReceived, contains(message));
+        assertThat(server.isStarted(), is(equalTo(false)));
     }
 
     @Test
@@ -347,6 +351,7 @@ class BaseServerUnitTest extends TestUtils {
         // Then
         assertThrows(IOException.class, () -> client.send(port, "Message 2"));
         assertThat(messagesReceived, contains(message));
+        assertThat(server.isStarted(), is(equalTo(false)));
     }
 
     @Test
@@ -362,6 +367,7 @@ class BaseServerUnitTest extends TestUtils {
         // Then
         assertThrows(IOException.class, () -> client.send(port, "Message 2"));
         assertThat(messagesReceived, contains(message));
+        assertThat(server.isStarted(), is(equalTo(false)));
     }
 
     @Test
@@ -374,6 +380,7 @@ class BaseServerUnitTest extends TestUtils {
         server.start(port);
         // Then
         assertThat(client.getActiveChannelsCount(), is(equalTo(0)));
+        assertThat(server.isStarted(), is(equalTo(true)));
     }
 
     @Test
@@ -394,6 +401,7 @@ class BaseServerUnitTest extends TestUtils {
         assertThat(messagesReceived, contains(message1, message2, message3));
         client.waitChannelsInactive();
         assertThat(client.getActiveChannelsCount(), is(equalTo(0)));
+        assertThat(server.isStarted(), is(equalTo(false)));
     }
 
     private static <T> void assertChannelAttribute(

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/LocalServerConfigUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/LocalServerConfigUnitTest.java
@@ -208,17 +208,6 @@ class LocalServerConfigUnitTest {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void shouldSetStarted(boolean state) {
-        // Given
-        LocalServerConfig server = new LocalServerConfig();
-        // When
-        server.setStarted(state);
-        // Then
-        assertThat(server.isStarted(), is(equalTo(state)));
-    }
-
-    @ParameterizedTest
     @EnumSource(names = {"API_AND_PROXY", "API"})
     void shouldHaveApiEnabledIfModeAllows(ServerMode mode) {
         // Given


### PR DESCRIPTION
Use the server itself instead of keeping that in the configuration, let
the extension handle the removal of started servers to later check the
available ports.