### PR TITLE
network: provide main proxy info

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Added
+- On weekly releases and versions after 2.11:
+  - Management of local servers/proxies, supersedes core functionality;
+  - Configuration of aliases for the servers/proxies ([Issue 3594](https://github.com/zaproxy/zaproxy/issues/3594));
+  - Pass-through connections ([Issue 6832](https://github.com/zaproxy/zaproxy/issues/6832)).
 
 ## [0.1.0] - 2022-02-01
 ### Added

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -101,6 +101,7 @@ import org.zaproxy.addon.network.internal.server.http.handlers.RemoveAcceptEncod
 import org.zaproxy.addon.network.internal.ui.LocalServerInfoLabel;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.Server;
+import org.zaproxy.addon.network.server.ServerInfo;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.extension.brk.ExtensionBreak;
@@ -147,6 +148,7 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
     private AliasChecker aliasChecker;
     private Map<String, LocalServer> localServers;
     private LocalServer mainProxyServer;
+    private ServerInfo mainProxyServerInfo;
     private LocalServerHandler.SerialiseState serialiseForBreak;
     private ExtensionBreak extensionBreak;
     private Method addBreakListenerMethod;
@@ -235,6 +237,20 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
     @Override
     public void initModel(Model model) {
         super.initModel(model);
+
+        mainProxyServerInfo =
+                new ServerInfo() {
+
+                    @Override
+                    public String getAddress() {
+                        return getModel().getOptionsParam().getProxyParam().getProxyIp();
+                    }
+
+                    @Override
+                    public int getPort() {
+                        return getModel().getOptionsParam().getProxyParam().getProxyPort();
+                    }
+                };
 
         if (!handleLocalServers) {
             return;
@@ -335,6 +351,16 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
                 getMainEventExecutorGroup(),
                 sslCertificateService,
                 handler);
+    }
+
+    /**
+     * Gets the server info of the main proxy.
+     *
+     * @return the server info.
+     * @since 0.2.0
+     */
+    public ServerInfo getMainProxyServerInfo() {
+        return mainProxyServerInfo;
     }
 
     /**

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/server/ServerInfo.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/server/ServerInfo.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.server;
+
+/**
+ * The information of a server.
+ *
+ * @since 0.2.0
+ */
+public interface ServerInfo {
+
+    /**
+     * Gets the address of the server.
+     *
+     * @return the address of the server.
+     */
+    String getAddress();
+
+    /**
+     * Gets the port of the server.
+     *
+     * @return the port of the server.
+     */
+    int getPort();
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ExtensionNetworkUnitTest.java
@@ -78,6 +78,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.parosproxy.paros.common.AbstractParam;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.proxy.ProxyParam;
 import org.parosproxy.paros.core.proxy.ProxyServer;
 import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -100,6 +101,7 @@ import org.zaproxy.addon.network.internal.server.http.Alias;
 import org.zaproxy.addon.network.internal.server.http.handlers.LegacyProxyListenerHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.Server;
+import org.zaproxy.addon.network.server.ServerInfo;
 import org.zaproxy.addon.network.testutils.TestClient;
 import org.zaproxy.addon.network.testutils.TextTestClient;
 import org.zaproxy.zap.ZAP;
@@ -176,6 +178,26 @@ class ExtensionNetworkUnitTest extends TestUtils {
         extension.init();
         // Then
         assertThat(extension.getSslCertificateService(), is(notNullValue()));
+    }
+
+    @Test
+    void shouldCreateMainProxyServerInfoOnInitModel() {
+        // Given
+        String address = "address";
+        int port = 1234;
+        ProxyParam proxyParam = mock(ProxyParam.class);
+        given(proxyParam.getProxyIp()).willReturn(address);
+        given(proxyParam.getProxyPort()).willReturn(port);
+        given(optionsParam.getProxyParam()).willReturn(proxyParam);
+        // When
+        extension.initModel(model);
+        // Then
+        ServerInfo serverInfo = extension.getMainProxyServerInfo();
+        assertThat(serverInfo, is(notNullValue()));
+        assertThat(serverInfo.getAddress(), is(equalTo(address)));
+        assertThat(serverInfo.getPort(), is(equalTo(port)));
+        verify(proxyParam).getProxyIp();
+        verify(proxyParam).getProxyPort();
     }
 
     @Test


### PR DESCRIPTION
Expose the address/port of the main proxy, to allow other add-ons to
stop using core.
Update changelog with latest changes.