### PR TITLE
openapi: Fix NPE on empty default server var value

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Properly generate Content-Type header when in presence of more than one supported content (Issue 7082).
 - Quote provided string values in JSON content (Issue 7128).
+- Properly handle empty default values in server variables.
 
 ## [26] - 2022-02-01
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -417,6 +417,39 @@ class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
+    void shouldInterpretServerVariablesWithEmptyDefaultValues()
+            throws NullPointerException, IOException, SwaggerException {
+        String test = "/OpenApiYaml/";
+        String defnName = "defn.yaml";
+
+        this.nano.addHandler(
+                new DefnServerHandler(
+                        test, defnName, "OpenApi_defn_servers_empty_default_value.yaml"));
+
+        Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        HttpMessage defnMsg = this.getHttpMessage(test + defnName);
+        SwaggerConverter converter =
+                new SwaggerConverter(
+                        requestor.getResponseBody(defnMsg.getRequestHeader().getURI()), null);
+
+        final Map<String, String> accessedUrls = new HashMap<>();
+        RequesterListener listener =
+                (message, initiator) -> {
+                    accessedUrls.put(
+                            message.getRequestHeader().getMethod()
+                                    + " "
+                                    + message.getRequestHeader().getURI().toString(),
+                            message.getRequestBody().toString());
+                };
+        requestor.addListener(listener);
+        requestor.run(converter.getRequestModels());
+
+        String baseUrl = "http://" + "localhost:" + nano.getListeningPort();
+        assertTrue(accessedUrls.containsKey("POST " + baseUrl + "/example"));
+        assertEquals("{\"key\":\"value\"}", accessedUrls.get("POST " + baseUrl + "/example"));
+    }
+
+    @Test
     void shouldGenerateAcceptHeaders() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_servers_empty_default_value.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_servers_empty_default_value.yaml
@@ -1,0 +1,34 @@
+openapi: 3.0.0
+info:
+  version: '1.0'
+  title: Example API
+  description: 'Example Description'
+servers:
+  - url: '{scheme}://localhost:@@@PORT@@@/{basePath}'
+    variables:
+      scheme:
+        enum:
+          - https
+          - http
+        default: http
+      basePath:
+        default: ''
+
+paths:
+  /example:
+    post:
+      tags:
+        - example
+      summary: example
+      requestBody:
+        content:
+          application/json:
+            example:
+              key: value
+      responses:
+        default:
+          description: Example response.
+          content:
+            application/json:
+              example:
+                message: Received request successfully.


### PR DESCRIPTION
Properly handle empty default values in server variables.

Signed-off-by: Akshath Kothari <akshath.kothari@levo.ai>