### PR TITLE
openapi: Add JSON body examples correctly

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- JSON body examples specified under `schema` were being enclosed in quotes.
 
 ## [27] - 2022-03-29
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/BodyGenerator.java
@@ -356,6 +356,7 @@ public class BodyGenerator {
         }
     }
 
+    @SuppressWarnings("rawtypes")
     private static String extractExampleBody(MediaType mediaType) {
         return Optional.ofNullable(mediaType.getExamples())
                 .map(Map::values)
@@ -363,6 +364,10 @@ public class BodyGenerator {
                 .map(stream -> stream.map(Example::getValue).filter(Objects::nonNull).findFirst())
                 .orElse(Optional.ofNullable(mediaType.getExample()))
                 .map(Object::toString)
-                .orElse(null);
+                .orElse(
+                        Optional.ofNullable(mediaType.getSchema())
+                                .map(Schema::getExample)
+                                .map(Object::toString)
+                                .orElse(null));
     }
 }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/BodyGeneratorUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/generators/BodyGeneratorUnitTest.java
@@ -24,6 +24,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,5 +55,16 @@ class BodyGeneratorUnitTest {
         String result = bodyGenerator.generateMultiPart(null, null);
         // Then
         assertThat(result, is(equalTo("")));
+    }
+
+    @Test
+    void shouldProperlyUseJsonExample() {
+        // Given
+        ObjectSchema schema = new ObjectSchema().example("{\"foo\":\"bar\"}");
+        MediaType mediaType = new MediaType().schema(schema);
+        // When
+        String body = bodyGenerator.generate(mediaType);
+        // Then
+        assertThat(body, is(equalTo("{\"foo\":\"bar\"}")));
     }
 }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -450,6 +450,38 @@ class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
+    void shouldAddObjectSchemaExamplesCorrectly()
+            throws NullPointerException, IOException, SwaggerException {
+        String test = "/OpenApiYaml/";
+        String defnName = "defn.yaml";
+
+        this.nano.addHandler(
+                new DefnServerHandler(test, defnName, "OpenApi_defn_body_with_json.yaml"));
+
+        Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        HttpMessage defnMsg = this.getHttpMessage(test + defnName);
+        SwaggerConverter converter =
+                new SwaggerConverter(
+                        requestor.getResponseBody(defnMsg.getRequestHeader().getURI()), null);
+
+        final Map<String, String> accessedUrls = new HashMap<>();
+        RequesterListener listener =
+                (message, initiator) -> {
+                    accessedUrls.put(
+                            message.getRequestHeader().getMethod()
+                                    + " "
+                                    + message.getRequestHeader().getURI().toString(),
+                            message.getRequestBody().toString());
+                };
+        requestor.addListener(listener);
+        requestor.run(converter.getRequestModels());
+
+        String baseUrl = "http://" + "localhost:" + nano.getListeningPort();
+        assertTrue(accessedUrls.containsKey("POST " + baseUrl + "/example"));
+        assertEquals("{\"foo\":\"bar\"}", accessedUrls.get("POST " + baseUrl + "/example"));
+    }
+
+    @Test
     void shouldGenerateAcceptHeaders() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_body_with_json.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/OpenApi_defn_body_with_json.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: Example Spec
+  version: 1.0.0
+servers:
+  - url: http://localhost:@@@PORT@@@
+paths:
+  /example:
+    post:
+      summary: Example Endpoint
+      description: This is an example endpoint.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                foo: bar
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: { }


### PR DESCRIPTION
Don't enclose JSON body examples in double quotes.

Output of running the new unit tests without the change:
```
Expected :{"foo":"bar"}
Actual   :"{"foo":"bar"}"
```

Discovered when I tried to import https://github.com/kmmanoj96/vulnerable-apis/blob/main/openAPISpecBank.yaml into ZAP.