### PR TITLE
fix: ascanrules: Remote File Inclusion rule no longer follows redirects

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).
 
 ## [46] - 2022-03-21
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/RemoteFileIncludeScanRule.java
@@ -211,7 +211,7 @@ public class RemoteFileIncludeScanRule extends AbstractAppParamPlugin {
 
                     // send the modified request, and see what we get back
                     try {
-                        sendAndReceive(msg);
+                        sendAndReceive(msg, false);
                     } catch (IllegalStateException | UnknownHostException ex) {
                         log.debug(
                                 "Caught {} {} when accessing: {}",


### PR DESCRIPTION
- CHANGELOG.md > Added fix note.
- RemoteFileIncludeScanRule.java > No longer follow redirects when checking content.
- RemoteFileIncludeScanRuleUnitTest.java > Add tests to assert the updated behavior and increase converage.

Fixes zaproxy/zaproxy#5887

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>