### PR TITLE
network: fix issues

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptions.java
@@ -627,7 +627,7 @@ public class LocalServersOptions extends VersionedAbstractParam {
             return TlsUtils.getSupportedProtocols();
         }
         LocalServerConfig config = new LocalServerConfig();
-        config.setAddress(getString("proxy.ip", ""));
+        config.setAddress(getString("proxy.ip", LocalServerConfig.DEFAULT_ADDRESS));
         config.setPort(getInt("proxy.port", LocalServerConfig.DEFAULT_PORT));
         config.setBehindNat(getBoolean("proxy.behindnat", false));
         config.setRemoveAcceptEncoding(getBoolean("proxy.removeUnsupportedEncodings", true));

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/LocalServersOptionsUnitTest.java
@@ -1382,14 +1382,14 @@ class LocalServersOptionsUnitTest {
         // Then
         assertServerFields(
                 options.getMainProxy(),
-                "0.0.0.0",
+                "localhost",
                 1234,
                 ServerMode.API_AND_PROXY,
                 false,
                 true,
                 true,
                 true);
-        assertThat(config.getProperty("proxy.ip"), is(nullValue()));
+        assertThat(config.getProperty("proxy.port"), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Use `localhost` when migrating core proxy options if the address is not
present, instead of "any address".
Use one of the local addresses when providing the main proxy address to
other extensions, when the main proxy is using "any address".
Set the core proxy address/port when changes are done to the main
proxy.