### PR TITLE
Stop using core for main proxy address/port

### DIFF
--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Use Network add-on to obtain main proxy address/port.
 
 ## [12] - 2021-10-07
 ### Added

--- a/addOns/plugnhack/plugnhack.gradle.kts
+++ b/addOns/plugnhack/plugnhack.gradle.kts
@@ -10,10 +10,22 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/plug-n-hack/")
+
+        dependencies {
+            addOns {
+                register("network") {
+                    version.set(">= 0.2.0")
+                }
+            }
+        }
     }
 
     apiClientGen {
         api.set("org.zaproxy.zap.extension.plugnhack.PlugNHackAPI")
         messages.set(file("src/main/resources/org/zaproxy/zap/extension/plugnhack/resources/Messages.properties"))
     }
+}
+
+dependencies {
+    compileOnly(parent!!.childProjects.get("network")!!)
 }

--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Spider checkboxes in Automated Scan will be disabled when scan is running. (Issue 7072)
+- Use Network add-on to obtain main proxy address/port.
 
 ### Fixed
 - Accept any 2xx result code instead of just 200.

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -61,7 +61,7 @@ zapAddOn {
                     version.set(">= 0.0.1")
                 }
                 register("network") {
-                    version.set(">= 0.0.1")
+                    version.set(">= 0.2.0")
                 }
             }
         }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
@@ -55,6 +55,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.callhome.ExtensionCallHome;
 import org.zaproxy.addon.callhome.InvalidServiceUrlException;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.addon.reports.ExtensionReports;
 import org.zaproxy.zap.extension.ext.ExtensionExtension;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
@@ -109,13 +110,9 @@ public class ExtensionQuickStart extends ExtensionAdaptor
 
     private ExtensionReports extReport;
 
-    private static final List<Class<? extends Extension>> DEPENDENCIES;
-
-    static {
-        List<Class<? extends Extension>> dependencies = new ArrayList<>(1);
-        dependencies.add(ExtensionReports.class);
-        DEPENDENCIES = Collections.unmodifiableList(dependencies);
-    }
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionReports.class, ExtensionNetwork.class));
 
     public ExtensionQuickStart() {
         super(NAME);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -276,7 +276,7 @@ public class QuickStartPanel extends AbstractPanel implements Tab {
     }
 
     public void optionsChanged(OptionsParam optionsParam) {
-        this.getDefaultExplorePanel().optionsChanged(optionsParam);
+        this.getDefaultExplorePanel().optionsChanged();
         this.getAttackPanel().optionsChanged(optionsParam);
     }
 

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Use Network add-on to obtain main proxy address/port.
 
 ## [15.8.0] - 2022-03-29
 ### Added

--- a/addOns/selenium/selenium.gradle.kts
+++ b/addOns/selenium/selenium.gradle.kts
@@ -10,6 +10,14 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/selenium/")
+
+        dependencies {
+            addOns {
+                register("network") {
+                    version.set(">=0.2.0")
+                }
+            }
+        }
     }
 
     apiClientGen {
@@ -24,5 +32,8 @@ dependencies {
     api("org.seleniumhq.selenium:htmlunit-driver:2.54.0")
     api("com.codeborne:phantomjsdriver:1.4.4")
 
+    compileOnly(parent!!.childProjects.get("network")!!)
+
+    testImplementation(parent!!.childProjects.get("network")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ExtensionZest.java
@@ -155,6 +155,8 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
     private int recordingWinId = 0;
     private ScriptNode recordingNode = null;
 
+    private ExtensionNetwork extensionNetwork;
+
     public ExtensionZest() {
         super(NAME);
         this.setOrder(73); // Almost looks like ZE ;)
@@ -1604,10 +1606,22 @@ public class ExtensionZest extends ExtensionAdaptor implements ProxyListener, Sc
             logger.error("Failed to find engine Mozilla Zest");
         } else if (script instanceof ZestScriptWrapper) {
             this.getZestScriptEngineFactory()
-                    .setRunner(new ZestZapRunner(this, (ZestScriptWrapper) script));
+                    .setRunner(
+                            new ZestZapRunner(
+                                    this, getExtensionNetwork(), (ZestScriptWrapper) script));
             clearResults();
             this.lastRunScript = ((ZestScriptWrapper) script).getZestScript();
         }
+    }
+
+    private ExtensionNetwork getExtensionNetwork() {
+        if (extensionNetwork == null) {
+            extensionNetwork =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionNetwork.class);
+        }
+        return extensionNetwork;
     }
 
     public void clearResults() {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestActiveRunner.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.ascan.ActiveScript;
 import org.zaproxy.zap.extension.ascan.ScriptsActiveScanner;
 import org.zaproxy.zest.core.v1.ZestRequest;
@@ -40,8 +41,9 @@ public class ZestActiveRunner extends ZestZapRunner implements ActiveScript {
 
     private static Logger logger = LogManager.getLogger(ZestActiveRunner.class);
 
-    public ZestActiveRunner(ExtensionZest extension, ZestScriptWrapper script) {
-        super(extension, script);
+    public ZestActiveRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper script) {
+        super(extension, extensionNetwork, script);
         this.extension = extension;
         this.script = script;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestAuthenticationRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestAuthenticationRunner.java
@@ -54,13 +54,11 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
 
     private ZestScriptWrapper script = null;
     private AuthenticationHelper helper;
-    private final ExtensionNetwork extensionNetwork;
 
     public ZestAuthenticationRunner(
             ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper script) {
-        super(extension, script);
+        super(extension, extensionNetwork, script);
         this.script = script;
-        this.extensionNetwork = extensionNetwork;
     }
 
     @Override
@@ -109,8 +107,10 @@ public class ZestAuthenticationRunner extends ZestZapRunner implements Authentic
         try {
             if (hasClientStatements()) {
                 proxyServer =
-                        extensionNetwork.createHttpProxy(
-                                helper.getHttpSender(), new ZestMessageHandler(this, helper));
+                        getExtensionNetwork()
+                                .createHttpProxy(
+                                        helper.getHttpSender(),
+                                        new ZestMessageHandler(this, helper));
                 int port = proxyServer.start(PROXY_ADDRESS, Server.ANY_PORT);
                 this.setProxy(PROXY_ADDRESS, port);
             }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestHttpSenderRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestHttpSenderRunner.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.script.HttpSenderScript;
 import org.zaproxy.zap.extension.script.HttpSenderScriptHelper;
 import org.zaproxy.zest.core.v1.ZestRequest;
@@ -45,8 +46,9 @@ public class ZestHttpSenderRunner extends ZestZapRunner implements HttpSenderScr
 
     private Logger logger = LogManager.getLogger(ZestHttpSenderRunner.class);
 
-    public ZestHttpSenderRunner(ExtensionZest extension, ZestScriptWrapper script) {
-        super(extension, script);
+    public ZestHttpSenderRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper script) {
+        super(extension, extensionNetwork, script);
         this.extension = extension;
         this.script = script;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestPassiveRunner.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.pscan.PassiveScript;
 import org.zaproxy.zap.extension.pscan.scanner.ScriptsPassiveScanner;
 import org.zaproxy.zest.core.v1.ZestRequest;
@@ -38,8 +39,9 @@ public class ZestPassiveRunner extends ZestZapRunner implements PassiveScript {
 
     private Logger logger = LogManager.getLogger(ZestPassiveRunner.class);
 
-    public ZestPassiveRunner(ExtensionZest extension, ZestScriptWrapper script) {
-        super(extension, script);
+    public ZestPassiveRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper script) {
+        super(extension, extensionNetwork, script);
         this.extension = extension;
         // this.runner = this.getExtension().getRunner(script);
         this.script = script;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestProxyRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestProxyRunner.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.script.ProxyScript;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestVariables;
@@ -41,8 +42,9 @@ public class ZestProxyRunner extends ZestZapRunner implements ProxyScript {
 
     private Logger logger = LogManager.getLogger(ZestProxyRunner.class);
 
-    public ZestProxyRunner(ExtensionZest extension, ZestScriptWrapper script) {
-        super(extension, script);
+    public ZestProxyRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper script) {
+        super(extension, extensionNetwork, script);
         this.extension = extension;
         this.script = script;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestScriptWrapper.java
@@ -123,26 +123,35 @@ public class ZestScriptWrapper extends ScriptWrapper {
     public <T> T getInterface(Class<T> class1) throws ScriptException, IOException {
         // Clone the wrapper so that we get a new instance every time
         if (class1.isAssignableFrom(ZestPassiveRunner.class)) {
-            return (T) new ZestPassiveRunner(this.getExtension(), this.clone());
+            return (T)
+                    new ZestPassiveRunner(this.getExtension(), getExtensionNetwork(), this.clone());
 
         } else if (class1.isAssignableFrom(ZestActiveRunner.class)) {
-            return (T) new ZestActiveRunner(this.getExtension(), this.clone());
+            return (T)
+                    new ZestActiveRunner(this.getExtension(), getExtensionNetwork(), this.clone());
 
         } else if (class1.isAssignableFrom(ZestTargetedRunner.class)) {
-            return (T) new ZestTargetedRunner(this.getExtension(), this.clone());
+            return (T)
+                    new ZestTargetedRunner(
+                            this.getExtension(), getExtensionNetwork(), this.clone());
 
         } else if (class1.isAssignableFrom(ZestHttpSenderRunner.class)) {
-            return (T) new ZestHttpSenderRunner(this.getExtension(), this.clone());
+            return (T)
+                    new ZestHttpSenderRunner(
+                            this.getExtension(), getExtensionNetwork(), this.clone());
 
         } else if (class1.isAssignableFrom(ZestProxyRunner.class)) {
-            return (T) new ZestProxyRunner(this.getExtension(), this.clone());
+            return (T)
+                    new ZestProxyRunner(this.getExtension(), getExtensionNetwork(), this.clone());
 
         } else if (class1.isAssignableFrom(ZestAuthenticationRunner.class)) {
             return (T)
                     new ZestAuthenticationRunner(
                             this.getExtension(), getExtensionNetwork(), this.clone());
         } else if (class1.isAssignableFrom(ZestSequenceRunner.class)) {
-            return (T) new ZestSequenceRunner(this.getExtension(), this.clone());
+            return (T)
+                    new ZestSequenceRunner(
+                            this.getExtension(), getExtensionNetwork(), this.clone());
         }
         return null;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestSequenceRunner.java
@@ -41,6 +41,7 @@ import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.script.SequenceScript;
 import org.zaproxy.zap.model.StructuralNode;
@@ -70,10 +71,12 @@ public class ZestSequenceRunner extends ZestZapRunner implements SequenceScript 
      * Initialize a ZestSequenceRunner.
      *
      * @param extension The Zest Extension.
+     * @param extensionNetwork the network extension.
      * @param wrapper A wrapper for the current script.
      */
-    public ZestSequenceRunner(ExtensionZest extension, ZestScriptWrapper wrapper) {
-        super(extension, wrapper);
+    public ZestSequenceRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper wrapper) {
+        super(extension, extensionNetwork, wrapper);
         this.script = wrapper;
         this.setStopOnAssertFail(false);
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTargetedRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTargetedRunner.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.zest;
 
 import javax.script.ScriptException;
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.ExtensionNetwork;
 import org.zaproxy.zap.extension.script.TargetedScript;
 
 public class ZestTargetedRunner extends ZestZapRunner implements TargetedScript {
@@ -28,8 +29,9 @@ public class ZestTargetedRunner extends ZestZapRunner implements TargetedScript 
     private ExtensionZest extension = null;
     private ZestScriptWrapper script = null;
 
-    public ZestTargetedRunner(ExtensionZest extension, ZestScriptWrapper script) {
-        super(extension, script);
+    public ZestTargetedRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper script) {
+        super(extension, extensionNetwork, script);
         this.extension = extension;
         this.script = script;
     }

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestZapRunner.java
@@ -37,6 +37,8 @@ import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.model.SiteNode;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.network.ExtensionNetwork;
+import org.zaproxy.addon.network.server.ServerInfo;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
@@ -72,6 +74,7 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
     private static Field fieldOutputWriter;
 
     private ExtensionZest extension;
+    private final ExtensionNetwork extensionNetwork;
     private ZestScriptWrapper wrapper = null;
     private HttpMessage target = null;
     private ZestResultWrapper lastResult = null;
@@ -86,11 +89,12 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
 
     private ScriptUI scriptUI;
 
-    /** */
-    public ZestZapRunner(ExtensionZest extension, ZestScriptWrapper wrapper) {
+    public ZestZapRunner(
+            ExtensionZest extension, ExtensionNetwork extensionNetwork, ZestScriptWrapper wrapper) {
         super(Default.TIMEOUT_IN_SECONDS, true);
         log.debug("Constructor");
         this.extension = extension;
+        this.extensionNetwork = extensionNetwork;
         this.wrapper = wrapper;
         this.scriptUI = extension.getExtScript().getScriptUI();
         this.setScriptEngineFactory(extension.getZestScriptEngineFactory());
@@ -99,9 +103,12 @@ public class ZestZapRunner extends ZestBasicRunner implements ScannerListener {
         this.setStopOnTestFail(false);
 
         // Always proxy via ZAP
-        this.setProxy(
-                Model.getSingleton().getOptionsParam().getProxyParam().getProxyIp(),
-                Model.getSingleton().getOptionsParam().getProxyParam().getProxyPort());
+        ServerInfo serverInfo = extensionNetwork.getMainProxyServerInfo();
+        this.setProxy(serverInfo.getAddress(), serverInfo.getPort());
+    }
+
+    protected ExtensionNetwork getExtensionNetwork() {
+        return extensionNetwork;
     }
 
     @Override

--- a/addOns/zest/zest.gradle.kts
+++ b/addOns/zest/zest.gradle.kts
@@ -24,7 +24,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("network") {
-                    version.set(">=0.1.0")
+                    version.set(">=0.2.0")
                 }
                 register("selenium") {
                     version.set("15.*")


### PR DESCRIPTION
Obtain the main proxy address/port from the Network add-on instead of
core.
Update changelogs where needed.
The plugnhack and selenium add-ons will now depend on network.