### PR TITLE
Ascanrules: Fix XSS false positive in textarea

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).
+- False positive where Cross Site Scripting payloads are safely rendered in a textarea tag.
 
 ## [46] - 2022-03-21
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContext.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContext.java
@@ -1,0 +1,251 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2011 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules.httputils;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class HtmlContext {
+
+    public static final int IGNORE_PARENT = 0x0001;
+    public static final int IGNORE_TAG = 0x0002;
+    public static final int IGNORE_QUOTES = 0x0004;
+    public static final int IGNORE_IN_SCRIPT = 0x0008;
+    public static final int IGNORE_IN_URL = 0x0010;
+    public static final int IGNORE_WITH_SRC = 0x0020;
+    public static final int IGNORE_HTML_COMMENT = 0x0040;
+    public static final int IGNORE_IN_SAFE = 0x0080;
+
+    private HttpMessage msg;
+    private String target;
+    private int start = 0;
+    private int end = 0;
+    private List<String> parentTags = new ArrayList<>();
+    private String tagAttribute = null;
+    private boolean inScriptAttribute = false;
+    private boolean inUrlAttribute = false;
+    private boolean inTagWithSrc = false;
+    private String surroundingQuote = "";
+    private boolean htmlComment = false;
+
+    public HtmlContext(HttpMessage msg, String target, int start, int end) {
+        super();
+        this.msg = msg;
+        this.target = target;
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append('{');
+        sb.append("tagAtt=");
+        sb.append(tagAttribute);
+        sb.append(',');
+        sb.append("inScriptAtt=");
+        sb.append(inScriptAttribute);
+        sb.append(',');
+        sb.append("inSafe=");
+        sb.append(isInSafeParentTag());
+        sb.append(',');
+        sb.append("inUrlAtt=");
+        sb.append(inUrlAttribute);
+        sb.append(',');
+        sb.append("inTagWithsrc=");
+        sb.append(inTagWithSrc);
+        sb.append(',');
+        sb.append("htmlComment=");
+        sb.append(htmlComment);
+        sb.append(',');
+        sb.append("quote=");
+        sb.append(surroundingQuote);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public int getStart() {
+        return start;
+    }
+
+    public void setStart(int start) {
+        this.start = start;
+    }
+
+    public int getEnd() {
+        return end;
+    }
+
+    public void setEnd(int end) {
+        this.end = end;
+    }
+
+    public HttpMessage getMsg() {
+        return msg;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public List<String> getParentTags() {
+        return parentTags;
+    }
+
+    public void setParentTags(List<String> surroundingTags) {
+        this.parentTags = surroundingTags;
+    }
+
+    public String getSurroundingQuote() {
+        return surroundingQuote;
+    }
+
+    public void setSurroundingQuote(String surroundingQuote) {
+        this.surroundingQuote = surroundingQuote;
+    }
+
+    public String getTagAttribute() {
+        return tagAttribute;
+    }
+
+    public void setTagAttribute(String tagAttribute) {
+        this.tagAttribute = tagAttribute;
+    }
+
+    public void addParentTag(String name) {
+        parentTags.add(0, name);
+    }
+
+    public String getParentTag() {
+        if (!parentTags.isEmpty()) {
+            return parentTags.get(parentTags.size() - 1);
+        }
+        return null;
+    }
+
+    public boolean isInScriptAttribute() {
+        return inScriptAttribute;
+    }
+
+    public void setInScriptAttribute(boolean inScriptAttribute) {
+        this.inScriptAttribute = inScriptAttribute;
+    }
+
+    /**
+     * Returns true if the target is in a 'safe' parent tag, ie one in which javascript will not be
+     * executed. The only known tag like this is 'textarea'.
+     *
+     * @return true if the target is in a 'safe' parent tag
+     */
+    public boolean isInSafeParentTag() {
+        if (!parentTags.isEmpty()) {
+            return parentTags.stream().anyMatch("textarea"::equalsIgnoreCase);
+        }
+        return false;
+    }
+
+    public boolean isHtmlComment() {
+        return htmlComment;
+    }
+
+    public void setHtmlComment(boolean htmlComment) {
+        this.htmlComment = htmlComment;
+    }
+
+    public boolean isInUrlAttribute() {
+        return inUrlAttribute;
+    }
+
+    public void setInUrlAttribute(boolean inUrlAttribute) {
+        this.inUrlAttribute = inUrlAttribute;
+    }
+
+    public boolean isInTagWithSrc() {
+        return inTagWithSrc;
+    }
+
+    public void setInTagWithSrc(boolean inTagWithSrc) {
+        this.inTagWithSrc = inTagWithSrc;
+    }
+
+    public boolean matches(HtmlContext context, int ignoreFlags) {
+
+        if (context == null) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_TAG) > 0) {
+            // check the tag
+            if (this.tagAttribute != null) {
+                if (!this.tagAttribute.equals(context.getTagAttribute())) {
+                    return false;
+                }
+            } else {
+                if (context.getTagAttribute() != null) {
+                    return false;
+                }
+            }
+        }
+        if ((ignoreFlags ^ IGNORE_QUOTES) > 0) {
+            // check the quotes
+            if (this.surroundingQuote != null) {
+                if (!this.surroundingQuote.equals(context.getSurroundingQuote())) {
+                    return false;
+                }
+            } else {
+                if (context.getSurroundingQuote() != null) {
+                    return false;
+                }
+            }
+        }
+        if ((ignoreFlags ^ IGNORE_PARENT) > 0) {
+            // check the parents
+            if (this.getParentTag() != null) {
+                if (!this.getParentTag().equals(context.getParentTag())) {
+                    return false;
+                }
+            } else {
+                if (context.getParentTag() != null) {
+                    return false;
+                }
+            }
+        }
+        if ((ignoreFlags ^ IGNORE_IN_SCRIPT) > 0
+                && this.inScriptAttribute != context.isInScriptAttribute()) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_IN_SAFE) > 0
+                && this.isInSafeParentTag() != context.isInSafeParentTag()) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_WITH_SRC) > 0 && this.inTagWithSrc != context.isInTagWithSrc()) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_IN_URL) > 0
+                && this.inUrlAttribute != context.isInUrlAttribute()) {
+            return false;
+        }
+        if ((ignoreFlags ^ IGNORE_HTML_COMMENT) > 0
+                && this.htmlComment != context.isHtmlComment()) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
@@ -1,0 +1,227 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2011 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.ascanrules.httputils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import net.htmlparser.jericho.Attribute;
+import net.htmlparser.jericho.Element;
+import net.htmlparser.jericho.Source;
+import org.parosproxy.paros.network.HttpMessage;
+
+public class HtmlContextAnalyser {
+
+    private char[] quotes = {'\'', '"'};
+
+    // Tag attributes which can contain javascript
+    private String[] scriptAttributes = {
+        "onBlur",
+        "onChange",
+        "onClick",
+        "onDblClick",
+        "onFocus",
+        "onKeydown",
+        "onKeyup",
+        "onKeypress",
+        "onLoad",
+        "onMousedown",
+        "onMouseup",
+        "onMouseover",
+        "onMousemove",
+        "onMouseout",
+        "onReset",
+        "onSelect",
+        "onSubmit",
+        "onUnload"
+    };
+
+    // Tag attributes which can contain a URL
+    private String[] urlAttributes = {
+        "action",
+        "background",
+        "cite",
+        "classid",
+        "codebase",
+        "data",
+        "formaction",
+        "href",
+        "icon",
+        "longdesc",
+        "manifest",
+        "poster",
+        "profile",
+        "src",
+        "usemap",
+    };
+
+    // Tags which can have a 'src' attribute
+    private String[] tagsWithSrcAttributes = {
+        "frame", "iframe", "img",
+        "input", // Special case - should also check to see if it has a type of 'image'
+        "script", "src",
+    };
+
+    private HttpMessage msg = null;
+    private String htmlPage = null;
+    private Source src = null;
+
+    public HtmlContextAnalyser(HttpMessage msg) {
+        this.msg = msg;
+        this.htmlPage = msg.getResponseBody().toString();
+        src = new Source(htmlPage);
+        src.fullSequentialParse();
+    }
+
+    private boolean isQuote(char chr) {
+        for (int i = 0; i < quotes.length; i++) {
+            if (chr == quotes[i]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isScriptAttribute(String att) {
+        for (int i = 0; i < scriptAttributes.length; i++) {
+            if (att.equalsIgnoreCase(scriptAttributes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isUrlAttribute(String att) {
+        for (int i = 0; i < urlAttributes.length; i++) {
+            if (att.equalsIgnoreCase(urlAttributes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isInTagWithSrcAttribute(String tag) {
+        for (int i = 0; i < tagsWithSrcAttributes.length; i++) {
+            if (tag.equalsIgnoreCase(tagsWithSrcAttributes[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<HtmlContext> getHtmlContexts(String target) {
+        return this.getHtmlContexts(target, null, 0);
+    }
+
+    public List<HtmlContext> getHtmlContexts(
+            String target, HtmlContext targetContext, int ignoreFlags) {
+        return this.getHtmlContexts(target, targetContext, ignoreFlags, false);
+    }
+
+    public List<HtmlContext> getHtmlContexts(
+            String target, HtmlContext targetContext, int ignoreFlags, boolean ignoreSafeParents) {
+        List<HtmlContext> contexts = new ArrayList<>();
+
+        int offset = 0;
+        while ((offset = htmlPage.indexOf(target, offset)) >= 0) {
+            HtmlContext context =
+                    new HtmlContext(this.msg, target, offset, offset + target.length());
+            offset += target.length();
+
+            // Is it in quotes?
+            char leftQuote = 0;
+            for (int i = context.getStart() - 1; i > 0; i--) {
+                char chr = htmlPage.charAt(i);
+                if (isQuote(chr)) {
+                    leftQuote = chr;
+                    break;
+                } else if (chr == '>') {
+                    // end of another tag
+                    break;
+                }
+            }
+            if (leftQuote != 0) {
+                for (int i = context.getEnd(); i < htmlPage.length(); i++) {
+                    char chr = htmlPage.charAt(i);
+                    if (leftQuote == chr) {
+                        // matching quote
+                        context.setSurroundingQuote("" + leftQuote);
+                        break;
+                    } else if (isQuote(chr)) {
+                        // Another non matching quote
+                        break;
+                    } else if (chr == '<') {
+                        // start of another tag
+                        break;
+                    }
+                }
+            }
+            // is it in an HTML comment?
+            String prefix = htmlPage.substring(0, context.getStart());
+            if (prefix.lastIndexOf("<!--") > prefix.lastIndexOf(">")) {
+                // Also check closing comment?
+                context.setHtmlComment(true);
+            }
+
+            // Work out the location in the DOM
+            Element element = src.getEnclosingElement(context.getStart());
+            if (element != null) {
+                // See if its in an attribute
+                boolean isInputTag =
+                        element.getName()
+                                .equalsIgnoreCase("input"); // Special case for input src attributes
+                boolean isImageInputTag = false;
+                Iterator<Attribute> iter = element.getAttributes().iterator();
+                while (iter.hasNext()) {
+                    Attribute att = iter.next();
+                    if (att.getValue() != null
+                            && att.getValue().toLowerCase().indexOf(target.toLowerCase()) >= 0) {
+                        // Found the injected value
+                        context.setTagAttribute(att.getName());
+                        context.setInUrlAttribute(this.isUrlAttribute(att.getName()));
+                        context.setInScriptAttribute(this.isScriptAttribute(att.getName()));
+                    }
+                    if (isInputTag
+                            && att.getName().equalsIgnoreCase("type")
+                            && "image".equalsIgnoreCase(att.getValue())) {
+                        isImageInputTag = true;
+                    }
+                }
+
+                // record the tag hierarchy
+                context.addParentTag(element.getName());
+                if (!isInputTag || isImageInputTag) {
+                    // Input tags only use the src attribute if the type is 'image'
+                    context.setInTagWithSrc(this.isInTagWithSrcAttribute(element.getName()));
+                }
+                while ((element = element.getParentElement()) != null) {
+                    context.addParentTag(element.getName());
+                }
+            }
+            if ((targetContext == null || targetContext.matches(context, ignoreFlags))
+                    && (!ignoreSafeParents || !context.isInSafeParentTag())) {
+                // Matches the supplied context
+                contexts.add(context);
+            }
+        }
+
+        return contexts;
+    }
+}

--- a/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInTextArea.html
+++ b/addOns/ascanrules/src/test/resources/org/zaproxy/zap/extension/ascanrules/crosssitescriptingscanrule/InputInTextArea.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<textarea>
+@@@text@@@
+</textarea>
+</head>
+</html>


### PR DESCRIPTION
A script tag will not run inside a textarea, previously the code would incorrectly report it as an XSS.

As part of this change I've copied HtmlContext and HtmlContextAnalyser from the core - I'll deprecate them in another PR.

Tested against Firing Range (no change) and WebSecLab locally - this fixes 2 of the FP's ZAP currently reports.
The plan is to publish the WebSecLab results on the website.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>