### PR TITLE
ascanrules: address FP in XSS

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Server Side Code Injection scan rule, prevent use of zero when injecting ASP multiplication to avoid false positives (Issue 7107).
 - External Redirect scan rule to detect redirects with dots deny listed.
+- Cross Site Scripting (Reflected) scan rule will no longer raise an alert for unsuccessful JavaScript string injections (Issue 1641).
 
 ## [44] - 2022-01-13
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -643,16 +643,19 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                             if (contexts2 == null) {
                                 break;
                             }
-                            if (contexts2.size() > 0) {
-                                // Yep, its vulnerable
-                                newAlert()
-                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                        .setParam(param)
-                                        .setAttack(contexts2.get(0).getTarget())
-                                        .setEvidence(contexts2.get(0).getTarget())
-                                        .setMessage(contexts2.get(0).getMsg())
-                                        .raise();
-                                attackWorked = true;
+                            for (HtmlContext ctx : contexts2) {
+                                if (!ctx.getSurroundingQuote().isEmpty()) {
+                                    // Yep, its vulnerable
+                                    newAlert()
+                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                            .setParam(param)
+                                            .setAttack(ctx.getTarget())
+                                            .setEvidence(ctx.getTarget())
+                                            .setMessage(ctx.getMsg())
+                                            .raise();
+                                    attackWorked = true;
+                                    break;
+                                }
                             }
                         } else {
                             // Try an img tag


### PR DESCRIPTION
Check that string injections are surrounded by the quote otherwise the
payload is still in the string where it was injected (cases where
quotes are filtered).

Fix zaproxy/zaproxy#1641.