### PR TITLE
ascanrules: address FNs in XSS

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Fix Cross Site Scripting (Reflected) scan rule false negatives introduced in previous version.
+
 ## [45] - 2022-03-15
 ### Changed 
 - Remote OS Command Injection rule now has more information in the Other Info field to differentiate feedback-based or time-based tests

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -644,7 +644,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                                 break;
                             }
                             for (HtmlContext ctx : contexts2) {
-                                if (!ctx.getSurroundingQuote().isEmpty()) {
+                                if (context.getSurroundingQuote().isEmpty()
+                                        || !ctx.getSurroundingQuote().isEmpty()) {
                                     // Yep, its vulnerable
                                     newAlert()
                                             .setConfidence(Alert.CONFIDENCE_MEDIUM)

--- a/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInScript.html
+++ b/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInScript.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 <script>
-var name = "@@@name@@@";
+@@@script@@@
 </script>
 </head>
 </html>


### PR DESCRIPTION
Do not require a surrounding quote when checking the reflection if
there was none originally.

Caused by #3661.