### PR TITLE
network: provide proxy.pac API endpoint

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -1352,4 +1352,25 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
         }
         return "";
     }
+
+    String getProxyPacContent(String hostname) {
+        LocalServerConfig serverConfig = localServersOptions.getMainProxy();
+        int port = serverConfig.getPort();
+        String domain = null;
+        if (serverConfig.isAnyLocalAddress()) {
+            String localDomain = hostname;
+            if (!API.API_DOMAIN.equals(localDomain)) {
+                domain = localDomain;
+            }
+        }
+        if (domain == null) {
+            domain = serverConfig.getAddress();
+        }
+
+        StringBuilder sb = new StringBuilder(100);
+        sb.append("function FindProxyForURL(url, host) {\n");
+        sb.append("  return \"PROXY ").append(domain).append(':').append(port).append("\";\n");
+        sb.append("} // End of function\n");
+        return sb.toString();
+    }
 }

--- a/addOns/network/src/main/javahelp/help/contents/api.html
+++ b/addOns/network/src/main/javahelp/help/contents/api.html
@@ -97,7 +97,18 @@
 
 	<h3>Other</h3>
 	<ul>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			proxy.pac: Provides a PAC file, proxying through the main proxy.
+		</li>
 		<li>rootCaCert: Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).</li>
+	</ul>
+
+	<h3>Shortcuts</h3>
+	<strong>Note:</strong> These endpoints are only available in weekly releases and versions after 2.11.
+	<ul>
+		<li>proxy.pac: Provides a PAC file, proxying through the main proxy.</li>
 	</ul>
 
 	<H2>See also</H2>

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -33,6 +33,7 @@ network.api.action.setRootCaCertValidity = Sets the Root CA certificate validity
 network.api.action.setRootCaCertValidity.param.validity = The number of days that the generated Root CA certificate will be valid for.
 network.api.action.setServerCertValidity = Sets the server certificate validity. Used when generating server certificates.
 network.api.action.setServerCertValidity.param.validity = The number of days that the generated server certificates will be valid for.
+network.api.other.proxy.pac = Provides a PAC file, proxying through the main proxy.
 network.api.other.rootCaCert = Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).
 network.api.view.getAliases = Gets the aliases used to identify the local servers/proxies.
 network.api.view.getLocalServers = Gets the local servers/proxies.


### PR DESCRIPTION
Provide an API endpoint and shortcut to obtain a PAC file, to move core
functionality.

Part of zaproxy/zaproxy#7240.