### PR TITLE
openapi: support content in parameters

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Support content field (JSON) in parameters (Issue 6166).
+
 ### Changed
 - Now depends on commonlib for display of import progress (Issue 6783).
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/DataGenerator.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.openapi.generators;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.DateSchema;
 import io.swagger.v3.oas.models.media.DateTimeSchema;
 import io.swagger.v3.oas.models.media.FileSchema;
@@ -122,6 +123,15 @@ public class DataGenerator {
         if (example != null && !example.isEmpty()) {
             return example;
         }
+
+        Content content = parameter.getContent();
+        if (content != null) {
+            if (content.containsKey("application/json")) {
+                return generators.getBodyGenerator().generate(content.get("application/json"));
+            }
+            return getExampleValue(parameter);
+        }
+
         if (isArray(parameter.getSchema().getType())) {
             return generateArrayValue(name, parameter);
         }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/DataGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/DataGeneratorUnitTest.java
@@ -1,0 +1,81 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.generators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link DataGenerator}. */
+class DataGeneratorUnitTest extends TestUtils {
+
+    private DataGenerator generator;
+
+    @BeforeAll
+    static void setUp() {
+        mockMessages(new ExtensionOpenApi());
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        Constant.messages = null;
+    }
+
+    @BeforeEach
+    void init() {
+        Generators generators = new Generators(null);
+        generator = generators.getDataGenerator();
+    }
+
+    @Test
+    void shouldUseContentInParameter() throws IOException {
+        // Given
+        OpenAPI openAPI = parseResource("defn-with-query-params.yml");
+        Parameter parameter =
+                openAPI.getPaths().get("/content-json").getGet().getParameters().get(0);
+        // When
+        String data = generator.generate(parameter.getName(), parameter);
+        // Then
+        assertEquals("{\"id\":10,\"name\":\"John Doe\"}", data);
+    }
+
+    private OpenAPI parseResource(String fileName) throws IOException {
+        ParseOptions options = new ParseOptions();
+        options.setResolveFully(true);
+        String defn =
+                IOUtils.toString(
+                        this.getClass().getResourceAsStream(fileName), StandardCharsets.UTF_8);
+        return new OpenAPIV3Parser().readContents(defn, new ArrayList<>(), options).getOpenAPI();
+    }
+}

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/generators/defn-with-query-params.yml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/generators/defn-with-query-params.yml
@@ -1,0 +1,30 @@
+openapi: 3.0.0
+info:
+  title: "Definition with warning (missing version)."
+  version: "0.1"
+servers:
+  - url: http://localhost:@@@PORT@@@/
+paths:
+  /content-json:
+    get:
+      parameters:
+        - name: param
+          in: query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+      responses:
+        '200':
+          description: OK
+
+components:
+  schemas:
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string


### PR DESCRIPTION
Change `DataGenerator` to check for `content` field in parameters and
generate the data (JSON, fallback to example if other type).

Fix zaproxy/zaproxy#6166.