### PR TITLE
websocket: stop when shutting down

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix exception when manually reconnecting to the server.
+- Stop properly when shutting down.
 
 ## [24] - 2021-10-06
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -491,12 +491,6 @@ public class ExtensionWebSocket extends ExtensionAdaptor
 
         HttpSender.removeListener(httpSenderListener);
 
-        // close all existing connections
-        for (Entry<Integer, WebSocketProxy> wsEntry : wsProxies.entrySet()) {
-            WebSocketProxy wsProxy = wsEntry.getValue();
-            wsProxy.shutdown();
-        }
-
         Control control = Control.getSingleton();
         ExtensionLoader extLoader = control.getExtensionLoader();
 
@@ -548,6 +542,15 @@ public class ExtensionWebSocket extends ExtensionAdaptor
         if (extensionScript != null) {
             removeAllChannelSenderListener(webSocketSenderScriptListener);
             extensionScript.removeScriptType(websocketSenderSciptType);
+        }
+    }
+
+    @Override
+    public void stop() {
+        // close all existing connections
+        for (Entry<Integer, WebSocketProxy> wsEntry : wsProxies.entrySet()) {
+            WebSocketProxy wsProxy = wsEntry.getValue();
+            wsProxy.shutdown();
         }
 
         // shut down Passive Scanner & unregister the WebSocket Passive Scan script type


### PR DESCRIPTION
Move some cleanup from `unload` to `stop`, to ensure it's also done
when ZAP is shutting down not just when the add-on is uninstalled.

---
Reported in IRC channel :)