### PR TITLE
Automation:  Register plans run by -autorun

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - The ascan job 'Scan All Header' GUI label
 
+### Fixed
+- Register plans run by -autorun to prevent NPEs when editing them
+
 ## [0.13.0] - 2022-02-25
 ### Fixed
 - Issue when adding or removing add-ons via the UI (Issue 7075)

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -373,7 +373,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         if (this.hasView()) {
             this.getAutomationPanel().setCurrentPlan(plan);
         }
-        this.plans.put(plan.getId(), plan);
+        registerPlan(plan);
     }
 
     public AutomationPlan getPlan(int planId) {
@@ -396,9 +396,7 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         }
         try {
             AutomationPlan plan = new AutomationPlan(this, f);
-            if (this.hasView()) {
-                this.getAutomationPanel().setCurrentPlan(plan);
-            }
+            this.displayPlan(plan);
             this.runPlan(plan, false);
             AutomationProgress progress = plan.getProgress();
 


### PR DESCRIPTION
To prevent NPEs when editing them.
To reproduce run the ZAP Gui with -autorun and then try to add a job to the plan - its will NPE.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>