### PR TITLE
wappalyzer: address report generation error

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated the pattern parser to deal with Confidence or Version fields extending DOM patterns (for the time being they're ignored).
 - Updated the passive scan rule to be thread safe.
 
+### Fixed
+- Address error when generating the report with Java 17 (Issue 6880).
+
 ## [21.9.0] - 2022-02-03
 ### Changed
 - Updated with upstream Wappalyzer icon and pattern changes.

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJobResultData.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/automation/WappalyzerJobResultData.java
@@ -20,7 +20,6 @@
 package org.zaproxy.zap.extension.wappalyzer.automation;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +55,10 @@ public class WappalyzerJobResultData extends JobResultData {
     public List<TechnologyData> getTechnologyForSite(String site) {
         List<TechnologyData> data = this.siteTechMap.get(site);
         if (data == null) {
-            return Collections.emptyList();
+            // XXX Do not use Collections.emptyList() breaks when running with Java 17, i.e.:
+            // Unable to make public int java.util.Collections$EmptyList.size() accessible:
+            // module java.base does not "opens java.util" to unnamed module @556150d9
+            return new ArrayList<>(0);
         }
         return data;
     }


### PR DESCRIPTION
Use an empty `ArrayList` instead of `Collections.emptyList()` when the
site is not defined to avoid errors in Thymeleaf when using Java 17.

Part of zaproxy/zaproxy#6880.