### PR TITLE
requester: fix class cast exception

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [6] - 2022-05-10
 ### Added

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/HttpPanelSender.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/HttpPanelSender.java
@@ -130,7 +130,17 @@ public class HttpPanelSender implements MessageSender {
                         }
                     });
 
-            ZapGetMethod method = (ZapGetMethod) httpMessage.getUserObject();
+            Object userObject = httpMessage.getUserObject();
+            if (userObject instanceof Socket) {
+                closeSilently((Socket) userObject);
+                return;
+            }
+
+            if (!(userObject instanceof ZapGetMethod)) {
+                return;
+            }
+
+            ZapGetMethod method = (ZapGetMethod) userObject;
             notifyPersistentConnectionListener(httpMessage, null, method);
 
         } catch (final HttpMalformedHeaderException mhe) {
@@ -148,6 +158,14 @@ public class HttpPanelSender implements MessageSender {
 
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
+        }
+    }
+
+    private static void closeSilently(Socket socket) {
+        try {
+            socket.close();
+        } catch (IOException ignore) {
+            // Nothing to do.
         }
     }
 


### PR DESCRIPTION
Change `HttpPanelSender` to check the type of the object present in the
message to prevent a class cast exception when it has other types. Also,
close the socket if it has one (i.e. from CONNECT request).