### PR TITLE
automation: show context URLs correctly in GUI

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Fixed
+- Show each context URL in its own line when editing in the GUI (Issue 7241).
 
 ## [0.15.0] - 2022-04-25
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
@@ -64,7 +64,7 @@ public class ContextDialog extends StandardFieldsDialog {
         this.context = context;
 
         this.addTextField(0, NAME_PARAM, context.getName());
-        this.addMultilineField(0, URLS_PARAM, StringUtils.join(context.getUrls().toArray()));
+        this.addMultilineField(0, URLS_PARAM, listToString(context.getUrls()));
 
         this.addMultilineField(1, INCLUDE_PARAM, listToString(context.getIncludePaths()));
 


### PR DESCRIPTION
Show each context URL in its own line when editing in the GUI, by
calling the method that joins the URLs with newline.

Fix zaproxy/zaproxy#7241.