### PR TITLE
retire: Performance adjustment & Minor naming tweak

### DIFF
--- a/addOns/retire/CHANGELOG.md
+++ b/addOns/retire/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Performance improvements (Issue 6959).
+- Add Retire.js reference to Alert and Rule name to make it more obvious in reports and the options panel.
 
 ## [0.12.0] - 2022-05-26
 ### Changed

--- a/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
+++ b/addOns/retire/src/main/java/org/zaproxy/addon/retire/RetireScanRule.java
@@ -71,7 +71,7 @@ public class RetireScanRule extends PluginPassiveScanner {
                 LOGGER.error("\tThe Retire.js repository was null.");
                 return;
             }
-            Result result = scanRepo.scanJS(msg);
+            Result result = scanRepo.scanJS(msg, source);
             if (result == null) {
                 LOGGER.debug("\tNo vulnerabilities found in record {} with URL {}", id, uri);
             } else {

--- a/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/Messages.properties
+++ b/addOns/retire/src/main/resources/org/zaproxy/addon/retire/resources/Messages.properties
@@ -1,6 +1,6 @@
 retire.desc = Retire.js
 
-retire.rule.name = Vulnerable JS Library
+retire.rule.name = Vulnerable JS Library (Retire.js)
 retire.rule.desc = The identified library {0}, version {1} is vulnerable.
 retire.rule.soln = Please upgrade to the latest version of {0}.
 retire.rule.otherinfo = The library matched the known vulnerable hash {0}.


### PR DESCRIPTION
- CHANGELOG > Added change note.
- Messages.properties > Updated name.
- Repo.java > Added script element extraction for html responses.
- RetireScanRule > Pass Jericho Source object instead of re-creating it.

Fixes zaproxy/zaproxy#6959

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>