### PR TITLE
network: add old options panel, link to new ones

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -66,6 +66,7 @@ import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionHookView;
 import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.ConnectionParam;
 import org.parosproxy.paros.network.HttpSender;
@@ -435,6 +436,12 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                 localServerInfoLabel =
                         new LocalServerInfoLabel(
                                 getView().getMainFrame().getMainFooterPanel(), localServersOptions);
+
+                ExtensionHookView hookView = extensionHook.getHookView();
+                hookView.addOptionPanel(
+                        new LegacyOptionsPanel("dynssl", serverCertificatesOptionsPanel.getName()));
+                hookView.addOptionPanel(
+                        new LegacyOptionsPanel("proxies", localServersOptionsPanel.getName()));
             }
         }
     }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LegacyOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LegacyOptionsPanel.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import javax.swing.GroupLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.AbstractParamPanel;
+import org.parosproxy.paros.view.View;
+
+class LegacyOptionsPanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    LegacyOptionsPanel(String sourceKey, String newPanelName) {
+        setName(Constant.messages.getString("network.ui.options.legacy." + sourceKey));
+
+        JLabel label =
+                new JLabel(
+                        Constant.messages.getString(
+                                "network.ui.options.legacy." + sourceKey + ".moved"));
+        JButton button =
+                new JButton(Constant.messages.getString("network.ui.options.legacy.opennew"));
+        button.addActionListener(
+                e -> View.getSingleton().getOptionsDialog(null).showParamPanel(newPanelName));
+
+        GroupLayout layout = new GroupLayout(this);
+        setLayout(layout);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup().addComponent(label).addComponent(button));
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup().addComponent(label).addComponent(button));
+    }
+
+    @Override
+    public void initParam(Object obj) {}
+
+    @Override
+    public void saveParam(Object obj) throws Exception {}
+}

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -92,6 +92,12 @@ network.ui.footer.proxies.tooltip.additional.disabled = Additional Proxies (Disa
 
 network.ui.options.name = Network
 
+network.ui.options.legacy.dynssl = Dynamic SSL Certificates
+network.ui.options.legacy.dynssl.moved = These options have been moved to Network > Server Certificates.
+network.ui.options.legacy.opennew = Go to New Screen
+network.ui.options.legacy.proxies = Local Proxies
+network.ui.options.legacy.proxies.moved = These options have been moved to Network > Local Servers/Proxies.
+
 network.ui.options.localservers.name = Local Servers/Proxies
 
 network.ui.options.localservers.desc = Set your browser proxy setting using one of the following proxies.\nThe HTTP port and HTTPS port must be the same port.


### PR DESCRIPTION
Add the old options panel, linking to the new ones, to make migration
easier.