### PR TITLE
improve: exim: Reduce logging and handle exceptions

### DIFF
--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ReadableFileChooser.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ReadableFileChooser.java
@@ -1,0 +1,78 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib.ui;
+
+import java.io.File;
+import java.nio.file.Files;
+import javax.swing.JFileChooser;
+import javax.swing.JOptionPane;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.Model;
+
+/**
+ * A utility class that provides a {@code JFileChooser} with some basic read permission handling
+ *
+ * @since 1.8.0
+ */
+public class ReadableFileChooser extends JFileChooser {
+
+    private static final long serialVersionUID = -8600149638325315048L;
+
+    public ReadableFileChooser() {
+        this(null);
+    }
+
+    public ReadableFileChooser(File currentDirectory) {
+        super(currentDirectory);
+        setFileHidingEnabled(false);
+    }
+
+    @Override
+    public void approveSelection() {
+        File selectedFile = getSelectedFile();
+
+        if (!Files.isReadable(selectedFile.toPath())) {
+            warnNotReadable(
+                    "commonlib.readable.file.chooser.warn.dialog.message",
+                    selectedFile.getAbsolutePath());
+            return;
+        }
+        Model.getSingleton().getOptionsParam().setUserDirectory(getCurrentDirectory());
+        super.approveSelection();
+    }
+
+    /**
+     * Convenience method that shows a warning dialogue with the given message and title.
+     *
+     * <p>The {@code parent} of the warning dialogue is this file chooser.
+     *
+     * @param message the warning message to display.
+     * @param title the title of the dialogue.
+     */
+    protected void showWarnDialog(String message, String title) {
+        JOptionPane.showMessageDialog(this, message, title, JOptionPane.WARNING_MESSAGE);
+    }
+
+    private void warnNotReadable(String i18nKeyMessage, String path) {
+        showWarnDialog(
+                Constant.messages.getString(i18nKeyMessage, path),
+                Constant.messages.getString("commonlib.readable.file.chooser.warn.dialog.title"));
+    }
+}

--- a/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/resources/Messages.properties
+++ b/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/resources/Messages.properties
@@ -8,3 +8,6 @@ commonlib.progress.panel.status.inprogress = In Progress
 commonlib.progress.pane.status = Status: {0} out of {1} tasks processed
 commonlib.progress.pane.completed = Completed.
 commonlib.progress.pane.title = Progress
+
+commonlib.readable.file.chooser.warn.dialog.message=Not readable:\n{0}\nDo you have appropriate permissions to read the file (or parent folder)?
+commonlib.readable.file.chooser.warn.dialog.title=Permissions Failure

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Reduce logging and display a warning dialog when unable to read files being imported (Issue 7081).
 
 ## [0.0.1] - 2021-12-22
 

--- a/addOns/exim/exim.gradle.kts
+++ b/addOns/exim/exim.gradle.kts
@@ -15,6 +15,13 @@ zapAddOn {
             baseName.set("help%LC%.helpset")
             localeToken.set("%LC%")
         }
+        dependencies {
+            addOns {
+                register("commonlib") {
+                    version.set(">= 1.8.0 & < 2.0.0")
+                }
+            }
+        }
     }
 }
 
@@ -26,7 +33,10 @@ crowdin {
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("commonlib")!!)
     implementation(files("lib/org.jwall.web.audit-0.2.15.jar"))
 
+    testImplementation(parent!!.childProjects.get("commonlib")!!)
+    testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation(project(":testutils"))
 }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.exim;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.exim.har.MenuImportHar;
 import org.zaproxy.addon.exim.har.PopupMenuItemSaveHarMessage;
 import org.zaproxy.addon.exim.log.MenuItemImportLogs;
@@ -30,6 +31,7 @@ import org.zaproxy.addon.exim.urls.MenuItemImportUrls;
 public class ExtensionExim extends ExtensionAdaptor {
 
     public static final String STATS_PREFIX = "stats.exim.";
+    public static final String EXIM_OUTPUT_ERROR = "exim.output.error";
     private static final String NAME = "ExtensionExim";
 
     public ExtensionExim() {
@@ -65,5 +67,13 @@ public class ExtensionExim extends ExtensionAdaptor {
     @Override
     public boolean canUnload() {
         return true;
+    }
+
+    public static void updateOutput(String messageKey, String filePath) {
+        if (View.isInitialised()) {
+            StringBuilder sb = new StringBuilder(128);
+            sb.append(Constant.messages.getString(messageKey, filePath)).append('\n');
+            View.getSingleton().getOutputPanel().append(sb.toString());
+        }
     }
 }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
@@ -113,7 +114,9 @@ public final class HarImporter {
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE);
             return true;
         } catch (IOException e) {
-            LOG.error(e);
+            LOG.warn(
+                    Constant.messages.getString(
+                            ExtensionExim.EXIM_OUTPUT_ERROR, file.getAbsolutePath()));
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_ERROR);
             return false;
         }
@@ -136,7 +139,7 @@ public final class HarImporter {
                             message);
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_MSG);
         } catch (Exception e) {
-            LOG.warn(e.getMessage(), e);
+            LOG.warn(e.getMessage());
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_MSG_ERROR);
             return;
         }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/MenuImportHar.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/MenuImportHar.java
@@ -24,6 +24,7 @@ import javax.swing.JFileChooser;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.commonlib.ui.ReadableFileChooser;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class MenuImportHar extends ZapMenuItem {
@@ -41,7 +42,7 @@ public class MenuImportHar extends ZapMenuItem {
         this.addActionListener(
                 e -> {
                     JFileChooser chooser =
-                            new JFileChooser(
+                            new ReadableFileChooser(
                                     Model.getSingleton().getOptionsParam().getUserDirectory());
                     int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
                     if (rc == JFileChooser.APPROVE_OPTION) {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/log/MenuItemImportLogs.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/log/MenuItemImportLogs.java
@@ -27,6 +27,7 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.commonlib.ui.ReadableFileChooser;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class MenuItemImportLogs extends ZapMenuItem {
@@ -40,7 +41,7 @@ public class MenuItemImportLogs extends ZapMenuItem {
                 e -> {
                     View view = View.getSingleton();
                     JFrame main = view.getMainFrame();
-                    JFileChooser fc = new JFileChooser();
+                    JFileChooser fc = new ReadableFileChooser();
                     fc.setAcceptAllFileFilterUsed(false);
                     FileFilter txtFilter =
                             new FileNameExtensionFilter(

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/MenuItemImportUrls.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/MenuItemImportUrls.java
@@ -24,6 +24,7 @@ import javax.swing.JFileChooser;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.commonlib.ui.ReadableFileChooser;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class MenuItemImportUrls extends ZapMenuItem {
@@ -41,7 +42,7 @@ public class MenuItemImportUrls extends ZapMenuItem {
         this.addActionListener(
                 e -> {
                     JFileChooser chooser =
-                            new JFileChooser(
+                            new ReadableFileChooser(
                                     Model.getSingleton().getOptionsParam().getUserDirectory());
                     int rc = chooser.showOpenDialog(View.getSingleton().getMainFrame());
                     if (rc == JFileChooser.APPROVE_OPTION) {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
@@ -57,7 +57,7 @@ public final class UrlsImporter {
             if (View.isInitialised()) {
                 View.getSingleton().getOutputPanel().setTabFocus();
             }
-            updateOutput("exim.output.start", file.toPath().toString());
+            ExtensionExim.updateOutput("exim.output.start", file.toPath().toString());
 
             HttpSender sender =
                     new HttpSender(
@@ -98,11 +98,13 @@ public final class UrlsImporter {
                     }
                 }
             }
-            updateOutput("exim.output.end", file.toPath().toString());
+            ExtensionExim.updateOutput("exim.output.end", file.toPath().toString());
         } catch (Exception e) {
-            LOG.error(e.getMessage(), e);
+            LOG.warn(
+                    Constant.messages.getString(
+                            ExtensionExim.EXIM_OUTPUT_ERROR, file.getAbsoluteFile()));
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_URL_FILE_ERROR);
-            updateOutput("exim.output.error", file.toPath().toString());
+            ExtensionExim.updateOutput(ExtensionExim.EXIM_OUTPUT_ERROR, file.toPath().toString());
             return false;
         }
         return true;
@@ -118,7 +120,7 @@ public final class UrlsImporter {
                             HistoryReference.TYPE_ZAP_USER,
                             message);
         } catch (Exception e) {
-            LOG.warn(e.getMessage(), e);
+            LOG.warn(e.getMessage());
             return;
         }
 
@@ -133,14 +135,6 @@ public final class UrlsImporter {
                                 .getSiteTree()
                                 .addPath(historyRef, message);
                     });
-        }
-    }
-
-    private static void updateOutput(String messageKey, String filePath) {
-        if (View.isInitialised()) {
-            StringBuilder sb = new StringBuilder(128);
-            sb.append(Constant.messages.getString(messageKey, filePath)).append('\n');
-            View.getSingleton().getOutputPanel().append(sb.toString());
         }
     }
 }


### PR DESCRIPTION
exim
- ExtensionExim > Add output error message key constant. Move updateOutput(String, String) out of Log and URL importer classes to reduce code duplication.
- HarImporter, LogsImporter, UrlsImporter > Reduce logging. Display read warning where applicable.
- Messages.properties > Add permissions hint to import error.
- CHANGELOG > Added change note.

commonlib
- Add `ReadableFileChooser`, similar to the core's `WritableFileChooser` a JFileChooser with basic permissions handling/warning dialog.
- Messages.properties > Add supporting resource name/value pairs.

Fixes zaproxy/zaproxy#7081

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>