### PR TITLE
oast: Fix flaky unit test

### DIFF
--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
@@ -178,6 +178,10 @@ public class InteractshService extends OastService implements OptionsChangedList
     }
 
     public synchronized void register() throws InteractshException {
+        register(true);
+    }
+
+    synchronized void register(boolean startPolling) throws InteractshException {
         try {
             if (isRegistered) {
                 return;
@@ -225,7 +229,9 @@ public class InteractshService extends OastService implements OptionsChangedList
                     reqMsg.getResponseHeader().getStatusCode(),
                     reqMsg.getResponseBody());
             isRegistered = true;
-            schedulePoller(0);
+            if (startPolling) {
+                schedulePoller(0);
+            }
         } catch (IOException | CloneNotSupportedException | NoSuchAlgorithmException e) {
             LOGGER.error("Error during interactsh register: {}", e.getMessage(), e);
             throw new InteractshException(

--- a/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/interactsh/InteractshServiceUnitTests.java
+++ b/addOns/oast/src/test/java/org/zaproxy/addon/oast/services/interactsh/InteractshServiceUnitTests.java
@@ -160,7 +160,7 @@ class InteractshServiceUnitTests extends TestUtils {
     private List<InteractshEvent> setUpMockRegisterAndPollEndpoints(InteractshService service)
             throws Exception {
         nano.addHandler(new StaticInteractshServerHandler("/register", ""));
-        service.register();
+        service.register(false);
 
         JSONObject eventJson = new JSONObject();
         eventJson.put("protocol", "http");


### PR DESCRIPTION
The issue was happening because of a race condition between the test and
the poller which was running in a different thread. They both were
calling the `getInteractions` method which led to the statistic being
incremented twice. When the poller called the method before the test,
the assertion failed because it was only expecting a single increment
but found two.

The fix was to disable the polling thread for the test.

Signed-off-by: ricekot <github@ricekot.com>