### PR TITLE
ascanrules: Fix xss context false negative

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -40,8 +40,8 @@ import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
-import org.zaproxy.zap.httputils.HtmlContext;
-import org.zaproxy.zap.httputils.HtmlContextAnalyser;
+import org.zaproxy.zap.extension.ascanrules.utils.HtmlContext;
+import org.zaproxy.zap.extension.ascanrules.utils.HtmlContextAnalyser;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -694,59 +694,55 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                                     return;
                                 }
                                 for (HtmlContext ctx : contexts2) {
-                                    if (ctx.getParentTag() != null) {
-                                        // Yep, its vulnerable
-                                        if (ctx.getMsg().getResponseHeader().isHtml()) {
+                                    // Yep, its vulnerable
+                                    if (ctx.getMsg().getResponseHeader().isHtml()) {
+                                        newAlert()
+                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                .setParam(param)
+                                                .setAttack(ctx.getTarget())
+                                                .setEvidence(ctx.getTarget())
+                                                .setMessage(contexts2.get(0).getMsg())
+                                                .raise();
+                                    } else {
+                                        HttpMessage ctx2Message = contexts2.get(0).getMsg();
+                                        if (StringUtils.containsIgnoreCase(
+                                                ctx.getMsg()
+                                                        .getResponseHeader()
+                                                        .getHeader(HttpHeader.CONTENT_TYPE),
+                                                "json")) {
                                             newAlert()
-                                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                                    .setRisk(Alert.RISK_LOW)
+                                                    .setConfidence(Alert.CONFIDENCE_LOW)
+                                                    .setName(
+                                                            Constant.messages.getString(
+                                                                    MESSAGE_PREFIX + "json.name"))
+                                                    .setDescription(
+                                                            Constant.messages.getString(
+                                                                    MESSAGE_PREFIX + "json.desc"))
                                                     .setParam(param)
-                                                    .setAttack(ctx.getTarget())
-                                                    .setEvidence(ctx.getTarget())
-                                                    .setMessage(contexts2.get(0).getMsg())
+                                                    .setAttack(scriptAlert)
+                                                    .setOtherInfo(
+                                                            Constant.messages.getString(
+                                                                    MESSAGE_PREFIX
+                                                                            + "otherinfo.nothtml"))
+                                                    .setMessage(ctx2Message)
                                                     .raise();
                                         } else {
-                                            HttpMessage ctx2Message = contexts2.get(0).getMsg();
-                                            if (StringUtils.containsIgnoreCase(
-                                                    ctx.getMsg()
-                                                            .getResponseHeader()
-                                                            .getHeader(HttpHeader.CONTENT_TYPE),
-                                                    "json")) {
-                                                newAlert()
-                                                        .setRisk(Alert.RISK_LOW)
-                                                        .setConfidence(Alert.CONFIDENCE_LOW)
-                                                        .setName(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "json.name"))
-                                                        .setDescription(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "json.desc"))
-                                                        .setParam(param)
-                                                        .setAttack(scriptAlert)
-                                                        .setOtherInfo(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "otherinfo.nothtml"))
-                                                        .setMessage(ctx2Message)
-                                                        .raise();
-                                            } else {
-                                                newAlert()
-                                                        .setConfidence(Alert.CONFIDENCE_LOW)
-                                                        .setParam(param)
-                                                        .setAttack(ctx.getTarget())
-                                                        .setOtherInfo(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "otherinfo.nothtml"))
-                                                        .setEvidence(ctx.getTarget())
-                                                        .setMessage(ctx2Message)
-                                                        .raise();
-                                            }
+                                            newAlert()
+                                                    .setConfidence(Alert.CONFIDENCE_LOW)
+                                                    .setParam(param)
+                                                    .setAttack(ctx.getTarget())
+                                                    .setOtherInfo(
+                                                            Constant.messages.getString(
+                                                                    MESSAGE_PREFIX
+                                                                            + "otherinfo.nothtml"))
+                                                    .setEvidence(ctx.getTarget())
+                                                    .setMessage(ctx2Message)
+                                                    .raise();
                                         }
-                                        attackWorked = true;
-                                        break;
                                     }
+                                    attackWorked = true;
+                                    break;
                                 }
                             }
                             if (attackWorked || isStop()) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
@@ -37,8 +37,8 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.SourceSinkUtils;
-import org.zaproxy.zap.httputils.HtmlContext;
-import org.zaproxy.zap.httputils.HtmlContextAnalyser;
+import org.zaproxy.zap.extension.ascanrules.utils.HtmlContext;
+import org.zaproxy.zap.extension.ascanrules.utils.HtmlContextAnalyser;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/utils/HtmlContext.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/utils/HtmlContext.java
@@ -1,0 +1,206 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2011 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class HtmlContext {
+
+    public static final int IGNORE_PARENT = 0x0001;
+    public static final int IGNORE_TAG = 0x0002;
+    public static final int IGNORE_QUOTES = 0x0004;
+    public static final int IGNORE_IN_SCRIPT = 0x0008;
+    public static final int IGNORE_IN_URL = 0x0010;
+    public static final int IGNORE_WITH_SRC = 0x0020;
+    public static final int IGNORE_HTML_COMMENT = 0x0040;
+
+    private HttpMessage msg;
+    private String target;
+    private int start = 0;
+    private int end = 0;
+    private List<String> parentTags = new ArrayList<>();
+    private String tagAttribute = null;
+    private boolean inScriptAttribute = false;
+    private boolean inUrlAttribute = false;
+    private boolean inTagWithSrc = false;
+    private String surroundingQuote = "";
+    private boolean htmlComment = false;
+
+    public HtmlContext(HttpMessage msg, String target, int start, int end) {
+        super();
+        this.msg = msg;
+        this.target = target;
+        this.start = start;
+        this.end = end;
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public void setStart(int start) {
+        this.start = start;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    public HttpMessage getMsg() {
+        return msg;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public List<String> getParentTags() {
+        return parentTags;
+    }
+
+    public void setParentTags(List<String> surroundingTags) {
+        this.parentTags = surroundingTags;
+    }
+
+    public String getSurroundingQuote() {
+        return surroundingQuote;
+    }
+
+    public void setSurroundingQuote(String surroundingQuote) {
+        this.surroundingQuote = surroundingQuote;
+    }
+
+    public String getTagAttribute() {
+        return tagAttribute;
+    }
+
+    public void setTagAttribute(String tagAttribute) {
+        this.tagAttribute = tagAttribute;
+    }
+
+    public void addParentTag(String name) {
+        parentTags.add(0, name);
+    }
+
+    public String getParentTag() {
+        if (parentTags.size() > 0) {
+            return parentTags.get(parentTags.size() - 1);
+        }
+        return null;
+    }
+
+    public boolean isInScriptAttribute() {
+        return inScriptAttribute;
+    }
+
+    public void setInScriptAttribute(boolean inScriptAttribute) {
+        this.inScriptAttribute = inScriptAttribute;
+    }
+
+    public boolean isHtmlComment() {
+        return htmlComment;
+    }
+
+    public void setHtmlComment(boolean htmlComment) {
+        this.htmlComment = htmlComment;
+    }
+
+    public boolean isInUrlAttribute() {
+        return inUrlAttribute;
+    }
+
+    public void setInUrlAttribute(boolean inUrlAttribute) {
+        this.inUrlAttribute = inUrlAttribute;
+    }
+
+    public boolean isInTagWithSrc() {
+        return inTagWithSrc;
+    }
+
+    public void setInTagWithSrc(boolean inTagWithSrc) {
+        this.inTagWithSrc = inTagWithSrc;
+    }
+
+    public boolean matches(HtmlContext context, int ignoreFlags) {
+
+        if (context == null) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_TAG) > 0) {
+            // check the tag
+            if (this.tagAttribute != null) {
+                if (!this.tagAttribute.equals(context.getTagAttribute())) {
+                    return false;
+                }
+            } else {
+                if (context.getTagAttribute() != null) {
+                    return false;
+                }
+            }
+        }
+        if ((ignoreFlags ^ IGNORE_QUOTES) > 0) {
+            // check the quotes
+            if (this.surroundingQuote != null) {
+                if (!this.surroundingQuote.equals(context.getSurroundingQuote())) {
+                    return false;
+                }
+            } else {
+                if (context.getSurroundingQuote() != null) {
+                    return false;
+                }
+            }
+        }
+        if ((ignoreFlags ^ IGNORE_PARENT) > 0) {
+            // check the parents
+            if (this.getParentTag() != null) {
+                if (!this.getParentTag().equals(context.getParentTag())) {
+                    return false;
+                }
+            } else {
+                if (context.getParentTag() != null) {
+                    return false;
+                }
+            }
+        }
+        if ((ignoreFlags ^ IGNORE_IN_SCRIPT) > 0
+                && this.inScriptAttribute != context.isInScriptAttribute()) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_WITH_SRC) > 0 && this.inTagWithSrc != context.isInTagWithSrc()) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_IN_URL) > 0
+                && this.inUrlAttribute != context.isInUrlAttribute()) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_HTML_COMMENT) > 0
+                && this.htmlComment != context.isHtmlComment()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/utils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/utils/HtmlContextAnalyser.java
@@ -176,7 +176,11 @@ public class HtmlContextAnalyser {
             }
 
             // Work out the location in the DOM
-            Element element = src.getEnclosingElement(context.getStart());
+            int start = context.getStart();
+            if (context.getTarget().startsWith("<") && start > 0) {
+                start--;
+            }
+            Element element = src.getEnclosingElement(start);
             if (element != null) {
                 // See if its in an attribute
                 boolean isInputTag =

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/utils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/utils/HtmlContextAnalyser.java
@@ -1,0 +1,224 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2011 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules.utils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import net.htmlparser.jericho.Attribute;
+import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.Source;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class HtmlContextAnalyser {
+
+    private char[] quotes = {'\'', '"'};
+
+    // Tag attributes which can contain javascript
+    private String[] scriptAttributes = {
+        "onBlur",
+        "onChange",
+        "onClick",
+        "onDblClick",
+        "onFocus",
+        "onKeydown",
+        "onKeyup",
+        "onKeypress",
+        "onLoad",
+        "onMousedown",
+        "onMouseup",
+        "onMouseover",
+        "onMousemove",
+        "onMouseout",
+        "onReset",
+        "onSelect",
+        "onSubmit",
+        "onUnload"
+    };
+
+    // Tag attributes which can contain a URL
+    private String[] urlAttributes = {
+        "action",
+        "background",
+        "cite",
+        "classid",
+        "codebase",
+        "data",
+        "formaction",
+        "href",
+        "icon",
+        "longdesc",
+        "manifest",
+        "poster",
+        "profile",
+        "src",
+        "usemap",
+    };
+
+    // Tags which can have a 'src' attribute
+    private String[] tagsWithSrcAttributes = {
+        "frame", "iframe", "img",
+        "input", // Special case - should also check to see if it has a type of 'image'
+        "script", "src",
+    };
+
+    private HttpMessage msg = null;
+    private String htmlPage = null;
+    private Source src = null;
+
+    public HtmlContextAnalyser(HttpMessage msg) {
+        this.msg = msg;
+        this.htmlPage = msg.getResponseBody().toString();
+        src = new Source(htmlPage);
+        src.fullSequentialParse();
+    }
+
+    private boolean isQuote(char chr) {
+        for (int i = 0; i < quotes.length; i++) {
+            if (chr == quotes[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isScriptAttribute(String att) {
+        for (int i = 0; i < scriptAttributes.length; i++) {
+            if (att.equalsIgnoreCase(scriptAttributes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isUrlAttribute(String att) {
+        for (int i = 0; i < urlAttributes.length; i++) {
+            if (att.equalsIgnoreCase(urlAttributes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isInTagWithSrcAttribute(String tag) {
+        for (int i = 0; i < tagsWithSrcAttributes.length; i++) {
+            if (tag.equalsIgnoreCase(tagsWithSrcAttributes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<HtmlContext> getHtmlContexts(String target) {
+        return this.getHtmlContexts(target, null, 0);
+    }
+
+    public List<HtmlContext> getHtmlContexts(
+            String target, HtmlContext targetContext, int ignoreFlags) {
+        List<HtmlContext> contexts = new ArrayList<>();
+
+        int offset = 0;
+        while ((offset = htmlPage.indexOf(target, offset)) >= 0) {
+            HtmlContext context =
+                    new HtmlContext(this.msg, target, offset, offset + target.length());
+            offset += target.length();
+
+            // Is it in quotes?
+            char leftQuote = 0;
+            for (int i = context.getStart() - 1; i > 0; i--) {
+                char chr = htmlPage.charAt(i);
+                if (isQuote(chr)) {
+                    leftQuote = chr;
+                    break;
+                } else if (chr == '>') {
+                    // end of another tag
+                    break;
+                }
+            }
+            if (leftQuote != 0) {
+                for (int i = context.getEnd(); i < htmlPage.length(); i++) {
+                    char chr = htmlPage.charAt(i);
+                    if (leftQuote == chr) {
+                        // matching quote
+                        context.setSurroundingQuote("" + leftQuote);
+                        break;
+                    } else if (isQuote(chr)) {
+                        // Another non matching quote
+                        break;
+                    } else if (chr == '<') {
+                        // start of another tag
+                        break;
+                    }
+                }
+            }
+            // is it in an HTML comment?
+            String prefix = htmlPage.substring(0, context.getStart());
+            if (prefix.lastIndexOf("<!--") > prefix.lastIndexOf(">")) {
+                // Also check closing comment?
+                context.setHtmlComment(true);
+            }
+
+            // Work out the location in the DOM
+            Element element = src.getEnclosingElement(context.getStart());
+            if (element != null) {
+                // See if its in an attribute
+                boolean isInputTag =
+                        element.getName()
+                                .equalsIgnoreCase("input"); // Special case for input src attributes
+                boolean isImageInputTag = false;
+                Iterator<Attribute> iter = element.getAttributes().iterator();
+                while (iter.hasNext()) {
+                    Attribute att = iter.next();
+                    if (att.getValue() != null
+                            && att.getValue().toLowerCase().indexOf(target.toLowerCase()) >= 0) {
+                        // Found the injected value
+                        context.setTagAttribute(att.getName());
+                        context.setInUrlAttribute(this.isUrlAttribute(att.getName()));
+                        context.setInScriptAttribute(this.isScriptAttribute(att.getName()));
+                    }
+                    if (isInputTag
+                            && att.getName().equalsIgnoreCase("type")
+                            && "image".equalsIgnoreCase(att.getValue())) {
+                        isImageInputTag = true;
+                    }
+                }
+
+                // record the tag hierarchy
+                context.addParentTag(element.getName());
+                if (!isInputTag || isImageInputTag) {
+                    // Input tags only use the src attribute if the type is 'image'
+                    context.setInTagWithSrc(this.isInTagWithSrcAttribute(element.getName()));
+                }
+                while ((element = element.getParentElement()) != null) {
+                    context.addParentTag(element.getName());
+                }
+            }
+            if (targetContext == null) {
+                // Always add
+                contexts.add(context);
+            } else if (targetContext.matches(context, ignoreFlags)) {
+                // Matches the supplied context
+                contexts.add(context);
+            }
+        }
+
+        return contexts;
+    }
+}

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRuleUnitTest.java
@@ -687,6 +687,7 @@ class CrossSiteScriptingScanRuleUnitTest extends ActiveScannerTest<CrossSiteScri
         HttpMessage msg = this.getHttpMessage(test + "?name=test");
 
         this.rule.init(msg, this.parent);
+        this.rule.setAlertThreshold(AlertThreshold.HIGH);
 
         this.rule.scan();
 


### PR DESCRIPTION
- Fixes an XSS false negative when increasing the threshold to high
- Move HtmlContext and HtmlContextAnalyser from core to ascanrules
- Exclude injected tag from being considered part of the context, which was causing the strict context comparison to fail
- Fix search for XSS outside of any tag requiring the parentTag to exist.

Closes https://github.com/zaproxy/zaproxy/issues/6727