### PR TITLE
chore: Active Scan rules: Leverage lang3 RandomStringUtils methods

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [37] - 2022-04-04
 ### Added

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -28,7 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -221,10 +221,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             // to see if a placebo attack has the same effect
             // the parameter will be the same length as the actual attack, but will contain purely
             // alphanumeric characters
-            String placeboAttack =
-                    RandomStringUtils.random(
-                            errorAttack.length(),
-                            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+            String placeboAttack = RandomStringUtils.randomAlphanumeric(errorAttack.length());
             HttpMessage placeboAttackMsg = getNewMsg();
             this.setParameter(placeboAttackMsg, paramname, placeboAttack);
             sendAndReceive(placeboAttackMsg);

--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [40] - 2022-03-15
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -39,8 +39,8 @@ import org.apache.commons.httpclient.ProxyClient;
 import org.apache.commons.httpclient.ProxyClient.ConnectResponse;
 import org.apache.commons.httpclient.StatusLine;
 import org.apache.commons.httpclient.URI;
-import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -366,12 +366,8 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
         // TRACE is supported in 1.0. TRACK is presumably the same, since it is
         // a alias for TRACE. Typical Microsoft.
         msg.getRequestHeader().setVersion(HttpRequestHeader.HTTP10);
-        String randomcookiename =
-                RandomStringUtils.random(
-                        15, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-        String randomcookievalue =
-                RandomStringUtils.random(
-                        40, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+        String randomcookiename = RandomStringUtils.randomAlphanumeric(15);
+        String randomcookievalue = RandomStringUtils.randomAlphanumeric(40);
         TreeSet<HtmlParameter> cookies = msg.getCookieParams();
         cookies.add(
                 new HtmlParameter(HtmlParameter.Type.cookie, randomcookiename, randomcookievalue));
@@ -520,12 +516,8 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
 
         if (httpMethod.equals(HttpRequestHeader.PUT)
                 || httpMethod.equals(HttpRequestHeader.PATCH)) {
-            String randomKey =
-                    RandomStringUtils.random(
-                            15, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-            String randomValue =
-                    RandomStringUtils.random(
-                            15, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+            String randomKey = RandomStringUtils.randomAlphanumeric(15);
+            String randomValue = RandomStringUtils.randomAlphanumeric(15);
             String randomResource =
                     RandomStringUtils.random(10, "abcdefghijklmnopqrstuvwxyz0123456789");
             String requestBody = '"' + randomKey + "\":\"" + randomValue + '"';

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ProxyDisclosureScanRule.java
@@ -32,7 +32,7 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -254,12 +254,8 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
             tracemsg.setRequestHeader(traceRequestHeader);
             // create a random cookie, and set it up, so we can detect if the TRACE is enabled (in
             // which case, it should echo it back in the response)
-            String randomcookiename =
-                    RandomStringUtils.random(
-                            15, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-            String randomcookievalue =
-                    RandomStringUtils.random(
-                            40, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+            String randomcookiename = RandomStringUtils.randomAlphanumeric(15);
+            String randomcookievalue = RandomStringUtils.randomAlphanumeric(40);
             TreeSet<HtmlParameter> cookies = tracemsg.getCookieParams();
             cookies.add(
                     new HtmlParameter(
@@ -454,14 +450,8 @@ public class ProxyDisclosureScanRule extends AbstractAppPlugin {
 
                     // create a random cookie, and set it up, so we can detect if the TRACE is
                     // enabled (in which case, it should echo it back in the response)
-                    String randomcookiename2 =
-                            RandomStringUtils.random(
-                                    15,
-                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
-                    String randomcookievalue2 =
-                            RandomStringUtils.random(
-                                    40,
-                                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+                    String randomcookiename2 = RandomStringUtils.randomAlphanumeric(15);
+                    String randomcookievalue2 = RandomStringUtils.randomAlphanumeric(40);
                     TreeSet<HtmlParameter> cookies2 = mfMethodMsg.getCookieParams();
                     cookies2.add(
                             new HtmlParameter(


### PR DESCRIPTION
- CHANGELOGs > Added maintenance note.
- Leverage randomAlphanumeric in cases where the full `a-zA-Z0-9` character set was passed.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>