### PR TITLE
feat: exim: Importer tweaks

### DIFF
--- a/addOns/commonlib/CHANGELOG.md
+++ b/addOns/commonlib/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [1.9.0] - 2022-03-21
 ### Changed

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPane.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPane.java
@@ -43,11 +43,11 @@ public class ProgressPane extends JPanel {
     private final JProgressBar progressBar;
     private final JLabel currentProgress;
     private boolean completed;
-    private boolean indeterminant;
+    private boolean indeterminate;
 
     /**
      * Constructs a progress pane with default title (no resource indication) which includes a
-     * determinant progress bar.
+     * determinate progress bar.
      */
     public ProgressPane() {
         this("");
@@ -55,7 +55,7 @@ public class ProgressPane extends JPanel {
 
     /**
      * Constructs a progress pane with an extended title including the identified resource (ex: a
-     * URL or file system path) which includes a determinant progress bar.
+     * URL or file system path) which includes a determinate progress bar.
      *
      * @param resource a string representing the location or source of the resource being processed
      *     (ex: a URL or file system path).
@@ -66,24 +66,24 @@ public class ProgressPane extends JPanel {
 
     /**
      * Constructs a progress pane with an extended title including the identified resource (ex: a
-     * URL or file system path) and indeterminant status indicated.
+     * URL or file system path) and indeterminate status indicated.
      *
      * @param resource a string representing the location or source of the resource being processed
      *     (ex: a URL or file system path).
-     * @param indeterminant a {@code boolean} indicating whether or not the associated progress bar
-     *     should be indeterminant (true) or not (false);
+     * @param indeterminate a {@code boolean} indicating whether or not the associated progress bar
+     *     should be indeterminate (true) or not (false);
      */
-    public ProgressPane(String resource, boolean indeterminant) {
+    public ProgressPane(String resource, boolean indeterminate) {
         super(new GridBagLayout());
-        this.indeterminant = indeterminant;
+        this.indeterminate = indeterminate;
         this.setBorder(BorderFactory.createTitledBorder(getTitle(resource)));
 
         progressStatus = new JLabel();
 
         progressBar = new JProgressBar();
         progressBar.setStringPainted(true);
-        progressBar.setIndeterminate(indeterminant);
-        if (indeterminant) {
+        progressBar.setIndeterminate(indeterminate);
+        if (indeterminate) {
             progressBar.setString(
                     Constant.messages.getString("commonlib.progress.panel.status.inprogress"));
         }
@@ -95,7 +95,7 @@ public class ProgressPane extends JPanel {
         c.gridy = 0;
         c.weightx = 1;
         c.fill = GridBagConstraints.HORIZONTAL;
-        if (!indeterminant) {
+        if (!indeterminate) {
             add(progressStatus, c);
         }
 
@@ -174,7 +174,7 @@ public class ProgressPane extends JPanel {
         EventQueue.invokeLater(
                 () -> {
                     completed = true;
-                    if (indeterminant) {
+                    if (indeterminate) {
                         progressBar.setString(
                                 Constant.messages.getString("commonlib.progress.pane.completed"));
                         progressBar.setIndeterminate(false);

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Tweaked import functionality to mark import progress components completed when an exception occurs during import (thus allowing them to be cleared properly).
+- HAR imports will now use an indeterminate progress bar if the count of entries cannot be determined.
 
 ## [0.1.0] - 2022-03-07
 ### Changed

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -65,10 +65,10 @@ public class HarImporter {
     public HarImporter(File file, ProgressPaneListener listener) {
         this.progressListener = listener;
         importHarFile(file);
+        completed();
     }
 
-    public static List<HttpMessage> getHttpMessages(HarLog log)
-            throws HttpMalformedHeaderException {
+    static List<HttpMessage> getHttpMessages(HarLog log) throws HttpMalformedHeaderException {
         List<HttpMessage> result = new ArrayList<>();
         HarEntries entries = log.getEntries();
         for (HarEntry entry : entries.getEntries()) {
@@ -131,7 +131,7 @@ public class HarImporter {
         }
     }
 
-    public void processMessages(File file) throws IOException {
+    private void processMessages(File file) throws IOException {
         List<HttpMessage> messages =
                 HarImporter.getHttpMessages(new HarFileReader().readHarFile(file));
         int count = 1;
@@ -140,7 +140,6 @@ public class HarImporter {
             updateProgress(count, msg.getRequestHeader().getURI().toString());
             count++;
         }
-        completed();
     }
 
     private static void persistMessage(HttpMessage message) {

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/MenuImportHar.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/MenuImportHar.java
@@ -61,9 +61,8 @@ public class MenuImportHar extends ZapMenuItem {
                                     public void run() {
                                         this.setName(THREAD_PREFIX + threadId++);
                                         File file = chooser.getSelectedFile();
-                                        ProgressPane currentImportPane =
-                                                new ProgressPane(file.getAbsolutePath());
                                         int tasks = 0;
+                                        boolean indeterminate;
                                         try {
                                             tasks =
                                                     new HarFileReader()
@@ -71,11 +70,16 @@ public class MenuImportHar extends ZapMenuItem {
                                                             .getEntries()
                                                             .getEntries()
                                                             .size();
+                                            indeterminate = false;
                                         } catch (IOException e) {
+                                            indeterminate = true;
                                             LOG.warn(
                                                     "Couldn't count entries in: {}",
                                                     file.getAbsoluteFile());
                                         }
+                                        ProgressPane currentImportPane =
+                                                new ProgressPane(
+                                                        file.getAbsolutePath(), indeterminate);
                                         currentImportPane.setTotalTasks(tasks);
                                         ExtensionExim.getProgressPanel()
                                                 .addProgressPane(currentImportPane);

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/urls/UrlsImporter.java
@@ -56,6 +56,7 @@ public class UrlsImporter {
     public UrlsImporter(File file, ProgressPaneListener listener) {
         this.progressListener = listener;
         importUrlFile(file);
+        completed();
     }
 
     private void importUrlFile(File file) {
@@ -86,7 +87,6 @@ public class UrlsImporter {
             success = false;
             return;
         }
-        completed();
         success = true;
     }
 

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/log/LogImporterUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/log/LogImporterUnitTest.java
@@ -1,0 +1,80 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.exim.log;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.zaproxy.addon.commonlib.ui.ProgressPaneListener;
+import org.zaproxy.addon.exim.log.LogsImporter.LogType;
+
+/** Unit test for {@link LogImporter}. */
+class LogImporterUnitTest {
+
+    @Test
+    void shouldBeFailureIfFileNotFound(@TempDir Path dir) throws Exception {
+        // Given
+        File file = dir.resolve("missing.raw").toFile();
+        // When
+        LogsImporter importer = new LogsImporter(file, LogType.ZAP);
+        // Then
+        assertThat(importer.isSuccess(), equalTo(false));
+    }
+
+    @Test
+    void shouldCompleteListenerIfFileNotFound(@TempDir Path dir) throws Exception {
+        // Given
+        File file = dir.resolve("missing.raw").toFile();
+        ProgressPaneListener listener = mock(ProgressPaneListener.class);
+        // When
+        LogsImporter importer = new LogsImporter(file, LogType.ZAP, listener);
+        // Then
+        assertThat(importer.isSuccess(), equalTo(false));
+        verify(listener).completed();
+    }
+
+    @Test
+    void shouldBeFailureIfFileNotFoundModSec2(@TempDir Path dir) throws Exception {
+        // Given
+        File file = dir.resolve("missing.log").toFile();
+        // When
+        LogsImporter importer = new LogsImporter(file, LogType.MOD_SECURITY_2);
+        // Then
+        assertThat(importer.isSuccess(), equalTo(false));
+    }
+
+    @Test
+    void shouldCompleteListenerIfFileNotFoundModSec2(@TempDir Path dir) throws Exception {
+        // Given
+        File file = dir.resolve("missing.log").toFile();
+        ProgressPaneListener listener = mock(ProgressPaneListener.class);
+        // When
+        LogsImporter importer = new LogsImporter(file, LogType.MOD_SECURITY_2, listener);
+        // Then
+        assertThat(importer.isSuccess(), equalTo(false));
+        verify(listener).completed();
+    }
+}

--- a/addOns/exim/src/test/java/org/zaproxy/addon/exim/urls/UrlsImporterUnitTest.java
+++ b/addOns/exim/src/test/java/org/zaproxy/addon/exim/urls/UrlsImporterUnitTest.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2020 The ZAP Development Team
+ * Copyright 2022 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,37 +17,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.addon.exim.har;
+package org.zaproxy.addon.exim.urls;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import edu.umass.cs.benchlab.har.HarEntries;
-import edu.umass.cs.benchlab.har.HarLog;
 import java.io.File;
 import java.nio.file.Path;
-import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.ui.ProgressPaneListener;
-import org.zaproxy.zap.utils.HarUtils;
 import org.zaproxy.zap.utils.I18N;
 
-/** Unit test for {@link HarImporter}. */
-class HarImporterUnitTest {
+/** Unit test for {@link UrlsImporter}. */
+class UrlsImporterUnitTest {
 
     @BeforeAll
     static void setup() {
         Constant.messages = mock(I18N.class);
-        given(Constant.messages.getString(any())).willReturn("");
     }
 
     @AfterAll
@@ -56,34 +48,11 @@ class HarImporterUnitTest {
     }
 
     @Test
-    void serializedAndDeserializedShouldMatch() throws Exception {
-        // Given
-        byte[] requestBody = {0x01, 0x02};
-        byte[] responseBody = {0x30, 0x31};
-        HttpMessage httpMessage =
-                new HttpMessage(
-                        "POST /path HTTP/1.1\r\nContent-Type: application/octet-stream\r\n\r\n",
-                        requestBody,
-                        "HTTP/1.1 200 OK\r\nContent-Type: text/plain;charset=US-ASCII\r\n\r\n",
-                        responseBody);
-
-        HarLog harLog = HarUtils.createZapHarLog();
-        HarEntries harEntries = new HarEntries();
-        harEntries.addEntry(HarUtils.createHarEntry(httpMessage));
-        harLog.setEntries(harEntries);
-        // When
-        List<HttpMessage> deserialized = HarImporter.getHttpMessages(harLog);
-        // Then
-        assertThat(deserialized.size(), equalTo(1));
-        assertThat(deserialized.get(0), equalTo(httpMessage));
-    }
-
-    @Test
     void shouldBeFailureIfFileNotFound(@TempDir Path dir) throws Exception {
         // Given
-        File file = dir.resolve("missing.har").toFile();
+        File file = dir.resolve("missing.txt").toFile();
         // When
-        HarImporter importer = new HarImporter(file);
+        UrlsImporter importer = new UrlsImporter(file);
         // Then
         assertThat(importer.isSuccess(), equalTo(false));
     }
@@ -91,10 +60,10 @@ class HarImporterUnitTest {
     @Test
     void shouldCompleteListenerIfFileNotFound(@TempDir Path dir) throws Exception {
         // Given
-        File file = dir.resolve("missing.har").toFile();
+        File file = dir.resolve("missing.txt").toFile();
         ProgressPaneListener listener = mock(ProgressPaneListener.class);
         // When
-        HarImporter importer = new HarImporter(file, listener);
+        UrlsImporter importer = new UrlsImporter(file, listener);
         // Then
         assertThat(importer.isSuccess(), equalTo(false));
         verify(listener).completed();


### PR DESCRIPTION
- Log, Urls, and Har importers will now set the progress components as complete even if an exception occurs during import (thus allowing them to be cleared from the progress tab).
- Log import exception handling simplified slightly.
- HAR import will now use an indeterminate progress bar if the count of entries can't be processed for some reason.
- exim/CHANGELOG.md > Added fix note.
- commoblib/CHANGELOG.md > Added maintenance note.
- commonlib/ProgressPane > Fix typo in javadoc and internal variable name in/determinant vs in-determinate.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>