### PR TITLE
Add Permanent Database Support

### DIFF
--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -19,6 +19,7 @@ import java.util.regex.Pattern
 plugins {
     eclipse
     jacoco
+    id("org.rm3l.datanucleus-gradle-plugin") version "1.7.0" apply false
     id("org.zaproxy.add-on") version "0.8.0" apply false
     id("org.zaproxy.crowdin") version "0.2.1" apply false
     id("me.champeau.gradle.japicmp") version "0.3.0" apply false
@@ -88,6 +89,7 @@ subprojects {
     apply(plugin = "eclipse")
     apply(plugin = "java-library")
     apply(plugin = "jacoco")
+    apply(plugin = "org.rm3l.datanucleus-gradle-plugin")
     apply(plugin = "org.zaproxy.add-on")
     if (useCrowdin) {
         apply(plugin = "org.zaproxy.crowdin")

--- a/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
+++ b/addOns/ascanrulesAlpha/ascanrulesAlpha.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     compileOnly(parent!!.childProjects.get("oast")!!)
 
     testImplementation(parent!!.childProjects.get("commonlib")!!)
+    testImplementation(parent!!.childProjects.get("database")!!)
     testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(parent!!.childProjects.get("oast")!!)
     testImplementation(project(":testutils"))

--- a/addOns/database/CHANGELOG.md
+++ b/addOns/database/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Provides the SQLite database engine for other add-ons to use.
+- Support for the ZAP permanent database.

--- a/addOns/database/database.gradle.kts
+++ b/addOns/database/database.gradle.kts
@@ -3,6 +3,9 @@ import org.zaproxy.gradle.addon.AddOnStatus
 
 description = "Provides database engines and related infrastructure."
 
+val datanucleus by configurations.creating
+configurations.api { extendsFrom(datanucleus) }
+
 val sqlite by configurations.creating
 configurations.api { extendsFrom(sqlite) }
 
@@ -21,6 +24,7 @@ zapAddOn {
         }
 
         bundledLibs {
+            libs.from(datanucleus)
             libs.from(sqlite)
         }
     }
@@ -44,7 +48,10 @@ spotless {
 }
 
 dependencies {
+    datanucleus("org.datanucleus:datanucleus-accessplatform-jdo-rdbms:6.0.1")
     sqlite("org.xerial:sqlite-jdbc:3.39.3.0")
+
+    implementation("org.flywaydb:flyway-core:9.4.0")
 
     testImplementation(project(":testutils"))
 }

--- a/addOns/database/src/main/java/org/zaproxy/addon/database/Database.java
+++ b/addOns/database/src/main/java/org/zaproxy/addon/database/Database.java
@@ -1,0 +1,135 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.database;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import javax.jdo.Constants;
+import javax.jdo.JDOHelper;
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Transaction;
+import org.datanucleus.PropertyNames;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.datanucleus.store.rdbms.RDBMSPropertyNames;
+import org.flywaydb.core.Flyway;
+
+public abstract class Database implements Closeable {
+
+    private final PersistenceManagerFactory pmf;
+    private final ClassLoader classLoader;
+
+    protected Database(String persistenceUnitName, ClassLoader classLoader) {
+        Properties jdoProperties = new Properties();
+        jdoProperties.setProperty(
+                Constants.PROPERTY_PERSISTENCE_MANAGER_FACTORY_CLASS,
+                JDOPersistenceManagerFactory.class.getName());
+        jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_URL, getDbUrl());
+        jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_USER_NAME, getDbUsername());
+        jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_PASSWORD, getDbPass());
+        jdoProperties.setProperty(Constants.PROPERTY_CONNECTION_DRIVER_NAME, getDbDriver());
+        jdoProperties.setProperty(Constants.PROPERTY_MAPPING, getDbType());
+        jdoProperties.setProperty(Constants.PROPERTY_PERSISTENCE_UNIT_NAME, persistenceUnitName);
+        jdoProperties.put(PropertyNames.PROPERTY_CLASSLOADER_PRIMARY, classLoader);
+        jdoProperties.put(PropertyNames.PROPERTY_DETACH_ALL_ON_COMMIT, Boolean.TRUE);
+
+        // Optimizations based on
+        // https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#performance_tuning
+        jdoProperties.put(RDBMSPropertyNames.PROPERTY_CONNECTION_POOL_MAX_POOL_SIZE, 2);
+        jdoProperties.put(RDBMSPropertyNames.PROPERTY_RDBMS_CHECK_EXISTS_TABLES_VIEWS, false);
+        jdoProperties.put(RDBMSPropertyNames.PROPERTY_RDBMS_INIT_COLUMN_INFO, "NONE");
+        jdoProperties.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_ALL, false);
+        jdoProperties.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_TABLES, false);
+        jdoProperties.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_COLUMNS, false);
+        jdoProperties.put(PropertyNames.PROPERTY_SCHEMA_AUTOCREATE_CONSTRAINTS, false);
+        jdoProperties.put(PropertyNames.PROPERTY_SCHEMA_VALIDATE_TABLES, false);
+        jdoProperties.put(PropertyNames.PROPERTY_SCHEMA_VALIDATE_COLUMNS, false);
+        jdoProperties.put(PropertyNames.PROPERTY_SCHEMA_VALIDATE_CONSTRAINTS, false);
+
+        pmf = JDOHelper.getPersistenceManagerFactory(jdoProperties, classLoader);
+        this.classLoader = classLoader;
+    }
+
+    @Override
+    public void close() {
+        if (pmf != null) {
+            pmf.close();
+        }
+    }
+
+    public void persistEntity(Object entity) {
+        if (entity == null) {
+            return;
+        }
+        PersistenceManager pm = pmf.getPersistenceManager();
+        Transaction tx = pm.currentTransaction();
+        try {
+            tx.begin();
+            pm.makePersistent(entity);
+            tx.commit();
+        } finally {
+            if (tx.isActive()) {
+                tx.rollback();
+            }
+            pm.close();
+        }
+    }
+
+    public <T> List<T> getAll(Class<T> clazz) {
+        if (clazz == null) {
+            throw new IllegalArgumentException("Class cannot be null.");
+        }
+        PersistenceManager pm = pmf.getPersistenceManager();
+        Transaction tx = pm.currentTransaction();
+        try {
+            tx.begin();
+            List<T> result = pm.newQuery(clazz).executeList();
+            tx.commit();
+            return result;
+        } catch (Exception ignored) {
+            return Collections.emptyList();
+        } finally {
+            if (tx.isActive()) {
+                tx.rollback();
+            }
+            pm.close();
+        }
+    }
+
+    protected void migrate() {
+        Flyway flyway =
+                Flyway.configure(classLoader)
+                        .dataSource(getDbUrl(), getDbUsername(), getDbPass())
+                        .load();
+        flyway.migrate();
+    }
+
+    protected abstract String getDbType();
+
+    protected abstract String getDbDriver();
+
+    protected abstract String getDbUrl();
+
+    protected abstract String getDbUsername();
+
+    protected abstract String getDbPass();
+}

--- a/addOns/database/src/main/java/org/zaproxy/addon/database/PermanentDatabase.java
+++ b/addOns/database/src/main/java/org/zaproxy/addon/database/PermanentDatabase.java
@@ -1,0 +1,64 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.database;
+
+import java.nio.file.Paths;
+import org.parosproxy.paros.Constant;
+
+public class PermanentDatabase extends Database {
+
+    private static final String PERMANENT_DB_TYPE = "hsql";
+    private static final String PERMANENT_DB_DRIVER = "org.hsqldb.jdbcDriver";
+    private static final String PERMANENT_DB_URL =
+            "jdbc:hsqldb:file:"
+                    + Paths.get(Constant.getZapHome(), "db", "permanent").toAbsolutePath();
+    private static final String PERMANENT_DB_USERNAME = "sa";
+    private static final String PERMANENT_DB_PASS = "";
+
+    public PermanentDatabase(String persistenceUnitName, ClassLoader classLoader) {
+        super(persistenceUnitName, classLoader);
+        migrate();
+    }
+
+    @Override
+    protected String getDbType() {
+        return PERMANENT_DB_TYPE;
+    }
+
+    @Override
+    protected String getDbDriver() {
+        return PERMANENT_DB_DRIVER;
+    }
+
+    @Override
+    protected String getDbUrl() {
+        return PERMANENT_DB_URL;
+    }
+
+    @Override
+    protected String getDbUsername() {
+        return PERMANENT_DB_USERNAME;
+    }
+
+    @Override
+    protected String getDbPass() {
+        return PERMANENT_DB_PASS;
+    }
+}

--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- BOAST Payloads are persisted in the permanent database, and polled in future ZAP sessions.
+
 ### Fixed
 - Deregister the Interactsh service even in case of error (Issue 7504).
 - Clear Interactsh payloads from the GUI when the service is deregistered.

--- a/addOns/oast/oast.gradle.kts
+++ b/addOns/oast/oast.gradle.kts
@@ -1,3 +1,5 @@
+import org.rm3l.datanucleus.gradle.DataNucleusApi
+import org.rm3l.datanucleus.gradle.extensions.enhance.EnhanceExtension
 import org.zaproxy.gradle.addon.AddOnStatus
 
 description = "Allows you to exploit out-of-band vulnerabilities"
@@ -13,6 +15,9 @@ zapAddOn {
 
         dependencies {
             addOns {
+                register("database") {
+                    version.set(">= 0.1.0")
+                }
                 register("network") {
                     version.set(">= 0.1.0")
                 }
@@ -48,7 +53,17 @@ crowdin {
     }
 }
 
+datanucleus {
+    enhance(
+        closureOf<EnhanceExtension> {
+            api(DataNucleusApi.JDO)
+            persistenceUnitName(zapAddOn.addOnId.get())
+        }
+    )
+}
+
 dependencies {
+    compileOnly(parent!!.childProjects["database"]!!)
     compileOnly(parent!!.childProjects["graaljs"]!!)
     compileOnly(parent!!.childProjects["network"]!!)
 

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -43,7 +43,10 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.database.PermanentDatabase;
 import org.zaproxy.addon.network.ExtensionNetwork;
+import org.zaproxy.addon.oast.OastState.OastStateEventType;
+import org.zaproxy.addon.oast.services.boast.BoastEntity;
 import org.zaproxy.addon.oast.services.boast.BoastOptionsPanelTab;
 import org.zaproxy.addon.oast.services.boast.BoastService;
 import org.zaproxy.addon.oast.services.callback.CallbackOptionsPanelTab;
@@ -68,6 +71,7 @@ public class ExtensionOast extends ExtensionAdaptor {
 
     private static final String NAME = ExtensionOast.class.getSimpleName();
     private static final Logger LOGGER = LogManager.getLogger(ExtensionOast.class);
+    private static final String OAST_PERSISTENCE_UNIT_NAME = "oast";
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
             Collections.unmodifiableList(Arrays.asList(ExtensionNetwork.class));
@@ -84,6 +88,8 @@ public class ExtensionOast extends ExtensionAdaptor {
     private BoastService boastService;
     private CallbackService callbackService;
     private InteractshService interactshService;
+    private PermanentDatabase permanentDatabase;
+    private boolean wasUsePermanentDatabase;
 
     public ExtensionOast() {
         super(NAME);
@@ -144,10 +150,14 @@ public class ExtensionOast extends ExtensionAdaptor {
         boastService.optionsLoaded();
         callbackService.optionsLoaded();
         interactshService.optionsLoaded();
+        wasUsePermanentDatabase = oastParam.isUsePermanentDatabase();
     }
 
     @Override
     public void postInit() {
+        if (oastParam.isUsePermanentDatabase()) {
+            getPermanentDatabase();
+        }
         boastService.startService();
         callbackService.startService();
         interactshService.startService();
@@ -155,6 +165,10 @@ public class ExtensionOast extends ExtensionAdaptor {
 
     private void optionsChanged(OptionsParam optionsParam) {
         getOastServices().values().forEach(OastService::fireOastStateChanged);
+        if (!wasUsePermanentDatabase && oastParam.isUsePermanentDatabase()) {
+            getPermanentDatabase();
+            wasUsePermanentDatabase = true;
+        }
     }
 
     public void deleteAllCallbacks() {
@@ -184,6 +198,7 @@ public class ExtensionOast extends ExtensionAdaptor {
             service.addOastRequestHandler(o -> getOastPanel().addOastRequest(o));
         }
         service.addOastRequestHandler(this::activeScanAlertOastRequestHandler);
+        service.addOastStateChangedListener(this::oastPersisterStateChangedListener);
         services.put(service.getName(), service);
     }
 
@@ -209,6 +224,14 @@ public class ExtensionOast extends ExtensionAdaptor {
 
     public void pollAllServices() {
         getOastServices().values().forEach(OastService::poll);
+    }
+
+    private PermanentDatabase getPermanentDatabase() {
+        if (permanentDatabase == null) {
+            permanentDatabase =
+                    new PermanentDatabase(OAST_PERSISTENCE_UNIT_NAME, getClass().getClassLoader());
+        }
+        return permanentDatabase;
     }
 
     private OastOptionsPanel getOastOptionsPanel() {
@@ -324,6 +347,7 @@ public class ExtensionOast extends ExtensionAdaptor {
         unregisterOastService(boastService);
         unregisterOastService(callbackService);
         unregisterOastService(interactshService);
+        getPermanentDatabase().close();
     }
 
     @Override
@@ -334,6 +358,16 @@ public class ExtensionOast extends ExtensionAdaptor {
     @Override
     public String getDescription() {
         return Constant.messages.getString("oast.ext.description");
+    }
+
+    private void oastPersisterStateChangedListener(OastState state) {
+        if (!oastParam.isUsePermanentDatabase()
+                || state.getEventType() != OastStateEventType.REGISTERED) {
+            return;
+        }
+        if (boastService.getName().equals(state.getServiceName())) {
+            getPermanentDatabase().persistEntity(boastService.getLastRegisteredServerEntity());
+        }
     }
 
     private class OastSessionChangedListener implements SessionChangedListener {
@@ -355,6 +389,9 @@ public class ExtensionOast extends ExtensionAdaptor {
                 }
                 s.addOastRequestHandler(ExtensionOast.this::activeScanAlertOastRequestHandler);
             }
+            if (oastParam.isUsePermanentDatabase()) {
+                addRegisteredServersFromPermanentDatabase();
+            }
         }
 
         private void addCallbacksFromDatabaseIntoCallbackPanel(Session session) {
@@ -374,6 +411,11 @@ public class ExtensionOast extends ExtensionAdaptor {
             } catch (DatabaseException | HttpMalformedHeaderException e) {
                 LOGGER.error(e.getMessage(), e);
             }
+        }
+
+        private void addRegisteredServersFromPermanentDatabase() {
+            List<BoastEntity> boastEntities = getPermanentDatabase().getAll(BoastEntity.class);
+            boastService.addEntitiesAsServers(boastEntities);
         }
 
         @Override

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastEntity.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastEntity.java
@@ -1,0 +1,22 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.oast;
+
+public interface OastEntity {}

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastParam.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastParam.java
@@ -28,6 +28,8 @@ public class OastParam extends VersionedAbstractParam {
 
     private static final String PARAM_ACTIVE_SCAN_SERVICE_NAME =
             PARAM_BASE_KEY + ".activeScanService";
+    private static final String PARAM_USE_PERMANENT_DATABASE =
+            PARAM_BASE_KEY + ".usePermanentDatabase";
 
     public static final String NO_ACTIVE_SCAN_SERVICE_SELECTED_OPTION = "None";
 
@@ -38,6 +40,7 @@ public class OastParam extends VersionedAbstractParam {
     private static final int PARAM_CURRENT_VERSION = 1;
 
     private String activeScanServiceName;
+    private boolean usePermanentDatabase;
 
     public OastParam() {}
 
@@ -50,10 +53,20 @@ public class OastParam extends VersionedAbstractParam {
         getConfig().setProperty(PARAM_ACTIVE_SCAN_SERVICE_NAME, activeScanServiceName);
     }
 
+    public boolean isUsePermanentDatabase() {
+        return usePermanentDatabase;
+    }
+
+    public void setUsePermanentDatabase(boolean usePermanentDatabase) {
+        this.usePermanentDatabase = usePermanentDatabase;
+        getConfig().setProperty(PARAM_USE_PERMANENT_DATABASE, usePermanentDatabase);
+    }
+
     @Override
     protected void parseImpl() {
         activeScanServiceName =
                 getString(PARAM_ACTIVE_SCAN_SERVICE_NAME, NO_ACTIVE_SCAN_SERVICE_SELECTED_OPTION);
+        usePermanentDatabase = getBoolean(PARAM_USE_PERMANENT_DATABASE, true);
     }
 
     @Override

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastService.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.oast;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -45,6 +46,10 @@ public abstract class OastService {
      * @throws Exception if it is unable to get a new payload.
      */
     public abstract String getNewPayload() throws Exception;
+
+    public OastEntity getLastRegisteredServerEntity() {
+        return null;
+    }
 
     public void poll() {}
 
@@ -77,9 +82,12 @@ public abstract class OastService {
     }
 
     public void fireOastStateChanged(OastState oastState) {
-        for (OastStateChangedListener handler : oastStateChangedListenerList) {
-            handler.stateChanged(oastState);
-        }
+        CompletableFuture.runAsync(
+                () -> {
+                    for (OastStateChangedListener handler : oastStateChangedListenerList) {
+                        handler.stateChanged(oastState);
+                    }
+                });
     }
 
     public void clearOastStateChangedListeners() {

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastState.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/OastState.java
@@ -25,11 +25,21 @@ public class OastState {
     private String serviceName;
     private boolean isRegistered;
     private LocalDateTime lastPollTime;
+    private OastStateEventType eventType;
 
     public OastState(String serviceName, boolean isRegistered, LocalDateTime lastPollTime) {
+        this(serviceName, isRegistered, lastPollTime, OastStateEventType.UNKNOWN);
+    }
+
+    public OastState(
+            String serviceName,
+            boolean isRegistered,
+            LocalDateTime lastPollTime,
+            OastStateEventType eventType) {
         this.serviceName = serviceName;
         this.isRegistered = isRegistered;
         this.lastPollTime = lastPollTime;
+        this.eventType = eventType;
     }
 
     public String getServiceName() {
@@ -50,5 +60,20 @@ public class OastState {
 
     public void setLastPollTime(LocalDateTime lastPollTime) {
         this.lastPollTime = lastPollTime;
+    }
+
+    public OastStateEventType getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(OastStateEventType eventType) {
+        this.eventType = eventType;
+    }
+
+    public enum OastStateEventType {
+        UNKNOWN,
+        REGISTERED,
+        POLLED,
+        UNREGISTERED,
     }
 }

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastEntity.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastEntity.java
@@ -1,0 +1,69 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.oast.services.boast;
+
+import java.sql.Timestamp;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.PrimaryKey;
+import org.datanucleus.api.jdo.annotations.CreateTimestamp;
+import org.zaproxy.addon.oast.OastEntity;
+
+@PersistenceCapable
+public class BoastEntity implements OastEntity {
+
+    @PrimaryKey private String id;
+    private String canary;
+    private String secret;
+    private String uri;
+
+    @CreateTimestamp private Timestamp registeredTimestamp;
+
+    public BoastEntity(String id, String canary, String secret, String uri) {
+        this.id = id;
+        this.canary = canary;
+        this.secret = secret;
+        this.uri = uri;
+    }
+
+    public static BoastEntity fromBoastServer(BoastServer server) {
+        return new BoastEntity(
+                server.getId(), server.getCanary(), server.getSecret(), server.getUri().toString());
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getCanary() {
+        return canary;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public Timestamp getRegisteredTimestamp() {
+        return registeredTimestamp;
+    }
+}

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastPoller.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastPoller.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.addon.oast.OastRequest;
 import org.zaproxy.addon.oast.OastState;
+import org.zaproxy.addon.oast.OastState.OastStateEventType;
 
 public class BoastPoller implements Runnable {
 
@@ -49,7 +50,11 @@ public class BoastPoller implements Runnable {
                 .flatMap(Collection::stream)
                 .forEach(this::handleBoastEvent);
         this.boastService.fireOastStateChanged(
-                new OastState(boastService.getName(), true, LocalDateTime.now()));
+                new OastState(
+                        boastService.getName(),
+                        true,
+                        LocalDateTime.now(),
+                        OastStateEventType.POLLED));
     }
 
     private void handleBoastEvent(BoastEvent boastEvent) {

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastServer.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastServer.java
@@ -47,6 +47,7 @@ public class BoastServer {
     private final URI uri;
     private final String id;
     private final String canary;
+    private final String secret;
     private final HttpMessage boastMsg;
     private final HttpSender httpSender;
     private final List<String> eventIds = new ArrayList<>();
@@ -61,12 +62,28 @@ public class BoastServer {
 
         uri = new URI(uriString, true);
         boastMsg = new HttpMessage(uri);
-        boastMsg.getRequestHeader().setHeader(HttpHeader.AUTHORIZATION, generateBoastSecret());
+        secret = generateBoastSecret();
+        boastMsg.getRequestHeader().setHeader(HttpHeader.AUTHORIZATION, "Secret " + secret);
         httpSender.sendAndReceive(boastMsg);
         JSONObject result = JSONObject.fromObject(boastMsg.getResponseBody().toString());
         id = result.getString("id");
         canary = result.getString("canary");
         Stats.incCounter("stats.oast.boast.payloadsGenerated");
+    }
+
+    BoastServer(BoastEntity entity) throws IOException {
+        httpSender =
+                new HttpSender(
+                        Model.getSingleton().getOptionsParam().getConnectionParam(),
+                        true,
+                        // TODO: Replace on next ZAP release with HttpSender.OAST_INITIATOR
+                        ExtensionOast.HTTP_SENDER_OAST_INITIATOR);
+        uri = new URI(entity.getUri(), true);
+        boastMsg = new HttpMessage(uri);
+        secret = entity.getSecret();
+        boastMsg.getRequestHeader().setHeader(HttpHeader.AUTHORIZATION, "Secret " + secret);
+        id = entity.getId();
+        canary = entity.getCanary();
     }
 
     /** @return new BOAST events found on polling */
@@ -117,10 +134,18 @@ public class BoastServer {
         return canary;
     }
 
+    String getSecret() {
+        return secret;
+    }
+
+    List<String> getEventIds() {
+        return eventIds;
+    }
+
     private String generateBoastSecret() {
         Random random = ThreadLocalRandom.current();
         byte[] r = new byte[32];
         random.nextBytes(r);
-        return "Secret " + Base64.encodeBase64String(r);
+        return Base64.encodeBase64String(r);
     }
 }

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastService.java
@@ -30,8 +30,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.extension.OptionsChangedListener;
 import org.parosproxy.paros.model.OptionsParam;
+import org.zaproxy.addon.oast.OastEntity;
 import org.zaproxy.addon.oast.OastService;
 import org.zaproxy.addon.oast.OastState;
+import org.zaproxy.addon.oast.OastState.OastStateEventType;
 
 public class BoastService extends OastService implements OptionsChangedListener {
 
@@ -117,8 +119,30 @@ public class BoastService extends OastService implements OptionsChangedListener 
         LOGGER.debug("Registering BOAST Server.");
         BoastServer boastServer = new BoastServer(getParam().getBoastUri());
         registeredServers.add(boastServer);
-        fireOastStateChanged(new OastState(getName(), true, null));
+        fireOastStateChanged(new OastState(getName(), true, null, OastStateEventType.REGISTERED));
         return boastServer;
+    }
+
+    public void addEntitiesAsServers(List<BoastEntity> entities) {
+        try {
+            for (BoastEntity entity : entities) {
+                LOGGER.debug(
+                        "Adding entity as BOAST Server: {}, {}, {}, {}, {}",
+                        entity.getUri(),
+                        entity.getId(),
+                        entity.getRegisteredTimestamp(),
+                        entity.getCanary(),
+                        entity.getSecret());
+                registeredServers.add(new BoastServer(entity));
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Could not add entities as servers: {}", e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public OastEntity getLastRegisteredServerEntity() {
+        return BoastEntity.fromBoastServer(registeredServers.get(registeredServers.size() - 1));
     }
 
     @Override

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
@@ -38,6 +38,7 @@ import org.jdesktop.swingx.JXTable;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.oast.OastState;
 import org.zaproxy.addon.oast.ui.OastOptionsPanelTab;
 import org.zaproxy.zap.utils.ThreadUtils;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
@@ -108,7 +109,7 @@ public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
 
         interactshService.addOastStateChangedListener(
                 e -> {
-                    if (e.isRegistered()) {
+                    if (e.getEventType() != OastState.OastStateEventType.UNREGISTERED) {
                         return;
                     }
 

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshPoller.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshPoller.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.db.DatabaseException;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.zaproxy.addon.oast.OastRequest;
 import org.zaproxy.addon.oast.OastState;
+import org.zaproxy.addon.oast.OastState.OastStateEventType;
 
 public class InteractshPoller implements Runnable {
 
@@ -44,7 +45,8 @@ public class InteractshPoller implements Runnable {
                 new OastState(
                         interactshService.getName(),
                         interactshService.isRegistered(),
-                        LocalDateTime.now()));
+                        LocalDateTime.now(),
+                        OastStateEventType.POLLED));
     }
 
     private void handleInteraction(InteractshEvent event) {

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshService.java
@@ -66,6 +66,7 @@ import org.parosproxy.paros.network.HttpSender;
 import org.zaproxy.addon.oast.ExtensionOast;
 import org.zaproxy.addon.oast.OastService;
 import org.zaproxy.addon.oast.OastState;
+import org.zaproxy.addon.oast.OastState.OastStateEventType;
 import org.zaproxy.zap.network.HttpRequestBody;
 import org.zaproxy.zap.utils.Stats;
 
@@ -229,6 +230,8 @@ public class InteractshService extends OastService implements OptionsChangedList
                     reqMsg.getResponseHeader().getStatusCode(),
                     reqMsg.getResponseBody());
             isRegistered = true;
+            fireOastStateChanged(
+                    new OastState(getName(), false, null, OastStateEventType.REGISTERED));
             if (startPolling) {
                 schedulePoller(0);
             }
@@ -259,7 +262,6 @@ public class InteractshService extends OastService implements OptionsChangedList
             return;
         }
         try {
-
             stopPoller();
             URI deregistrationUri = (URI) serverUrl.clone();
             deregistrationUri.setPath("/deregister");
@@ -272,19 +274,18 @@ public class InteractshService extends OastService implements OptionsChangedList
             HttpMessage deregisterMsg = new HttpMessage(reqHeader, reqBody);
             httpSender.sendAndReceive(deregisterMsg);
             if (deregisterMsg.getResponseHeader().getStatusCode() != 200) {
-
                 LOGGER.warn(
                         "Error during interactsh deregister, due to bad HTTP code {}. Content: {}",
                         deregisterMsg.getResponseHeader().getStatusCode(),
                         deregisterMsg.getResponseBody());
             }
             LOGGER.debug("Deregistered correlationId: {}", correlationId);
-
         } catch (Exception e) {
             LOGGER.error("Error during interactsh deregister: {}", e.getMessage(), e);
         } finally {
             isRegistered = false;
-            fireOastStateChanged(new OastState(getName(), false, null));
+            fireOastStateChanged(
+                    new OastState(getName(), false, null, OastStateEventType.UNREGISTERED));
         }
     }
 

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/GeneralOastOptionsPanelTab.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/GeneralOastOptionsPanelTab.java
@@ -23,6 +23,7 @@ import java.awt.GridBagConstraints;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import org.parosproxy.paros.Constant;
@@ -37,6 +38,7 @@ public class GeneralOastOptionsPanelTab extends OastOptionsPanelTab {
 
     private static final long serialVersionUID = 1L;
     private JComboBox<String> activeScanServices;
+    private JCheckBox usePermanentDatabase;
 
     public GeneralOastOptionsPanelTab() {
         super(Constant.messages.getString("oast.options.general.title"));
@@ -51,6 +53,9 @@ public class GeneralOastOptionsPanelTab extends OastOptionsPanelTab {
                 getActiveScanServicesComboBox(),
                 LayoutHelper.getGBC(1, rowIndex, GridBagConstraints.REMAINDER, 1.0, 0));
         add(
+                getUsePermanentDatabaseCheckbox(),
+                LayoutHelper.getGBC(0, ++rowIndex, GridBagConstraints.REMAINDER, 1.0, 0));
+        add(
                 new JLabel(),
                 LayoutHelper.getGBC(0, ++rowIndex, GridBagConstraints.REMAINDER, 1.0, 1.0));
     }
@@ -59,6 +64,7 @@ public class GeneralOastOptionsPanelTab extends OastOptionsPanelTab {
     public void initParam(OptionsParam options) {
         final OastParam param = options.getParamSet(OastParam.class);
         getActiveScanServicesComboBox().setSelectedItem(param.getActiveScanServiceName());
+        getUsePermanentDatabaseCheckbox().setSelected(param.isUsePermanentDatabase());
     }
 
     @Override
@@ -68,6 +74,7 @@ public class GeneralOastOptionsPanelTab extends OastOptionsPanelTab {
                 Optional.ofNullable(getActiveScanServicesComboBox().getSelectedItem())
                         .orElse(OastParam.NO_ACTIVE_SCAN_SERVICE_SELECTED_OPTION)
                         .toString());
+        param.setUsePermanentDatabase(getUsePermanentDatabaseCheckbox().isSelected());
     }
 
     private JComboBox<String> getActiveScanServicesComboBox() {
@@ -82,5 +89,15 @@ public class GeneralOastOptionsPanelTab extends OastOptionsPanelTab {
                     Constant.messages.getString("oast.options.activeScanService.tooltip"));
         }
         return activeScanServices;
+    }
+
+    private JCheckBox getUsePermanentDatabaseCheckbox() {
+        if (usePermanentDatabase == null) {
+            usePermanentDatabase =
+                    new JCheckBox(Constant.messages.getString("oast.options.usePermanentDatabase"));
+            usePermanentDatabase.setToolTipText(
+                    Constant.messages.getString("oast.options.usePermanentDatabase.tooltip"));
+        }
+        return usePermanentDatabase;
     }
 }

--- a/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/options.html
+++ b/addOns/oast/src/main/javahelp/org/zaproxy/addon/oast/resources/help/contents/options.html
@@ -17,6 +17,14 @@ These are options not specific to a single OAST service.
 <h3>Active Scan Service</h3>
 A dropdown menu that allows you to select the out-of-band service that will be used by active scan rules.
 
+<h3>Permanent Database</h3>
+Enabling the "Use Permanent Database" option will allow you to persist registered out-of-band payloads in ZAP's
+permanent database. The persisted payloads will be loaded into memory and polled along with other payloads as per the
+set polling interval. The permanent database is currently only supported by the BOAST service.
+
+<strong>NOTE</strong>: This means that Alerts may appear in a ZAP session which is not directly or specifically related
+to the original assessment/scan.
+
 <h2>Service-Specific Configurations</h2>
 Look at the individual options page of each service for more information about the available settings for that service.
 

--- a/addOns/oast/src/main/resources/META-INF/package-hsql.orm
+++ b/addOns/oast/src/main/resources/META-INF/package-hsql.orm
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE orm SYSTEM "file:/javax/jdo/orm.dtd">
+<orm>
+    <package name="org.zaproxy.addon.oast.services.boast">
+        <class name="BoastEntity" table="BOAST">
+            <field name="id">
+                <column name="ID" length="26" jdbc-type="CHAR"/>
+            </field>
+            <field name="canary">
+                <column name="CANARY" length="26" jdbc-type="CHAR"/>
+            </field>
+            <field name="secret">
+                <column name="SECRET" length="44" jdbc-type="CHAR"/>
+            </field>
+            <field name="uri">
+                <column name="URI" length="512" jdbc-type="VARCHAR"/>
+            </field>
+            <field name="registeredTimestamp">
+                <column name="REGISTERED_TIMESTAMP" jdbc-type="TIMESTAMP"/>
+            </field>
+        </class>
+    </package>
+</orm>

--- a/addOns/oast/src/main/resources/META-INF/persistence.xml
+++ b/addOns/oast/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+        http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd" version="2.1">
+
+    <persistence-unit name="oast">
+        <class>org.zaproxy.addon.oast.services.boast.BoastEntity</class>
+        <exclude-unlisted-classes/>
+    </persistence-unit>
+</persistence>

--- a/addOns/oast/src/main/resources/db/migration/V1__Create_table_boast.sql
+++ b/addOns/oast/src/main/resources/db/migration/V1__Create_table_boast.sql
@@ -1,0 +1,7 @@
+create table BOAST (
+    ID char(26) not null,
+    CANARY char(26) not null,
+    SECRET char(44) not null,
+    URI varchar(512) not null,
+    REGISTERED_TIMESTAMP timestamp not null
+);

--- a/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
+++ b/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
@@ -43,6 +43,9 @@ oast.options.activeScanService=OOB Service Used In Active Scans:
 oast.options.activeScanService.tooltip=The selected service will be used to generate payloads for active scan \
   rules that support OAST.
 oast.options.general.title=General
+oast.options.usePermanentDatabase=Use Permanent Database
+oast.options.usePermanentDatabase.tooltip=Use the Permanent Database to persist registered OAST service instances \
+across ZAP sessions.
 
 oast.panel.name=OAST
 oast.panel.clear.button.label=Clear


### PR DESCRIPTION
Here is an overview of the changes in this PR (click to expand):

<details><summary>Datanucleus</summary>

[Datanucleus](https://www.datanucleus.org/) allows mapping java classes to tables in a database. This makes it convenient to interact with data simply by interacting with java objects.

### Files affected
- `addOns/addOns.gradle.kts`: The datanucleus gradle plugin is added here. Datanucleus modifies Java bytecode to add methods to classes with appropriate annotations. For this, it provides a tool called an "enhancer" that does this. The [unofficial gradle plugin](https://datanucleus-gradle-plugin.rm3l.org/) used here adds enhancement tasks to all the add-ons. While they can be called manually, annotated classes are automatically enhanced during building which is convenient.

</details>

<details><summary>Flyway</summary>

[Flyway](https://flywaydb.org/) is a tool that allows database migrations. We will be using this programmatically. For example, if the permanent database does not exist in the user's ZAP home directory, it will be created.

Flyway also provides the flexibility to have multiple SQL scripts for various databases. This will be useful when we want to use databases other than HSQLDB like MySQL or PostgreSQL.
</details>

<details><summary>Changes to commonlib</summary>

- `addOns/commonlib/commonlib.gradle.kts`: 
	- Datanucleus is added as a dependency to the commonlib add-on. This means that any add-on that wants to use the permanent db will have to depend on commonlib. Note that the datanucleus requires its jar files to be present in the classpath so they are added as `bundledLibs`.
	- Flyway is also added as a dependency.
- `addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/db/Database.java`: An abstract class that should be overriden by database implementations. Some common methods like `persistEntity` are defined here.
- `addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/db/PermanentDatabase.java`: Extends the Database class and provides implementation details for the permanent database. These include the DB type (`hsql`), connection URL, username, password, etc.
</details>

<details><summary>Changes to oast</summary>

- `addOns/oast/oast.gradle.kts`:
	- commonlib is added as a dependency
	- the datanucleus gradle plugin is configured.
- `addOns/oast/src/main/resources/META-INF/package-hsql.orm`: Mapping for datanucleus between the tables in the permanent database and the oast entity classes.
- `addOns/oast/src/main/resources/META-INF/persistence.xml`: Configuration for datanucleus. Tells datanucleus which classes must be enhanced.
- `addOns/oast/src/main/resources/db/migration/V1__Create_tables.sql`: Flyway SQL v1 script for creating the oast tables in the permanent db.
- `BoastEntity`, `InteractshEntity`: `PersistenceCapable` annotated classes. Each class maps to a table in the permanent DB and each instance variable of these classes is a column in the tables. They both override `OastEntity` for convenience.
- `OastParam.java`, `GeneralOastOptionsPanelTab`: A new option is added for the user to select whether they want to use the permanent DB or not.
- `OastState.java`: The events emitted by OAST actions are updated to include the event types (e.g. REGISTERED, POLLED, UNREGISTERED). This allows for a clean implementation where the services are (mostly) oblivious about the permanent DB.
  `ExtensionOast`  is responsible for actually persisting / retrieving entities from the database. This was done mainly to keep the services independent of the extension.
- If the "Use permanent DB" option is enabled, registered OAST servers from the DB are added to a list in the OAST services when the session is changed. They are polled according to the set interval in their options.
</details>


<details><summary>Miscellaneous</summary>

#### Permanent DB Location
The permanent DB is created under `zapHome/db/permanent`.

#### SQL Workbench Screenshots
##### Tables
![zap-permanent-db-sql-workbench-tables](https://user-images.githubusercontent.com/16446369/162996325-200dec47-a56d-471a-b6d9-427c7db2f0e0.png)

##### BOAST
###### Column Definitions
![zap-permanent-db-sql-workbench-boast-column-definitions](https://user-images.githubusercontent.com/16446369/162996392-dd14a18c-55de-4991-bbeb-f33f5d01e039.png)

###### Example Data
![zap-permanent-db-sql-workbench-boast-example-data](https://user-images.githubusercontent.com/16446369/162996507-c1b6988f-0de0-4e96-a945-18763fc16638.png)

##### Interactsh
###### Column Definitions
![zap-permanent-db-sql-workbench-interactsh-column-definitions](https://user-images.githubusercontent.com/16446369/162996557-4047ccd5-b18f-4b5c-9708-d9125b292d28.png)

###### Example Data
![zap-permanent-db-sql-workbench-interactsh-example-data](https://user-images.githubusercontent.com/16446369/162996629-a02554c2-098d-4bff-8932-adff601b70fc.png)

</details>


<details><summary>What's pending?</summary>

- Testing that everything works as expected.
- Are all (or most) DB best practices being followed in this implementation?
</details>

<details><summary>What's next?</summary>

- Persist Interactsh payloads.
- Adding an option to pick the "age" of servers that are polled or deleted.
- Alternative DB implementations like MySQL or PostgreSQL.
- Integration tests with DbUnit.
</details>

Signed-off-by: ricekot <github@ricekot.com>