### PR TITLE
feat: ascanrulesBeta: Leverage aws.zaproxy.org

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Adding more checks to Hidden File Finder scan rule.
+- The Cloud Metadata scan rule will now be attempted with a second payload.
 
 ## [40] - 2022-03-15
 ### Changed


### PR DESCRIPTION
- CHANGELOG.md > Added change note.
- CloudMetadataScanRule.java > Updated to attempt multiple payloads. Reduced logging level on exception handling, and allow to continue payloads if an exception is encountered.
- CloudMetadataScanRuleUnitTest.java > Updated in two ways:
    - Make UnitTest for non 200 conditions use content that aligns with the response status code.
    - Parameterize the 200 condition test to align with and assert the new behavior.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>