### PR TITLE
websocket: cache passive rules and handle errors

### DIFF
--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Cache WebSocket Passive Rules scripts for better performance with all script engines.
+
+### Fixed
+- Handle errors caused by WebSocket Passive Rules scripts, which would break the passive scan.
 
 ## [25] - 2022-03-14
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ExtensionWebSocket.java
@@ -454,7 +454,7 @@ public class ExtensionWebSocket extends ExtensionAdaptor
                             getView() != null ? getScriptPassiveScanIcon() : null,
                             true);
             this.extensionScript.registerScriptType(websocketPassiveScanScriptType);
-            webSocketScriptPassiveScanner = new ScriptsWebSocketPassiveScanner();
+            webSocketScriptPassiveScanner = new ScriptsWebSocketPassiveScanner(extensionScript);
 
             webSocketPassiveScannerManager.add(webSocketScriptPassiveScanner);
             webSocketPassiveScannerManager.setAllEnable(true);

--- a/addOns/websocket/src/main/resources/org/zaproxy/zap/extension/websocket/resources/Messages.properties
+++ b/addOns/websocket/src/main/resources/org/zaproxy/zap/extension/websocket/resources/Messages.properties
@@ -131,7 +131,7 @@ websocket.script.type.websocketsender.desc = Scripts that are called before forw
 websocket.script.error.websocketsender = Error in WebSocket Sender script
 
 websocket.pscan.scripts.type.passive             = WebSocket Passive Rules
-websocket.pscan.scripts.interface.passive.error  = The provided Passive Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
+websocket.pscan.scripts.interface.passive.error  = The provided WebSocket Passive Rules script ({0}) does not implement the required interface.\nPlease refer to the provided templates for examples.
 
 websocket.treemap.title                       = WebSocket Map
 websocket.treemap.folder.root                 = WebSocket Connections


### PR DESCRIPTION
Cache the passive rules for better performance with all script engines.
Handle the errors that the scripts might cause, which were stopping the
passive scan thread.
Include WebSocket in the error message shown when the script does not
implement the interface to avoid confusions with (HTTP) Passive Rules.

---
Reported in the IRC channel.
