### PR TITLE
fix: retest: Use SessionChangedListener to reset between sessions

### DIFF
--- a/addOns/retest/CHANGELOG.md
+++ b/addOns/retest/CHANGELOG.md
@@ -9,6 +9,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update minimum ZAP version to 2.11.1.
 - Scan Rule ID values are no longer displayed with commas.
 
+### Fixed
+- The Retest dialog now properly resets between ZAP sessions (Issue 7147).
+
 ## [0.2.0] - 2021-10-06
 ### Changed
 - Update minimum ZAP version to 2.11.0.

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/ExtensionRetest.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/ExtensionRetest.java
@@ -23,10 +23,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control.Mode;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.SessionChangedListener;
+import org.parosproxy.paros.model.Session;
 import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.ExtensionAutomation;
 import org.zaproxy.addon.automation.tests.AutomationAlertTest;
@@ -65,6 +68,7 @@ public class ExtensionRetest extends ExtensionAdaptor {
         extensionHook.addApiImplementor(retestApi);
 
         if (hasView()) {
+            extensionHook.addSessionListener(new SessionChangedListenerImpl());
             extensionHook.getHookMenu().addPopupMenuItem(getRetestMenu());
             extensionHook.getHookMenu().addToolsMenuItem(getMenuItemRetest());
         }
@@ -78,8 +82,13 @@ public class ExtensionRetest extends ExtensionAdaptor {
     @Override
     public void unload() {
         super.unload();
+        disposeDialog();
+    }
+
+    private void disposeDialog() {
         if (retestDialog != null) {
             retestDialog.dispose();
+            retestDialog = null;
         }
     }
 
@@ -130,5 +139,22 @@ public class ExtensionRetest extends ExtensionAdaptor {
                 && data.getConfidence().equals(testData.getConfidence())
                 && data.getRisk().equals(testData.getRisk())
                 && data.getOtherInfo().equals(testData.getOtherInfo());
+    }
+
+    private class SessionChangedListenerImpl implements SessionChangedListener {
+
+        @Override
+        public void sessionScopeChanged(Session session) {}
+
+        @Override
+        public void sessionModeChanged(Mode mode) {}
+
+        @Override
+        public void sessionChanged(Session session) {}
+
+        @Override
+        public void sessionAboutToChange(Session session) {
+            disposeDialog();
+        }
     }
 }


### PR DESCRIPTION
- CHANGELOG > Added fix note.
- ExtensionRetest > Added SessionChangedListener implementation which resets the Retest dialog when the ZAP session changes.

Fixes zaproxy/zaproxy#7147

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>