### PR TITLE
graphql: replace vars in schemaFile

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Replace variables present in `schemaFile` when running the automation job.
 
 ## [0.8.0] - 2022-02-02
 ### Changed

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJob.java
@@ -109,10 +109,11 @@ public class GraphQlJob extends AutomationJob {
             String schemaUrl = this.getParameters().getSchemaUrl();
 
             if (schemaFile != null && !schemaFile.isEmpty()) {
+                String file = env.replaceVars(schemaFile);
                 progress.info(
                         Constant.messages.getString(
-                                "graphql.automation.info.import.file", schemaFile, endpointUrl));
-                parser.importFile(schemaFile);
+                                "graphql.automation.info.import.file", file, endpointUrl));
+                parser.importFile(file);
             } else if (schemaUrl != null && !schemaUrl.isEmpty()) {
                 String url = env.replaceVars(schemaUrl);
                 progress.info(

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
@@ -66,6 +66,8 @@ public class GraphQlJobDialog extends StandardFieldsDialog {
     private static final String QUERY_SPLIT_TYPE_PARAM = "graphql.automation.dialog.querysplittype";
     private static final String REQUEST_METHOD_PARAM = "graphql.automation.dialog.requestmethod";
 
+    private static final String VARIABLE_TOKEN = "${";
+
     private GraphQlJob job;
 
     private DefaultComboBoxModel<GraphQlParam.ArgsTypeOption> argsTypeModel;
@@ -99,6 +101,9 @@ public class GraphQlJobDialog extends StandardFieldsDialog {
             f = new File(fileName);
         }
         this.addFileSelectField(0, SCHEMA_FILE_PARAM, f, JFileChooser.FILES_AND_DIRECTORIES, null);
+        if (fileName != null && fileName.contains(VARIABLE_TOKEN)) {
+            setFieldValue(SCHEMA_FILE_PARAM, fileName);
+        }
 
         this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
 


### PR DESCRIPTION
Replace variables present in `schemaFile` when running the automation
job.

---
From OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/XSG4GasGoYY/m/tQt6Kq84CAAJ