### PR TITLE
chore: wappalyzer: Add start of parse log message

### DIFF
--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/WappalyzerJsonParser.java
@@ -76,6 +76,7 @@ public class WappalyzerJsonParser {
     }
 
     WappalyzerData parse(String categories, List<String> technologies) {
+        logger.info("Starting to parse Wappalyzer technologies.");
         WappalyzerData wappalyzerData = new WappalyzerData();
         parseCategories(wappalyzerData, getStringResource(categories));
         technologies.forEach(path -> parseJson(wappalyzerData, getStringResource(path)));


### PR DESCRIPTION
During ZAP startup there's a pause when wappalzer is parsing patterns. Add a start log message so that it's more clear what's going on.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>