### PR TITLE
chore: webdrivers: Upgrade Gecko and Chrome drivers

### DIFF
--- a/addOns/webdrivers/webdriverlinux/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverlinux/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update geckodriver to 0.31.0.
+- Update ChromeDriver to 100.0.4896.60.
 
 ## [36] - 2022-03-04
 ### Changed

--- a/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+++ b/addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
@@ -9,8 +9,8 @@
 <p>
 The Linux WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 99.0.4844.51</li>
-    <li>Firefox - geckodriver 0.30.0</li>
+    <li>Chrome - ChromeDriver 100.0.4896.60</li>
+    <li>Firefox - geckodriver 0.31.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivermacos/CHANGELOG.md
+++ b/addOns/webdrivers/webdrivermacos/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update geckodriver to 0.31.0.
+- Update ChromeDriver to 100.0.4896.60.
 
 ## [37] - 2022-03-29
 ### Added

--- a/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+++ b/addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
@@ -9,8 +9,8 @@
 <p>
 The MacOS WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 99.0.4844.51</li>
-    <li>Firefox - geckodriver 0.30.0</li>
+    <li>Chrome - ChromeDriver 100.0.4896.60</li>
+    <li>Firefox - geckodriver 0.31.0</li>
 </ul>
 
 <H2>See also</H2>

--- a/addOns/webdrivers/webdrivers.gradle.kts
+++ b/addOns/webdrivers/webdrivers.gradle.kts
@@ -5,8 +5,8 @@ import org.zaproxy.gradle.tasks.DownloadWebDriver
 
 description = "Common configuration of the WebDriver add-ons."
 
-val geckodriverVersion = "0.30.0"
-val chromeDriverVersion = "99.0.4844.51"
+val geckodriverVersion = "0.31.0"
+val chromeDriverVersion = "100.0.4896.60"
 
 fun configureDownloadTask(outputDir: File, targetOs: DownloadWebDriver.OS, task: DownloadWebDriver) {
     val geckodriver = task.browser.get() == DownloadWebDriver.Browser.FIREFOX

--- a/addOns/webdrivers/webdriverwindows/CHANGELOG.md
+++ b/addOns/webdrivers/webdriverwindows/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Update geckodriver to 0.31.0.
+- Update ChromeDriver to 100.0.4896.60.
 
 ## [36] - 2022-03-04
 ### Changed

--- a/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+++ b/addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
@@ -9,8 +9,8 @@
 <p>
 The Windows WebDrivers add-on provides WebDrivers for the following browsers:
 <ul>
-    <li>Chrome - ChromeDriver 99.0.4844.51</li>
-    <li>Firefox - geckodriver 0.30.0</li>
+    <li>Chrome - ChromeDriver 100.0.4896.60</li>
+    <li>Firefox - geckodriver 0.31.0</li>
 </ul>
 
 <H2>See also</H2>


### PR DESCRIPTION
Gecko -> 0.31.0
Chrome -> 100.0.4896.60

- Added change note to CHANGELOGs.
- Updated version in help files.
- Updated version in the build file.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>