### PR TITLE
network: add classes for client cert management

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CertificateEntry.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CertificateEntry.java
@@ -1,0 +1,154 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.security.KeyStore;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.util.Objects;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSessionContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** A certificate of a {@link KeyStoreEntry}. */
+public class CertificateEntry {
+
+    private static final Logger LOGGER = LogManager.getLogger(CertificateEntry.class);
+
+    private static final TrustManager[] LAX_TRUST_MANAGER =
+            new TrustManager[] {new LaxTrustManager()};
+
+    private final KeyStoreEntry parent;
+    private final Certificate certificate;
+    private final String alias;
+    private final String name;
+    private final int index;
+    private SSLContext sslContext;
+
+    CertificateEntry(KeyStoreEntry parent, Certificate certificate, String alias, int index) {
+        this.parent = Objects.requireNonNull(parent);
+        this.certificate = Objects.requireNonNull(certificate);
+        this.alias = Objects.requireNonNull(alias);
+        this.name = extractName(certificate, alias);
+        this.index = index;
+    }
+
+    public KeyStoreEntry getParent() {
+        return parent;
+    }
+
+    public Certificate getCertificate() {
+        return certificate;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public boolean isUnlocked() {
+        return sslContext != null;
+    }
+
+    public boolean unlock(String password) {
+        KeyStore keyStore = parent.getKeyStore();
+        SingleAliasKeyManager keyManager =
+                new SingleAliasKeyManager(keyStore, alias, password.toCharArray());
+
+        if (keyManager.getPrivateKey(alias) == null) {
+            return false;
+        }
+
+        try {
+            sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(new KeyManager[] {keyManager}, LAX_TRUST_MANAGER, new SecureRandom());
+            return true;
+        } catch (Exception e) {
+            LOGGER.error(
+                    "An error occurred while initialising the SSLContext: {}", e.getMessage(), e);
+            sslContext = null;
+            return false;
+        }
+    }
+
+    public SSLSocketFactory getSocketFactory() {
+        if (sslContext == null) {
+            return null;
+        }
+        return sslContext.getSocketFactory();
+    }
+
+    void invalidateSession() {
+        if (sslContext == null) {
+            return;
+        }
+
+        invalidateSession(sslContext.getClientSessionContext());
+        invalidateSession(sslContext.getServerSessionContext());
+    }
+
+    private static void invalidateSession(SSLSessionContext session) {
+        if (session == null) {
+            return;
+        }
+
+        int timeout = session.getSessionTimeout();
+        session.setSessionTimeout(1);
+        session.setSessionTimeout(timeout);
+    }
+
+    private static String extractName(Certificate certificate, String alias) {
+        String cn = getCn(certificate);
+        if (cn == null || cn.isEmpty()) {
+            return alias;
+        }
+        return cn + " [" + alias + "]";
+    }
+
+    private static String getCn(Certificate certificate) {
+        String dn = certificate.toString();
+        int i = 0;
+        i = dn.indexOf("CN=");
+        if (i == -1) {
+            return null;
+        }
+        dn = dn.substring(i + 3);
+
+        char[] dnChars = dn.toCharArray();
+        for (i = 0; i < dnChars.length; i++) {
+            if (dnChars[i] == ',' && i > 0 && dnChars[i - 1] != '\\') {
+                break;
+            }
+        }
+        return dn.substring(0, i);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/KeyStoreEntry.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/KeyStoreEntry.java
@@ -1,0 +1,167 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** A keystore, provides its name, type, and the certificates. */
+public class KeyStoreEntry {
+
+    private static final Logger LOGGER = LogManager.getLogger(KeyStoreEntry.class);
+
+    /** The type of keystores supported. */
+    public enum Type {
+        PKCS11("PKCS#11"),
+        PKCS12("PKCS#12");
+
+        private final String name;
+
+        private Type(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    private static Boolean ibmPkcs11Provider;
+
+    private final String name;
+    private final Type type;
+    private final KeyStore keyStore;
+    private final List<CertificateEntry> certificates;
+
+    KeyStoreEntry(Type type, String name, KeyStore keyStore, String password)
+            throws KeyStoresException {
+        this.type = Objects.requireNonNull(type);
+        this.name = type + ": " + Objects.requireNonNull(name);
+        this.keyStore = Objects.requireNonNull(keyStore);
+
+        this.certificates = Collections.unmodifiableList(readCertificates(this, keyStore));
+        this.certificates.forEach(
+                e -> {
+                    if (!e.unlock(password)) {
+                        LOGGER.warn("Failed to unlock certificate: {}", e.getName());
+                    }
+                });
+    }
+
+    /**
+     * Gets the type of the keystore.
+     *
+     * @return the type, never {@code null}.
+     */
+    public Type getType() {
+        return type;
+    }
+
+    /**
+     * Gets the name of the keystore.
+     *
+     * @return the name, never {@code null}.
+     */
+    public String getName() {
+        return name;
+    }
+
+    KeyStore getKeyStore() {
+        return keyStore;
+    }
+
+    /**
+     * Gets the certificate at the given index of the keystore.
+     *
+     * @param index the index of the certificate.
+     * @return the certificate, might be {@code null}.
+     */
+    public CertificateEntry getCertificate(int index) {
+        if (index < 0 || index >= certificates.size()) {
+            return null;
+        }
+        return certificates.get(index);
+    }
+
+    /**
+     * Gets the certificates of the keystore.
+     *
+     * @return the certificates.
+     */
+    public List<CertificateEntry> getCertificates() {
+        return certificates;
+    }
+
+    private static List<CertificateEntry> readCertificates(KeyStoreEntry parent, KeyStore keyStore)
+            throws KeyStoresException {
+        List<CertificateEntry> certificates = new ArrayList<>();
+        try {
+            Enumeration<String> en = keyStore.aliases();
+
+            boolean ibmProvider = isIbmPKCS11Provider();
+            while (en.hasMoreElements()) {
+                String alias = en.nextElement();
+                // Sun's and IBM's KeyStore implementations behave differently...
+                // With IBM's KeyStore impl #getCertificate(String) returns null when
+                // #isKeyEntry(String) returns true.
+                // If IBM add all certificates and let the user choose the correct one.
+                if (keyStore.isKeyEntry(alias)
+                        || (ibmProvider && keyStore.isCertificateEntry(alias))) {
+                    Certificate certificate = keyStore.getCertificate(alias);
+                    // IBM: Maybe we should check the KeyUsage?
+                    // ((X509Certificate) cert).getKeyUsage()[0]
+                    certificates.add(
+                            new CertificateEntry(parent, certificate, alias, certificates.size()));
+                }
+            }
+        } catch (KeyStoreException e) {
+            throw new KeyStoresException(e);
+        }
+        return certificates;
+    }
+
+    private static boolean isIbmPKCS11Provider() {
+        if (ibmPkcs11Provider != null) {
+            return ibmPkcs11Provider;
+        }
+
+        ibmPkcs11Provider = false;
+        try {
+            Class.forName(KeyStores.IBM_PKCS11_CANONICAL_CLASS_NAME);
+            ibmPkcs11Provider = true;
+        } catch (Throwable ignore) {
+        }
+        return ibmPkcs11Provider;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/KeyStores.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/KeyStores.java
@@ -1,0 +1,339 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.Provider;
+import java.security.Security;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.EventListenerList;
+import org.apache.commons.io.FileUtils;
+
+/** A list of KeyStores. */
+public class KeyStores extends AbstractList<KeyStoreEntry> {
+
+    /** The canonical class name of Sun PKCS#11 Provider. */
+    public static final String SUN_PKCS11_CANONICAL_CLASS_NAME = "sun.security.pkcs11.SunPKCS11";
+
+    /** The canonical class name of IBMPKCS11Impl Provider. */
+    public static final String IBM_PKCS11_CANONICAL_CLASS_NAME =
+            "com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl";
+
+    /**
+     * The name for providers of type PKCS#11.
+     *
+     * @see #isProviderAvailable(String)
+     */
+    private static final String PKCS11_PROVIDER_TYPE = "PKCS11";
+
+    /** The name of Sun PKCS#11 Provider. */
+    private static final String SUN_PKCS11_PROVIDER_NAME = "SunPKCS11";
+
+    /**
+     * The name of the {@code KeyStore} type of Sun PKCS#11 Provider.
+     *
+     * @see KeyStore#getInstance(String, Provider)
+     */
+    private static final String SUN_PKCS11_KEYSTORE_TYPE = "PKCS11";
+
+    /**
+     * The name of the {@code KeyStore} type of IBMPKCS11Impl Provider.
+     *
+     * @see KeyStore#getInstance(String, Provider)
+     */
+    private static final String IBM_PKCS11_KEYSTORE_TYPE = "PKCS11IMPLKS";
+
+    /**
+     * Flag that indicates if the check for Java 9 and SunPKCS11 was already done.
+     *
+     * @see #isJava9SunPkcs11()
+     */
+    private static Boolean java9SunPkcs11;
+
+    private final EventListenerList eventListeners;
+    private ChangeEvent changeEvent;
+
+    private final List<KeyStoreEntry> entries;
+    private CertificateEntry activeCertificate;
+
+    public KeyStores() {
+        eventListeners = new EventListenerList();
+
+        entries = new ArrayList<>();
+    }
+
+    public KeyStoreEntry addPkcs12KeyStore(String path, String password) throws KeyStoresException {
+        Objects.requireNonNull(path);
+        Objects.requireNonNull(password);
+
+        Path file = Paths.get(path);
+        if (Files.notExists(file)) {
+            throw new KeyStoresException("The file does not exist: " + file);
+        }
+
+        try (InputStream is = Files.newInputStream(file)) {
+            KeyStore keyStore = KeyStore.getInstance("PKCS12");
+            keyStore.load(is, password.toCharArray());
+            KeyStoreEntry keyStoreEntry =
+                    new KeyStoreEntry(
+                            KeyStoreEntry.Type.PKCS12,
+                            file.getFileName().toString(),
+                            keyStore,
+                            password);
+            entries.add(keyStoreEntry);
+            fireStateChanged();
+            return keyStoreEntry;
+        } catch (Exception e) {
+            throw new KeyStoresException("An error occurred while adding the PKCS#12 keystore:", e);
+        }
+    }
+
+    public KeyStoreEntry addPkcs11KeyStore(String name, String configuration, String password)
+            throws KeyStoresException {
+        Objects.requireNonNull(configuration);
+
+        if (!isProviderAvailable(PKCS11_PROVIDER_TYPE)) {
+            return null;
+        }
+        try {
+            Provider pkcs11 = createPkcs11Provider(configuration);
+            Security.addProvider(pkcs11);
+
+            KeyStore keyStore = createPkcs11KeyStore(pkcs11.getName());
+            keyStore.load(null, password == null ? null : password.toCharArray());
+            KeyStoreEntry keyStoreEntry =
+                    new KeyStoreEntry(KeyStoreEntry.Type.PKCS11, name, keyStore, password);
+            entries.add(keyStoreEntry);
+            fireStateChanged();
+            return keyStoreEntry;
+        } catch (Exception e) {
+            throw new KeyStoresException("An error occurred while adding the PKCS#11 keystore:", e);
+        }
+    }
+
+    private static Provider createPkcs11Provider(String configuration) throws Exception {
+        if (isSunPkcs11Provider()) {
+            if (isJava9SunPkcs11()) {
+                Provider provider = Security.getProvider(SUN_PKCS11_PROVIDER_NAME);
+                Method configure = provider.getClass().getMethod("configure", String.class);
+                File configFile = File.createTempFile("pkcs11", ".cfg");
+                configFile.deleteOnExit();
+                FileUtils.write(configFile, configuration, StandardCharsets.UTF_8);
+                return (Provider) configure.invoke(provider, configFile.getAbsolutePath());
+            }
+
+            return createInstance(
+                    SUN_PKCS11_CANONICAL_CLASS_NAME,
+                    InputStream.class,
+                    toInputStream(configuration));
+        }
+        if (isIbmPkcs11Provider()) {
+            return createInstance(
+                    IBM_PKCS11_CANONICAL_CLASS_NAME,
+                    BufferedReader.class,
+                    new BufferedReader(new InputStreamReader(toInputStream(configuration))));
+        }
+        return null;
+    }
+
+    private static ByteArrayInputStream toInputStream(String data) {
+        return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Provider createInstance(String name, Class<?> paramClass, Object param)
+            throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
+                    IllegalAccessException, InvocationTargetException {
+        Class<?> instanceClass = Class.forName(name);
+        Constructor<?> c = instanceClass.getConstructor(new Class<?>[] {paramClass});
+        return (Provider) c.newInstance(new Object[] {param});
+    }
+
+    private static boolean isSunPkcs11Provider() {
+        try {
+            Class.forName(SUN_PKCS11_CANONICAL_CLASS_NAME);
+            return true;
+        } catch (Throwable ignore) {
+        }
+        return false;
+    }
+
+    private static boolean isJava9SunPkcs11() {
+        if (java9SunPkcs11 != null) {
+            return java9SunPkcs11;
+        }
+
+        java9SunPkcs11 = Boolean.FALSE;
+        try {
+            Provider provider = Security.getProvider(SUN_PKCS11_PROVIDER_NAME);
+            if (provider != null) {
+                provider.getClass().getMethod("configure", String.class);
+                java9SunPkcs11 = Boolean.TRUE;
+            }
+        } catch (NoSuchMethodException ignore) {
+            // The provider/method is available only in Java 9+.
+        }
+        return java9SunPkcs11;
+    }
+
+    private static boolean isIbmPkcs11Provider() {
+        try {
+            Class.forName(IBM_PKCS11_CANONICAL_CLASS_NAME);
+            return true;
+        } catch (Throwable ignore) {
+        }
+        return false;
+    }
+
+    private static KeyStore createPkcs11KeyStore(String providerName) throws KeyStoreException {
+        String keyStoreType = SUN_PKCS11_KEYSTORE_TYPE;
+        if (isIbmPkcs11Provider()) {
+            keyStoreType = IBM_PKCS11_KEYSTORE_TYPE;
+        }
+        return KeyStore.getInstance(keyStoreType, Security.getProvider(providerName));
+    }
+
+    private static boolean isProviderAvailable(String type) {
+        try {
+            if (type.equals(PKCS11_PROVIDER_TYPE)) {
+                try {
+                    Class.forName(SUN_PKCS11_CANONICAL_CLASS_NAME);
+                    return true;
+                } catch (Throwable ignore) {
+                    Class.forName(IBM_PKCS11_CANONICAL_CLASS_NAME);
+                    return true;
+                }
+            }
+
+            if (type.equals("msks")) {
+                Class.forName("se.assembla.jce.provider.ms.MSProvider");
+                return true;
+            }
+        } catch (Throwable ignore) {
+        }
+        return false;
+    }
+
+    /**
+     * Gets the active certificate.
+     *
+     * @return the active certificate, might be {@code null}.
+     */
+    public CertificateEntry getActiveCertificate() {
+        return activeCertificate;
+    }
+
+    /**
+     * Sets the active certificate.
+     *
+     * <p>Listeners are notified of the change.
+     *
+     * @param certificate the certificate, might be {@code null}.
+     */
+    public void setActiveCertificate(CertificateEntry certificate) {
+        if (activeCertificate == certificate) {
+            return;
+        }
+
+        if (activeCertificate != null) {
+            activeCertificate.invalidateSession();
+        }
+        activeCertificate = certificate;
+        fireStateChanged();
+    }
+
+    /**
+     * Adds the given listener to be notified when a KeyStore is added or removed, and when the
+     * active certificate changes.
+     *
+     * @param listener the listener to add.
+     */
+    public void addChangeListener(ChangeListener listener) {
+        eventListeners.add(ChangeListener.class, listener);
+    }
+
+    /**
+     * Removes the given listener.
+     *
+     * @param listener the listener to remove.
+     */
+    public void removeChangeListener(ChangeListener listener) {
+        eventListeners.remove(ChangeListener.class, listener);
+    }
+
+    private void fireStateChanged() {
+        Object[] listeners = eventListeners.getListenerList();
+        for (int i = listeners.length - 2; i >= 0; i -= 2) {
+            if (listeners[i] == ChangeListener.class) {
+                if (changeEvent == null) {
+                    changeEvent = new ChangeEvent(this);
+                }
+                ((ChangeListener) listeners[i + 1]).stateChanged(changeEvent);
+            }
+        }
+    }
+
+    @Override
+    public KeyStoreEntry get(int index) {
+        return entries.get(index);
+    }
+
+    @Override
+    public int size() {
+        return entries.size();
+    }
+
+    @Override
+    public KeyStoreEntry remove(int index) {
+        KeyStoreEntry keyStoreEntry = entries.remove(index);
+        if (activeCertificate != null && activeCertificate.getParent() == keyStoreEntry) {
+            activeCertificate = null;
+        }
+        fireStateChanged();
+        return keyStoreEntry;
+    }
+
+    @Override
+    public int hashCode() {
+        return entries.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return entries.equals(o);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/KeyStoresException.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/KeyStoresException.java
@@ -1,0 +1,54 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+/** An exception that indicates an error during the handling of {@link KeyStores}. */
+public class KeyStoresException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a {@code KeyStoresException} with the given message.
+     *
+     * @param message the detail message.
+     */
+    public KeyStoresException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a {@code KeyStoresException} with the given cause.
+     *
+     * @param cause the cause of the exception.
+     */
+    public KeyStoresException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructs a {@code KeyStoresException} with the given message and cause.
+     *
+     * @param message the detail message.
+     * @param cause the cause of the exception.
+     */
+    public KeyStoresException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/LaxTrustManager.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/LaxTrustManager.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.net.Socket;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+/** A {@link X509ExtendedTrustManager} that trusts all certificates. */
+public class LaxTrustManager extends X509ExtendedTrustManager {
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        return null;
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/Pkcs11Configuration.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/Pkcs11Configuration.java
@@ -1,0 +1,205 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2014 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * A representation of PKCS#11 provider configuration. Used to create configurations for instances
+ * of {@code sun.security.pkcs11.SunPKCS11} and {@code
+ * com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl}.
+ *
+ * <p>Example usage:
+ *
+ * <blockquote>
+ *
+ * <pre>
+ * Pkcs11Configuration configuration = Pkcs11Configuration.builder()
+ *         .setName(&quot;Provider X&quot;)
+ *         .setLibrary(&quot;/path/to/pkcs11library&quot;)
+ *         .setSlotId(1)
+ *         .build();
+ *
+ * java.security.Provider p = new sun.security.pkcs11.SunPKCS11(new ByteArrayInputStream(configuration.toString().getBytes()));
+ * java.security.Security.addProvider(p);
+ * </pre>
+ *
+ * </blockquote>
+ *
+ * <p><strong>Note:</strong> Only the mandatory attributes, <i>name</i> and <i>library</i>, and the
+ * optional attributes, <i>description</i>, <i>slot</i> and <i>slotListIndex</i> are implemented.
+ *
+ * @see <a
+ *     href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/p11guide.html#Config">Sun
+ *     PKCS#11 Configuration</a>
+ * @see <a
+ *     href="http://pic.dhe.ibm.com/infocenter/java7sdk/v7r0/index.jsp?topic=%2Fcom.ibm.java.security.component.71.doc%2Fsecurity-component%2Fpkcs11implDocs%2Fconfigfile.html">IBM
+ *     PKCS#11 Configuration</a>
+ */
+public class Pkcs11Configuration {
+
+    private final String name;
+
+    private final String library;
+
+    private final String description;
+
+    private final int slotId;
+
+    private final int slotListIndex;
+
+    private Pkcs11Configuration(
+            String name, String library, String description, int slotId, int slotListIndex) {
+        super();
+
+        this.name = name;
+        this.library = library;
+        this.description = description;
+        this.slotId = slotId;
+        this.slotListIndex = slotListIndex;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getLibrary() {
+        return library;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getSlotListIndex() {
+        return slotListIndex;
+    }
+
+    public int getSlotId() {
+        return slotId;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sbConfiguration = new StringBuilder(150);
+        sbConfiguration
+                .append("name = \"")
+                .append(escapeBackslashesAndQuotationMarks(name))
+                .append("\"\n");
+        sbConfiguration.append("library = ").append(library).append('\n');
+
+        if (description != null && !description.isEmpty()) {
+            sbConfiguration.append("description = ").append(description).append('\n');
+        }
+
+        if (slotListIndex != -1) {
+            sbConfiguration.append("slotListIndex = ").append(slotListIndex);
+        } else {
+            sbConfiguration.append("slot = ").append(slotId);
+        }
+        sbConfiguration.append('\n');
+
+        return sbConfiguration.toString();
+    }
+
+    private static String escapeBackslashesAndQuotationMarks(String value) {
+        String[] searchValues = new String[] {"\\", "\""};
+        String[] replacementValues = new String[] {"\\\\", "\\\""};
+
+        return StringUtils.replaceEach(value, searchValues, replacementValues);
+    }
+
+    public static Pkcs11ConfigurationBuilder builder() {
+        return new Pkcs11ConfigurationBuilder();
+    }
+
+    public static final class Pkcs11ConfigurationBuilder {
+
+        private String name;
+
+        private String library;
+
+        private String description;
+
+        private int slotId;
+
+        private int slotListIndex;
+
+        private Pkcs11ConfigurationBuilder() {
+            slotId = -1;
+            slotListIndex = 0;
+        }
+
+        public Pkcs11ConfigurationBuilder setName(String name) {
+            if (name == null || name.isEmpty()) {
+                throw new IllegalArgumentException("Parameter name must not be null or empty.");
+            }
+            this.name = name;
+            return this;
+        }
+
+        public Pkcs11ConfigurationBuilder setLibrary(String library) {
+            if (library == null || library.isEmpty()) {
+                throw new IllegalArgumentException("Parameter library must not be null or empty.");
+            }
+            this.library = library;
+            return this;
+        }
+
+        public Pkcs11ConfigurationBuilder setDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Pkcs11ConfigurationBuilder setSlotListIndex(int slotListIndex) {
+            if (slotListIndex < 0) {
+                throw new IllegalArgumentException(
+                        "Parameter slotListIndex must be greater or equal to zero.");
+            }
+            this.slotListIndex = slotListIndex;
+            this.slotId = -1;
+            return this;
+        }
+
+        public final Pkcs11ConfigurationBuilder setSlotId(int slotId) {
+            if (slotId < 0) {
+                throw new IllegalArgumentException(
+                        "Parameter slotId must be greater or equal to zero.");
+            }
+            this.slotId = slotId;
+            this.slotListIndex = -1;
+            return this;
+        }
+
+        public Pkcs11Configuration build() {
+            validateBuilderState();
+            return new Pkcs11Configuration(name, library, description, slotId, slotListIndex);
+        }
+
+        private void validateBuilderState() {
+            if (name == null) {
+                throw new IllegalStateException("A name must be set.");
+            }
+            if (library == null) {
+                throw new IllegalStateException("A library must be set.");
+            }
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/Pkcs11Driver.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/Pkcs11Driver.java
@@ -20,6 +20,7 @@
 package org.zaproxy.addon.network.internal.client;
 
 import java.util.Objects;
+import org.zaproxy.addon.network.internal.client.Pkcs11Configuration.Pkcs11ConfigurationBuilder;
 
 /**
  * A PKCS#11 driver.
@@ -92,6 +93,24 @@ public class Pkcs11Driver {
      */
     public int getSlotListIndex() {
         return slotListIndex;
+    }
+
+    /**
+     * Gets the configuration to use with a PKCS#11 provider.
+     *
+     * @param useSlotListIndex {@code true} to use the slot list index, {@code false} to use the
+     *     slot.
+     * @return the configuration.
+     */
+    public String getConfiguration(boolean useSlotListIndex) {
+        Pkcs11ConfigurationBuilder confBuilder =
+                Pkcs11Configuration.builder().setName(getName()).setLibrary(getLibrary());
+        if (useSlotListIndex) {
+            confBuilder.setSlotListIndex(getSlotListIndex());
+        } else {
+            confBuilder.setSlotId(getSlot());
+        }
+        return confBuilder.build().toString();
     }
 
     @Override

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/SingleAliasKeyManager.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/SingleAliasKeyManager.java
@@ -1,0 +1,96 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+import javax.net.ssl.X509KeyManager;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** A {@link X509KeyManager} for a single alias. */
+public class SingleAliasKeyManager implements X509KeyManager {
+
+    private static final Logger LOGGER = LogManager.getLogger(SingleAliasKeyManager.class);
+
+    private final KeyStore keyStore;
+    private final String[] alias;
+    private final char[] password;
+
+    public SingleAliasKeyManager(KeyStore keyStore, String alias, char[] password) {
+        this.keyStore = Objects.requireNonNull(keyStore);
+        Objects.requireNonNull(alias);
+        this.alias = new String[] {alias};
+        Objects.requireNonNull(password);
+        this.password = password;
+    }
+
+    @Override
+    public PrivateKey getPrivateKey(String alias) {
+        try {
+            return (PrivateKey) keyStore.getKey(alias, password);
+        } catch (Exception e) {
+            LOGGER.warn("Failed to get the private key:", e);
+        }
+        return null;
+    }
+
+    @Override
+    public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+        return alias[0];
+    }
+
+    @Override
+    public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+        return alias[0];
+    }
+
+    @Override
+    public String[] getClientAliases(String keyType, Principal[] issuers) {
+        return alias;
+    }
+
+    @Override
+    public String[] getServerAliases(String keyType, Principal[] issuers) {
+        return alias;
+    }
+
+    @Override
+    public X509Certificate[] getCertificateChain(String alias) {
+        try {
+            Certificate[] certificateChain = keyStore.getCertificateChain(alias);
+            if (certificateChain == null) {
+                return null;
+            }
+            X509Certificate[] x509CertificateChain = new X509Certificate[certificateChain.length];
+            System.arraycopy(certificateChain, 0, x509CertificateChain, 0, certificateChain.length);
+            return x509CertificateChain;
+        } catch (KeyStoreException e) {
+            LOGGER.warn("Failed to get the certificate chain:", e);
+        }
+        return null;
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/CertificateEntryUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/CertificateEntryUnitTest.java
@@ -1,0 +1,177 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link CertificateEntry}. */
+class CertificateEntryUnitTest {
+
+    private String alias;
+    private int index;
+    private String password;
+    private PrivateKey privateKey;
+    private KeyStore keyStore;
+    private KeyStoreEntry parent;
+    private Certificate certificate;
+
+    private CertificateEntry certificateEntry;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        alias = "Alias";
+        index = 1234;
+        password = "password";
+        privateKey = mock(PrivateKey.class);
+        keyStore = mock(KeyStore.class);
+        given(keyStore.getKey(alias, password.toCharArray())).willReturn(privateKey);
+        parent = mock(KeyStoreEntry.class);
+        given(parent.getKeyStore()).willReturn(keyStore);
+        certificate = mock(Certificate.class);
+        certificateEntry = new CertificateEntry(parent, certificate, alias, index);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingCertificateEntryWithNullParent() {
+        // Given
+        parent = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new CertificateEntry(parent, certificate, alias, index));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingCertificateEntryWithNullCertificate() {
+        // Given
+        certificate = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new CertificateEntry(parent, certificate, alias, index));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingCertificateEntryWithNullAlias() {
+        // Given
+        alias = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new CertificateEntry(parent, certificate, alias, index));
+    }
+
+    @Test
+    void shouldGetParent() {
+        assertThat(certificateEntry.getParent(), is(equalTo(parent)));
+    }
+
+    @Test
+    void shouldGetCertificate() {
+        assertThat(certificateEntry.getCertificate(), is(equalTo(certificate)));
+    }
+
+    @Test
+    void shouldGetIndex() {
+        assertThat(certificateEntry.getIndex(), is(equalTo(index)));
+    }
+
+    @Test
+    void shouldExtractNameFromCertificate() {
+        // Given
+        given(certificate.toString())
+                .willReturn(
+                        "C=EX, ST=Example, O=Example, CN=Abc 123\n  Signature Algorithm: SHA256withRSA");
+        // When
+        certificateEntry = new CertificateEntry(parent, certificate, alias, index);
+        // Then
+        assertThat(
+                certificateEntry.getName(),
+                is(equalTo("Abc 123\n  Signature Algorithm: SHA256withRSA [Alias]")));
+    }
+
+    @Test
+    void shouldUseOnlyAliasIfUnableToExtractNameExtractNameFromCertificate() {
+        // Given
+        given(certificate.toString()).willReturn("No CN");
+        // When
+        certificateEntry = new CertificateEntry(parent, certificate, alias, index);
+        // Then
+        assertThat(certificateEntry.getName(), is(equalTo("Alias")));
+    }
+
+    @Test
+    void shouldUnlockCertificate() {
+        // Given / When
+        boolean unlocked = certificateEntry.unlock(password);
+        // Then
+        assertThat(unlocked, is(equalTo(true)));
+        assertThat(certificateEntry.isUnlocked(), is(equalTo(true)));
+        assertThat(certificateEntry.getSocketFactory(), is(notNullValue()));
+    }
+
+    @Test
+    void shouldNotUnlockCertificateIfNoPrivateKey() throws Exception {
+        // Given
+        given(keyStore.getKey(alias, password.toCharArray())).willReturn(null);
+        // When
+        boolean unlocked = certificateEntry.unlock(password);
+        // Then
+        assertThat(unlocked, is(equalTo(false)));
+        assertThat(certificateEntry.isUnlocked(), is(equalTo(false)));
+        assertThat(certificateEntry.getSocketFactory(), is(nullValue()));
+    }
+
+    @Test
+    void shouldInvalidateSessions() throws Exception {
+        // Given
+        boolean unlocked = certificateEntry.unlock(password);
+        // When / Then
+        assertDoesNotThrow(() -> certificateEntry.invalidateSession());
+        assertThat(unlocked, is(equalTo(true)));
+    }
+
+    @Test
+    void shouldDoNothingIfNotUnlockedOnInvalidateSessions() throws Exception {
+        assertDoesNotThrow(() -> certificateEntry.invalidateSession());
+    }
+
+    @Test
+    void shouldReturnNameForStringRepresentation() throws Exception {
+        // Given
+        String name = certificateEntry.getName();
+        // When / Then
+        assertThat(certificateEntry.toString(), is(equalTo(name)));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/KeyStoreEntryUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/KeyStoreEntryUnitTest.java
@@ -1,0 +1,217 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.addon.network.internal.client.KeyStoreEntry.Type;
+
+/** Unit test for {@link KeyStoreEntry}. */
+class KeyStoreEntryUnitTest {
+
+    private Type type;
+    private String name;
+    private KeyStore keyStore;
+    private String password;
+
+    private String alias1;
+    private Certificate certificate1;
+    private String alias3;
+    private Certificate certificate3;
+    private KeyStoreEntry keyStoreEntry;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        type = Type.PKCS11;
+        name = "Name";
+        password = "password";
+        keyStore = mock(KeyStore.class);
+        alias1 = "Alias 1";
+        alias3 = "Alias 3";
+        given(keyStore.aliases())
+                .willReturn(Collections.enumeration(Arrays.asList(alias1, "Alias 2", alias3)));
+        certificate1 = mock(Certificate.class);
+        given(keyStore.isKeyEntry(alias1)).willReturn(true);
+        given(keyStore.getCertificate(alias1)).willReturn(certificate1);
+        certificate3 = mock(Certificate.class);
+        given(keyStore.isKeyEntry(alias3)).willReturn(true);
+        given(keyStore.getCertificate(alias3)).willReturn(certificate3);
+        keyStoreEntry = new KeyStoreEntry(type, name, keyStore, password);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingKeyStoreEntryWithNullType() {
+        // Given
+        type = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new KeyStoreEntry(type, name, keyStore, password));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingKeyStoreEntryWithNullName() {
+        // Given
+        name = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new KeyStoreEntry(type, name, keyStore, password));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingKeyStoreEntryWithNullKeyStore() {
+        // Given
+        keyStore = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new KeyStoreEntry(type, name, keyStore, password));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"PKCS11,PKCS#11: Name", "PKCS12,PKCS#12: Name"})
+    void shouldGetNameWithKeyStoreType(Type type, String expectedName) throws Exception {
+        // Given / When
+        keyStoreEntry = new KeyStoreEntry(type, name, keyStore, password);
+        // Then
+        assertThat(keyStoreEntry.getName(), is(equalTo(expectedName)));
+    }
+
+    @Test
+    void shouldGetKeyStore() {
+        assertThat(keyStoreEntry.getKeyStore(), is(sameInstance(keyStore)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(Type.class)
+    void shouldGetType(Type type) throws Exception {
+        // Given / When
+        keyStoreEntry = new KeyStoreEntry(type, name, keyStore, password);
+        // Then
+        assertThat(keyStoreEntry.getType(), is(equalTo(type)));
+    }
+
+    @Test
+    void shouldThrowExceptionOccurredWhileReadingCertificates() throws Exception {
+        // Given
+        given(keyStore.aliases()).willThrow(KeyStoreException.class);
+        // When / Then
+        assertThrows(
+                KeyStoresException.class, () -> new KeyStoreEntry(type, name, keyStore, password));
+    }
+
+    @Test
+    void shouldHaveNoCertificatesIfNoneInKeyStore() throws Exception {
+        // Given
+        given(keyStore.aliases()).willReturn(Collections.emptyEnumeration());
+        keyStoreEntry = new KeyStoreEntry(type, name, keyStore, password);
+        // When
+        List<CertificateEntry> certificateEntries = keyStoreEntry.getCertificates();
+        // Then
+        assertThat(certificateEntries, is(notNullValue()));
+        assertThat(certificateEntries, is(empty()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void shouldGetCertificateEntry(int index) {
+        // Given / When
+        CertificateEntry certificateEntry = keyStoreEntry.getCertificate(index);
+        // Then
+        assertThat(certificateEntry, is(notNullValue()));
+    }
+
+    @Test
+    void shouldHaveSelfAsCertificateEntryParent() {
+        // Given / When
+        CertificateEntry certificateEntry = keyStoreEntry.getCertificate(0);
+        // Then
+        assertThat(certificateEntry, is(notNullValue()));
+        assertThat(certificateEntry.getParent(), is(sameInstance(keyStoreEntry)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    void shouldHaveCorrectIndexInCertificateEntry(int index) {
+        // Given / When
+        CertificateEntry certificateEntry = keyStoreEntry.getCertificate(index);
+        // Then
+        assertThat(certificateEntry, is(notNullValue()));
+        assertThat(certificateEntry.getIndex(), is(equalTo(index)));
+    }
+
+    @Test
+    void shouldHaveCorrectCertificateInCertificateEntry() {
+        // Given / When
+        CertificateEntry certificateEntry = keyStoreEntry.getCertificate(1);
+        // Then
+        assertThat(certificateEntry, is(notNullValue()));
+        assertThat(certificateEntry.getCertificate(), is(sameInstance(certificate3)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 2})
+    void shouldGetNullCertificateForInvalidIndex(int index) {
+        // Given / When
+        CertificateEntry certificateEntry = keyStoreEntry.getCertificate(index);
+        // Then
+        assertThat(certificateEntry, is(nullValue()));
+    }
+
+    @Test
+    void shouldGetCertificates() {
+        // Given / When
+        List<CertificateEntry> certificateEntries = keyStoreEntry.getCertificates();
+        // Then
+        assertThat(certificateEntries, is(notNullValue()));
+        assertThat(certificateEntries, hasSize(2));
+    }
+
+    @Test
+    void shouldReturnNameForStringRepresentation() {
+        // Given
+        String name = keyStoreEntry.getName();
+        // When / Then
+        assertThat(keyStoreEntry.toString(), is(equalTo(name)));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/KeyStoresUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/KeyStoresUnitTest.java
@@ -1,0 +1,165 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link KeyStores}. */
+class KeyStoresUnitTest {
+
+    private KeyStores keyStores;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        keyStores = new KeyStores();
+    }
+
+    @Test
+    void shouldNotHaveActiveCertificateByDefault() {
+        assertThat(keyStores.getActiveCertificate(), is(nullValue()));
+    }
+
+    @Test
+    void shouldSetActiveCertificate() {
+        // Given
+        CertificateEntry certificate = mock(CertificateEntry.class);
+        // When
+        keyStores.setActiveCertificate(certificate);
+        // Then
+        assertThat(keyStores.getActiveCertificate(), is(sameInstance(certificate)));
+    }
+
+    @Test
+    void shouldResetActiveCertificate() {
+
+        // Given
+        CertificateEntry certificate = mock(CertificateEntry.class);
+        // When
+        keyStores.setActiveCertificate(certificate);
+        keyStores.setActiveCertificate(null);
+        // Then
+        assertThat(keyStores.getActiveCertificate(), is(nullValue()));
+    }
+
+    @Test
+    void shouldInvalidateSessionCertificateOnReset() {
+
+        // Given
+        CertificateEntry certificate = mock(CertificateEntry.class);
+        // When
+        keyStores.setActiveCertificate(certificate);
+        keyStores.setActiveCertificate(null);
+        // Then
+        verify(certificate).invalidateSession();
+    }
+
+    @Test
+    void shouldNotifyChangeListenersOnActiveCertificateSet() {
+        // Given
+        CertificateEntry certificate = mock(CertificateEntry.class);
+        ChangeListener listener1 = mock(ChangeListener.class);
+        ChangeListener listener2 = mock(ChangeListener.class);
+        keyStores.addChangeListener(listener1);
+        keyStores.addChangeListener(listener2);
+        // When
+        keyStores.setActiveCertificate(certificate);
+        // Then
+        verify(listener1).stateChanged(any(ChangeEvent.class));
+        verify(listener2).stateChanged(any(ChangeEvent.class));
+    }
+
+    @Test
+    void shouldNotNotifyChangeListenersOnSameActiveCertificateSet() {
+        // Given
+        CertificateEntry certificate = mock(CertificateEntry.class);
+        ChangeListener listener1 = mock(ChangeListener.class);
+        ChangeListener listener2 = mock(ChangeListener.class);
+        keyStores.addChangeListener(listener1);
+        keyStores.addChangeListener(listener2);
+        // When
+        keyStores.setActiveCertificate(certificate);
+        keyStores.setActiveCertificate(certificate);
+        // Then
+        verify(listener1, times(1)).stateChanged(any(ChangeEvent.class));
+        verify(listener2, times(1)).stateChanged(any(ChangeEvent.class));
+    }
+
+    @Test
+    void shouldNotifyChangeListenersOnDifferentActiveCertificateSet() {
+        // Given
+        CertificateEntry certificate1 = mock(CertificateEntry.class);
+        CertificateEntry certificate2 = mock(CertificateEntry.class);
+        ChangeListener listener1 = mock(ChangeListener.class);
+        ChangeListener listener2 = mock(ChangeListener.class);
+        keyStores.addChangeListener(listener1);
+        keyStores.addChangeListener(listener2);
+        // When
+        keyStores.setActiveCertificate(certificate1);
+        keyStores.setActiveCertificate(certificate2);
+        // Then
+        verify(listener1, times(2)).stateChanged(any(ChangeEvent.class));
+        verify(listener2, times(2)).stateChanged(any(ChangeEvent.class));
+    }
+
+    @Test
+    void shouldNotifyChangeListenersOnActiveCertificateReset() {
+        // Given
+        CertificateEntry certificate = mock(CertificateEntry.class);
+        ChangeListener listener1 = mock(ChangeListener.class);
+        ChangeListener listener2 = mock(ChangeListener.class);
+        keyStores.addChangeListener(listener1);
+        keyStores.addChangeListener(listener2);
+        // When
+        keyStores.setActiveCertificate(certificate);
+        keyStores.setActiveCertificate(null);
+        // Then
+        verify(listener1, times(2)).stateChanged(any(ChangeEvent.class));
+        verify(listener2, times(2)).stateChanged(any(ChangeEvent.class));
+    }
+
+    @Test
+    void shouldRemoveChangeListener() {
+        // Given
+        CertificateEntry certificate = mock(CertificateEntry.class);
+        ChangeListener listener1 = mock(ChangeListener.class);
+        ChangeListener listener2 = mock(ChangeListener.class);
+        keyStores.addChangeListener(listener1);
+        keyStores.addChangeListener(listener2);
+        // When
+        keyStores.removeChangeListener(listener2);
+        keyStores.setActiveCertificate(certificate);
+        // Then
+        verify(listener1).stateChanged(any(ChangeEvent.class));
+        verifyNoInteractions(listener2);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/LaxTrustManagerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/LaxTrustManagerUnitTest.java
@@ -1,0 +1,80 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.net.Socket;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLEngine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link LaxTrustManager}. */
+class LaxTrustManagerUnitTest {
+
+    private LaxTrustManager laxTrustManager;
+
+    @BeforeEach
+    void setUp() {
+        laxTrustManager = new LaxTrustManager();
+    }
+
+    @Test
+    void shouldGetNullAcceptedIssuers() {
+        // Given / When
+        X509Certificate[] issuers = laxTrustManager.getAcceptedIssuers();
+        // Then
+        assertThat(issuers, is(nullValue()));
+    }
+
+    @Test
+    void shouldTrustClient() {
+        assertDoesNotThrow(() -> laxTrustManager.checkClientTrusted(null, null));
+    }
+
+    @Test
+    void shouldTrustServer() {
+        assertDoesNotThrow(() -> laxTrustManager.checkServerTrusted(null, null));
+    }
+
+    @Test
+    void shouldTrustClientWithSocket() {
+        assertDoesNotThrow(() -> laxTrustManager.checkClientTrusted(null, null, (Socket) null));
+    }
+
+    @Test
+    void shouldTrustServerWithSocket() {
+        assertDoesNotThrow(() -> laxTrustManager.checkServerTrusted(null, null, (Socket) null));
+    }
+
+    @Test
+    void shouldTrustClientWithSslEngine() {
+        assertDoesNotThrow(() -> laxTrustManager.checkClientTrusted(null, null, (SSLEngine) null));
+    }
+
+    @Test
+    void shouldTrustServerWithSslEngine() {
+        assertDoesNotThrow(() -> laxTrustManager.checkServerTrusted(null, null, (SSLEngine) null));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/Pkcs11ConfigurationUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/Pkcs11ConfigurationUnitTest.java
@@ -1,0 +1,371 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.network.internal.client.Pkcs11Configuration.Pkcs11ConfigurationBuilder;
+
+/** Unit test for {@link Pkcs11Configuration} */
+class Pkcs11ConfigurationUnitTest {
+
+    private static final String NAME = "Provider Name";
+    private static final String LIBRARY = "path/to/library";
+
+    private Pkcs11Configuration configuration;
+
+    private static Pkcs11ConfigurationBuilder getConfigurationBuilderWithNameAndLibrarySet() {
+        return Pkcs11Configuration.builder().setName(NAME).setLibrary(LIBRARY);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenBuildingAConfigurationWithoutNameAndLibrary() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder();
+        // When
+        IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenBuildingAConfigurationWithoutName() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder().setLibrary(LIBRARY);
+        // When
+        IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingAConfigurationWithoutLibrary() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder().setName(NAME);
+        // When
+        IllegalStateException e = assertThrows(IllegalStateException.class, builder::build);
+        // Then
+        assertThat(e.getMessage(), containsString("library"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSettingAnEmptyName() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder();
+        String name = "";
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setName(name));
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSettingANullName() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder();
+        String name = null;
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setName(name));
+        // Then
+        assertThat(e.getMessage(), containsString("name"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSettingAnEmptyLibrary() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder();
+        String library = "";
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setLibrary(library));
+        // Then
+        assertThat(e.getMessage(), containsString("library"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSettingANullLibrary() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder();
+        String library = null;
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setLibrary(library));
+        // Then
+        assertThat(e.getMessage(), containsString("library"));
+    }
+
+    @Test
+    void shouldCreateConfigurationWithNonEmptyNameAndNonEmptyLibrary() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = Pkcs11Configuration.builder();
+        String nonEmptyName = "ProviderName";
+        String nonEmptyLibrary = "Library";
+        // When / Then
+        assertDoesNotThrow(() -> builder.setName(nonEmptyName).setLibrary(nonEmptyLibrary).build());
+    }
+
+    @Test
+    void shouldRetrieveNameSet() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().build();
+        // When
+        String retrievedName = configuration.getName();
+        // Then
+        assertThat(retrievedName, is(equalTo(NAME)));
+    }
+
+    @Test
+    void shouldRetrieveLibrarySet() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().build();
+        // When
+        String retrievedLibrary = configuration.getLibrary();
+        // Then
+        assertThat(retrievedLibrary, is(equalTo(LIBRARY)));
+    }
+
+    @Test
+    void shouldRetrieveDefaultSlotListIndexFromNewlyCreatedConfiguration() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().build();
+        // When
+        int retrievedSlotListIndex = configuration.getSlotListIndex();
+        // Then
+        assertThat(retrievedSlotListIndex, is(equalTo(0)));
+    }
+
+    @Test
+    void shouldRetrieveUndefinedSlotIdFromNewlyCreatedConfiguration() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().build();
+        // When
+        int retrievedSlotId = configuration.getSlotId();
+        // Then
+        assertThat(retrievedSlotId, is(equalTo(-1)));
+    }
+
+    @Test
+    void shouldRetrieveStringRepresentationFromNewlyCreatedConfiguration() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().build();
+        // When
+        String retrievedStringRepresentation = configuration.toString();
+        // Then
+        assertThat(retrievedStringRepresentation, containsString("name = \"" + NAME + "\""));
+        assertThat(retrievedStringRepresentation, containsString("library = " + LIBRARY));
+        assertThat(retrievedStringRepresentation, containsString("slotListIndex = 0"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSettingNegativeSlotListIndex() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = getConfigurationBuilderWithNameAndLibrarySet();
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setSlotListIndex(-1));
+        // Then
+        assertThat(e.getMessage(), containsString("slotListIndex"));
+    }
+
+    @Test
+    void shouldRetrieveDescriptionSet() {
+        // Given
+        String description = "Description of Provider X";
+        configuration =
+                getConfigurationBuilderWithNameAndLibrarySet().setDescription(description).build();
+        // When
+        String retrievedDescription = configuration.getDescription();
+        // Then
+        assertThat(retrievedDescription, is(equalTo(description)));
+    }
+
+    @Test
+    void shouldRetrieveNullDescriptionSet() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().setDescription(null).build();
+        // When
+        String retrievedDescription = configuration.getDescription();
+        // Then
+        assertThat(retrievedDescription, is(nullValue()));
+    }
+
+    @Test
+    void shouldRetrieveEmptyDescriptionSet() {
+        // Given
+        String description = "";
+        configuration =
+                getConfigurationBuilderWithNameAndLibrarySet().setDescription(description).build();
+        // When
+        String retrievedDescription = configuration.getDescription();
+        // Then
+        assertThat(retrievedDescription, is(equalTo(description)));
+    }
+
+    @Test
+    void shouldRetrieveUndefinedDescriptionFromNewlyCreatedConfiguration() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().build();
+        // When
+        String retrievedDescription = configuration.getDescription();
+        // Then
+        assertThat(retrievedDescription, is(nullValue()));
+    }
+
+    @Test
+    void shouldRetrieveStringRepresentationWithDescriptionSet() {
+        // Given
+        String description = "Description of Provider X";
+        configuration =
+                getConfigurationBuilderWithNameAndLibrarySet().setDescription(description).build();
+        // When
+        String retrievedStringRepresentation = configuration.toString();
+        // Then
+        assertThat(retrievedStringRepresentation, containsString("description = " + description));
+    }
+
+    @Test
+    void shouldRetrieveStringRepresentationWithOutDescriptionWhenEmptyDescriptionSet() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().setDescription("").build();
+        // When
+        String retrievedStringRepresentation = configuration.toString();
+        // Then
+        assertThat(retrievedStringRepresentation, not(containsString("description = ")));
+    }
+
+    @Test
+    void shouldRetrieveStringRepresentationWithOutDescriptionWhenNullDescriptionSet() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().setDescription(null).build();
+        // When
+        String retrievedStringRepresentation = configuration.toString();
+        // Then
+        assertThat(retrievedStringRepresentation, not(containsString("description = ")));
+    }
+
+    @Test
+    void shouldRetrieveSlotListIndexSet() {
+        // Given
+        int slotListIndexSet = 1;
+        configuration =
+                getConfigurationBuilderWithNameAndLibrarySet()
+                        .setSlotListIndex(slotListIndexSet)
+                        .build();
+        // When
+        int retrievedSlotListIndexSet = configuration.getSlotListIndex();
+        // Then
+        assertThat(retrievedSlotListIndexSet, is(equalTo(slotListIndexSet)));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSettingNegativeSlotId() {
+        // Given
+        Pkcs11ConfigurationBuilder builder = getConfigurationBuilderWithNameAndLibrarySet();
+        // When
+        IllegalArgumentException e =
+                assertThrows(IllegalArgumentException.class, () -> builder.setSlotId(-1));
+        // Then
+        assertThat(e.getMessage(), containsString("slotId"));
+    }
+
+    @Test
+    void shouldRetrieveSlotIdSet() {
+        // Given
+        int slotIdSet = 1;
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().setSlotId(slotIdSet).build();
+        // When
+        int retrievedSlotId = configuration.getSlotId();
+        // Then
+        assertThat(retrievedSlotId, is(equalTo(slotIdSet)));
+    }
+
+    @Test
+    void shouldRetrieveSlotIdAsUndefinedGivenASlotListIndexSet() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().setSlotListIndex(1).build();
+        // When
+        int retrievedSlotId = configuration.getSlotId();
+        // Then
+        assertThat(retrievedSlotId, is(equalTo(-1)));
+    }
+
+    @Test
+    void shouldRetrieveSlotListIndexAsUndefinedGivenASlotIdSet() {
+        // Given
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().setSlotId(1).build();
+        // When
+        int retrievedSlotListIndex = configuration.getSlotListIndex();
+        // Then
+        assertThat(retrievedSlotListIndex, is(equalTo(-1)));
+    }
+
+    @Test
+    void
+            shouldRetrieveStringRepresentationWithAttributeSlotInsteadOfAttributeSlotListIndexGivenASlotIdSet() {
+        // Given
+        int slotId = 1;
+        configuration = getConfigurationBuilderWithNameAndLibrarySet().setSlotId(slotId).build();
+        // When
+        String retrievedStringRepresentation = configuration.toString();
+        // Then
+        assertThat(retrievedStringRepresentation, containsString("slot = " + slotId));
+        assertThat(retrievedStringRepresentation, not(containsString("slotListIndex")));
+    }
+
+    @Test
+    void shouldRetrieveStringRepresentationWithBackslashesPresentInNameEscapedWithBackslashes() {
+        // Given
+        String nameWithBackslash = "\\";
+        configuration =
+                Pkcs11Configuration.builder()
+                        .setName(nameWithBackslash)
+                        .setLibrary(LIBRARY)
+                        .build();
+        // When
+        String retrievedStringRepresentation = configuration.toString();
+        // Then
+        assertThat(retrievedStringRepresentation, containsString("\\\\"));
+    }
+
+    @Test
+    void shouldRetrieveStringRepresentationWithQuotationMarksPresentInNameEscapedWithBackslashes() {
+        // Given
+        String nameWithQuotationMark = "\"";
+        configuration =
+                Pkcs11Configuration.builder()
+                        .setName(nameWithQuotationMark)
+                        .setLibrary(LIBRARY)
+                        .build();
+        // When
+        String retrievedStringRepresentation = configuration.toString();
+        // Then
+        assertThat(retrievedStringRepresentation, containsString("\\\""));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/Pkcs11DriverUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/Pkcs11DriverUnitTest.java
@@ -20,8 +20,10 @@
 package org.zaproxy.addon.network.internal.client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -34,7 +36,7 @@ class Pkcs11DriverUnitTest {
     private static final String NAME = "Card 1";
     private static final String LIBRARY = "/path/to/library";
     private static final int SLOT = 0;
-    private static final int SLOT_LIST_INDEX = 0;
+    private static final int SLOT_LIST_INDEX = 1;
 
     @Test
     void shouldNotCreatePkcs11DriverWithNullName() {
@@ -209,5 +211,49 @@ class Pkcs11DriverUnitTest {
         String representation = pkcs11Driver.toString();
         // Then
         assertThat(representation, is(equalTo(name)));
+    }
+
+    @Test
+    void shouldGetConfigurationWithSlotListIndex() {
+        // Given
+        boolean useSlotListIndex = true;
+        Pkcs11Driver pkcs11Driver = new Pkcs11Driver(NAME, LIBRARY, SLOT, SLOT_LIST_INDEX);
+        // When
+        String configuration = pkcs11Driver.getConfiguration(useSlotListIndex);
+        // Then
+        assertThat(configuration, containsString("slotListIndex = " + SLOT_LIST_INDEX));
+        assertThat(configuration, not(containsString("slot = ")));
+    }
+
+    @Test
+    void shouldGetConfigurationWithSlot() {
+        // Given
+        boolean useSlotListIndex = false;
+        Pkcs11Driver pkcs11Driver = new Pkcs11Driver(NAME, LIBRARY, SLOT, SLOT_LIST_INDEX);
+        // When
+        String configuration = pkcs11Driver.getConfiguration(useSlotListIndex);
+        // Then
+        assertThat(configuration, containsString("slot = " + SLOT));
+        assertThat(configuration, not(containsString("slotListIndex = ")));
+    }
+
+    @Test
+    void shouldGetConfigurationWithNameQuoted() {
+        // Given
+        Pkcs11Driver pkcs11Driver = new Pkcs11Driver(NAME, LIBRARY, SLOT, SLOT_LIST_INDEX);
+        // When
+        String configuration = pkcs11Driver.getConfiguration(false);
+        // Then
+        assertThat(configuration, containsString("name = \"" + NAME + "\""));
+    }
+
+    @Test
+    void shouldGetConfigurationWithLibrary() {
+        // Given
+        Pkcs11Driver pkcs11Driver = new Pkcs11Driver(NAME, LIBRARY, SLOT, SLOT_LIST_INDEX);
+        // When
+        String configuration = pkcs11Driver.getConfiguration(false);
+        // Then
+        assertThat(configuration, containsString("library = " + LIBRARY));
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/SingleAliasKeyManagerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/SingleAliasKeyManagerUnitTest.java
@@ -1,0 +1,186 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.Mockito.mock;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link SingleAliasKeyManager}. */
+class SingleAliasKeyManagerUnitTest {
+
+    private KeyStore keyStore;
+    private String alias;
+    private char[] password;
+    private SingleAliasKeyManager singleAliasKeyManager;
+
+    @BeforeEach
+    void setUp() {
+        keyStore = mock(KeyStore.class);
+        alias = "Alias";
+        password = new char[] {'a', 'b', 'c'};
+        singleAliasKeyManager = new SingleAliasKeyManager(keyStore, alias, password);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingSingleAliasKeyManagerWithNullKeyStore() {
+        // Given
+        keyStore = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new SingleAliasKeyManager(keyStore, alias, password));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingSingleAliasKeyManagerWithNullAlias() {
+        // Given
+        alias = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new SingleAliasKeyManager(keyStore, alias, password));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreatingSingleAliasKeyManagerWithNullPassword() {
+        // Given
+        password = null;
+        // When / Then
+        assertThrows(
+                NullPointerException.class,
+                () -> new SingleAliasKeyManager(keyStore, alias, password));
+    }
+
+    @Test
+    void shouldGetPrivateKey() throws Exception {
+        // Given
+        PrivateKey privateKey = mock(PrivateKey.class);
+        given(keyStore.getKey(alias, password)).willReturn(privateKey);
+        // When
+        PrivateKey obtainedPrivatekey = singleAliasKeyManager.getPrivateKey(alias);
+        // Then
+        assertThat(obtainedPrivatekey, is(sameInstance(privateKey)));
+        verify(keyStore).getKey(alias, password);
+    }
+
+    @Test
+    void shouldReturnNullWhenFailedToGetPrivateKey() throws Exception {
+        // Given
+        given(keyStore.getKey(alias, password)).willThrow(KeyStoreException.class);
+        // When
+        PrivateKey obtainedPrivatekey = singleAliasKeyManager.getPrivateKey(alias);
+        // Then
+        assertThat(obtainedPrivatekey, is(nullValue()));
+    }
+
+    @Test
+    void shouldNotGetPrivateKeyIfNotSameAlias() throws Exception {
+        // Given
+        given(keyStore.getKey(alias, password)).willReturn(null);
+        // When
+        PrivateKey obtainedPrivatekey = singleAliasKeyManager.getPrivateKey(alias);
+        // Then
+        assertThat(obtainedPrivatekey, is(nullValue()));
+    }
+
+    @Test
+    void shouldChooseClientAlias() {
+        // Given / When
+        String chosenAlias = singleAliasKeyManager.chooseClientAlias(null, null, null);
+        // Then
+        assertThat(chosenAlias, is(equalTo(alias)));
+    }
+
+    @Test
+    void shouldChooseServerAlias() {
+        // Given / When
+        String chosenAlias = singleAliasKeyManager.chooseServerAlias(null, null, null);
+        // Then
+        assertThat(chosenAlias, is(equalTo(alias)));
+    }
+
+    @Test
+    void shouldGetClientAliases() {
+        // Given / When
+        String[] clientAliases = singleAliasKeyManager.getClientAliases(null, null);
+        // Then
+        assertThat(clientAliases, is(arrayContaining(alias)));
+    }
+
+    @Test
+    void shouldGetServerAliases() {
+        // Given / When
+        String[] serverAliases = singleAliasKeyManager.getServerAliases(null, null);
+        // Then
+        assertThat(serverAliases, is(arrayContaining(alias)));
+    }
+
+    @Test
+    void shoudGetCertificateChain() throws Exception {
+        // Given
+        X509Certificate cert1 = mock(X509Certificate.class);
+        X509Certificate cert2 = mock(X509Certificate.class);
+        given(keyStore.getCertificateChain(alias)).willReturn(new X509Certificate[] {cert1, cert2});
+        // When
+        X509Certificate[] obtainedCertificateChain =
+                singleAliasKeyManager.getCertificateChain(alias);
+        // Then
+        assertThat(obtainedCertificateChain, is(arrayContaining(cert1, cert2)));
+    }
+
+    @Test
+    void shouldReturnNullWhenFailedToGetCertificateChain() throws Exception {
+        // Given
+        given(keyStore.getCertificateChain(alias)).willThrow(KeyStoreException.class);
+        // When
+        X509Certificate[] obtainedCertificateChain =
+                singleAliasKeyManager.getCertificateChain(alias);
+        // Then
+        assertThat(obtainedCertificateChain, is(nullValue()));
+    }
+
+    @Test
+    void shoudNotGetCertificateChainIfNotSameAlias() throws Exception {
+        // Given
+        X509Certificate cert1 = mock(X509Certificate.class);
+        X509Certificate cert2 = mock(X509Certificate.class);
+        given(keyStore.getCertificateChain(alias)).willReturn(new X509Certificate[] {cert1, cert2});
+        // When
+        X509Certificate[] obtainedCertificateChain =
+                singleAliasKeyManager.getCertificateChain("Other Alias");
+        // Then
+        assertThat(obtainedCertificateChain, is(nullValue()));
+    }
+}


### PR DESCRIPTION
Add classes to support the management of client certificates, to stop
relying on core classes which are now deprecated.