### PR TITLE
chore: Relocate PersistentXssUtils

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [45] - 2022-03-15
 ### Changed 

--- a/addOns/ascanrules/ascanrules.gradle.kts
+++ b/addOns/ascanrules/ascanrules.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.6.0 & < 2.0.0")
+                    version.set(">= 1.9.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExtensionAscanRules.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ExtensionAscanRules.java
@@ -20,11 +20,7 @@
 package org.zaproxy.zap.extension.ascanrules;
 
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
-import org.parosproxy.paros.extension.ExtensionHook;
-import org.parosproxy.paros.extension.SessionChangedListener;
-import org.parosproxy.paros.model.Session;
 
 /**
  * A null extension just to cause the message bundle and help file to get loaded
@@ -46,29 +42,5 @@ public class ExtensionAscanRules extends ExtensionAdaptor {
     @Override
     public boolean canUnload() {
         return true;
-    }
-
-    @Override
-    public void hook(ExtensionHook hook) {
-        super.hook(hook);
-
-        hook.addSessionListener(new SessionChangedListenerImpl());
-    }
-
-    private static class SessionChangedListenerImpl implements SessionChangedListener {
-
-        @Override
-        public void sessionScopeChanged(Session session) {}
-
-        @Override
-        public void sessionModeChanged(Mode mode) {}
-
-        @Override
-        public void sessionChanged(Session session) {}
-
-        @Override
-        public void sessionAboutToChange(Session session) {
-            PersistentXssUtils.reset();
-        }
     }
 }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssPrimeScanRule.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.SourceSinkUtils;
 
 public class PersistentXssPrimeScanRule extends AbstractAppParamPlugin {
 
@@ -68,7 +69,7 @@ public class PersistentXssPrimeScanRule extends AbstractAppParamPlugin {
     public void scan(HttpMessage msg, String param, String value) {
         try {
             HttpMessage msg1 = msg.cloneRequest();
-            this.setParameter(msg1, param, PersistentXssUtils.getUniqueValue(msg1, param));
+            this.setParameter(msg1, param, SourceSinkUtils.getUniqueValue(msg1, param));
             log.debug("Prime msg={} param={}", msg1.getRequestHeader().getURI(), param);
             sendAndReceive(msg1, false);
         } catch (Exception e) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
@@ -36,6 +36,7 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
+import org.zaproxy.addon.commonlib.SourceSinkUtils;
 import org.zaproxy.zap.httputils.HtmlContext;
 import org.zaproxy.zap.httputils.HtmlContextAnalyser;
 import org.zaproxy.zap.model.Vulnerabilities;
@@ -185,7 +186,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                         sourceMsg.getRequestHeader().getURI().toString());
 
         try {
-            Set<Integer> sinks = PersistentXssUtils.getSinksIdsForSource(sourceMsg, param);
+            Set<Integer> sinks = SourceSinkUtils.getSinksIdsForSource(sourceMsg, param);
 
             if (sinks != null) {
                 // Loop through each one
@@ -201,7 +202,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                         break;
                     }
 
-                    HttpMessage sinkMsg = PersistentXssUtils.getMessage(sinkMsgId);
+                    HttpMessage sinkMsg = SourceSinkUtils.getMessage(sinkMsgId);
                     if (sinkMsg == null) {
                         continue;
                     }

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssSpiderScanRule.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.core.scanner.AbstractAppPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.commonlib.SourceSinkUtils;
 
 public class PersistentXssSpiderScanRule extends AbstractAppPlugin {
 
@@ -76,7 +77,7 @@ public class PersistentXssSpiderScanRule extends AbstractAppPlugin {
         try {
             HttpMessage msg1 = msg.cloneRequest();
             sendAndReceive(msg1, false);
-            PersistentXssUtils.testForSink(msg1);
+            SourceSinkUtils.testForSink(msg1);
 
         } catch (Exception e) {
             log.error(e.getMessage(), e);

--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [1.8.0] - 2022-03-07
 ### Added

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ExtensionCommonlib.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ExtensionCommonlib.java
@@ -34,8 +34,8 @@ public class ExtensionCommonlib extends ExtensionAdaptor {
     public void hook(ExtensionHook extensionHook) {
         if (hasView()) {
             extensionHook.getHookView().addStatusPanel(getProgressPanel());
-            extensionHook.addSessionListener(new SessionChangedListenerImpl());
         }
+        extensionHook.addSessionListener(new SessionChangedListenerImpl());
     }
 
     public ProgressPanel getProgressPanel() {
@@ -64,7 +64,10 @@ public class ExtensionCommonlib extends ExtensionAdaptor {
 
         @Override
         public void sessionAboutToChange(Session session) {
-            getProgressPanel().clearAndDispose();
+            if (hasView()) {
+                getProgressPanel().clearAndDispose();
+            }
+            SourceSinkUtils.reset();
         }
 
         @Override

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/SourceSinkUtils.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/SourceSinkUtils.java
@@ -17,13 +17,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.ascanrules;
+package org.zaproxy.addon.commonlib;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.collections.map.AbstractReferenceMap;
 import org.apache.commons.collections.map.ReferenceMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,13 +34,22 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 
-public class PersistentXssUtils {
+/**
+ * A utility class to assist in identifying input sources and their related sinks. Useful, for
+ * example, in identifying SSTI issues, or persistent XSS.
+ *
+ * @since 1.9.0
+ */
+public final class SourceSinkUtils {
 
     private static int uniqueIndex;
     public static final String PXSS_PREFIX = "zApPX";
     public static final String PXSS_POSTFIX = "sS";
     private static Map<String, UserDataSource> map;
     private static Map<String, HashSet<Integer>> sourceToSinks;
+
+    private SourceSinkUtils() {}
+
     /**
      * A {@code Map} to cache the URIs used by source messages ({@code UserDataSource}).
      *
@@ -65,7 +75,7 @@ public class PersistentXssUtils {
      */
     private static Map<String, String> cachedParams;
 
-    private static Logger log = LogManager.getLogger(PersistentXssUtils.class);
+    private static Logger log = LogManager.getLogger(SourceSinkUtils.class);
 
     static {
         reset();
@@ -150,9 +160,11 @@ public class PersistentXssUtils {
         map = new HashMap<>();
         sourceToSinks = new HashMap<>();
         cachedUris =
-                Collections.synchronizedMap(new ReferenceMap(ReferenceMap.SOFT, ReferenceMap.SOFT));
+                Collections.synchronizedMap(
+                        new ReferenceMap(AbstractReferenceMap.SOFT, AbstractReferenceMap.SOFT));
         cachedParams =
-                Collections.synchronizedMap(new ReferenceMap(ReferenceMap.SOFT, ReferenceMap.SOFT));
+                Collections.synchronizedMap(
+                        new ReferenceMap(AbstractReferenceMap.SOFT, AbstractReferenceMap.SOFT));
     }
 
     /**
@@ -170,15 +182,6 @@ public class PersistentXssUtils {
             log.warn("Failed to read HTTP message from database:", e);
         }
         return null;
-    }
-
-    private static String getCachedItem(Map<String, String> map, String item) {
-        String cachedItem = map.get(item);
-        if (cachedItem != null) {
-            return cachedItem;
-        }
-        map.put(item, item);
-        return item;
     }
 
     private static class UserDataSource {
@@ -205,6 +208,15 @@ public class PersistentXssUtils {
 
         public String getParam() {
             return param;
+        }
+
+        private static String getCachedItem(Map<String, String> map, String item) {
+            String cachedItem = map.get(item);
+            if (cachedItem != null) {
+                return cachedItem;
+            }
+            map.put(item, item);
+            return item;
         }
     }
 }


### PR DESCRIPTION
- Add maintenance note to changelogs.
- Move PersistentXssUtils to commonlib, renaming it to SourceSinkUtils.
- Update ascanrules dependant files to use the renamed class.
- Update ascanrules build file to depend on commonlib 1.9.0+.
- Also addressed a few SAST (SonarLint) items in SourceSinkUtils.
    - `ReferenceMap` &gt; `AbstractReferenceMap` for static access.
    - Private `getCachedItem(Map, String)` method moved to inner class which was the only place it was used.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>