### PR TITLE
oast: Synchronize alert cache accesses to avoid locks

### DIFF
--- a/addOns/oast/CHANGELOG.md
+++ b/addOns/oast/CHANGELOG.md
@@ -13,6 +13,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Default services notes in the help documents.
 - Extension description and UI name.
 
+### Fixed
+- Synchronized alerts cache access to avoid locks
+
 ## [0.10.0] - 2022-02-18
 ### Added
 - The following two statistics for each OAST service:


### PR DESCRIPTION
Were getting some scans stuck. The rules that were stuck were always rules that use OAST. After some debugging found out that the thread was getting stuck at the method `registerAlertAndGetPayload()` in the line `alertCache.put(payload, alert);`. This happens very infrequently. 