### PR TITLE
pscanrules: Updated CSP add detailed info into the otherInfo field

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Moved the detail information in Content Security Policy Rule to the otherInfo field and added alertRef ids.
 - Address false positive condition for Timestamp Disclosure scan rule when values are percentages (Issue 7057).
 - Update Cache-control scan rule name, description, and solution to make it more clear that there are cases in which caching is reasonable. Reduced risk to Info (Issue 6462).
 - Maintenance changes.

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -121,10 +121,11 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
         if (!xcspOptions.isEmpty()) {
             raiseAlert(
                     Constant.messages.getString(MESSAGE_PREFIX + "xcsp.name"),
-                    Constant.messages.getString(MESSAGE_PREFIX + "xcsp.desc"),
+                    Constant.messages.getString(MESSAGE_PREFIX + "xcsp.otherinfo"),
                     getHeaderField(msg, HTTP_HEADER_XCSP).get(0),
                     cspHeaderFound ? Alert.RISK_INFO : Alert.RISK_LOW,
-                    xcspOptions.get(0));
+                    xcspOptions.get(0),
+                    "1");
         }
 
         // X-WebKit-CSP is supported by Chrome 14+, and Safari 6+
@@ -133,10 +134,11 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
         if (!xwkcspOptions.isEmpty()) {
             raiseAlert(
                     Constant.messages.getString(MESSAGE_PREFIX + "xwkcsp.name"),
-                    Constant.messages.getString(MESSAGE_PREFIX + "xwkcsp.desc"),
+                    Constant.messages.getString(MESSAGE_PREFIX + "xwkcsp.otherinfo"),
                     getHeaderField(msg, HTTP_HEADER_WEBKIT_CSP).get(0),
                     cspHeaderFound ? Alert.RISK_INFO : Alert.RISK_LOW,
-                    xwkcspOptions.get(0));
+                    xwkcspOptions.get(0),
+                    "2");
         }
 
         if (cspHeaderFound) {
@@ -170,7 +172,8 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                             cspNoticesString,
                             "",
                             noticesRisk,
-                            csp);
+                            csp,
+                            "3");
                 }
 
                 List<String> allowedWildcardSources = getAllowedWildcardSources(csp);
@@ -181,21 +184,22 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                                     .filter(DIRECTIVES_WITHOUT_FALLBACK::contains)
                                     .collect(Collectors.toList());
                     String allowedWildcardSrcs = String.join(", ", allowedWildcardSources);
-                    String wildcardSrcDesc =
+                    String wildcardSrcOtherInfo =
                             Constant.messages.getString(
-                                    MESSAGE_PREFIX + "wildcard.desc", allowedWildcardSrcs);
+                                    MESSAGE_PREFIX + "wildcard.otherinfo", allowedWildcardSrcs);
                     if (!allowedDirectivesWithoutFallback.isEmpty()) {
-                        wildcardSrcDesc +=
+                        wildcardSrcOtherInfo +=
                                 Constant.messages.getString(
-                                        "pscanrules.csp.desc.extended",
+                                        "pscanrules.csp.otherinfo.extended",
                                         String.join(", ", allowedDirectivesWithoutFallback));
                     }
                     raiseAlert(
                             Constant.messages.getString(MESSAGE_PREFIX + "wildcard.name"),
-                            wildcardSrcDesc,
+                            wildcardSrcOtherInfo,
                             "",
                             Alert.RISK_MEDIUM,
-                            csp);
+                            csp,
+                            "4");
                 }
 
                 Optional<SourceExpressionDirective> optDirective =
@@ -208,10 +212,11 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                                 Constant.messages.getString(
                                         MESSAGE_PREFIX + "scriptsrc.unsafe.name"),
                                 Constant.messages.getString(
-                                        MESSAGE_PREFIX + "scriptsrc.unsafe.desc"),
+                                        MESSAGE_PREFIX + "scriptsrc.unsafe.otherinfo"),
                                 "",
                                 Alert.RISK_MEDIUM,
-                                csp);
+                                csp,
+                                "5");
                     }
                 }
 
@@ -224,10 +229,11 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                                 Constant.messages.getString(
                                         MESSAGE_PREFIX + "stylesrc.unsafe.name"),
                                 Constant.messages.getString(
-                                        MESSAGE_PREFIX + "stylesrc.unsafe.desc"),
+                                        MESSAGE_PREFIX + "stylesrc.unsafe.otherinfo"),
                                 "",
                                 Alert.RISK_MEDIUM,
-                                csp);
+                                csp,
+                                "6");
                     }
                 }
             }
@@ -418,18 +424,25 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
     }
 
     private void raiseAlert(
-            String name, String description, String param, int risk, String evidence) {
+            String name,
+            String otherInfo,
+            String param,
+            int risk,
+            String evidence,
+            String alertRef) {
         String alertName = StringUtils.isEmpty(name) ? getName() : getName() + ": " + name;
 
         newAlert()
                 .setName(alertName)
                 .setRisk(risk)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                .setDescription(description)
+                .setDescription(Constant.messages.getString(MESSAGE_PREFIX + "desc"))
+                .setOtherInfo(otherInfo)
                 .setParam(param)
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence)
+                .setAlertRef(PLUGIN_ID + "-" + alertRef)
                 .setCweId(getCweId())
                 .setWascId(getWascId())
                 .raise();

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -182,7 +182,7 @@ pscanrules.crossdomainscriptinclusion.soln=Ensure JavaScript source files are lo
 
 pscanrules.csp.name=CSP
 pscanrules.csp.desc=Content Security Policy (CSP) is an added layer of security that helps to detect and mitigate certain types of attacks. Including (but not limited to) Cross Site Scripting (XSS), and data injection attacks. These attacks are used for everything from data theft to site defacement or distribution of malware. CSP provides a set of standard HTTP headers that allow website owners to declare approved sources of content that browsers should be allowed to load on that page \u2014 covered types are JavaScript, CSS, HTML frames, fonts, images and embeddable objects such as Java applets, ActiveX, audio and video files.
-pscanrules.csp.desc.extended=\n\nThe directive(s): {0} are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.
+pscanrules.csp.otherinfo.extended=\n\nThe directive(s): {0} are among the directives that do not fallback to default-src, missing/excluding them is the same as allowing anything.
 pscanrules.csp.refs=http://www.w3.org/TR/CSP2/\nhttp://www.w3.org/TR/CSP/\nhttp://caniuse.com/#search=content+security+policy\nhttp://content-security-policy.com/\nhttps://github.com/shapesecurity/salvation\nhttps://developers.google.com/web/fundamentals/security/csp#policy_applies_to_a_wide_variety_of_resources
 pscanrules.csp.soln=Ensure that your web server, application server, load balancer, etc. is properly configured to set the Content-Security-Policy header.
 pscanrules.csp.notices.name=Notices
@@ -190,15 +190,15 @@ pscanrules.csp.notices.errors=Errors:
 pscanrules.csp.notices.warnings=Warnings:
 pscanrules.csp.notices.infoitems=Info Items:
 pscanrules.csp.scriptsrc.unsafe.name=script-src unsafe-inline
-pscanrules.csp.scriptsrc.unsafe.desc=script-src includes unsafe-inline.
+pscanrules.csp.scriptsrc.unsafe.otherinfo=script-src includes unsafe-inline.
 pscanrules.csp.stylesrc.unsafe.name=style-src unsafe-inline
-pscanrules.csp.stylesrc.unsafe.desc=style-src includes unsafe-inline.
+pscanrules.csp.stylesrc.unsafe.otherinfo=style-src includes unsafe-inline.
 pscanrules.csp.wildcard.name=Wildcard Directive
-pscanrules.csp.wildcard.desc=The following directives either allow wildcard sources (or ancestors), are not defined, or are overly broadly defined: \n{0}
+pscanrules.csp.wildcard.otherinfo=The following directives either allow wildcard sources (or ancestors), are not defined, or are overly broadly defined: \n{0}
 pscanrules.csp.xcsp.name=X-Content-Security-Policy
-pscanrules.csp.xcsp.desc=The header X-Content-Security-Policy was found on this response. While it is a good sign that CSP is implemented to some degree the policy specified in this header has not been analyzed by ZAP. To ensure full support by modern browsers ensure that the Content-Security-Policy header is defined and attached to responses.
+pscanrules.csp.xcsp.otherinfo=The header X-Content-Security-Policy was found on this response. While it is a good sign that CSP is implemented to some degree the policy specified in this header has not been analyzed by ZAP. To ensure full support by modern browsers ensure that the Content-Security-Policy header is defined and attached to responses.
 pscanrules.csp.xwkcsp.name=X-WebKit-CSP
-pscanrules.csp.xwkcsp.desc=The header X-WebKit-CSP was found on this response. While it is a good sign that CSP is implemented to some degree the policy specified in this header has not been analyzed by ZAP. To ensure full support by modern browsers ensure that the Content-Security-Policy header is defined and attached to responses.
+pscanrules.csp.xwkcsp.otherinfo=The header X-WebKit-CSP was found on this response. While it is a good sign that CSP is implemented to some degree the policy specified in this header has not been analyzed by ZAP. To ensure full support by modern browsers ensure that the Content-Security-Policy header is defined and attached to responses.
 
 pscanrules.mixedcontent.name = Secure Pages Include Mixed Content
 pscanrules.mixedcontent.name.inclscripts = Secure Pages Include Mixed Content (Including Scripts)


### PR DESCRIPTION
I move the detailed alert info into the otherInfo field to keep the rich CSP description. 
Also adds an alertRef to differentiate between all the alerts this plugin may raise.
Updated the Changelog.

Live streamed the whole thing :) https://youtu.be/MqpskwSuSjc


Signed-off-by: Scott Gerlach <scott.gerlach@stackhawk.com>