### PR TITLE
ascanrules: check file type for XSS

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Updated the External Redirect scan rule to be more accurate.
+- The Reflected XSS scan rule now generates alerts for all content-types when alert threshold set to LOW. If alert threshold MEDIUM or HIGH, alerts are raised for HTML responses only.
 
 ### Fixed
 - The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).

--- a/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
+++ b/addOns/ascanrules/src/main/javahelp/org/zaproxy/zap/extension/ascanrules/resources/help/contents/ascanrules.html
@@ -54,7 +54,9 @@ It then performs a series of attacks specifically targeted at the location in wh
 including tag attributes, URL attributes, attributes in tags which support src attributes, html comments etc. <br>
 Note: <br>
 This rule only scans HTTP PUT requests at LOW threshold.<br>
-If an XSS injection is located in a JSON response a LOW risk and LOW confidence alert is raised.
+If the alert threshold is set to LOW, XSS injection located in a JSON response results in a LOW risk and LOW confidence alert is raised.
+For other response content-types a LOW confidence alert is raised.<br>
+If the alert threshold is set to either MEDIUM or HIGH, XSS injection located in non-HTML responses do not generate alerts.<br>
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java">CrossSiteScriptingScanRule.java</a>
 

--- a/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/example.csv
+++ b/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/example.csv
@@ -1,0 +1,2 @@
+name,age,car
+@@@name@@@,30,null


### PR DESCRIPTION
Related to issue [6617](https://github.com/zaproxy/zaproxy/issues/6617)

I found that content-type tests done [HERE](https://github.com/zaproxy/zap-extensions/blob/fe232e2bda5286eb73910f09a39d6c66fbeb6c87/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java#L692-L746) were not being done [HERE](https://github.com/zaproxy/zap-extensions/blob/fe232e2bda5286eb73910f09a39d6c66fbeb6c87/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java#L269-L290). 

I have added the content-type tests for 'direct attacks' & 'is the payload reflected outside of any tags' attacks (these are the comments above the two attacks I have implemented this feature in). This is because I felt it was best to only show attacks on non-html responses when the alert threshold is at LOW.

So new behaviour is as follows:
Alert threshold LOW - All content-types can generate XSS (Reflected) alerts.
Alert threshold MEDIUM or HIGH - only html responses can generate XSS (Reflected) alerts.