### PR TITLE
Ascanrules: XSS Header splitting

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Cross Site Scripting header splitting attacks.
+
 ### Fixed
 - The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).
 - False positive where Cross Site Scripting payloads are safely rendered in a textarea tag.

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -85,6 +85,9 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                     B_MOUSE_ALERT,
                     SVG_ONLOAD_ALERT,
                     getURLEncode(GENERIC_SCRIPT_ALERT));
+
+    private static final String HEADER_SPLITTING = "\n\r\n\r";
+
     private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_8");
     private static Logger log = LogManager.getLogger(CrossSiteScriptingScanRule.class);
     private int currentParamType;
@@ -170,6 +173,28 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             boolean findDecoded,
             boolean isNullByteSpecialHandling,
             boolean ignoreSafeParents) {
+        return this.performAttack(
+                msg,
+                param,
+                attack,
+                targetContext,
+                attack,
+                ignoreFlags,
+                findDecoded,
+                isNullByteSpecialHandling,
+                ignoreSafeParents);
+    }
+
+    private List<HtmlContext> performAttack(
+            HttpMessage msg,
+            String param,
+            String attack,
+            HtmlContext targetContext,
+            String evidence,
+            int ignoreFlags,
+            boolean findDecoded,
+            boolean isNullByteSpecialHandling,
+            boolean ignoreSafeParents) {
         if (isStop()) {
             return null;
         }
@@ -200,19 +225,456 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
              * so parent context is null.
              */
             attack = attack.replaceFirst(NULL_BYTE_CHARACTER, "");
+            evidence = attack;
         }
         HtmlContextAnalyser hca = new HtmlContextAnalyser(msg2);
         if (Plugin.AlertThreshold.HIGH.equals(this.getAlertThreshold())) {
             // High level, so check all results are in the expected context
             return hca.getHtmlContexts(
-                    findDecoded ? getURLDecode(attack) : attack,
+                    findDecoded ? getURLDecode(evidence) : evidence,
                     targetContext,
                     ignoreFlags,
                     ignoreSafeParents);
         }
-
         return hca.getHtmlContexts(
-                findDecoded ? getURLDecode(attack) : attack, null, 0, ignoreSafeParents);
+                findDecoded ? getURLDecode(evidence) : evidence, null, 0, ignoreSafeParents);
+    }
+
+    private boolean performDirectAttack(HttpMessage msg, String param, String value) {
+        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
+            List<HtmlContext> contexts2 = performAttack(msg, param, "'\"" + scriptAlert, null, 0);
+            if (contexts2 == null) {
+                continue;
+            }
+            if (!contexts2.isEmpty()) {
+                // Yep, its vulnerable
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_LOW)
+                        .setParam(param)
+                        .setAttack(contexts2.get(0).getTarget())
+                        .setEvidence(contexts2.get(0).getTarget())
+                        .setMessage(contexts2.get(0).getMsg())
+                        .raise();
+                return true;
+            }
+
+            if (isStop()) {
+                break;
+            }
+        }
+        return false;
+    }
+
+    private boolean performTagAttack(
+            HtmlContext context, HttpMessage msg, String param, String value) {
+
+        if (context.isInScriptAttribute()) {
+            // Good chance this will be vulnerable
+            // Try a simple alert attack
+            List<HtmlContext> contexts2 = performAttack(msg, param, ";alert(1)", context, 0);
+            if (contexts2 == null) {
+                return false;
+            }
+
+            for (HtmlContext context2 : contexts2) {
+                if (context2.getTagAttribute() != null && context2.isInScriptAttribute()) {
+                    // Yep, its vulnerable
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(context2.getTarget())
+                            .setEvidence(context2.getTarget())
+                            .setMessage(context2.getMsg())
+                            .raise();
+                    return true;
+                }
+            }
+            log.debug(
+                    "Failed to find vuln in script attribute on {}",
+                    msg.getRequestHeader().getURI());
+
+        } else if (context.isInUrlAttribute()) {
+            // Its a url attribute
+            List<HtmlContext> contexts2 =
+                    performAttack(msg, param, "javascript:alert(1);", context, 0);
+            if (contexts2 == null) {
+                return false;
+            }
+
+            for (HtmlContext ctx : contexts2) {
+                if (ctx.isInUrlAttribute()) {
+                    // Yep, its vulnerable
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(ctx.getTarget())
+                            .setEvidence(ctx.getTarget())
+                            .setMessage(ctx.getMsg())
+                            .raise();
+                    return true;
+                }
+            }
+            log.debug(
+                    "Failed to find vuln in url attribute on {}", msg.getRequestHeader().getURI());
+        }
+        if (context.isInTagWithSrc()) {
+            // Its in an attribute in a tag which supports src
+            // attributes
+            List<HtmlContext> contexts2 =
+                    performAttack(
+                            msg,
+                            param,
+                            context.getSurroundingQuote() + " src=http://badsite.com",
+                            context,
+                            HtmlContext.IGNORE_TAG);
+            if (contexts2 == null) {
+                return false;
+            }
+
+            if (!contexts2.isEmpty()) {
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(contexts2.get(0).getTarget())
+                        .setEvidence(contexts2.get(0).getTarget())
+                        .setMessage(contexts2.get(0).getMsg())
+                        .raise();
+                return true;
+            }
+            log.debug(
+                    "Failed to find vuln in tag with src attribute on {}",
+                    msg.getRequestHeader().getURI());
+        }
+
+        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
+            // Try a simple alert attack
+            List<HtmlContext> contexts2 =
+                    performAttack(
+                            msg,
+                            param,
+                            context.getSurroundingQuote() + ">" + scriptAlert,
+                            context,
+                            HtmlContext.IGNORE_TAG);
+            if (contexts2 == null) {
+                return false;
+            }
+            if (!contexts2.isEmpty()) {
+                // Yep, its vulnerable
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(contexts2.get(0).getTarget())
+                        .setEvidence(contexts2.get(0).getTarget())
+                        .setMessage(contexts2.get(0).getMsg())
+                        .raise();
+                return true;
+            }
+            log.debug(
+                    "Failed to find vuln with simple script attack {}",
+                    msg.getRequestHeader().getURI());
+            if (isStop()) {
+                return false;
+            }
+        }
+        // Try adding an onMouseOver
+        List<HtmlContext> contexts2 =
+                performAttack(
+                        msg,
+                        param,
+                        context.getSurroundingQuote()
+                                + " onMouseOver="
+                                + context.getSurroundingQuote()
+                                + "alert(1);",
+                        context,
+                        HtmlContext.IGNORE_TAG);
+        if (contexts2 == null) {
+            return false;
+        }
+        if (!contexts2.isEmpty()) {
+            // Yep, its vulnerable
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setParam(param)
+                    .setAttack(contexts2.get(0).getTarget())
+                    .setEvidence(contexts2.get(0).getTarget())
+                    .setMessage(contexts2.get(0).getMsg())
+                    .raise();
+            return true;
+        }
+        log.debug(
+                "Failed to find vuln in with simple onmounseover {}",
+                msg.getRequestHeader().getURI());
+        return false;
+    }
+
+    private boolean performCommentAttack(HtmlContext context, HttpMessage msg, String param) {
+        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
+            List<HtmlContext> contexts2 =
+                    performAttack(
+                            msg,
+                            param,
+                            "-->" + scriptAlert + "<!--",
+                            context,
+                            HtmlContext.IGNORE_HTML_COMMENT);
+            if (contexts2 == null) {
+                return false;
+            }
+            if (!contexts2.isEmpty()) {
+                // Yep, its vulnerable
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(contexts2.get(0).getTarget())
+                        .setEvidence(contexts2.get(0).getTarget())
+                        .setMessage(contexts2.get(0).getMsg())
+                        .raise();
+                return true;
+            }
+
+            if (isStop()) {
+                return false;
+            }
+        }
+        // Maybe they're blocking script tags
+        List<HtmlContext> contexts2 =
+                performAttack(
+                        msg,
+                        param,
+                        "-->" + B_MOUSE_ALERT + "<!--",
+                        context,
+                        HtmlContext.IGNORE_HTML_COMMENT);
+        if (contexts2 == null) {
+            return false;
+        }
+        if (!contexts2.isEmpty()) {
+            // Yep, its vulnerable
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setParam(param)
+                    .setAttack(contexts2.get(0).getTarget())
+                    .setEvidence(contexts2.get(0).getTarget())
+                    .setMessage(contexts2.get(0).getMsg())
+                    .raise();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean performBodyAttack(HtmlContext context, HttpMessage msg, String param) {
+        // Try a simple alert attack
+        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
+            List<HtmlContext> contexts2 =
+                    performAttack(msg, param, scriptAlert, null, HtmlContext.IGNORE_PARENT);
+            if (contexts2 == null) {
+                continue;
+            }
+            if (!contexts2.isEmpty()) {
+                // Yep, its vulnerable
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(contexts2.get(0).getTarget())
+                        .setEvidence(contexts2.get(0).getTarget())
+                        .setMessage(contexts2.get(0).getMsg())
+                        .raise();
+                return true;
+            }
+            if (isStop()) {
+                return false;
+            }
+        }
+        // Maybe they're blocking script tags
+        List<HtmlContext> contexts2 =
+                performAttack(msg, param, B_MOUSE_ALERT, context, HtmlContext.IGNORE_PARENT);
+        if (contexts2 != null) {
+            for (HtmlContext context2 : contexts2) {
+                if ("body".equalsIgnoreCase(context2.getParentTag())
+                        || "b".equalsIgnoreCase(context2.getParentTag())) {
+                    // Yep, its vulnerable
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(contexts2.get(0).getTarget())
+                            .setEvidence(contexts2.get(0).getTarget())
+                            .setMessage(contexts2.get(0).getMsg())
+                            .raise();
+                    return true;
+                }
+            }
+        }
+        if (GET_POST_TYPES.contains(currentParamType)) {
+            // Try double encoded
+            List<HtmlContext> contexts3 =
+                    performAttack(msg, param, getURLEncode(GENERIC_SCRIPT_ALERT), null, 0, true);
+            if (contexts3 != null && !contexts3.isEmpty()) {
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(getURLEncode(getURLEncode(contexts3.get(0).getTarget())))
+                        .setEvidence(GENERIC_SCRIPT_ALERT)
+                        .setMessage(contexts3.get(0).getMsg())
+                        .raise();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean performCloseTagAttack(HtmlContext context, HttpMessage msg, String param) {
+        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
+            List<HtmlContext> contexts2 =
+                    performAttack(
+                            msg,
+                            param,
+                            "</"
+                                    + context.getParentTag()
+                                    + ">"
+                                    + scriptAlert
+                                    + "<"
+                                    + context.getParentTag()
+                                    + ">",
+                            context,
+                            HtmlContext.IGNORE_IN_SCRIPT);
+            if (contexts2 == null) {
+                return false;
+            }
+            for (HtmlContext ctx : contexts2) {
+                if (ctx.getSurroundingQuote().isEmpty()) {
+                    // Yep, its vulnerable
+                    newAlert()
+                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                            .setParam(param)
+                            .setAttack(ctx.getTarget())
+                            .setEvidence(ctx.getTarget())
+                            .setMessage(ctx.getMsg())
+                            .raise();
+                    return true;
+                }
+            }
+            if (isStop()) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private boolean performScriptAttack(HtmlContext context, HttpMessage msg, String param) {
+        List<HtmlContext> contexts2 =
+                performAttack(
+                        msg,
+                        param,
+                        context.getSurroundingQuote()
+                                + ";alert(1);"
+                                + context.getSurroundingQuote(),
+                        context,
+                        0);
+        if (contexts2 == null) {
+            return false;
+        }
+        for (HtmlContext ctx : contexts2) {
+            if (context.getSurroundingQuote().isEmpty() || !ctx.getSurroundingQuote().isEmpty()) {
+                // Yep, its vulnerable
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(ctx.getTarget())
+                        .setEvidence(ctx.getTarget())
+                        .setMessage(ctx.getMsg())
+                        .raise();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean performOutsideTagsAttack(HtmlContext context, HttpMessage msg, String param) {
+        for (String scriptAlert : OUTSIDE_OF_TAGS_PAYLOADS) {
+            if (context.getMsg().getResponseBody().toString().contains(context.getTarget())) {
+                List<HtmlContext> contexts2 =
+                        performAttack(msg, param, scriptAlert, null, 0, false, true, true);
+                if (contexts2 == null) {
+                    continue;
+                }
+                for (HtmlContext ctx : contexts2) {
+                    if (ctx.getParentTag() != null) {
+                        // Yep, its vulnerable
+                        if (ctx.getMsg().getResponseHeader().isHtml()) {
+                            newAlert()
+                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                                    .setParam(param)
+                                    .setAttack(ctx.getTarget())
+                                    .setEvidence(ctx.getTarget())
+                                    .setMessage(contexts2.get(0).getMsg())
+                                    .raise();
+                        } else {
+                            HttpMessage ctx2Message = contexts2.get(0).getMsg();
+                            if (StringUtils.containsIgnoreCase(
+                                    ctx.getMsg()
+                                            .getResponseHeader()
+                                            .getHeader(HttpHeader.CONTENT_TYPE),
+                                    "json")) {
+                                newAlert()
+                                        .setRisk(Alert.RISK_LOW)
+                                        .setConfidence(Alert.CONFIDENCE_LOW)
+                                        .setName(
+                                                Constant.messages.getString(
+                                                        MESSAGE_PREFIX + "json.name"))
+                                        .setDescription(
+                                                Constant.messages.getString(
+                                                        MESSAGE_PREFIX + "json.desc"))
+                                        .setParam(param)
+                                        .setAttack(scriptAlert)
+                                        .setOtherInfo(
+                                                Constant.messages.getString(
+                                                        MESSAGE_PREFIX + "otherinfo.nothtml"))
+                                        .setMessage(ctx2Message)
+                                        .raise();
+                            } else {
+                                newAlert()
+                                        .setConfidence(Alert.CONFIDENCE_LOW)
+                                        .setParam(param)
+                                        .setAttack(ctx.getTarget())
+                                        .setOtherInfo(
+                                                Constant.messages.getString(
+                                                        MESSAGE_PREFIX + "otherinfo.nothtml"))
+                                        .setEvidence(ctx.getTarget())
+                                        .setMessage(ctx2Message)
+                                        .raise();
+                            }
+                        }
+                        return true;
+                    }
+                }
+            }
+            if (isStop()) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private boolean performImageTagAttack(HtmlContext context, HttpMessage msg, String param) {
+        List<HtmlContext> contextsA =
+                performAttack(
+                        msg,
+                        param,
+                        GENERIC_ONERROR_ALERT,
+                        context,
+                        HtmlContext.IGNORE_IN_SCRIPT,
+                        false,
+                        false,
+                        true);
+        if (contextsA != null && !contextsA.isEmpty()) {
+            newAlert()
+                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                    .setParam(param)
+                    .setAttack(contextsA.get(0).getTarget())
+                    .setEvidence(contextsA.get(0).getTarget())
+                    .setMessage(contextsA.get(0).getMsg())
+                    .raise();
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -225,6 +687,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         try {
             // Inject the 'safe' eyecatcher and see where it appears
             boolean attackWorked = false;
+            boolean appendedValue = false;
             HttpMessage msg2 = getNewMsg();
             setParameter(msg2, param, Constant.getEyeCatcher());
             try {
@@ -257,6 +720,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 // value
                 msg2 = getNewMsg();
                 setParameter(msg2, param, value + Constant.getEyeCatcher());
+                appendedValue = true;
                 try {
                     sendAndReceive(msg2);
                 } catch (URIException e) {
@@ -271,29 +735,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 contexts = hca.getHtmlContexts(value + Constant.getEyeCatcher(), null, 0);
             }
             if (contexts.isEmpty()) {
-                // No luck - lets just try a direct attack
-                for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
-                    List<HtmlContext> contexts2 =
-                            performAttack(msg, param, "'\"" + scriptAlert, null, 0);
-                    if (contexts2 == null) {
-                        return;
-                    }
-                    if (!contexts2.isEmpty()) {
-                        // Yep, its vulnerable
-                        newAlert()
-                                .setConfidence(Alert.CONFIDENCE_LOW)
-                                .setParam(param)
-                                .setAttack(contexts2.get(0).getTarget())
-                                .setEvidence(contexts2.get(0).getTarget())
-                                .setMessage(contexts2.get(0).getMsg())
-                                .raise();
-                        attackWorked = true;
-                    }
-
-                    if (attackWorked || isStop()) {
-                        return;
-                    }
-                }
+                attackWorked = performDirectAttack(msg, param, value);
             }
 
             for (HtmlContext context : contexts) {
@@ -304,476 +746,67 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 }
                 if (context.getTagAttribute() != null) {
                     // its in a tag attribute - lots of attack vectors possible
+                    attackWorked = performTagAttack(context, msg, param, value);
 
-                    if (context.isInScriptAttribute()) {
-                        // Good chance this will be vulnerable
-                        // Try a simple alert attack
-                        List<HtmlContext> contexts2 =
-                                performAttack(msg, param, ";alert(1)", context, 0);
-                        if (contexts2 == null) {
-                            break;
-                        }
-
-                        for (HtmlContext context2 : contexts2) {
-                            if (context2.getTagAttribute() != null
-                                    && context2.isInScriptAttribute()) {
-                                // Yep, its vulnerable
-                                newAlert()
-                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                        .setParam(param)
-                                        .setAttack(context2.getTarget())
-                                        .setEvidence(context2.getTarget())
-                                        .setMessage(context2.getMsg())
-                                        .raise();
-                                attackWorked = true;
-                                break;
-                            }
-                        }
-                        if (!attackWorked) {
-                            log.debug(
-                                    "Failed to find vuln in script attribute on {}",
-                                    msg.getRequestHeader().getURI());
-                        }
-
-                    } else if (context.isInUrlAttribute()) {
-                        // Its a url attribute
-                        List<HtmlContext> contexts2 =
-                                performAttack(msg, param, "javascript:alert(1);", context, 0);
-                        if (contexts2 == null) {
-                            break;
-                        }
-
-                        for (HtmlContext ctx : contexts2) {
-                            if (ctx.isInUrlAttribute()) {
-                                // Yep, its vulnerable
-                                newAlert()
-                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                        .setParam(param)
-                                        .setAttack(ctx.getTarget())
-                                        .setEvidence(ctx.getTarget())
-                                        .setMessage(ctx.getMsg())
-                                        .raise();
-                                attackWorked = true;
-                                break;
-                            }
-                        }
-                        if (!attackWorked) {
-                            log.debug(
-                                    "Failed to find vuln in url attribute on {}",
-                                    msg.getRequestHeader().getURI());
-                        }
-                    }
-                    if (!attackWorked && context.isInTagWithSrc()) {
-                        // Its in an attribute in a tag which supports src
-                        // attributes
-                        List<HtmlContext> contexts2 =
-                                performAttack(
-                                        msg,
-                                        param,
-                                        context.getSurroundingQuote() + " src=http://badsite.com",
-                                        context,
-                                        HtmlContext.IGNORE_TAG);
-                        if (contexts2 == null) {
-                            break;
-                        }
-
-                        if (!contexts2.isEmpty()) {
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setParam(param)
-                                    .setAttack(contexts2.get(0).getTarget())
-                                    .setEvidence(contexts2.get(0).getTarget())
-                                    .setMessage(contexts2.get(0).getMsg())
-                                    .raise();
-                            attackWorked = true;
-                        }
-                        if (!attackWorked) {
-                            log.debug(
-                                    "Failed to find vuln in tag with src attribute on {}",
-                                    msg.getRequestHeader().getURI());
-                        }
-                    }
-
-                    if (!attackWorked) {
-                        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
-                            // Try a simple alert attack
-                            List<HtmlContext> contexts2 =
-                                    performAttack(
-                                            msg,
-                                            param,
-                                            context.getSurroundingQuote() + ">" + scriptAlert,
-                                            context,
-                                            HtmlContext.IGNORE_TAG);
-                            if (contexts2 == null) {
-                                return;
-                            }
-                            if (!contexts2.isEmpty()) {
-                                // Yep, its vulnerable
-                                newAlert()
-                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                        .setParam(param)
-                                        .setAttack(contexts2.get(0).getTarget())
-                                        .setEvidence(contexts2.get(0).getTarget())
-                                        .setMessage(contexts2.get(0).getMsg())
-                                        .raise();
-                                attackWorked = true;
-                            }
-                            if (!attackWorked) {
-                                log.debug(
-                                        "Failed to find vuln with simple script attack {}",
-                                        msg.getRequestHeader().getURI());
-                            }
-
-                            if (attackWorked || isStop()) {
-                                return;
-                            }
-                        }
-                    }
-                    if (!attackWorked) {
-                        // Try adding an onMouseOver
-                        List<HtmlContext> contexts2 =
-                                performAttack(
-                                        msg,
-                                        param,
-                                        context.getSurroundingQuote()
-                                                + " onMouseOver="
-                                                + context.getSurroundingQuote()
-                                                + "alert(1);",
-                                        context,
-                                        HtmlContext.IGNORE_TAG);
-                        if (contexts2 == null) {
-                            break;
-                        }
-                        if (!contexts2.isEmpty()) {
-                            // Yep, its vulnerable
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setParam(param)
-                                    .setAttack(contexts2.get(0).getTarget())
-                                    .setEvidence(contexts2.get(0).getTarget())
-                                    .setMessage(contexts2.get(0).getMsg())
-                                    .raise();
-                            attackWorked = true;
-                        }
-                        if (!attackWorked) {
-                            log.debug(
-                                    "Failed to find vuln in with simple onmounseover {}",
-                                    msg.getRequestHeader().getURI());
-                        }
-                    }
                 } else if (context.isHtmlComment()) {
                     // Try breaking out of the comment
-                    for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
-                        List<HtmlContext> contexts2 =
-                                performAttack(
-                                        msg,
-                                        param,
-                                        "-->" + scriptAlert + "<!--",
-                                        context,
-                                        HtmlContext.IGNORE_HTML_COMMENT);
-                        if (contexts2 == null) {
-                            return;
-                        }
-                        if (!contexts2.isEmpty()) {
-                            // Yep, its vulnerable
-                            newAlert()
-                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                    .setParam(param)
-                                    .setAttack(contexts2.get(0).getTarget())
-                                    .setEvidence(contexts2.get(0).getTarget())
-                                    .setMessage(contexts2.get(0).getMsg())
-                                    .raise();
-                            attackWorked = true;
-                        }
-
-                        if (attackWorked || isStop()) {
-                            return;
-                        }
-                    }
-                    // Maybe they're blocking script tags
-                    List<HtmlContext> contexts2 =
-                            performAttack(
-                                    msg,
-                                    param,
-                                    "-->" + B_MOUSE_ALERT + "<!--",
-                                    context,
-                                    HtmlContext.IGNORE_HTML_COMMENT);
-                    if (contexts2 == null) {
-                        break;
-                    }
-                    if (!contexts2.isEmpty()) {
-                        // Yep, its vulnerable
-                        newAlert()
-                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                .setParam(param)
-                                .setAttack(contexts2.get(0).getTarget())
-                                .setEvidence(contexts2.get(0).getTarget())
-                                .setMessage(contexts2.get(0).getMsg())
-                                .raise();
-                        attackWorked = true;
-                    }
-
+                    attackWorked = performCommentAttack(context, msg, param);
                 } else {
                     // its not in a tag attribute
                     if ("body".equalsIgnoreCase(context.getParentTag())) {
                         // Immediately under a body tag
-                        // Try a simple alert attack
-                        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
-                            List<HtmlContext> contexts2 =
-                                    performAttack(
-                                            msg,
-                                            param,
-                                            scriptAlert,
-                                            null,
-                                            HtmlContext.IGNORE_PARENT);
-                            if (contexts2 == null) {
-                                return;
-                            }
-                            if (!contexts2.isEmpty()) {
-                                // Yep, its vulnerable
-                                newAlert()
-                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                        .setParam(param)
-                                        .setAttack(contexts2.get(0).getTarget())
-                                        .setEvidence(contexts2.get(0).getTarget())
-                                        .setMessage(contexts2.get(0).getMsg())
-                                        .raise();
-                                attackWorked = true;
-                            }
-                            if (attackWorked || isStop()) {
-                                return;
-                            }
-                        }
-                        // Maybe they're blocking script tags
-                        List<HtmlContext> contexts2 =
-                                performAttack(
-                                        msg,
-                                        param,
-                                        B_MOUSE_ALERT,
-                                        context,
-                                        HtmlContext.IGNORE_PARENT);
-                        if (contexts2 != null) {
-                            for (HtmlContext context2 : contexts2) {
-                                if ("body".equalsIgnoreCase(context2.getParentTag())
-                                        || "b".equalsIgnoreCase(context2.getParentTag())) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(contexts2.get(0).getTarget())
-                                            .setEvidence(contexts2.get(0).getTarget())
-                                            .setMessage(contexts2.get(0).getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if (!attackWorked) {
-                            if (GET_POST_TYPES.contains(currentParamType)) {
-                                // Try double encoded
-                                List<HtmlContext> contexts3 =
-                                        performAttack(
-                                                msg,
-                                                param,
-                                                getURLEncode(GENERIC_SCRIPT_ALERT),
-                                                null,
-                                                0,
-                                                true);
-                                if (contexts3 != null && !contexts3.isEmpty()) {
-                                    attackWorked = true;
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(
-                                                    getURLEncode(
-                                                            getURLEncode(
-                                                                    contexts3.get(0).getTarget())))
-                                            .setEvidence(GENERIC_SCRIPT_ALERT)
-                                            .setMessage(contexts3.get(0).getMsg())
-                                            .raise();
-                                }
-                                break;
-                            }
-                        }
+                        attackWorked = performBodyAttack(context, msg, param);
 
                     } else if (context.getParentTag() != null) {
                         // Its not immediately under a body tag, try to close
                         // the tag
-                        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
-                            List<HtmlContext> contexts2 =
-                                    performAttack(
-                                            msg,
-                                            param,
-                                            "</"
-                                                    + context.getParentTag()
-                                                    + ">"
-                                                    + scriptAlert
-                                                    + "<"
-                                                    + context.getParentTag()
-                                                    + ">",
-                                            context,
-                                            HtmlContext.IGNORE_IN_SCRIPT);
-                            if (contexts2 == null) {
-                                return;
-                            }
-                            for (HtmlContext ctx : contexts2) {
-                                if (ctx.getSurroundingQuote().isEmpty()) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(ctx.getTarget())
-                                            .setEvidence(ctx.getTarget())
-                                            .setMessage(ctx.getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                    break;
-                                }
-                            }
-                            if (attackWorked || isStop()) {
-                                return;
-                            }
-                        }
-                        if ("script".equalsIgnoreCase(context.getParentTag())) {
+                        attackWorked = performCloseTagAttack(context, msg, param);
+
+                        if (attackWorked) {
+                            break;
+                        } else if ("script".equalsIgnoreCase(context.getParentTag())) {
                             // its in a script tag...
-                            List<HtmlContext> contexts2 =
-                                    performAttack(
-                                            msg,
-                                            param,
-                                            context.getSurroundingQuote()
-                                                    + ";alert(1);"
-                                                    + context.getSurroundingQuote(),
-                                            context,
-                                            0);
-                            if (contexts2 == null) {
-                                break;
-                            }
-                            for (HtmlContext ctx : contexts2) {
-                                if (context.getSurroundingQuote().isEmpty()
-                                        || !ctx.getSurroundingQuote().isEmpty()) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(ctx.getTarget())
-                                            .setEvidence(ctx.getTarget())
-                                            .setMessage(ctx.getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                    break;
-                                }
-                            }
+                            attackWorked = performScriptAttack(context, msg, param);
                         } else {
                             // Try an img tag
-                            List<HtmlContext> contextsA =
-                                    performAttack(
-                                            msg,
-                                            param,
-                                            GENERIC_ONERROR_ALERT,
-                                            context,
-                                            HtmlContext.IGNORE_IN_SCRIPT,
-                                            false,
-                                            false,
-                                            true);
-                            if (contextsA != null && !contextsA.isEmpty()) {
-                                newAlert()
-                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                        .setParam(param)
-                                        .setAttack(contextsA.get(0).getTarget())
-                                        .setEvidence(contextsA.get(0).getTarget())
-                                        .setMessage(contextsA.get(0).getMsg())
-                                        .raise();
-                                attackWorked = true;
-                                break;
-                            }
+                            attackWorked = performImageTagAttack(context, msg, param);
                         }
                     } else {
                         // Last chance - is the payload reflected outside of any
                         // tags
-                        for (String scriptAlert : OUTSIDE_OF_TAGS_PAYLOADS) {
-                            if (context.getMsg()
-                                    .getResponseBody()
-                                    .toString()
-                                    .contains(context.getTarget())) {
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                msg,
-                                                param,
-                                                scriptAlert,
-                                                null,
-                                                0,
-                                                false,
-                                                true,
-                                                true);
-                                if (contexts2 == null) {
-                                    return;
-                                }
-                                for (HtmlContext ctx : contexts2) {
-                                    if (ctx.getParentTag() != null) {
-                                        // Yep, its vulnerable
-                                        if (ctx.getMsg().getResponseHeader().isHtml()) {
-                                            newAlert()
-                                                    .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                    .setParam(param)
-                                                    .setAttack(ctx.getTarget())
-                                                    .setEvidence(ctx.getTarget())
-                                                    .setMessage(contexts2.get(0).getMsg())
-                                                    .raise();
-                                        } else {
-                                            HttpMessage ctx2Message = contexts2.get(0).getMsg();
-                                            if (StringUtils.containsIgnoreCase(
-                                                    ctx.getMsg()
-                                                            .getResponseHeader()
-                                                            .getHeader(HttpHeader.CONTENT_TYPE),
-                                                    "json")) {
-                                                newAlert()
-                                                        .setRisk(Alert.RISK_LOW)
-                                                        .setConfidence(Alert.CONFIDENCE_LOW)
-                                                        .setName(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "json.name"))
-                                                        .setDescription(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "json.desc"))
-                                                        .setParam(param)
-                                                        .setAttack(scriptAlert)
-                                                        .setOtherInfo(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "otherinfo.nothtml"))
-                                                        .setMessage(ctx2Message)
-                                                        .raise();
-                                            } else {
-                                                newAlert()
-                                                        .setConfidence(Alert.CONFIDENCE_LOW)
-                                                        .setParam(param)
-                                                        .setAttack(ctx.getTarget())
-                                                        .setOtherInfo(
-                                                                Constant.messages.getString(
-                                                                        MESSAGE_PREFIX
-                                                                                + "otherinfo.nothtml"))
-                                                        .setEvidence(ctx.getTarget())
-                                                        .setMessage(ctx2Message)
-                                                        .raise();
-                                            }
-                                        }
-                                        attackWorked = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (attackWorked || isStop()) {
-                                return;
-                            }
-                        }
+                        attackWorked = performOutsideTagsAttack(context, msg, param);
                     }
                 }
             }
+            // Always attack the header if the eyecatcher is reflected in it - this will be
+            // different to any alert raised above
+            if (msg2.getResponseHeader().toString().contains(Constant.getEyeCatcher())) {
+                attackHeader(msg, param, appendedValue ? value : "");
+            }
+
         } catch (Exception e) {
             log.error(e.getMessage(), e);
+        }
+    }
+
+    private void attackHeader(HttpMessage msg, String param, String value) {
+        // We know the eyecatcher was reflected in the header, lets try some header splitting
+        // attacks
+        for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
+            String attack = value + HEADER_SPLITTING + scriptAlert;
+            List<HtmlContext> contexts2 =
+                    performAttack(msg, param, attack, null, scriptAlert, 0, false, false, true);
+            if (contexts2 != null && !contexts2.isEmpty()) {
+                // Yep, its vulnerable
+                newAlert()
+                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                        .setParam(param)
+                        .setAttack(attack)
+                        .setEvidence(contexts2.get(0).getTarget())
+                        .setMessage(contexts2.get(0).getMsg())
+                        .raise();
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
This finds a header splitting vulnerability in https://github.com/yahoo/webseclab

Also restructured the XSS scan(..) method to split it up.
The plan was for this to make no changes but I spotted some cases when we exited on finding no HtmlContexts where I think we should just continue to try the next payload, so changed those cases. This hasnt affected the unit tests at all.

I havnt updated the help as its pretty generic but happy to do so if anyone things it would help.

Signed-off-by: Simon Bennetts <psiinon@gmail.com>