### PR TITLE
network: add unsafe SSL/TLS renegotiation option

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
@@ -129,6 +129,7 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
         private final JCheckBox globalHttpStateCheckBox;
         private final ZapNumberSpinner dnsTtlSuccessfulNumberSpinner;
         private final SecurityProtocolsPanel securityProtocolsPanel;
+        private final JCheckBox allowUnsafeRenegotiationCheckBox;
         private final JPanel panel;
 
         GeneralPanel() {
@@ -214,6 +215,13 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
                             .addComponent(dnsTtlSuccessfulNumberSpinner));
 
             securityProtocolsPanel = new SecurityProtocolsPanel();
+            allowUnsafeRenegotiationCheckBox =
+                    new JCheckBox(
+                            Constant.messages.getString(
+                                    "network.ui.options.connection.general.unsaferenegotiation"));
+            allowUnsafeRenegotiationCheckBox.setToolTipText(
+                    Constant.messages.getString(
+                            "network.ui.options.connection.general.unsaferenegotiation.tooltip"));
 
             Component spacer = Box.createHorizontalGlue();
 
@@ -241,7 +249,8 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
                             .addComponent(globalHttpStateCheckBox)
                             .addComponent(spacer)
                             .addComponent(dnsPanel)
-                            .addComponent(securityProtocolsPanel));
+                            .addComponent(securityProtocolsPanel)
+                            .addComponent(allowUnsafeRenegotiationCheckBox));
 
             layout.setVerticalGroup(
                     layout.createSequentialGroup()
@@ -261,7 +270,8 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
                             .addComponent(globalHttpStateCheckBox)
                             .addComponent(spacer)
                             .addComponent(dnsPanel)
-                            .addComponent(securityProtocolsPanel));
+                            .addComponent(securityProtocolsPanel)
+                            .addComponent(allowUnsafeRenegotiationCheckBox));
         }
 
         private void updateUserAgentsComboBox() {
@@ -281,6 +291,7 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
             globalHttpStateCheckBox.setSelected(options.isUseGlobalHttpState());
             dnsTtlSuccessfulNumberSpinner.setValue(options.getDnsTtlSuccessfulQueries());
             securityProtocolsPanel.setSecurityProtocolsEnabled(options.getTlsProtocols());
+            allowUnsafeRenegotiationCheckBox.setSelected(options.isAllowUnsafeRenegotiation());
         }
 
         void validate() throws Exception {
@@ -293,6 +304,7 @@ class ConnectionOptionsPanel extends AbstractParamPanel {
             options.setUseGlobalHttpState(globalHttpStateCheckBox.isSelected());
             options.setDnsTtlSuccessfulQueries(dnsTtlSuccessfulNumberSpinner.getValue());
             options.setTlsProtocols(securityProtocolsPanel.getSelectedProtocols());
+            options.setAllowUnsafeRenegotiation(allowUnsafeRenegotiationCheckBox.isSelected());
         }
     }
 

--- a/addOns/network/src/main/javahelp/help/contents/options/connection.html
+++ b/addOns/network/src/main/javahelp/help/contents/options/connection.html
@@ -46,6 +46,12 @@
 	<br>The option SSLv2Hello must be selected in conjunction with at least one SSL/TLS version.
 	<br>Default: All protocols supported.
 
+	<H3>Enable unsafe SSL/TLS renegotiation</H3>
+	Allows unsafe SSL/TLS renegotiations (<a href="https://www.cve.org/CVERecord?id=CVE-2009-3555">CVE-2009-3555</a>) for
+	compatibility with older servers.<br/>
+	<strong>Note:</strong> The option must be set before establishing any HTTPS connection, a ZAP restart might be required.
+	<br>Default: <code>unselected</code>.
+
 	<H2>HTTP Proxy</H2>
 	This tab allows you to configure an outgoing HTTP proxy. This is often required in a corporate environment.
 	<H3>Enabled</H3>

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -153,6 +153,8 @@ network.ui.options.connection.general.dns.ttlsuccessful.toolTip = <html>Defines 
 <li>Zero, disables caching;</li>\
 <li>Positive number, the number of seconds the queries will be cached.</li></ul>\
 <strong>Note:</strong> Changes are applied after a restart.</html>
+network.ui.options.connection.general.unsaferenegotiation = Enable unsafe SSL/TLS renegotiation
+network.ui.options.connection.general.unsaferenegotiation.tooltip = To enable unsafe SSL/TLS renegotiation you must turn it on before establishing any HTTPS connection.\nIf it is not working, restart ZAP.
 
 network.ui.options.connection.httpproxy.tab = HTTP Proxy
 network.ui.options.connection.httpproxy.enabled = Enabled:


### PR DESCRIPTION
Add option to allow unsafe SSL/TLS renegotiations, to replace core
option.

Related to zaproxy/zaproxy#7294.