### PR TITLE
network: tweak logging

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/handlers/ServerExceptionHandler.java
@@ -26,6 +26,7 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.handler.timeout.ReadTimeoutException;
 import java.io.IOException;
 import javax.net.ssl.SSLHandshakeException;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
@@ -92,9 +93,15 @@ public class ServerExceptionHandler extends ChannelInboundHandlerAdapter {
         }
 
         if (nestedCause instanceof SSLHandshakeException) {
-            LOGGER.warn(
-                    "Failed while establishing secure connection, cause: {}",
-                    cause.getCause().getMessage());
+            Level level = Level.WARN;
+            String causeMessage = nestedCause.getMessage();
+            if (causeMessage != null && causeMessage.contains("unknown_ca")) {
+                causeMessage = "the client does not trust ZAP's Root CA Certificate.";
+                level = Level.DEBUG;
+            }
+
+            LOGGER.log(
+                    level, "Failed while establishing secure connection, cause: {}", causeMessage);
             return;
         }
 


### PR DESCRIPTION
Reduce logging "noise" when the client does not trust ZAP's Root CA
cert and when not able to write the response because the client
already closed the connection.