### PR TITLE
fix: pscanrules: ViewState "unsure" alert only raised at Low threshold

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- The "Viewstate without MAC Signature (Unsure)" alert will now only be raised at Low Alert Threshold (Issue 7230).
 
 ## [40] - 2022-04-05
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java
@@ -34,6 +34,7 @@ import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTag;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
@@ -63,9 +64,13 @@ public class ViewstateScanRule extends PluginPassiveScanner {
         // consider it as valid.
         if (!v.isValid()) return;
 
-        if (!v.hasMACtest1() || !v.hasMACtest2())
-            if (!v.hasMACtest1() && !v.hasMACtest2()) alertNoMACforSure().raise();
-            else alertNoMACUnsure().raise();
+        if (!v.hasMACtest1() || !v.hasMACtest2()) {
+            if (!v.hasMACtest1() && !v.hasMACtest2()) {
+                alertNoMACforSure().raise();
+            } else if (AlertThreshold.LOW.equals(getAlertThreshold())) {
+                alertNoMACUnsure().raise();
+            }
+        }
 
         if (!v.isLatestAspNetVersion()) alertOldAspVersion().raise();
 

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -248,6 +248,7 @@ measures such as:
 	<li>Split VIEWSTATE.</li>
 	<li>VIEWSTATE containing email or IP patterns.</li>
 </ul>
+The "Viewstate without MAC Signature (Unsure)" alert will only be raised at LOW threshold.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ViewstateScanRule.java">ViewstateScanRule.java</a>
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ViewStateScanRuleUnitTest.java
@@ -31,7 +31,10 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.core.scanner.Plugin.AlertThreshold;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
@@ -105,12 +108,14 @@ class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
     }
 
     @Test
-    void shouldRaiseAlertAsThereIsNoValidMACUnsure() {
+    void shouldRaiseAlertAsThereIsNoValidMACUnsureLowThreshold() {
+        // Given
         msg.setResponseBody(
                 "<input name=\"__VIEWSTATE\" value=\"/wEPDWUKMTkwNjc4NTIwMWRkaKrolbpTKYmPUNsab597kh8iOBU=\">");
-
+        rule.setAlertThreshold(AlertThreshold.LOW);
+        // When
         scanHttpResponseReceive(msg);
-
+        // Then
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_HIGH));
         assertThat(
@@ -119,6 +124,22 @@ class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
         assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10032-4"));
         assertSame(msg, alertsRaised.get(0).getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = AlertThreshold.class,
+            names = {"MEDIUM", "HIGH"})
+    void shouldNotRaiseAlertAsThereIsNoValidMACUnsureMediumOrHighThreshold(
+            AlertThreshold threshold) {
+        // Given
+        msg.setResponseBody(
+                "<input name=\"__VIEWSTATE\" value=\"/wEPDWUKMTkwNjc4NTIwMWRkaKrolbpTKYmPUNsab597kh8iOBU=\">");
+        rule.setAlertThreshold(threshold);
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), equalTo(0));
     }
 
     @Test
@@ -145,14 +166,14 @@ class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
 
         scanHttpResponseReceive(msg);
 
-        assertThat("There should be two alerts raised.", alertsRaised.size(), equalTo(2));
-        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_LOW));
-        assertThat(alertsRaised.get(1).getName(), equalTo("Old Asp.Net Version in Use"));
-        assertThat(alertsRaised.get(1).getWascId(), equalTo(14));
-        assertThat(alertsRaised.get(1).getCweId(), equalTo(642));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10032-3"));
-        assertSame(msg, alertsRaised.get(1).getMessage());
+        assertThat("There should be one alert raised.", alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
+        assertThat(alertsRaised.get(0).getName(), equalTo("Old Asp.Net Version in Use"));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10032-3"));
+        assertSame(msg, alertsRaised.get(0).getMessage());
     }
 
     @Test
@@ -217,12 +238,12 @@ class ViewStateScanRuleUnitTest extends PassiveScannerTest<ViewstateScanRule> {
 
         scanHttpResponseReceive(msg);
 
-        assertThat(alertsRaised.size(), equalTo(2));
-        assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_INFO));
-        assertThat(alertsRaised.get(1).getName(), equalTo("Split Viewstate in Use"));
-        assertThat(alertsRaised.get(1).getWascId(), equalTo(14));
-        assertThat(alertsRaised.get(1).getCweId(), equalTo(642));
-        assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10032-6"));
+        assertThat(alertsRaised.size(), equalTo(1));
+        assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_INFO));
+        assertThat(alertsRaised.get(0).getName(), equalTo("Split Viewstate in Use"));
+        assertThat(alertsRaised.get(0).getWascId(), equalTo(14));
+        assertThat(alertsRaised.get(0).getCweId(), equalTo(642));
+        assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10032-6"));
         assertSame(msg, alertsRaised.get(0).getMessage());
     }
 


### PR DESCRIPTION
- CHANGELOG.md > Added change note.
- pscanrules.html > Added note about threshold handling.
- ViewstateScanRule.java > Minor tweak to conditionals to only raise the "unsure" alert when threshold is Low.
- ViewstateScanRuleUnitTest.java > Add tests to assert the new behavior, and update existing tests as applicable.

Fixes zaproxy/zaproxy#7230

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>