### PR TITLE
selenium: restore usage of bundled ChromeDriver

### DIFF
--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use Network add-on to obtain main proxy address/port.
 
+### Fixed
+- Restore usage of bundled ChromeDriver ([Issue #7272](https://github.com/zaproxy/zaproxy/issues/7272)).
+
 ## [15.8.0] - 2022-03-29
 ### Added
 - Support aarch64/arm64 WebDrivers.

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/Browser.java
@@ -203,7 +203,16 @@ public enum Browser {
 
         Path basePath = getWebDriversDir().resolve(osDirName);
         String archDir = getArchDir();
-        Path driver = basePath.resolve(archDir).resolve(driverName);
+        String driverPath = process(basePath.resolve(archDir).resolve(driverName));
+        if (driverPath != null) {
+            return driverPath;
+        }
+
+        // Fallback to 32 in case the WebDriver does not have a 64 specific.
+        return process(basePath.resolve("32").resolve(driverName));
+    }
+
+    private static String process(Path driver) {
         if (Files.exists(driver)) {
             try {
                 setExecutable(driver);


### PR DESCRIPTION
Restore the fallback to 32bits when checking for bundled WebDrivers to
default to the 32bits ChromeDriver binary.

Fix zaproxy/zaproxy#7272.