### PR TITLE
ascanrulesBeta: Improved text and sources for Integer Overflow

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Improved description, solution, and references for the Integer Overflow scan rule.
 
 ### Added
 - New User Agent strings to the User Agent fuzz scan rule.

--- a/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
+++ b/addOns/ascanrulesBeta/src/main/resources/org/zaproxy/zap/extension/ascanrulesBeta/resources/Messages.properties
@@ -127,9 +127,9 @@ ascanbeta.insecurehttpmethod.webdav.exploitable.extrainfo = See the discussion o
 
 
 ascanbeta.integeroverflow.name = Integer Overflow Error
-ascanbeta.integeroverflow.desc = An integer overflow condition exists when an integer, which has not been properly checked from the input stream is used within a compiled program. 
-ascanbeta.integeroverflow.soln = Rewrite the background program using proper checking of the size of integer being input to prevent overflows and divide by 0 errors.  This will require a recompile of the background executable.
-ascanbeta.integeroverflow.refs = http://projects.webappsec.org/w/page/13246946/Integer%20Overflows
+ascanbeta.integeroverflow.desc = An integer overflow condition exists when an integer used in a compiled program extends beyond the range limits and has not been properly checked from the input stream.
+ascanbeta.integeroverflow.soln = In order to prevent overflows and divide by 0 (zero) errors in the application, please rewrite the backend program, checking if the values of integers being processed are within the application's allowed range. This will require a recompilation of the backend executable.
+ascanbeta.integeroverflow.refs = https://en.wikipedia.org/wiki/Integer_overflow\nhttps://cwe.mitre.org/data/definitions/190.html\nhttp://projects.webappsec.org/w/page/13246946/Integer%20Overflows
 ascanbeta.integeroverflow.error1 = Potential Integer Overflow.  Status code changed on the input of a long string of random integers.
 ascanbeta.integeroverflow.error2 = Potential Integer Overflow.  Status code changed on the input of a long string of zeros.
 ascanbeta.integeroverflow.error3 = Potential Integer Overflow.  Status code changed on the input of a long string of ones.


### PR DESCRIPTION
The link and description for Integer Overflow hadn't been updated in 12 years. Improved the description and added modern links that are both secure to visit and contain information for multiple programming languages and scenarios.

Fix zaproxy/zaproxy#7245.