### PR TITLE
automation: delay job registration

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Changed
+- Maintenance changes.
+
 ### Fixed
 - Show each context URL in its own line when editing in the GUI (Issue 7241).
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -101,16 +101,22 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         super(NAME);
         setI18nPrefix(PREFIX);
 
-        this.registerAutomationJob(new AddOnJob());
-        this.registerAutomationJob(new PassiveScanConfigJob());
-        this.registerAutomationJob(new RequestorJob());
-        this.registerAutomationJob(new PassiveScanWaitJob());
-        this.registerAutomationJob(new SpiderJob());
-        this.registerAutomationJob(new DelayJob());
-        this.registerAutomationJob(new ActiveScanJob());
-        this.registerAutomationJob(new ParamsJob());
         // Instantiate early so its visible to potential consumers
         AutomationEventPublisher.getPublisher();
+    }
+
+    @Override
+    public void init() {
+        super.init();
+
+        registerAutomationJob(new AddOnJob());
+        registerAutomationJob(new PassiveScanConfigJob());
+        registerAutomationJob(new RequestorJob());
+        registerAutomationJob(new PassiveScanWaitJob());
+        registerAutomationJob(new SpiderJob());
+        registerAutomationJob(new DelayJob());
+        registerAutomationJob(new ActiveScanJob());
+        registerAutomationJob(new ParamsJob());
     }
 
     @Override

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/ExtentionAutomationUnitTest.java
@@ -102,11 +102,12 @@ class ExtentionAutomationUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldRegisterBuiltInJobs() {
+    void shouldRegisterBuiltInJobsOnInit() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
 
         // When
+        extAuto.init();
         Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
 
         // Then
@@ -125,49 +126,38 @@ class ExtentionAutomationUnitTest extends TestUtils {
     void shouldRegisterNewJob() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
-        String jobName = "testjob";
-
-        AutomationJob job =
-                new AutomationJobImpl() {
-                    @Override
-                    public String getType() {
-                        return jobName;
-                    }
-
-                    @Override
-                    public Order getOrder() {
-                        return Order.REPORT;
-                    }
-                };
+        AutomationJob job = new AutomationJobImpl("testjob");
 
         // When
         extAuto.registerAutomationJob(job);
         Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
 
         // Then
-        assertThat(jobs.size(), is(equalTo(9)));
-        assertThat(jobs.containsKey(jobName), is(equalTo(true)));
+        assertThat(jobs.size(), is(equalTo(1)));
+        assertThat(jobs.containsKey(job.getType()), is(equalTo(true)));
     }
 
     @Test
     void shouldUnregisterExistingJob() {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
+        AutomationJob job = new AutomationJobImpl("testjob");
+        extAuto.registerAutomationJob(job);
 
         // When
-        Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
-        int origSize = jobs.size();
-        extAuto.unregisterAutomationJob(jobs.get(SpiderJob.JOB_NAME));
+        extAuto.unregisterAutomationJob(job);
 
         // Then
-        assertThat(jobs.size(), is(equalTo(origSize - 1)));
-        assertThat(jobs.containsKey(SpiderJob.JOB_NAME), is(equalTo(false)));
+        Map<String, AutomationJob> jobs = extAuto.getAutomationJobs();
+        assertThat(jobs.size(), is(equalTo(0)));
+        assertThat(jobs.containsKey(job.getType()), is(equalTo(false)));
     }
 
     @Test
     void shouldCreateMinTemplateFile() throws Exception {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
+        extAuto.init();
         Path filePath = getResourcePath("resources/template-min.yaml");
         String expectedTemplate = new String(Files.readAllBytes(filePath));
 
@@ -187,6 +177,7 @@ class ExtentionAutomationUnitTest extends TestUtils {
     void shouldCreateMaxTemplateFile() throws Exception {
         // Given
         ExtensionAutomation extAuto = new ExtensionAutomation();
+        extAuto.init();
         Path filePath = getResourcePath("resources/template-max.yaml");
         String expectedTemplate = new String(Files.readAllBytes(filePath));
 
@@ -219,6 +210,7 @@ class ExtentionAutomationUnitTest extends TestUtils {
         Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
 
         ExtensionAutomation extAuto = new ExtensionAutomation();
+        extAuto.init();
         Path filePath = getResourcePath("resources/template-config.yaml");
         String expectedTemplate = new String(Files.readAllBytes(filePath));
 
@@ -853,6 +845,10 @@ class ExtentionAutomationUnitTest extends TestUtils {
         private boolean testsLogError = false;
 
         public AutomationJobImpl() {}
+
+        public AutomationJobImpl(String type) {
+            this.type = type;
+        }
 
         public AutomationJobImpl(Object paramMethodObject) {
             this.paramMethodObject = paramMethodObject;


### PR DESCRIPTION
Register the jobs when the extension is initialised instead of when the
extension is instantiated, to allow other extensions (e.g. network) to
setup themselves.