### PR TITLE
fix: ascanrulesBeta: HFF don't follow redirects on HFF requests

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Adapted Cloud Metadata Attack scan rule to use Custom Pages and active scan analyzer to help reduce false positives in certain cases (Issue 7033).
 - Generic Padding Oracle scan rule will no longer raise an alert for validation fields when the error response contains expected error patterns (Issue 6183).
+- Hidden File Finder no longer follows redirects when sending requests for potential hidden files which should make it less false positive prone (Issue 7036).
 
 ## [39] - 2021-12-13
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
@@ -165,7 +165,7 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
             testMsg.getRequestHeader().setMethod(HttpRequestHeader.GET);
             testMsg.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
             testMsg.setRequestBody("");
-            sendAndReceive(testMsg);
+            sendAndReceive(testMsg, false);
             return testMsg;
         } catch (URIException uEx) {
             LOG.debug(


### PR DESCRIPTION
- CHANGELOG.md > Added fix note.
- HiddenFilesScanRule > No longer follow redirects when making hidden file requests.
- HiddenFilesScanRule > Add a test based on redirects. Correct the path in one existing test (more of a cosmetic or consistency issue ... clean code), also corrected expected vs. actual values in one existing test method.

Fixes zaproxy/zaproxy#7036

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>