### PR TITLE
network: minor help tweaks

### DIFF
--- a/addOns/network/CHANGELOG.md
+++ b/addOns/network/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Minor tweaks in help pages for better rendering.
 
 ## [0.2.0] - 2022-04-06
 ### Added

--- a/addOns/network/src/main/javahelp/help/contents/options/localservers.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/localservers.html
@@ -52,6 +52,7 @@
 	instance's metadata</a>.<br>
 	ZAP should be started with this option enabled if access to the API, through the public IP address, is required:
 	<blockquote>zap.sh -daemon -port 8080 -host 0.0.0.0 -config network.localServers.mainProxy.behindNat=true</blockquote>
+	<br>
 	Also, the API needs to be configured to accept external IP addresses (i.e. the IP address from where ZAP is being accessed).
 
 	<H4>Remove Accept-Encoding Request Header</H4>
@@ -71,7 +72,7 @@
 	For example, if you have a Linux machine you use for testing, you can do something like the following to forward all HTTP and
 	HTTPS traffic to a local proxy listening on <code>192.168.0.14:8080</code>:
 	<pre><code>iptables -t nat -A OUTPUT -p tcp --dport 443 -j DNAT --to-destination 192.168.0.14:8080
-	iptables -t nat -A OUTPUT -p tcp --dport 80 -j DNAT --to-destination 192.168.0.14:8080
+iptables -t nat -A OUTPUT -p tcp --dport 80 -j DNAT --to-destination 192.168.0.14:8080
 	</code></pre>
 
 	<H2>Aliases</H2>

--- a/addOns/network/src/main/javahelp/help/contents/options/options.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/options.html
@@ -15,8 +15,6 @@
 			<td><a href="localservers.html">Local Servers/Proxies</a></td>
 			<td>Allows to manage and configure the local servers/proxies.</td>
 		</tr>
-	</table>
-	<table>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 			<td><a href="servercertificates.html">Server Certificates</a></td>


### PR DESCRIPTION
Add newline after a quote for proper rendering in the site.
Remove extra space for correct alignment of example commands.
Merge related tables.