### PR TITLE
pscanrules: Specify that rule 10015 applies only to secure content

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Clarify the alert solution for the Cache Control scan rule.
 
 ## [39] - 2022-03-07
 ### Added

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -157,7 +157,7 @@ pscanrules.applicationerrors.soln = Review the source code of this page. Impleme
 
 pscanrules.cachecontrol.name = Re-examine Cache-control Directives
 pscanrules.cachecontrol.desc = The cache-control header has not been set properly or is missing, allowing the browser and proxies to cache content. For static assets like css, js, or image files this might be intended, however, the resources should be reviewed to ensure that no sensitive content will be cached.
-pscanrules.cachecontrol.soln = Whenever possible ensure the cache-control HTTP header is set with "no-cache, no-store, must-revalidate". If an asset should be cached consider setting the directives "public, max-age, immutable".
+pscanrules.cachecontrol.soln = For secure content, ensure the cache-control HTTP header is set with "no-cache, no-store, must-revalidate". If an asset should be cached consider setting the directives "public, max-age, immutable".
 pscanrules.cachecontrol.refs = https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#web-content-caching\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 
 pscanrules.contenttypemissing.name = Content-Type Header Missing


### PR DESCRIPTION
**- Summary**

After a question on IRC, @psiinon suggested I make the change to better reflect what pscanrules actually checks

Follow up to https://github.com/zaproxy/zaproxy-website/pull/886 after feedback from @thc202 

**- Description for the changelog**

Document that rule 10015 applies only to secure content
