### PR TITLE
Quit all browsers when ZAP shuts down

### DIFF
--- a/addOns/domxss/CHANGELOG.md
+++ b/addOns/domxss/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.11.1.
 - Use Network add-on to proxy browser requests.
 
+### Fixed
+- Stop the proxy when ZAP shuts down.
+
 ## [12] - 2021-12-06
 ### Changed
 - Dependency updates.

--- a/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/ExtensionDomXSS.java
+++ b/addOns/domxss/src/main/java/org/zaproxy/zap/extension/domxss/ExtensionDomXSS.java
@@ -79,11 +79,7 @@ public class ExtensionDomXSS extends ExtensionAdaptor {
     }
 
     @Override
-    public void unload() {
-        super.unload();
-
-        PluginFactory.unloadedPlugin(scanner);
-
+    public void stop() {
         Server proxy = DomXssScanRule.proxy;
         if (proxy != null) {
             try {
@@ -92,6 +88,13 @@ public class ExtensionDomXSS extends ExtensionAdaptor {
                 LOGGER.debug("An error occurred while stopping the proxy.", e);
             }
         }
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+
+        PluginFactory.unloadedPlugin(scanner);
     }
 
     @Override

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Fixed
+- Quit all browsers when ZAP shuts down ([Issue #6643](https://github.com/zaproxy/zaproxy/issues/6643)).
 
 ## [15.6.0] - 2021-12-13
 ### Changed

--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use Network add-on to proxy Crawljax/browser requests.
 - Maintenance changes.
 
+### Fixed
+- Stop the spider scans when ZAP shuts down ([Issue #6643](https://github.com/zaproxy/zaproxy/issues/6643)).
+
 ## [23.7.0] - 2021-11-02
 ### Added
 - Automation authentication support

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderAPI.java
@@ -468,7 +468,7 @@ public class AjaxSpiderAPI extends ApiImplementor implements SpiderListener {
         return (extension.isSpiderRunning() && spiderThread != null);
     }
 
-    private void stopSpider() {
+    void stopSpider() {
         if (isSpiderRunning()) {
             spiderThread.stopSpider();
             spiderThread = null;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/ExtensionAjax.java
@@ -129,8 +129,7 @@ public class ExtensionAjax extends ExtensionAdaptor {
 
     @Override
     public void unload() {
-        if (getView() != null) {
-            getSpiderPanel().stopScan();
+        if (hasView()) {
             getSpiderPanel().unload();
 
             SpiderEventPublisher.unregisterPublisher();
@@ -143,6 +142,14 @@ public class ExtensionAjax extends ExtensionAdaptor {
         }
 
         super.unload();
+    }
+
+    @Override
+    public void stop() {
+        if (hasView()) {
+            stopScan();
+        }
+        ajaxSpiderApi.stopSpider();
     }
 
     @Override


### PR DESCRIPTION
Change `ExtensionSelenium` to quit all WebDrivers not just the ones
that were created to proxy through the main proxy, also, quit them
later when the extension is destroyed, to allow other extensions to
stop gracefully.
Change AJAX Spider to stop the spiders (GUI and API) on stop, so they
are stopped always previously just stopped when the add-on was
uninstalled.
Change `ExtensionDomXSS` to stop the server on stop not just when the
add-on is uninstalled.

Fix zaproxy/zaproxy#6643.