### PR TITLE
ascanrulesBeta: address FP in Padding Oracle

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Adapted Cloud Metadata Attack scan rule to use Custom Pages and active scan analyzer to help reduce false positives in certain cases (Issue 7033).
+- Generic Padding Oracle scan rule will no longer raise an alert for validation fields when the error response contains expected error patterns (Issue 6183).
 
 ## [39] - 2021-12-13
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/PaddingOracleScanRule.java
@@ -38,7 +38,7 @@ import org.zaproxy.addon.commonlib.CommonAlertTag;
 public class PaddingOracleScanRule extends AbstractAppParamPlugin {
 
     // List of all possible errors
-    private static final String[] ERROR_PATTERNS = {
+    static final String[] ERROR_PATTERNS = {
         "BadPaddingException",
         "padding",
         "runtime",
@@ -181,13 +181,16 @@ public class PaddingOracleScanRule extends AbstractAppParamPlugin {
                     // Otherwise check the response with the last bit changed
                     String lastBitResponse = msg.getResponseBody().toString();
 
+                    String emptyValueResponse = getEmptyValueResponse(paramName);
+
                     // Check if changing the last bit produced a result that
                     // changing the first bit didn't. These results are based
                     // on a list of error strings.
                     for (String pattern : ERROR_PATTERNS) {
 
                         if (lastBitResponse.contains(pattern)
-                                && !controlResponse.contains(pattern)) {
+                                && !controlResponse.contains(pattern)
+                                && !emptyValueResponse.contains(pattern)) {
 
                             // We Found IT!
                             // First do logging
@@ -229,6 +232,13 @@ public class PaddingOracleScanRule extends AbstractAppParamPlugin {
         }
 
         return false;
+    }
+
+    private String getEmptyValueResponse(String paramName) throws IOException {
+        HttpMessage msg = getNewMsg();
+        setParameter(msg, paramName, "");
+        sendAndReceive(msg);
+        return msg.getResponseBody().toString();
     }
 
     /**


### PR DESCRIPTION
Double check error patterns with an empty value to prevent false
positives with validation fields.

Fix zaproxy/zaproxy#6183.