### PR TITLE
network: use the option panels for selection

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ExtensionNetwork.java
@@ -557,9 +557,9 @@ public class ExtensionNetwork extends ExtensionAdaptor implements CommandLineLis
 
                 ExtensionHookView hookView = extensionHook.getHookView();
                 hookView.addOptionPanel(
-                        new LegacyOptionsPanel("dynssl", serverCertificatesOptionsPanel.getName()));
+                        new LegacyOptionsPanel("dynssl", serverCertificatesOptionsPanel));
                 hookView.addOptionPanel(
-                        new LegacyOptionsPanel("proxies", localServersOptionsPanel.getName()));
+                        new LegacyOptionsPanel("proxies", localServersOptionsPanel));
             }
         }
     }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LegacyOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LegacyOptionsPanel.java
@@ -30,7 +30,7 @@ class LegacyOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;
 
-    LegacyOptionsPanel(String sourceKey, String newPanelName) {
+    LegacyOptionsPanel(String sourceKey, AbstractParamPanel newPanel) {
         setName(Constant.messages.getString("network.ui.options.legacy." + sourceKey));
 
         JLabel label =
@@ -40,7 +40,7 @@ class LegacyOptionsPanel extends AbstractParamPanel {
         JButton button =
                 new JButton(Constant.messages.getString("network.ui.options.legacy.opennew"));
         button.addActionListener(
-                e -> View.getSingleton().getOptionsDialog(null).showParamPanel(newPanelName));
+                e -> View.getSingleton().getOptionsDialog(null).showParamPanel(newPanel, ""));
 
         GroupLayout layout = new GroupLayout(this);
         setLayout(layout);


### PR DESCRIPTION
Use the panels themselves for selection instead of their names which
might not be unique, leading to wrong panel being selected/shown.