### PR TITLE
network: manage connection options

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptions.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptions.java
@@ -1,0 +1,872 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import java.net.PasswordAuthentication;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.configuration.HierarchicalConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.SSLConnector;
+import org.zaproxy.addon.network.internal.TlsUtils;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+import org.zaproxy.addon.network.internal.client.SocksProxy;
+import org.zaproxy.addon.network.internal.client.SocksProxy.Version;
+import org.zaproxy.zap.common.VersionedAbstractParam;
+
+/** The options related to the connection. */
+public class ConnectionOptions extends VersionedAbstractParam {
+
+    private static final Logger LOGGER = LogManager.getLogger(ConnectionOptions.class);
+
+    public static final String DEFAULT_DEFAULT_USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0";
+
+    /** The default connection timeout (in seconds). */
+    public static final int DEFAULT_TIMEOUT = 20;
+
+    /** The default TTL (in seconds) of successful DNS queries. */
+    public static final int DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES = 30;
+
+    /**
+     * The current version of the configurations. Used to keep track of configuration changes
+     * between releases, in case changes/updates are needed.
+     *
+     * <p>It only needs to be incremented for configuration changes (not releases of the add-on).
+     *
+     * @see #CONFIG_VERSION_KEY
+     * @see #updateConfigsImpl(int)
+     */
+    private static final int CURRENT_CONFIG_VERSION = 1;
+
+    private static final String BASE_KEY = "network.connection";
+
+    /**
+     * The configuration key for the version of the configurations.
+     *
+     * @see #CURRENT_CONFIG_VERSION
+     */
+    private static final String CONFIG_VERSION_KEY = BASE_KEY + VERSION_ATTRIBUTE;
+
+    private static final String TIMEOUT_KEY = BASE_KEY + ".timeoutInSecs";
+    private static final String DEFAULT_USER_AGENT_KEY = BASE_KEY + ".defaultUserAgent";
+    private static final String USE_GLOBAL_HTTP_STATE_KEY = BASE_KEY + ".useGlobalHttpState";
+    private static final String DNS_TTL_SUCCESSFUL_QUERIES_KEY =
+            BASE_KEY + ".dnsTtlSuccessfulQueries";
+
+    private static final String TLS_PROTOCOLS_KEY = BASE_KEY + ".tlsProtocols";
+    private static final String TLS_PROTOCOL_KEY = TLS_PROTOCOLS_KEY + ".protocol";
+
+    private static final String HTTP_PROXY_BASE_KEY = BASE_KEY + ".httpProxy.";
+    private static final String HTTP_PROXY_ENABLED_KEY = HTTP_PROXY_BASE_KEY + "enabled";
+    private static final String HTTP_PROXY_HOST_KEY = HTTP_PROXY_BASE_KEY + "host";
+    private static final String HTTP_PROXY_PORT_KEY = HTTP_PROXY_BASE_KEY + "port";
+    private static final String HTTP_PROXY_AUTH_ENABLED_KEY = HTTP_PROXY_BASE_KEY + "authEnabled";
+    private static final String STORE_HTTP_PROXY_PASS_KEY = HTTP_PROXY_BASE_KEY + "storePass";
+    private static final String HTTP_PROXY_REALM_KEY = HTTP_PROXY_BASE_KEY + "realm";
+    private static final String HTTP_PROXY_USERNAME_KEY = HTTP_PROXY_BASE_KEY + "username";
+    private static final String HTTP_PROXY_PASSWORD_KEY = HTTP_PROXY_BASE_KEY + "password";
+
+    private static final String HTTP_PROXY_EXCLUSIONS_KEY = HTTP_PROXY_BASE_KEY + "exclusions";
+    private static final String HTTP_PROXY_EXCLUSION_KEY = HTTP_PROXY_EXCLUSIONS_KEY + ".exclusion";
+    private static final String HTTP_PROXY_EXCLUSION_HOST_KEY = "host";
+    private static final String HTTP_PROXY_EXCLUSION_ENABLED_KEY = "enabled";
+    private static final String HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE =
+            HTTP_PROXY_EXCLUSIONS_KEY + ".confirmRemove";
+
+    private static final String SOCKS_PROXY_BASE_KEY = BASE_KEY + ".socksProxy.";
+    private static final String SOCKS_PROXY_ENABLED_KEY = SOCKS_PROXY_BASE_KEY + "enabled";
+    private static final String SOCKS_PROXY_HOST_KEY = SOCKS_PROXY_BASE_KEY + "host";
+    private static final String SOCKS_PROXY_PORT_KEY = SOCKS_PROXY_BASE_KEY + "port";
+    private static final String SOCKS_PROXY_VERSION_KEY = SOCKS_PROXY_BASE_KEY + "version";
+    private static final String SOCKS_PROXY_DNS_KEY = SOCKS_PROXY_BASE_KEY + "dns";
+    private static final String SOCKS_PROXY_USERNAME_KEY = SOCKS_PROXY_BASE_KEY + "username";
+    private static final String SOCKS_PROXY_PASSWORD_KEY = SOCKS_PROXY_BASE_KEY + "password";
+
+    /** The default HTTP proxy configuration. */
+    public static final HttpProxy DEFAULT_HTTP_PROXY =
+            new HttpProxy("localhost", 8090, "", new PasswordAuthentication("", new char[0]));
+
+    /** The default SOCKS proxy configuration. */
+    public static final SocksProxy DEFAULT_SOCKS_PROXY =
+            new SocksProxy(
+                    "localhost",
+                    1080,
+                    Version.SOCKS5,
+                    true,
+                    new PasswordAuthentication("", new char[0]));
+
+    /**
+     * Pattern with loopback names and addresses that should be always resolved (when creating the
+     * {@link java.net.InetSocketAddress}).
+     *
+     * <p>Same pattern used by default proxy selector.
+     *
+     * @see #shouldResolveRemoteHostname(String)
+     */
+    private static final Pattern LOOPBACK_PATTERN =
+            Pattern.compile("\\Qlocalhost\\E|\\Q127.\\E.*|\\Q[::1]\\E|\\Q0.0.0.0\\E|\\Q[::0]\\E");
+
+    /** The security property for TTL of successful DNS queries. */
+    private static final String DNS_TTL_SUCCESSFUL_QUERIES_SECURITY_PROPERTY =
+            "networkaddress.cache.ttl";
+
+    private static final boolean DEFAULT_STORE_HTTP_PROXY_PASS = true;
+
+    private int timeoutInSecs = DEFAULT_TIMEOUT;
+    private String defaultUserAgent = DEFAULT_DEFAULT_USER_AGENT;
+    private boolean useGlobalHttpState;
+    private int dnsTtlSuccessfulQueries = DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES;
+    private List<String> tlsProtocols = TlsUtils.getSupportedProtocols();
+
+    private boolean httpProxyEnabled;
+    private HttpProxy httpProxy = DEFAULT_HTTP_PROXY;
+    private boolean httpProxyAuthEnabled;
+    private boolean storeHttpProxyPass = DEFAULT_STORE_HTTP_PROXY_PASS;
+    private List<HttpProxyExclusion> httpProxyExclusions = new ArrayList<>();
+    private boolean confirmRemoveHttpProxyExclusion = true;
+
+    private boolean socksProxyEnabled;
+    private SocksProxy socksProxy = DEFAULT_SOCKS_PROXY;
+
+    @Override
+    protected int getCurrentVersion() {
+        return CURRENT_CONFIG_VERSION;
+    }
+
+    @Override
+    protected String getConfigVersionKey() {
+        return CONFIG_VERSION_KEY;
+    }
+
+    @Override
+    protected void updateConfigsImpl(int fileVersion) {
+        // Nothing to do.
+    }
+
+    @Override
+    protected void parseImpl() {
+        // Do always, for now, in case -config args are in use.
+        migrateCoreConfigs();
+
+        setTimeoutInSecsImpl(getInt(TIMEOUT_KEY, DEFAULT_TIMEOUT));
+        setDefaultUserAgentImpl(getString(DEFAULT_USER_AGENT_KEY, DEFAULT_DEFAULT_USER_AGENT));
+        useGlobalHttpState = getBoolean(USE_GLOBAL_HTTP_STATE_KEY, false);
+
+        dnsTtlSuccessfulQueries =
+                getInt(DNS_TTL_SUCCESSFUL_QUERIES_KEY, DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES);
+        Security.setProperty(
+                DNS_TTL_SUCCESSFUL_QUERIES_SECURITY_PROPERTY,
+                Integer.toString(dnsTtlSuccessfulQueries));
+
+        List<String> protocols =
+                getConfig().getList(TLS_PROTOCOL_KEY).stream()
+                        .map(Object::toString)
+                        .collect(Collectors.toList());
+        if (protocols.isEmpty()) {
+            protocols = TlsUtils.getSupportedProtocols();
+        } else {
+            try {
+                protocols = TlsUtils.filterUnsupportedProtocols(protocols);
+            } catch (Exception e) {
+                LOGGER.warn("An error occurred while setting TLS protocols:", e);
+                protocols = TlsUtils.getSupportedProtocols();
+            }
+        }
+        tlsProtocols = protocols;
+        applyTlsProtocols();
+
+        parseHttpProxyOptions();
+        parseSocksProxyOptions();
+    }
+
+    private void migrateCoreConfigs() {
+        migrateConfig("connection.timeoutInSecs", TIMEOUT_KEY);
+        migrateConfig("connection.defaultUserAgent", DEFAULT_USER_AGENT_KEY);
+        migrateConfig("connection.httpStateEnabled", USE_GLOBAL_HTTP_STATE_KEY);
+        migrateConfig("connection.dnsTtlSuccessfulQueries", DNS_TTL_SUCCESSFUL_QUERIES_KEY);
+
+        try {
+            List<Object> list = getConfig().getList("connection.securityProtocolsEnabled.protocol");
+            if (!list.isEmpty()) {
+                persistTlsProtocols(
+                        TlsUtils.filterUnsupportedProtocols(
+                                list.stream()
+                                        .map(Object::toString)
+                                        .filter(e -> !e.isEmpty())
+                                        .collect(Collectors.toList())));
+            }
+        } catch (Exception e) {
+            LOGGER.warn("An error occurred while migrating old TLS protocols configuration:", e);
+        }
+
+        migrateConfig("connection.proxyChain.enabled", HTTP_PROXY_ENABLED_KEY);
+        migrateConfig("connection.proxyChain.hostName", HTTP_PROXY_HOST_KEY);
+        migrateConfig("connection.proxyChain.port", HTTP_PROXY_PORT_KEY);
+        migrateConfig("connection.proxyChain.authEnabled", HTTP_PROXY_AUTH_ENABLED_KEY);
+        Object promptPassword = getConfig().getProperty("connection.proxyChain.prompt");
+        if (promptPassword != null) {
+            getConfig()
+                    .setProperty(
+                            STORE_HTTP_PROXY_PASS_KEY,
+                            !Boolean.parseBoolean(promptPassword.toString()));
+        }
+        migrateConfig("connection.proxyChain.realm", HTTP_PROXY_REALM_KEY);
+        migrateConfig("connection.proxyChain.userName", HTTP_PROXY_USERNAME_KEY);
+        migrateConfig("connection.proxyChain.password", HTTP_PROXY_PASSWORD_KEY);
+
+        try {
+            int migratedExclusions = 0;
+            List<HierarchicalConfiguration> exclusions =
+                    ((HierarchicalConfiguration) getConfig())
+                            .configurationsAt("connection.proxyChain.exclusions.exclusion");
+            for (int i = 0; i < exclusions.size(); ++i) {
+                String oldConfig = "connection.proxyChain.exclusions.exclusion(" + i + ").";
+                String oldName = getString(oldConfig + "name", "");
+                if (!oldName.isEmpty()) {
+                    String newConfig = HTTP_PROXY_EXCLUSION_KEY + "(" + migratedExclusions + ").";
+                    migrateConfig(
+                            oldConfig + "enabled", newConfig + HTTP_PROXY_EXCLUSION_ENABLED_KEY);
+                    if (!getBoolean(oldConfig + "regex", false)) {
+                        oldName = Pattern.quote(oldName);
+                    }
+                    getConfig().setProperty(newConfig + HTTP_PROXY_EXCLUSION_HOST_KEY, oldName);
+                    migratedExclusions++;
+                }
+            }
+            migrateConfig(
+                    "connection.proxyChain.confirmRemoveExcludedDomain",
+                    HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE);
+        } catch (Exception e) {
+            LOGGER.warn("An error occurred while migrating old proxy exclusions:", e);
+        }
+
+        migrateConfig("connection.socksProxy.enabled", SOCKS_PROXY_ENABLED_KEY);
+        migrateConfig("connection.socksProxy.host", SOCKS_PROXY_HOST_KEY);
+        migrateConfig("connection.socksProxy.port", SOCKS_PROXY_PORT_KEY);
+        migrateConfig("connection.socksProxy.version", SOCKS_PROXY_VERSION_KEY);
+        migrateConfig("connection.socksProxy.dns", SOCKS_PROXY_DNS_KEY);
+        migrateConfig("connection.socksProxy.username", SOCKS_PROXY_USERNAME_KEY);
+        migrateConfig("connection.socksProxy.password", SOCKS_PROXY_PASSWORD_KEY);
+
+        ((HierarchicalConfiguration) getConfig()).clearTree("connection");
+    }
+
+    private void migrateConfig(String oldConfig, String newConfig) {
+        Object oldValue = getConfig().getProperty(oldConfig);
+        if (oldValue != null) {
+            getConfig().setProperty(newConfig, oldValue);
+        }
+    }
+
+    /**
+     * Sets the timeout, for reads and connects.
+     *
+     * @param timeoutInSecs the timeout, in seconds.
+     */
+    public void setTimeoutInSecs(int timeoutInSecs) {
+        setTimeoutInSecsImpl(timeoutInSecs);
+        getConfig().setProperty(TIMEOUT_KEY, this.timeoutInSecs);
+    }
+
+    private void setTimeoutInSecsImpl(int timeoutInSecs) {
+        this.timeoutInSecs = timeoutInSecs < 0 ? DEFAULT_TIMEOUT : timeoutInSecs;
+    }
+
+    /**
+     * Gets the timeout.
+     *
+     * @return the timeout, in seconds.
+     */
+    public int getTimeoutInSecs() {
+        return timeoutInSecs;
+    }
+
+    /**
+     * Sets the default user-agent.
+     *
+     * @param defaultUserAgent the default user-agent, might be {@code null}.
+     */
+    public void setDefaultUserAgent(String defaultUserAgent) {
+        setDefaultUserAgentImpl(defaultUserAgent);
+        getConfig().setProperty(DEFAULT_USER_AGENT_KEY, defaultUserAgent);
+    }
+
+    private void setDefaultUserAgentImpl(String defaultUserAgent) {
+        this.defaultUserAgent = defaultUserAgent;
+        HttpRequestHeader.setDefaultUserAgent(defaultUserAgent);
+    }
+
+    /**
+     * Gets the default user-agent.
+     *
+     * @return the default user-agent, might be {@code null}.
+     */
+    public String getDefaultUserAgent() {
+        return defaultUserAgent;
+    }
+
+    /**
+     * Sets whether or not to use the global HTTP state.
+     *
+     * @param useGlobalHttpState {@code true} if the global HTTP state should be used, {@code false}
+     *     otherwise.
+     */
+    public void setUseGlobalHttpState(boolean useGlobalHttpState) {
+        this.useGlobalHttpState = useGlobalHttpState;
+        getConfig().setProperty(USE_GLOBAL_HTTP_STATE_KEY, useGlobalHttpState);
+    }
+
+    /**
+     * Tells whether or not to use global HTTP state.
+     *
+     * @return {@code true} if the global HTTP state should be used, {@code false} otherwise.
+     */
+    public boolean isUseGlobalHttpState() {
+        return useGlobalHttpState;
+    }
+
+    /**
+     * Gets the TTL (in seconds) of successful DNS queries.
+     *
+     * @return the TTL in seconds
+     * @see #setDnsTtlSuccessfulQueries(int)
+     */
+    public int getDnsTtlSuccessfulQueries() {
+        return dnsTtlSuccessfulQueries;
+    }
+
+    /**
+     * Sets the TTL (in seconds) of successful DNS queries.
+     *
+     * <p>Some values have special meaning:
+     *
+     * <ul>
+     *   <li>Negative number, cache forever;
+     *   <li>Zero, disables caching;
+     *   <li>Positive number, the number of seconds the successful DNS queries will be cached.
+     * </ul>
+     *
+     * @param ttl the TTL in seconds
+     * @see #getDnsTtlSuccessfulQueries()
+     */
+    public void setDnsTtlSuccessfulQueries(int ttl) {
+        dnsTtlSuccessfulQueries = ttl;
+        getConfig().setProperty(DNS_TTL_SUCCESSFUL_QUERIES_KEY, ttl);
+    }
+
+    /**
+     * Sets the SSL/TLS protocols for outgoing connections.
+     *
+     * @param tlsProtocols the SSL/TLS protocols for outgoing connections.
+     * @throws IllegalArgumentException if no protocol is provided or none supported.
+     */
+    public void setTlsProtocols(List<String> tlsProtocols) {
+        this.tlsProtocols = TlsUtils.filterUnsupportedProtocols(tlsProtocols);
+        persistTlsProtocols(tlsProtocols);
+        applyTlsProtocols();
+    }
+
+    private void persistTlsProtocols(List<String> tlsProtocols) {
+        ((HierarchicalConfiguration) getConfig()).clearTree(TLS_PROTOCOLS_KEY);
+        for (int i = 0; i < tlsProtocols.size(); ++i) {
+            String elementBaseKey = TLS_PROTOCOL_KEY + "(" + i + ")";
+            getConfig().setProperty(elementBaseKey, tlsProtocols.get(i));
+        }
+    }
+
+    private void applyTlsProtocols() {
+        try {
+            SSLConnector.setClientEnabledProtocols(tlsProtocols.toArray(new String[0]));
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn(
+                    "Failed to apply protocols {} falling back to {} caused by: {}",
+                    tlsProtocols,
+                    TlsUtils.getSupportedProtocols(),
+                    e.getMessage());
+            tlsProtocols = TlsUtils.getSupportedProtocols();
+            SSLConnector.setClientEnabledProtocols(tlsProtocols.toArray(new String[0]));
+        }
+    }
+
+    /**
+     * Gets the SSL/TLS protocols for outgoing connections.
+     *
+     * @return the SSL/TLS protocols for outgoing connections.
+     */
+    public List<String> getTlsProtocols() {
+        return tlsProtocols;
+    }
+
+    private void parseHttpProxyOptions() {
+
+        httpProxyEnabled = getBoolean(HTTP_PROXY_ENABLED_KEY, false);
+        httpProxyAuthEnabled = getBoolean(HTTP_PROXY_AUTH_ENABLED_KEY, false);
+        storeHttpProxyPass = getBoolean(STORE_HTTP_PROXY_PASS_KEY, DEFAULT_STORE_HTTP_PROXY_PASS);
+
+        PasswordAuthentication passwordAuthentication =
+                new PasswordAuthentication(
+                        getString(HTTP_PROXY_USERNAME_KEY, ""),
+                        getString(HTTP_PROXY_PASSWORD_KEY, "").toCharArray());
+        String host = getString(HTTP_PROXY_HOST_KEY, DEFAULT_HTTP_PROXY.getHost());
+        if (host.isEmpty()) {
+            host = DEFAULT_HTTP_PROXY.getHost();
+        }
+        httpProxy =
+                new HttpProxy(
+                        host,
+                        parsePort(
+                                getConfig().getString(HTTP_PROXY_PORT_KEY),
+                                DEFAULT_HTTP_PROXY.getPort()),
+                        getString(HTTP_PROXY_REALM_KEY, DEFAULT_HTTP_PROXY.getRealm()),
+                        passwordAuthentication);
+
+        List<HierarchicalConfiguration> fields =
+                ((HierarchicalConfiguration) getConfig())
+                        .configurationsAt(HTTP_PROXY_EXCLUSION_KEY);
+        httpProxyExclusions = new ArrayList<>(fields.size());
+        for (HierarchicalConfiguration sub : fields) {
+            try {
+                Pattern pattern =
+                        createHttpProxyExclusionPattern(
+                                sub.getString(HTTP_PROXY_EXCLUSION_HOST_KEY, ""));
+                if (pattern != null) {
+                    httpProxyExclusions.add(
+                            new HttpProxyExclusion(
+                                    pattern,
+                                    sub.getBoolean(HTTP_PROXY_EXCLUSION_ENABLED_KEY, true)));
+                }
+            } catch (ConversionException e) {
+                LOGGER.warn("An error occurred while reading a HTTP proxy exclusion:", e);
+            }
+        }
+        confirmRemoveHttpProxyExclusion = getBoolean(HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE, true);
+    }
+
+    private static int parsePort(String value, int defaultPort) {
+        if (value == null || value.isEmpty()) {
+            return defaultPort;
+        }
+
+        int port;
+        try {
+            port = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            LOGGER.warn("Failed to parse the port: {}", value, e);
+            return defaultPort;
+        }
+
+        if (port > 0 && port <= 65535) {
+            return port;
+        }
+
+        LOGGER.warn("Invalid port: {}", value);
+        return defaultPort;
+    }
+
+    /**
+     * Tells whether or not to HTTP proxy should be used for the given host.
+     *
+     * @param host the host to check.
+     * @return {@code true} if the HTTP proxy should be used, {@code false} otherwise.
+     */
+    public boolean isUseHttpProxy(String host) {
+        if (!httpProxyEnabled || host == null || host.isEmpty()) {
+            return false;
+        }
+
+        for (HttpProxyExclusion exclusion : httpProxyExclusions) {
+            if (exclusion.test(host)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Tells whether or not the HTTP proxy is enabled.
+     *
+     * @return {@code true} if the HTTP proxy is enabled, {@code false} otherwise.
+     */
+    public boolean isHttpProxyEnabled() {
+        return httpProxyEnabled;
+    }
+
+    /**
+     * Sets whether or not the HTTP proxy is enabled.
+     *
+     * @param enabled {@code true} if the HTTP proxy should be enabled, {@code false} otherwise.
+     */
+    public void setHttpProxyEnabled(boolean enabled) {
+        this.httpProxyEnabled = enabled;
+        getConfig().setProperty(HTTP_PROXY_ENABLED_KEY, enabled);
+    }
+
+    /**
+     * Tells whether or not the HTTP proxy authentication is enabled.
+     *
+     * @return {@code true} if the HTTP proxy authentication is enabled, {@code false} otherwise.
+     */
+    public boolean isHttpProxyAuthEnabled() {
+        return httpProxyAuthEnabled;
+    }
+
+    /**
+     * Sets whether or not the HTTP proxy authentication is enabled.
+     *
+     * @param enabled {@code true} if the HTTP proxy authentication should be enabled, {@code false}
+     *     otherwise.
+     */
+    public void setHttpProxyAuthEnabled(boolean enabled) {
+        this.httpProxyAuthEnabled = enabled;
+        getConfig().setProperty(HTTP_PROXY_AUTH_ENABLED_KEY, enabled);
+    }
+
+    /**
+     * Tells whether or not the HTTP proxy password is stored in the configuration file.
+     *
+     * @return {@code true} if the HTTP proxy password is stored in the configuration file, {@code
+     *     false} otherwise.
+     */
+    public boolean isStoreHttpProxyPass() {
+        return storeHttpProxyPass;
+    }
+
+    /**
+     * Sets whether or not the HTTP proxy password should be stored in the configuration file.
+     *
+     * @param store {@code true} if the HTTP proxy password should be stored in the configuration
+     *     file, {@code false} otherwise.
+     */
+    public void setStoreHttpProxyPass(boolean store) {
+        this.storeHttpProxyPass = store;
+
+        getConfig().setProperty(STORE_HTTP_PROXY_PASS_KEY, store);
+        storeHttpProxyPass();
+    }
+
+    private void storeHttpProxyPass() {
+        String password =
+                storeHttpProxyPass
+                        ? new String(httpProxy.getPasswordAuthentication().getPassword())
+                        : "";
+        getConfig().setProperty(HTTP_PROXY_PASSWORD_KEY, password);
+    }
+
+    /**
+     * Gets the HTTP proxy.
+     *
+     * @return the HTTP proxy, never {@code null}.
+     */
+    public HttpProxy getHttpProxy() {
+        return httpProxy;
+    }
+
+    /**
+     * Sets the HTTP proxy.
+     *
+     * @param httpProxy the HTTP proxy.
+     * @throws NullPointerException if the given {@code httpProxy} is {@code null}.
+     */
+    public void setHttpProxy(HttpProxy httpProxy) {
+        if (this.httpProxy.equals(httpProxy)) {
+            return;
+        }
+
+        this.httpProxy = Objects.requireNonNull(httpProxy);
+
+        getConfig().setProperty(HTTP_PROXY_HOST_KEY, httpProxy.getHost());
+        getConfig().setProperty(HTTP_PROXY_PORT_KEY, httpProxy.getPort());
+        getConfig().setProperty(HTTP_PROXY_REALM_KEY, httpProxy.getRealm());
+        getConfig()
+                .setProperty(
+                        HTTP_PROXY_USERNAME_KEY,
+                        httpProxy.getPasswordAuthentication().getUserName());
+        storeHttpProxyPass();
+    }
+
+    /**
+     * Adds the given HTTP proxy exclusion.
+     *
+     * @param httpProxyExclusion the HTTP proxy exclusion.
+     * @throws NullPointerException if the given HTTP proxy exclusion is {@code null}.
+     */
+    public void addHttpProxyExclusion(HttpProxyExclusion httpProxyExclusion) {
+        Objects.requireNonNull(httpProxyExclusion);
+        httpProxyExclusions.add(httpProxyExclusion);
+        persistHttpProxyExclusions();
+    }
+
+    private void persistHttpProxyExclusions() {
+        ((HierarchicalConfiguration) getConfig()).clearTree(HTTP_PROXY_EXCLUSIONS_KEY);
+
+        for (int i = 0, size = httpProxyExclusions.size(); i < size; ++i) {
+            String elementBaseKey = HTTP_PROXY_EXCLUSION_KEY + "(" + i + ").";
+            HttpProxyExclusion httpProxyExclusion = httpProxyExclusions.get(i);
+
+            getConfig()
+                    .setProperty(
+                            elementBaseKey + HTTP_PROXY_EXCLUSION_HOST_KEY,
+                            httpProxyExclusion.getHost().pattern());
+            getConfig()
+                    .setProperty(
+                            elementBaseKey + HTTP_PROXY_EXCLUSION_ENABLED_KEY,
+                            httpProxyExclusion.isEnabled());
+        }
+    }
+
+    /**
+     * Sets whether or not the HTTP proxy exclusion with the given host should be enabled.
+     *
+     * @param host the value of the host.
+     * @param enabled {@code true} if the HTTP proxy exclusion should be enabled, {@code false}
+     *     otherwise.
+     * @return {@code true} if the HTTP proxy exclusion was changed, {@code false} otherwise.
+     * @throws NullPointerException if the given host is {@code null}.
+     */
+    public boolean setHttpProxyExclusionEnabled(String host, boolean enabled) {
+        Objects.requireNonNull(host);
+        for (Iterator<HttpProxyExclusion> it = httpProxyExclusions.iterator(); it.hasNext(); ) {
+            HttpProxyExclusion httpProxyExclusion = it.next();
+            if (host.equals(httpProxyExclusion.getHost().pattern())) {
+                httpProxyExclusion.setEnabled(enabled);
+                persistHttpProxyExclusions();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes a HTTP proxy exclusion.
+     *
+     * @param host the value of the host.
+     * @return {@code true} if the HTTP proxy exclusion was removed, {@code false} otherwise.
+     */
+    public boolean removeHttpProxyExclusion(String host) {
+        Objects.requireNonNull(host);
+        for (Iterator<HttpProxyExclusion> it = httpProxyExclusions.iterator(); it.hasNext(); ) {
+            if (host.equals(it.next().getHost().pattern())) {
+                it.remove();
+                persistHttpProxyExclusions();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Sets the HTTP proxy exclusions.
+     *
+     * @param httpProxyExclusions the HTTP proxy exclusions.
+     * @throws NullPointerException if the given list is {@code null}.
+     */
+    public void setHttpProxyExclusions(List<HttpProxyExclusion> httpProxyExclusions) {
+        Objects.requireNonNull(httpProxyExclusions);
+
+        this.httpProxyExclusions = new ArrayList<>(httpProxyExclusions);
+        persistHttpProxyExclusions();
+    }
+
+    /**
+     * Gets all the HTTP proxy exclusions.
+     *
+     * @return the list of HTTP proxy exclusions, never {@code null}.
+     */
+    public List<HttpProxyExclusion> getHttpProxyExclusions() {
+        return httpProxyExclusions;
+    }
+
+    /**
+     * Sets whether or not the removal of a HTTP proxy exclusion needs confirmation.
+     *
+     * @param confirmRemove {@code true} if the removal needs confirmation, {@code false} otherwise.
+     */
+    public void setConfirmRemoveHttpProxyExclusion(boolean confirmRemove) {
+        this.confirmRemoveHttpProxyExclusion = confirmRemove;
+        getConfig()
+                .setProperty(HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE, confirmRemoveHttpProxyExclusion);
+    }
+
+    /**
+     * Tells whether or not the removal of a HTTP proxy exclusion needs confirmation.
+     *
+     * @return {@code true} if the removal needs confirmation, {@code false} otherwise.
+     */
+    public boolean isConfirmRemoveHttpProxyExclusion() {
+        return confirmRemoveHttpProxyExclusion;
+    }
+
+    private static Pattern createHttpProxyExclusionPattern(String value) {
+        try {
+            return HttpProxyExclusion.createHostPattern(value);
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Ignoring invalid HTTP proxy exclusion pattern:", e);
+            return null;
+        }
+    }
+
+    private void parseSocksProxyOptions() {
+        String host = System.getProperty("socksProxyHost");
+        int port;
+        String version;
+        boolean useDns = getBoolean(SOCKS_PROXY_DNS_KEY, DEFAULT_SOCKS_PROXY.isUseDns());
+
+        if (host != null && !host.isEmpty()) {
+            port = parseSocksPort(System.getProperty("socksProxyPort"));
+            version = System.getProperty("socksProxyVersion");
+
+            socksProxyEnabled = true;
+        } else {
+            host = getString(SOCKS_PROXY_HOST_KEY, DEFAULT_SOCKS_PROXY.getHost());
+            if (host.isEmpty()) {
+                host = DEFAULT_SOCKS_PROXY.getHost();
+            }
+            port = parseSocksPort(getConfig().getString(SOCKS_PROXY_PORT_KEY));
+            version =
+                    getString(
+                            SOCKS_PROXY_VERSION_KEY,
+                            String.valueOf(DEFAULT_SOCKS_PROXY.getVersion().number()));
+
+            socksProxyEnabled = getBoolean(SOCKS_PROXY_ENABLED_KEY, false);
+        }
+
+        PasswordAuthentication passwordAuthentication =
+                new PasswordAuthentication(
+                        getString(SOCKS_PROXY_USERNAME_KEY, ""),
+                        getString(SOCKS_PROXY_PASSWORD_KEY, "").toCharArray());
+        socksProxy =
+                new SocksProxy(
+                        host,
+                        port,
+                        SocksProxy.Version.from(version),
+                        useDns,
+                        passwordAuthentication);
+        applySocksProxy();
+    }
+
+    private static int parseSocksPort(String value) {
+        return parsePort(value, DEFAULT_SOCKS_PROXY.getPort());
+    }
+
+    /**
+     * Applies the SOCKS proxy configuration to the SOCKS system properties.
+     *
+     * <p>If the SOCKS proxy is not in use (i.e. {@link #useSocksProxy} is {@code false}) the system
+     * properties are cleared.
+     */
+    private void applySocksProxy() {
+        String host = "";
+        String port = "";
+        String version = "";
+        if (socksProxyEnabled) {
+            host = socksProxy.getHost();
+            port = Integer.toString(socksProxy.getPort());
+            version = Integer.toString(socksProxy.getVersion().number());
+        }
+        System.setProperty("socksProxyHost", host);
+        System.setProperty("socksProxyPort", port);
+        System.setProperty("socksProxyVersion", version);
+    }
+
+    /**
+     * Tells whether or not the given host should be resolved.
+     *
+     * <p>The names should not be resolved when ZAP is configured to use a SOCKSv5 proxy and rely on
+     * it for resolution.
+     *
+     * @param host the name to check.
+     * @return {@code true} if the given {@code host} should be resolved, {@code false} otherwise.
+     */
+    public boolean shouldResolveRemoteHostname(String host) {
+        if (!socksProxyEnabled
+                || !socksProxy.isUseDns()
+                || socksProxy.getVersion() != SocksProxy.Version.SOCKS5) {
+            return true;
+        }
+        return LOOPBACK_PATTERN.matcher(host).matches();
+    }
+
+    /**
+     * Tells whether or not the SOCKS proxy is enabled.
+     *
+     * @return {@code true} if the SOCKS proxy is enabled, {@code false} otherwise.
+     */
+    public boolean isSocksProxyEnabled() {
+        return socksProxyEnabled;
+    }
+
+    /**
+     * Sets whether or not the SOCKS proxy is enabled.
+     *
+     * @param enabled {@code true} if the SOCKS proxy should be enabled, {@code false} otherwise.
+     */
+    public void setSocksProxyEnabled(boolean enabled) {
+        this.socksProxyEnabled = enabled;
+
+        getConfig().setProperty(SOCKS_PROXY_ENABLED_KEY, enabled);
+
+        applySocksProxy();
+    }
+
+    /**
+     * Gets the SOCKS proxy.
+     *
+     * @return the SOCKS proxy, never {@code null}.
+     */
+    public SocksProxy getSocksProxy() {
+        return socksProxy;
+    }
+
+    /**
+     * Sets the SOCKS proxy.
+     *
+     * @param socksProxy the SOCKS proxy.
+     * @throws NullPointerException if the given {@code socksProxy} is {@code null}.
+     */
+    public void setSocksProxy(SocksProxy socksProxy) {
+        if (this.socksProxy.equals(socksProxy)) {
+            return;
+        }
+
+        this.socksProxy = Objects.requireNonNull(socksProxy);
+
+        getConfig().setProperty(SOCKS_PROXY_HOST_KEY, socksProxy.getHost());
+        getConfig().setProperty(SOCKS_PROXY_PORT_KEY, socksProxy.getPort());
+        getConfig().setProperty(SOCKS_PROXY_VERSION_KEY, socksProxy.getVersion().number());
+        getConfig().setProperty(SOCKS_PROXY_DNS_KEY, socksProxy.isUseDns());
+        PasswordAuthentication auth = socksProxy.getPasswordAuthentication();
+        getConfig().setProperty(SOCKS_PROXY_USERNAME_KEY, auth.getUserName());
+        getConfig().setProperty(SOCKS_PROXY_PASSWORD_KEY, new String(auth.getPassword()));
+
+        if (socksProxyEnabled) {
+            applySocksProxy();
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
@@ -1,0 +1,779 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import java.awt.Component;
+import java.awt.event.ItemEvent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.net.PasswordAuthentication;
+import java.util.Arrays;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.ButtonGroup;
+import javax.swing.GroupLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JRadioButton;
+import javax.swing.JTabbedPane;
+import javax.swing.border.TitledBorder;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.model.OptionsParam;
+import org.parosproxy.paros.network.ConnectionParam;
+import org.parosproxy.paros.view.AbstractParamPanel;
+import org.zaproxy.addon.network.internal.client.CommonUserAgents;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+import org.zaproxy.addon.network.internal.client.SocksProxy;
+import org.zaproxy.addon.network.internal.ui.HttpProxyExclusionTableModel;
+import org.zaproxy.addon.network.internal.ui.HttpProxyExclusionTablePanel;
+import org.zaproxy.addon.network.internal.ui.SecurityProtocolsPanel;
+import org.zaproxy.zap.utils.FontUtils;
+import org.zaproxy.zap.utils.ZapNumberSpinner;
+import org.zaproxy.zap.utils.ZapPortNumberSpinner;
+import org.zaproxy.zap.utils.ZapTextField;
+
+class ConnectionOptionsPanel extends AbstractParamPanel {
+
+    private static final long serialVersionUID = 1L;
+
+    private final GeneralPanel generalPanel;
+    private final HttpProxyPanel httpProxyPanel;
+    private final SocksProxyPanel socksProxyPanel;
+
+    public ConnectionOptionsPanel() {
+        generalPanel = new GeneralPanel();
+        httpProxyPanel = new HttpProxyPanel();
+        socksProxyPanel = new SocksProxyPanel();
+
+        setName(Constant.messages.getString("network.ui.options.connection.name"));
+
+        JTabbedPane tabbedPane = new JTabbedPane();
+        tabbedPane.add(
+                Constant.messages.getString("network.ui.options.connection.general.tab"),
+                generalPanel.getPanel());
+        tabbedPane.add(
+                Constant.messages.getString("network.ui.options.connection.httpproxy.tab"),
+                httpProxyPanel.getPanel());
+        tabbedPane.add(
+                Constant.messages.getString("network.ui.options.connection.socksproxy.tab"),
+                socksProxyPanel.getPanel());
+
+        GroupLayout mainLayout = new GroupLayout(this);
+        setLayout(mainLayout);
+        mainLayout.setAutoCreateGaps(true);
+        mainLayout.setAutoCreateContainerGaps(true);
+
+        mainLayout.setHorizontalGroup(mainLayout.createParallelGroup().addComponent(tabbedPane));
+        mainLayout.setVerticalGroup(mainLayout.createSequentialGroup().addComponent(tabbedPane));
+    }
+
+    @Override
+    public void initParam(Object mainOptions) {
+        ConnectionOptions options = getConnectionOptions(mainOptions);
+
+        generalPanel.init(options);
+        httpProxyPanel.init(options);
+        socksProxyPanel.init(options);
+    }
+
+    private static ConnectionOptions getConnectionOptions(Object mainOptions) {
+        return ((OptionsParam) mainOptions).getParamSet(ConnectionOptions.class);
+    }
+
+    @Override
+    public void validateParam(Object mainOptions) throws Exception {
+        generalPanel.validate();
+        httpProxyPanel.validate();
+        socksProxyPanel.validate();
+    }
+
+    @Override
+    public void saveParam(Object mainOptions) throws Exception {
+        ConnectionOptions options = getConnectionOptions(mainOptions);
+
+        generalPanel.save(options);
+        httpProxyPanel.save(options);
+        socksProxyPanel.save(options);
+    }
+
+    @Override
+    public String getHelpIndex() {
+        return "addon.network.options.connection";
+    }
+
+    private static class GeneralPanel {
+
+        private final ZapNumberSpinner timeoutNumberSpinner;
+        private final JComboBox<String> systemsComboBox;
+        private final ZapTextField userAgentTextField;
+        private final JCheckBox globalHttpStateCheckBox;
+        private final ZapNumberSpinner dnsTtlSuccessfulNumberSpinner;
+        private final SecurityProtocolsPanel securityProtocolsPanel;
+        private final JPanel panel;
+
+        GeneralPanel() {
+            JLabel timeoutLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.general.timeout"));
+            timeoutNumberSpinner =
+                    new ZapNumberSpinner(0, ConnectionOptions.DEFAULT_TIMEOUT, Integer.MAX_VALUE);
+            timeoutLabel.setLabelFor(timeoutNumberSpinner);
+
+            userAgentTextField = new ZapTextField();
+            userAgentTextField.addActionListener(e -> updateUserAgentsComboBox());
+            userAgentTextField.addKeyListener(
+                    new KeyAdapter() {
+
+                        @Override
+                        public void keyReleased(KeyEvent e) {
+                            updateUserAgentsComboBox();
+                        }
+                    });
+            JLabel userAgentLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.general.useragent"));
+            systemsComboBox = new JComboBox<>(CommonUserAgents.getSystems());
+            if (systemsComboBox.getItemCount() == 0) {
+                systemsComboBox.setEnabled(false);
+            }
+            systemsComboBox.addItem("");
+            systemsComboBox.addActionListener(
+                    e -> {
+                        String userAgent =
+                                CommonUserAgents.getUserAgentFromSystem(
+                                        (String) systemsComboBox.getSelectedItem());
+                        if (userAgent != null) {
+                            userAgentTextField.setText(userAgent);
+                        }
+                    });
+            userAgentLabel.setLabelFor(systemsComboBox);
+
+            globalHttpStateCheckBox =
+                    new JCheckBox(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.general.globalhttpstate"));
+
+            dnsTtlSuccessfulNumberSpinner =
+                    new ZapNumberSpinner(
+                            -1,
+                            ConnectionOptions.DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES,
+                            Integer.MAX_VALUE);
+
+            JPanel dnsPanel = new JPanel();
+            dnsPanel.setBorder(
+                    BorderFactory.createTitledBorder(
+                            null,
+                            Constant.messages.getString("conn.options.dns.title"),
+                            TitledBorder.DEFAULT_JUSTIFICATION,
+                            TitledBorder.DEFAULT_POSITION,
+                            FontUtils.getFont(FontUtils.Size.standard)));
+
+            GroupLayout layout = new GroupLayout(dnsPanel);
+            dnsPanel.setLayout(layout);
+            layout.setAutoCreateGaps(true);
+            layout.setAutoCreateContainerGaps(true);
+
+            JLabel dnsTtlSuccessfulLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "conn.options.dns.ttlSuccessfulQueries.label"));
+            dnsTtlSuccessfulLabel.setToolTipText(
+                    Constant.messages.getString("conn.options.dns.ttlSuccessfulQueries.toolTip"));
+            dnsTtlSuccessfulLabel.setLabelFor(dnsTtlSuccessfulNumberSpinner);
+
+            layout.setHorizontalGroup(
+                    layout.createSequentialGroup()
+                            .addComponent(dnsTtlSuccessfulLabel)
+                            .addComponent(dnsTtlSuccessfulNumberSpinner));
+
+            layout.setVerticalGroup(
+                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                            .addComponent(dnsTtlSuccessfulLabel)
+                            .addComponent(dnsTtlSuccessfulNumberSpinner));
+
+            securityProtocolsPanel = new SecurityProtocolsPanel();
+
+            Component spacer = Box.createHorizontalGlue();
+
+            panel = new JPanel();
+            layout = new GroupLayout(panel);
+            panel.setLayout(layout);
+            layout.setAutoCreateGaps(true);
+            layout.setAutoCreateContainerGaps(true);
+
+            layout.setHorizontalGroup(
+                    layout.createParallelGroup()
+                            .addGroup(
+                                    layout.createSequentialGroup()
+                                            .addGroup(
+                                                    layout.createParallelGroup(
+                                                                    GroupLayout.Alignment.TRAILING)
+                                                            .addComponent(timeoutLabel)
+                                                            .addComponent(userAgentLabel))
+                                            .addGroup(
+                                                    layout.createParallelGroup(
+                                                                    GroupLayout.Alignment.LEADING)
+                                                            .addComponent(timeoutNumberSpinner)
+                                                            .addComponent(systemsComboBox)))
+                            .addComponent(userAgentTextField)
+                            .addComponent(globalHttpStateCheckBox)
+                            .addComponent(spacer)
+                            .addComponent(dnsPanel)
+                            .addComponent(securityProtocolsPanel));
+
+            layout.setVerticalGroup(
+                    layout.createSequentialGroup()
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(timeoutLabel)
+                                            .addComponent(timeoutNumberSpinner))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(userAgentLabel)
+                                            .addComponent(systemsComboBox))
+                            .addComponent(
+                                    userAgentTextField,
+                                    GroupLayout.PREFERRED_SIZE,
+                                    GroupLayout.PREFERRED_SIZE,
+                                    GroupLayout.PREFERRED_SIZE)
+                            .addComponent(globalHttpStateCheckBox)
+                            .addComponent(spacer)
+                            .addComponent(dnsPanel)
+                            .addComponent(securityProtocolsPanel));
+        }
+
+        private void updateUserAgentsComboBox() {
+            String name = CommonUserAgents.getSystemFromUserAgent(userAgentTextField.getText());
+            systemsComboBox.setSelectedItem(name != null ? name : "");
+        }
+
+        JPanel getPanel() {
+            return panel;
+        }
+
+        void init(ConnectionOptions options) {
+            timeoutNumberSpinner.setValue(options.getTimeoutInSecs());
+            userAgentTextField.setText(options.getDefaultUserAgent());
+            updateUserAgentsComboBox();
+            userAgentTextField.discardAllEdits();
+            globalHttpStateCheckBox.setSelected(options.isUseGlobalHttpState());
+            dnsTtlSuccessfulNumberSpinner.setValue(options.getDnsTtlSuccessfulQueries());
+            securityProtocolsPanel.setSecurityProtocolsEnabled(options.getTlsProtocols());
+        }
+
+        void validate() throws Exception {
+            securityProtocolsPanel.validateSecurityProtocolsWithException();
+        }
+
+        void save(ConnectionOptions options) {
+            options.setTimeoutInSecs(timeoutNumberSpinner.getValue());
+            options.setDefaultUserAgent(userAgentTextField.getText());
+            options.setUseGlobalHttpState(globalHttpStateCheckBox.isSelected());
+            options.setDnsTtlSuccessfulQueries(dnsTtlSuccessfulNumberSpinner.getValue());
+            options.setTlsProtocols(securityProtocolsPanel.getSelectedProtocols());
+        }
+    }
+
+    private static class HttpProxyPanel {
+
+        private final JCheckBox proxyEnabledCheckBox;
+        private final ZapTextField hostTextField;
+        private final ZapPortNumberSpinner portNumberSpinner;
+        private final JCheckBox authEnabledCheckBox;
+        private final JCheckBox storePassCheckBox;
+        private final ZapTextField realmTextField;
+        private final ZapTextField usernameTextField;
+        private final JPasswordField passwordField;
+        private final HttpProxyExclusionTableModel tableModel;
+        private final HttpProxyExclusionTablePanel tablePanel;
+        private final JPanel panel;
+
+        HttpProxyPanel() {
+            panel = new JPanel();
+            GroupLayout layout = new GroupLayout(panel);
+            panel.setLayout(layout);
+            layout.setAutoCreateGaps(true);
+            layout.setAutoCreateContainerGaps(true);
+
+            hostTextField = new ZapTextField();
+            hostTextField.setText(ConnectionParam.DEFAULT_SOCKS_PROXY.getHost());
+            JLabel hostLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.host"));
+            hostLabel.setLabelFor(hostTextField);
+
+            portNumberSpinner =
+                    new ZapPortNumberSpinner(ConnectionParam.DEFAULT_SOCKS_PROXY.getPort());
+            JLabel portLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.port"));
+            portLabel.setLabelFor(portNumberSpinner);
+
+            realmTextField = new ZapTextField();
+            JLabel realmLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.realm"));
+            realmLabel.setLabelFor(realmTextField);
+
+            usernameTextField = new ZapTextField();
+            JLabel usernameLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.username"));
+            usernameLabel.setLabelFor(usernameTextField);
+
+            passwordField = new JPasswordField();
+            JLabel passwordLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.password"));
+            passwordLabel.setLabelFor(passwordField);
+
+            storePassCheckBox =
+                    new JCheckBox(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.auth.storepass"),
+                            true);
+
+            JLabel authEnabledLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.auth.enabled"));
+            authEnabledCheckBox = new JCheckBox((String) null, true);
+            authEnabledCheckBox.addItemListener(
+                    e -> {
+                        boolean state =
+                                authEnabledCheckBox.isEnabled()
+                                        && e.getStateChange() == ItemEvent.SELECTED;
+                        storePassCheckBox.setEnabled(state);
+                        realmTextField.setEnabled(state);
+                        usernameTextField.setEnabled(state);
+                        passwordField.setEnabled(state);
+                    });
+            authEnabledCheckBox.setSelected(false);
+            authEnabledLabel.setLabelFor(authEnabledCheckBox);
+
+            JLabel exclusionsLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.exclusions"));
+            tableModel = new HttpProxyExclusionTableModel();
+            tablePanel = new HttpProxyExclusionTablePanel(tableModel);
+
+            JLabel proxyEnabledLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.httpproxy.enabled"));
+            proxyEnabledCheckBox = new JCheckBox((String) null, true);
+            proxyEnabledCheckBox.addItemListener(
+                    e -> {
+                        boolean state = e.getStateChange() == ItemEvent.SELECTED;
+                        hostTextField.setEnabled(state);
+                        portNumberSpinner.setEnabled(state);
+                        authEnabledCheckBox.setEnabled(state);
+                        boolean authState = state && authEnabledCheckBox.isSelected();
+                        storePassCheckBox.setEnabled(authState);
+                        realmTextField.setEnabled(authState);
+                        usernameTextField.setEnabled(authState);
+                        passwordField.setEnabled(authState);
+                        tablePanel.setComponentEnabled(state);
+                    });
+            proxyEnabledCheckBox.setSelected(false);
+            proxyEnabledLabel.setLabelFor(proxyEnabledCheckBox);
+
+            layout.setHorizontalGroup(
+                    layout.createParallelGroup()
+                            .addGroup(
+                                    layout.createSequentialGroup()
+                                            .addGroup(
+                                                    layout.createParallelGroup(
+                                                                    GroupLayout.Alignment.TRAILING)
+                                                            .addComponent(proxyEnabledLabel)
+                                                            .addComponent(hostLabel)
+                                                            .addComponent(portLabel)
+                                                            .addComponent(authEnabledLabel)
+                                                            .addComponent(realmLabel)
+                                                            .addComponent(usernameLabel)
+                                                            .addComponent(passwordLabel))
+                                            .addGroup(
+                                                    layout.createParallelGroup(
+                                                                    GroupLayout.Alignment.LEADING)
+                                                            .addComponent(proxyEnabledCheckBox)
+                                                            .addComponent(hostTextField)
+                                                            .addComponent(portNumberSpinner)
+                                                            .addComponent(authEnabledCheckBox)
+                                                            .addComponent(realmTextField)
+                                                            .addComponent(usernameTextField)
+                                                            .addComponent(passwordField)
+                                                            .addComponent(storePassCheckBox)))
+                            .addGroup(
+                                    layout.createParallelGroup()
+                                            .addComponent(exclusionsLabel)
+                                            .addComponent(tablePanel)));
+
+            layout.setVerticalGroup(
+                    layout.createSequentialGroup()
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(proxyEnabledLabel)
+                                            .addComponent(proxyEnabledCheckBox))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(hostLabel)
+                                            .addComponent(hostTextField))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(portLabel)
+                                            .addComponent(portNumberSpinner))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(authEnabledLabel)
+                                            .addComponent(authEnabledCheckBox))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(realmLabel)
+                                            .addComponent(realmTextField))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(usernameLabel)
+                                            .addComponent(usernameTextField))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(passwordLabel)
+                                            .addComponent(passwordField))
+                            .addComponent(storePassCheckBox)
+                            .addComponent(exclusionsLabel)
+                            .addComponent(tablePanel));
+        }
+
+        JPanel getPanel() {
+            return panel;
+        }
+
+        void init(ConnectionOptions options) {
+            proxyEnabledCheckBox.setSelected(options.isHttpProxyEnabled());
+
+            HttpProxy httpProxy = options.getHttpProxy();
+            hostTextField.setText(httpProxy.getHost());
+            hostTextField.discardAllEdits();
+            portNumberSpinner.setValue(httpProxy.getPort());
+
+            authEnabledCheckBox.setSelected(options.isHttpProxyAuthEnabled());
+            storePassCheckBox.setSelected(options.isStoreHttpProxyPass());
+            realmTextField.setText(httpProxy.getRealm());
+            realmTextField.discardAllEdits();
+            PasswordAuthentication passwordAuthentication = httpProxy.getPasswordAuthentication();
+            usernameTextField.setText(passwordAuthentication.getUserName());
+            usernameTextField.discardAllEdits();
+            passwordField.setText(new String(passwordAuthentication.getPassword()));
+
+            tableModel.setHttpProxyExclusions(options.getHttpProxyExclusions());
+        }
+
+        void validate() throws Exception {
+            if (!proxyEnabledCheckBox.isSelected()) {
+                if (hostTextField.getText().isEmpty()) {
+                    hostTextField.setText(ConnectionOptions.DEFAULT_HTTP_PROXY.getHost());
+                }
+                return;
+            }
+
+            if (hostTextField.getText().isEmpty()) {
+                hostTextField.requestFocus();
+                throw new Exception(
+                        Constant.messages.getString(
+                                "network.ui.options.connection.httpproxy.host.empty"));
+            }
+
+            if (!authEnabledCheckBox.isSelected()) {
+                return;
+            }
+
+            if (usernameTextField.getText().isEmpty()) {
+                usernameTextField.requestFocus();
+                throw new Exception(
+                        Constant.messages.getString(
+                                "network.ui.options.connection.httpproxy.username.empty"));
+            }
+        }
+
+        void save(ConnectionOptions options) {
+            options.setHttpProxyEnabled(proxyEnabledCheckBox.isSelected());
+            options.setHttpProxyAuthEnabled(authEnabledCheckBox.isSelected());
+            options.setStoreHttpProxyPass(storePassCheckBox.isSelected());
+
+            HttpProxy oldHttpProxy = options.getHttpProxy();
+            PasswordAuthentication passwordAuthentication =
+                    oldHttpProxy.getPasswordAuthentication();
+            char[] password = passwordField.getPassword();
+            if (!oldHttpProxy.getHost().equals(hostTextField.getText())
+                    || oldHttpProxy.getPort() != portNumberSpinner.getValue()
+                    || !oldHttpProxy.getRealm().equals(realmTextField.getText())
+                    || !passwordAuthentication.getUserName().equals(usernameTextField.getText())
+                    || !Arrays.equals(passwordAuthentication.getPassword(), password)) {
+                options.setHttpProxy(
+                        new HttpProxy(
+                                hostTextField.getText(),
+                                portNumberSpinner.getValue(),
+                                realmTextField.getText(),
+                                new PasswordAuthentication(usernameTextField.getText(), password)));
+            }
+
+            options.setHttpProxyExclusions(tableModel.getElements());
+        }
+    }
+
+    private static class SocksProxyPanel {
+
+        private final JCheckBox proxyEnabledCheckBox;
+        private final ZapTextField hostTextField;
+        private final ZapPortNumberSpinner portNumberSpinner;
+        private final JRadioButton version4RadioButton;
+        private final JRadioButton version5RadioButton;
+        private final JCheckBox useSocksDnsCheckBox;
+        private final ZapTextField usernameTextField;
+        private final JPasswordField passwordField;
+        private final JPanel panel;
+
+        public SocksProxyPanel() {
+            panel = new JPanel();
+            GroupLayout layout = new GroupLayout(panel);
+            panel.setLayout(layout);
+            layout.setAutoCreateGaps(true);
+            layout.setAutoCreateContainerGaps(true);
+
+            hostTextField = new ZapTextField();
+            hostTextField.setText(ConnectionParam.DEFAULT_SOCKS_PROXY.getHost());
+            JLabel hostLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.socksproxy.host"));
+            hostLabel.setLabelFor(hostTextField);
+
+            portNumberSpinner =
+                    new ZapPortNumberSpinner(ConnectionParam.DEFAULT_SOCKS_PROXY.getPort());
+            JLabel portLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.socksproxy.port"));
+            portLabel.setLabelFor(portNumberSpinner);
+
+            JLabel versionLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.socksproxy.version"));
+            version4RadioButton = new JRadioButton("4a");
+            version5RadioButton = new JRadioButton("5");
+
+            ButtonGroup versionButtonGroup = new ButtonGroup();
+            versionButtonGroup.add(version4RadioButton);
+            versionButtonGroup.add(version5RadioButton);
+            version4RadioButton.setSelected(true);
+
+            useSocksDnsCheckBox =
+                    new JCheckBox(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.socksproxy.dns"));
+            useSocksDnsCheckBox.setToolTipText(
+                    Constant.messages.getString(
+                            "network.ui.options.connection.socksproxy.dns.tooltip"));
+            useSocksDnsCheckBox.setSelected(true);
+
+            usernameTextField = new ZapTextField();
+            JLabel usernameLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.socksproxy.username"));
+            usernameLabel.setLabelFor(usernameTextField);
+
+            passwordField = new JPasswordField();
+            JLabel passwordLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.socksproxy.password"));
+            passwordLabel.setLabelFor(passwordField);
+
+            JLabel proxyEnabledLabel =
+                    new JLabel(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.socksproxy.enabled"));
+            proxyEnabledCheckBox = new JCheckBox((String) null, true);
+            proxyEnabledCheckBox.addItemListener(
+                    e -> {
+                        boolean state = e.getStateChange() == ItemEvent.SELECTED;
+                        hostTextField.setEnabled(state);
+                        portNumberSpinner.setEnabled(state);
+                        version4RadioButton.setEnabled(state);
+                        version5RadioButton.setEnabled(state);
+                        useSocksDnsCheckBox.setEnabled(state && version5RadioButton.isSelected());
+                        usernameTextField.setEnabled(state);
+                        passwordField.setEnabled(state);
+                    });
+            proxyEnabledCheckBox.setSelected(false);
+            proxyEnabledLabel.setLabelFor(proxyEnabledCheckBox);
+
+            version5RadioButton.addItemListener(
+                    e ->
+                            useSocksDnsCheckBox.setEnabled(
+                                    e.getStateChange() == ItemEvent.SELECTED
+                                            && proxyEnabledCheckBox.isSelected()));
+            setSelectedVersion(ConnectionOptions.DEFAULT_SOCKS_PROXY.getVersion());
+
+            layout.setHorizontalGroup(
+                    layout.createSequentialGroup()
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+                                            .addComponent(proxyEnabledLabel)
+                                            .addComponent(hostLabel)
+                                            .addComponent(portLabel)
+                                            .addComponent(versionLabel)
+                                            .addComponent(usernameLabel)
+                                            .addComponent(passwordLabel))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                            .addComponent(proxyEnabledCheckBox)
+                                            .addComponent(hostTextField)
+                                            .addComponent(portNumberSpinner)
+                                            .addGroup(
+                                                    layout.createParallelGroup()
+                                                            .addGroup(
+                                                                    layout.createSequentialGroup()
+                                                                            .addComponent(
+                                                                                    version4RadioButton)
+                                                                            .addComponent(
+                                                                                    version5RadioButton))
+                                                            .addComponent(useSocksDnsCheckBox))
+                                            .addComponent(usernameTextField)
+                                            .addComponent(passwordField)));
+
+            layout.setVerticalGroup(
+                    layout.createSequentialGroup()
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(proxyEnabledLabel)
+                                            .addComponent(proxyEnabledCheckBox))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(hostLabel)
+                                            .addComponent(hostTextField))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(portLabel)
+                                            .addComponent(portNumberSpinner))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(versionLabel)
+                                            .addComponent(version4RadioButton)
+                                            .addComponent(version5RadioButton))
+                            .addComponent(useSocksDnsCheckBox)
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(usernameLabel)
+                                            .addComponent(usernameTextField))
+                            .addGroup(
+                                    layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                            .addComponent(passwordLabel)
+                                            .addComponent(passwordField)));
+        }
+
+        JPanel getPanel() {
+            return panel;
+        }
+
+        private void setSelectedVersion(SocksProxy.Version version) {
+            switch (version) {
+                case SOCKS4A:
+                    version4RadioButton.setSelected(true);
+                    break;
+                case SOCKS5:
+                default:
+                    version5RadioButton.setSelected(true);
+            }
+        }
+
+        private SocksProxy.Version getSelectedVersion() {
+            if (version4RadioButton.isSelected()) {
+                return SocksProxy.Version.SOCKS4A;
+            }
+            return SocksProxy.Version.SOCKS5;
+        }
+
+        void init(ConnectionOptions options) {
+            proxyEnabledCheckBox.setSelected(options.isSocksProxyEnabled());
+
+            SocksProxy socksProxy = options.getSocksProxy();
+            hostTextField.setText(socksProxy.getHost());
+            hostTextField.discardAllEdits();
+            portNumberSpinner.setValue(socksProxy.getPort());
+            setSelectedVersion(socksProxy.getVersion());
+            useSocksDnsCheckBox.setSelected(socksProxy.isUseDns());
+
+            PasswordAuthentication passwordAuthentication = socksProxy.getPasswordAuthentication();
+            usernameTextField.setText(passwordAuthentication.getUserName());
+            usernameTextField.discardAllEdits();
+            passwordField.setText(new String(passwordAuthentication.getPassword()));
+        }
+
+        void validate() throws Exception {
+            if (!hostTextField.getText().isEmpty()) {
+                return;
+            }
+
+            if (proxyEnabledCheckBox.isSelected()) {
+                hostTextField.requestFocus();
+                throw new Exception(
+                        Constant.messages.getString(
+                                "network.ui.options.connection.socksproxy.host.empty"));
+            }
+            hostTextField.setText(ConnectionOptions.DEFAULT_SOCKS_PROXY.getHost());
+        }
+
+        void save(ConnectionOptions options) {
+            options.setSocksProxyEnabled(proxyEnabledCheckBox.isSelected());
+
+            SocksProxy oldSocksProxy = options.getSocksProxy();
+            PasswordAuthentication passwordAuthentication =
+                    oldSocksProxy.getPasswordAuthentication();
+            char[] password = passwordField.getPassword();
+            if (!oldSocksProxy.getHost().equals(hostTextField.getText())
+                    || oldSocksProxy.getPort() != portNumberSpinner.getValue()
+                    || oldSocksProxy.getVersion() != getSelectedVersion()
+                    || oldSocksProxy.isUseDns() != useSocksDnsCheckBox.isSelected()
+                    || !passwordAuthentication.getUserName().equals(usernameTextField.getText())
+                    || !Arrays.equals(passwordAuthentication.getPassword(), password)) {
+                options.setSocksProxy(
+                        new SocksProxy(
+                                hostTextField.getText(),
+                                portNumberSpinner.getValue(),
+                                getSelectedVersion(),
+                                useSocksDnsCheckBox.isSelected(),
+                                new PasswordAuthentication(usernameTextField.getText(), password)));
+            }
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CommonUserAgents.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CommonUserAgents.java
@@ -1,0 +1,85 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2015 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** Provides common user-agent values. */
+public final class CommonUserAgents {
+
+    private static final String COMMENT_TOKEN = "#";
+
+    private static final Map<String, String> SYSTEM_TO_USER_AGENT;
+    private static final Map<String, String> USER_AGENT_TO_SYSTEM;
+
+    private static final Logger logger = LogManager.getLogger(CommonUserAgents.class);
+
+    static {
+        SYSTEM_TO_USER_AGENT = new HashMap<>();
+        USER_AGENT_TO_SYSTEM = new HashMap<>();
+
+        try (InputStream is = CommonUserAgents.class.getResourceAsStream("common-user-agents.txt");
+                BufferedReader reader =
+                        new BufferedReader(new InputStreamReader(is, StandardCharsets.US_ASCII))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty() || line.startsWith(COMMENT_TOKEN)) {
+                    continue;
+                }
+
+                String[] array = line.split("\t");
+                if (array.length != 3) {
+                    logger.error("Unexpected format in line: {}", line);
+                } else {
+                    SYSTEM_TO_USER_AGENT.put(array[2], array[1]);
+                    USER_AGENT_TO_SYSTEM.put(array[1], array[2]);
+                }
+            }
+
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+        }
+    }
+
+    private CommonUserAgents() {}
+
+    public static String getUserAgentFromSystem(String system) {
+        return SYSTEM_TO_USER_AGENT.get(system);
+    }
+
+    public static String getSystemFromUserAgent(String userAgent) {
+        return USER_AGENT_TO_SYSTEM.get(userAgent);
+    }
+
+    public static String[] getSystems() {
+        String[] names = SYSTEM_TO_USER_AGENT.keySet().toArray(new String[0]);
+        Arrays.sort(names);
+        return names;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/HttpProxy.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/HttpProxy.java
@@ -1,0 +1,152 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.net.PasswordAuthentication;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A HTTP proxy.
+ *
+ * <p>Contains the host, port, realm, and password authentication.
+ */
+public class HttpProxy {
+
+    private final String host;
+    private final int port;
+    private final String realm;
+    private final PasswordAuthentication passwordAuthentication;
+
+    /**
+     * Constructs a {@code SocksProxy} with the given data.
+     *
+     * @param host the host, must not be {@code null} or empty.
+     * @param port the port.
+     * @param realm the realm of the HTTP proxy, must not be {@code null}.
+     * @param passwordAuthentication the password authentication, must not be {@code null}.
+     * @throws NullPointerException if the {@code host} or {@code passwordAuthentication} is {@code
+     *     null}.
+     * @throws IllegalArgumentException if the {@code host} is empty or the {@code port} is not a
+     *     valid port number.
+     */
+    public HttpProxy(
+            String host, int port, String realm, PasswordAuthentication passwordAuthentication) {
+        Objects.requireNonNull(host, "The host must not be null.");
+        Objects.requireNonNull(realm, "The realm must not be null.");
+        Objects.requireNonNull(
+                passwordAuthentication, "The password authentication must not be null.");
+        if (host.isEmpty()) {
+            throw new IllegalArgumentException("The host must not be empty.");
+        }
+        if (port <= 0 || port > 65535) {
+            throw new IllegalArgumentException(
+                    "The port is not valid, must be between 0 and 65535.");
+        }
+        this.host = host;
+        this.port = port;
+        this.realm = realm;
+        this.passwordAuthentication = passwordAuthentication;
+    }
+
+    /**
+     * Gets the host (name or address).
+     *
+     * @return the host, never {@code null} or empty.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Gets the port.
+     *
+     * @return the port.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Gets the realm.
+     *
+     * @return the realm, never {@code null}.
+     */
+    public String getRealm() {
+        return realm;
+    }
+
+    /**
+     * Gets the password authentication.
+     *
+     * @return the password authentication, never {@code null}.
+     */
+    public PasswordAuthentication getPasswordAuthentication() {
+        return passwordAuthentication;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode(
+                host,
+                port,
+                passwordAuthentication.getUserName(),
+                passwordAuthentication.getPassword());
+    }
+
+    private static int hashCode(Object... values) {
+        return Arrays.deepHashCode(values);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof HttpProxy)) {
+            return false;
+        }
+        HttpProxy other = (HttpProxy) obj;
+        return Objects.equals(host, other.host)
+                && port == other.port
+                && Objects.equals(realm, other.realm)
+                && Objects.equals(
+                        passwordAuthentication.getUserName(),
+                        other.passwordAuthentication.getUserName())
+                && Arrays.equals(
+                        passwordAuthentication.getPassword(),
+                        other.passwordAuthentication.getPassword());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder strBuilder = new StringBuilder(75);
+        strBuilder.append("[Host=").append(host);
+        strBuilder.append(", Port=").append(port);
+        strBuilder.append(", Realm=").append(realm);
+        strBuilder.append(", UserName=").append(passwordAuthentication.getUserName());
+        strBuilder.append(", Password=***");
+        strBuilder.append(']');
+        return strBuilder.toString();
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/HttpProxyExclusion.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/HttpProxyExclusion.java
@@ -1,0 +1,120 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import org.zaproxy.zap.utils.Enableable;
+
+/** A HTTP Proxy exclusion. */
+public class HttpProxyExclusion extends Enableable implements Predicate<String> {
+
+    private Pattern host;
+
+    /**
+     * Constructs a {@code HttpProxyExclusion} with the given values.
+     *
+     * @param host the host pattern.
+     * @param enabled {@code true} if enabled, {@code false} otherwise.
+     * @throws NullPointerException if the given host is {@code null}.
+     */
+    public HttpProxyExclusion(Pattern host, boolean enabled) {
+        super(enabled);
+        setHost(host);
+    }
+
+    /**
+     * Constructs a {@code HttpProxyExclusion} from the given instance.
+     *
+     * @param other the other instance.
+     * @throws NullPointerException if the given value is {@code null}.
+     */
+    public HttpProxyExclusion(HttpProxyExclusion other) {
+        super(Objects.requireNonNull(other).isEnabled());
+
+        this.host = other.host;
+    }
+
+    /**
+     * Gets the host pattern.
+     *
+     * @return the host.
+     */
+    public Pattern getHost() {
+        return host;
+    }
+
+    /**
+     * Sets the host pattern.
+     *
+     * @param host the host
+     * @throws NullPointerException if the given host is {@code null}.
+     */
+    public void setHost(Pattern host) {
+        this.host = Objects.requireNonNull(host);
+    }
+
+    @Override
+    public boolean test(String host) {
+        if (!isEnabled()) {
+            return false;
+        }
+
+        return this.host.matcher(host).find();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(host.pattern());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        if (!(obj instanceof HttpProxyExclusion)) {
+            return false;
+        }
+        HttpProxyExclusion other = (HttpProxyExclusion) obj;
+        return Objects.equals(host.pattern(), other.host.pattern());
+    }
+
+    /**
+     * Creates the host pattern.
+     *
+     * @param value the value of the host.
+     * @return the pattern or {@code null} if the given value is {@code null} or empty.
+     * @throws IllegalArgumentException if the given value is not a valid pattern.
+     */
+    public static Pattern createHostPattern(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        return Pattern.compile(value, Pattern.CASE_INSENSITIVE);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/SocksProxy.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/SocksProxy.java
@@ -1,0 +1,245 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.net.PasswordAuthentication;
+import java.util.Arrays;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A SOCKS proxy.
+ *
+ * <p>Contains the host, port, version, if names should be resolved by the proxy, and password
+ * authentication.
+ */
+public class SocksProxy {
+
+    private static final Logger LOGGER = LogManager.getLogger(SocksProxy.class);
+
+    /** The version of the SOCKS proxy. */
+    public enum Version {
+        /** Version 4. */
+        SOCKS4A(4),
+        /**
+         * Version 5.
+         *
+         * <p>Can resolve names and require authentication.
+         */
+        SOCKS5(5);
+
+        private final int number;
+
+        Version(int number) {
+            this.number = number;
+        }
+
+        /**
+         * Gets the number of the version.
+         *
+         * @return the number of the version.
+         */
+        public int number() {
+            return number;
+        }
+
+        /**
+         * Gets a {@code Version} from the given value (version number).
+         *
+         * <p>Defaults to {@link #SOCKS5} when the {@code value} is:
+         *
+         * <ul>
+         *   <li>null
+         *   <li>empty
+         *   <li>not a number
+         *   <li>unknown version
+         * </ul>
+         *
+         * @param value the value to convert
+         * @return the version.
+         */
+        public static Version from(String value) {
+            if (value == null || value.isEmpty()) {
+                return SOCKS5;
+            }
+            int number;
+            try {
+                number = Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                LOGGER.warn("Failed to parse the version: {}", value, e);
+                return SOCKS5;
+            }
+
+            if (number == SOCKS4A.number) {
+                return SOCKS4A;
+            }
+            if (number == SOCKS5.number) {
+                return SOCKS5;
+            }
+
+            LOGGER.warn("Unknown version: {}", value);
+            return SOCKS5;
+        }
+    }
+
+    private final String host;
+    private final int port;
+    private final Version version;
+    private final boolean useDns;
+    private final PasswordAuthentication passwordAuthentication;
+
+    /**
+     * Constructs a {@code SocksProxy} with the given data.
+     *
+     * @param host the host, must not be {@code null} or empty.
+     * @param port the port.
+     * @param version the version, must not be {@code null}.
+     * @param useDns {@code true} if the names should be resolved by the proxy, {@code false}
+     *     otherwise.
+     * @param passwordAuthentication the password authentication, must not be {@code null}.
+     * @throws NullPointerException if the {@code host}, {@code version}, or {@code
+     *     passwordAuthentication} is {@code null}.
+     * @throws IllegalArgumentException if the {@code host} is empty or the {@code port} is not a
+     *     valid port number.
+     */
+    public SocksProxy(
+            String host,
+            int port,
+            Version version,
+            boolean useDns,
+            PasswordAuthentication passwordAuthentication) {
+        Objects.requireNonNull(host, "The host must not be null.");
+        Objects.requireNonNull(version, "The version must not be null.");
+        Objects.requireNonNull(
+                passwordAuthentication, "The password authentication must not be null.");
+        if (host.isEmpty()) {
+            throw new IllegalArgumentException("The host must not be empty.");
+        }
+        if (port <= 0 || port > 65535) {
+            throw new IllegalArgumentException(
+                    "The port is not valid, must be between 0 and 65535.");
+        }
+        this.host = host;
+        this.port = port;
+        this.version = version;
+        this.useDns = useDns;
+        this.passwordAuthentication = passwordAuthentication;
+    }
+
+    /**
+     * Gets the host (name or address).
+     *
+     * @return the host, never {@code null} or empty.
+     */
+    public String getHost() {
+        return host;
+    }
+
+    /**
+     * Gets the port.
+     *
+     * @return the port.
+     */
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Gets the version.
+     *
+     * @return the version, never {@code null}.
+     */
+    public Version getVersion() {
+        return version;
+    }
+
+    /**
+     * Tells whether or not the names should be resolved by the proxy.
+     *
+     * <p>Only supported by {@link Version#SOCKS5}.
+     *
+     * @return {@code true} if the names should be resolved by the proxy, {@code false} otherwise.
+     */
+    public boolean isUseDns() {
+        return useDns;
+    }
+
+    /**
+     * Gets the password authentication.
+     *
+     * @return the password authentication, never {@code null}.
+     */
+    public PasswordAuthentication getPasswordAuthentication() {
+        return passwordAuthentication;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode(
+                host,
+                port,
+                useDns,
+                version.number,
+                passwordAuthentication.getUserName(),
+                passwordAuthentication.getPassword());
+    }
+
+    private static int hashCode(Object... values) {
+        return Arrays.deepHashCode(values);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof SocksProxy)) {
+            return false;
+        }
+        SocksProxy other = (SocksProxy) obj;
+        return host.equals(other.host)
+                && port == other.port
+                && useDns == other.useDns
+                && version == other.version
+                && Objects.equals(
+                        passwordAuthentication.getUserName(),
+                        other.passwordAuthentication.getUserName())
+                && Arrays.equals(
+                        passwordAuthentication.getPassword(),
+                        other.passwordAuthentication.getPassword());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder strBuilder = new StringBuilder(75);
+        strBuilder.append("[Host=").append(host);
+        strBuilder.append(", Port=").append(port);
+        strBuilder.append(", Version=").append(version.number);
+        strBuilder.append(", UseDns=").append(useDns);
+        strBuilder.append(", UserName=").append(passwordAuthentication.getUserName());
+        strBuilder.append(", Password=***");
+        strBuilder.append(']');
+        return strBuilder.toString();
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddHttpProxyExclusionDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddHttpProxyExclusionDialog.java
@@ -1,0 +1,178 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import java.awt.Dialog;
+import javax.swing.GroupLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+import org.zaproxy.zap.utils.ZapTextField;
+import org.zaproxy.zap.view.AbstractFormDialog;
+
+public class AddHttpProxyExclusionDialog extends AbstractFormDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final JPanel fieldsPanel;
+    protected final ZapTextField hostTextField;
+    protected final JCheckBox enabledCheckBox;
+
+    protected HttpProxyExclusion httpProxyExclusion;
+
+    public AddHttpProxyExclusionDialog(Dialog owner) {
+        this(
+                owner,
+                Constant.messages.getString(
+                        "network.ui.options.connection.httpproxy.exclusions.add.title"));
+    }
+
+    protected AddHttpProxyExclusionDialog(Dialog owner, String title) {
+        super(owner, title, false);
+
+        fieldsPanel = new JPanel();
+
+        GroupLayout layout = new GroupLayout(fieldsPanel);
+        fieldsPanel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        JLabel hostLabel =
+                new JLabel(
+                        Constant.messages.getString(
+                                "network.ui.options.connection.httpproxy.exclusions.add.field.host"));
+        hostTextField = new ZapTextField(25);
+        hostTextField.getDocument().addDocumentListener(new EnableButtonDocumentListener());
+        hostLabel.setLabelFor(hostTextField);
+
+        JLabel enabledLabel =
+                new JLabel(
+                        Constant.messages.getString(
+                                "network.ui.options.connection.httpproxy.exclusions.add.field.enabled"));
+        enabledCheckBox = new JCheckBox();
+        enabledLabel.setLabelFor(enabledCheckBox);
+
+        layout.setHorizontalGroup(
+                layout.createSequentialGroup()
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.TRAILING)
+                                        .addComponent(hostLabel)
+                                        .addComponent(enabledLabel))
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+                                        .addComponent(hostTextField)
+                                        .addComponent(enabledCheckBox)));
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(hostLabel)
+                                        .addComponent(hostTextField))
+                        .addGroup(
+                                layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                                        .addComponent(enabledLabel)
+                                        .addComponent(enabledCheckBox)));
+
+        initView();
+    }
+
+    @Override
+    protected JPanel getFieldsPanel() {
+        return fieldsPanel;
+    }
+
+    @Override
+    protected String getConfirmButtonLabel() {
+        return Constant.messages.getString(
+                "network.ui.options.connection.httpproxy.exclusions.add.button");
+    }
+
+    @Override
+    protected void init() {
+        hostTextField.setText("");
+        hostTextField.discardAllEdits();
+        enabledCheckBox.setSelected(true);
+        httpProxyExclusion = null;
+    }
+
+    @Override
+    protected boolean validateFields() {
+        String value = hostTextField.getText();
+
+        try {
+            HttpProxyExclusion.createHostPattern(value);
+        } catch (IllegalArgumentException e) {
+            JOptionPane.showMessageDialog(
+                    this,
+                    Constant.messages.getString(
+                            "network.ui.options.connection.httpproxy.exclusions.warn.invalidregex.message",
+                            e.getMessage()),
+                    Constant.messages.getString(
+                            "network.ui.options.connection.httpproxy.exclusions.warn.invalidregex.title"),
+                    JOptionPane.INFORMATION_MESSAGE);
+            hostTextField.requestFocusInWindow();
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    protected void performAction() {
+        String value = hostTextField.getText();
+        httpProxyExclusion =
+                new HttpProxyExclusion(
+                        HttpProxyExclusion.createHostPattern(value), enabledCheckBox.isSelected());
+    }
+
+    public HttpProxyExclusion getHttpProxyExclusion() {
+        HttpProxyExclusion httpProxyExclusion = this.httpProxyExclusion;
+        this.httpProxyExclusion = null;
+        return httpProxyExclusion;
+    }
+
+    private class EnableButtonDocumentListener implements DocumentListener {
+
+        @Override
+        public void removeUpdate(DocumentEvent e) {
+            checkAndEnableConfirmButton(e);
+        }
+
+        @Override
+        public void insertUpdate(DocumentEvent e) {
+            checkAndEnableConfirmButton(e);
+        }
+
+        @Override
+        public void changedUpdate(DocumentEvent e) {
+            checkAndEnableConfirmButton(e);
+        }
+
+        private void checkAndEnableConfirmButton(DocumentEvent e) {
+            setConfirmButtonEnabled(e.getDocument().getLength() > 0);
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTableModel.java
@@ -1,0 +1,111 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
+
+public class HttpProxyExclusionTableModel
+        extends AbstractMultipleOptionsTableModel<HttpProxyExclusion> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] COLUMN_NAMES = {
+        Constant.messages.getString(
+                "network.ui.options.connection.httpproxy.exclusions.table.header.enabled"),
+        Constant.messages.getString(
+                "network.ui.options.connection.httpproxy.exclusions.table.header.host")
+    };
+
+    private static final int COLUMN_COUNT = COLUMN_NAMES.length;
+
+    private List<HttpProxyExclusion> exclusions;
+
+    public HttpProxyExclusionTableModel() {
+        super();
+
+        exclusions = Collections.emptyList();
+    }
+
+    @Override
+    public String getColumnName(int col) {
+        return COLUMN_NAMES[col];
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COLUMN_COUNT;
+    }
+
+    @Override
+    public int getRowCount() {
+        return exclusions.size();
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return columnIndex == 0;
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        switch (columnIndex) {
+            case 0:
+                return getElement(rowIndex).isEnabled();
+            case 1:
+                return getElement(rowIndex).getHost().pattern();
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+        if (columnIndex == 0 && aValue instanceof Boolean) {
+            exclusions.get(rowIndex).setEnabled((Boolean) aValue);
+            fireTableCellUpdated(rowIndex, columnIndex);
+        }
+    }
+
+    @Override
+    public Class<?> getColumnClass(int c) {
+        if (c == 0) {
+            return Boolean.class;
+        }
+        return String.class;
+    }
+
+    public void setHttpProxyExclusions(List<HttpProxyExclusion> exclusions) {
+        this.exclusions = new ArrayList<>(exclusions.size());
+        for (HttpProxyExclusion exclusion : exclusions) {
+            this.exclusions.add(new HttpProxyExclusion(exclusion));
+        }
+        fireTableDataChanged();
+    }
+
+    @Override
+    public List<HttpProxyExclusion> getElements() {
+        return exclusions;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTablePanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTablePanel.java
@@ -1,0 +1,116 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import javax.swing.JCheckBox;
+import javax.swing.JOptionPane;
+import javax.swing.SortOrder;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
+
+public class HttpProxyExclusionTablePanel
+        extends AbstractMultipleOptionsTablePanel<HttpProxyExclusion> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String REMOVE_DIALOG_TITLE =
+            Constant.messages.getString(
+                    "network.ui.options.connection.httpproxy.exclusions.remove.title");
+    private static final String REMOVE_DIALOG_TEXT =
+            Constant.messages.getString(
+                    "network.ui.options.connection.httpproxy.exclusions.remove.text");
+
+    private static final String REMOVE_DIALOG_CONFIRM_BUTTON_LABEL =
+            Constant.messages.getString(
+                    "network.ui.options.connection.httpproxy.exclusions.remove.button.confirm");
+    private static final String REMOVE_DIALOG_CANCEL_BUTTON_LABEL =
+            Constant.messages.getString(
+                    "network.ui.options.connection.httpproxy.exclusions.remove.button.cancel");
+
+    private static final String REMOVE_DIALOG_CHECKBOX_LABEL =
+            Constant.messages.getString(
+                    "network.ui.options.connection.httpproxy.exclusions.remove.checkbox.label");
+
+    private AddHttpProxyExclusionDialog addDialog;
+    private ModifyHttpProxyExclusionDialog modifyDialog;
+
+    public HttpProxyExclusionTablePanel(HttpProxyExclusionTableModel model) {
+        super(model);
+
+        getTable().setSortOrder(1, SortOrder.ASCENDING);
+    }
+
+    @Override
+    public HttpProxyExclusion showAddDialogue() {
+        if (addDialog == null) {
+            addDialog = new AddHttpProxyExclusionDialog(View.getSingleton().getOptionsDialog(null));
+            addDialog.pack();
+        }
+        addDialog.setVisible(true);
+        return addDialog.getHttpProxyExclusion();
+    }
+
+    @Override
+    public HttpProxyExclusion showModifyDialogue(HttpProxyExclusion e) {
+        if (modifyDialog == null) {
+            modifyDialog =
+                    new ModifyHttpProxyExclusionDialog(View.getSingleton().getOptionsDialog(null));
+            modifyDialog.pack();
+        }
+        modifyDialog.setHttpProxyExclusion(e);
+        modifyDialog.setVisible(true);
+
+        HttpProxyExclusion httpProxyExclusion = modifyDialog.getHttpProxyExclusion();
+
+        if (!httpProxyExclusion.equals(e)) {
+            return httpProxyExclusion;
+        }
+
+        return null;
+    }
+
+    @Override
+    public boolean showRemoveDialogue(HttpProxyExclusion e) {
+        JCheckBox removeWithoutConfirmationCheckBox = new JCheckBox(REMOVE_DIALOG_CHECKBOX_LABEL);
+        Object[] messages = {REMOVE_DIALOG_TEXT, " ", removeWithoutConfirmationCheckBox};
+        int option =
+                JOptionPane.showOptionDialog(
+                        View.getSingleton().getMainFrame(),
+                        messages,
+                        REMOVE_DIALOG_TITLE,
+                        JOptionPane.OK_CANCEL_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        new String[] {
+                            REMOVE_DIALOG_CONFIRM_BUTTON_LABEL, REMOVE_DIALOG_CANCEL_BUTTON_LABEL
+                        },
+                        null);
+
+        if (option == JOptionPane.OK_OPTION) {
+            setRemoveWithoutConfirmation(removeWithoutConfirmationCheckBox.isSelected());
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/ModifyHttpProxyExclusionDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/ModifyHttpProxyExclusionDialog.java
@@ -1,0 +1,53 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import java.awt.Dialog;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+
+public class ModifyHttpProxyExclusionDialog extends AddHttpProxyExclusionDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    public ModifyHttpProxyExclusionDialog(Dialog owner) {
+        super(
+                owner,
+                Constant.messages.getString(
+                        "network.ui.options.connection.httpproxy.exclusions.modify.title"));
+    }
+
+    @Override
+    protected String getConfirmButtonLabel() {
+        return Constant.messages.getString(
+                "network.ui.options.connection.httpproxy.exclusions.modify.button");
+    }
+
+    public void setHttpProxyExclusion(HttpProxyExclusion httpProxyExclusion) {
+        this.httpProxyExclusion = httpProxyExclusion;
+    }
+
+    @Override
+    protected void init() {
+        hostTextField.setText(httpProxyExclusion.getHost().pattern());
+        hostTextField.discardAllEdits();
+        enabledCheckBox.setSelected(httpProxyExclusion.isEnabled());
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PromptHttpProxyPasswordDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PromptHttpProxyPasswordDialog.java
@@ -1,0 +1,92 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import javax.swing.GroupLayout;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.zap.view.AbstractFormDialog;
+
+public class PromptHttpProxyPasswordDialog extends AbstractFormDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private final JPanel fieldsPanel;
+    private final JPasswordField passwordField;
+    private char[] password;
+
+    public PromptHttpProxyPasswordDialog() {
+        super(
+                (JFrame) null,
+                Constant.messages.getString("network.ui.prompt.httpproxy.password.title"),
+                false);
+
+        password = new char[0];
+        fieldsPanel = new JPanel();
+
+        GroupLayout layout = new GroupLayout(fieldsPanel);
+        fieldsPanel.setLayout(layout);
+        layout.setAutoCreateGaps(true);
+        layout.setAutoCreateContainerGaps(true);
+
+        JLabel passwordLabel =
+                new JLabel(
+                        Constant.messages.getString("network.ui.prompt.httpproxy.password.label"));
+        passwordField = new JPasswordField();
+        passwordLabel.setLabelFor(passwordField);
+
+        layout.setHorizontalGroup(
+                layout.createParallelGroup()
+                        .addComponent(passwordLabel)
+                        .addComponent(passwordField));
+
+        layout.setVerticalGroup(
+                layout.createSequentialGroup()
+                        .addComponent(passwordLabel)
+                        .addComponent(passwordField));
+        initView();
+        setConfirmButtonEnabled(true);
+
+        pack();
+        setVisible(true);
+    }
+
+    @Override
+    protected void performAction() {
+        password = passwordField.getPassword();
+    }
+
+    @Override
+    protected JPanel getFieldsPanel() {
+        return fieldsPanel;
+    }
+
+    @Override
+    protected String getConfirmButtonLabel() {
+        return Constant.messages.getString("network.ui.prompt.httpproxy.password.button");
+    }
+
+    public char[] getPassword() {
+        return password;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/SecurityProtocolsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/SecurityProtocolsPanel.java
@@ -124,6 +124,14 @@ public class SecurityProtocolsPanel extends JPanel {
     }
 
     public boolean validateSecurityProtocols() {
+        return validateSecurityProtocolsImpl(false);
+    }
+
+    public void validateSecurityProtocolsWithException() {
+        validateSecurityProtocolsImpl(true);
+    }
+
+    private boolean validateSecurityProtocolsImpl(boolean exception) {
         int protocolsSelected = 0;
         JCheckBox checkBoxEnabledProtocol = null;
         for (Entry<String, JCheckBox> entry : checkBoxesSslTlsProtocols.entrySet()) {
@@ -143,14 +151,14 @@ public class SecurityProtocolsPanel extends JPanel {
 
         if (checkBoxEnabledProtocol != null) {
             if (protocolsSelected == 0) {
-                showMessage("noprotocolsselected");
+                handleValidationError("noprotocolsselected", exception);
                 checkBoxEnabledProtocol.requestFocusInWindow();
                 return false;
             }
 
             if (protocolsSelected == 1
                     && checkBoxesSslTlsProtocols.get(TlsUtils.SSL_V2_HELLO).isSelected()) {
-                showMessage("justsslv2helloselected");
+                handleValidationError("justsslv2helloselected", exception);
                 checkBoxEnabledProtocol.requestFocusInWindow();
                 return false;
             }
@@ -158,10 +166,15 @@ public class SecurityProtocolsPanel extends JPanel {
         return true;
     }
 
-    private void showMessage(String key) {
+    private void handleValidationError(String key, boolean exception) {
+        String message =
+                Constant.messages.getString("network.ui.options.securityprotocols.error." + key);
+        if (exception) {
+            throw new IllegalArgumentException(message);
+        }
         JOptionPane.showMessageDialog(
                 this,
-                Constant.messages.getString("network.ui.options.securityprotocols.error." + key),
+                message,
                 Constant.messages.getString("network.ui.options.securityprotocols.error.title"),
                 JOptionPane.INFORMATION_MESSAGE);
     }

--- a/addOns/network/src/main/javahelp/help/contents/api.html
+++ b/addOns/network/src/main/javahelp/help/contents/api.html
@@ -22,6 +22,15 @@
 		<li>
 			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
 			<br>
+			addHttpProxyExclusion (host* enabled): Adds a host to be excluded from the HTTP proxy.
+			<ul>
+				<li>host: The value of the host, a regular expression.</li>
+				<li>enabled: The enabled state, true or false.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
 			addLocalServer (address* port* api proxy behindNat decodeResponse removeAcceptEncoding): Adds a local server/proxy.
 			<ul>
 				<li>address: The address of the local server/proxy.</li>
@@ -59,6 +68,14 @@
 		<li>
 			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
 			<br>
+			removeHttpProxyExclusion (host*): Removes a HTTP proxy exclusion.
+			<ul>
+				<li>host: The value of the host.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
 			removeLocalServer (address* port*): Removes a local server/proxy.
 			<ul>
 				<li>address: The address of the local server/proxy.</li>
@@ -79,6 +96,67 @@
 			setAliasEnabled (name* enabled): Sets whether or not an alias is enabled.
 			<ul>
 				<li>name: The name of the alias.</li>
+				<li>enabled: The enabled state, true or false.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setConnectionTimeout (timeout*): Sets the timeout, for reads and connects.
+			<ul>
+				<li>timeout: The timeout, in seconds.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setDefaultUserAgent (userAgent*): Sets the default user-agent.
+			<ul>
+				<li>userAgent: The default user-agent.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setDnsTtlSuccessfulQueries (ttl*): Sets the TTL of successful DNS queries.
+			<ul>
+				<li>ttl: The TTL, in seconds. Negative number, cache forever. Zero, disables caching. Positive number, the number of seconds the successful DNS queries will be cached.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setHttpProxy (host* port* realm username password): Sets the HTTP proxy configuration.
+			<ul>
+				<li>host: The host, name or address.</li>
+				<li>port: The port.</li>
+				<li>realm: The authentication realm.</li>
+				<li>username: The user name.</li>
+				<li>password: The password.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setHttpProxyAuthEnabled (enabled*): Sets whether or not the HTTP proxy authentication is enabled.
+			<ul>
+				<li>enabled: The enabled state, true or false.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setHttpProxyEnabled (enabled*): Sets whether or not the HTTP proxy is enabled.
+			<ul>
+				<li>enabled: The enabled state, true or false.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setHttpProxyExclusionEnabled (host* enabled*): Sets whether or not a HTTP proxy exclusion is enabled.
+			<ul>
+				<li>host: The value of the host.</li>
 				<li>enabled: The enabled state, true or false.</li>
 			</ul>
 		</li>
@@ -107,16 +185,55 @@
 				<li>validity: The number of days that the generated server certificates will be valid for.</li>
 			</ul>
 		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setSocksProxy (host* port* version useDns username password): Sets the SOCKS proxy configuration.
+			<ul>
+				<li>host: The host, name or address.</li>
+				<li>port: The port.</li>
+				<li>version: The SOCKS version.</li>
+				<li>useDns: If the names should be resolved by the SOCKS proxy, true or false.</li>
+				<li>username: The user name.</li>
+				<li>password: The password.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setSocksProxyEnabled (enabled*): Sets whether or not the SOCKS proxy is enabled.
+			<ul>
+				<li>enabled: The enabled state, true or false.</li>
+			</ul>
+		</li>
+		<li>
+			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
+			<br>
+			setUseGlobalHttpState (use*): Sets whether or not to use the global HTTP state.
+			<ul>
+				<li>use: The use state, true or false.</li>
+			</ul>
+		</li>
 	</ul>
 
 	<h3>Views</h3>
 	<strong>Note:</strong> These endpoints are only available in weekly releases and versions after 2.11.
 	<ul>
 		<li>getAliases: Gets the aliases used to identify the local servers/proxies.</li>
+		<li>getConnectionTimeout: Gets the connection timeout, in seconds.</li>
+		<li>getDefaultUserAgent: Gets the default user-agent.</li>
+		<li>getDnsTtlSuccessfulQueries: Gets the TTL (in seconds) of successful DNS queries.</li>
+		<li>getHttpProxy: Gets the HTTP proxy.</li>
+		<li>getHttpProxyExclusions: Gets the HTTP proxy exclusions.</li>
 		<li>getLocalServers: Gets the local servers/proxies.</li>
 		<li>getPassThroughs: Gets the authorities that will pass-through the local proxies.</li>
 		<li>getRootCaCertValidity: Gets the Root CA certificate validity, in days. Used when generating a new Root CA certificate.</li>
 		<li>getServerCertValidity:  Gets the server certificate validity, in days. Used when generating server certificates.</li>
+		<li>getSocksProxy: Gets the SOCKS proxy.</li>
+		<li>isHttpProxyAuthEnabled: Tells whether or not the HTTP proxy authentication is enabled.</li>
+		<li>isHttpProxyEnabled: Tells whether or not the HTTP proxy is enabled.</li>
+		<li>isSocksProxyEnabled: Tells whether or not the SOCKS proxy is enabled.</li>
+		<li>isUseGlobalHttpState: Tells whether or not to use global HTTP state.</li>
 	</ul>
 
 	<h3>Other</h3>
@@ -130,9 +247,9 @@
 		<li>
 			<strong>Note:</strong> This endpoint is only available in weekly releases and versions after 2.11.
 			<br>
-			setProxy (proxy*): Sets the outgoing proxy configuration.
+			setProxy (proxy*): Sets the HTTP proxy configuration.
 			<ul>
-				<li>proxy: The JSON object containing the outgoing proxy configuration.</li>
+				<li>proxy: The JSON object containing the HTTP proxy configuration.</li>
 			</ul>
 		</li>
 	</ul>
@@ -142,9 +259,9 @@
 	<ul>
 		<li>proxy.pac: Provides a PAC file, proxying through the main proxy.</li>
 		<li>
-			setproxy: Sets the outgoing proxy configuration.
+			setproxy: Sets the HTTP proxy configuration.
 			<ul>
-				<li>Request body: The JSON object containing the outgoing proxy configuration.</li>
+				<li>Request body: The JSON object containing the HTTP proxy configuration.</li>
 			</ul>
 		</li>
 	</ul>

--- a/addOns/network/src/main/javahelp/help/contents/options/connection.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/connection.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>Connection</TITLE>
+</HEAD>
+<BODY>
+	<H1>Connection</H1>
+	<strong>Note:</strong> This feature is only available in weekly releases and versions after 2.11.
+	<br>
+
+	<H2>General</H2>
+	This tab allows you to configure the general connection options.
+
+	<H3>Timeout (in seconds)</H3>
+	Allows to configure the connection and read timeout, a higher timeout allows to test slower applications.
+	<br>Default: <code>20</code>.
+
+	<H3>Default User Agent</H3>
+	The user agent that should be used when creating HTTP messages (for example, spider messages or CONNECT
+	requests to the HTTP proxy).
+
+	<H3>Use Global HTTP State</H3>
+	Allows the usage of a global HTTP state, to keep track of cookies and HTTP authentication.<br/>
+	This option must be selected to enable the "Use current tracking session" option in the
+	Manual Request Editor dialogs.<br/>
+	Session tracking ensures that any requests are sent with the latest session details.<br/>
+	For example you may record a session when logged in as one user and then logout and login as another user.<br/>
+	If you resend a request from the first session without session tracking then it will use the cookies from
+	the first session.<br/>
+	If you resend the same request with session tracking then it will use the cookies from the second session.
+	<br>Default: <code>unselected</code>.
+
+	<H3>DNS</H3>
+	<H4>TTL Successful Queries (in seconds)</H4>
+	Defines for how long the successful DNS queries should be cached:<ul>
+	<li>Negative number, cache forever;</li>
+	<li>Zero, disables caching;</li>
+	<li>Positive number, the number of seconds the queries will be cached.</li></ul>
+	<br>Default: <code>30</code>.
+	<br><strong>Note:</strong> Changes are applied after a restart.
+
+	<H3>Security Protocols</H3>
+	Allows to choose the SSL/TLS versions enabled for outgoing connections (for example, to servers). At least
+	one version must be enabled, versions unsupported by the JRE will be unselected and disabled.
+	<br>The option SSLv2Hello must be selected in conjunction with at least one SSL/TLS version.
+	<br>Default: All protocols supported.
+
+	<H2>HTTP Proxy</H2>
+	This tab allows you to configure an outgoing HTTP proxy. This is often required in a corporate environment.
+	<H3>Enabled</H3>
+	Enables the usage of the configured HTTP proxy.
+	<br>Default: <code>unselected</code>.
+	<H3>Host</H3>
+	The host name or address of the HTTP proxy.
+	<br>Default: <code>localhost</code>.
+	<H3>Port</H3>
+	The port of the HTTP proxy.
+	<br>Default: <code>8090</code>.
+	<H3>Authenticate</H3>
+	Enables the usage of the authentication credentials, to authenticate to the HTTP proxy.
+	<H3>Realm</H3>
+	The authentication realm.
+	<br>Default: none.
+	<H3>User Name</H3>
+	The user name. It is required.
+	<br>Default: none.
+	<H3>Password</H3>
+	The password.
+	<br>Default: none.
+	<br><strong>Note:</strong> Stored in clear text in the configuration file, if allowed.
+	<H3>Store Password</H3>
+	Allows to store the password in the configuration file. If not allowed ZAP prompts for the password during start up, it can still
+	be changed in this panel.
+	<br>Default: <code>selected</code>.
+	<H3>Exclusions</H3>
+	The hosts that should be excluded from the HTTP proxy. The <code>host</code> is a regular expression matched against the requested host name.
+
+	<H2>SOCKS Proxy</H2>
+	This tab allows you to configure an outgoing SOCKS proxy, by default the SOCKS proxy configuration applies to all connections made by ZAP,
+	taking precedence over the HTTP proxy.
+	<p>
+	The SOCKS proxy system properties (e.g. <code>socksProxyHost</code>, <code>socksProxyPort</code>) take precedence over the persisted
+	configurations for compatibility with older ZAP versions. ZAP will use and display the values of the system's properties when defined at
+	startup, the configurations can still be changed in this panel.
+	<p><strong>Note:</strong> Loopback addresses (e.g. <code>localhost</code>, <code>127.0.01</code>, <code>::1</code>) are not proxied through
+	the SOCKS proxy, the connections will be done directly.
+	<H3>Enabled</H3>
+	Enables the usage of the configured SOCKS proxy.
+	<br>Default: <code>unselected</code>, unless the SOCKS proxy system properties are defined, in which case it is <code>selected</code>.
+	<H3>Host</H3>
+	The host name or address of the SOCKS proxy.
+	<br>Default: <code>localhost</code>.
+	<H3>Port</H3>
+	The port of the SOCKS proxy.
+	<br>Default: <code>1080</code>.
+	<H3>Version</H3>
+	The version of the SOCKS proxy.
+	<br>Default: <code>5</code>.
+	<H3>Use SOCKS' DNS</H3>
+	If the host names should be resolved by the SOCKS proxy. Requires a version 5 SOCKS proxy.
+	<br>This might lead to connection failures if the SOCKS proxy is not able to resolve the host name (e.g. use of names that are defined in a
+	<code>hosts</code> file).
+	<br>Default: <code>selected</code>.
+	<H3>Authentication</H3>
+	The following fields allow to configure the authentication credentials for the SOCKS proxy.
+	<H4>User Name</H4>
+	The user name.
+	<br>Default: none.
+	<H4>Password</H4>
+	The password.
+	<br>Default: none.
+	<br><strong>Note:</strong> Stored in clear text in the configuration file.
+
+	<H2>See also</H2>
+	<table>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td><a href="../network.html">Network</a></td>
+			<td>the introduction to Network add-on</td>
+		</tr>
+	</table>
+
+</BODY>
+</HTML>

--- a/addOns/network/src/main/javahelp/help/contents/options/options.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/options.html
@@ -12,6 +12,11 @@
 	<table>
 		<tr>
 			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+			<td><a href="connection.html">Connection</a></td>
+			<td>Allows to configure the connection.</td>
+		</tr>
+		<tr>
+			<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
 			<td><a href="localservers.html">Local Servers/Proxies</a></td>
 			<td>Allows to manage and configure the local servers/proxies.</td>
 		</tr>

--- a/addOns/network/src/main/javahelp/help/map.jhm
+++ b/addOns/network/src/main/javahelp/help/map.jhm
@@ -9,6 +9,7 @@
     <mapID target="addon.network.api" url="contents/api.html" />
     <mapID target="addon.network.cmdline" url="contents/cmdline.html" />
     <mapID target="addon.network.options" url="contents/options/options.html" />
+    <mapID target="addon.network.options.connection" url="contents/options/connection.html" />
     <mapID target="addon.network.options.servercertificates" url="contents/options/servercertificates.html" />
     <mapID target="addon.network.options.localservers" url="contents/options/localservers.html" />
 </map>

--- a/addOns/network/src/main/javahelp/help/toc.xml
+++ b/addOns/network/src/main/javahelp/help/toc.xml
@@ -10,6 +10,7 @@
                 <tocitem text="API" target="addon.network.api" />
                 <tocitem text="Command Line"  target="addon.network.cmdline" />
                 <tocitem text="Options" target="addon.network.options">
+                    <tocitem text="Connection" target="addon.network.options.connection" />
                     <tocitem text="Local Servers/Proxies" target="addon.network.options.localservers" />
                     <tocitem text="Server Certificates" target="addon.network.options.servercertificates" />
                 </tocitem>

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/internal/client/common-user-agents.txt
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/internal/client/common-user-agents.txt
@@ -1,0 +1,68 @@
+# Most common user agents c/o https://techblog.willshouse.com/2012/01/03/most-common-user-agents/
+# Last Updated: Fri, 13 May 2022 14:05:15 +0000
+# This is used in the UI under Network > Connection > Default User Agent
+14.7%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36	Chrome 100.0 Win10
+6.7%	Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:99.0) Gecko/20100101 Firefox/99.0	Firefox 99.0 Win10
+5.7%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36	Chrome 101.0 Win10
+5.6%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36	Chrome 100.0 macOS
+5.4%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36	Chrome 100.0 Win10
+3.2%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15	Safari 15.4 macOS
+2.6%	Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0	Firefox 100.0 Win10
+2.6%	Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99.0	Firefox 99.0 Linux
+2.6%	Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0	Firefox 91.0 Win10
+2.5%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36	Chrome 100.0 Win10
+2.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36	Chrome 100.0 macOS
+2.1%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36	Chrome 101.0 macOS
+1.8%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:99.0) Gecko/20100101 Firefox/99.0	Firefox 99.0 macOS
+1.5%	Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99.0	Firefox 99.0 Linux
+1.4%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Safari/537.36	Chrome 101.0 Win10
+1.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36	Chrome 100.0 macOS
+1.1%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36 Edg/100.0.1185.50	Edge 100.0 Win10
+0.9%	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36	Chrome 100.0 Linux
+0.9%	Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0	Firefox 100.0 Linux
+0.8%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36 Edg/100.0.1185.44	Edge 100.0 Win10
+0.8%	Mozilla/5.0 (X11; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0	Firefox 91.0 Linu
+0.7%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36	Chrome 101.0 Win10
+0.7%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Safari/605.1.15	Safari 15.3 macOS
+0.7%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Safari/537.36 Edg/101.0.1210.32	Edge 101.0 Win10
+0.6%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Safari/537.36	Chrome 101.0 macOS
+0.6%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36 Edg/101.0.1210.39	Edge 101.0 Win10
+0.6%	Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:98.0) Gecko/20100101 Firefox/98.0	Firefox 98.0 Win10
+0.5%	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36	Chrome 101.0 Linux
+0.5%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:100.0) Gecko/20100101 Firefox/100.0	Firefox 100.0 macOS
+0.5%	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.41 Safari/537.36	Chrome 101.0 Linux
+0.5%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36 OPR/85.0.4341.75	Opera Generic Win10
+0.5%	Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36	Chrome 100.0 Win7
+0.4%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36	Chrome 99.0 Win10
+0.4%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36	Chrome 99.0 Win10
+0.4%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36 Edg/100.0.1185.39	Edge 100.0 Win10
+0.4%	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36	Chrome 100.0 Linux
+0.3%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.82 Safari/537.36	Chrome 99.0 Win10
+0.3%	Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0	Firefox 91.0 Win10
+0.3%	Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:99.0) Gecko/20100101 Firefox/99.0	Firefox 99.0 Win7
+0.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36	Chrome 99.0 macOS
+0.3%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Safari/537.36	Chrome 100.0 Win10
+0.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.2 Safari/605.1.15	Safari 15.2 macOS
+0.3%	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36	Chrome 100.0 Linux
+0.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15	Safari 15.4 macOS
+0.3%	Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99.0	Firefox 99.0 Linux
+0.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15	Safari 14.1 macOS
+0.3%	Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36	Chrome 100.0 Win7
+0.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36	Chrome 79.0 macOS
+0.3%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.64 Safari/537.36	Chrome 101.0 macOS
+0.3%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.141 YaBrowser/22.3.3.852 Yowser/2.5 Safari/537.36	Yandex Browser Generic Win10
+0.3%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36 OPR/85.0.4341.72	Opera Generic Win10
+0.3%	Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36	Chrome 100.0 Win10
+0.2%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.60 Safari/537.36	Chrome 100.0 macOS
+0.2%	Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0	Firefox 78.0 Linux
+0.2%	Mozilla/5.0 (X11; Linux x86_64; rv:98.0) Gecko/20100101 Firefox/98.0	Firefox 98.0 Linux
+0.2%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.83 Safari/537.36	Chrome 99.0 macOS
+0.2%	Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15	Safari 15.1 macOS
+0.2%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.141 YaBrowser/22.3.2.644 Yowser/2.5 Safari/537.36	Yandex Browser Generic Win10
+0.2%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36 OPR/85.0.4341.71	Opera Generic  Win10
+0.2%	Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:97.0) Gecko/20100101 Firefox/97.0	Firefox 97.0 Win10
+0.2%	Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36	Chrome 86.0 Win10
+0.2%	Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.4951.54 Safari/537.36	Chrome 101.0 Win7
+0.2%	Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.7113.93 Safari/537.36	Chrome 99.0 Win10
+0.2%	Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36 OPR/85.0.4341.60	Opera Generic Win10
+0.2%	Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0	Firefox 100.0 Linux

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -2,6 +2,9 @@ network.api.desc = Allows to access and configure core networking capabilities.
 network.api.action.addAlias = Adds an alias for the local servers/proxies.
 network.api.action.addAlias.param.name = The name of the alias.
 network.api.action.addAlias.param.enabled = The enabled state, true or false.
+network.api.action.addHttpProxyExclusion = Adds a host to be excluded from the HTTP proxy.
+network.api.action.addHttpProxyExclusion.param.host = The value of the host, a regular expression.
+network.api.action.addHttpProxyExclusion.param.enabled = The enabled state, true or false.
 network.api.action.addLocalServer = Adds a local server/proxy.
 network.api.action.addLocalServer.param.address = The address of the local server/proxy.
 network.api.action.addLocalServer.param.api = If the ZAP API is available, true or false.
@@ -18,6 +21,8 @@ network.api.action.importRootCaCert = Imports a Root CA certificate to be used t
 network.api.action.importRootCaCert.param.filePath = The file system path to the PEM file, containing the certificate and private key.
 network.api.action.removeAlias = Removes an alias.
 network.api.action.removeAlias.param.name = The name of the alias.
+network.api.action.removeHttpProxyExclusion = Removes a HTTP proxy exclusion.
+network.api.action.removeHttpProxyExclusion.param.host = The value of the host.
 network.api.action.removeLocalServer = Removes a local server/proxy.
 network.api.action.removeLocalServer.param.address = The address of the local server/proxy.
 network.api.action.removeLocalServer.param.port = The port of the local server/proxy.
@@ -26,6 +31,25 @@ network.api.action.removePassThrough.param.authority = The value of the authorit
 network.api.action.setAliasEnabled = Sets whether or not an alias is enabled.
 network.api.action.setAliasEnabled.param.name = The name of the alias.
 network.api.action.setAliasEnabled.param.enabled = The enabled state, true or false.
+network.api.action.setConnectionTimeout = Sets the timeout, for reads and connects.
+network.api.action.setConnectionTimeout.param.timeout = The timeout, in seconds.
+network.api.action.setDefaultUserAgent = Sets the default user-agent.
+network.api.action.setDefaultUserAgent.param.userAgent = The default user-agent.
+network.api.action.setDnsTtlSuccessfulQueries = Sets the TTL of successful DNS queries.
+network.api.action.setDnsTtlSuccessfulQueries.param.ttl = The TTL, in seconds. Negative number, cache forever. Zero, disables caching. Positive number, the number of seconds the successful DNS queries will be cached.
+network.api.action.setHttpProxy = Sets the HTTP proxy configuration.
+network.api.action.setHttpProxy.param.host = The host, name or address.
+network.api.action.setHttpProxy.param.port = The port.
+network.api.action.setHttpProxy.param.realm = The authentication realm.
+network.api.action.setHttpProxy.param.username = The user name.
+network.api.action.setHttpProxy.param.password = The password.
+network.api.action.setHttpProxyAuthEnabled = Sets whether or not the HTTP proxy authentication is enabled.
+network.api.action.setHttpProxyAuthEnabled.param.enabled = The enabled state, true or false.
+network.api.action.setHttpProxyEnabled = Sets whether or not the HTTP proxy is enabled.
+network.api.action.setHttpProxyEnabled.param.enabled = The enabled state, true or false.
+network.api.action.setHttpProxyExclusionEnabled = Sets whether or not a HTTP proxy exclusion is enabled.
+network.api.action.setHttpProxyExclusionEnabled.param.host = The value of the host.
+network.api.action.setHttpProxyExclusionEnabled.param.enabled = The enabled state, true or false.
 network.api.action.setPassThroughEnabled = Sets whether or not a pass-through is enabled.
 network.api.action.setPassThroughEnabled.param.authority = The value of the authority.
 network.api.action.setPassThroughEnabled.param.enabled = The enabled state, true or false.
@@ -33,15 +57,37 @@ network.api.action.setRootCaCertValidity = Sets the Root CA certificate validity
 network.api.action.setRootCaCertValidity.param.validity = The number of days that the generated Root CA certificate will be valid for.
 network.api.action.setServerCertValidity = Sets the server certificate validity. Used when generating server certificates.
 network.api.action.setServerCertValidity.param.validity = The number of days that the generated server certificates will be valid for.
+network.api.action.setSocksProxy = Sets the SOCKS proxy configuration.
+network.api.action.setSocksProxy.param.host = The host, name or address.
+network.api.action.setSocksProxy.param.port = The port.
+network.api.action.setSocksProxy.param.version = The SOCKS version.
+network.api.action.setSocksProxy.param.useDns = If the names should be resolved by the SOCKS proxy, true or false.
+network.api.action.setSocksProxy.param.username = The user name.
+network.api.action.setSocksProxy.param.password = The password.
+network.api.action.setSocksProxyEnabled = Sets whether or not the SOCKS proxy is enabled.
+network.api.action.setSocksProxyEnabled.param.enabled = The enabled state, true or false.
+network.api.action.setSocksProxyEnabled = Sets whether or not the SOCKS proxy is enabled.
+network.api.action.setUseGlobalHttpState = Sets whether or not to use the global HTTP state.
+network.api.action.setUseGlobalHttpState.param.use = The use state, true or false.
 network.api.other.proxy.pac = Provides a PAC file, proxying through the main proxy.
 network.api.other.rootCaCert = Gets the Root CA certificate used to issue server certificates. Suitable to import into client applications (e.g. browsers).
+network.api.other.setProxy = Sets the HTTP proxy configuration.
+network.api.other.setProxy.param.proxy = The JSON object containing the HTTP proxy configuration.
 network.api.view.getAliases = Gets the aliases used to identify the local servers/proxies.
-network.api.other.setProxy = Sets the outgoing proxy configuration.
-network.api.other.setProxy.param.proxy = The JSON object containing the outgoing proxy configuration.
+network.api.view.getConnectionTimeout = Gets the connection timeout, in seconds.
+network.api.view.getDefaultUserAgent = Gets the default user-agent.
+network.api.view.getDnsTtlSuccessfulQueries = Gets the TTL (in seconds) of successful DNS queries.
+network.api.view.getHttpProxy = Gets the HTTP proxy.
+network.api.view.getHttpProxyExclusions = Gets the HTTP proxy exclusions.
 network.api.view.getLocalServers = Gets the local servers/proxies.
 network.api.view.getPassThroughs = Gets the authorities that will pass-through the local proxies.
 network.api.view.getRootCaCertValidity = Gets the Root CA certificate validity, in days. Used when generating a new Root CA certificate.
 network.api.view.getServerCertValidity = Gets the server certificate validity, in days. Used when generating server certificates.
+network.api.view.getSocksProxy = Gets the SOCKS proxy.
+network.api.view.isHttpProxyAuthEnabled = Tells whether or not the HTTP proxy authentication is enabled.
+network.api.view.isHttpProxyEnabled = Tells whether or not the HTTP proxy is enabled.
+network.api.view.isSocksProxyEnabled = Tells whether or not the SOCKS proxy is enabled.
+network.api.view.isUseGlobalHttpState = Tells whether or not to use global HTTP state.
 
 network.api.legacy.api.action.addAdditionalProxy = Adds a new proxy using the details supplied.
 network.api.legacy.api.action.removeAdditionalProxy = Removes the additional proxy with the specified address and port.
@@ -95,6 +141,61 @@ network.ui.footer.proxies.tooltip.additional.disabled = Additional Proxies (Disa
 
 network.ui.options.name = Network
 
+network.ui.options.connection.name = Connection
+network.ui.options.connection.general.tab = General
+network.ui.options.connection.general.timeout = Timeout (in seconds):
+network.ui.options.connection.general.useragent = Default User Agent:
+network.ui.options.connection.general.globalhttpstate = Use Global HTTP State
+network.ui.options.connection.general.dns.title = DNS
+network.ui.options.connection.general.dns.ttlsuccessful.label = TTL Successful Queries (in seconds):
+network.ui.options.connection.general.dns.ttlsuccessful.toolTip = <html>Defines for how long the successful DNS queries should be cached:<ul>\
+<li>Negative number, cache forever;</li>\
+<li>Zero, disables caching;</li>\
+<li>Positive number, the number of seconds the queries will be cached.</li></ul>\
+<strong>Note:</strong> Changes are applied after a restart.</html>
+
+network.ui.options.connection.httpproxy.tab = HTTP Proxy
+network.ui.options.connection.httpproxy.enabled = Enabled:
+network.ui.options.connection.httpproxy.host = Host:
+network.ui.options.connection.httpproxy.host.empty = The HTTP proxy host is empty.
+network.ui.options.connection.httpproxy.port = Port:
+network.ui.options.connection.httpproxy.auth.enabled = Authenticate:
+network.ui.options.connection.httpproxy.auth.storepass = Store Password
+network.ui.options.connection.httpproxy.realm = Realm:
+network.ui.options.connection.httpproxy.username = User Name:
+network.ui.options.connection.httpproxy.username.empty = The HTTP proxy user name is empty.
+network.ui.options.connection.httpproxy.password = Password:
+
+network.ui.options.connection.httpproxy.exclusions = Exclusions:
+network.ui.options.connection.httpproxy.exclusions.add.title = Add HTTP Proxy Exclusion
+network.ui.options.connection.httpproxy.exclusions.add.field.host = Host:
+network.ui.options.connection.httpproxy.exclusions.add.field.enabled = Enabled:
+network.ui.options.connection.httpproxy.exclusions.add.button = Add
+network.ui.options.connection.httpproxy.exclusions.table.header.enabled = Enabled
+network.ui.options.connection.httpproxy.exclusions.table.header.host = Host
+network.ui.options.connection.httpproxy.exclusions.modify.title = Modify HTTP Proxy Exclusion
+network.ui.options.connection.httpproxy.exclusions.modify.button = Modify
+network.ui.options.connection.httpproxy.exclusions.remove.title = Remove HTTP Proxy Exclusion
+network.ui.options.connection.httpproxy.exclusions.remove.text = Are you sure you want to remove the selected exclusion?
+network.ui.options.connection.httpproxy.exclusions.remove.button.cancel = Cancel
+network.ui.options.connection.httpproxy.exclusions.remove.button.confirm = Remove
+network.ui.options.connection.httpproxy.exclusions.remove.checkbox.label = Do not show this message again
+network.ui.options.connection.httpproxy.exclusions.warn.invalidregex.message = The provided regular expression is not valid:\n{0}
+network.ui.options.connection.httpproxy.exclusions.warn.invalidregex.title = Invalid Regular Expression
+
+network.ui.options.connection.socksproxy.tab = SOCKS Proxy
+network.ui.options.connection.socksproxy.enabled = Enabled:
+network.ui.options.connection.socksproxy.host = Host:
+network.ui.options.connection.socksproxy.host.empty = The SOCKS host is empty.
+network.ui.options.connection.socksproxy.port = Port:
+network.ui.options.connection.socksproxy.version = Version:
+network.ui.options.connection.socksproxy.dns = Use SOCKS' DNS
+network.ui.options.connection.socksproxy.dns.tooltip = Only supported with version 5.
+network.ui.options.connection.socksproxy.username = User Name:
+network.ui.options.connection.socksproxy.password = Password:
+
+network.ui.options.legacy.connection = Connection
+network.ui.options.legacy.connection.moved = These options have been moved to Network > Connection.
 network.ui.options.legacy.dynssl = Dynamic SSL Certificates
 network.ui.options.legacy.dynssl.moved = These options have been moved to Network > Server Certificates.
 network.ui.options.legacy.opennew = Go to New Screen
@@ -215,6 +316,10 @@ network.ui.options.servercertificates.import.pem.failed.title = Error Import Roo
 
 network.ui.options.servercertificates.tab.rootcacert = Root CA Certificate
 network.ui.options.servercertificates.tab.issuedcerts = Issued Certificates
+
+network.ui.prompt.httpproxy.password.title = HTTP Proxy Password Required
+network.ui.prompt.httpproxy.password.label = HTTP Proxy Password:
+network.ui.prompt.httpproxy.password.button = OK
 
 network.warn.cert.expired = ZAP''s Root CA certificate has expired as of {0} (now: {1}).\nYou should regenerate it and re-install it in your browsers.\n\
 Regenerate the certificate and go to the relevant options screen now?

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/ConnectionOptionsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/ConnectionOptionsUnitTest.java
@@ -1,0 +1,1539 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.zaproxy.addon.network.ConnectionOptions.DEFAULT_DEFAULT_USER_AGENT;
+import static org.zaproxy.addon.network.ConnectionOptions.DEFAULT_TIMEOUT;
+import static org.zaproxy.addon.network.ConnectionOptions.DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES;
+
+import java.io.ByteArrayInputStream;
+import java.net.PasswordAuthentication;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.network.internal.TlsUtils;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+import org.zaproxy.addon.network.internal.client.SocksProxy;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link ConnectionOptions}. */
+class ConnectionOptionsUnitTest {
+
+    private static final String TIMEOUT_KEY = "network.connection.timeoutInSecs";
+    private static final String DEFAULT_USER_AGENT_KEY = "network.connection.defaultUserAgent";
+    private static final String GLOBAL_HTTP_STATE_ENABLED_KEY =
+            "network.connection.useGlobalHttpState";
+    private static final String DNS_TTL_SUCCESSFUL_QUERIES_KEY =
+            "network.connection.dnsTtlSuccessfulQueries";
+
+    private static final String TLS_PROTOCOL_KEY = "network.connection.tlsProtocols.protocol";
+
+    private static final String HTTP_PROXY_KEY = "network.connection.httpProxy";
+    private static final String HTTP_PROXY_PASSWORD_KEY = HTTP_PROXY_KEY + ".password";
+    private static final String HTTP_PROXY_ENABLED_KEY = HTTP_PROXY_KEY + ".enabled";
+    private static final String HTTP_PROXY_AUTH_ENABLED_KEY = HTTP_PROXY_KEY + ".authEnabled";
+    private static final String STORE_HTTP_PROXY_PASS_KEY = HTTP_PROXY_KEY + ".storePass";
+
+    private static final String HTTP_PROXY_EXCLUSION_KEY =
+            "network.connection.httpProxy.exclusions.exclusion";
+    private static final String HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE =
+            "network.connection.httpProxy.exclusions.confirmRemove";
+
+    private static final String SOCKS_PROXY_KEY = "network.connection.socksProxy";
+    private static final String SOCKS_PROXY_ENABLED_KEY = SOCKS_PROXY_KEY + ".enabled";
+
+    private static final PasswordAuthentication EMPTY_CREDENTIALS =
+            new PasswordAuthentication("", "".toCharArray());
+
+    private ZapXmlConfiguration config;
+    private ConnectionOptions options;
+
+    @BeforeEach
+    void setUp() {
+        cleanUp();
+
+        options = new ConnectionOptions();
+        config = new ZapXmlConfiguration();
+        options.load(config);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        HttpRequestHeader.setDefaultUserAgent("");
+        System.setProperty("socksProxyHost", "");
+    }
+
+    @Test
+    void shouldHaveConfigVersionKey() {
+        assertThat(options.getConfigVersionKey(), is(equalTo("network.connection[@version]")));
+    }
+
+    @Test
+    void shouldHaveDefaultValues() {
+        // Given
+        options = new ConnectionOptions();
+        // When / Then
+        assertDefaultValues();
+    }
+
+    private void assertDefaultValues() {
+        assertThat(options.getTimeoutInSecs(), is(equalTo(ConnectionOptions.DEFAULT_TIMEOUT)));
+        assertThat(
+                options.getDefaultUserAgent(),
+                is(equalTo(ConnectionOptions.DEFAULT_DEFAULT_USER_AGENT)));
+        assertThat(
+                HttpRequestHeader.getDefaultUserAgent(),
+                is(equalTo(ConnectionOptions.DEFAULT_DEFAULT_USER_AGENT)));
+        assertThat(options.isUseGlobalHttpState(), is(equalTo(false)));
+        assertThat(
+                options.getDnsTtlSuccessfulQueries(),
+                is(equalTo(ConnectionOptions.DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES)));
+        assertThat(options.getTlsProtocols(), is(equalTo(TlsUtils.getSupportedProtocols())));
+
+        HttpProxy httpProxy = options.getHttpProxy();
+        assertThat(options.isHttpProxyEnabled(), is(equalTo(false)));
+        assertThat(options.isHttpProxyAuthEnabled(), is(equalTo(false)));
+        assertThat(options.isStoreHttpProxyPass(), is(equalTo(true)));
+        assertHttpProxyFields(httpProxy, "localhost", 8090, "", "", "");
+        assertThat(httpProxy, is(equalTo(ConnectionOptions.DEFAULT_HTTP_PROXY)));
+        assertThat(options.getHttpProxyExclusions(), is(empty()));
+        assertThat(options.isConfirmRemoveHttpProxyExclusion(), is(equalTo(true)));
+
+        SocksProxy socksProxy = options.getSocksProxy();
+        assertThat(options.isSocksProxyEnabled(), is(equalTo(false)));
+        assertSocksProxyFields(
+                socksProxy, "localhost", 1080, SocksProxy.Version.SOCKS5, true, "", "");
+        assertThat(socksProxy, is(equalTo(ConnectionOptions.DEFAULT_SOCKS_PROXY)));
+    }
+
+    private static void assertHttpProxyFields(
+            HttpProxy httpProxy,
+            String host,
+            int port,
+            String realm,
+            String userName,
+            String password) {
+        assertThat(httpProxy.getHost(), is(equalTo(host)));
+        assertThat(httpProxy.getPort(), is(equalTo(port)));
+        assertThat(httpProxy.getRealm(), is(equalTo(realm)));
+        assertThat(httpProxy.getPasswordAuthentication().getUserName(), is(equalTo(userName)));
+        assertThat(
+                httpProxy.getPasswordAuthentication().getPassword(),
+                is(equalTo(password.toCharArray())));
+    }
+
+    private static void assertSocksProxyFields(
+            SocksProxy socksProxy,
+            String host,
+            int port,
+            SocksProxy.Version version,
+            boolean useDns,
+            String userName,
+            String password) {
+        assertThat(socksProxy.getHost(), is(equalTo(host)));
+        assertThat(socksProxy.getPort(), is(equalTo(port)));
+        assertThat(socksProxy.getVersion(), is(equalTo(version)));
+        assertThat(socksProxy.isUseDns(), is(equalTo(useDns)));
+        assertThat(socksProxy.getPasswordAuthentication().getUserName(), is(equalTo(userName)));
+        assertThat(
+                socksProxy.getPasswordAuthentication().getPassword(),
+                is(equalTo(password.toCharArray())));
+    }
+
+    @Test
+    void shouldLoadEmptyConfig() {
+        // Given
+        ZapXmlConfiguration emptyConfig = new ZapXmlConfiguration();
+        // When
+        options.load(emptyConfig);
+        // Then
+        assertDefaultValues();
+    }
+
+    @Test
+    void shouldLoadConfigWithTimeoutInSecs() {
+        // Given
+        config.setProperty(TIMEOUT_KEY, "60");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getTimeoutInSecs(), is(equalTo(60)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-1", "" + Long.MAX_VALUE, "A", ""})
+    void shouldUseDefaultWithInvalidTimeoutInSecs(String timeout) {
+        // Given
+        config.setProperty(TIMEOUT_KEY, timeout);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getTimeoutInSecs(), is(equalTo(DEFAULT_TIMEOUT)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"-1, " + DEFAULT_TIMEOUT, "0, 0", "10, 10"})
+    void shouldSetAndPersistTimeoutInSecs(int value, int expected) throws Exception {
+        // Given / When
+        options.setTimeoutInSecs(value);
+        // Then
+        assertThat(options.getTimeoutInSecs(), is(equalTo(expected)));
+        assertThat(config.getInt(TIMEOUT_KEY), is(equalTo(expected)));
+    }
+
+    @Test
+    void shouldLoadConfigWithDefaultUserAgent() {
+        // Given
+        String userAgent = "user-agent";
+        config.setProperty(DEFAULT_USER_AGENT_KEY, userAgent);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getDefaultUserAgent(), is(equalTo(userAgent)));
+        assertThat(HttpRequestHeader.getDefaultUserAgent(), is(equalTo(userAgent)));
+    }
+
+    @Test
+    void shouldUseDefaultWithNoDefaultUserAgent() {
+        // Given
+        config.setProperty(DEFAULT_USER_AGENT_KEY, null);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getDefaultUserAgent(), is(equalTo(DEFAULT_DEFAULT_USER_AGENT)));
+        assertThat(
+                HttpRequestHeader.getDefaultUserAgent(), is(equalTo(DEFAULT_DEFAULT_USER_AGENT)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"user-agent"})
+    void shouldSetAndPersistDefaultUserAgent(String userAgent) throws Exception {
+        // Given / When
+        options.setDefaultUserAgent(userAgent);
+        // Then
+        assertThat(options.getDefaultUserAgent(), is(equalTo(userAgent)));
+        assertThat(config.getString(DEFAULT_USER_AGENT_KEY), is(equalTo(userAgent)));
+        assertThat(HttpRequestHeader.getDefaultUserAgent(), is(equalTo(userAgent)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithUseGlobalHttpState(boolean enabled) {
+        // Given
+        config.setProperty(GLOBAL_HTTP_STATE_ENABLED_KEY, enabled);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isUseGlobalHttpState(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldUseDefaultWithInvalidUseGlobalHttpState() {
+        // Given
+        config.setProperty(GLOBAL_HTTP_STATE_ENABLED_KEY, "not boolean");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isUseGlobalHttpState(), is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistUseGlobalHttpState(boolean enabled) throws Exception {
+        // Given / When
+        options.setUseGlobalHttpState(enabled);
+        // Then
+        assertThat(options.isUseGlobalHttpState(), is(equalTo(enabled)));
+        assertThat(config.getBoolean(GLOBAL_HTTP_STATE_ENABLED_KEY), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldLoadConfigWithDnsTtlSuccessfulQueries() {
+        // Given
+        config.setProperty(DNS_TTL_SUCCESSFUL_QUERIES_KEY, "60");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getDnsTtlSuccessfulQueries(), is(equalTo(60)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"" + Long.MAX_VALUE, "A", ""})
+    void shouldUseDefaultWithInvalidDnsTtlSuccessfulQueries(String ttl) {
+        // Given
+        config.setProperty(DNS_TTL_SUCCESSFUL_QUERIES_KEY, ttl);
+        // When
+        options.load(config);
+        // Then
+        assertThat(
+                options.getDnsTtlSuccessfulQueries(),
+                is(equalTo(DNS_DEFAULT_TTL_SUCCESSFUL_QUERIES)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 10})
+    void shouldSetAndPersistDnsTtlSuccessfulQueries(int value) throws Exception {
+        // Given / When
+        options.setDnsTtlSuccessfulQueries(value);
+        // Then
+        assertThat(options.getDnsTtlSuccessfulQueries(), is(equalTo(value)));
+        assertThat(config.getInt(DNS_TTL_SUCCESSFUL_QUERIES_KEY), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldLoadConfigWithTlsProtocols() {
+        // Given
+        config.setProperty(TLS_PROTOCOL_KEY + "(0)", TlsUtils.getSupportedProtocols().get(0));
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getTlsProtocols(), contains(TlsUtils.getSupportedProtocols().get(0)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "Not Supported"})
+    void shouldUseDefaultWithInvalidTlsProtocols(String tlsProtocol) {
+        // Given
+        config.setProperty(TLS_PROTOCOL_KEY + "(0)", tlsProtocol);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getTlsProtocols(), is(equalTo(TlsUtils.getSupportedProtocols())));
+    }
+
+    @Test
+    void shouldSetAndPersistTlsProtocols() throws Exception {
+        // Given
+        List<String> tlsProtocols =
+                Collections.singletonList(TlsUtils.getSupportedProtocols().get(0));
+        // When
+        options.setTlsProtocols(tlsProtocols);
+        // Then
+        assertThat(options.getTlsProtocols(), is(equalTo(tlsProtocols)));
+        assertThat(
+                config.getString(TLS_PROTOCOL_KEY + "(0)"),
+                is(equalTo(TlsUtils.getSupportedProtocols().get(0))));
+    }
+
+    @Test
+    void shouldThrowIfSettingInvalidTlsProtocols() throws Exception {
+        // Given
+        List<String> tlsProtocols = Collections.singletonList("");
+        // When / Then
+        assertThrows(IllegalArgumentException.class, () -> options.setTlsProtocols(tlsProtocols));
+        assertThat(config.getString(TLS_PROTOCOL_KEY + "(0)"), is(nullValue()));
+    }
+
+    @Test
+    void shouldLoadConfigWithHttpProxy() {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <httpProxy>\n"
+                                + "      <host>example.com</host>\n"
+                                + "      <port>1234</port>\n"
+                                + "      <realm>Realm</realm>\n"
+                                + "      <username>UserName</username>\n"
+                                + "      <password>Password</password>\n"
+                                + "    </httpProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertHttpProxyFields(
+                options.getHttpProxy(), "example.com", 1234, "Realm", "UserName", "Password");
+    }
+
+    @Test
+    void shouldLoadConfigWithEmptyHttpProxyHost() {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <httpProxy>\n"
+                                + "      <host></host>\n"
+                                + "    </httpProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(
+                options.getHttpProxy().getHost(),
+                is(equalTo(ConnectionOptions.DEFAULT_HTTP_PROXY.getHost())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "not an int", "-1", "0", "65536"})
+    void shouldLoadConfigWithInvalidHttpProxyPort(String port) {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <httpProxy>\n"
+                                + "      <port>"
+                                + port
+                                + "</port>\n"
+                                + "    </httpProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(
+                options.getHttpProxy().getPort(),
+                is(equalTo(ConnectionOptions.DEFAULT_HTTP_PROXY.getPort())));
+    }
+
+    static Stream<Arguments> httpProxyPersistenceData() {
+        return Stream.of(
+                arguments("127.0.0.1", 1001, "Realm 1", "UserName 1", "Password 1"),
+                arguments("127.0.0.2", 1002, "", "UserName 2", "Password 2"),
+                arguments("127.0.0.3", 1003, "", "", "Password 3"),
+                arguments("127.0.0.4", 1004, "", "", ""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("httpProxyPersistenceData")
+    void shouldSetAndPersistHttpProxy(
+            String host, int port, String realm, String userName, String password) {
+
+        // Given
+        HttpProxy httpProxy =
+                new HttpProxy(
+                        host,
+                        port,
+                        realm,
+                        new PasswordAuthentication(userName, password.toCharArray()));
+        // When
+        options.setHttpProxy(httpProxy);
+        // Then
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".host"), is(equalTo(host)));
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".port"), is(equalTo(port)));
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".realm"), is(equalTo(realm)));
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".username"), is(equalTo(userName)));
+        assertThat(config.getProperty(HTTP_PROXY_PASSWORD_KEY), is(equalTo(password)));
+    }
+
+    @Test
+    void shouldNotSetAndPersistSameHttpProxy() {
+        // Given
+        HttpProxy httpProxy = ConnectionOptions.DEFAULT_HTTP_PROXY;
+        // When
+        options.setHttpProxy(httpProxy);
+        // Then
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".host"), is(nullValue()));
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".port"), is(nullValue()));
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".realm"), is(nullValue()));
+        assertThat(config.getProperty(HTTP_PROXY_KEY + ".username"), is(nullValue()));
+        assertThat(config.getProperty(HTTP_PROXY_PASSWORD_KEY), is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("httpProxyPersistenceData")
+    void shouldNotStorePasswordIfStoreHttpProxyPassNotSet(
+            String host, int port, String realm, String userName, String password) {
+        // Given
+        options.setStoreHttpProxyPass(false);
+        HttpProxy httpProxy =
+                new HttpProxy(
+                        host,
+                        port,
+                        realm,
+                        new PasswordAuthentication(userName, password.toCharArray()));
+        // When
+        options.setHttpProxy(httpProxy);
+        // Then
+        assertThat(config.getProperty(HTTP_PROXY_PASSWORD_KEY), is(equalTo("")));
+    }
+
+    @Test
+    void shouldThrowIfSettingNullHttpProxy() {
+        // Given
+        HttpProxy httpProxy = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> options.setHttpProxy(httpProxy));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithHttpProxyEnabled(boolean enabled) {
+        // Given
+        config.setProperty(HTTP_PROXY_ENABLED_KEY, enabled);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isHttpProxyEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldUseDefaultWithNoHttpProxyEnabled() {
+        // Given
+        config.setProperty(HTTP_PROXY_ENABLED_KEY, null);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isHttpProxyEnabled(), is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistHttpProxyEnabled(boolean enabled) throws Exception {
+        // Given / When
+        options.setHttpProxyEnabled(enabled);
+        // Then
+        assertThat(options.isHttpProxyEnabled(), is(equalTo(enabled)));
+        assertThat(config.getBoolean(HTTP_PROXY_ENABLED_KEY), is(equalTo(enabled)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithHttpProxyAuthEnabled(boolean enabled) {
+        // Given
+        config.setProperty(HTTP_PROXY_AUTH_ENABLED_KEY, enabled);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isHttpProxyAuthEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldUseDefaultWithNoHttpProxyAuthEnabled() {
+        // Given
+        config.setProperty(HTTP_PROXY_AUTH_ENABLED_KEY, null);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isHttpProxyAuthEnabled(), is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistHttpProxyAuthEnabled(boolean enabled) throws Exception {
+        // Given / When
+        options.setHttpProxyAuthEnabled(enabled);
+        // Then
+        assertThat(options.isHttpProxyAuthEnabled(), is(equalTo(enabled)));
+        assertThat(config.getBoolean(HTTP_PROXY_AUTH_ENABLED_KEY), is(equalTo(enabled)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithStoreHttpProxyPass(boolean store) {
+        // Given
+        config.setProperty(STORE_HTTP_PROXY_PASS_KEY, store);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isStoreHttpProxyPass(), is(equalTo(store)));
+    }
+
+    @Test
+    void shouldUseDefaultWithNoStoreHttpProxyPass() {
+        // Given
+        config.setProperty(STORE_HTTP_PROXY_PASS_KEY, null);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isStoreHttpProxyPass(), is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistStoreHttpProxyPass(boolean store) throws Exception {
+        // Given / When
+        options.setStoreHttpProxyPass(store);
+        // Then
+        assertThat(options.isStoreHttpProxyPass(), is(equalTo(store)));
+        assertThat(config.getBoolean(STORE_HTTP_PROXY_PASS_KEY), is(equalTo(store)));
+    }
+
+    @Test
+    void shouldClearStoredPassIfSettingToNotStoreHttpProxyPass() throws Exception {
+        // Given
+        config.setProperty(HTTP_PROXY_PASSWORD_KEY, "password");
+        options.load(config);
+        // When
+        options.setStoreHttpProxyPass(false);
+        // Then
+        assertThat(config.getString(HTTP_PROXY_PASSWORD_KEY), is(equalTo("")));
+    }
+
+    @Test
+    void shouldNotClearStoredPassIfSettingToStoreHttpProxyPass() throws Exception {
+        // Given
+        config.setProperty(HTTP_PROXY_PASSWORD_KEY, "password");
+        options.load(config);
+        // When
+        options.setStoreHttpProxyPass(true);
+        // Then
+        assertThat(config.getString(HTTP_PROXY_PASSWORD_KEY), is(equalTo("password")));
+    }
+
+    @Test
+    void shouldUseHttpProxyForHostIfProxyEnabledAndHostNotExcluded() throws Exception {
+        // Given
+        String host = "example.org";
+        options.setHttpProxyEnabled(true);
+        options.addHttpProxyExclusion(exclusion("other.example.com", true));
+        options.addHttpProxyExclusion(exclusion(Pattern.quote(host), false));
+        // When
+        boolean useProxy = options.isUseHttpProxy(host);
+        // Then
+        assertThat(useProxy, is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldNotUseHttpProxyForHostIfProxyEnabledAndHostIsNullOrEmpty(String host)
+            throws Exception {
+        // Given
+        options.setHttpProxyEnabled(true);
+        // When
+        boolean useProxy = options.isUseHttpProxy(host);
+        // Then
+        assertThat(useProxy, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotUseHttpProxyForHostIfProxyNotEnabled() throws Exception {
+        // Given
+        String host = "example.org";
+        options.setHttpProxyEnabled(false);
+        // When
+        boolean useProxy = options.isUseHttpProxy(host);
+        // Then
+        assertThat(useProxy, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotUseHttpProxyForHostIfProxyEnabledAndHostExcluded() throws Exception {
+        // Given
+        String host = "example.org";
+        options.setHttpProxyEnabled(true);
+        options.addHttpProxyExclusion(exclusion(Pattern.quote(host), true));
+        // When
+        boolean useProxy = options.isUseHttpProxy(host);
+        // Then
+        assertThat(useProxy, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldAddHttpProxyExclusion() {
+        // Given
+        HttpProxyExclusion exclusion = exclusion("example.org", true);
+        // When
+        options.addHttpProxyExclusion(exclusion);
+        // Then
+        assertThat(options.getHttpProxyExclusions(), hasSize(1));
+        assertPersistedExclusion(0, "example.org", true);
+    }
+
+    @Test
+    void shouldThrowIfAddingNullHttpProxyExclusion() {
+        // Given
+        HttpProxyExclusion exclusion = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> options.addHttpProxyExclusion(exclusion));
+        assertThat(options.getHttpProxyExclusions(), hasSize(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetHttpProxyExclusionEnabled(boolean enabled) {
+        // Given
+        options.addHttpProxyExclusion(exclusion("example.org", !enabled));
+        options.addHttpProxyExclusion(exclusion("example.com", true));
+        // When
+        boolean changed = options.setHttpProxyExclusionEnabled("example.org", enabled);
+        // Then
+        assertThat(changed, is(equalTo(true)));
+        assertThat(options.getHttpProxyExclusions(), hasSize(2));
+        assertPersistedExclusion(0, "example.org", enabled);
+        assertPersistedExclusion(1, "example.com", true);
+    }
+
+    @Test
+    void shouldReturnFalseIfHttpProxyExclusionNotChanged() {
+        // Given
+        options.addHttpProxyExclusion(exclusion("example.org", true));
+        options.addHttpProxyExclusion(exclusion("example.com", true));
+        // When
+        boolean changed = options.setHttpProxyExclusionEnabled("other.example.org", false);
+        // Then
+        assertThat(changed, is(equalTo(false)));
+        assertThat(options.getHttpProxyExclusions(), hasSize(2));
+        assertPersistedExclusion(0, "example.org", true);
+        assertPersistedExclusion(1, "example.com", true);
+    }
+
+    @Test
+    void shouldThrowIfSettingNullHttpProxyExclusionEnabled() {
+        // Given
+        String host = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class, () -> options.setHttpProxyExclusionEnabled(host, true));
+        assertThat(options.getHttpProxyExclusions(), hasSize(0));
+    }
+
+    @Test
+    void shouldRemoveHttpProxyExclusion() {
+        // Given
+        options.addHttpProxyExclusion(exclusion("example.org", true));
+        options.addHttpProxyExclusion(exclusion("example.com", true));
+        // When
+        boolean removed = options.removeHttpProxyExclusion("example.org");
+        // Then
+        assertThat(removed, is(equalTo(true)));
+        assertThat(options.getHttpProxyExclusions(), hasSize(1));
+        assertPersistedExclusion(0, "example.com", true);
+        assertPersistedExclusion(1, null, null);
+    }
+
+    @Test
+    void shouldReturnFalseIfHttpProxyExclusionNotRemoved() {
+        // Given
+        options.addHttpProxyExclusion(exclusion("example.org", true));
+        options.addHttpProxyExclusion(exclusion("example.com", true));
+        // When
+        boolean removed = options.removeHttpProxyExclusion("other.example.org");
+        // Then
+        assertThat(removed, is(equalTo(false)));
+        assertThat(options.getHttpProxyExclusions(), hasSize(2));
+        assertPersistedExclusion(0, "example.org", true);
+        assertPersistedExclusion(1, "example.com", true);
+    }
+
+    @Test
+    void shouldThrowIfRemovingNullHostHttpProxyExclusion() {
+        // Given
+        String host = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> options.removeHttpProxyExclusion(host));
+        assertThat(options.getHttpProxyExclusions(), hasSize(0));
+    }
+
+    @Test
+    void shouldLoadConfigWithHttpProxyExclusions() {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <httpProxy>\n"
+                                + "      <exclusions>\n"
+                                + "        <exclusion>\n"
+                                + "          <host>example.org</host>\n"
+                                + "          <enabled>true</enabled>\n"
+                                + "        </exclusion>\n"
+                                + "        <exclusion>\n"
+                                + "          <host>example.com</host>\n"
+                                + "          <enabled>false</enabled>\n"
+                                + "        </exclusion>\n"
+                                + "      </exclusions>\n"
+                                + "    </httpProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getHttpProxyExclusions(), hasSize(2));
+        assertExclusion(0, "example.org", true);
+        assertExclusion(1, "example.com", false);
+    }
+
+    @Test
+    void shouldSetAndPersistHttpProxyExclusions() {
+        // Given
+        List<HttpProxyExclusion> exclusions =
+                Arrays.asList(exclusion("example.org", true), exclusion("example.com", false));
+        // When
+        options.setHttpProxyExclusions(exclusions);
+        // Then
+        assertThat(options.getHttpProxyExclusions(), hasSize(2));
+        assertExclusion(0, "example.org", true);
+        assertExclusion(1, "example.com", false);
+    }
+
+    @Test
+    void shouldLoadConfigWhileIgnoringInvalidHttpProxyExclusions() {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <httpProxy>\n"
+                                + "      <exclusions>\n"
+                                + "        <exclusion>\n"
+                                + "          <host></host>\n"
+                                + "          <enabled>true</enabled>\n"
+                                + "        </exclusion>\n"
+                                + "        <exclusion>\n"
+                                + "          <enabled>false</enabled>\n"
+                                + "        </exclusion>\n"
+                                + "        <exclusion>\n"
+                                + "          <host>*</host>\n"
+                                + "          <enabled>false</enabled>\n"
+                                + "        </exclusion>\n"
+                                + "        <exclusion>\n"
+                                + "          <host>example.com</host>\n"
+                                + "          <enabled>not a boolean</enabled>\n"
+                                + "        </exclusion>\n"
+                                + "        <exclusion>\n"
+                                + "          <host>valid.example.com</host>\n"
+                                + "        </exclusion>\n"
+                                + "      </exclusions>\n"
+                                + "    </httpProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getHttpProxyExclusions(), hasSize(1));
+        assertExclusion(0, "valid.example.com", true);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithConfirmRemoveHttpProxyExclusion(boolean value) {
+        // Given
+        config.setProperty(HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE, value);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isConfirmRemoveHttpProxyExclusion(), is(equalTo(value)));
+    }
+
+    @Test
+    void shouldLoadConfigWithInvalidConfirmRemoveHttpProxyExclusion() {
+        // Given
+        config.setProperty(HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE, "not boolean");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isConfirmRemoveHttpProxyExclusion(), is(equalTo(true)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistConfirmRemoveHttpProxyExclusion(boolean confirm) throws Exception {
+        // Given / When
+        options.setConfirmRemoveHttpProxyExclusion(confirm);
+        // Then
+        assertThat(options.isConfirmRemoveHttpProxyExclusion(), is(equalTo(confirm)));
+        assertThat(config.getBoolean(HTTP_PROXY_EXCLUSIONS_CONFIRM_REMOVE), is(equalTo(confirm)));
+    }
+
+    @Test
+    void shouldLoadConfigWithSocksProxy() {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <socksProxy>\n"
+                                + "      <host>example.com</host>\n"
+                                + "      <port>1234</port>\n"
+                                + "      <version>4</version>\n"
+                                + "      <dns>false</dns>\n"
+                                + "      <username>UserName</username>\n"
+                                + "      <password>Password</password>\n"
+                                + "    </socksProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertSocksProxyFields(
+                options.getSocksProxy(),
+                "example.com",
+                1234,
+                SocksProxy.Version.SOCKS4A,
+                false,
+                "UserName",
+                "Password");
+    }
+
+    @Test
+    void shouldLoadConfigWithEmptySocksProxyHost() {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <socksProxy>\n"
+                                + "      <host></host>\n"
+                                + "    </socksProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(
+                options.getSocksProxy().getHost(),
+                is(equalTo(ConnectionOptions.DEFAULT_SOCKS_PROXY.getHost())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "not an int", "-1", "0", "65536"})
+    void shouldLoadConfigWithInvalidSocksProxyPort(String port) {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <socksProxy>\n"
+                                + "      <port>"
+                                + port
+                                + "</port>\n"
+                                + "    </socksProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(
+                options.getSocksProxy().getPort(),
+                is(equalTo(ConnectionOptions.DEFAULT_SOCKS_PROXY.getPort())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "not a version", "0"})
+    void shouldLoadConfigWithInvalidSocksProxyVersion(String version) {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <socksProxy>\n"
+                                + "      <version>"
+                                + version
+                                + "</version>\n"
+                                + "    </socksProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(
+                options.getSocksProxy().getVersion(),
+                is(equalTo(ConnectionOptions.DEFAULT_SOCKS_PROXY.getVersion())));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "not a boolean"})
+    void shouldLoadConfigWithInvalidSocksProxyDns(String dns) {
+        // Given
+        config =
+                configWith(
+                        "<network>\n"
+                                + "  <connection version=\"1\">\n"
+                                + "    <socksProxy>\n"
+                                + "      <dns>"
+                                + dns
+                                + "</dns>\n"
+                                + "    </socksProxy>\n"
+                                + "  </connection>\n"
+                                + "</network>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(
+                options.getSocksProxy().isUseDns(),
+                is(equalTo(ConnectionOptions.DEFAULT_SOCKS_PROXY.isUseDns())));
+    }
+
+    static Stream<Arguments> socksProxyPersistenceData() {
+        return Stream.of(
+                arguments(
+                        "127.0.0.1",
+                        1001,
+                        SocksProxy.Version.SOCKS5,
+                        true,
+                        "UserName 1",
+                        "Password 1"),
+                arguments(
+                        "127.0.0.2",
+                        1002,
+                        SocksProxy.Version.SOCKS5,
+                        false,
+                        "UserName 2",
+                        "Password 2"),
+                arguments("127.0.0.3", 1003, SocksProxy.Version.SOCKS4A, true, "", "Password 3"),
+                arguments("127.0.0.4", 1004, SocksProxy.Version.SOCKS4A, false, "", ""));
+    }
+
+    @ParameterizedTest
+    @MethodSource("socksProxyPersistenceData")
+    void shouldSetAndPersistSocksProxy(
+            String host,
+            int port,
+            SocksProxy.Version version,
+            boolean useDns,
+            String userName,
+            String password) {
+
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        host,
+                        port,
+                        version,
+                        useDns,
+                        new PasswordAuthentication(userName, password.toCharArray()));
+        // When
+        options.setSocksProxy(socksProxy);
+        // Then
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".host"), is(equalTo(host)));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".port"), is(equalTo(port)));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".version"), is(equalTo(version.number())));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".dns"), is(equalTo(useDns)));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".username"), is(equalTo(userName)));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".password"), is(equalTo(password)));
+    }
+
+    @Test
+    void shouldNotSetAndPersistSameSocksProxy() {
+        // Given
+        SocksProxy socksProxy = ConnectionOptions.DEFAULT_SOCKS_PROXY;
+        // When
+        options.setSocksProxy(socksProxy);
+        // Then
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".host"), is(nullValue()));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".port"), is(nullValue()));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".version"), is(nullValue()));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".dns"), is(nullValue()));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".username"), is(nullValue()));
+        assertThat(config.getProperty(SOCKS_PROXY_KEY + ".password"), is(nullValue()));
+    }
+
+    @Test
+    void shouldThrowIfSettingNullSocksProxy() {
+        // Given
+        SocksProxy socksProxy = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> options.setSocksProxy(socksProxy));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldLoadConfigWithSocksProxyEnabled(boolean enabled) {
+        // Given
+        config.setProperty(SOCKS_PROXY_ENABLED_KEY, enabled);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isSocksProxyEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldUseDefaultWithNoSocksProxyEnabled() {
+        // Given
+        config.setProperty(SOCKS_PROXY_ENABLED_KEY, null);
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isSocksProxyEnabled(), is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetAndPersistSocksProxyEnabled(boolean enabled) throws Exception {
+        // Given / When
+        options.setSocksProxyEnabled(enabled);
+        // Then
+        assertThat(options.isSocksProxyEnabled(), is(equalTo(enabled)));
+        assertThat(config.getBoolean(SOCKS_PROXY_ENABLED_KEY), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldApplySocksProxySystemPropertiesWhenEnabled() throws Exception {
+        // Given
+        SocksProxy socksProxy = ConnectionOptions.DEFAULT_SOCKS_PROXY;
+        // When
+        options.setSocksProxyEnabled(true);
+        // Then
+        assertThat(System.getProperty("socksProxyHost"), is(equalTo(socksProxy.getHost())));
+        assertThat(
+                System.getProperty("socksProxyPort"),
+                is(equalTo(String.valueOf(socksProxy.getPort()))));
+        assertThat(
+                System.getProperty("socksProxyVersion"),
+                is(equalTo(String.valueOf(socksProxy.getVersion().number()))));
+    }
+
+    @Test
+    void shouldClearSocksProxySystemPropertiesWhenNotEnabled() throws Exception {
+        // Given
+        options.setSocksProxyEnabled(true);
+        // When
+        options.setSocksProxyEnabled(false);
+        // Then
+        assertThat(System.getProperty("socksProxyHost"), is(equalTo("")));
+        assertThat(System.getProperty("socksProxyPort"), is(equalTo("")));
+        assertThat(System.getProperty("socksProxyVersion"), is(equalTo("")));
+    }
+
+    @Test
+    void shouldApplySocksProxySystemPropertiesWhenSettingEnabledSocksProxy() throws Exception {
+        // Given
+        options.setSocksProxyEnabled(true);
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "example.com", 1234, SocksProxy.Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        // When
+        options.setSocksProxy(socksProxy);
+        // Then
+        assertThat(System.getProperty("socksProxyHost"), is(equalTo(socksProxy.getHost())));
+        assertThat(
+                System.getProperty("socksProxyPort"),
+                is(equalTo(String.valueOf(socksProxy.getPort()))));
+        assertThat(
+                System.getProperty("socksProxyVersion"),
+                is(equalTo(String.valueOf(socksProxy.getVersion().number()))));
+    }
+
+    @Test
+    void shouldClearSocksProxySystemPropertiesWhenSettingNotEnabledSocksProxy() throws Exception {
+        // Given
+        options.setSocksProxyEnabled(false);
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "example.com", 1234, SocksProxy.Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        // When
+        options.setSocksProxy(socksProxy);
+        // Then
+        assertThat(System.getProperty("socksProxyHost"), is(equalTo("")));
+        assertThat(System.getProperty("socksProxyPort"), is(equalTo("")));
+        assertThat(System.getProperty("socksProxyVersion"), is(equalTo("")));
+    }
+
+    @Test
+    void shouldApplySocksProxySystemPropertiesOnLoadifSocksProxyEnabled() throws Exception {
+        // Given
+        options.setSocksProxyEnabled(true);
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "example.com", 1234, SocksProxy.Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        // When
+        options.setSocksProxy(socksProxy);
+        // Then
+        assertThat(System.getProperty("socksProxyHost"), is(equalTo(socksProxy.getHost())));
+        assertThat(
+                System.getProperty("socksProxyPort"),
+                is(equalTo(String.valueOf(socksProxy.getPort()))));
+        assertThat(
+                System.getProperty("socksProxyVersion"),
+                is(equalTo(String.valueOf(socksProxy.getVersion().number()))));
+    }
+
+    @Test
+    void shouldUseSocksProxySystemPropertiesOnLoadIfPresent() throws Exception {
+        // Given
+        String host = "example.org";
+        int port = 443;
+        SocksProxy.Version version = SocksProxy.Version.SOCKS4A;
+        System.setProperty("socksProxyHost", host);
+        System.setProperty("socksProxyPort", String.valueOf(port));
+        System.setProperty("socksProxyVersion", String.valueOf(version.number()));
+        // When
+        options.load(config);
+        // Then
+        SocksProxy socksProxy = options.getSocksProxy();
+        assertSocksProxyFields(
+                socksProxy,
+                host,
+                port,
+                version,
+                ConnectionOptions.DEFAULT_SOCKS_PROXY.isUseDns(),
+                "",
+                "");
+        assertThat(System.getProperty("socksProxyHost"), is(equalTo(host)));
+        assertThat(System.getProperty("socksProxyPort"), is(equalTo(String.valueOf(port))));
+        assertThat(
+                System.getProperty("socksProxyVersion"),
+                is(equalTo(String.valueOf(version.number()))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "not an int", "-1", "0", "65536"})
+    void shouldUseDefaultPortForSocksProxySystemPropertiesOnLoadIfInvalidOrMissing(String port)
+            throws Exception {
+        // Given
+        String host = "example.org";
+        SocksProxy.Version version = SocksProxy.Version.SOCKS4A;
+        System.setProperty("socksProxyHost", host);
+        System.setProperty("socksProxyPort", port);
+        System.setProperty("socksProxyVersion", String.valueOf(version.number()));
+        // When
+        options.load(config);
+        // Then
+        SocksProxy socksProxy = options.getSocksProxy();
+        assertSocksProxyFields(
+                socksProxy,
+                host,
+                ConnectionOptions.DEFAULT_SOCKS_PROXY.getPort(),
+                version,
+                ConnectionOptions.DEFAULT_SOCKS_PROXY.isUseDns(),
+                "",
+                "");
+        assertThat(
+                System.getProperty("socksProxyPort"),
+                is(equalTo(String.valueOf(ConnectionOptions.DEFAULT_SOCKS_PROXY.getPort()))));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "not a version", "0"})
+    void shouldUseDefaultVersionForSocksProxySystemPropertiesOnLoadIfMissing(String version)
+            throws Exception {
+        // Given
+        String host = "example.org";
+        int port = 443;
+        System.setProperty("socksProxyHost", host);
+        System.setProperty("socksProxyPort", String.valueOf(port));
+        System.setProperty("socksProxyVersion", version);
+        // When
+        options.load(config);
+        // Then
+        SocksProxy socksProxy = options.getSocksProxy();
+        assertSocksProxyFields(
+                socksProxy,
+                host,
+                port,
+                ConnectionOptions.DEFAULT_SOCKS_PROXY.getVersion(),
+                ConnectionOptions.DEFAULT_SOCKS_PROXY.isUseDns(),
+                "",
+                "");
+        assertThat(
+                System.getProperty("socksProxyVersion"),
+                is(
+                        equalTo(
+                                String.valueOf(
+                                        ConnectionOptions.DEFAULT_SOCKS_PROXY
+                                                .getVersion()
+                                                .number()))));
+    }
+
+    @Test
+    void shouldNotResolveRemoteHostnameWithSocksProxyEnabledUseDnsAndVersion5() {
+        // Given
+        options.setSocksProxyEnabled(true);
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "example.com", 1234, SocksProxy.Version.SOCKS5, true, EMPTY_CREDENTIALS);
+        options.setSocksProxy(socksProxy);
+        String host = "example.org";
+        // When
+        boolean resolve = options.shouldResolveRemoteHostname(host);
+        // Then
+        assertThat(resolve, is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"localhost", "127.0.0.1", "[::1]", "[::0]"})
+    void shouldNResolveRemoteHostnameWithSocksProxyEnabledUseDnsAndVersion5IfLooback(String host) {
+        // Given
+        options.setSocksProxyEnabled(true);
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "example.com", 1234, SocksProxy.Version.SOCKS5, true, EMPTY_CREDENTIALS);
+        options.setSocksProxy(socksProxy);
+        // When
+        boolean resolve = options.shouldResolveRemoteHostname(host);
+        // Then
+        assertThat(resolve, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldResolveRemoteHostnameIfSocksProxyNotEnabled() {
+        // Given
+        options.setSocksProxyEnabled(false);
+        String host = "example.org";
+        // When
+        boolean resolve = options.shouldResolveRemoteHostname(host);
+        // Then
+        assertThat(resolve, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldResolveRemoteHostnameIfSocksProxyNotUseDns() {
+        // Given
+        options.setSocksProxyEnabled(true);
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "example.com", 1234, SocksProxy.Version.SOCKS5, false, EMPTY_CREDENTIALS);
+        options.setSocksProxy(socksProxy);
+        String host = "example.org";
+        // When
+        boolean resolve = options.shouldResolveRemoteHostname(host);
+        // Then
+        assertThat(resolve, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldResolveRemoteHostnameIfSocksProxyNotVersion5() {
+        // Given
+        options.setSocksProxyEnabled(true);
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "example.com", 1234, SocksProxy.Version.SOCKS4A, true, EMPTY_CREDENTIALS);
+        options.setSocksProxy(socksProxy);
+        String host = "example.org";
+        // When
+        boolean resolve = options.shouldResolveRemoteHostname(host);
+        // Then
+        assertThat(resolve, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldMigrateGeneralOptions() {
+        // Given
+        config =
+                configWith(
+                        "<connection>\n"
+                                + "  <timeoutInSecs>123</timeoutInSecs>\n"
+                                + "  <defaultUserAgent>User-Agent</defaultUserAgent>\n"
+                                + "  <httpStateEnabled>true</httpStateEnabled>\n"
+                                + "  <dnsTtlSuccessfulQueries>321</dnsTtlSuccessfulQueries>\n"
+                                + "  <securityProtocolsEnabled>\n"
+                                + "    <protocol>SSLv3</protocol>\n"
+                                + "    <protocol>TLSv1</protocol>\n"
+                                + "    <protocol>TLSv1.1</protocol>\n"
+                                + "    <protocol>TLSv1.2</protocol>\n"
+                                + "    <protocol>TLSv1.3</protocol>\n"
+                                + "  </securityProtocolsEnabled>\n"
+                                + "</connection>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getTimeoutInSecs(), is(equalTo(123)));
+        assertThat(options.getDefaultUserAgent(), is(equalTo("User-Agent")));
+        assertThat(options.isUseGlobalHttpState(), is(equalTo(true)));
+        assertThat(options.getDnsTtlSuccessfulQueries(), is(equalTo(321)));
+        assertThat(options.getTlsProtocols(), is(equalTo(TlsUtils.getSupportedProtocols())));
+        assertThat(config.getKeys("connection").hasNext(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldIgnoreUnsuppportedTlsProtocolsWhileMigrating() {
+        // Given
+        config =
+                configWith(
+                        "<connection>\n"
+                                + "  <securityProtocolsEnabled>\n"
+                                + "    <protocol>Not known</protocol>\n"
+                                + "    <protocol></protocol>\n"
+                                + "    <protocol>SSLv3</protocol>\n"
+                                + "    <protocol>TLSv1</protocol>\n"
+                                + "    <protocol>TLSv1.1</protocol>\n"
+                                + "    <protocol>TLSv1.2</protocol>\n"
+                                + "    <protocol>TLSv1.3</protocol>\n"
+                                + "  </securityProtocolsEnabled>\n"
+                                + "</connection>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getTlsProtocols(), is(equalTo(TlsUtils.getSupportedProtocols())));
+        assertThat(config.getKeys("connection").hasNext(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldUseAllTlsProtocolsIfNoneWhileMigrating() {
+        // Given
+        config =
+                configWith(
+                        "<connection><securityProtocolsEnabled></securityProtocolsEnabled></connection>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.getTlsProtocols(), is(equalTo(TlsUtils.getSupportedProtocols())));
+        assertThat(config.getKeys("connection").hasNext(), is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldMigrateHttpProxy(boolean prompt) {
+        // Given
+        config =
+                configWith(
+                        "<connection>\n"
+                                + "  <proxyChain>\n"
+                                + "    <enabled>true</enabled>\n"
+                                + "    <hostName>example.org</hostName>\n"
+                                + "    <port>1234</port>\n"
+                                + "    <realm>Realm</realm>\n"
+                                + "    <userName>User Name</userName>\n"
+                                + "    <prompt>"
+                                + prompt
+                                + "</prompt>\n"
+                                + "    <password>Password</password>\n"
+                                + "    <authEnabled>true</authEnabled>\n"
+                                + "  </proxyChain>\n"
+                                + "</connection>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isHttpProxyEnabled(), is(equalTo(true)));
+        assertThat(options.isHttpProxyAuthEnabled(), is(equalTo(true)));
+        assertThat(options.isStoreHttpProxyPass(), is(equalTo(!prompt)));
+        assertHttpProxyFields(
+                options.getHttpProxy(), "example.org", 1234, "Realm", "User Name", "Password");
+        assertThat(config.getKeys("connection").hasNext(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldMigrateHttpProxyExclusions() {
+        // Given
+        config =
+                configWith(
+                        "<connection>\n"
+                                + "  <proxyChain>\n"
+                                + "    <confirmRemoveExcludedDomain>false</confirmRemoveExcludedDomain>\n"
+                                + "    <exclusions>\n"
+                                + "      <exclusion>\n"
+                                + "        <name>localhost</name>\n"
+                                + "        <enabled>true</enabled>\n"
+                                + "        <regex>false</regex>\n"
+                                + "      </exclusion>\n"
+                                + "      <exclusion>\n"
+                                + "        <enabled>false</enabled>\n"
+                                + "      </exclusion>\n"
+                                + "      <exclusion>\n"
+                                + "        <name>*</name>\n"
+                                + "        <regex>true</regex>\n"
+                                + "      </exclusion>\n"
+                                + "      <exclusion>\n"
+                                + "        <name>127\\.0\\.0.*</name>\n"
+                                + "        <enabled>true</enabled>\n"
+                                + "        <regex>true</regex>\n"
+                                + "      </exclusion>\n"
+                                + "      <exclusion>\n"
+                                + "        <name>example.org</name>\n"
+                                + "      </exclusion>\n"
+                                + "    </exclusions>\n"
+                                + "  </proxyChain>\n"
+                                + "</connection>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isConfirmRemoveHttpProxyExclusion(), is(equalTo(false)));
+        assertThat(options.getHttpProxyExclusions(), hasSize(3));
+        assertExclusion(0, "\\Qlocalhost\\E", true);
+        assertExclusion(1, "127\\.0\\.0.*", true);
+        assertExclusion(2, "\\Qexample.org\\E", true);
+        assertThat(config.getKeys("connection").hasNext(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldMigrateSocksProxy() {
+        // Given
+        config =
+                configWith(
+                        "<connection>\n"
+                                + "  <socksProxy>\n"
+                                + "    <enabled>true</enabled>\n"
+                                + "    <host>example.org</host>\n"
+                                + "    <port>1234</port>\n"
+                                + "    <version>4</version>\n"
+                                + "    <dns>false</dns>\n"
+                                + "    <username>User Name</username>\n"
+                                + "    <password>Password</password>\n"
+                                + "  </socksProxy>\n"
+                                + "</connection>");
+        // When
+        options.load(config);
+        // Then
+        assertThat(options.isSocksProxyEnabled(), is(equalTo(true)));
+        assertSocksProxyFields(
+                options.getSocksProxy(),
+                "example.org",
+                1234,
+                SocksProxy.Version.SOCKS4A,
+                false,
+                "User Name",
+                "Password");
+        assertThat(config.getKeys("connection").hasNext(), is(equalTo(false)));
+    }
+
+    private static HttpProxyExclusion exclusion(String pattern, boolean enabled) {
+        return new HttpProxyExclusion(Pattern.compile(pattern), enabled);
+    }
+
+    private void assertPersistedExclusion(int index, String host, Boolean enabled) {
+        String indexKey = "(" + index + ")";
+        assertThat(
+                config.getProperty(HTTP_PROXY_EXCLUSION_KEY + indexKey + ".host"),
+                is(equalTo(host)));
+        assertThat(
+                config.getProperty(HTTP_PROXY_EXCLUSION_KEY + indexKey + ".enabled"),
+                is(equalTo(enabled)));
+    }
+
+    private void assertExclusion(int index, String host, boolean enabled) {
+        HttpProxyExclusion exclusion = options.getHttpProxyExclusions().get(index);
+        assertThat(exclusion.getHost().pattern(), is(equalTo(host)));
+        assertThat(exclusion.isEnabled(), is(equalTo(enabled)));
+    }
+
+    private static ZapXmlConfiguration configWith(String value) {
+        ZapXmlConfiguration config = new ZapXmlConfiguration();
+        String contents =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                        + "<config>\n"
+                        + value
+                        + "\n</config>";
+        try {
+            config.load(new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return config;
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/LegacyConnectionParamUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/LegacyConnectionParamUnitTest.java
@@ -1,0 +1,497 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.net.PasswordAuthentication;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import org.apache.commons.httpclient.HttpState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+import org.zaproxy.zap.network.DomainMatcher;
+
+/** Unit test for {@link LegacyConnectionParam}. */
+@ExtendWith(MockitoExtension.class)
+class LegacyConnectionParamUnitTest {
+
+    private static final String PASSWORD = "Password";
+    private static final HttpProxy HTTP_PROXY =
+            new HttpProxy(
+                    "example.org",
+                    443,
+                    "Realm",
+                    new PasswordAuthentication("UserName", PASSWORD.toCharArray()));
+
+    private static final HttpProxyExclusion EXCLUSION_A =
+            new HttpProxyExclusion(Pattern.compile("A"), false);
+    private static final HttpProxyExclusion EXCLUSION_B =
+            new HttpProxyExclusion(Pattern.compile("\\QB\\E"), true);
+    private static final List<HttpProxyExclusion> EXCLUSIONS =
+            Collections.unmodifiableList(Arrays.asList(EXCLUSION_A, EXCLUSION_B));
+
+    private ConnectionOptions connectionOptions;
+    private LegacyConnectionParam legacyConnectionParam;
+
+    @Captor private ArgumentCaptor<List<HttpProxyExclusion>> exclusionsCaptor;
+
+    @BeforeEach
+    void setUp() {
+        connectionOptions = mock(ConnectionOptions.class);
+        legacyConnectionParam = new LegacyConnectionParam(() -> null, connectionOptions);
+    }
+
+    @Test
+    void shouldGetDefaultUserAgentFromConnectionOptions() {
+        // Given
+        String defaultUserAgent = "user-agent";
+        given(connectionOptions.getDefaultUserAgent()).willReturn(defaultUserAgent);
+        // When
+        String obtainedDefaultUserAgent = legacyConnectionParam.getDefaultUserAgent();
+        // Then
+        assertThat(obtainedDefaultUserAgent, is(equalTo(defaultUserAgent)));
+        verify(connectionOptions).getDefaultUserAgent();
+    }
+
+    @Test
+    void shouldSetDefaultUserAgentToConnectionOptions() {
+        // Given
+        String defaultUserAgent = "user-agent";
+        // When
+        legacyConnectionParam.setDefaultUserAgent(defaultUserAgent);
+        // Then
+        verify(connectionOptions).setDefaultUserAgent(defaultUserAgent);
+    }
+
+    @Test
+    void shouldGetDnsTtlSuccessfulQueriesFromConnectionOptions() {
+        // Given
+        int ttl = 30;
+        given(connectionOptions.getDnsTtlSuccessfulQueries()).willReturn(ttl);
+        // When
+        int obtainedTtl = legacyConnectionParam.getDnsTtlSuccessfulQueries();
+        // Then
+        assertThat(obtainedTtl, is(equalTo(ttl)));
+        verify(connectionOptions).getDnsTtlSuccessfulQueries();
+    }
+
+    @Test
+    void shouldSetDnsTtlSuccessfulQueriesToConnectionOptions() {
+        // Given
+        int ttl = 30;
+        // When
+        legacyConnectionParam.setDnsTtlSuccessfulQueries(ttl);
+        // Then
+        verify(connectionOptions).setDnsTtlSuccessfulQueries(ttl);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldGetHttpStateFromSupplier() {
+        // Given
+        HttpState httpState = new HttpState();
+        Supplier<HttpState> httpStateSupplier = mock(Supplier.class);
+        given(httpStateSupplier.get()).willReturn(httpState);
+        legacyConnectionParam = new LegacyConnectionParam(httpStateSupplier, connectionOptions);
+        // When
+        HttpState obtainedHttpState = legacyConnectionParam.getHttpState();
+        // Then
+        assertThat(obtainedHttpState, is(sameInstance(httpState)));
+        verify(httpStateSupplier).get();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldObtainIsHttpStateEnabledFromConnectionOptions(boolean httpStateEnabled) {
+        // Given
+        given(connectionOptions.isUseGlobalHttpState()).willReturn(httpStateEnabled);
+        // When
+        boolean obtainedHttpStateEnabled = legacyConnectionParam.isHttpStateEnabled();
+        // Then
+        assertThat(obtainedHttpStateEnabled, is(equalTo(httpStateEnabled)));
+        verify(connectionOptions).isUseGlobalHttpState();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetHttpStateEnabledToConnectionOptions(boolean httpStateEnabled) {
+        // Given / When
+        legacyConnectionParam.setHttpStateEnabled(httpStateEnabled);
+        // Then
+        verify(connectionOptions).setUseGlobalHttpState(httpStateEnabled);
+    }
+
+    @Test
+    void shouldGetProxyChainNameFromConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        // When
+        String host = legacyConnectionParam.getProxyChainName();
+        // Then
+        assertThat(host, is(equalTo(HTTP_PROXY.getHost())));
+        verify(connectionOptions).getHttpProxy();
+    }
+
+    @Test
+    void shouldSetProxyChainNameToConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        String host = "other.example.org";
+        // When
+        legacyConnectionParam.setProxyChainName(host);
+        // Then
+        verify(connectionOptions)
+                .setHttpProxy(
+                        new HttpProxy(
+                                host,
+                                HTTP_PROXY.getPort(),
+                                HTTP_PROXY.getRealm(),
+                                HTTP_PROXY.getPasswordAuthentication()));
+    }
+
+    @Test
+    void shouldGetProxyChainPasswordFromConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        // When
+        String password = legacyConnectionParam.getProxyChainPassword();
+        // Then
+        assertThat(password, is(equalTo(PASSWORD)));
+        verify(connectionOptions).getHttpProxy();
+    }
+
+    @Test
+    void shouldSetProxyChainPasswordToConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        String password = "Other Password";
+        // When
+        legacyConnectionParam.setProxyChainPassword(password);
+        // Then
+        verify(connectionOptions)
+                .setHttpProxy(
+                        new HttpProxy(
+                                HTTP_PROXY.getHost(),
+                                HTTP_PROXY.getPort(),
+                                HTTP_PROXY.getRealm(),
+                                new PasswordAuthentication(
+                                        HTTP_PROXY.getPasswordAuthentication().getUserName(),
+                                        password.toCharArray())));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void shouldSetProxyChainSkipName() {
+        // Given
+        String proxyChainSkipName = "example.org;example.com";
+        // When
+        legacyConnectionParam.setProxyChainSkipName(proxyChainSkipName);
+        // Then
+        verify(connectionOptions).setHttpProxyExclusions(exclusionsCaptor.capture());
+        List<HttpProxyExclusion> exclusions = exclusionsCaptor.getValue();
+        assertExclusion(exclusions.get(0), "\\Qexample.org\\E", true);
+        assertExclusion(exclusions.get(1), "\\Qexample.com\\E", true);
+    }
+
+    @Test
+    void shouldGetProxyChainPortFromConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        // When
+        int port = legacyConnectionParam.getProxyChainPort();
+        // Then
+        assertThat(port, is(equalTo(HTTP_PROXY.getPort())));
+        verify(connectionOptions).getHttpProxy();
+    }
+
+    @Test
+    void shouldSetProxyChainPortToConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        int proxyChainPort = 1234;
+        // When
+        legacyConnectionParam.setProxyChainPort(proxyChainPort);
+        // Then
+        verify(connectionOptions)
+                .setHttpProxy(
+                        new HttpProxy(
+                                HTTP_PROXY.getHost(),
+                                proxyChainPort,
+                                HTTP_PROXY.getRealm(),
+                                HTTP_PROXY.getPasswordAuthentication()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldObtainIsProxyChainPromptFromConnectionOptions(boolean proxyPrompt) {
+        // Given
+        given(connectionOptions.isStoreHttpProxyPass()).willReturn(!proxyPrompt);
+        // When
+        boolean obtainedProxyPrompt = legacyConnectionParam.isProxyChainPrompt();
+        // Then
+        assertThat(obtainedProxyPrompt, is(equalTo(proxyPrompt)));
+        verify(connectionOptions).isStoreHttpProxyPass();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetProxyChainPromptToConnectionOptions(boolean proxyPrompt) {
+        // Given / When
+        legacyConnectionParam.setProxyChainPrompt(proxyPrompt);
+        // Then
+        verify(connectionOptions).setStoreHttpProxyPass(!proxyPrompt);
+    }
+
+    @Test
+    void shouldGetProxyChainRealmFromConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        // When
+        String realm = legacyConnectionParam.getProxyChainRealm();
+        // Then
+        assertThat(realm, is(equalTo(HTTP_PROXY.getRealm())));
+        verify(connectionOptions).getHttpProxy();
+    }
+
+    @Test
+    void shouldSetProxyChainRealmToConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        String realm = "Other Realm";
+        // When
+        legacyConnectionParam.setProxyChainRealm(realm);
+        // Then
+        verify(connectionOptions)
+                .setHttpProxy(
+                        new HttpProxy(
+                                HTTP_PROXY.getHost(),
+                                HTTP_PROXY.getPort(),
+                                realm,
+                                HTTP_PROXY.getPasswordAuthentication()));
+    }
+
+    @Test
+    void shouldGetProxyChainUserNameFromConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        // When
+        String userName = legacyConnectionParam.getProxyChainUserName();
+        // Then
+        assertThat(userName, is(equalTo(HTTP_PROXY.getPasswordAuthentication().getUserName())));
+        verify(connectionOptions).getHttpProxy();
+    }
+
+    @Test
+    void shouldSetProxyChainUserNameToConnectionOptions() {
+        // Given
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        String userName = "Other UserName";
+        // When
+        legacyConnectionParam.setProxyChainUserName(userName);
+        // Then
+        verify(connectionOptions)
+                .setHttpProxy(
+                        new HttpProxy(
+                                HTTP_PROXY.getHost(),
+                                HTTP_PROXY.getPort(),
+                                HTTP_PROXY.getRealm(),
+                                new PasswordAuthentication(
+                                        userName,
+                                        HTTP_PROXY.getPasswordAuthentication().getPassword())));
+    }
+
+    @ParameterizedTest
+    @SuppressWarnings("deprecation")
+    @ValueSource(booleans = {true, false})
+    void shouldHaveSingleCookieRequestHeaderAsTrueAlways(boolean singleCookie) {
+        // Given / When
+        legacyConnectionParam.setSingleCookieRequestHeader(singleCookie);
+        // Then
+        assertThat(legacyConnectionParam.isSingleCookieRequestHeader(), is(equalTo(true)));
+        verifyNoInteractions(connectionOptions);
+    }
+
+    @Test
+    void shouldGetTimeoutInSecsFromConnectionOptions() {
+        // Given
+        int timeoutInSecs = 20;
+        given(connectionOptions.getTimeoutInSecs()).willReturn(timeoutInSecs);
+        // When
+        int obtainedTimeoutInSecs = legacyConnectionParam.getTimeoutInSecs();
+        // Then
+        assertThat(obtainedTimeoutInSecs, is(equalTo(timeoutInSecs)));
+        verify(connectionOptions).getTimeoutInSecs();
+    }
+
+    @Test
+    void shouldSetTimeoutInSecsToConnectionOptions() {
+        // Given
+        int timeoutInSecs = 20;
+        // When
+        legacyConnectionParam.setTimeoutInSecs(timeoutInSecs);
+        // Then
+        verify(connectionOptions).setTimeoutInSecs(timeoutInSecs);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldObtainIsUseProxyChainFromConnectionOptions(boolean useProxyChain) {
+        // Given
+        given(connectionOptions.isHttpProxyEnabled()).willReturn(useProxyChain);
+        // When
+        boolean obtainedUseProxyChain = legacyConnectionParam.isUseProxyChain();
+        // Then
+        assertThat(obtainedUseProxyChain, is(equalTo(useProxyChain)));
+        verify(connectionOptions).isHttpProxyEnabled();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetUseProxyChainToConnectionOptions(boolean useProxyChain) {
+        // Given / When
+        legacyConnectionParam.setUseProxyChain(useProxyChain);
+        // Then
+        verify(connectionOptions).setHttpProxyEnabled(useProxyChain);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldObtainIsUseProxyChainAuthFromConnectionOptions(boolean useProxyChainAuth) {
+        // Given
+        given(connectionOptions.isHttpProxyAuthEnabled()).willReturn(useProxyChainAuth);
+        // When
+        boolean obtainedUseProxyChainAuth = legacyConnectionParam.isUseProxyChainAuth();
+        // Then
+        assertThat(obtainedUseProxyChainAuth, is(equalTo(useProxyChainAuth)));
+        verify(connectionOptions).isHttpProxyAuthEnabled();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetUseProxyChainAuthToConnectionOptions(boolean useProxyChainAuth) {
+        // Given / When
+        legacyConnectionParam.setUseProxyChainAuth(useProxyChainAuth);
+        // Then
+        verify(connectionOptions).setHttpProxyAuthEnabled(useProxyChainAuth);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldObtainIsUseSocksProxyFromConnectionOptions(boolean useSocksProxy) {
+        // Given
+        given(connectionOptions.isSocksProxyEnabled()).willReturn(useSocksProxy);
+        // When
+        boolean obtainedUseSocksProxy = legacyConnectionParam.isUseSocksProxy();
+        // Then
+        assertThat(obtainedUseSocksProxy, is(equalTo(useSocksProxy)));
+        verify(connectionOptions).isSocksProxyEnabled();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldSetUseSocksProxyToConnectionOptions(boolean useSocksProxy) {
+        // Given / When
+        legacyConnectionParam.setUseSocksProxy(useSocksProxy);
+        // Then
+        verify(connectionOptions).setSocksProxyEnabled(useSocksProxy);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"example.org, true", "example.com, false"})
+    void shouldUseProxyFromConnectionOptions(String hostname, boolean result) {
+        // Given
+        given(connectionOptions.isUseHttpProxy(any())).willReturn(result);
+        // When
+        boolean obtainedResult = legacyConnectionParam.isUseProxy(hostname);
+        // Then
+        assertThat(obtainedResult, is(equalTo(result)));
+        verify(connectionOptions).isUseHttpProxy(hostname);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"example.org, true", "example.com, false"})
+    void shouldResolveRemoteHostnameWithConnectionOptions(String hostname, boolean result) {
+        // Given
+        given(connectionOptions.shouldResolveRemoteHostname(any())).willReturn(result);
+        // When
+        boolean obtainedResult = legacyConnectionParam.shouldResolveRemoteHostname(hostname);
+        // Then
+        assertThat(obtainedResult, is(equalTo(result)));
+        verify(connectionOptions).shouldResolveRemoteHostname(hostname);
+    }
+
+    @Test
+    void shouldGetProxyExcludedDomainsFromConnectionOptions() {
+
+        // Given
+        given(connectionOptions.getHttpProxyExclusions()).willReturn(EXCLUSIONS);
+        // When
+        List<DomainMatcher> excludedDomains = legacyConnectionParam.getProxyExcludedDomains();
+        // Then
+        assertThat(
+                excludedDomains,
+                contains(domainMatcher("A", false), domainMatcher("\\QB\\E", true)));
+    }
+
+    @Test
+    void shouldSetProxyExcludedDomainsToConnectionOptions() {
+        // Given
+        List<DomainMatcher> excludedDomains =
+                Arrays.asList(domainMatcher("A", false), new DomainMatcher("B"));
+        // When
+        legacyConnectionParam.setProxyExcludedDomains(excludedDomains);
+        // Then
+        verify(connectionOptions).setHttpProxyExclusions(EXCLUSIONS);
+    }
+
+    private static void assertExclusion(
+            HttpProxyExclusion exclusion, String host, boolean enabled) {
+        assertThat(exclusion.getHost().pattern(), is(equalTo(host)));
+        assertThat(exclusion.isEnabled(), is(equalTo(enabled)));
+    }
+
+    private static DomainMatcher domainMatcher(String regex, boolean enabled) {
+        DomainMatcher domainMatcher = new DomainMatcher(Pattern.compile(regex));
+        domainMatcher.setEnabled(enabled);
+        return domainMatcher;
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/CommonUserAgentsUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/CommonUserAgentsUnitTest.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link CommonUserAgents}. */
+class CommonUserAgentsUnitTest {
+
+    @Test
+    void shouldLoadUserAgents() {
+        // Given / When
+        String[] systems = CommonUserAgents.getSystems();
+        // Then
+        assertThat(systems, arrayWithSize(greaterThan(5)));
+    }
+
+    @Test
+    void shouldGetUserAgentFromSystem() {
+        // Given
+        String system = CommonUserAgents.getSystems()[0];
+        // When
+        String userAgent = CommonUserAgents.getUserAgentFromSystem(system);
+        // Then
+        assertThat(userAgent, startsWith("Mozilla/5.0 "));
+    }
+
+    @Test
+    void shouldGetSystemFromUserAgent() {
+        // Given
+        String originalSystem = CommonUserAgents.getSystems()[0];
+        String userAgent = CommonUserAgents.getUserAgentFromSystem(originalSystem);
+        // When
+        String system = CommonUserAgents.getSystemFromUserAgent(userAgent);
+        // Then
+        assertThat(system, is(equalTo(originalSystem)));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpProxyExclusionUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpProxyExclusionUnitTest.java
@@ -1,0 +1,273 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit test for {@link HttpProxyExclusion}. */
+class HttpProxyExclusionUnitTest {
+
+    @Test
+    void shouldCreateWithGivenValues() {
+        // Given
+        Pattern host = Pattern.compile("example.org");
+        boolean enabled = false;
+        // When
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(host, enabled);
+        // Then
+        assertThat(exclusion.getHost(), is(equalTo(host)));
+        assertThat(exclusion.isEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldThrowWhenCreatingWithNullHost() {
+        // Given
+        Pattern host = null;
+        boolean enabled = false;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new HttpProxyExclusion(host, enabled));
+    }
+
+    @Test
+    void shouldCreateWithOtherInstance() {
+        // Given
+        Pattern host = Pattern.compile("example.org");
+        boolean enabled = false;
+        HttpProxyExclusion other = new HttpProxyExclusion(host, enabled);
+        // When
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(other);
+        // Then
+        assertThat(exclusion.getHost(), is(equalTo(host)));
+        assertThat(exclusion.isEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldThrowWhenCreatingWithNullOtherInstance() {
+        // Given
+        HttpProxyExclusion other = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> new HttpProxyExclusion(other));
+    }
+
+    @Test
+    void shouldSetEnabledState() {
+        // Given
+        Pattern host = Pattern.compile("example.org");
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(host, true);
+        boolean enabled = false;
+        // When
+        exclusion.setEnabled(enabled);
+        // Then
+        assertThat(exclusion.isEnabled(), is(equalTo(enabled)));
+    }
+
+    @Test
+    void shouldSetHost() {
+        // Given
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(Pattern.compile("example.org"), true);
+        Pattern host = Pattern.compile("example.com");
+        // When
+        exclusion.setHost(host);
+        // Then
+        assertThat(exclusion.getHost(), is(equalTo(host)));
+    }
+
+    @Test
+    void shouldThrowWhenSettingNullHost() {
+        // Given
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(Pattern.compile("example.org"), true);
+        Pattern host = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> exclusion.setHost(host));
+    }
+
+    @Test
+    void shouldProduceConsistentHashCodes() {
+        // Given
+        HttpProxyExclusion exclusion =
+                new HttpProxyExclusion(Pattern.compile("example.org"), false);
+        // When
+        int hashCode = exclusion.hashCode();
+        // Then
+        assertThat(hashCode, is(equalTo(-1943962101)));
+    }
+
+    @Test
+    void shouldBeEqualToItself() {
+        // Given
+        HttpProxyExclusion exclusion =
+                new HttpProxyExclusion(Pattern.compile("example.org"), false);
+        // When
+        boolean equals = exclusion.equals(exclusion);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    static Stream<Arguments> constructorArgsProvider() {
+        return Stream.of(
+                arguments(Pattern.compile("example.org"), false),
+                arguments(Pattern.compile("example.com"), true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("constructorArgsProvider")
+    void shouldBeEqualToDifferentHttpProxyExclusionWithSameContents(Pattern host, boolean enabled) {
+        // Given
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(host, enabled);
+        HttpProxyExclusion otherEqualHttpProxyExclusion = new HttpProxyExclusion(host, enabled);
+        // When
+        boolean equals = exclusion.equals(otherEqualHttpProxyExclusion);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotBeEqualToNull() {
+        // Given
+        HttpProxyExclusion exclusion =
+                new HttpProxyExclusion(Pattern.compile("example.org"), false);
+        // When
+        boolean equals = exclusion.equals(null);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    static Stream<Arguments> differencesProvider() {
+        Pattern host = Pattern.compile("example.org");
+        Pattern otherHost = Pattern.compile("example.com");
+        return Stream.of(
+                arguments(host, false, host, true),
+                arguments(host, true, host, false),
+                arguments(host, true, otherHost, true),
+                arguments(otherHost, true, host, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("differencesProvider")
+    void shouldNotBeEqualToHttpProxyExclusionWithDifferentValues(
+            Pattern host, boolean enabled, Pattern otherHost, boolean otherEnabled) {
+        // Given
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(host, enabled);
+        HttpProxyExclusion otherHttpProxyExclusion =
+                new HttpProxyExclusion(otherHost, otherEnabled);
+        // When
+        boolean equals = exclusion.equals(otherHttpProxyExclusion);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToExtendedHttpProxyExclusion() {
+        // Given
+        HttpProxyExclusion exclusion =
+                new HttpProxyExclusion(Pattern.compile("example.org"), false);
+        HttpProxyExclusion otherHttpProxyExclusion =
+                new HttpProxyExclusion(Pattern.compile("example.org"), false) {
+                    // Anonymous HttpProxyExclusion
+                };
+        // When
+        boolean equals = exclusion.equals(otherHttpProxyExclusion);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "example.org",
+                "subdomain.example.org",
+                "example.org:443",
+                "example.org:8080"
+            })
+    void shouldReturnTrueWhenTestingWithMatchingHost(String host) {
+        // Given
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(Pattern.compile("example.org"), true);
+        // When
+        boolean result = exclusion.test(host);
+        // Then
+        assertThat(result, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldReturnFalseWhenTestingWithMatchingHostButNotEnabled() {
+        // Given
+        boolean enabled = false;
+        HttpProxyExclusion exclusion =
+                new HttpProxyExclusion(Pattern.compile("example.org"), enabled);
+        // When
+        boolean result = exclusion.test("subdomain.example.org");
+        // Then
+        assertThat(result, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldReturnFalseWhenTestingWithNonMatchingHost() {
+        // Given
+        HttpProxyExclusion exclusion = new HttpProxyExclusion(Pattern.compile("example.org"), true);
+        // When
+        boolean result = exclusion.test("example.com");
+        // Then
+        assertThat(result, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldCreateHostPattern() {
+        // Given
+        String value = "example.org";
+        // When
+        Pattern host = HttpProxyExclusion.createHostPattern(value);
+        // Then
+        assertThat(host, is(notNullValue()));
+        assertThat(host.pattern(), is(equalTo(value)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldReturnNullForEmptyAndNullHostPattern(String value) {
+        // Given / When
+        Pattern host = HttpProxyExclusion.createHostPattern(value);
+        // Then
+        assertThat(host, is(nullValue()));
+    }
+
+    @Test
+    void shouldThrowWhenCreatingWithInvalidHostPattern() {
+        // Given
+        String value = "[";
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class, () -> HttpProxyExclusion.createHostPattern(value));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpProxyUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpProxyUnitTest.java
@@ -1,0 +1,254 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.PasswordAuthentication;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Unit test for {@link HttpProxy}. */
+class HttpProxyUnitTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 8090;
+    private static final String REALM = "realm";
+    private static final PasswordAuthentication EMPTY_CREDENTIALS =
+            new PasswordAuthentication("", new char[] {});
+
+    @Test
+    void shouldNotCreateHttpProxyWithNullHost() {
+        // Given
+        String host = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new HttpProxy(host, PORT, REALM, EMPTY_CREDENTIALS));
+    }
+
+    @Test
+    void shouldNotCreateHttpProxyWithEmptyHost() {
+        // Given
+        String host = "";
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new HttpProxy(host, PORT, REALM, EMPTY_CREDENTIALS));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, 65546})
+    void shouldNotCreateHttpProxyWithInvalidPort(int port) {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new HttpProxy(HOST, port, REALM, EMPTY_CREDENTIALS));
+    }
+
+    @Test
+    void shouldNotCreateHttpProxyWithNullRealm() {
+        // Given
+        String realm = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new HttpProxy(HOST, PORT, realm, EMPTY_CREDENTIALS));
+    }
+
+    @Test
+    void shouldNotCreateHttpProxyWithNullCredentials() {
+        // Given
+        PasswordAuthentication credentials = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class, () -> new HttpProxy(HOST, PORT, REALM, credentials));
+    }
+
+    @Test
+    void shouldCreateHttpProxy() {
+        // Given
+        String host = "127.0.1.1";
+        int port = 1234;
+        String realm = "Realm";
+        String username = "UserName";
+        char[] password = {'1', '2', '3'};
+        PasswordAuthentication credentials = new PasswordAuthentication(username, password);
+        // When
+        HttpProxy httpProxy = new HttpProxy(host, port, realm, credentials);
+        // Then
+        assertThat(httpProxy.getHost(), is(equalTo(host)));
+        assertThat(httpProxy.getPort(), is(equalTo(port)));
+        assertThat(httpProxy.getRealm(), is(equalTo(realm)));
+        assertThat(httpProxy.getPasswordAuthentication().getUserName(), is(equalTo(username)));
+        assertThat(httpProxy.getPasswordAuthentication().getPassword(), is(equalTo(password)));
+    }
+
+    @Test
+    void shouldProduceConsistentHashCode() {
+        // Given
+        HttpProxy httpProxy =
+                new HttpProxy(
+                        "127.0.0.1",
+                        8190,
+                        "realm A",
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        // When
+        int hashCode = httpProxy.hashCode();
+        // Then
+        assertThat(hashCode, is(equalTo(-27052655)));
+    }
+
+    @Test
+    void shouldBeEqualToItself() {
+        // Given
+        HttpProxy httpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = httpProxy.equals(httpProxy);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldBeEqualToDifferentHttpProxyWithSameContents() {
+        // Given
+        HttpProxy httpProxy =
+                new HttpProxy(HOST, PORT, REALM, new PasswordAuthentication("A", new char[] {'1'}));
+        HttpProxy otherEqualHttpProxy =
+                new HttpProxy(HOST, PORT, REALM, new PasswordAuthentication("A", new char[] {'1'}));
+        // When
+        boolean equals = httpProxy.equals(otherEqualHttpProxy);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotBeEqualToNull() {
+        // Given
+        HttpProxy httpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = httpProxy.equals(null);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToHttpProxyWithJustDifferentHost() {
+        // Given
+        HttpProxy httpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS);
+        HttpProxy otherHttpProxy = new HttpProxy("example.com", PORT, REALM, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = httpProxy.equals(otherHttpProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToHttpProxyWithJustDifferentPort() {
+        // Given
+        HttpProxy httpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS);
+        HttpProxy otherHttpProxy = new HttpProxy(HOST, 1234, REALM, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = httpProxy.equals(otherHttpProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToHttpProxyWithJustDifferentRealm() {
+        // Given
+        HttpProxy httpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS);
+        HttpProxy otherHttpProxy = new HttpProxy(HOST, PORT, "Other Realm", EMPTY_CREDENTIALS);
+        // When
+        boolean equals = httpProxy.equals(otherHttpProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToHttpProxyWithJustDifferentUsername() {
+        // Given
+        HttpProxy httpProxy =
+                new HttpProxy(HOST, PORT, REALM, new PasswordAuthentication("A", new char[] {'1'}));
+        HttpProxy otherHttpProxy =
+                new HttpProxy(HOST, PORT, REALM, new PasswordAuthentication("B", new char[] {'1'}));
+        // When
+        boolean equals = httpProxy.equals(otherHttpProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToHttpProxyWithJustDifferentPassword() {
+        // Given
+        HttpProxy httpProxy =
+                new HttpProxy(HOST, PORT, REALM, new PasswordAuthentication("A", new char[] {'1'}));
+        HttpProxy otherHttpProxy =
+                new HttpProxy(HOST, PORT, REALM, new PasswordAuthentication("A", new char[] {'2'}));
+        // When
+        boolean equals = httpProxy.equals(otherHttpProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldBeEqualToExtendedHttpProxy() {
+        // Given
+        HttpProxy httpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS);
+        HttpProxy otherHttpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS) {
+                    // Anonymous HttpProxy
+                };
+        // When
+        boolean equals = httpProxy.equals(otherHttpProxy);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotBeEqualToDifferentType() {
+        // Given
+        HttpProxy httpProxy = new HttpProxy(HOST, PORT, REALM, EMPTY_CREDENTIALS);
+        String otherType = "";
+        // When
+        boolean equals = httpProxy.equals(otherType);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldProduceConsistentStringRepresentation() {
+        // Given
+        HttpProxy httpProxy =
+                new HttpProxy(
+                        "localhost",
+                        8090,
+                        "realm",
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        // When
+        String representation = httpProxy.toString();
+        // Then
+        assertThat(
+                representation,
+                is(equalTo("[Host=localhost, Port=8090, Realm=realm, UserName=A, Password=***]")));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/SocksProxyUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/SocksProxyUnitTest.java
@@ -1,0 +1,363 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.net.PasswordAuthentication;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.addon.network.internal.client.SocksProxy.Version;
+
+/** Unit test for {@link SocksProxy}. */
+class SocksProxyUnitTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 1080;
+    private static final PasswordAuthentication EMPTY_CREDENTIALS =
+            new PasswordAuthentication("", new char[] {});
+
+    @Test
+    void shouldNotCreateSocksProxyWithNullHost() {
+        // Given
+        String host = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new SocksProxy(host, PORT, Version.SOCKS5, true, EMPTY_CREDENTIALS));
+    }
+
+    @Test
+    void shouldNotCreateSocksProxyWithEmptyHost() {
+        // Given
+        String host = "";
+        // When / Then
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new SocksProxy(host, PORT, Version.SOCKS5, true, EMPTY_CREDENTIALS));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1, 65546})
+    void shouldNotCreateSocksProxyWithInvalidPort(int port) {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new SocksProxy(HOST, port, Version.SOCKS5, true, EMPTY_CREDENTIALS));
+    }
+
+    @Test
+    void shouldNotCreateSocksProxyWithNullVersion() {
+        // Given
+        Version version = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new SocksProxy(HOST, PORT, version, true, EMPTY_CREDENTIALS));
+    }
+
+    @Test
+    void shouldNotCreateSocksProxyWithNullCredentials() {
+        // Given
+        PasswordAuthentication credentials = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new SocksProxy(HOST, PORT, Version.SOCKS5, true, credentials));
+    }
+
+    @Test
+    void shouldCreateSocksProxy() {
+        // Given
+        String host = "127.0.1.1";
+        int port = 1234;
+        Version version = Version.SOCKS5;
+        boolean useDns = true;
+        String username = "UserName";
+        char[] password = {'1', '2', '3'};
+        PasswordAuthentication credentials = new PasswordAuthentication(username, password);
+        // When
+        SocksProxy socksProxy = new SocksProxy(host, port, version, useDns, credentials);
+        // Then
+        assertThat(socksProxy.getHost(), is(equalTo(host)));
+        assertThat(socksProxy.getPort(), is(equalTo(port)));
+        assertThat(socksProxy.getVersion(), is(equalTo(version)));
+        assertThat(socksProxy.isUseDns(), is(equalTo(useDns)));
+        assertThat(socksProxy.getPasswordAuthentication().getUserName(), is(equalTo(username)));
+        assertThat(socksProxy.getPasswordAuthentication().getPassword(), is(equalTo(password)));
+    }
+
+    @Test
+    void shouldProduceConsistentHashCode() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "127.0.0.1",
+                        9150,
+                        Version.SOCKS5,
+                        false,
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        // When
+        int hashCode = socksProxy.hashCode();
+        // Then
+        assertThat(hashCode, is(equalTo(693627553)));
+    }
+
+    @Test
+    void shouldBeEqualToItself() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = socksProxy.equals(socksProxy);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldBeEqualToDifferentSocksProxyWithSameContents() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        HOST,
+                        PORT,
+                        Version.SOCKS4A,
+                        false,
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        SocksProxy otherEqualSocksProxy =
+                new SocksProxy(
+                        HOST,
+                        PORT,
+                        Version.SOCKS4A,
+                        false,
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        // When
+        boolean equals = socksProxy.equals(otherEqualSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotBeEqualToNull() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = socksProxy.equals(null);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToSocksProxyWithJustDifferentHost() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        SocksProxy otherSocksProxy =
+                new SocksProxy("example.com", PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = socksProxy.equals(otherSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToSocksProxyWithJustDifferentPort() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        SocksProxy otherSocksProxy =
+                new SocksProxy(HOST, 1234, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = socksProxy.equals(otherSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToSocksProxyWithJustDifferentVersion() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        SocksProxy otherSocksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS5, false, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = socksProxy.equals(otherSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToSocksProxyWithJustDifferentUseDns() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        SocksProxy otherSocksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, true, EMPTY_CREDENTIALS);
+        // When
+        boolean equals = socksProxy.equals(otherSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToSocksProxyWithJustDifferentUsername() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        HOST,
+                        PORT,
+                        Version.SOCKS4A,
+                        false,
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        SocksProxy otherSocksProxy =
+                new SocksProxy(
+                        HOST,
+                        PORT,
+                        Version.SOCKS4A,
+                        false,
+                        new PasswordAuthentication("B", new char[] {'1'}));
+        // When
+        boolean equals = socksProxy.equals(otherSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldNotBeEqualToSocksProxyWithJustDifferentPassword() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        HOST,
+                        PORT,
+                        Version.SOCKS4A,
+                        false,
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        SocksProxy otherSocksProxy =
+                new SocksProxy(
+                        HOST,
+                        PORT,
+                        Version.SOCKS4A,
+                        false,
+                        new PasswordAuthentication("A", new char[] {'2'}));
+        // When
+        boolean equals = socksProxy.equals(otherSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldBeEqualToExtendedSocksProxy() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        SocksProxy otherSocksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS) {
+                    // Anonymous SocksProxy
+                };
+        // When
+        boolean equals = socksProxy.equals(otherSocksProxy);
+        // Then
+        assertThat(equals, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldNotBeEqualToDifferentType() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(HOST, PORT, Version.SOCKS4A, false, EMPTY_CREDENTIALS);
+        String otherType = "";
+        // When
+        boolean equals = socksProxy.equals(otherType);
+        // Then
+        assertThat(equals, is(equalTo(false)));
+    }
+
+    @Test
+    void shouldProduceConsistentStringRepresentation() {
+        // Given
+        SocksProxy socksProxy =
+                new SocksProxy(
+                        "localhost",
+                        1080,
+                        Version.SOCKS5,
+                        true,
+                        new PasswordAuthentication("A", new char[] {'1'}));
+        // When
+        String representation = socksProxy.toString();
+        // Then
+        assertThat(
+                representation,
+                is(
+                        equalTo(
+                                "[Host=localhost, Port=1080, Version=5, UseDns=true, UserName=A, Password=***]")));
+    }
+
+    @Test
+    void shouldGetSocks4From4() {
+        // Given
+        String value = "4";
+        // When
+        Version version = Version.from(value);
+        // Then
+        assertThat(version, is(equalTo(Version.SOCKS4A)));
+    }
+
+    @Test
+    void shouldGetSocks5From5() {
+        // Given
+        String value = "5";
+        // When
+        Version version = Version.from(value);
+        // Then
+        assertThat(version, is(equalTo(Version.SOCKS5)));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"3", "NotAVersion"})
+    void shouldGetSocks5FromInvalidValues(String value) {
+        // Given value
+        // When
+        Version version = Version.from(value);
+        // Then
+        assertThat(version, is(equalTo(Version.SOCKS5)));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldGetExpectedVersionNumberFromVersion(Version version, int number) {
+        // Given version, number
+        // When / Then
+        assertThat(version.number(), is(equalTo(number)));
+    }
+
+    static Stream<Arguments> shouldGetExpectedVersionNumberFromVersion() {
+        return Stream.of(arguments(Version.SOCKS4A, 4), arguments(Version.SOCKS5, 5));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTableModelUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTableModelUnitTest.java
@@ -1,0 +1,61 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
+import org.zaproxy.zap.utils.I18N;
+
+/** Unit test for {@link HttpProxyExclusionTableModel}. */
+class HttpProxyExclusionTableModelUnitTest {
+
+    @BeforeAll
+    static void setUpAll() {
+        Constant.messages = mock(I18N.class);
+    }
+
+    @Test
+    void shouldCreateCopyOfCollectionAndValues() {
+        // Given
+        HttpProxyExclusionTableModel model = new HttpProxyExclusionTableModel();
+        List<HttpProxyExclusion> exclusions = new ArrayList<>();
+        HttpProxyExclusion original =
+                new HttpProxyExclusion(HttpProxyExclusion.createHostPattern("localhost"), false);
+        exclusions.add(original);
+        // When
+        model.setHttpProxyExclusions(exclusions);
+        model.setAllEnabled(true);
+        exclusions.clear();
+        // Then
+        assertThat(original.isEnabled(), is(equalTo(false)));
+        assertThat(model.getElements(), hasSize(1));
+        assertThat(model.getElements().get(0).isEnabled(), is(equalTo(true)));
+    }
+}


### PR DESCRIPTION
Manage the connection options, through the UI and API, when the core
ones are deprecated.

Related to zaproxy/zaproxy#7291.