### PR TITLE
ascanrulesAlpha: correct path in web cache rule

### DIFF
--- a/addOns/ascanrulesAlpha/CHANGELOG.md
+++ b/addOns/ascanrulesAlpha/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix an exception in Spring Actuator Information Leak scan rule when scanning responses without Content-Type header.
+- Correct path composition in Web Cache Deception scan rule.
 
 ## [38] - 2022-04-08
 ### Added

--- a/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRule.java
+++ b/addOns/ascanrulesAlpha/src/main/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRule.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -82,9 +83,10 @@ public class WebCacheDeceptionScanRule extends AbstractAppPlugin {
                 URI uri = authorisedMessage.getRequestHeader().getURI();
                 ArrayList<String> extensions = new ArrayList<>();
                 String path = uri.getPath();
+                String basePath = getBasePath(path);
                 // checks whether the page with appended path gets cached or not
                 for (String ext : TEST_EXTENSIONS) {
-                    String newPath = path + "/test." + ext;
+                    String newPath = basePath + "/test." + ext;
                     uri.setPath(newPath);
                     authorisedMessage.getRequestHeader().setURI(uri);
                     sendAndReceive(authorisedMessage);
@@ -122,6 +124,13 @@ public class WebCacheDeceptionScanRule extends AbstractAppPlugin {
         }
     }
 
+    private static String getBasePath(String path) throws URIException {
+        if (path != null && !"/".equals(path)) {
+            return path;
+        }
+        return "";
+    }
+
     private HttpMessage makeUnauthorisedRequest(URI uri, String method) throws IOException {
 
         HttpMessage unauthorisedMessage = new HttpMessage(uri);
@@ -148,7 +157,7 @@ public class WebCacheDeceptionScanRule extends AbstractAppPlugin {
                 return false;
             }
             String path = uri.getPath();
-            String newPath = path + "/test";
+            String newPath = getBasePath(path) + "/test";
             uri.setPath(newPath);
             authorisedMessage.getRequestHeader().setURI(uri);
             sendAndReceive(authorisedMessage);

--- a/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRuleUnitTest.java
+++ b/addOns/ascanrulesAlpha/src/test/java/org/zaproxy/zap/extension/ascanrulesAlpha/WebCacheDeceptionScanRuleUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.ascanrulesAlpha;
 import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -70,6 +71,22 @@ class WebCacheDeceptionScanRuleUnitTest extends ActiveScannerTest<WebCacheDecept
     @Override
     protected WebCacheDeceptionScanRule createScanner() {
         return new WebCacheDeceptionScanRule();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "/"})
+    void shouldSendRequestsWithExpectedPath(String basePath) throws Exception {
+        // Given
+        HttpMessage message = this.getHttpMessage(basePath);
+        HttpRequestHeader headers = message.getRequestHeader();
+        headers.addHeader("authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
+        message.setRequestHeader(headers);
+        nano.addHandler(new CachedTestResponse(basePath, "authorization"));
+        rule.init(message, this.parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(nano.getRequestedUris(), hasItems("/", "/test", "/test.css"));
     }
 
     @Test

--- a/testutils/src/main/java/org/zaproxy/zap/testutils/HTTPDTestServer.java
+++ b/testutils/src/main/java/org/zaproxy/zap/testutils/HTTPDTestServer.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class HTTPDTestServer extends NanoHTTPD {
 
     private List<NanoServerHandler> handlers = new ArrayList<>();
+    private List<String> requestedUris = new ArrayList<>();
 
     private NanoServerHandler handler404 =
             new NanoServerHandler("") {
@@ -43,9 +44,15 @@ public class HTTPDTestServer extends NanoHTTPD {
         super(port);
     }
 
+    public List<String> getRequestedUris() {
+        return requestedUris;
+    }
+
     @Override
     public Response serve(IHTTPSession session) {
         String uri = session.getUri();
+        requestedUris.add(uri);
+
         for (NanoServerHandler handler : handlers) {
             if (uri.startsWith(handler.getName())) {
                 return handler.serve(session);


### PR DESCRIPTION
Check that the path exists or it's not a single slash when composing
the new path, otherwise it would add "null" to the domain/port or add
two slashes to the path, e.g.:
 - `http://example.org:1234null/test`
 - `http://example.org:1234//test`