### PR TITLE
oast: Add statistics

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- The following two statistics for each OAST service:
+  - `stats.oast.<service>.payloadsGenerated`
+  - `stats.oast.<service>.interactions`
+
 ### Changed
 - Use Network add-on to serve callback requests.
 - Maintenance changes.

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -66,7 +66,6 @@ public class ExtensionOast extends ExtensionAdaptor {
 
     private static final String NAME = ExtensionOast.class.getSimpleName();
     private static final Logger LOGGER = LogManager.getLogger(ExtensionOast.class);
-    static final int HISTORY_TYPE_OAST = HistoryReference.TYPE_OAST;
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
             Collections.unmodifiableList(Arrays.asList(ExtensionNetwork.class));
@@ -162,7 +161,8 @@ public class ExtensionOast extends ExtensionAdaptor {
                     .getDb()
                     .getTableHistory()
                     .deleteHistoryType(
-                            this.getModel().getSession().getSessionId(), HISTORY_TYPE_OAST);
+                            this.getModel().getSession().getSessionId(),
+                            HistoryReference.TYPE_OAST);
         } catch (DatabaseException e) {
             LOGGER.error(e.getMessage(), e);
         }
@@ -348,7 +348,8 @@ public class ExtensionOast extends ExtensionAdaptor {
                         getModel()
                                 .getDb()
                                 .getTableHistory()
-                                .getHistoryIdsOfHistType(session.getSessionId(), HISTORY_TYPE_OAST);
+                                .getHistoryIdsOfHistType(
+                                        session.getSessionId(), HistoryReference.TYPE_OAST);
 
                 for (int historyId : historyIds) {
                     HistoryReference historyReference = new HistoryReference(historyId);

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastRequest.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastRequest.java
@@ -45,9 +45,7 @@ public class OastRequest extends DefaultHistoryReferencesTableEntry {
             throws DatabaseException, HttpMalformedHeaderException {
         HistoryReference historyReference =
                 new HistoryReference(
-                        Model.getSingleton().getSession(),
-                        ExtensionOast.HISTORY_TYPE_OAST,
-                        httpMessage);
+                        Model.getSingleton().getSession(), HistoryReference.TYPE_OAST, httpMessage);
         historyReference.addTag(source);
         historyReference.addTag(handler);
         return create(historyReference);

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastServer.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastServer.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.oast.ExtensionOast;
+import org.zaproxy.zap.utils.Stats;
 
 public class BoastServer {
 
@@ -65,6 +66,7 @@ public class BoastServer {
         JSONObject result = JSONObject.fromObject(boastMsg.getResponseBody().toString());
         id = result.getString("id");
         canary = result.getString("canary");
+        Stats.incCounter("stats.oast.boast.payloadsGenerated");
     }
 
     /** @return new BOAST events found on polling */
@@ -81,6 +83,7 @@ public class BoastServer {
                     eventIds.add(event.getString("id"));
                 }
             }
+            Stats.incCounter("stats.oast.boast.interactions", newBoastEvents.size());
             return newBoastEvents;
         } catch (IOException e) {
             LOGGER.warn(

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListener.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.network.HttpStatusCode;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.addon.oast.OastRequest;
+import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.ThreadUtils;
 
 class CallbackProxyListener implements HttpMessageHandler {
@@ -60,6 +61,7 @@ class CallbackProxyListener implements HttpMessageHandler {
         ctx.overridden();
 
         try {
+            Stats.incCounter("stats.oast.callback.interactions");
             msg.setTimeSentMillis(System.currentTimeMillis());
             String path = msg.getRequestHeader().getURI().getPath();
             LOGGER.debug(

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackService.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.network.server.Server;
 import org.zaproxy.addon.oast.OastService;
+import org.zaproxy.zap.utils.Stats;
 
 public class CallbackService extends OastService implements OptionsChangedListener {
 
@@ -136,6 +137,7 @@ public class CallbackService extends OastService implements OptionsChangedListen
         }
         String uuid = UUID.randomUUID().toString();
         handlers.put(uuid, handler);
+        Stats.incCounter("stats.oast.callback.payloadsGenerated");
         return getCallbackAddress() + uuid;
     }
 

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
@@ -67,6 +67,7 @@ import org.zaproxy.addon.oast.ExtensionOast;
 import org.zaproxy.addon.oast.OastService;
 import org.zaproxy.addon.oast.OastState;
 import org.zaproxy.zap.network.HttpRequestBody;
+import org.zaproxy.zap.utils.Stats;
 
 public class InteractshService extends OastService implements OptionsChangedListener {
 
@@ -295,6 +296,7 @@ public class InteractshService extends OastService implements OptionsChangedList
         if (!isRegistered) {
             register();
         }
+        Stats.incCounter("stats.oast.interactsh.payloadsGenerated");
         return RandomStringUtils.randomAlphanumeric(1).toLowerCase(Locale.ROOT)
                 + '.'
                 + correlationId
@@ -389,6 +391,7 @@ public class InteractshService extends OastService implements OptionsChangedList
                             event.getRemoteAddress());
                 }
             }
+            Stats.incCounter("stats.oast.interactsh.interactions", result.size());
             return result;
         } catch (Exception e) {
             LOGGER.error("Error during interactsh poll: {}", e.getMessage(), e);

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/boast/BoastServerUnitTests.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/boast/BoastServerUnitTests.java
@@ -31,8 +31,10 @@ import net.sf.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.Stats;
 
 class BoastServerUnitTests extends TestUtils {
 
@@ -65,6 +67,19 @@ class BoastServerUnitTests extends TestUtils {
     }
 
     @Test
+    void shouldIncrementStatPayloadsGeneratedCorrectly() throws Exception {
+        // Given
+        StaticBoastServerHandler handler = new StaticBoastServerHandler();
+        nano.addHandler(handler);
+        InMemoryStats stats = new InMemoryStats();
+        Stats.addListener(stats);
+        // When
+        new BoastServer(boastUrl);
+        // Then
+        assertThat(stats.getStat("stats.oast.boast.payloadsGenerated"), is(1L));
+    }
+
+    @Test
     void shouldReturnBoastEventsOnPolling() throws Exception {
         // Given
         StaticBoastServerHandler handler = new StaticBoastServerHandler();
@@ -82,6 +97,20 @@ class BoastServerUnitTests extends TestUtils {
 
         // Then
         assertThat(events, is(expectedEvents));
+    }
+
+    @Test
+    void shouldIncrementStatInteractionsCorrectly() throws Exception {
+        // Given
+        StaticBoastServerHandler handler = new StaticBoastServerHandler();
+        nano.addHandler(handler);
+        BoastServer boastServer = new BoastServer(boastUrl);
+        InMemoryStats stats = new InMemoryStats();
+        Stats.addListener(stats);
+        // When
+        List<BoastEvent> events = boastServer.poll();
+        // Then
+        assertThat(stats.getStat("stats.oast.boast.interactions"), is((long) events.size()));
     }
 
     @Test

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackProxyListenerUnitTest.java
@@ -45,7 +45,9 @@ import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.addon.oast.ExtensionOast;
 import org.zaproxy.addon.oast.OastRequest;
+import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.Stats;
 
 /* Unit test for {@link CallbackProxyListener}. */
 class CallbackProxyListenerUnitTest extends TestUtils {
@@ -138,6 +140,18 @@ class CallbackProxyListenerUnitTest extends TestUtils {
         // Then
         verify(ctx, times(0)).overridden();
         verify(callbackService, times(0)).handleOastRequest(oastRequest);
+    }
+
+    @Test
+    void shouldIncrementStatInteractionsCorrectly() throws Exception {
+        // Given
+        given(ctx.isFromClient()).willReturn(true);
+        InMemoryStats stats = new InMemoryStats();
+        Stats.addListener(stats);
+        // When
+        listener.handleMessage(ctx, message);
+        // Then
+        assertThat(stats.getStat("stats.oast.callback.interactions"), is(1L));
     }
 
     private void verifyServiceAndFactory(String handler) throws Exception {

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackServiceUnitTest.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/callback/CallbackServiceUnitTest.java
@@ -19,6 +19,8 @@
  */
 package org.zaproxy.addon.oast.services.callback;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,7 +44,9 @@ import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.oast.ExtensionOast;
 import org.zaproxy.addon.oast.OastRequest;
 import org.zaproxy.addon.oast.OastRequestHandler;
+import org.zaproxy.zap.extension.stats.InMemoryStats;
 import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 
 /** Unit test for {@link CallbackService}. */
@@ -160,6 +164,18 @@ class CallbackServiceUnitTest extends TestUtils {
         httpSender.sendAndReceive(serverRequest);
         // Then
         verify(oastRequestHandler, times(2)).handle(oastRequest);
+    }
+
+    @Test
+    void shouldIncrementStatPayloadsGeneratedCorrectly() throws Exception {
+        // Given
+        callbackService.startService();
+        InMemoryStats stats = new InMemoryStats();
+        Stats.addListener(stats);
+        // When
+        callbackService.getNewPayload();
+        // Then
+        assertThat(stats.getStat("stats.oast.callback.payloadsGenerated"), is(1L));
     }
 
     private HttpMessage createServerRequest(String path) throws Exception {


### PR DESCRIPTION
Add the following two statistics:
- `stats.oast.<service>.payloadsGenerated`
- `stats.oast.<service>.interactions`

Also use HistoryReference.TYPE_OAST directly instead of assigning it to
a variable and using that.