### PR TITLE
Add Java 17 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
 
     steps:
       - uses: actions/checkout@v2

--- a/addOns/codedx/CHANGELOG.md
+++ b/addOns/codedx/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Dependency updates.
+- Maintenance changes.
 
 ## [9] - 2021-10-07
 ### Added

--- a/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/security/InvalidCertificateDialogStrategy.java
+++ b/addOns/codedx/src/main/java/org/zaproxy/zap/extension/codedx/security/InvalidCertificateDialogStrategy.java
@@ -86,7 +86,7 @@ public class InvalidCertificateDialogStrategy implements InvalidCertificateStrat
 			
 			message.add(issuer,gbc);
 			gbc.gridx = 1;
-			message.add(new JLabel(cert.getIssuerDN().toString()),gbc);
+			message.add(new JLabel(cert.getIssuerX500Principal().getName()),gbc);
 			
 			try {
 				JLabel fingerprint = new JLabel(Constant.messages.getString("codedx.ssl.fingerprint") + " ");

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/AbstractFuzzer.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/AbstractFuzzer.java
@@ -639,8 +639,7 @@ public abstract class AbstractFuzzer<M extends Message> implements Fuzzer<M> {
         public FuzzerThreadFactory(String namePrefix) {
             threadNumber = new AtomicInteger(1);
             this.namePrefix = namePrefix;
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            group = Thread.currentThread().getThreadGroup();
         }
 
         @Override

--- a/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PacScriptUnitTest.java
+++ b/addOns/graaljs/src/test/java/org/zaproxy/zap/extension/graaljs/PacScriptUnitTest.java
@@ -40,6 +40,8 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.zaproxy.zap.extension.graaljs.PacScript.Setting;
 import org.zaproxy.zap.extension.graaljs.PacScript.Setting.Type;
 import org.zaproxy.zap.testutils.TestUtils;
@@ -49,6 +51,7 @@ import org.zaproxy.zap.testutils.TestUtils;
  *
  * @author aine-rb
  */
+@EnabledForJreRange(min = JRE.JAVA_8, max = JRE.JAVA_11)
 class PacScriptUnitTest extends TestUtils {
 
     private static final String DATERANGE_FILE_NAME = "dateRange.pac";

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/handlers/TlsProtocolHandlerUnitTest.java
@@ -371,16 +371,7 @@ class TlsProtocolHandlerUnitTest {
         // When
         Channel clientChannel = clientTls.connect(port, message);
         // Then
-        assertThat(
-                clientChannel
-                        .pipeline()
-                        .get(SslHandler.class)
-                        .engine()
-                        .getSession()
-                        .getPeerCertificateChain()[0]
-                        .getSubjectDN()
-                        .getName(),
-                containsString("CN=example.org"));
+        assertThat(getCertificate(clientChannel).toString(), containsString("CN=example.org"));
     }
 
     @Test
@@ -406,19 +397,21 @@ class TlsProtocolHandlerUnitTest {
         // When
         Channel clientChannel = clientTls.connect(port, message);
         // Then
-        assertThat(
-                clientChannel
-                        .pipeline()
-                        .get(SslHandler.class)
-                        .engine()
-                        .getSession()
-                        .getPeerCertificateChain()[0]
-                        .toString(),
-                containsString("IPAddress: " + localAddress));
+        assertThat(getCertificate(clientChannel), containsString("IPAddress: " + localAddress));
     }
 
     private void waitForServerChannel() throws InterruptedException {
         serverChannelReady.await(5, TimeUnit.SECONDS);
         assertThat(serverChannel, is(notNullValue()));
+    }
+
+    private static String getCertificate(Channel clientChannel) throws Exception {
+        return clientChannel
+                .pipeline()
+                .get(SslHandler.class)
+                .engine()
+                .getSession()
+                .getPeerCertificates()[0]
+                .toString();
     }
 }

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.10.0] - 2022-02-18
 ### Added

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastService.java
@@ -91,8 +91,7 @@ public abstract class OastService {
         public OastThreadFactory(String namePrefix) {
             threadNumber = new AtomicInteger(1);
             this.namePrefix = namePrefix;
-            SecurityManager s = System.getSecurityManager();
-            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+            group = Thread.currentThread().getThreadGroup();
         }
 
         @Override


### PR DESCRIPTION
Build with Java 17 which is a LTS version.
Address deprecation warnings:
 - Remove Security Manager usage which will be removed in a future
 release, JEP 411;
 - Replace usage of deprecated methods.

Disable PAC tests on newer Java versions, no longer works (requires
Nashorn classes).
Update changelogs where needed.