### PR TITLE
chore: wappalyzer: Update Help URL Reference

### DIFF
--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+###Changed
+- Update Wappalyzer URL in help documentation.
 
 ### Fixed
 - Threading issue - only reproducible with currently unreleased core changes.

--- a/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
+++ b/addOns/wappalyzer/src/main/javahelp/org/zaproxy/zap/extension/wappalyzer/resources/help/contents/wappalyzer.html
@@ -41,7 +41,7 @@ Technology data is available to reports via the
 	<td>The Wappalyzer Homepage</td></tr>
 <tr>
 	<td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
-	<td><a href="https://github.com/AliasIO/Wappalyzer">https://github.com/AliasIO/Wappalyzer</a></td>
+	<td><a href="https://github.com/wappalyzer/wappalyzer">https://github.com/wappalyzer/wappalyzer</a></td>
 	<td>The Wappalyzer Repository</td>
 </tr>
 </table>


### PR DESCRIPTION
- Wappalyzer is now part of the Wappalyzer organization, no longer within a personal repo of AliasIO, update help documentation accordingly.
- CHANGELOG > Add change note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>