### PR TITLE
ascanrulesBeta: rely more on newer HttpSender

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [41] - 2022-06-08
 ### Changed


### PR DESCRIPTION
Change `InsecureHttpMethodScanRule` to use the `HttpSender` to send the
CONNECT request if the newer implementation is available in the
classpath, to reduce usage of superseded implementation details in
newer versions.