### PR TITLE
fix: callhome: Handle CA chain failures with more user friendly messages

### DIFF
--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Show a more user friendly log and Output tab message when Java's truststore may not contain the CA certificate(s) for intermediate proxy(ies) (Issue 1623).
 
 ## [0.3.0] - 2022-01-21
 ### Added

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -56,6 +56,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.network.HttpStatusCode;
+import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.control.ExtensionFactory;
 import org.zaproxy.zap.extension.autoupdate.ExtensionAutoUpdate;
@@ -256,6 +257,12 @@ public class ExtensionCallHome extends ExtensionAdaptor
         try {
             return getCheckForUpdatesData();
         } catch (Exception e) {
+            if (e.getMessage().contains("PKIX path building failed")) {
+                String message = Constant.messages.getString("callhome.pkix.fail.message");
+                LOGGER.warn(message);
+                updateOutput(message);
+                return null;
+            }
             LOGGER.error(e.getMessage(), e);
         }
         return null;
@@ -563,5 +570,13 @@ public class ExtensionCallHome extends ExtensionAdaptor
     public List<String> getHandledExtensions() {
         // Not supported
         return null;
+    }
+
+    private static void updateOutput(String message) {
+        if (View.isInitialised()) {
+            StringBuilder sb = new StringBuilder(message.length() + 1);
+            sb.append(message).append('\n');
+            View.getSingleton().getOutputPanel().append(sb.toString());
+        }
     }
 }

--- a/addOns/callhome/src/main/resources/org/zaproxy/addon/callhome/resources/Messages.properties
+++ b/addOns/callhome/src/main/resources/org/zaproxy/addon/callhome/resources/Messages.properties
@@ -3,3 +3,4 @@ callhome.cmdline.notel.help = Turns off telemetry calls
 callhome.optionspanel.name = Call Home
 callhome.optionspanel.label.telenabled = Telemetry Enabled
 callhome.optionspanel.label.tellastdata = Last Telemetry Data Sent:
+callhome.pkix.fail.message = Certificate chain may be invalid. Are you using a corporate or intermediate proxy? Is its CA certificate in your Java truststore?


### PR DESCRIPTION
- CHANGELOG > Added change note.
- ExtensionCallHome > Add exception handling for relevant circumstance

Fixes zaproxy/zaproxy#1623

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>