### PR TITLE
feat: Add GitHub workflow for updating WebDrivers

### DIFF
--- a/.github/workflows/create_webdriver_update.yml
+++ b/.github/workflows/create_webdriver_update.yml
@@ -1,0 +1,84 @@
+name: Create Webdriver Update PR
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      chrome_version:
+        description: 'ChromeDriver version?'
+        required: true
+        default: 'cxx'
+      gecko_version:
+        description: 'geckodriver version?'
+        required: true
+        default: 'gxx'
+
+jobs:
+  create_pr:
+    name: Create Pull Request
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Feature Branch and Raise PR
+      run: |
+        sudo apt install jq -y
+        # Setup git details
+        export GITHUB_USER=zapbot
+        git config --global user.email "12745184+zapbot@users.noreply.github.com"
+        git config --global user.name $GITHUB_USER
+        # Clone repos
+        git clone -o upstream https://github.com/zaproxy/zap-extensions.git
+        cd zap-extensions
+        git remote add origin https://github.com/$GITHUB_USER/zap-extensions.git
+        # Setup env vars for later
+        BRANCH="webdriver-update"
+        export GITHUB_TOKEN=${{ secrets.ZAPBOT_TOKEN }}
+        if [ "${{ github.event.inputs.chrome_version }}" == "cxx" ]; then
+          CHROME_VERS=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
+        else
+          CHROME_VERS=${{ github.event.inputs.chrome_version }}
+        fi
+        if [ "${{ github.event.inputs.gecko_version }}" == "gxx" ]; then
+          GECKO_VERS=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest|jq -r .name)
+        else
+          GECKO_VERS=${{ github.event.inputs.gecko_version }}
+        fi
+        # Build the feature branch
+        git checkout -b $BRANCH
+        git remote set-url origin https://$GITHUB_USER:$GITHUB_TOKEN@github.com/$GITHUB_USER/zap-extensions.git
+        # Update ChromeDriver version strings in help and build file
+        sed -i -e 's|val chromeDriverVersion = "[0-9\.]*"|val chromeDriverVersion = "'"$CHROME_VERS"'"|g' addOns/webdrivers/webdrivers.gradle.kts
+        sed -i -e "s|Chrome - ChromeDriver [0-9\.]*</li>|Chrome - ChromeDriver $CHROME_VERS</li>|g" addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+        sed -i -e "s|Chrome - ChromeDriver [0-9\.]*</li>|Chrome - ChromeDriver $CHROME_VERS</li>|g" addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+        sed -i -e "s|Chrome - ChromeDriver [0-9\.]*</li>|Chrome - ChromeDriver $CHROME_VERS</li>|g" addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+        git update-index -q --refresh
+        # If there are changes update changelog, and commit
+        if ! git diff-index --quiet HEAD --; then
+          IS_UPDT=1
+         ./gradlew :addOns:webdriverlinux:updateChangelog --change="- Update ChromeDriver to $CHROME_VERS."
+         ./gradlew :addOns:webdrivermacos:updateChangelog --change="- Update ChromeDriver to $CHROME_VERS."
+         ./gradlew :addOns:webdriverwindows:updateChangelog --change="- Update ChromeDriver to $CHROME_VERS."
+          git add .
+          git commit -m "Webdriver Update" -m "ChromeDriver update to $CHROME_VERS" --signoff
+        fi
+        # Update geckodriver version strings in help and build file
+        sed -i -e 's|val geckodriverVersion = "[0-9\.]*"|val geckodriverVersion = "'"$GECKO_VERS"'"|g' addOns/webdrivers/webdrivers.gradle.kts
+        sed -i -e "s|Firefox - geckodriver [0-9\.]*</li>|Firefox - geckodriver $GECKO_VERS</li>|g" addOns/webdrivers/webdriverlinux/src/main/javahelp/org/zaproxy/zap/extension/webdriverlinux/resources/help/contents/webdriverlinux.html
+        sed -i -e "s|Firefox - geckodriver [0-9\.]*</li>|Firefox - geckodriver $GECKO_VERS</li>|g" addOns/webdrivers/webdrivermacos/src/main/javahelp/org/zaproxy/zap/extension/webdrivermacos/resources/help/contents/webdrivermacos.html
+        sed -i -e "s|Firefox - geckodriver [0-9\.]*</li>|Firefox - geckodriver $GECKO_VERS</li>|g" addOns/webdrivers/webdriverwindows/src/main/javahelp/org/zaproxy/zap/extension/webdriverwindows/resources/help/contents/webdriverwindows.html
+        git update-index -q --refresh
+        # If there are changes update changelog, and commit
+        if ! git diff-index --quiet HEAD --; then
+          IS_UPDT=1
+          ./gradlew :addOns:webdriverlinux:updateChangelog --change="- Update geckodriver to $GECKO_VERS."
+          ./gradlew :addOns:webdrivermacos:updateChangelog --change="- Update geckodriver to $GECKO_VERS."
+          ./gradlew :addOns:webdriverwindows:updateChangelog --change="- Update geckodriver to $GECKO_VERS."
+          git add .
+          git commit -m "Webdriver Update" -m "geckodriver update to $GECKO_VERS" --signoff
+        fi
+        ## If there are changes: push and PR
+        if [ $IS_UPDT -eq 1 ]; then
+          git push --set-upstream origin $BRANCH --force
+          # Open the PR
+          hub pull-request --no-edit
+        fi


### PR DESCRIPTION
- Triggered on schedule every day or manually.
- When triggered manually the version can be specified at trigger time. (In order to work around issues like: mozilla/geckodriver#2009)
- The workflow updates help and build file replacing the version strings as necessary, as well as adding a change note to the CHANGELOGs.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>