### PR TITLE
fix: pscanrules: CSP scan rule consider unsafe-inline in default-src

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - The CSRF Token scan rule will now raise alerts as Medium risk and Low confidence (Issue 7021).
 
+### Fixed
+- CSP scan rule will now alert in situations where default-src contains 'unsafe-inline' or is not defined (Issue 7120). In certain situations this may mean a marked increase in CSP related Alerts.
+
 ## [38] - 2022-01-07
 ### Changed
 - Update minimum ZAP version to 2.11.1.

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRule.java
@@ -19,10 +19,9 @@
  */
 package org.zaproxy.zap.extension.pscanrules;
 
-import com.shapesecurity.salvation2.Directives.SourceExpressionDirective;
-import com.shapesecurity.salvation2.FetchDirectiveKind;
 import com.shapesecurity.salvation2.Policy;
 import com.shapesecurity.salvation2.Policy.PolicyErrorConsumer;
+import com.shapesecurity.salvation2.PolicyInOrigin;
 import com.shapesecurity.salvation2.URLs.URI;
 import com.shapesecurity.salvation2.URLs.URLWithScheme;
 import java.util.ArrayList;
@@ -202,39 +201,27 @@ public class ContentSecurityPolicyScanRule extends PluginPassiveScanner {
                             "4");
                 }
 
-                Optional<SourceExpressionDirective> optDirective =
-                        policy.getFetchDirective(FetchDirectiveKind.ScriptSrc);
-                if (optDirective.isPresent()) {
-                    SourceExpressionDirective directive = optDirective.get();
-                    boolean allowed = directive.unsafeInline();
-                    if (allowed) {
-                        raiseAlert(
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "scriptsrc.unsafe.name"),
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "scriptsrc.unsafe.otherinfo"),
-                                "",
-                                Alert.RISK_MEDIUM,
-                                csp,
-                                "5");
-                    }
+                PolicyInOrigin p = new PolicyInOrigin(policy, URI.parseURI(RAND_FQDN).orElse(null));
+                if (p.allowsUnsafeInlineScript()) {
+                    raiseAlert(
+                            Constant.messages.getString(MESSAGE_PREFIX + "scriptsrc.unsafe.name"),
+                            Constant.messages.getString(
+                                    MESSAGE_PREFIX + "scriptsrc.unsafe.otherinfo"),
+                            "",
+                            Alert.RISK_MEDIUM,
+                            csp,
+                            "5");
                 }
 
-                optDirective = policy.getFetchDirective(FetchDirectiveKind.StyleSrc);
-                if (optDirective.isPresent()) {
-                    SourceExpressionDirective directive = optDirective.get();
-                    boolean allowed = directive.unsafeInline();
-                    if (allowed) {
-                        raiseAlert(
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "stylesrc.unsafe.name"),
-                                Constant.messages.getString(
-                                        MESSAGE_PREFIX + "stylesrc.unsafe.otherinfo"),
-                                "",
-                                Alert.RISK_MEDIUM,
-                                csp,
-                                "6");
-                    }
+                if (p.allowsUnsafeInlineStyle()) {
+                    raiseAlert(
+                            Constant.messages.getString(MESSAGE_PREFIX + "stylesrc.unsafe.name"),
+                            Constant.messages.getString(
+                                    MESSAGE_PREFIX + "stylesrc.unsafe.otherinfo"),
+                            "",
+                            Alert.RISK_MEDIUM,
+                            csp,
+                            "6");
                 }
             }
         }

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -97,7 +97,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         rule.setAlertThreshold(AlertThreshold.LOW);
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.size(), equalTo(4));
     }
 
     @Test
@@ -107,7 +107,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.size(), equalTo(4));
 
         assertThat(alertsRaised.get(0).getName(), equalTo("CSP: Notices"));
         assertThat(
@@ -147,7 +147,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.size(), equalTo(4));
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: Wildcard Directive"));
         assertThat(alertsRaised.get(1).getOtherInfo(), not(containsString("frame-ancestors")));
         assertThat(
@@ -270,12 +270,14 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(2));
-        // Verify the specific alert
+        assertThat(alertsRaised.size(), equalTo(3));
+        // Verify the specific alerts
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
+
+        assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
     }
 
     @Test
@@ -285,12 +287,14 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(2));
-        // Verify the specific alert
-        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: style-src unsafe-inline"));
+        assertThat(alertsRaised.size(), equalTo(3));
+        // Verify the specific alerts
+        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-6"));
+        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
+
+        assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
     }
 
     @Test
@@ -301,17 +305,50 @@ class ContentSecurityPolicyScanRuleUnitTest
         // When
         scanHttpResponseReceive(msg);
         // Then
-        assertThat(alertsRaised.size(), equalTo(2));
+        assertThat(alertsRaised.size(), equalTo(3));
         // Verify the specific alerts
         assertThat(alertsRaised.get(0).getName(), equalTo("CSP: Wildcard Directive"));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo("style-src 'unsafe-inline'"));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-4"));
 
-        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: style-src unsafe-inline"));
+        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
         assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
         assertThat(alertsRaised.get(1).getEvidence(), equalTo("style-src 'unsafe-inline'"));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-6"));
+        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
+
+        assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
+        assertThat(alertsRaised.get(2).getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(2).getEvidence(), equalTo("style-src 'unsafe-inline'"));
+        assertThat(alertsRaised.get(2).getAlertRef(), equalTo("10055-6"));
+    }
+
+    @Test
+    void shouldRaiseAlertOnUnsafeInDefaultSrc() {
+        // Given
+        HttpMessage msg = createHttpMessageWithReasonableCsp(HTTP_HEADER_CSP);
+        msg.getResponseHeader().addHeader(HTTP_HEADER_CSP, "default-src 'unsafe-inline'");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(3));
+        // Verify the specific alerts
+        assertThat(alertsRaised.get(0).getName(), equalTo("CSP: Wildcard Directive"));
+        assertThat(alertsRaised.get(0).getEvidence(), equalTo("default-src 'unsafe-inline'"));
+        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-4"));
+
+        assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
+        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getEvidence(), equalTo("default-src 'unsafe-inline'"));
+        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
+
+        assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
+        assertThat(alertsRaised.get(2).getRisk(), equalTo(Alert.RISK_MEDIUM));
+        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(2).getEvidence(), equalTo("default-src 'unsafe-inline'"));
+        assertThat(alertsRaised.get(2).getAlertRef(), equalTo("10055-6"));
     }
 
     private HttpMessage createHttpMessageWithReasonableCsp(String cspHeaderName) {


### PR DESCRIPTION
- CHANGELOG.md > Added fix note.
- ContentSecurityPolicyScanRule > Tweak unsafe-inline handling.
- ContentSecurityPolicyScanRuleUnitTest > Updated to reflect the new behavior.

Fixes zaproxy/zaproxy#7120

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>