### PR TITLE
network: correct core proxy migration

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
@@ -623,12 +623,11 @@ public class LocalServersOptions extends VersionedAbstractParam {
     }
 
     private List<String> migrateMainProxy() {
-        String address = getString("proxy.ip", null);
-        if (address == null) {
+        if (!getConfig().containsKey("proxy.port")) {
             return TlsUtils.getSupportedProtocols();
         }
         LocalServerConfig config = new LocalServerConfig();
-        config.setAddress(address);
+        config.setAddress(getString("proxy.ip", ""));
         config.setPort(getInt("proxy.port", LocalServerConfig.DEFAULT_PORT));
         config.setBehindNat(getBoolean("proxy.behindnat", false));
         config.setRemoveAcceptEncoding(getBoolean("proxy.removeUnsupportedEncodings", true));
@@ -638,6 +637,9 @@ public class LocalServersOptions extends VersionedAbstractParam {
                 getConfig().getList("proxy.securityProtocolsEnabled.protocol").stream()
                         .map(Object::toString)
                         .collect(Collectors.toList());
+        if (tlsProtocols.isEmpty()) {
+            tlsProtocols = TlsUtils.getSupportedProtocols();
+        }
         config.setTlsProtocols(tlsProtocols);
 
         setMainProxy(config);

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
@@ -1374,6 +1374,25 @@ class LocalServersOptionsUnitTest {
     }
 
     @Test
+    void shouldMigrateCoreProxyWithJustPort() {
+        // Given
+        ZapXmlConfiguration config = configWith("<proxy><port>1234</port></proxy>");
+        // When
+        options.load(config);
+        // Then
+        assertServerFields(
+                options.getMainProxy(),
+                "0.0.0.0",
+                1234,
+                ServerMode.API_AND_PROXY,
+                false,
+                true,
+                true,
+                true);
+        assertThat(config.getProperty("proxy.ip"), is(nullValue()));
+    }
+
+    @Test
     void shouldUseDefaultsIfCoreProxyDataNotPresent() {
         // Given
         ZapXmlConfiguration config = configWith("<proxy></proxy>");


### PR DESCRIPTION
Cope with address missing, check the presence of the port instead.
Use all supported protocols if none present.