### PR TITLE
chore: websocket: Tweak Log Message WS Handshake Not Found

### DIFF
--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertWrapper.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/alerts/WebSocketAlertWrapper.java
@@ -197,7 +197,7 @@ public class WebSocketAlertWrapper {
                         webSocketMessageDTO.getChannel().getHandshakeReference().getHttpMessage();
             } catch (Exception e) {
                 LOGGER.info(
-                        "Couldn't get the Handshake Http Message for this specific channel. Channel ID: {}",
+                        "Couldn't get the Handshake HTTP Message for this specific channel. Channel ID: {}",
                         webSocketMessageDTO.getChannel().getId(),
                         e);
                 return this;


### PR DESCRIPTION
- WebSockertAlertWrapper > Tweaked logging when Handshake HTTP Message can't be found.

Related to zaproxy/zaproxy#5601

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>