### PR TITLE
 feat: exim: Add progress bars (openapi: tweak progress bar impl) 

### DIFF
--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPane.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPane.java
@@ -45,10 +45,12 @@ public class ProgressPane extends JPanel {
     private boolean completed;
 
     public ProgressPane() {
+        this("");
+    }
+
+    public ProgressPane(String resource) {
         super(new GridBagLayout());
-        this.setBorder(
-                BorderFactory.createTitledBorder(
-                        Constant.messages.getString("commonlib.progress.pane.title")));
+        this.setBorder(BorderFactory.createTitledBorder(getTitle(resource)));
 
         progressStatus = new JLabel();
 
@@ -76,6 +78,13 @@ public class ProgressPane extends JPanel {
 
         setTotalTasks(100);
         setCurrentTask("");
+    }
+
+    private String getTitle(String resource) {
+        if (resource == null || resource.isEmpty()) {
+            return Constant.messages.getString("commonlib.progress.pane.title");
+        }
+        return Constant.messages.getString("commonlib.progress.pane.title.extended", resource);
     }
 
     /**

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPane.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPane.java
@@ -43,19 +43,50 @@ public class ProgressPane extends JPanel {
     private final JProgressBar progressBar;
     private final JLabel currentProgress;
     private boolean completed;
+    private boolean indeterminant;
 
+    /**
+     * Constructs a progress pane with default title (no resource indication) which includes a
+     * determinant progress bar.
+     */
     public ProgressPane() {
         this("");
     }
 
+    /**
+     * Constructs a progress pane with an extended title including the identified resource (ex: a
+     * URL or file system path) which includes a determinant progress bar.
+     *
+     * @param resource a string representing the location or source of the resource being processed
+     *     (ex: a URL or file system path).
+     */
     public ProgressPane(String resource) {
+        this(resource, false);
+    }
+
+    /**
+     * Constructs a progress pane with an extended title including the identified resource (ex: a
+     * URL or file system path) and indeterminant status indicated.
+     *
+     * @param resource a string representing the location or source of the resource being processed
+     *     (ex: a URL or file system path).
+     * @param indeterminant a {@code boolean} indicating whether or not the associated progress bar
+     *     should be indeterminant (true) or not (false);
+     */
+    public ProgressPane(String resource, boolean indeterminant) {
         super(new GridBagLayout());
+        this.indeterminant = indeterminant;
         this.setBorder(BorderFactory.createTitledBorder(getTitle(resource)));
 
         progressStatus = new JLabel();
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
+        progressBar.setIndeterminate(indeterminant);
+        if (indeterminant) {
+            progressBar.setString(
+                    Constant.messages.getString("commonlib.progress.panel.status.inprogress"));
+        }
 
         currentProgress = new JLabel();
 
@@ -64,7 +95,9 @@ public class ProgressPane extends JPanel {
         c.gridy = 0;
         c.weightx = 1;
         c.fill = GridBagConstraints.HORIZONTAL;
-        add(progressStatus, c);
+        if (!indeterminant) {
+            add(progressStatus, c);
+        }
 
         c.gridy++;
         c.ipady = 5;
@@ -136,11 +169,17 @@ public class ProgressPane extends JPanel {
         return completed;
     }
 
-    /** Sets that the process as having been completed. */
+    /** Sets the process as having been completed. */
     public void completed() {
         EventQueue.invokeLater(
                 () -> {
                     completed = true;
+                    if (indeterminant) {
+                        progressBar.setString(
+                                Constant.messages.getString("commonlib.progress.pane.completed"));
+                        progressBar.setIndeterminate(false);
+                        progressBar.setValue(100);
+                    }
                     currentProgress.setText(
                             Constant.messages.getString("commonlib.progress.pane.completed"));
                 });

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPaneListener.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPaneListener.java
@@ -25,7 +25,7 @@ package org.zaproxy.addon.commonlib.ui;
  *
  * @since 1.8.0
  */
-public abstract class ProgressPaneListener {
+public class ProgressPaneListener {
 
     private final ProgressPane progressPane;
     private int tasksDone;
@@ -35,7 +35,7 @@ public abstract class ProgressPaneListener {
      *
      * @param progressPane the pane the listener pertains to.
      */
-    protected ProgressPaneListener(ProgressPane progressPane) {
+    public ProgressPaneListener(ProgressPane progressPane) {
         this.progressPane = progressPane;
     }
 
@@ -62,7 +62,22 @@ public abstract class ProgressPaneListener {
      *
      * @param tasksDone the number of tasks which have been processed.
      */
-    protected void setTasksDone(int tasksDone) {
+    public void setTasksDone(int tasksDone) {
+        getProgressPane().setProcessedTasks(tasksDone);
         this.tasksDone = tasksDone;
+    }
+
+    /**
+     * Sets the description of the task currently being processed.
+     *
+     * @param task the description of the task currently being processed.
+     */
+    public void setCurrentTask(String task) {
+        progressPane.setCurrentTask(task);
+    }
+
+    /** Sets the completed state of the {@code ProgressPane}. */
+    public void completed() {
+        progressPane.completed();
     }
 }

--- a/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/resources/Messages.properties
+++ b/addOns/commonlib/src/main/resources/org/zaproxy/addon/commonlib/resources/Messages.properties
@@ -8,6 +8,7 @@ commonlib.progress.panel.status.inprogress = In Progress
 commonlib.progress.pane.status = Status: {0} out of {1} tasks processed
 commonlib.progress.pane.completed = Completed.
 commonlib.progress.pane.title = Progress
+commonlib.progress.pane.title.extended = Progress - {0}
 
 commonlib.readable.file.chooser.warn.dialog.message=Not readable:\n{0}\nDo you have appropriate permissions to read the file (or parent folder)?
 commonlib.readable.file.chooser.warn.dialog.title=Permissions Failure

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Reduce logging and display a warning dialog when unable to read files being imported (Issue 7081).
 - Promoted to Beta.
 
+### Added
+- Importing a file of URLs or HAR is now displayed in the progress panel provided via commonlib.
+
 ## [0.0.1] - 2021-12-22
 
 - First release.

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ExtensionExim.java
@@ -19,10 +19,17 @@
  */
 package org.zaproxy.addon.exim;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.commonlib.ExtensionCommonlib;
+import org.zaproxy.addon.commonlib.ui.ProgressPanel;
 import org.zaproxy.addon.exim.har.MenuImportHar;
 import org.zaproxy.addon.exim.har.PopupMenuItemSaveHarMessage;
 import org.zaproxy.addon.exim.log.MenuItemImportLogs;
@@ -33,9 +40,16 @@ public class ExtensionExim extends ExtensionAdaptor {
     public static final String STATS_PREFIX = "stats.exim.";
     public static final String EXIM_OUTPUT_ERROR = "exim.output.error";
     private static final String NAME = "ExtensionExim";
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(Arrays.asList(ExtensionCommonlib.class));
 
     public ExtensionExim() {
         super(NAME);
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
     }
 
     @Override
@@ -75,5 +89,12 @@ public class ExtensionExim extends ExtensionAdaptor {
             sb.append(Constant.messages.getString(messageKey, filePath)).append('\n');
             View.getSingleton().getOutputPanel().append(sb.toString());
         }
+    }
+
+    public static ProgressPanel getProgressPanel() {
+        return Control.getSingleton()
+                .getExtensionLoader()
+                .getExtension(ExtensionCommonlib.class)
+                .getProgressPanel();
     }
 }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ImportExportApi.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ImportExportApi.java
@@ -68,12 +68,12 @@ public class ImportExportApi extends ApiImplementor {
         switch (name) {
             case ACTION_IMPORT_HAR:
                 file = new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH));
-                success = HarImporter.importHarFile(file);
-                return handleFileImportResponse(success, file);
+                HarImporter harImporter = new HarImporter(file);
+                return handleFileImportResponse(harImporter.isSuccess(), file);
             case ACTION_IMPORT_URLS:
                 file = new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH));
-                success = UrlsImporter.importUrlFile(file);
-                return handleFileImportResponse(success, file);
+                UrlsImporter importer = new UrlsImporter(file);
+                return handleFileImportResponse(importer.isSuccess(), file);
             case ACTION_IMPORT_ZAP_LOGS:
                 file = new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH));
                 success = LogsImporter.processInput(file, LogsImporter.LogType.ZAP);

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/ImportExportApi.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/ImportExportApi.java
@@ -63,7 +63,6 @@ public class ImportExportApi extends ApiImplementor {
     public ApiResponse handleApiAction(String name, JSONObject params) throws ApiException {
         LOG.debug("handleApiAction {} {}", name, params);
 
-        boolean success;
         File file;
         switch (name) {
             case ACTION_IMPORT_HAR:
@@ -76,12 +75,13 @@ public class ImportExportApi extends ApiImplementor {
                 return handleFileImportResponse(importer.isSuccess(), file);
             case ACTION_IMPORT_ZAP_LOGS:
                 file = new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH));
-                success = LogsImporter.processInput(file, LogsImporter.LogType.ZAP);
-                return handleFileImportResponse(success, file);
+                LogsImporter zapImporter = new LogsImporter(file, LogsImporter.LogType.ZAP);
+                return handleFileImportResponse(zapImporter.isSuccess(), file);
             case ACTION_IMPORT_MODSEC2_LOGS:
                 file = new File(ApiUtils.getNonEmptyStringParam(params, PARAM_FILE_PATH));
-                success = LogsImporter.processInput(file, LogsImporter.LogType.MOD_SECURITY_2);
-                return handleFileImportResponse(success, file);
+                LogsImporter logsImporter =
+                        new LogsImporter(file, LogsImporter.LogType.MOD_SECURITY_2);
+                return handleFileImportResponse(logsImporter.isSuccess(), file);
             default:
                 throw new ApiException(Type.BAD_ACTION);
         }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -117,19 +117,17 @@ public class HarImporter {
         }
     }
 
-    public boolean importHarFile(File file) {
+    private void importHarFile(File file) {
         try {
             processMessages(file);
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE);
             success = true;
-            return success;
         } catch (IOException e) {
             LOG.warn(
                     Constant.messages.getString(
                             ExtensionExim.EXIM_OUTPUT_ERROR, file.getAbsolutePath()));
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_ERROR);
             success = false;
-            return success;
         }
     }
 
@@ -189,7 +187,7 @@ public class HarImporter {
         if (progressListener != null) {
             progressListener.setTasksDone(count);
             progressListener.setCurrentTask(
-                    Constant.messages.getString("exim.har.progress.currentimport", line));
+                    Constant.messages.getString("exim.progress.currentimport", line));
         }
     }
 

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -40,23 +40,32 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpResponseHeader;
+import org.zaproxy.addon.commonlib.ui.ProgressPaneListener;
 import org.zaproxy.addon.exim.ExtensionExim;
 import org.zaproxy.zap.network.HttpResponseBody;
 import org.zaproxy.zap.utils.HarUtils;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.utils.ThreadUtils;
 
-public final class HarImporter {
+public class HarImporter {
 
     private static final Logger LOG = LogManager.getLogger(HarImporter.class);
     private static final String STATS_HAR_FILE = "import.har.file";
     private static final String STATS_HAR_FILE_ERROR = "import.har.file.errors";
     private static final String STATS_HAR_FILE_MSG = "import.har.file.message";
     private static final String STATS_HAR_FILE_MSG_ERROR = "import.har.file.message.errors";
-
+    private ProgressPaneListener progressListener;
+    private boolean success;
     private static ExtensionHistory extHistory;
 
-    private HarImporter() {}
+    public HarImporter(File file) {
+        this(file, null);
+    }
+
+    public HarImporter(File file, ProgressPaneListener listener) {
+        this.progressListener = listener;
+        importHarFile(file);
+    }
 
     public static List<HttpMessage> getHttpMessages(HarLog log)
             throws HttpMalformedHeaderException {
@@ -108,24 +117,32 @@ public final class HarImporter {
         }
     }
 
-    public static boolean importHarFile(File file) {
+    public boolean importHarFile(File file) {
         try {
             processMessages(file);
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE);
-            return true;
+            success = true;
+            return success;
         } catch (IOException e) {
             LOG.warn(
                     Constant.messages.getString(
                             ExtensionExim.EXIM_OUTPUT_ERROR, file.getAbsolutePath()));
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_HAR_FILE_ERROR);
-            return false;
+            success = false;
+            return success;
         }
     }
 
-    public static void processMessages(File file) throws IOException {
+    public void processMessages(File file) throws IOException {
         List<HttpMessage> messages =
                 HarImporter.getHttpMessages(new HarFileReader().readHarFile(file));
-        messages.forEach(HarImporter::persistMessage);
+        int count = 1;
+        for (HttpMessage msg : messages) {
+            persistMessage(msg);
+            updateProgress(count, msg.getRequestHeader().getURI().toString());
+            count++;
+        }
+        completed();
     }
 
     private static void persistMessage(HttpMessage message) {
@@ -162,5 +179,23 @@ public final class HarImporter {
     private static void addMessage(HistoryReference historyRef, HttpMessage message) {
         getExtensionHistory().addHistory(historyRef);
         Model.getSingleton().getSession().getSiteTree().addPath(historyRef, message);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    private void updateProgress(int count, String line) {
+        if (progressListener != null) {
+            progressListener.setTasksDone(count);
+            progressListener.setCurrentTask(
+                    Constant.messages.getString("exim.har.progress.currentimport", line));
+        }
+    }
+
+    private void completed() {
+        if (progressListener != null) {
+            progressListener.completed();
+        }
     }
 }

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/log/MenuItemImportLogs.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/log/MenuItemImportLogs.java
@@ -27,7 +27,10 @@ import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.commonlib.ui.ProgressPane;
+import org.zaproxy.addon.commonlib.ui.ProgressPaneListener;
 import org.zaproxy.addon.commonlib.ui.ReadableFileChooser;
+import org.zaproxy.addon.exim.ExtensionExim;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 public class MenuItemImportLogs extends ZapMenuItem {
@@ -79,7 +82,13 @@ public class MenuItemImportLogs extends ZapMenuItem {
                         int openChoice = fc.showOpenDialog(main);
                         if (openChoice == JFileChooser.APPROVE_OPTION) {
                             File newFile = fc.getSelectedFile();
-                            LogsImporter.processInput(newFile, logChoice);
+                            ProgressPane currentImportPane =
+                                    new ProgressPane(newFile.getAbsolutePath(), true);
+                            ExtensionExim.getProgressPanel().addProgressPane(currentImportPane);
+                            new LogsImporter(
+                                    newFile,
+                                    logChoice,
+                                    new ProgressPaneListener(currentImportPane));
                         }
                     }
                 });

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
@@ -156,7 +156,7 @@ public class UrlsImporter {
         if (progressListener != null) {
             progressListener.setTasksDone(count);
             progressListener.setCurrentTask(
-                    Constant.messages.getString("exim.importurls.progress.currentimport", line));
+                    Constant.messages.getString("exim.progress.currentimport", line));
         }
     }
 

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
@@ -35,67 +35,45 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.commonlib.ui.ProgressPaneListener;
 import org.zaproxy.addon.exim.ExtensionExim;
 import org.zaproxy.zap.utils.Stats;
 
-public final class UrlsImporter {
+public class UrlsImporter {
 
     private static final Logger LOG = LogManager.getLogger(UrlsImporter.class);
     private static final String STATS_URL_FILE = "import.url.file";
     private static final String STATS_URL_FILE_ERROR = "import.url.file.errors";
     private static final String STATS_URL_FILE_URL = "import.url.file.url";
     private static final String STATS_URL_FILE_URL_ERROR = "import.url.file.url.errors";
+    private ProgressPaneListener progressListener;
+    private boolean success;
 
-    private UrlsImporter() {}
+    public UrlsImporter(File file) {
+        this(file, null);
+    }
 
-    public static boolean importUrlFile(File file) {
+    public UrlsImporter(File file, ProgressPaneListener listener) {
+        this.progressListener = listener;
+        importUrlFile(file);
+    }
+
+    private void importUrlFile(File file) {
         if (file == null) {
-            return false;
+            success = false;
+            return;
         }
         try (BufferedReader in = Files.newBufferedReader(file.toPath())) {
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_URL_FILE);
-            if (View.isInitialised()) {
-                View.getSingleton().getOutputPanel().setTabFocus();
-            }
             ExtensionExim.updateOutput("exim.output.start", file.toPath().toString());
 
-            HttpSender sender =
-                    new HttpSender(
-                            Model.getSingleton().getOptionsParam().getConnectionParam(),
-                            true,
-                            HttpSender.MANUAL_REQUEST_INITIATOR);
-
+            int count = 1;
             String line;
-            StringBuilder outputLine = new StringBuilder();
             while ((line = in.readLine()) != null) {
                 if (!line.startsWith("#") && line.trim().length() > 0) {
-                    try {
-                        outputLine
-                                .append(HttpRequestHeader.GET)
-                                .append('\t')
-                                .append(line)
-                                .append('\t');
-                        HttpMessage msg = new HttpMessage(new URI(line, false));
-                        sender.sendAndReceive(msg, true);
-                        persistMessage(msg);
-
-                        outputLine.append(msg.getResponseHeader().getStatusCode());
-                        Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_URL_FILE_URL);
-
-                    } catch (Exception e) {
-                        outputLine.append(e.getMessage());
-                        Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_URL_FILE_URL_ERROR);
-                    }
-                    outputLine.append('\n');
-                    if (View.isInitialised()) {
-                        EventQueue.invokeLater(
-                                () -> {
-                                    View.getSingleton()
-                                            .getOutputPanel()
-                                            .append(outputLine.toString());
-                                    outputLine.delete(0, outputLine.length());
-                                });
-                    }
+                    updateProgress(count, line);
+                    processLine(line);
+                    count++;
                 }
             }
             ExtensionExim.updateOutput("exim.output.end", file.toPath().toString());
@@ -105,9 +83,41 @@ public final class UrlsImporter {
                             ExtensionExim.EXIM_OUTPUT_ERROR, file.getAbsoluteFile()));
             Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_URL_FILE_ERROR);
             ExtensionExim.updateOutput(ExtensionExim.EXIM_OUTPUT_ERROR, file.toPath().toString());
-            return false;
+            success = false;
+            return;
         }
-        return true;
+        completed();
+        success = true;
+    }
+
+    private void processLine(String line) {
+        HttpSender sender =
+                new HttpSender(
+                        Model.getSingleton().getOptionsParam().getConnectionParam(),
+                        true,
+                        HttpSender.MANUAL_REQUEST_INITIATOR);
+        StringBuilder outputLine = new StringBuilder();
+        try {
+            outputLine.append(HttpRequestHeader.GET).append('\t').append(line).append('\t');
+            HttpMessage msg = new HttpMessage(new URI(line, false));
+            sender.sendAndReceive(msg, true);
+            persistMessage(msg);
+
+            outputLine.append(msg.getResponseHeader().getStatusCode());
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_URL_FILE_URL);
+
+        } catch (Exception e) {
+            outputLine.append(e.getMessage());
+            Stats.incCounter(ExtensionExim.STATS_PREFIX + STATS_URL_FILE_URL_ERROR);
+        }
+        outputLine.append('\n');
+        if (View.isInitialised()) {
+            EventQueue.invokeLater(
+                    () -> {
+                        View.getSingleton().getOutputPanel().append(outputLine.toString());
+                        outputLine.delete(0, outputLine.length());
+                    });
+        }
     }
 
     private static void persistMessage(HttpMessage message) {
@@ -135,6 +145,24 @@ public final class UrlsImporter {
                                 .getSiteTree()
                                 .addPath(historyRef, message);
                     });
+        }
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    private void updateProgress(int count, String line) {
+        if (progressListener != null) {
+            progressListener.setTasksDone(count);
+            progressListener.setCurrentTask(
+                    Constant.messages.getString("exim.importurls.progress.currentimport", line));
+        }
+    }
+
+    private void completed() {
+        if (progressListener != null) {
+            progressListener.completed();
         }
     }
 }

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -4,14 +4,12 @@ exim.ui.name = Import/Export
 exim.file.save.error = Error saving file to {0}.
 
 exim.har.file.import.error = Could not import the file {0}
-exim.har.progress.currentimport = Importing: {0}
 exim.har.topmenu.import.importhar = Import HAR (HTTP Archive File)
 exim.har.topmenu.import.importhar.tooltip = Import a HTTP Archive File and add the messages to the sites tree and history panel.
 
 exim.api.action.importurls = Imports URLs (one per line) from the file with the given file system path.
 exim.importurls.topmenu.import = Import a File Containing URLs
 exim.importurls.topmenu.import.tooltip = The file must be plain text with one URL per line.\nBlank lines and lines starting with a # are ignored.
-exim.importurls.progress.currentimport = Importing: {0}
 
 exim.api.action.importzaplogs = Imports previously exported ZAP messages from the file with the given file system path.
 exim.api.action.importmodsec2logs = Imports ModSecurity2 logs from the file with the given file system path.
@@ -33,6 +31,8 @@ exim.popup.option.body = Body
 exim.popup.option.header = Header
 exim.popup.option.request = Request
 exim.popup.option.response = Response
+
+exim.progress.currentimport = Importing: {0}
 
 exim.saveraw.file.description = Raw Binary (*.raw)
 exim.saveraw.popup.option = Save Raw

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -4,12 +4,14 @@ exim.ui.name = Import/Export
 exim.file.save.error = Error saving file to {0}.
 
 exim.har.file.import.error = Could not import the file {0}
+exim.har.progress.currentimport = Importing: {0}
 exim.har.topmenu.import.importhar = Import HAR (HTTP Archive File)
 exim.har.topmenu.import.importhar.tooltip = Import a HTTP Archive File and add the messages to the sites tree and history panel.
 
 exim.api.action.importurls = Imports URLs (one per line) from the file with the given file system path.
 exim.importurls.topmenu.import = Import a File Containing URLs
 exim.importurls.topmenu.import.tooltip = The file must be plain text with one URL per line.\nBlank lines and lines starting with a # are ignored.
+exim.importurls.progress.currentimport = Importing: {0}
 
 exim.api.action.importzaplogs = Imports previously exported ZAP messages from the file with the given file system path.
 exim.api.action.importmodsec2logs = Imports ModSecurity2 logs from the file with the given file system path.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ProgressListener.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ProgressListener.java
@@ -37,11 +37,9 @@ public class ProgressListener extends ProgressPaneListener implements RequesterL
         if (!HttpStatusCode.isRedirection(message.getResponseHeader().getStatusCode())) {
             setTasksDone(getTasksDone() + 1);
         }
-        getProgressPane().setProcessedTasks(getTasksDone());
-        getProgressPane()
-                .setCurrentTask(
-                        Constant.messages.getString(
-                                "openapi.progress.importpane.currentimport",
-                                message.getRequestHeader().getURI().toString()));
+        setCurrentTask(
+                Constant.messages.getString(
+                        "openapi.progress.importpane.currentimport",
+                        message.getRequestHeader().getURI().toString()));
     }
 }


### PR DESCRIPTION
* commonlib
    - ProgressPane.java > Allow to set a "resource" (such as a URL or file system location as part of the pane's title.
    - ProgressPaneListener.java > No longer abstract. Provides convenience methods to set the current task and completed status of the associated pane.
    - Messages.properties > Key/value pair to support the extended pane title.

* exim
    - CHANGELOG.md > Noted the addition of progress panels for URLs and HAR.
    - ExtensionExim.java > Depend on commonlib and add convenience method to get the progress panel.
    - ImportExportApi.java > Updated to leverage the updated importer functionality.
    - HarImporter.java > Updated constructors to allow passing the progress listener. Added functionality to update/display progress.
    - MenuImportHar.java > Updated to handle process display/details.
    - MenuImportUrls.java > Updated to handle process display/details.
    - UrlsIMporter.java > Updated constructors to allow passing the progress listener. Added functionality to update/display progress.
    - Messages.properties > Key/value pairs to indicate the current item being imported.

* openapi
    - ProgressListener > Updated to accommodate the changes to ProgressPaneListener.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>