### PR TITLE
ascanrules: do not use zero for multiplication

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Path Traversal scan rule, updated the regex for case 5 to be case-insensitive when searching for Error or Exception in content body.
 - Maintenance changes.
 
+### Fixed
+- Server Side Code Injection scan rule, prevent use of zero when injecting ASP multiplication to avoid false positives (Issue 7107).
+
 ## [44] - 2022-01-13
 ### Changed
 - Update minimum ZAP version to 2.11.1.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CodeInjectionScanRule.java
@@ -81,7 +81,7 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
     private static final Logger log = LogManager.getLogger(CodeInjectionScanRule.class);
 
     private static final Random RAND = new Random();
-    private static final int MAX_VALUE = 999999;
+    private static final int MAX_VALUE = 999998;
 
     @Override
     public int getId() {
@@ -237,8 +237,8 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
      * @see #ASP_PAYLOADS
      */
     private boolean testAspInjection(String paramName) {
-        int bignum1 = RAND.nextInt(MAX_VALUE);
-        int bignum2 = RAND.nextInt(MAX_VALUE);
+        int bignum1 = getRandomValue();
+        int bignum2 = getRandomValue();
 
         for (String aspPayload : ASP_PAYLOADS) {
             if (isStop()) {
@@ -284,5 +284,9 @@ public class CodeInjectionScanRule extends AbstractAppParamPlugin {
         }
 
         return false;
+    }
+
+    private static int getRandomValue() {
+        return RAND.nextInt(MAX_VALUE) + 1;
     }
 }


### PR DESCRIPTION
Do not use zero when injecting ASP multiplication to avoid false
positives.

Fix zaproxy/zaproxy#7107.