### PR TITLE
feat: retire: Include CVEs as Alert Tags when available

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,13 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Relevant CVEs will now be added as Alert Tags when available.
 
 ## [0.11.0] - 2022-05-03
 ### Changed
 - Updated with upstream retire.js pattern changes.
-
-
 
 ## [0.10.0] - 2022-02-02
 ### Changed

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/Result.java
@@ -19,6 +19,7 @@
  */
 package org.zaproxy.addon.retire;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -70,5 +71,12 @@ public class Result {
 
     public boolean hasOtherInfo() {
         return otherinfo != null && !otherinfo.isEmpty();
+    }
+
+    public Set<String> getCves() {
+        if (information.isEmpty() || !information.containsKey(CVE)) {
+            return Collections.emptySet();
+        }
+        return information.get(CVE);
     }
 }

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -22,6 +22,7 @@ package org.zaproxy.addon.retire;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,6 +102,7 @@ public class RetireScanRule extends PluginPassiveScanner {
                         Constant.messages.getString(
                                 "retire.rule.desc", result.getFilename(), result.getVersion()))
                 .setOtherInfo(otherInfo)
+                .setTags(getAllAlertTags(result))
                 .setReference(getDetails(Result.INFO, result.getInformation()))
                 .setSolution(Constant.messages.getString("retire.rule.soln", result.getFilename()))
                 .setEvidence(result.getEvidence().trim())
@@ -125,6 +127,13 @@ public class RetireScanRule extends PluginPassiveScanner {
             sb.append(item).append('\n');
         }
         return sb.toString();
+    }
+
+    private Map<String, String> getAllAlertTags(Result result) {
+        Map<String, String> alertTags = new HashMap<>();
+        result.getCves().forEach(value -> alertTags.put(value, ""));
+        alertTags.putAll(getAlertTags());
+        return alertTags;
     }
 
     @Override

--- a/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
+++ b/addOns/retire/src/test/java/org/zaproxy/addon/retire/RetireScanRuleUnitTest.java
@@ -152,6 +152,8 @@ class RetireScanRuleUnitTest extends PassiveScannerTest<RetireScanRule> {
         assertEquals(
                 "https://github.com/twbs/bootstrap/issues/20184\n",
                 alertsRaised.get(0).getReference());
+        // Two Constant OWASP tags plus one CVE
+        assertEquals(3, alertsRaised.get(0).getTags().size());
     }
 
     @Test


### PR DESCRIPTION
- CHANGELOG > Added change note.
- Result > Add convenience method to get a list of associated CVEs.
- RetireScanRule > Added functionality to add CVEs as alert tags when they're available.
- RetireScanRuleUnitTest > Asserted the new behavior in one unittest.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>