### PR TITLE
quickstart: delay news fetch

### DIFF
--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/ExtensionQuickStart.java
@@ -164,7 +164,10 @@ public class ExtensionQuickStart extends ExtensionAdaptor
         if (View.isInitialised()) {
             getQuickStartPanel().optionsLoaded(this.getQuickStartParam());
         }
+    }
 
+    @Override
+    public void postInit() {
         if (Constant.isSilent()) {
             LOGGER.info("Shh! No check-for-news - silent mode enabled");
             return;


### PR DESCRIPTION
Fetch the news on `postInit` instead of `optionsLoaded` to allow the
network add-on to fully initialise, required to send the HTTP request.