### PR TITLE
feat: openapi: When importing indicate success

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- When no errors are encountered during import the API will now respond with content indicating things are okay (Issue 3951).
 
 ## [27] - 2022-03-29
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/OpenApiAPI.java
@@ -97,13 +97,7 @@ public class OpenApiAPI extends ApiImplementor {
                 throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA, PARAM_FILE);
             }
 
-            ApiResponseList result = new ApiResponseList(name);
-            for (String error : errors) {
-                result.addItem(new ApiResponseElement("warning", error));
-            }
-
-            return result;
-
+            return createResponse(name, errors);
         } else if (ACTION_IMPORT_URL.equals(name)) {
 
             try {
@@ -120,13 +114,7 @@ public class OpenApiAPI extends ApiImplementor {
                     throw new ApiException(
                             ApiException.Type.ILLEGAL_PARAMETER, "Failed to access the target.");
                 }
-
-                ApiResponseList result = new ApiResponseList(name);
-                for (String error : errors) {
-                    result.addItem(new ApiResponseElement("warning", error));
-                }
-
-                return result;
+                return createResponse(name, errors);
             } catch (URIException e) {
                 throw new ApiException(ApiException.Type.ILLEGAL_PARAMETER, PARAM_URL);
             } catch (InvalidUrlException e) {
@@ -136,6 +124,19 @@ public class OpenApiAPI extends ApiImplementor {
         } else {
             throw new ApiException(ApiException.Type.BAD_ACTION);
         }
+    }
+
+    private static ApiResponseList createResponse(String name, List<String> errors)
+            throws ApiException {
+        if (!errors.isEmpty()) {
+            throw new ApiException(ApiException.Type.BAD_EXTERNAL_DATA, String.join(",", errors));
+        }
+
+        ApiResponseList result = new ApiResponseList(name);
+        if (errors.isEmpty()) {
+            result.addItem(ApiResponseElement.OK);
+        }
+        return result;
     }
 
     private static int getContextId(JSONObject params) throws ApiException {


### PR DESCRIPTION
When no import errors occur `{"importUrl":["ok"]}`

- CHANGELOG.md > Add change note.
- OpenApiAPI.java > Indicate success when no errors occur. Respond 400 when an error does occur.

Example when "Report error details via API": `{"code":"bad_external_data","message":"The external data provided is not valid.","detail":"attribute paths.'/store/order'(post).operationId is repeated"}`

Fixes zaproxy/zaproxy#3951

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>