### PR TITLE
network: handle API requests always

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandler.java
@@ -20,15 +20,16 @@
 package org.zaproxy.addon.network.internal.server.http.handlers;
 
 import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 
 /**
- * A {@link HttpRequestHandler} that {@link HttpMessageHandlerContext#close closes} if a recursive
+ * A {@link HttpMessageHandler} that {@link HttpMessageHandlerContext#close closes} if a recursive
  * request.
  *
  * @see #getInstance()
  */
-public class CloseOnRecursiveRequestHandler extends HttpRequestHandler {
+public class CloseOnRecursiveRequestHandler implements HttpMessageHandler {
 
     private static final CloseOnRecursiveRequestHandler INSTANCE =
             new CloseOnRecursiveRequestHandler();
@@ -43,8 +44,8 @@ public class CloseOnRecursiveRequestHandler extends HttpRequestHandler {
     }
 
     @Override
-    protected void handleRequest(HttpMessageHandlerContext ctx, HttpMessage msg) {
-        if (ctx.isRecursive()) {
+    public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (ctx.isFromClient() && ctx.isRecursive()) {
             ctx.close();
         }
     }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpRequestHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/HttpRequestHandler.java
@@ -20,10 +20,9 @@
 package org.zaproxy.addon.network.internal.server.http.handlers;
 
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 
-/** A {@link HttpMessageHandler} that's interested only in HTTP requests. */
+/** A {@link HttpIncludedMessageHandler} that's interested only in HTTP requests. */
 public abstract class HttpRequestHandler extends HttpIncludedMessageHandler {
 
     @Override

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/ZapApiHandler.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/server/http/handlers/ZapApiHandler.java
@@ -31,12 +31,13 @@ import org.parosproxy.paros.network.HttpInputStream;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpOutputStream;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.network.server.HttpMessageHandler;
 import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
 import org.zaproxy.zap.extension.api.API;
 import org.zaproxy.zap.network.HttpRequestBody;
 
 /** Handles API requests by calling the {@link API}. */
-public class ZapApiHandler extends HttpRequestHandler {
+public class ZapApiHandler implements HttpMessageHandler {
 
     private static final Logger LOGGER = LogManager.getLogger(ZapApiHandler.class);
 
@@ -53,7 +54,13 @@ public class ZapApiHandler extends HttpRequestHandler {
     }
 
     @Override
-    protected void handleRequest(HttpMessageHandlerContext ctx, HttpMessage msg) {
+    public void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (ctx.isFromClient()) {
+            handleRequest(ctx, msg);
+        }
+    }
+
+    private void handleRequest(HttpMessageHandlerContext ctx, HttpMessage msg) {
         if (!state.isEnabled()) {
             return;
         }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/CloseOnRecursiveRequestHandlerUnitTest.java
@@ -45,14 +45,14 @@ class CloseOnRecursiveRequestHandlerUnitTest {
     }
 
     @Test
-    void shouldNotHandleExcludedMessage() throws Exception {
+    void shouldCloseRecursiveExcludedMessage() throws Exception {
         // Given
         given(ctx.isRecursive()).willReturn(true);
         given(ctx.isExcluded()).willReturn(true);
         // When
         handler.handleMessage(ctx, message);
         // Then
-        verify(ctx, times(0)).close();
+        verify(ctx).close();
     }
 
     @Test

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/ZapApiHandlerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/server/http/handlers/ZapApiHandlerUnitTest.java
@@ -62,13 +62,13 @@ class ZapApiHandlerUnitTest {
     }
 
     @Test
-    void shouldNotHandleExcludedMessage() throws Exception {
+    void shouldHandleExcludedMessage() throws Exception {
         // Given
         given(ctx.isExcluded()).willReturn(true);
         // When
         handler.handleMessage(ctx, message);
         // Then
-        verify(message, times(0)).getRequestHeader();
+        verify(message).getRequestBody();
     }
 
     @Test


### PR DESCRIPTION
Do not check if the requests are excluded from the proxy in the API
handler, they should be handled even if excluded.
Apply same logic to close on recursive request handler.

Fix zaproxy/zaproxy#7301.