### PR TITLE
ascanrulesAlpha: fix NPE in spring actuator

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Fix an exception in Spring Actuator Information Leak scan rule when scanning responses without Content-Type header.
+
 ## [38] - 2022-04-08
 ### Added
 - Scan rules for Server Side Template Injection ([Issue 2332](https://github.com/zaproxy/zaproxy/issues/2332)).

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRule.java
@@ -134,7 +134,7 @@ public class SpringActuatorScanRule extends AbstractHostPlugin {
                     continue;
                 }
                 String contentType = testMsg.getResponseHeader().getNormalisedContentTypeValue();
-                if (isPage200(testMsg)) {
+                if (contentType != null && isPage200(testMsg)) {
                     String responseBody = testMsg.getResponseBody().toString();
                     boolean matches =
                             CONTENT_TYPE.matcher(contentType).find()

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/SpringActuatorScanRuleUnitTest.java
@@ -109,6 +109,27 @@ class SpringActuatorScanRuleUnitTest extends ActiveScannerTest<SpringActuatorSca
     }
 
     @Test
+    void shouldScanResponseWithoutContentType() throws HttpMalformedHeaderException {
+        // Given
+        String servePath = "";
+        String alertPath = REQ_PATH;
+        this.nano.addHandler(
+                new NanoServerHandler("/" + alertPath) {
+                    @Override
+                    protected Response serve(NanoHTTPD.IHTTPSession session) {
+                        return newFixedLengthResponse(Response.Status.OK, null, RELEVANT_BODY);
+                    }
+                });
+        HttpMessage msg = this.getHttpMessage(servePath);
+        rule.init(msg, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(0));
+        assertThat(httpMessagesSent, hasSize(2));
+    }
+
+    @Test
     void shouldHandleNetworkErrors() throws HttpMalformedHeaderException {
         // Given
         String path = "/";


### PR DESCRIPTION
Add null check for the content type, which might not be present in the
response.