### PR TITLE
network: make tests reliable, again

### DIFF
--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/BaseServerUnitTest.java
@@ -376,12 +376,12 @@ class BaseServerUnitTest extends TestUtils {
         // Given
         int port = server.start(Server.ANY_PORT);
         client.connect(port, "");
-        assertThat(client.getActiveChannelsCount(), is(equalTo(1)));
+        assertThat(client.getChannelsCount(), is(equalTo(1)));
         // When
         server.start(port);
         // Then
-        client.waitChannelsInactive();
-        assertThat(client.getActiveChannelsCount(), is(equalTo(0)));
+        client.waitChannelsClosed();
+        assertThat(client.getChannelsCount(), is(equalTo(0)));
         assertThat(server.isStarted(), is(equalTo(true)));
     }
 
@@ -401,8 +401,8 @@ class BaseServerUnitTest extends TestUtils {
         // Then
         assertThrows(IOException.class, () -> client.send(port, "Message A"));
         assertThat(messagesReceived, contains(message1, message2, message3));
-        client.waitChannelsInactive();
-        assertThat(client.getActiveChannelsCount(), is(equalTo(0)));
+        client.waitChannelsClosed();
+        assertThat(client.getChannelsCount(), is(equalTo(0)));
         assertThat(server.isStarted(), is(equalTo(false)));
     }
 

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestClient.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestClient.java
@@ -72,11 +72,11 @@ public class TestClient implements Closeable {
     }
 
     /**
-     * Gets the count of active channels.
+     * Gets the count of channels.
      *
-     * @return the count of active channels.
+     * @return the count of channels.
      */
-    public int getActiveChannelsCount() {
+    public int getChannelsCount() {
         return allChannels.size();
     }
 
@@ -124,12 +124,12 @@ public class TestClient implements Closeable {
     }
 
     /**
-     * Waits until all channels are inactive.
+     * Waits until all channels are closed.
      *
-     * @throws InterruptedException if interrupted while waiting for the channels to be inactive.
+     * @throws InterruptedException if interrupted while waiting for the channels to be closed.
      */
-    public void waitChannelsInactive() throws InterruptedException {
-        while (allChannels.stream().anyMatch(Channel::isActive)) {
+    public void waitChannelsClosed() throws InterruptedException {
+        while (!allChannels.isEmpty()) {
             Thread.sleep(150);
         }
     }


### PR DESCRIPTION
Wait for the channels to be closed instead of checking if they are no
longer active.