### PR TITLE
fix: Eval Villain workflow follow redirects to save properly

### DIFF
--- a/.github/workflows/create_eval_villian_update.yml
+++ b/.github/workflows/create_eval_villian_update.yml
@@ -18,7 +18,7 @@ jobs:
         git config --global user.email "12745184+zapbot@users.noreply.github.com"
         git config --global user.name $GITHUB_USER
         # Download extension and Clone repo
-        curl https://addons.mozilla.org/firefox/downloads/latest/eval-villain/addon-3904727-latest.xpi --output eval_villain-latest-fx.xpi
+        curl -L https://addons.mozilla.org/firefox/downloads/latest/eval-villain/addon-3904727-latest.xpi --output eval_villain-latest-fx.xpi
         git clone -o upstream https://github.com/zaproxy/zap-extensions.git
         cd zap-extensions
         git remote add origin https://github.com/$GITHUB_USER/zap-extensions.git


### PR DESCRIPTION
Related to: zaproxy/zaproxy#7008

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>