### PR TITLE
fix: replacer: Allow changing the "type" of rule

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Fixed
+- Allow the replacement type to be changed in existing rules (Issue 3840).
+
 ### Added
  - Allow to manage the replacer rules programmatically, for example, through ZAP scripts.
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/HexString.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/HexString.java
@@ -27,6 +27,10 @@ class HexString {
     private static final Pattern HEX_VALUE = Pattern.compile("\\\\?\\\\x\\p{XDigit}{2}");
     private static final String ESCAPED_ESCAPE_CHAR = "\\\\";
 
+    private HexString() {
+        // Utility class
+    }
+
     static String compile(String binaryRegex) {
         Matcher matcher = HEX_VALUE.matcher(binaryRegex);
         StringBuffer sb = new StringBuffer();

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerTableModel.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerTableModel.java
@@ -60,11 +60,6 @@ public class OptionsReplacerTableModel
     }
 
     @Override
-    public void addElement(ReplacerParamRule rule) {
-        super.addElement(rule);
-    }
-
-    @Override
     public String getColumnName(int col) {
         return COLUMN_NAMES[col];
     }
@@ -109,11 +104,9 @@ public class OptionsReplacerTableModel
 
     @Override
     public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
-        if (columnIndex == 0) {
-            if (aValue instanceof Boolean) {
-                rules.get(rowIndex).setEnabled(((Boolean) aValue).booleanValue());
-                fireTableCellUpdated(rowIndex, columnIndex);
-            }
+        if (columnIndex == 0 && aValue instanceof Boolean) {
+            rules.get(rowIndex).setEnabled(((Boolean) aValue).booleanValue());
+            fireTableCellUpdated(rowIndex, columnIndex);
         }
     }
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
@@ -123,7 +123,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         this.addFieldListener(
                 MATCH_TYPE_FIELD,
                 e -> {
-                    save();
+                    saveImpl();
                     initFields();
                 });
         this.addFieldListener(INIT_TYPE_ALL_FIELD, e -> setUpInitiatorFields());
@@ -235,37 +235,41 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
 
     @Override
     public void save() {
+        saveImpl();
+    }
+
+    public void saveImpl() {
         List<Integer> initiators = null;
-        if (!getBoolValue(INIT_TYPE_ALL_FIELD)) {
+        if (Boolean.FALSE.equals(getBoolValue(INIT_TYPE_ALL_FIELD))) {
             initiators = new ArrayList<>();
-            if (getBoolValue(INIT_TYPE_PROXY_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_PROXY_FIELD))) {
                 initiators.add(HttpSender.PROXY_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_SPIDER_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_SPIDER_FIELD))) {
                 initiators.add(HttpSender.SPIDER_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_SCANNER_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_SCANNER_FIELD))) {
                 initiators.add(HttpSender.ACTIVE_SCANNER_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_BRUTE_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_BRUTE_FIELD))) {
                 initiators.add(HttpSender.FORCED_BROWSE_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_FUZZER_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_FUZZER_FIELD))) {
                 initiators.add(HttpSender.FUZZER_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_SPIDER_AJAX_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_SPIDER_AJAX_FIELD))) {
                 initiators.add(HttpSender.AJAX_SPIDER_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_AUTH_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_AUTH_FIELD))) {
                 initiators.add(HttpSender.AUTHENTICATION_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_AC_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_AC_FIELD))) {
                 initiators.add(HttpSender.ACCESS_CONTROL_SCANNER_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_USER_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_USER_FIELD))) {
                 initiators.add(HttpSender.MANUAL_REQUEST_INITIATOR);
             }
-            if (getBoolValue(INIT_TYPE_TOKEN_GEN_FIELD)) {
+            if (Boolean.TRUE.equals(getBoolValue(INIT_TYPE_TOKEN_GEN_FIELD))) {
                 initiators.add(HttpSender.TOKEN_GENERATOR_INITIATOR);
             }
         }
@@ -296,7 +300,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         if (this.isEmptyField(MATCH_STR_FIELD)) {
             return Constant.messages.getString("replacer.add.warning.nomatch");
         }
-        if (this.getBoolValue(REGEX_FIELD)) {
+        if (Boolean.TRUE.equals(this.getBoolValue(REGEX_FIELD))) {
             // Check the regex is valid
             try {
                 Pattern.compile(this.getStringValue(MATCH_STR_FIELD));

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
@@ -47,6 +47,7 @@ public class ReplacerParam extends AbstractParam {
     private static final String RULE_INITIATORS_KEY = "initiators";
 
     private static final String CONFIRM_REMOVE_RULE_KEY = REPLACER_BASE_KEY + ".confirmRemoveToken";
+    private static final String FALSE_STRING = "false";
 
     private static ArrayList<ReplacerParamRule> defaultList = new ArrayList<>();
 
@@ -62,33 +63,33 @@ public class ReplacerParam extends AbstractParam {
                 ReplacerParamRule.MatchType.RESP_HEADER.name(),
                 "Content-Security-Policy",
                 "",
-                "false",
+                FALSE_STRING,
                 "",
-                "false"
+                FALSE_STRING
             },
             {
                 "Remove HSTS",
                 ReplacerParamRule.MatchType.RESP_HEADER.name(),
                 "Strict-Transport-Security",
                 "",
-                "false",
+                FALSE_STRING,
                 "",
-                "false"
+                FALSE_STRING
             },
             {
                 "Replace User-Agent with shellshock attack",
                 ReplacerParamRule.MatchType.REQ_HEADER.name(),
                 "User-Agent",
                 "() {:;}; /bin/cat /etc/passwd",
-                "false",
+                FALSE_STRING,
                 "",
-                "false"
+                FALSE_STRING
             }
         };
 
         for (String[] row : defaultListArray) {
-            boolean regex = row[4].equalsIgnoreCase("true") ? true : false;
-            boolean enabled = row[6].equalsIgnoreCase("true") ? true : false;
+            boolean regex = row[4].equalsIgnoreCase("true");
+            boolean enabled = row[6].equalsIgnoreCase("true");
             defaultList.add(
                     new ReplacerParamRule(
                             row[0],


### PR DESCRIPTION
- CHANGELOG.md > Added change note.
- ReplacerRuleAddDialog > Internalize the save that way the modify can still reset the description in the save method while preserving the current state when changing the type.
- other > Address SAST (SonarLit) findings.

Fixes zaproxy/zaproxy#3840

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>