### PR TITLE
chore: Bugtracker: Address github library deprecations

### DIFF
--- a/addOns/bugtracker/CHANGELOG.md
+++ b/addOns/bugtracker/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.11.1.
 - Dependency updates.
 - Maintenance changes.
+- Updated to use PAT not password (https://github.blog/changelog/2021-08-12-git-password-authentication-is-shutting-down/).
 
 ## [3] - 2021-10-07
 ### Added

--- a/addOns/bugtracker/bugtracker.gradle.kts
+++ b/addOns/bugtracker/bugtracker.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
         // Not needed.
         exclude(group = "junit")
     }
-    implementation("org.kohsuke:github-api:1.135") {
+    implementation("org.kohsuke:github-api:1.303") {
         // Not needed.
         exclude(group = "com.infradna.tool")
         // Provided by ZAP.

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithub.java
@@ -50,7 +50,7 @@ public class BugTrackerGithub extends BugTracker {
     private String FIELD_ASSIGNEE_MANUAL = "bugtracker.trackers.github.issue.assignee.manual";
     private String FIELD_ASSIGNEE_LIST = "bugtracker.trackers.github.issue.assignee.list";
     private String FIELD_USERNAME = "bugtracker.trackers.github.issue.username";
-    private String FIELD_PASSWORD = "bugtracker.trackers.github.issue.password";
+    private String FIELD_TOKEN = "bugtracker.trackers.github.issue.token";
     private String FIELD_GITHUB_CONFIG = "bugtracker.trackers.github.issue.config";
     private String titleIssue = null;
     private String bodyIssue = null;
@@ -102,7 +102,7 @@ public class BugTrackerGithub extends BugTracker {
         dialog.addTextField(FIELD_ASSIGNEE_MANUAL, "");
         dialog.addComboField(FIELD_ASSIGNEE_LIST, new ArrayList<>(), "");
         dialog.addTextField(FIELD_USERNAME, "");
-        dialog.addTextField(FIELD_PASSWORD, "");
+        dialog.addTextField(FIELD_TOKEN, "");
         updateAssigneeList();
         dialog.addFieldListener(FIELD_GITHUB_CONFIG, e -> updateAssigneeList());
     }
@@ -121,7 +121,7 @@ public class BugTrackerGithub extends BugTracker {
                         repoFormatted = repoFormatted.split("https://www.github.com/")[1];
                     }
                     collaborators =
-                            getCollaborators(config.getName(), config.getPassword(), repoFormatted);
+                            getCollaborators(config.getName(), config.getToken(), repoFormatted);
                     if (collaborators != null && collaborators.size() > 0) {
                         List<String> assignees = new ArrayList<>(collaborators);
                         dialog.setComboFields(FIELD_ASSIGNEE_LIST, assignees, "");
@@ -264,9 +264,9 @@ public class BugTrackerGithub extends BugTracker {
         return this.labelsIssue;
     }
 
-    public Set<String> getCollaborators(String username, String password, String repo)
+    public Set<String> getCollaborators(String username, String token, String repo)
             throws IOException {
-        GitHub github = GitHub.connectUsingPassword(username, password);
+        GitHub github = GitHub.connect(username, token);
         Set<String> collaborators = null;
         try {
             GHRepository repository = github.getRepository(repo);
@@ -295,9 +295,9 @@ public class BugTrackerGithub extends BugTracker {
             String labels,
             String assignee,
             String username,
-            String password)
+            String token)
             throws IOException {
-        GitHub github = GitHub.connectUsingPassword(username, password);
+        GitHub github = GitHub.connect(username, token);
         try {
             GHRepository repository = github.getRepository(repo);
             GHIssueBuilder issue = repository.createIssue(title);
@@ -361,14 +361,14 @@ public class BugTrackerGithub extends BugTracker {
         labels = dialog.getStringValue(FIELD_LABELS);
         assignee = dialog.getStringValue(FIELD_ASSIGNEE_MANUAL);
         username = dialog.getStringValue(FIELD_USERNAME);
-        password = dialog.getStringValue(FIELD_PASSWORD);
+        password = dialog.getStringValue(FIELD_TOKEN);
         configGithub = dialog.getStringValue(FIELD_GITHUB_CONFIG);
         if (repo.equals("") || username.equals("") || password.equals("")) {
             List<BugTrackerGithubConfigParams> configs = getOptions().getConfigs();
             for (BugTrackerGithubConfigParams config : configs) {
                 if (config.getName().equals(configGithub)) {
                     username = config.getName();
-                    password = config.getPassword();
+                    password = config.getToken();
                 }
             }
         }

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubConfigParams.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubConfigParams.java
@@ -24,29 +24,29 @@ import org.zaproxy.zap.utils.Enableable;
 class BugTrackerGithubConfigParams extends Enableable {
 
     private String username;
-    private String password;
+    private String token;
     private String repoUrl;
 
     public BugTrackerGithubConfigParams() {
         this("", "", "");
     }
 
-    public BugTrackerGithubConfigParams(String username, String password, String repoUrl) {
+    public BugTrackerGithubConfigParams(String username, String token, String repoUrl) {
         this.username = username;
-        this.password = password;
+        this.token = token;
         this.repoUrl = repoUrl;
     }
 
     public BugTrackerGithubConfigParams(BugTrackerGithubConfigParams config) {
-        this(config.username, config.password, config.repoUrl);
+        this(config.username, config.token, config.repoUrl);
     }
 
     public String getName() {
         return username;
     }
 
-    public String getPassword() {
-        return password;
+    public String getToken() {
+        return token;
     }
 
     public String getRepoUrl() {
@@ -57,8 +57,8 @@ class BugTrackerGithubConfigParams extends Enableable {
         this.username = username;
     }
 
-    public void setPassword(String password) {
-        this.password = password;
+    public void setToken(String token) {
+        this.token = token;
     }
 
     public void setRepoUrl(String repoUrl) {
@@ -69,7 +69,7 @@ class BugTrackerGithubConfigParams extends Enableable {
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + ((password == null) ? 0 : password.hashCode());
+        result = prime * result + ((token == null) ? 0 : token.hashCode());
         result = prime * result + ((repoUrl == null) ? 0 : repoUrl.hashCode());
         result = prime * result + ((username == null) ? 0 : username.hashCode());
         return result;
@@ -94,11 +94,11 @@ class BugTrackerGithubConfigParams extends Enableable {
         } else if (!username.equals(other.username)) {
             return false;
         }
-        if (password == null) {
-            if (other.password != null) {
+        if (token == null) {
+            if (other.token != null) {
                 return false;
             }
-        } else if (!password.equals(other.password)) {
+        } else if (!token.equals(other.token)) {
             return false;
         }
         if (repoUrl == null) {

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubParam.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubParam.java
@@ -38,7 +38,7 @@ public class BugTrackerGithubParam extends AbstractParam {
     private static final String ALL_CONFIGS_KEY = GITHUB_BASE_KEY + ".configs.config";
 
     private static final String CONFIG_NAME_KEY = "name";
-    private static final String CONFIG_PASSWORD_KEY = "password";
+    private static final String CONFIG_TOKEN_KEY = "token";
     private static final String CONFIG_REPO_URL_KEY = "repoUrl";
 
     private static final String CONFIRM_REMOVE_CONFIG_KEY =
@@ -59,7 +59,7 @@ public class BugTrackerGithubParam extends AbstractParam {
             List<String> tempConfigsNames = new ArrayList<>(fields.size());
             for (HierarchicalConfiguration sub : fields) {
                 String name = sub.getString(CONFIG_NAME_KEY, "");
-                String password = sub.getString(CONFIG_PASSWORD_KEY, "");
+                String password = sub.getString(CONFIG_TOKEN_KEY, "");
                 String repoUrl = sub.getString(CONFIG_REPO_URL_KEY, "");
                 if (!"".equals(name) && !tempConfigsNames.contains(name)) {
                     this.configs.add(new BugTrackerGithubConfigParams(name, password, repoUrl));
@@ -94,7 +94,7 @@ public class BugTrackerGithubParam extends AbstractParam {
             BugTrackerGithubConfigParams config = configs.get(i);
 
             getConfig().setProperty(elementBaseKey + CONFIG_NAME_KEY, config.getName());
-            getConfig().setProperty(elementBaseKey + CONFIG_PASSWORD_KEY, config.getPassword());
+            getConfig().setProperty(elementBaseKey + CONFIG_TOKEN_KEY, config.getToken());
             getConfig().setProperty(elementBaseKey + CONFIG_REPO_URL_KEY, config.getRepoUrl());
         }
     }

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubTableModel.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/BugTrackerGithubTableModel.java
@@ -31,7 +31,7 @@ public class BugTrackerGithubTableModel
 
     private static final String[] COLUMN_NAMES = {
         Constant.messages.getString("bugtracker.trackers.github.table.header.username"),
-        Constant.messages.getString("bugtracker.trackers.github.table.header.password"),
+        Constant.messages.getString("bugtracker.trackers.github.table.header.token"),
         Constant.messages.getString("bugtracker.trackers.github.table.header.repoUrl")
     };
 

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogAddGithubConfig.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogAddGithubConfig.java
@@ -46,9 +46,9 @@ class DialogAddGithubConfig extends AbstractFormDialog {
     private static final String NAME_FIELD_LABEL =
             Constant.messages.getString(
                     "bugtracker.trackers.github.dialog.config.field.label.name");
-    private static final String PASSWORD_FIELD_LABEL =
+    private static final String TOKEN_FIELD_LABEL =
             Constant.messages.getString(
-                    "bugtracker.trackers.github.dialog.config.field.label.password");
+                    "bugtracker.trackers.github.dialog.config.field.label.token");
     private static final String REPO_URL_FIELD_LABEL =
             Constant.messages.getString(
                     "bugtracker.trackers.github.dialog.config.field.label.repoUrl");
@@ -61,7 +61,7 @@ class DialogAddGithubConfig extends AbstractFormDialog {
                     "bugtracker.trackers.github.dialog.config.warning.name.repeated.text");
 
     private ZapTextField nameTextField;
-    private JPasswordField passwordTextField;
+    private JPasswordField tokenTextField;
     private ZapTextField repoUrlTextField;
 
     protected BugTrackerGithubConfigParams config;
@@ -85,7 +85,7 @@ class DialogAddGithubConfig extends AbstractFormDialog {
         layout.setAutoCreateContainerGaps(true);
 
         JLabel nameLabel = new JLabel(NAME_FIELD_LABEL);
-        JLabel passwordLabel = new JLabel(PASSWORD_FIELD_LABEL);
+        JLabel tokenLabel = new JLabel(TOKEN_FIELD_LABEL);
         JLabel repoUrlLabel = new JLabel(REPO_URL_FIELD_LABEL);
 
         layout.setHorizontalGroup(
@@ -93,12 +93,12 @@ class DialogAddGithubConfig extends AbstractFormDialog {
                         .addGroup(
                                 layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
                                         .addComponent(nameLabel)
-                                        .addComponent(passwordLabel)
+                                        .addComponent(tokenLabel)
                                         .addComponent(repoUrlLabel))
                         .addGroup(
                                 layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                                         .addComponent(getNameTextField())
-                                        .addComponent(getPasswordTextField())
+                                        .addComponent(getTokenTextField())
                                         .addComponent(getRepoUrlTextField())));
 
         layout.setVerticalGroup(
@@ -109,8 +109,8 @@ class DialogAddGithubConfig extends AbstractFormDialog {
                                         .addComponent(getNameTextField()))
                         .addGroup(
                                 layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
-                                        .addComponent(passwordLabel)
-                                        .addComponent(getPasswordTextField()))
+                                        .addComponent(tokenLabel)
+                                        .addComponent(getTokenTextField()))
                         .addGroup(
                                 layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                                         .addComponent(repoUrlLabel)
@@ -127,7 +127,7 @@ class DialogAddGithubConfig extends AbstractFormDialog {
     @Override
     protected void init() {
         getNameTextField().setText("");
-        getPasswordTextField().setText("");
+        getTokenTextField().setText("");
         getRepoUrlTextField().setText("");
         config = null;
     }
@@ -155,7 +155,7 @@ class DialogAddGithubConfig extends AbstractFormDialog {
         config =
                 new BugTrackerGithubConfigParams(
                         getNameTextField().getText(),
-                        new String(getPasswordTextField().getPassword()),
+                        new String(getTokenTextField().getPassword()),
                         getRepoUrlTextField().getText());
     }
 
@@ -163,7 +163,7 @@ class DialogAddGithubConfig extends AbstractFormDialog {
     protected void clearFields() {
         getNameTextField().setText("");
         getNameTextField().discardAllEdits();
-        getPasswordTextField().setText("");
+        getTokenTextField().setText("");
         getRepoUrlTextField().setText("");
         getRepoUrlTextField().discardAllEdits();
     }
@@ -205,10 +205,10 @@ class DialogAddGithubConfig extends AbstractFormDialog {
         return nameTextField;
     }
 
-    protected JPasswordField getPasswordTextField() {
-        if (passwordTextField == null) {
-            passwordTextField = new JPasswordField(50);
-            passwordTextField
+    protected JPasswordField getTokenTextField() {
+        if (tokenTextField == null) {
+            tokenTextField = new JPasswordField(50);
+            tokenTextField
                     .getDocument()
                     .addDocumentListener(
                             new DocumentListener() {
@@ -230,12 +230,12 @@ class DialogAddGithubConfig extends AbstractFormDialog {
 
                                 private void checkAndEnableConfirmButton() {
                                     setConfirmButtonEnabled(
-                                            getPasswordTextField().getDocument().getLength() > 0);
+                                            getTokenTextField().getDocument().getLength() > 0);
                                 }
                             });
         }
 
-        return passwordTextField;
+        return tokenTextField;
     }
 
     protected ZapTextField getRepoUrlTextField() {

--- a/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogModifyGithubConfig.java
+++ b/addOns/bugtracker/src/main/java/org/zaproxy/zap/extension/bugtracker/DialogModifyGithubConfig.java
@@ -58,7 +58,7 @@ class DialogModifyGithubConfig extends DialogAddGithubConfig {
     protected void init() {
         getNameTextField().setText(config.getName());
         getNameTextField().discardAllEdits();
-        getPasswordTextField().setText(config.getPassword());
+        getTokenTextField().setText(config.getToken());
         getRepoUrlTextField().setText(config.getRepoUrl());
         getRepoUrlTextField().discardAllEdits();
     }

--- a/addOns/bugtracker/src/main/javahelp/org/zaproxy/zap/extension/bugtracker/resources/help/contents/bugtracker.html
+++ b/addOns/bugtracker/src/main/javahelp/org/zaproxy/zap/extension/bugtracker/resources/help/contents/bugtracker.html
@@ -11,7 +11,7 @@ The Bug Tracker add-on can help the user raise the Alerts that they receive in t
 
 <H2>Configuration of Bug Trackers</H2>
 <p>
-The user may configure the Bug Trackers with their important details like Username, Password, Repository URL, etc. by going to <b>Options->Bug Tracker</b> and then selecting the appropriate Bug Tracker.
+The user may configure the Bug Trackers with their important details like Username, Password/Token, Repository URL, etc. by going to <b>Options->Bug Tracker</b> and then selecting the appropriate Bug Tracker.
 </p>
 
 <H2>Raising the Issues</H2>

--- a/addOns/bugtracker/src/main/resources/org/zaproxy/zap/extension/bugtracker/resources/Messages.properties
+++ b/addOns/bugtracker/src/main/resources/org/zaproxy/zap/extension/bugtracker/resources/Messages.properties
@@ -15,7 +15,7 @@ bugtracker.trackers.github.issue.labels 	= Labels
 bugtracker.trackers.github.issue.assignee.manual 	= Assignee
 bugtracker.trackers.github.issue.assignee.list 	= Choose Assignee from Collaborators
 bugtracker.trackers.github.issue.username 	= Username
-bugtracker.trackers.github.issue.password 	= Password
+bugtracker.trackers.github.issue.token 	= Token
 bugtracker.trackers.github.issue.config     = Choose a saved Configuration
 bugtracker.trackers.github.issue.msg.auth   = Authorization Unsuccesful: Check your credentials
 bugtracker.trackers.github.issue.msg.repo   = The repository/resource doesnt exist
@@ -75,17 +75,15 @@ bugtracker.table.header.tracker = Bug Tracker
 bugtracker.table.header.config  = Configuration
 
 bugtracker.trackers.github.table.header.username             = Username/Email
-bugtracker.trackers.github.table.header.password               = Password
+bugtracker.trackers.github.table.header.token               = Token
 bugtracker.trackers.github.table.header.repoUrl               = Repository URL
-bugtracker.trackers.github.label.configs            = <html><body><p>These configs are treated as anti CSRF configs.</p><p>At the moment only FORM parameter configs are supported</p><p>All config names are treated as being case-insensitive.</p><p>If you add or change any of the config names then you MUST revisit pages containing those configs before they will be recognised</p> </body></html>
-bugtracker.trackers.github.title                   = Anti CSRF Tokens
 
 bugtracker.trackers.github.dialog.config.add.button.cancel           = Cancel
 bugtracker.trackers.github.dialog.config.add.button.confirm          = Add
 bugtracker.trackers.github.dialog.config.add.title                   = Add Github User Configuration
 bugtracker.trackers.github.dialog.config.field.label.enabled         = Enabled:
 bugtracker.trackers.github.dialog.config.field.label.name            = Username/Email:
-bugtracker.trackers.github.dialog.config.field.label.password        = Password:
+bugtracker.trackers.github.dialog.config.field.label.token        = Token:
 bugtracker.trackers.github.dialog.config.field.label.repoUrl         = Repository URL:
 bugtracker.trackers.github.dialog.config.modify.button.confirm       = Modify
 bugtracker.trackers.github.dialog.config.modify.title                = Modify Github User Configuration
@@ -100,8 +98,6 @@ bugtracker.trackers.github.dialog.config.warning.name.repeated.title = Duplicate
 bugtracker.trackers.bugzilla.table.header.username             = Username/Email
 bugtracker.trackers.bugzilla.table.header.password               = Password
 bugtracker.trackers.bugzilla.table.header.bugzillaUrl               = Bugzilla URL
-bugtracker.trackers.bugzilla.label.configs            = <html><body><p>These configs are treated as anti CSRF configs.</p><p>At the moment only FORM parameter configs are supported</p><p>All config names are treated as being case-insensitive.</p><p>If you add or change any of the config names then you MUST revisit pages containing those configs before they will be recognised</p> </body></html>
-bugtracker.trackers.bugzilla.title                   = Anti CSRF Tokens
 
 bugtracker.trackers.bugzilla.dialog.config.add.button.cancel           = Cancel
 bugtracker.trackers.bugzilla.dialog.config.add.button.confirm          = Add


### PR DESCRIPTION
- Update help to mention tokens along with passwords.
- Update UI and config classes to use "Token" for variables etc where applicable.
- Update CHANGELOG adding change note.
- Update Messages.properties key/value pairs as applicable
- Removed a few unused key/value pairs. (As a clean code activity.)
- Update build file to use the updated library.

Fixes zaproxy/zaproxy#6893

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>