### PR TITLE
automation: address exceptions in dialogues

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Test type to check for presence of a URL.
 
+### Fixed
+- Exceptions when using the GUI.
+
 ## [0.14.0] - 2022-04-05
 ### Added
 - Import Job profile (Issue 7078).

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
@@ -284,6 +284,7 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
         if (this.modifyButton == null) {
             this.modifyButton =
                     new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            modifyButton.setEnabled(false);
             this.modifyButton.addActionListener(
                     e -> {
                         int row = getRulesTable().getSelectedRow();
@@ -358,6 +359,9 @@ public class ActiveScanJobDialog extends StandardFieldsDialog {
                         public void mouseClicked(MouseEvent me) {
                             if (me.getClickCount() == 2) {
                                 int row = getRulesTable().getSelectedRow();
+                                if (row == -1) {
+                                    return;
+                                }
                                 try {
                                     AddAscanRuleDialog dialog =
                                             new AddAscanRuleDialog(

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
@@ -138,6 +138,7 @@ public class EnvironmentDialog extends StandardFieldsDialog {
         if (this.modifyContextButton == null) {
             this.modifyContextButton =
                     new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            modifyContextButton.setEnabled(false);
             this.modifyContextButton.addActionListener(
                     e -> {
                         int row = getContextsTable().getSelectedRow();
@@ -190,6 +191,9 @@ public class EnvironmentDialog extends StandardFieldsDialog {
                         public void mouseClicked(MouseEvent me) {
                             if (me.getClickCount() == 2) {
                                 int row = contextsTable.getSelectedRow();
+                                if (row == -1) {
+                                    return;
+                                }
                                 ContextDialog dialog =
                                         new ContextDialog(
                                                 EnvironmentDialog.this,
@@ -231,6 +235,7 @@ public class EnvironmentDialog extends StandardFieldsDialog {
         if (this.modifyEnvVarButton == null) {
             this.modifyEnvVarButton =
                     new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            modifyEnvVarButton.setEnabled(false);
             this.modifyEnvVarButton.addActionListener(
                     e -> {
                         int row = getEnvVarsTable().getSelectedRow();
@@ -282,6 +287,9 @@ public class EnvironmentDialog extends StandardFieldsDialog {
                         public void mouseClicked(MouseEvent me) {
                             if (me.getClickCount() == 2) {
                                 int row = envVarTable.getSelectedRow();
+                                if (row == -1) {
+                                    return;
+                                }
                                 EnvVarDialog dialog =
                                         new EnvVarDialog(
                                                 EnvironmentDialog.this,

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
@@ -130,6 +130,7 @@ public class PassiveScanConfigJobDialog extends StandardFieldsDialog {
         if (this.modifyButton == null) {
             this.modifyButton =
                     new JButton(Constant.messages.getString("automation.dialog.button.modify"));
+            modifyButton.setEnabled(false);
             this.modifyButton.addActionListener(
                     e -> {
                         int row = getRulesTable().getSelectedRow();
@@ -194,6 +195,9 @@ public class PassiveScanConfigJobDialog extends StandardFieldsDialog {
                         public void mouseClicked(MouseEvent me) {
                             if (me.getClickCount() == 2) {
                                 int row = getRulesTable().getSelectedRow();
+                                if (row == -1) {
+                                    return;
+                                }
                                 AddPscanRuleDialog dialog =
                                         new AddPscanRuleDialog(
                                                 getRulesModel(),

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
@@ -174,6 +174,9 @@ public class RequestorJobDialog extends StandardFieldsDialog {
                         public void mouseClicked(MouseEvent me) {
                             if (me.getClickCount() == 2) {
                                 int row = getRulesTable().getSelectedRow();
+                                if (row == -1) {
+                                    return;
+                                }
                                 AddRequestDialog dialog =
                                         new AddRequestDialog(
                                                 getRulesModel(),

--- a/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
+++ b/addOns/automation/src/main/resources/org/zaproxy/addon/automation/resources/Messages.properties
@@ -175,6 +175,7 @@ automation.dialog.pscanconfig.remove.confirm = Are you sure you want to remove t
 
 automation.dialog.requestor.summary = URL Count: {0}
 automation.dialog.requestor.title = Requestor Job
+automation.dialog.requestor.remove.confirm = Are you sure you want to remove this Request?
 automation.dialog.requestor.tab.requests = Requests
 
 automation.dialog.requests.table.header.method = Method


### PR DESCRIPTION
Check that a row is selected before attempting to get it.
Disable modify buttons by default, no entries selected to modify
initially.
Add missing resource message, shown when removing a request.