### PR TITLE
Remove handling of internal exceptions

### DIFF
--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/RelativePathConfusionScanRule.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.CircularRedirectException;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.RandomStringUtils;
@@ -250,11 +249,7 @@ public class RelativePathConfusionScanRule extends AbstractAppPlugin {
                 } catch (Exception e) {
                     log.warn("Could not set the cookies from the base request: {}", e);
                 }
-                try {
-                    sendAndReceive(hackedMessage, true); // follow redirects
-                } catch (CircularRedirectException e) {
-                    log.warn("Ignoring a CircularRedirectException {}", e);
-                }
+                sendAndReceive(hackedMessage, true); // follow redirects
 
                 // get ready to parse the HTML
                 Document doc = Jsoup.parse(new String(hackedMessage.getResponseBody().getBytes()));

--- a/addOns/sqliplugin/CHANGELOG.md
+++ b/addOns/sqliplugin/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Maintenance changes.
 
 ## [15] - 2021-10-20
 ### Fixed

--- a/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
+++ b/addOns/sqliplugin/src/main/java/org/zaproxy/zap/extension/sqliplugin/SQLInjectionScanRule.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1156,15 +1155,6 @@ public class SQLInjectionScanRule extends AbstractAppParamPlugin {
             if (errorPattern.matcher(tempMsg.getResponseBody().toString()).find()) {
                 lastErrorPageUID = lastRequestUID;
             }
-
-        } catch (HttpException e) {
-            log.debug(
-                    "SQL Injection vulnerability check failed for parameter [{}] and payload [{}] due to: {}",
-                    paramName,
-                    payload,
-                    e.getClass().getCanonicalName(),
-                    e);
-            return null;
 
         } catch (IOException ex) {
             // Ok we got an error, but take in care always the given response


### PR DESCRIPTION
Reduce usage of implementation details.
The `CircularRedirectException` should no longer happen, they are now
allowed always (zaproxy/zaproxy#7256).
The `HttpException` would be thrown in very specific cases and for the
scan rule those do not need a different handling than the generic
`IOException` already being caught.