### PR TITLE
network: remove incorrect escape in message

### DIFF
--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -121,7 +121,7 @@ network.ui.options.localservers.field.mode.api = API
 network.ui.options.localservers.field.mode.apiproxy = API and Proxy
 network.ui.options.localservers.field.mode.proxy = Proxy
 network.ui.options.localservers.field.behindnat = Behind NAT
-network.ui.options.localservers.field.behindnat.tooltip = <html>Indicates that ZAP is behind NAT.<br>When selected ZAP will attempt to determine the public IP address,<br>\\
+network.ui.options.localservers.field.behindnat.tooltip = <html>Indicates that ZAP is behind NAT.<br>When selected ZAP will attempt to determine the public IP address,<br>\
 to properly detect and handle requests with the public IP address.<br>Refer to the help page for more details.</html>
 network.ui.options.localservers.field.decoderesponse = Decode Response
 network.ui.options.localservers.field.decoderesponse.tooltip = <html>Always automatically decode (i.e. gzip, deflate) the response.<br>\


### PR DESCRIPTION
Remove incorrect escape in a resource message, should be escaping the
newline.