### PR TITLE
retire: correct retire.js data

### DIFF
--- a/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/jsrepository.json
+++ b/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/jsrepository.json
@@ -1531,7 +1531,7 @@
 				"severity": "low",
 				"identifiers": { 
 					"summary" : "Regular Expression Denial of Service (ReDoS)",
-					"CVE" : "CVE-2017-18214" 
+					"CVE" : ["CVE-2017-18214"]
 				},
 				"info" : [ 
 					"https://security.snyk.io/vuln/npm:moment:20170905",

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/UpstreamJsRepositoryUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/UpstreamJsRepositoryUnitTest.java
@@ -1,0 +1,37 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.retire;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.retire.model.Repo;
+
+/** Tests for upstream {@code jsrepository.json} file. */
+class UpstreamJsRepositoryUnitTest {
+
+    @Test
+    void shouldParseUpstreamJsRepository() {
+        // Given
+        String path = "/org/zaproxy/addon/retire/resources/jsrepository.json";
+        // When / Then
+        assertDoesNotThrow(() -> new Repo(path));
+    }
+}


### PR DESCRIPTION
Fix expected type for CVE entry, array instead of string.
Add test to ensure the `jsrepository.json` can be parsed.