### PR TITLE
Remove handling of redirect exception

### DIFF
--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -25,7 +25,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -206,7 +205,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         } catch (URIException e) {
             log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
             return null;
-        } catch (InvalidRedirectLocationException | UnknownHostException e) {
+        } catch (UnknownHostException e) {
             // Not an error, just means we probably attacked the redirect
             // location
             return null;
@@ -695,7 +694,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             } catch (URIException e) {
                 log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
                 return;
-            } catch (InvalidRedirectLocationException | UnknownHostException e) {
+            } catch (UnknownHostException e) {
                 // Not an error, just means we probably attacked the redirect
                 // location
                 // Try the second eye catcher
@@ -726,7 +725,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 } catch (URIException e) {
                     log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
                     return;
-                } catch (InvalidRedirectLocationException | UnknownHostException e) {
+                } catch (UnknownHostException e) {
                     // Second eyecatcher failed for some reason, no need to
                     // continue
                     return;

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/FormatStringScanRule.java
@@ -42,7 +42,6 @@ package org.zaproxy.zap.extension.ascanrules;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Map;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -144,7 +143,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             setParameter(testMsg, param, initialMessage);
             try {
                 sendAndReceive(testMsg);
-            } catch (InvalidRedirectLocationException | UnknownHostException ex) {
+            } catch (UnknownHostException ex) {
                 log.debug(
                         "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),
@@ -180,7 +179,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             setParameter(intialAttackMsg, param, initialAttackPayload);
             try {
                 sendAndReceive(intialAttackMsg);
-            } catch (InvalidRedirectLocationException | UnknownHostException ex) {
+            } catch (UnknownHostException ex) {
                 log.debug(
                         "Caught {} {} when accessing: {}.\nThe target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),
@@ -201,7 +200,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
                 setParameter(verificationMsg, param, secondAttackPayload);
                 try {
                     sendAndReceive(verificationMsg);
-                } catch (InvalidRedirectLocationException | UnknownHostException ex) {
+                } catch (UnknownHostException ex) {
                     log.debug(
                             "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                             ex.getClass().getName(),
@@ -256,7 +255,7 @@ public class FormatStringScanRule extends AbstractAppParamPlugin {
             setParameter(microsoftTestMsg, param, microsoftAttackMessage);
             try {
                 sendAndReceive(microsoftTestMsg);
-            } catch (InvalidRedirectLocationException | UnknownHostException ex) {
+            } catch (UnknownHostException ex) {
                 log.debug(
                         "Caught {} {} when accessing: {}. \nThe target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/ParameterTamperScanRule.java
@@ -35,7 +35,6 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -124,8 +123,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
 
         try {
             sendAndReceive(normalMsg);
-        } catch (InvalidRedirectLocationException
-                | SocketException
+        } catch (SocketException
                 | IllegalStateException
                 | IllegalArgumentException
                 | URIException
@@ -159,8 +157,7 @@ public class ParameterTamperScanRule extends AbstractAppParamPlugin {
             try {
                 try {
                     sendAndReceive(testMsg);
-                } catch (InvalidRedirectLocationException
-                        | SocketException
+                } catch (SocketException
                         | IllegalStateException
                         | IllegalArgumentException
                         | URIException

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PathTraversalScanRule.java
@@ -28,7 +28,6 @@ import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
@@ -461,7 +460,6 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                         | IllegalStateException
                         | UnknownHostException
                         | IllegalArgumentException
-                        | InvalidRedirectLocationException
                         | URIException ex) {
                     log.debug(
                             "Caught {} {} when accessing: {}",
@@ -508,7 +506,6 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                                 | IllegalStateException
                                 | UnknownHostException
                                 | IllegalArgumentException
-                                | InvalidRedirectLocationException
                                 | URIException ex) {
                             log.debug(
                                     "Caught {} {} when accessing: {}",
@@ -608,7 +605,6 @@ public class PathTraversalScanRule extends AbstractAppParamPlugin {
                 | IllegalStateException
                 | UnknownHostException
                 | IllegalArgumentException
-                | InvalidRedirectLocationException
                 | URIException ex) {
             log.debug(
                     "Caught {} {} when accessing: {}",

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/SqlInjectionScanRule.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1698,8 +1697,6 @@ public class SqlInjectionScanRule extends AbstractAppParamPlugin {
                 } // not a login page
             } // no sql Injection Found For Url
 
-        } catch (InvalidRedirectLocationException e) {
-            // Not an error, just means we probably attacked the redirect location
         } catch (Exception e) {
             // Do not try to internationalise this.. we need an error message in any event..
             // if it's in English, it's still better than not having it at all.

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/LdapInjectionScanRule.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -511,7 +510,7 @@ public class LdapInjectionScanRule extends AbstractAppParamPlugin {
             // the response.
             // but that's a task for another day.
 
-        } catch (InvalidRedirectLocationException | UnknownHostException | URIException e) {
+        } catch (UnknownHostException | URIException e) {
             log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
         } catch (Exception e) {
             // Do not try to internationalise this.. we need an error message in any event..

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/ExpressionLanguageInjectionScanRule.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Random;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -150,10 +149,7 @@ public class ExpressionLanguageInjectionScanRule extends AbstractAppParamPlugin 
             try {
                 // Send the request and retrieve the response
                 sendAndReceive(msg);
-            } catch (InvalidRedirectLocationException
-                    | URIException
-                    | UnknownHostException
-                    | IllegalArgumentException ex) {
+            } catch (URIException | UnknownHostException | IllegalArgumentException ex) {
                 LOG.debug(
                         "Caught {} {} when accessing: {}.\n The target may have replied with a poorly formed redirect due to our input.",
                         ex.getClass().getName(),

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionHypersonicScanRule.java
@@ -23,7 +23,6 @@ import java.net.SocketException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -397,8 +396,6 @@ public class SqlInjectionHypersonicScanRule extends AbstractAppParamPlugin {
             } // for each time based SQL index
             // end of check for time based SQL Injection
 
-        } catch (InvalidRedirectLocationException e) {
-            // Not an error, just means we probably attacked the redirect location
         } catch (Exception e) {
             // Do not try to internationalise this.. we need an error message in any event..
             // if it's in English, it's still better than not having it at all.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMsSqlScanRule.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -274,8 +273,6 @@ public class SqlInjectionMsSqlScanRule extends AbstractAppParamPlugin {
                 }
             }
             // end of check for time based SQL Injection
-        } catch (InvalidRedirectLocationException e) {
-            log.debug("Probably, we hit the redirection location");
         } catch (Exception e) {
             log.error("An error occurred checking a url for MsSQL Injection vulnerabilities", e);
         }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMySqlScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionMySqlScanRule.java
@@ -23,7 +23,6 @@ import java.net.SocketException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -441,8 +440,6 @@ public class SqlInjectionMySqlScanRule extends AbstractAppParamPlugin {
             } // for each time based SQL index
             // end of check for MySQL time based SQL Injection
 
-        } catch (InvalidRedirectLocationException e) {
-            // Not an error, just means we probably attacked the redirect location
         } catch (Exception e) {
             // Do not try to internationalise this.. we need an error message in any event..
             // if it's in English, it's still better than not having it at all.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionOracleScanRule.java
@@ -21,7 +21,6 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -332,8 +331,6 @@ public class SqlInjectionOracleScanRule extends AbstractAppParamPlugin {
             } // for each time based SQL index
             // end of check for time based SQL Injection
 
-        } catch (InvalidRedirectLocationException e) {
-            // Not an error, just means we probably attacked the redirect location
         } catch (Exception e) {
             // Do not try to internationalise this.. we need an error message in any event..
             // if it's in English, it's still better than not having it at all.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionPostgreScanRule.java
@@ -23,7 +23,6 @@ import java.net.SocketException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.configuration.ConversionException;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -384,8 +383,6 @@ public class SqlInjectionPostgreScanRule extends AbstractAppParamPlugin {
             } // for each time based SQL index
             // end of check for time based SQL Injection
 
-        } catch (InvalidRedirectLocationException e) {
-            // Not an error, just means we probably attacked the redirect location
         } catch (Exception e) {
             // Do not try to internationalise this.. we need an error message in any event..
             // if it's in English, it's still better than not having it at all.

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/SqlInjectionSqLiteScanRule.java
@@ -23,7 +23,6 @@ import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.InvalidRedirectLocationException;
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -760,7 +759,7 @@ public class SqlInjectionSqLiteScanRule extends AbstractAppParamPlugin {
                 }
             } // end of doUnionBased
 
-        } catch (InvalidRedirectLocationException | UnknownHostException | URIException e) {
+        } catch (UnknownHostException | URIException e) {
             log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
         } catch (Exception e) {
             // Do not try to internationalise this.. we need an error message in any event..


### PR DESCRIPTION
Reduce usage of implementation details, moreover the exception should
no longer be thrown with the change of core (zaproxy/zaproxy#7177), it
will always resolve the redirection to something, the request might
still fail but it would be with a different exception.