### PR TITLE
fuzz: allow circular redirects always

### DIFF
--- a/addOns/fuzz/CHANGELOG.md
+++ b/addOns/fuzz/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Allow circular redirects always.
 - Maintenance changes.
 
 ## [13.6.0] - 2022-01-14

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzer.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzer.java
@@ -85,7 +85,6 @@ public class HttpFuzzer extends AbstractFuzzer<HttpMessage> {
         if (fuzzerOptions.isFollowRedirects()) {
             httpSender.setFollowRedirect(fuzzerOptions.isFollowRedirects());
             httpSender.setMaxRedirects(fuzzerOptions.getMaximumRedirects());
-            httpSender.setAllowCircularRedirects(fuzzerOptions.isAllowCircularRedirects());
         }
 
         httpSender.setRemoveUserDefinedAuthHeaders(true);

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandlerOptionsPanel.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerHandlerOptionsPanel.java
@@ -83,8 +83,7 @@ public class HttpFuzzerHandlerOptionsPanel implements FuzzerHandlerOptionsPanel<
 
     @Override
     public HttpFuzzerOptions getOptions(FuzzerOptions baseOptions) {
-        return new HttpFuzzerOptions(
-                baseOptions, followRedirectsCheckBox.isSelected(), false, 100, false);
+        return new HttpFuzzerOptions(baseOptions, followRedirectsCheckBox.isSelected(), false, 100);
     }
 
     @Override

--- a/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerOptions.java
+++ b/addOns/fuzz/src/main/java/org/zaproxy/zap/extension/fuzz/httpfuzzer/HttpFuzzerOptions.java
@@ -26,20 +26,17 @@ public class HttpFuzzerOptions extends FuzzerOptions {
     private final boolean followRedirects;
     private final boolean showRedirectMessages;
     private final int maximumRedirects;
-    private final boolean allowCircularRedirects;
 
     public HttpFuzzerOptions(
             FuzzerOptions baseOptions,
             boolean followRedirects,
             boolean showRedirectMessages,
-            int maximumRedirects,
-            boolean allowCircularRedirects) {
+            int maximumRedirects) {
         super(baseOptions);
 
         this.followRedirects = followRedirects;
         this.showRedirectMessages = showRedirectMessages;
         this.maximumRedirects = maximumRedirects;
-        this.allowCircularRedirects = allowCircularRedirects;
     }
 
     public boolean isFollowRedirects() {
@@ -52,9 +49,5 @@ public class HttpFuzzerOptions extends FuzzerOptions {
 
     public int getMaximumRedirects() {
         return maximumRedirects;
-    }
-
-    public boolean isAllowCircularRedirects() {
-        return allowCircularRedirects;
     }
 }


### PR DESCRIPTION
Remove the call that was disabling circular redirects always, also,
remove code that's no longer used/needed.

Related to zaproxy/zaproxy#7256.