### PR TITLE
Automation: Fix turning off specific active scan rules

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Register plans run by -autorun to prevent NPEs when editing them
+- Issue when turning off specific active scan rules
 
 ## [0.13.0] - 2022-02-25
 ### Fixed

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJob.java
@@ -324,7 +324,7 @@ public class ActiveScanJob extends AutomationJob {
                     JobUtils.parseAlertThreshold(rule.getThreshold(), this.getName(), progress);
             if (pluginTh != null) {
                 plugin.setAlertThreshold(pluginTh);
-                plugin.setEnabled(true);
+                plugin.setEnabled(!AlertThreshold.OFF.equals(pluginTh));
                 progress.info(
                         Constant.messages.getString(
                                 "automation.info.ascan.rule.setthreshold",

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobUnitTest.java
@@ -490,6 +490,51 @@ class ActiveScanJobUnitTest {
     }
 
     @Test
+    void shouldTurnOffSpecifiedRule() throws MalformedURLException {
+        // There is one built in rule, and mocking more is tricky outside of the package :/
+
+        // Given
+        ActiveScanJob job = new ActiveScanJob();
+        AutomationProgress progress = new AutomationProgress();
+
+        LinkedHashMap<String, Object> ruleDefn = new LinkedHashMap<>();
+        ruleDefn.put("id", 50000);
+        ruleDefn.put("strength", "medium");
+        ruleDefn.put("threshold", "oFF");
+
+        LinkedHashMap<String, List<?>> policyDefn = new LinkedHashMap<>();
+
+        ArrayList<LinkedHashMap<?, ?>> rulesDefn = new ArrayList<>();
+        rulesDefn.add(ruleDefn);
+        policyDefn.put("rules", rulesDefn);
+
+        LinkedHashMap<String, LinkedHashMap<?, ?>> data = new LinkedHashMap<>();
+        data.put("policyDefinition", policyDefn);
+
+        // When
+        job.setJobData(data);
+        job.verifyParameters(progress);
+        ScanPolicy policy = job.getScanPolicy(progress);
+
+        // Then
+        assertThat(policy, is(notNullValue()));
+        assertThat(policy.getPluginFactory(), is(notNullValue()));
+        assertThat(policy.getPluginFactory().getAllPlugin(), is(notNullValue()));
+        assertThat(policy.getPluginFactory().getAllPlugin().size(), is(1));
+        assertThat(policy.getPluginFactory().getAllPlugin().get(0), is(notNullValue()));
+        assertThat(policy.getPluginFactory().getAllPlugin().get(0).isEnabled(), is(equalTo(false)));
+        assertThat(policy.getPluginFactory().getAllPlugin().get(0).getId(), is(equalTo(50000)));
+        assertThat(
+                policy.getPluginFactory().getAllPlugin().get(0).getAttackStrength(),
+                is(equalTo(AttackStrength.MEDIUM)));
+        assertThat(
+                policy.getPluginFactory().getAllPlugin().get(0).getAlertThreshold(),
+                is(equalTo(AlertThreshold.OFF)));
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
     void shouldWarnOnUnknownRule() throws MalformedURLException {
         // Given
         ActiveScanJob job = new ActiveScanJob();


### PR DESCRIPTION
Setting a rule to enabled changes the threshold from OFF to DEFAULT ;)

https://github.com/zaproxy/zaproxy/blob/c4dcce58e572c078fdb0a7919088343faa4e574b/zap/src/main/java/org/parosproxy/paros/core/scanner/AbstractPlugin.java#L777-L779

Signed-off-by: Simon Bennetts <psiinon@gmail.com>