### PR TITLE
Webdrivers for macos M1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-            ~/.m2/repository/webdriver
+            ~/.cache/selenium
           key: ${{ runner.os }}-gradle-${{ matrix.java }}-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-${{ matrix.java }}-

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,7 +22,7 @@ jobs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-          ~/.m2/repository/webdriver/
+          ~/.cache/selenium
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Support aarch64/arm64 WebDrivers.
 
 
 ## [15.7.0] - 2022-02-17

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
@@ -202,20 +202,8 @@ public enum Browser {
         }
 
         Path basePath = getWebDriversDir().resolve(osDirName);
-        Path driver;
-        if (isOs64Bits()) {
-            driver = basePath.resolve("64").resolve(driverName);
-            if (Files.exists(driver)) {
-                try {
-                    setExecutable(driver);
-                    return driver.toAbsolutePath().toString();
-                } catch (IOException e) {
-                    logger.warn("Failed to set the bundled WebDriver executable:", e);
-                }
-            }
-        }
-
-        driver = basePath.resolve("32").resolve(driverName);
+        String archDir = getArchDir();
+        Path driver = basePath.resolve(archDir).resolve(driverName);
         if (Files.exists(driver)) {
             try {
                 setExecutable(driver);
@@ -254,9 +242,15 @@ public enum Browser {
         return null;
     }
 
-    private static boolean isOs64Bits() {
+    private static String getArchDir() {
         String arch = System.getProperty("os.arch");
-        return arch.contains("amd64") || arch.contains("x86_64");
+        String archDir = "32";
+        if (arch.contains("amd64") || arch.contains("x86_64")) {
+            archDir = "64";
+        } else if (arch.contains("aarch64")) {
+            archDir = "arm64";
+        }
+        return archDir;
     }
 
     private static void setExecutable(Path file) throws IOException {

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Add aarch64/arm64 WebDrivers.
 
 
 ## [36] - 2022-03-04

--- a/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
+++ b/addOns/webdrivers/webdrivermacos/webdrivermacos.gradle.kts
@@ -26,8 +26,18 @@ tasks {
         arch.set(DownloadWebDriver.Arch.X64)
     }
 
+    register<DownloadWebDriver>("downloadChromeDriverArm") {
+        browser.set(DownloadWebDriver.Browser.CHROME)
+        arch.set(DownloadWebDriver.Arch.ARM64)
+    }
+
     register<DownloadWebDriver>("downloadGeckodriver") {
         browser.set(DownloadWebDriver.Browser.FIREFOX)
         arch.set(DownloadWebDriver.Arch.X64)
+    }
+
+    register<DownloadWebDriver>("downloadGeckodriverArm") {
+        browser.set(DownloadWebDriver.Browser.FIREFOX)
+        arch.set(DownloadWebDriver.Arch.ARM64)
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,7 +29,9 @@ tasks.withType<JavaCompile>().configureEach {
 
 dependencies {
     implementation("commons-codec:commons-codec:1.15")
-    implementation("io.github.bonigarcia:webdrivermanager:3.7.1")
+    implementation("io.github.bonigarcia:webdrivermanager:5.1.0") {
+        exclude("com.fasterxml.jackson.core")
+    }
     implementation("com.diffplug.spotless:spotless-plugin-gradle:5.14.2")
 }
 


### PR DESCRIPTION
Updated webdriver manager to 5.1.0
added aarch64/arm64 drivers macos

Fix zaproxy/zaproxy#7008.

Signed-off-by: kcberg <kc.berg@stackhawk.com>