### PR TITLE
feat: oast: Add Name and Description methods to extension class

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -9,6 +9,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 - Maintenance changes.
 
+### Added
+- Extension description and UI name.
+
 ## [0.10.0] - 2022-02-18
 ### Added
 - The following two statistics for each OAST service:

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ExtensionOast.java
@@ -321,6 +321,16 @@ public class ExtensionOast extends ExtensionAdaptor {
         unregisterOastService(interactshService);
     }
 
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("oast.ext.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("oast.ext.description");
+    }
+
     private class OastSessionChangedListener implements SessionChangedListener {
         @Override
         public void sessionChanged(Session session) {

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/scripts/ExtensionOastScripts.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/scripts/ExtensionOastScripts.java
@@ -62,6 +62,11 @@ public class ExtensionOastScripts extends ExtensionAdaptor {
     }
 
     @Override
+    public String getUIName() {
+        return Constant.messages.getString("oast.scripts.name");
+    }
+
+    @Override
     public String getDescription() {
         return Constant.messages.getString("oast.scripts.desc");
     }

--- a/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
+++ b/addOns/oast/src/main/resources/org/zaproxy/addon/oast/resources/Messages.properties
@@ -24,6 +24,9 @@ oast.boast.event.badMsgDump=Malformed HTTP Message: Dumping entire message in re
 oast.boast.param.info.minPollingFrequency=The polling frequency ({0} seconds) is less than the minimum permissible \
   value (10 seconds). The polling frequency will be set to 10 seconds.
 
+oast.ext.description=Adds Out-of-band Application Security Testing functionality.
+oast.ext.name=Out-of-band Application Security Testing
+
 oast.interactsh.options.label.url=Server URL:
 oast.interactsh.options.label.authToken=Authorization Token:
 oast.interactsh.options.label.pollingFrequency=Polling Frequency (in seconds):
@@ -54,6 +57,7 @@ oast.panel.currentState.tooltip.lastPolled = {0}: Last Polled Time
 oast.panel.currentState.lastPoll= {0}: {1}
 
 oast.scripts.desc=Adds OAST scripts.
+oast.scripts.name=OAST Scripts
 oast.scripts.warn.couldNotAddScripts=Could not add OAST scripts: {0}.
 oast.scripts.requestHandler.desc=This script registers an OAST message handler. Change it to do whatever you want to do.
 oast.scripts.getBoastServers.desc=This script lists the details of all registered BOAST Servers.


### PR DESCRIPTION
- Add getDescription() and getUIName() methods to ExtensionOast.
- CHANGELOG add change note.
- Messages.properties add supporting key/value pairs.

Before
`12490 [ZAP-BootstrapGUI] INFO org.parosproxy.paros.extension.ExtensionLoader - Initializing ExtensionOast -  ExtensionOast`

After
`11260 [ZAP-BootstrapGUI] INFO org.parosproxy.paros.extension.ExtensionLoader - Initializing Out-of-band Application Security Testing -  Adds Out-of-band Application Security Testing functionality.`

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>