### PR TITLE
openapi: correct generation of Content-Type

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Now depends on commonlib for display of import progress (Issue 6783).
 
+### Fixed
+- Properly generate Content-Type header when in presence of more than one supported content (Issue 7082).
+
 ## [26] - 2022-02-01
 
 ### Fixed

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/HeadersGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/HeadersGeneratorUnitTest.java
@@ -145,14 +145,13 @@ class HeadersGeneratorUnitTest {
     }
 
     @Test
-    void shouldGenerateJustFirstSupportedContentType() {
+    void shouldGenerateJustFirstSupportedContentTypeInBodyGeneratedOrder() {
         // Given
-        RequestBody request =
-                mockRequestWithMediaTypes("application/json", "application/x-www-form-urlencoded");
+        RequestBody request = mockRequestWithMediaTypes("multipart/form-data", "application/json");
         Operation operation = mockOperationWithRequest(request);
         List<HttpHeaderField> headers = new ArrayList<>();
         // When
-        headersGenerator.generateContentTypeHeaders(operation, headers, "");
+        headersGenerator.generateContentTypeHeaders(operation, headers, "{\"a\":\"b\"}");
         // Then
         assertThat(headers, contains(header("Content-Type", "application/json")));
     }


### PR DESCRIPTION
Generate the Content-Type header in the same order the body is
generated to return the expected value (and prevent exception).

Fix zaproxy/zaproxy#7082.