### PR TITLE
automation: correct resource keys

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Show each context URL in its own line when editing in the GUI (Issue 7241).
+- Correct error messages.
 
 ## [0.15.0] - 2022-04-25
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddJobDialog.java
@@ -80,7 +80,7 @@ public class AddJobDialog extends StandardFieldsDialog {
                     .showWarningDialog(
                             thisDialog,
                             Constant.messages.getString(
-                                    "automation.dialog.error.misc ", e.getMessage()));
+                                    "automation.dialog.error.misc", e.getMessage()));
         }
     }
 

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/NewPlanDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/NewPlanDialog.java
@@ -235,7 +235,7 @@ public class NewPlanDialog extends StandardFieldsDialog {
                     .showWarningDialog(
                             thisDialog,
                             Constant.messages.getString(
-                                    "automation.dialog.error.misc ", e.getMessage()));
+                                    "automation.dialog.error.misc", e.getMessage()));
         }
     }
 


### PR DESCRIPTION
Remove extra space from the resource keys.

---
Reported in the IRC channel.