### PR TITLE
network: provide HttpSender implementation

### DIFF
--- a/addOns/network/network.gradle.kts
+++ b/addOns/network/network.gradle.kts
@@ -44,10 +44,25 @@ crowdin {
     }
 }
 
+spotless {
+    java {
+        target(fileTree(projectDir) {
+            include("src/**/*.java")
+            exclude("src/main/java/org/apache/hc/client5/**/Zap*.java")
+        })
+    }
+}
+
 dependencies {
     val nettyVersion = "4.1.73.Final"
     implementation("io.netty:netty-codec:$nettyVersion")
     implementation("io.netty:netty-handler:$nettyVersion")
+
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.2-beta1")
+    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.17.2") {
+        // Provided by ZAP.
+        exclude(group = "org.apache.logging.log4j")
+    }
 
     val bcVersion = "1.69"
     bouncyCastle("org.bouncycastle:bcmail-jdk15on:$bcVersion")

--- a/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/CustomHttpClientCreator.java
+++ b/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/CustomHttpClientCreator.java
@@ -1,0 +1,119 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hc.client5.http.impl.classic;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.client5.http.auth.AuthSchemeFactory;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.classic.ExecChainHandler;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.impl.ChainElement;
+import org.apache.hc.client5.http.impl.CookieSpecSupport;
+import org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy;
+import org.apache.hc.client5.http.impl.DefaultClientConnectionReuseStrategy;
+import org.apache.hc.client5.http.impl.DefaultConnectionKeepAliveStrategy;
+import org.apache.hc.client5.http.impl.DefaultSchemePortResolver;
+import org.apache.hc.client5.http.impl.DefaultUserTokenHandler;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.routing.HttpRoutePlanner;
+import org.apache.hc.core5.http.ConnectionReuseStrategy;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.NamedElementChain;
+import org.apache.hc.core5.http.protocol.HttpProcessor;
+import org.zaproxy.addon.network.internal.client.apachev5.ZapHttpRequestExecutor;
+
+public final class CustomHttpClientCreator {
+
+    private CustomHttpClientCreator() {}
+
+    public static CloseableHttpClient create(
+            HttpClientConnectionManager connectionManager,
+            HttpRoutePlanner routePlanner,
+            Lookup<AuthSchemeFactory> authSchemeRegistry,
+            CredentialsProvider credentialsProvider,
+            RequestConfig defaultRequestConfig,
+            HttpProcessor proxyHttpProcessor,
+            HttpProcessor httpProcessor,
+            HttpRequestRetryStrategy requestRetryStrategy) {
+
+        boolean authCachingDisabled = false;
+        ConnectionReuseStrategy reuseStrategy = DefaultClientConnectionReuseStrategy.INSTANCE;
+
+        NamedElementChain<ExecChainHandler> execChainDefinition = new NamedElementChain<>();
+
+        execChainDefinition.addLast(
+                new MainClientExec(
+                        connectionManager,
+                        httpProcessor,
+                        reuseStrategy,
+                        DefaultConnectionKeepAliveStrategy.INSTANCE,
+                        DefaultUserTokenHandler.INSTANCE),
+                ChainElement.MAIN_TRANSPORT.name());
+
+        execChainDefinition.addFirst(
+                new ConnectExec(
+                        reuseStrategy,
+                        proxyHttpProcessor,
+                        DefaultAuthenticationStrategy.INSTANCE,
+                        DefaultSchemePortResolver.INSTANCE,
+                        authCachingDisabled),
+                ChainElement.CONNECT.name());
+
+        execChainDefinition.addFirst(
+                new ProtocolExec(
+                        DefaultAuthenticationStrategy.INSTANCE,
+                        DefaultAuthenticationStrategy.INSTANCE,
+                        DefaultSchemePortResolver.INSTANCE,
+                        authCachingDisabled),
+                ChainElement.PROTOCOL.name());
+
+        execChainDefinition.addFirst(
+                new ZapHttpRequestRetryExec(requestRetryStrategy), ChainElement.RETRY.name());
+
+        NamedElementChain<ExecChainHandler>.Node current = execChainDefinition.getLast();
+        ExecChainElement execChain = null;
+        while (current != null) {
+            execChain = new ExecChainElement(current.getValue(), execChain);
+            current = current.getPrevious();
+        }
+
+        List<Closeable> closeables = new ArrayList<>(1);
+        if (connectionManager instanceof PoolingHttpClientConnectionManager) {
+            closeables.add(connectionManager);
+        }
+
+        return new ZapInternalHttpClient(
+                connectionManager,
+                new ZapHttpRequestExecutor(),
+                execChain,
+                routePlanner,
+                CookieSpecSupport.createDefault(),
+                authSchemeRegistry,
+                new BasicCookieStore(),
+                credentialsProvider,
+                defaultRequestConfig,
+                closeables);
+    }
+}

--- a/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapHttpRequestRetryExec.java
+++ b/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapHttpRequestRetryExec.java
@@ -1,0 +1,179 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.classic;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+
+import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.classic.ExecChain;
+import org.apache.hc.client5.http.classic.ExecChain.Scope;
+import org.apache.hc.client5.http.classic.ExecChainHandler;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.NoHttpResponseException;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation from {@link HttpRequestRetryExec} but with custom request copy.
+ */
+public class ZapHttpRequestRetryExec implements ExecChainHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ZapHttpRequestRetryExec.class);
+
+    private final HttpRequestRetryStrategy retryStrategy;
+
+    public ZapHttpRequestRetryExec(
+            final HttpRequestRetryStrategy retryStrategy) {
+        Args.notNull(retryStrategy, "retryStrategy");
+        this.retryStrategy = retryStrategy;
+    }
+
+    @Override
+    public ClassicHttpResponse execute(
+            final ClassicHttpRequest request,
+            final Scope scope,
+            final ExecChain chain) throws IOException, HttpException {
+        Args.notNull(request, "request");
+        Args.notNull(scope, "scope");
+        final String exchangeId = scope.exchangeId;
+        final HttpRoute route = scope.route;
+        final HttpClientContext context = scope.clientContext;
+        ClassicHttpRequest currentRequest = request;
+
+        for (int execCount = 1; ; execCount++) {
+            final ClassicHttpResponse response;
+            try {
+                response = chain.proceed(currentRequest, scope);
+            } catch (final IOException ex) {
+                if (scope.execRuntime.isExecutionAborted()) {
+                    throw new RequestFailedException("Request aborted");
+                }
+                final HttpEntity requestEntity = request.getEntity();
+                if (requestEntity != null && !requestEntity.isRepeatable()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("{} cannot retry non-repeatable request", exchangeId);
+                    }
+                    throw ex;
+                }
+                if (retryStrategy.retryRequest(request, ex, execCount, context)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("{} {}", exchangeId, ex.getMessage(), ex);
+                    }
+                    if (LOG.isInfoEnabled()) {
+                        LOG.info("Recoverable I/O exception ({}) caught when processing request to {}",
+                                ex.getClass().getName(), route);
+                    }
+                    final TimeValue nextInterval = retryStrategy.getRetryInterval(request, ex, execCount, context);
+                    if (TimeValue.isPositive(nextInterval)) {
+                        try {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{} wait for {}", exchangeId, nextInterval);
+                            }
+                            nextInterval.sleep();
+                        } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new InterruptedIOException();
+                        }
+                    }
+                    currentRequest = copy(scope.originalRequest);
+                    continue;
+                } else {
+                    if (ex instanceof NoHttpResponseException) {
+                        final NoHttpResponseException updatedex = new NoHttpResponseException(
+                                route.getTargetHost().toHostString() + " failed to respond");
+                        updatedex.setStackTrace(ex.getStackTrace());
+                        throw updatedex;
+                    }
+                    throw ex;
+                }
+            }
+
+            try {
+                final HttpEntity entity = request.getEntity();
+                if (entity != null && !entity.isRepeatable()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("{} cannot retry non-repeatable request", exchangeId);
+                    }
+                    return response;
+                }
+                if (retryStrategy.retryRequest(response, execCount, context)) {
+                    final TimeValue nextInterval = retryStrategy.getRetryInterval(response, execCount, context);
+                    // Make sure the retry interval does not exceed the response timeout
+                    if (TimeValue.isPositive(nextInterval)) {
+                        final RequestConfig requestConfig = context.getRequestConfig();
+                        final Timeout responseTimeout = requestConfig.getResponseTimeout();
+                        if (responseTimeout != null && nextInterval.compareTo(responseTimeout) > 0) {
+                            return response;
+                        }
+                    }
+                    response.close();
+                    if (TimeValue.isPositive(nextInterval)) {
+                        try {
+                            if (LOG.isDebugEnabled()) {
+                                LOG.debug("{} wait for {}", exchangeId, nextInterval);
+                            }
+                            nextInterval.sleep();
+                        } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new InterruptedIOException();
+                        }
+                    }
+                    currentRequest = copy(scope.originalRequest);
+                } else {
+                    return response;
+                }
+            } catch (final RuntimeException ex) {
+                response.close();
+                throw ex;
+            }
+        }
+    }
+
+    private static ClassicHttpRequest copy(ClassicHttpRequest request) {
+        final BasicClassicHttpRequest result =
+                new BasicClassicHttpRequest(
+                        request.getMethod(),
+                        request.getScheme(),
+                        request.getAuthority(),
+                        request.getPath());
+        result.setVersion(request.getVersion());
+        result.setHeaders(request.getHeaders());
+        result.setEntity(request.getEntity());
+        return result;
+    }
+}

--- a/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapInternalHttpClient.java
+++ b/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapInternalHttpClient.java
@@ -1,0 +1,206 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.classic;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.auth.AuthSchemeFactory;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.classic.ExecChain;
+import org.apache.hc.client5.http.classic.ExecRuntime;
+import org.apache.hc.client5.http.config.Configurable;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.CookieSpecFactory;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.impl.ExecSupport;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.routing.HttpRoutePlanner;
+import org.apache.hc.client5.http.routing.RoutingSupport;
+import org.apache.hc.core5.concurrent.CancellableDependency;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
+import org.apache.hc.core5.http.protocol.BasicHttpContext;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.io.ModalCloseable;
+import org.apache.hc.core5.util.Args;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation from {@link InternalHttpClient} but with custom request copy.
+ */
+public class ZapInternalHttpClient extends CloseableHttpClient
+        implements Configurable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ZapInternalHttpClient.class);
+
+    private final HttpClientConnectionManager connManager;
+    private final HttpRequestExecutor requestExecutor;
+    private final ExecChainElement execChain;
+    private final HttpRoutePlanner routePlanner;
+    private final Lookup<CookieSpecFactory> cookieSpecRegistry;
+    private final Lookup<AuthSchemeFactory> authSchemeRegistry;
+    private final CookieStore cookieStore;
+    private final CredentialsProvider credentialsProvider;
+    private final RequestConfig defaultConfig;
+    private final ConcurrentLinkedQueue<Closeable> closeables;
+
+    public ZapInternalHttpClient(
+            final HttpClientConnectionManager connManager,
+            final HttpRequestExecutor requestExecutor,
+            final ExecChainElement execChain,
+            final HttpRoutePlanner routePlanner,
+            final Lookup<CookieSpecFactory> cookieSpecRegistry,
+            final Lookup<AuthSchemeFactory> authSchemeRegistry,
+            final CookieStore cookieStore,
+            final CredentialsProvider credentialsProvider,
+            final RequestConfig defaultConfig,
+            final List<Closeable> closeables) {
+        super();
+        this.connManager = Args.notNull(connManager, "Connection manager");
+        this.requestExecutor = Args.notNull(requestExecutor, "Request executor");
+        this.execChain = Args.notNull(execChain, "Execution chain");
+        this.routePlanner = Args.notNull(routePlanner, "Route planner");
+        this.cookieSpecRegistry = cookieSpecRegistry;
+        this.authSchemeRegistry = authSchemeRegistry;
+        this.cookieStore = cookieStore;
+        this.credentialsProvider = credentialsProvider;
+        this.defaultConfig = defaultConfig;
+        this.closeables = closeables != null ? new ConcurrentLinkedQueue<>(closeables) : null;
+    }
+
+    private HttpRoute determineRoute(final HttpHost target, final HttpContext context) throws HttpException {
+        return this.routePlanner.determineRoute(target, context);
+    }
+
+    private void setupContext(final HttpClientContext context) {
+        if (context.getAttribute(HttpClientContext.AUTHSCHEME_REGISTRY) == null) {
+            context.setAttribute(HttpClientContext.AUTHSCHEME_REGISTRY, this.authSchemeRegistry);
+        }
+        if (context.getAttribute(HttpClientContext.COOKIESPEC_REGISTRY) == null) {
+            context.setAttribute(HttpClientContext.COOKIESPEC_REGISTRY, this.cookieSpecRegistry);
+        }
+        if (context.getAttribute(HttpClientContext.COOKIE_STORE) == null) {
+            context.setAttribute(HttpClientContext.COOKIE_STORE, this.cookieStore);
+        }
+        if (context.getAttribute(HttpClientContext.CREDS_PROVIDER) == null) {
+            context.setAttribute(HttpClientContext.CREDS_PROVIDER, this.credentialsProvider);
+        }
+        if (context.getAttribute(HttpClientContext.REQUEST_CONFIG) == null) {
+            context.setAttribute(HttpClientContext.REQUEST_CONFIG, this.defaultConfig);
+        }
+    }
+
+    @Override
+    protected CloseableHttpResponse doExecute(
+            final HttpHost target,
+            final ClassicHttpRequest request,
+            final HttpContext context) throws IOException {
+        Args.notNull(request, "HTTP request");
+        try {
+            final HttpClientContext localcontext = HttpClientContext.adapt(
+                    context != null ? context : new BasicHttpContext());
+            RequestConfig config = null;
+            if (request instanceof Configurable) {
+                config = ((Configurable) request).getConfig();
+            }
+            if (config != null) {
+                localcontext.setRequestConfig(config);
+            }
+            setupContext(localcontext);
+            final HttpRoute route = determineRoute(
+                            target != null ? target : RoutingSupport.determineHost(request),
+                            localcontext);
+            final String exchangeId = ExecSupport.getNextExchangeId();
+            localcontext.setExchangeId(exchangeId);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} preparing request execution", exchangeId);
+            }
+
+            final ExecRuntime execRuntime = new InternalExecRuntime(LOG, connManager, requestExecutor,
+                    request instanceof CancellableDependency ? (CancellableDependency) request : null);
+            final ExecChain.Scope scope = new ExecChain.Scope(exchangeId, route, request, execRuntime, localcontext);
+            final ClassicHttpResponse response = this.execChain.execute(copy(request), scope);
+            return CloseableHttpResponse.adapt(response);
+        } catch (final HttpException httpException) {
+            throw new ClientProtocolException(httpException.getMessage(), httpException);
+        }
+    }
+
+    private static ClassicHttpRequest copy(ClassicHttpRequest request) {
+        final BasicClassicHttpRequest result =
+                new BasicClassicHttpRequest(
+                        request.getMethod(),
+                        request.getScheme(),
+                        request.getAuthority(),
+                        request.getPath());
+        result.setVersion(request.getVersion());
+        result.setHeaders(request.getHeaders());
+        result.setEntity(request.getEntity());
+        return result;
+    }
+
+    @Override
+    public RequestConfig getConfig() {
+        return this.defaultConfig;
+    }
+
+    @Override
+    public void close() {
+        close(CloseMode.GRACEFUL);
+    }
+
+    @Override
+    public void close(final CloseMode closeMode) {
+        if (this.closeables != null) {
+            Closeable closeable;
+            while ((closeable = this.closeables.poll()) != null) {
+                try {
+                    if (closeable instanceof ModalCloseable) {
+                        ((ModalCloseable) closeable).close(closeMode);
+                    } else {
+                        closeable.close();
+                    }
+                } catch (final IOException ex) {
+                    LOG.error(ex.getMessage(), ex);
+                }
+            }
+        }
+    }
+
+}

--- a/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapRequestAddCookies.java
+++ b/addOns/network/src/main/java/org/apache/hc/client5/http/impl/classic/ZapRequestAddCookies.java
@@ -1,0 +1,216 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+
+package org.apache.hc.client5.http.impl.classic;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.apache.hc.client5.http.RouteInfo;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.Cookie;
+import org.apache.hc.client5.http.cookie.CookieOrigin;
+import org.apache.hc.client5.http.cookie.CookieSpec;
+import org.apache.hc.client5.http.cookie.CookieSpecFactory;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
+import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.protocol.RequestAddCookies;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.net.URIAuthority;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.TextUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zaproxy.addon.network.internal.client.apachev5.ZapHttpClientContext;
+
+/**
+ * Implementation from {@link RequestAddCookies} but with logic to keep just one cookie header.
+ */
+public class ZapRequestAddCookies implements HttpRequestInterceptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ZapRequestAddCookies.class);
+
+    public ZapRequestAddCookies() {
+        super();
+    }
+
+    @Override
+    public void process(final HttpRequest request, final EntityDetails entity, final HttpContext context)
+            throws HttpException, IOException {
+        Args.notNull(request, "HTTP request");
+        Args.notNull(context, "HTTP context");
+
+        final String method = request.getMethod();
+        if (Method.CONNECT.isSame(method) || Method.TRACE.isSame(method)) {
+            return;
+        }
+
+        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+        final String exchangeId = clientContext.getExchangeId();
+
+        // Obtain cookie store
+        final CookieStore cookieStore = clientContext.getCookieStore();
+        if (cookieStore == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} Cookie store not specified in HTTP context", exchangeId);
+            }
+            return;
+        }
+
+        // Obtain the registry of cookie specs
+        final Lookup<CookieSpecFactory> registry = clientContext.getCookieSpecRegistry();
+        if (registry == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} CookieSpec registry not specified in HTTP context", exchangeId);
+            }
+            return;
+        }
+
+        // Obtain the route (required)
+        final RouteInfo route = clientContext.getHttpRoute();
+        if (route == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} Connection route not set in the context", exchangeId);
+            }
+            return;
+        }
+
+        final RequestConfig config = clientContext.getRequestConfig();
+        String cookieSpecName = config.getCookieSpec();
+        if (cookieSpecName == null) {
+            cookieSpecName = StandardCookieSpec.STRICT;
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{} Cookie spec selected: {}", exchangeId, cookieSpecName);
+        }
+
+        final URIAuthority authority = request.getAuthority();
+        String path = request.getPath();
+        if (TextUtils.isEmpty(path)) {
+            path = "/";
+        }
+        String hostName = authority != null ? authority.getHostName() : null;
+        if (hostName == null) {
+            hostName = route.getTargetHost().getHostName();
+        }
+        int port = authority != null ? authority.getPort() : -1;
+        if (port < 0) {
+            port = route.getTargetHost().getPort();
+        }
+        final CookieOrigin cookieOrigin = new CookieOrigin(hostName, port, path, route.isSecure());
+
+        // Get an instance of the selected cookie policy
+        final CookieSpecFactory factory = registry.lookup(cookieSpecName);
+        if (factory == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("{} Unsupported cookie spec: {}", exchangeId, cookieSpecName);
+            }
+            return;
+        }
+        final CookieSpec cookieSpec = factory.create(clientContext);
+        // Get all cookies available in the HTTP state
+        final List<Cookie> cookies = cookieStore.getCookies();
+        // Find cookies matching the given origin
+        final List<Cookie> matchedCookies = new ArrayList<>();
+        final Instant now = Instant.now();
+        boolean expired = false;
+        for (final Cookie cookie : cookies) {
+            if (!cookie.isExpired(now)) {
+                if (cookieSpec.match(cookie, cookieOrigin)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("{} Cookie {} match {}", exchangeId, cookie, cookieOrigin);
+                    }
+                    matchedCookies.add(cookie);
+                }
+            } else {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("{} Cookie {} expired", exchangeId, cookie);
+                }
+                expired = true;
+            }
+        }
+        // Per RFC 6265, 5.3
+        // The user agent must evict all expired cookies if, at any time, an expired cookie
+        // exists in the cookie store
+        if (expired) {
+            cookieStore.clearExpired(now);
+        }
+        // Generate Cookie request headers
+        if (!matchedCookies.isEmpty()) {
+            collectCookies(request, matchedCookies);
+            final List<Header> headers = cookieSpec.formatCookies(matchedCookies);
+            for (final Header header : headers) {
+                request.addHeader(header);
+            }
+        }
+
+        // Stick the CookieSpec and CookieOrigin instances to the HTTP context
+        // so they could be obtained by the response interceptor
+        context.setAttribute(HttpClientContext.COOKIE_SPEC, cookieSpec);
+        context.setAttribute(HttpClientContext.COOKIE_ORIGIN, cookieOrigin);
+
+        if (clientContext instanceof ZapHttpClientContext) {
+            ZapHttpClientContext zapContext = (ZapHttpClientContext) clientContext;
+            if (zapContext.getRequestCount() == 1) {
+                zapContext.setCookieSetup(cookieStore, registry, route, config, request);
+            }
+        }
+    }
+
+    private static void collectCookies(HttpRequest request, List<Cookie> matchedCookies) {
+        if (!request.containsHeader(HttpHeaders.COOKIE)) {
+            return;
+        }
+
+        HashMap<String, Cookie> allCookies = new LinkedHashMap<>();
+        for (Header cookieHeader : request.getHeaders(HttpHeaders.COOKIE)) {
+            for (String cookie : cookieHeader.getValue().split(";")) {
+                String[] nvp = cookie.split("=", 2);
+                String name = nvp[0].trim();
+                String value = nvp.length == 1 ? "" : nvp[1].trim();
+                allCookies.put(name, new BasicClientCookie(name, value));
+            }
+        }
+        matchedCookies.forEach(e -> allCookies.put(e.getName(), e));
+        matchedCookies.clear();
+        matchedCookies.addAll(allCookies.values());
+        request.removeHeaders(HttpHeaders.COOKIE);
+    }
+}

--- a/addOns/network/src/main/java/org/apache/hc/client5/http/impl/io/ZapHttpClientConnectionOperator.java
+++ b/addOns/network/src/main/java/org/apache/hc/client5/http/impl/io/ZapHttpClientConnectionOperator.java
@@ -1,0 +1,182 @@
+/*
+ * ====================================================================
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the Apache Software Foundation.  For more
+ * information on the Apache Software Foundation, please see
+ * <http://www.apache.org/>.
+ *
+ */
+package org.apache.hc.client5.http.impl.io;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import org.apache.hc.client5.http.ConnectExceptionSupport;
+import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.SchemePortResolver;
+import org.apache.hc.client5.http.UnsupportedSchemeException;
+import org.apache.hc.client5.http.impl.ConnPoolSupport;
+import org.apache.hc.client5.http.impl.DefaultSchemePortResolver;
+import org.apache.hc.client5.http.io.ManagedHttpClientConnection;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.Args;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link DefaultHttpClientConnectionOperator} that optionally does not resolve the host name.
+ */
+public class ZapHttpClientConnectionOperator extends DefaultHttpClientConnectionOperator {
+
+    public static final String NO_RESOLVE_HOSTNAME = "zap.no-resolve-hostname";
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ZapHttpClientConnectionOperator.class);
+
+    private final Lookup<ConnectionSocketFactory> socketFactoryRegistry;
+    private final SchemePortResolver schemePortResolver;
+
+    public ZapHttpClientConnectionOperator(
+            final Lookup<ConnectionSocketFactory> socketFactoryRegistry,
+            final SchemePortResolver schemePortResolver,
+            final DnsResolver dnsResolver) {
+        super(socketFactoryRegistry, schemePortResolver, dnsResolver);
+        this.socketFactoryRegistry = socketFactoryRegistry;
+        this.schemePortResolver =
+                schemePortResolver != null
+                        ? schemePortResolver
+                        : DefaultSchemePortResolver.INSTANCE;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Lookup<ConnectionSocketFactory> getSocketFactoryRegistry(final HttpContext context) {
+        Lookup<ConnectionSocketFactory> reg =
+                (Lookup<ConnectionSocketFactory>) context.getAttribute(SOCKET_FACTORY_REGISTRY);
+        if (reg == null) {
+            reg = this.socketFactoryRegistry;
+        }
+        return reg;
+    }
+
+    @Override
+    public void connect(
+            final ManagedHttpClientConnection conn,
+            final HttpHost host,
+            final InetSocketAddress localAddress,
+            final Timeout connectTimeout,
+            final SocketConfig socketConfig,
+            final Object attachment,
+            final HttpContext context)
+            throws IOException {
+        if (!isSet(context, NO_RESOLVE_HOSTNAME)) {
+            super.connect(
+                    conn, host, localAddress, connectTimeout, socketConfig, attachment, context);
+            return;
+        }
+
+        Args.notNull(conn, "Connection");
+        Args.notNull(host, "Host");
+        Args.notNull(socketConfig, "Socket config");
+        Args.notNull(context, "Context");
+        final Lookup<ConnectionSocketFactory> registry = getSocketFactoryRegistry(context);
+        final ConnectionSocketFactory sf = registry.lookup(host.getSchemeName());
+        if (sf == null) {
+            throw new UnsupportedSchemeException(
+                    host.getSchemeName() + " protocol is not supported");
+        }
+
+        final Timeout soTimeout = socketConfig.getSoTimeout();
+
+        final int port = this.schemePortResolver.resolve(host);
+        Socket sock = sf.createSocket(context);
+        if (soTimeout != null) {
+            sock.setSoTimeout(soTimeout.toMillisecondsIntBound());
+        }
+        sock.setReuseAddress(socketConfig.isSoReuseAddress());
+        sock.setTcpNoDelay(socketConfig.isTcpNoDelay());
+        sock.setKeepAlive(socketConfig.isSoKeepAlive());
+        if (socketConfig.getRcvBufSize() > 0) {
+            sock.setReceiveBufferSize(socketConfig.getRcvBufSize());
+        }
+        if (socketConfig.getSndBufSize() > 0) {
+            sock.setSendBufferSize(socketConfig.getSndBufSize());
+        }
+
+        final int linger = socketConfig.getSoLinger().toMillisecondsIntBound();
+        if (linger >= 0) {
+            sock.setSoLinger(true, linger);
+        }
+        conn.bind(sock);
+
+        final InetSocketAddress remoteAddress =
+                InetSocketAddress.createUnresolved(host.getHostName(), port);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "{}:{} connecting {}->{} ({})",
+                    host.getHostName(),
+                    host.getPort(),
+                    localAddress,
+                    remoteAddress,
+                    connectTimeout);
+        }
+        try {
+            sock =
+                    sf.connectSocket(
+                            sock,
+                            host,
+                            remoteAddress,
+                            localAddress,
+                            connectTimeout,
+                            attachment,
+                            context);
+            conn.bind(sock);
+            conn.setSocketTimeout(soTimeout);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "{}:{} connected {}->{} as {}",
+                        host.getHostName(),
+                        host.getPort(),
+                        localAddress,
+                        remoteAddress,
+                        ConnPoolSupport.getId(conn));
+            }
+        } catch (final IOException ex) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "{}:{} connection to {} failed ({}); terminating operation",
+                        host.getHostName(),
+                        host.getPort(),
+                        remoteAddress,
+                        ex.getClass());
+            }
+            throw ConnectExceptionSupport.enhance(ex, host);
+        }
+    }
+
+    private static boolean isSet(HttpContext context, String attributeName) {
+        return Boolean.TRUE.equals(context.getAttribute(attributeName));
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/HttpSenderNetwork.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/HttpSenderNetwork.java
@@ -1,0 +1,174 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network;
+
+import java.io.Closeable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Path;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.internal.client.CloseableHttpSenderImpl;
+import org.zaproxy.addon.network.internal.client.core.HttpSenderContext;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.network.HttpSenderListener;
+import org.zaproxy.zap.users.User;
+
+class HttpSenderNetwork<T extends HttpSenderContext> implements Closeable {
+
+    private static final Logger LOGGER = LogManager.getLogger(HttpSenderNetwork.class);
+
+    private final CloseableHttpSenderImpl<T> sender;
+    private final Object implementation;
+    private final Method setImpl;
+
+    HttpSenderNetwork(ConnectionOptions connectionOptions, CloseableHttpSenderImpl<T> sender) {
+        Objects.requireNonNull(connectionOptions);
+        this.sender = Objects.requireNonNull(sender);
+
+        try {
+            Class<?> implClass = Class.forName("org.zaproxy.zap.network.HttpSenderImpl");
+            Class<?>[] contextClass =
+                    new Class<?>[] {Class.forName("org.zaproxy.zap.network.HttpSenderContext")};
+
+            InvocationHandler invocationHandler =
+                    (o, method, args) -> {
+                        switch (method.getName()) {
+                            case "isGlobalStateEnabled":
+                                return connectionOptions.isUseGlobalHttpState();
+
+                            case "addListener":
+                                sender.addListener((HttpSenderListener) args[0]);
+                                return null;
+
+                            case "removeListener":
+                                sender.removeListener((HttpSenderListener) args[0]);
+                                return null;
+
+                            case "createContext":
+                                T context =
+                                        sender.createContext((HttpSender) args[0], (int) args[1]);
+                                return Proxy.newProxyInstance(
+                                        getClass().getClassLoader(),
+                                        contextClass,
+                                        new ContextProxy(context));
+
+                            case "sendAndReceive":
+                                @SuppressWarnings("unchecked")
+                                ContextProxy contextProxy =
+                                        (ContextProxy) Proxy.getInvocationHandler(args[0]);
+                                sender.sendAndReceive(
+                                        contextProxy.getContext(),
+                                        (HttpRequestConfig) args[1],
+                                        (HttpMessage) args[2],
+                                        (Path) args[3]);
+                                return null;
+
+                            default:
+                                return null;
+                        }
+                    };
+
+            implementation =
+                    Proxy.newProxyInstance(
+                            getClass().getClassLoader(),
+                            new Class<?>[] {implClass},
+                            invocationHandler);
+
+            setImpl = HttpSender.class.getDeclaredMethod("setImpl", implClass);
+            setHttpSenderImpl(implementation);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void setHttpSenderImpl(Object value) {
+        try {
+            setImpl.invoke(HttpSender.class, value);
+        } catch (Exception e) {
+            LOGGER.error("An error occurred while setting the HttpSender implementation:", e);
+        }
+    }
+
+    void unload() {
+        setHttpSenderImpl(null);
+    }
+
+    @Override
+    public void close() {
+        sender.close();
+    }
+
+    private class ContextProxy implements InvocationHandler {
+
+        private final T context;
+
+        ContextProxy(T context) {
+            this.context = context;
+        }
+
+        T getContext() {
+            return context;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            switch (method.getName()) {
+                case "setUseGlobalState":
+                    context.setUseGlobalState((boolean) args[0]);
+                    return null;
+
+                case "setUseCookies":
+                    context.setUseCookies((boolean) args[0]);
+                    return null;
+
+                case "setFollowRedirects":
+                    context.setFollowRedirects((boolean) args[0]);
+                    return null;
+
+                case "setMaxRedirects":
+                    context.setMaxRedirects((int) args[0]);
+                    return null;
+
+                case "setMaxRetriesOnIoError":
+                    context.setMaxRetriesOnIoError((int) args[0]);
+                    return null;
+
+                case "setRemoveUserDefinedAuthHeaders":
+                    context.setRemoveUserDefinedAuthHeaders((boolean) args[0]);
+                    return null;
+
+                case "setUser":
+                    context.setUser((User) args[0]);
+                    return null;
+
+                case "getUser":
+                    return context.getUser((HttpMessage) args[0]);
+
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSender.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSender.java
@@ -1,0 +1,456 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.httpclient.InvalidRedirectLocationException;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.network.HttpRedirectionValidator;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.network.HttpSenderListener;
+import org.zaproxy.zap.users.User;
+
+/**
+ * The base implementation of {@link CloseableHttpSenderImpl}.
+ *
+ * @param <T1> the type of the main context.
+ * @param <T2> the type of the request context.
+ * @param <T3> the type of the response body.
+ */
+public abstract class BaseHttpSender<T1 extends BaseHttpSenderContext, T2, T3>
+        implements CloseableHttpSenderImpl<T1> {
+
+    private static final Logger LOGGER = LogManager.getLogger(BaseHttpSender.class);
+
+    private static final ThreadLocal<Boolean> IN_LISTENER = new ThreadLocal<>();
+
+    private static final Comparator<HttpSenderListener> LISTENERS_COMPARATOR =
+            (o1, o2) -> Integer.compare(o1.getListenerOrder(), o2.getListenerOrder());
+
+    private static final HttpRequestConfig NO_REDIRECTS = HttpRequestConfig.builder().build();
+    private static final HttpRequestConfig FOLLOW_REDIRECTS =
+            HttpRequestConfig.builder().setFollowRedirects(true).build();
+
+    private final List<HttpSenderListener> listeners;
+
+    protected BaseHttpSender() {
+        listeners = new ArrayList<>();
+    }
+
+    @Override
+    public void addListener(HttpSenderListener listener) {
+        Objects.requireNonNull(listener);
+        listeners.add(listener);
+        Collections.sort(listeners, LISTENERS_COMPARATOR);
+    }
+
+    @Override
+    public void removeListener(HttpSenderListener listener) {
+        Objects.requireNonNull(listener);
+        listeners.remove(listener);
+    }
+
+    protected void notifyRequestListeners(T1 ctx, HttpMessage msg) {
+        if (IN_LISTENER.get() != null) {
+            return;
+        }
+
+        try {
+            IN_LISTENER.set(true);
+            for (HttpSenderListener listener : listeners) {
+                try {
+                    listener.onHttpRequestSend(msg, ctx.getInitiator(), ctx.getParent());
+                } catch (Exception e) {
+                    LOGGER.error(e.getMessage(), e);
+                }
+            }
+        } finally {
+            IN_LISTENER.remove();
+        }
+    }
+
+    protected void notifyResponseListeners(T1 ctx, HttpMessage msg) {
+        if (IN_LISTENER.get() != null) {
+            return;
+        }
+
+        try {
+            IN_LISTENER.set(true);
+            for (HttpSenderListener listener : listeners) {
+                try {
+                    listener.onHttpResponseReceive(msg, ctx.getInitiator(), ctx.getParent());
+                } catch (Exception e) {
+                    LOGGER.error(e.getMessage(), e);
+                }
+            }
+        } finally {
+            IN_LISTENER.remove();
+        }
+    }
+
+    private final ResponseBodyConsumer<T3> defaultBodyConsumer =
+            (msg, entity) -> {
+                if (msg.isEventStream()) {
+                    msg.getResponseBody().setCharset(msg.getResponseHeader().getCharset());
+                    msg.getResponseBody().setLength(0);
+                    return;
+                }
+
+                msg.setResponseBody(getBytes(entity));
+            };
+
+    protected abstract InputStream getStream(T3 body) throws IOException;
+
+    protected abstract byte[] getBytes(T3 body) throws IOException;
+
+    protected abstract T2 createRequestContext(T1 ctx, HttpRequestConfig requestConfig);
+
+    @Override
+    public void sendAndReceive(T1 ctx, HttpRequestConfig config, HttpMessage msg, Path file)
+            throws IOException {
+        HttpRequestConfig effectiveConfig = getEffectiveConfig(ctx, config);
+        T2 requestCtx = createRequestContext(ctx, effectiveConfig);
+
+        ResponseBodyConsumer<T3> bodyConsumer = defaultBodyConsumer;
+        if (file != null) {
+            bodyConsumer =
+                    (message, body) -> {
+                        if (effectiveConfig.isFollowRedirects()
+                                && isRedirectionNeeded(
+                                        message.getResponseHeader().getStatusCode())) {
+                            defaultBodyConsumer.accept(message, body);
+                            return;
+                        }
+
+                        HttpResponseHeader header = message.getResponseHeader();
+                        try (FileChannel channel =
+                                        (FileChannel)
+                                                Files.newByteChannel(
+                                                        file,
+                                                        EnumSet.of(
+                                                                StandardOpenOption.WRITE,
+                                                                StandardOpenOption.CREATE,
+                                                                StandardOpenOption
+                                                                        .TRUNCATE_EXISTING));
+                                InputStream is = getStream(body)) {
+                            if (is == null) {
+                                return;
+                            }
+                            long totalRead = 0;
+                            while ((totalRead +=
+                                            channel.transferFrom(
+                                                    Channels.newChannel(is), totalRead, 1 << 24))
+                                    < header.getContentLength()) ;
+                        }
+                    };
+        }
+
+        send(ctx, requestCtx, effectiveConfig, msg, bodyConsumer);
+    }
+
+    private HttpRequestConfig getEffectiveConfig(T1 ctx, HttpRequestConfig config) {
+        if (config != null) {
+            return config;
+        }
+        return ctx.isFollowRedirects() ? FOLLOW_REDIRECTS : NO_REDIRECTS;
+    }
+
+    /**
+     * Helper method that sends the request of the given HTTP {@code message} with the given
+     * configurations.
+     *
+     * <p>No redirections are followed (see {@link #followRedirections(HttpMessage,
+     * HttpRequestConfig)}).
+     *
+     * @param message the message that will be sent.
+     * @param requestConfig the request configurations.
+     * @throws IOException if an error occurred while sending the message or following the
+     *     redirections.
+     */
+    protected void send(
+            T1 ctx,
+            T2 requestCtx,
+            HttpRequestConfig requestConfig,
+            HttpMessage message,
+            ResponseBodyConsumer<T3> responseBodyConsumer)
+            throws IOException {
+        sendNoRedirections(ctx, requestCtx, requestConfig, message, responseBodyConsumer, false);
+
+        if (requestConfig.isFollowRedirects()) {
+            followRedirections(ctx, requestCtx, requestConfig, message, responseBodyConsumer);
+        }
+
+        updateInitialMessage(ctx, requestCtx, message);
+
+        if (requestConfig.isNotifyListeners()) {
+            notifyResponseListeners(ctx, message);
+        }
+    }
+
+    protected void updateInitialMessage(T1 ctx, T2 requestCtx, HttpMessage message) {}
+
+    /**
+     * Helper method that sends the request of the given HTTP {@code message} with the given
+     * configurations.
+     *
+     * <p>No redirections are followed (see {@link #send(BaseHttpSenderContext, HttpRequestConfig,
+     * HttpMessage, ResponseBodyConsumer)}).
+     *
+     * @param message the message that will be sent.
+     * @param requestConfig the request configurations.
+     * @throws IOException if an error occurred while sending the message or following the
+     *     redirections.
+     */
+    private void sendNoRedirections(
+            T1 ctx,
+            T2 requestCtx,
+            HttpRequestConfig requestConfig,
+            HttpMessage message,
+            ResponseBodyConsumer<T3> responseBodyConsumer,
+            boolean notifyResponse)
+            throws IOException {
+        LOGGER.debug(
+                "Sending {} {}",
+                message.getRequestHeader().getMethod(),
+                message.getRequestHeader().getURI());
+        try {
+            if (requestConfig.isNotifyListeners()) {
+                notifyRequestListeners(ctx, message);
+            }
+
+            sendAuthenticated(ctx, requestCtx, requestConfig, message, responseBodyConsumer);
+
+        } finally {
+            LOGGER.debug(
+                    "Received response after {}ms for {} {}",
+                    message.getTimeElapsedMillis(),
+                    message.getRequestHeader().getMethod(),
+                    message.getRequestHeader().getURI());
+
+            if (notifyResponse && requestConfig.isNotifyListeners()) {
+                notifyResponseListeners(ctx, message);
+            }
+        }
+    }
+
+    private void sendAuthenticated(
+            T1 ctx,
+            T2 requestCtx,
+            HttpRequestConfig requestConfig,
+            HttpMessage message,
+            ResponseBodyConsumer<T3> responseBodyConsumer)
+            throws IOException {
+        User user = ctx.getUser(message);
+        if (user != null) {
+            if (ctx.getInitiator() == HttpSender.AUTHENTICATION_POLL_INITIATOR) {
+                user.processMessageToMatchAuthenticatedSession(message);
+            } else if (ctx.getInitiator() != HttpSender.AUTHENTICATION_INITIATOR) {
+                user.processMessageToMatchUser(message);
+            }
+        }
+
+        LOGGER.debug("Sending message to: {}", message.getRequestHeader().getURI());
+        sendImpl(ctx, requestCtx, requestConfig, message, responseBodyConsumer);
+
+        if (user != null && isAuthenticationRequired(ctx, message, user)) {
+            LOGGER.debug(
+                    "First try to send authenticated message failed for {}. Authenticating and trying again...",
+                    message.getRequestHeader().getURI());
+            user.queueAuthentication(message);
+            user.processMessageToMatchUser(message);
+            sendImpl(ctx, requestCtx, requestConfig, message, responseBodyConsumer);
+        } else {
+            LOGGER.debug("SUCCESSFUL");
+        }
+    }
+
+    private boolean isAuthenticationRequired(T1 ctx, HttpMessage message, User user) {
+        return ctx.getInitiator() != HttpSender.AUTHENTICATION_INITIATOR
+                && ctx.getInitiator() != HttpSender.AUTHENTICATION_POLL_INITIATOR
+                && !message.getRequestHeader().isImage()
+                && !user.isAuthenticated(message);
+    }
+
+    protected abstract void sendImpl(
+            T1 ctx,
+            T2 requestCtx,
+            HttpRequestConfig requestConfig,
+            HttpMessage message,
+            ResponseBodyConsumer<T3> responseBodyConsumer)
+            throws IOException;
+
+    /**
+     * Follows redirections using the response of the given {@code message}. The {@code validator}
+     * in the given request configuration will be called for each redirection received. After the
+     * call to this method the given {@code message} will have the contents of the last response
+     * received (possibly the response of a redirection).
+     *
+     * <p>The validator is notified of each message sent and received (first message and
+     * redirections followed, if any).
+     *
+     * @param message the message that will be sent, must not be {@code null}
+     * @param requestConfig the request configuration that contains the validator responsible for
+     *     validation of redirections, must not be {@code null}.
+     * @throws IOException if an error occurred while sending the message or following the
+     *     redirections
+     * @see #isRedirectionNeeded(int)
+     */
+    protected void followRedirections(
+            T1 ctx,
+            T2 requestCtx,
+            HttpRequestConfig requestConfig,
+            HttpMessage message,
+            ResponseBodyConsumer<T3> responseBodyConsumer)
+            throws IOException {
+        HttpRedirectionValidator validator = requestConfig.getRedirectionValidator();
+        validator.notifyMessageReceived(message);
+
+        User requestingUser = ctx.getUser(message);
+        HttpMessage redirectMessage = message;
+        int maxRedirections = ctx.getMaxRedirects();
+        for (int i = 0;
+                i < maxRedirections
+                        && isRedirectionNeeded(redirectMessage.getResponseHeader().getStatusCode());
+                i++) {
+            URI newLocation = extractRedirectLocation(redirectMessage);
+            if (newLocation == null || !validator.isValid(newLocation)) {
+                return;
+            }
+
+            redirectMessage = redirectMessage.cloneAll();
+            redirectMessage.setRequestingUser(requestingUser);
+            redirectMessage.getRequestHeader().setURI(newLocation);
+
+            if (isRequestRewriteNeeded(redirectMessage)) {
+                redirectMessage.getRequestHeader().setMethod(HttpRequestHeader.GET);
+                redirectMessage.getRequestHeader().setHeader(HttpHeader.CONTENT_TYPE, null);
+                redirectMessage.getRequestHeader().setHeader(HttpHeader.CONTENT_LENGTH, null);
+                redirectMessage.setRequestBody("");
+            }
+
+            sendNoRedirections(
+                    ctx, requestCtx, requestConfig, redirectMessage, responseBodyConsumer, true);
+            validator.notifyMessageReceived(redirectMessage);
+
+            // Update the response of the (original) message
+            message.setResponseHeader(redirectMessage.getResponseHeader());
+            message.setResponseBody(redirectMessage.getResponseBody());
+        }
+    }
+
+    /**
+     * Tells whether or not a redirection is needed based on the given status code.
+     *
+     * <p>A redirection is needed if the status code is 301, 302, 303, 307 or 308.
+     *
+     * @param statusCode the status code that will be checked
+     * @return {@code true} if a redirection is needed, {@code false} otherwise
+     * @see #isRequestRewriteNeeded(HttpMessage)
+     */
+    protected static boolean isRedirectionNeeded(int statusCode) {
+        switch (statusCode) {
+            case 301:
+            case 302:
+            case 303:
+            case 307:
+            case 308:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Tells whether or not the (original) request of the redirection, should be rewritten.
+     *
+     * <p>For status codes 301 and 302 the request should be changed from POST to GET when following
+     * redirections, for status code 303 it should be changed to GET for all methods except GET/HEAD
+     * (mimicking the behaviour of browsers, which per <a
+     * href="https://tools.ietf.org/html/rfc7231#section-6.4">RFC 7231, Section 6.4</a> is now OK).
+     *
+     * @param message the message with the redirection.
+     * @return {@code true} if the request should be rewritten, {@code false} otherwise
+     * @see #isRedirectionNeeded(int)
+     */
+    private static boolean isRequestRewriteNeeded(HttpMessage message) {
+        int statusCode = message.getResponseHeader().getStatusCode();
+        String method = message.getRequestHeader().getMethod();
+        if (statusCode == 301 || statusCode == 302) {
+            return HttpRequestHeader.POST.equalsIgnoreCase(method);
+        }
+        return statusCode == 303
+                && !(HttpRequestHeader.GET.equalsIgnoreCase(method)
+                        || HttpRequestHeader.HEAD.equalsIgnoreCase(method));
+    }
+
+    /**
+     * Extracts a {@code URI} from the {@code Location} header of the given HTTP {@code message}.
+     *
+     * <p>If there's no {@code Location} header this method returns {@code null}.
+     *
+     * @param message the HTTP message that will processed
+     * @return the {@code URI} created from the value of the {@code Location} header, might be
+     *     {@code null}
+     * @throws InvalidRedirectLocationException if the value of {@code Location} header is not a
+     *     valid {@code URI}
+     */
+    private static URI extractRedirectLocation(HttpMessage message)
+            throws InvalidRedirectLocationException {
+        String location = message.getResponseHeader().getHeader(HttpHeader.LOCATION);
+        if (location == null) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("No Location header found: " + message.getResponseHeader());
+            }
+            return null;
+        }
+
+        try {
+            return new URI(message.getRequestHeader().getURI(), location, true);
+        } catch (URIException ex) {
+            try {
+                // Handle redirect URLs that are unencoded
+                return new URI(message.getRequestHeader().getURI(), location, false);
+            } catch (URIException e) {
+                throw new InvalidRedirectLocationException(
+                        "Invalid redirect location: " + location, location, ex);
+            }
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSenderContext.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/BaseHttpSenderContext.java
@@ -1,0 +1,127 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.internal.client.core.HttpSenderContext;
+import org.zaproxy.zap.users.User;
+
+public abstract class BaseHttpSenderContext implements HttpSenderContext {
+
+    private final HttpSender parent;
+    private final int initiator;
+
+    private boolean followRedirects;
+    private User user;
+    private boolean useCookies;
+    private boolean useGlobalState;
+    private int maxRedirects;
+    private int maxRetriesOnIoError;
+    private boolean removeUserDefinedAuthHeaders;
+
+    protected BaseHttpSenderContext(HttpSender parent, int initiator) {
+        this.parent = parent;
+        this.initiator = initiator;
+        this.maxRedirects = 100;
+        setMaxRetriesOnIoError(3);
+    }
+
+    public int getInitiator() {
+        return initiator;
+    }
+
+    public HttpSender getParent() {
+        return parent;
+    }
+
+    @Override
+    public void setUseGlobalState(boolean use) {
+        useGlobalState = use;
+    }
+
+    public boolean isUseGlobalState() {
+        return useGlobalState;
+    }
+
+    @Override
+    public void setUseCookies(boolean use) {
+        useCookies = use;
+    }
+
+    public boolean isUseCookies() {
+        return useCookies;
+    }
+
+    @Override
+    public void setFollowRedirects(boolean follow) {
+        followRedirects = follow;
+    }
+
+    public boolean isFollowRedirects() {
+        return followRedirects;
+    }
+
+    @Override
+    public void setMaxRedirects(int max) {
+        if (max < 0) {
+            throw new IllegalArgumentException("The maximum must be greater or equal to zero.");
+        }
+        maxRedirects = max;
+    }
+
+    public int getMaxRedirects() {
+        return maxRedirects;
+    }
+
+    @Override
+    public void setMaxRetriesOnIoError(int max) {
+        if (max < 0) {
+            throw new IllegalArgumentException("The maximum must be greater or equal to zero.");
+        }
+        maxRetriesOnIoError = max;
+    }
+
+    public int getMaxRetriesOnIoError() {
+        return maxRetriesOnIoError;
+    }
+
+    @Override
+    public void setRemoveUserDefinedAuthHeaders(boolean remove) {
+        removeUserDefinedAuthHeaders = remove;
+    }
+
+    public boolean isRemoveUserDefinedAuthHeaders() {
+        return removeUserDefinedAuthHeaders;
+    }
+
+    @Override
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public User getUser(HttpMessage msg) {
+        if (user != null) {
+            return user;
+        }
+        return msg.getRequestingUser();
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CloseableHttpSenderImpl.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/CloseableHttpSenderImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import org.zaproxy.addon.network.internal.client.core.HttpSenderContext;
+import org.zaproxy.addon.network.internal.client.core.HttpSenderImpl;
+
+/**
+ * A {@link HttpSenderImpl} that can be closed.
+ *
+ * @param <T> the type of the main context.
+ */
+public interface CloseableHttpSenderImpl<T extends HttpSenderContext> extends HttpSenderImpl<T> {
+
+    /** Close the sender implementation. */
+    void close();
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/LegacyUtils.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/LegacyUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.util.Date;
+import org.apache.commons.httpclient.Cookie;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
+
+public final class LegacyUtils {
+
+    private LegacyUtils() {}
+
+    public static CookieStore httpStateToCookieStore(HttpState httpState) {
+        BasicCookieStore cookieStore = new BasicCookieStore();
+        if (httpState == null) {
+            return cookieStore;
+        }
+
+        for (Cookie cookie : httpState.getCookies()) {
+            BasicClientCookie c = new BasicClientCookie(cookie.getName(), cookie.getValue());
+            c.setDomain(cookie.getDomain());
+            c.setPath(cookie.getPath());
+            c.setSecure(cookie.getSecure());
+            c.setExpiryDate(cookie.getExpiryDate().toInstant());
+            cookieStore.addCookie(c);
+        }
+        return cookieStore;
+    }
+
+    public static void updateHttpState(HttpState httpState, CookieStore cookieStore) {
+        if (httpState == null) {
+            return;
+        }
+
+        httpState.clearCookies();
+        for (org.apache.hc.client5.http.cookie.Cookie cookie : cookieStore.getCookies()) {
+            httpState.addCookie(
+                    new Cookie(
+                            cookie.getDomain(),
+                            cookie.getName(),
+                            cookie.getValue(),
+                            cookie.getPath(),
+                            new Date(cookie.getExpiryInstant().toEpochMilli()),
+                            cookie.isSecure()));
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/ResponseBodyConsumer.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/ResponseBodyConsumer.java
@@ -1,0 +1,28 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import java.io.IOException;
+import org.parosproxy.paros.network.HttpMessage;
+
+public interface ResponseBodyConsumer<T> {
+
+    void accept(HttpMessage message, T body) throws IOException;
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ConnectRequestInterceptor.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ConnectRequestInterceptor.java
@@ -1,0 +1,49 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.zaproxy.addon.network.ConnectionOptions;
+
+/**
+ * A {@link HttpRequestInterceptor} that adds the configured user-agent.
+ *
+ * <p>It's expected to be used just for automatic CONNECT requests.
+ */
+public class ConnectRequestInterceptor implements HttpRequestInterceptor {
+
+    private final ConnectionOptions connectionOptions;
+
+    public ConnectRequestInterceptor(ConnectionOptions connectionOptions) {
+        this.connectionOptions = connectionOptions;
+    }
+
+    @Override
+    public void process(HttpRequest request, EntityDetails entity, HttpContext context) {
+        String userAgent = connectionOptions.getDefaultUserAgent();
+        if (userAgent != null && !userAgent.isEmpty()) {
+            request.addHeader(HttpHeaders.USER_AGENT, userAgent);
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpConnector.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpConnector.java
@@ -1,0 +1,88 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.io.IOException;
+import java.net.Socket;
+import org.apache.hc.client5.http.HttpRoute;
+import org.apache.hc.client5.http.RouteInfo.LayerType;
+import org.apache.hc.client5.http.RouteInfo.TunnelType;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.io.ManagedHttpClientConnection;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.apache.hc.core5.http.io.HttpConnectionFactory;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
+import org.apache.hc.core5.http.protocol.HttpProcessor;
+
+/** A HTTP connector, sends CONNECT request to a target and returns the connected socket. */
+public class HttpConnector {
+
+    private final HttpConnectionFactory<ManagedHttpClientConnection> connectionFactory;
+    private final RequestConfig requestConfig;
+    private final HttpProcessor httpProcessor;
+    private final HttpRequestExecutor requestExecutor;
+
+    public HttpConnector(
+            HttpConnectionFactory<ManagedHttpClientConnection> connectionFactory,
+            RequestConfig requestConfig,
+            HttpProcessor httpProcessor) {
+        super();
+        this.connectionFactory = connectionFactory;
+        this.requestConfig = requestConfig;
+        this.httpProcessor = httpProcessor;
+        this.requestExecutor = new HttpRequestExecutor();
+    }
+
+    public void connect(
+            ClassicHttpRequest request,
+            HttpClientContext context,
+            HttpHost target,
+            ConnectResponseHandler responseHandler)
+            throws IOException {
+        HttpRoute route =
+                new HttpRoute(target, null, target, false, TunnelType.TUNNELLED, LayerType.PLAIN);
+
+        context.setAttribute(HttpCoreContext.HTTP_REQUEST, request);
+        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+        context.setAttribute(HttpClientContext.REQUEST_CONFIG, requestConfig);
+
+        try {
+            ManagedHttpClientConnection connection = connectionFactory.createConnection(null);
+
+            requestExecutor.preProcess(request, httpProcessor, context);
+            Socket socket = new Socket(target.getHostName(), target.getPort());
+            connection.bind(socket);
+            ClassicHttpResponse response = requestExecutor.execute(request, connection, context);
+            responseHandler.handleResponse(response, socket);
+        } catch (HttpException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public interface ConnectResponseHandler {
+
+        void handleResponse(ClassicHttpResponse response, Socket socket) throws IOException;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -1,0 +1,569 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.apache.commons.httpclient.URI;
+import org.apache.hc.client5.http.auth.AuthSchemeFactory;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.config.TlsConfig;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.cookie.StandardCookieSpec;
+import org.apache.hc.client5.http.impl.auth.BasicSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.DigestSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.KerberosSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.NTLMSchemeFactory;
+import org.apache.hc.client5.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CustomHttpClientCreator;
+import org.apache.hc.client5.http.impl.classic.ZapRequestAddCookies;
+import org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.ZapHttpClientConnectionOperator;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.client5.http.protocol.ResponseProcessCookies;
+import org.apache.hc.client5.http.socket.LayeredConnectionSocketFactory;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpVersion;
+import org.apache.hc.core5.http.MessageHeaders;
+import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.config.Lookup;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicClassicHttpRequest;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http.protocol.HttpProcessor;
+import org.apache.hc.core5.http.protocol.HttpProcessorBuilder;
+import org.apache.hc.core5.http.protocol.RequestTargetHost;
+import org.apache.hc.core5.http2.HttpVersionPolicy;
+import org.apache.hc.core5.io.CloseMode;
+import org.apache.hc.core5.net.URIAuthority;
+import org.apache.hc.core5.util.Timeout;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpHeaderField;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.ClientCertificatesOptions;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.BaseHttpSender;
+import org.zaproxy.addon.network.internal.client.LegacyUtils;
+import org.zaproxy.addon.network.internal.client.ResponseBodyConsumer;
+import org.zaproxy.addon.network.internal.client.SocksProxy;
+import org.zaproxy.zap.ZapGetMethod;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.users.User;
+
+/** A {@link BaseHttpSender} using Apache HttpComponents Client. */
+public class HttpSenderApache
+        extends BaseHttpSender<HttpSenderContextApache, ZapHttpClientContext, HttpEntity> {
+
+    private static final Logger LOGGER = LogManager.getLogger(HttpSenderApache.class);
+
+    private final Supplier<CookieStore> globalCookieStoreProvider;
+    private final ConnectionOptions options;
+
+    private final Lookup<AuthSchemeFactory> authSchemeRegistry;
+
+    private final ProxyRoutePlanner routePlanner;
+    private final ProxyCredentialsProvider credentialsProvider;
+    private final RequestConfig defaultRequestConfig;
+    private final ManagedHttpClientConnectionFactory managedHttpClientConnectionFactory;
+    private final OutgoingContentStrategy outgoingContentStrategy;
+    private final LayeredConnectionSocketFactory sslSocketFactory;
+
+    private final PoolingHttpClientConnectionManager connectionManager;
+    private final HttpProcessor proxyHttpProcessor;
+    private final ZapRequestAddCookies zapRequestAddCookies;
+    private final HttpProcessor mainHttpProcessor;
+    private final RequestRetryStrategy requestRetryStrategy;
+    private final CloseableHttpClient clientImpl;
+    private final HttpConnector httpConnector;
+
+    public HttpSenderApache(
+            Supplier<CookieStore> globalCookieStoreProvider,
+            ConnectionOptions options,
+            ClientCertificatesOptions clientCertificatesOptions) {
+        this.globalCookieStoreProvider = Objects.requireNonNull(globalCookieStoreProvider);
+        this.options = Objects.requireNonNull(options);
+
+        authSchemeRegistry =
+                RegistryBuilder.<AuthSchemeFactory>create()
+                        .register(StandardAuthScheme.BASIC, BasicSchemeFactory.INSTANCE)
+                        .register(StandardAuthScheme.DIGEST, DigestSchemeFactory.INSTANCE)
+                        .register(StandardAuthScheme.NTLM, NTLMSchemeFactory.INSTANCE)
+                        .register(StandardAuthScheme.SPNEGO, SPNegoSchemeFactory.DEFAULT)
+                        .register(StandardAuthScheme.KERBEROS, KerberosSchemeFactory.DEFAULT)
+                        .build();
+
+        routePlanner = new ProxyRoutePlanner(options);
+        credentialsProvider = new ProxyCredentialsProvider(options);
+        defaultRequestConfig =
+                RequestConfig.custom()
+                        .setCookieSpec(StandardCookieSpec.IGNORE)
+                        .setAuthenticationEnabled(false)
+                        .build();
+
+        outgoingContentStrategy = new OutgoingContentStrategy();
+
+        managedHttpClientConnectionFactory =
+                ManagedHttpClientConnectionFactory.builder()
+                        .outgoingContentLengthStrategy(outgoingContentStrategy)
+                        .responseParserFactory(new LenientMessageParserFactory())
+                        .build();
+
+        sslSocketFactory = new SslConnectionSocketFactory(options, clientCertificatesOptions);
+
+        connectionManager =
+                new ZapPoolingHttpClientConnectionManager(
+                        sslSocketFactory, managedHttpClientConnectionFactory);
+
+        proxyHttpProcessor =
+                HttpProcessorBuilder.create()
+                        .add(new RequestTargetHost())
+                        .add(new ConnectRequestInterceptor(options))
+                        .build();
+
+        zapRequestAddCookies = new ZapRequestAddCookies();
+        mainHttpProcessor =
+                HttpProcessorBuilder.create()
+                        .add(zapRequestAddCookies)
+                        .add(new ResponseProcessCookies())
+                        .add(new RemoveAuthHeader(options))
+                        .add(new RemoveTransferEncoding())
+                        .build();
+
+        requestRetryStrategy = new RequestRetryStrategy();
+
+        clientImpl =
+                CustomHttpClientCreator.create(
+                        connectionManager,
+                        routePlanner,
+                        authSchemeRegistry,
+                        credentialsProvider,
+                        defaultRequestConfig,
+                        proxyHttpProcessor,
+                        mainHttpProcessor,
+                        requestRetryStrategy);
+
+        refreshConnectionManager();
+        options.addChangesListener(this::refreshConnectionManager);
+
+        httpConnector =
+                new HttpConnector(
+                        managedHttpClientConnectionFactory,
+                        defaultRequestConfig,
+                        HttpProcessorBuilder.create().build());
+    }
+
+    private void refreshConnectionManager() {
+        Timeout timeout = Timeout.ofSeconds(options.getTimeoutInSecs());
+        connectionManager.setDefaultConnectionConfig(
+                ConnectionConfig.custom()
+                        .setConnectTimeout(timeout)
+                        .setSocketTimeout(timeout)
+                        .build());
+
+        connectionManager.setDefaultTlsConfig(
+                TlsConfig.custom()
+                        .setHandshakeTimeout(timeout)
+                        .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1)
+                        .setSupportedProtocols(options.getTlsProtocols().toArray(new String[0]))
+                        .build());
+    }
+
+    @Override
+    public void close() {
+        clientImpl.close(CloseMode.GRACEFUL);
+    }
+
+    @Override
+    public boolean isGlobalStateEnabled() {
+        return options.isUseGlobalHttpState();
+    }
+
+    @Override
+    public HttpSenderContextApache createContext(HttpSender parent, int initiator) {
+        return new HttpSenderContextApache(parent, initiator);
+    }
+
+    @Override
+    public ZapHttpClientContext createRequestContext(
+            HttpSenderContextApache ctx, HttpRequestConfig requestConfig) {
+        ZapHttpClientContext context = new ZapHttpClientContext();
+
+        if (ctx.getInitiator() != HttpSender.CHECK_FOR_UPDATES_INITIATOR) {
+            context.setAttribute(SslConnectionSocketFactory.LAX_ATTR_NAME, Boolean.TRUE);
+        }
+
+        if (ctx.isRemoveUserDefinedAuthHeaders()) {
+            context.setAttribute(RemoveAuthHeader.ATTR_NAME, Boolean.TRUE);
+        }
+
+        context.setAttribute(RequestRetryStrategy.CUSTOM_RETRY, ctx.getRequestRetryStrategy());
+
+        if (requestConfig.getSoTimeout() != HttpRequestConfig.NO_VALUE_SET) {
+            context.setRequestConfig(
+                    RequestConfig.custom()
+                            .setResponseTimeout(
+                                    Timeout.ofMilliseconds(requestConfig.getSoTimeout()))
+                            .build());
+        }
+
+        SocksProxy socksProxy = options.getSocksProxy();
+        if (!options.isHttpProxyEnabled()
+                && options.isSocksProxyEnabled()
+                && socksProxy.getVersion() == SocksProxy.Version.SOCKS5
+                && socksProxy.isUseDns()) {
+            context.setAttribute(ZapHttpClientConnectionOperator.NO_RESOLVE_HOSTNAME, Boolean.TRUE);
+        }
+
+        return context;
+    }
+
+    @Override
+    protected byte[] getBytes(HttpEntity body) throws IOException {
+        return EntityUtils.toByteArray(body);
+    }
+
+    @Override
+    protected InputStream getStream(HttpEntity body) throws IOException {
+        return body.getContent();
+    }
+
+    @Override
+    protected void sendImpl(
+            HttpSenderContextApache ctx,
+            ZapHttpClientContext requestContext,
+            HttpRequestConfig requestConfig,
+            HttpMessage message,
+            ResponseBodyConsumer<HttpEntity> responseBodyConsumer)
+            throws IOException {
+        try {
+            sendImpl0(ctx, requestContext, message, responseBodyConsumer);
+        } catch (IOException e) {
+            LOGGER.debug("An I/O error occurred while sending the request:", e);
+            throw e;
+        } catch (Exception e) {
+            LOGGER.warn("An error occurred while sending the request:", e);
+            throw new IOException(e);
+        }
+    }
+
+    private void sendImpl0(
+            HttpSenderContextApache ctx,
+            ZapHttpClientContext requestCtx,
+            HttpMessage message,
+            ResponseBodyConsumer<HttpEntity> responseBodyConsumer)
+            throws IOException {
+
+        RequestConfig.Builder requestConfigBuilder =
+                RequestConfig.copy(requestCtx.getRequestConfig());
+
+        User user = ctx.getUser(message);
+        if (user != null) {
+            requestConfigBuilder.setCookieSpec(StandardCookieSpec.RELAXED);
+            requestCtx.setCookieStore(
+                    LegacyUtils.httpStateToCookieStore(user.getCorrespondingHttpState()));
+            requestCtx.setCredentialsProvider(
+                    new HttpStateCredentialsProvider(user.getCorrespondingHttpState()));
+        } else {
+            switch (ctx.getCookieUsage()) {
+                case GLOBAL:
+                    if (isGlobalStateEnabled()) {
+                        requestConfigBuilder.setCookieSpec(StandardCookieSpec.RELAXED);
+                        requestCtx.setCookieStore(globalCookieStoreProvider.get());
+                    } else {
+                        requestConfigBuilder.setCookieSpec(StandardCookieSpec.IGNORE);
+                    }
+                    break;
+                case LOCAL:
+                    requestConfigBuilder.setCookieSpec(StandardCookieSpec.RELAXED);
+                    requestCtx.setCookieStore(ctx.getLocalCookieStore());
+                    break;
+                case IGNORE:
+                default:
+                    requestConfigBuilder.setCookieSpec(StandardCookieSpec.IGNORE);
+                    break;
+            }
+            requestCtx.setCredentialsProvider(credentialsProvider);
+        }
+        requestCtx.setRequestConfig(requestConfigBuilder.build());
+
+        ClassicHttpRequest request = createHttpRequest(message);
+
+        requestCtx.increaseRequestCount();
+        message.setTimeSentMillis(System.currentTimeMillis());
+        try {
+            if (HttpRequestHeader.CONNECT.equals(message.getRequestHeader().getMethod())) {
+                String host = message.getRequestHeader().getHostName();
+                int port = message.getRequestHeader().getHostPort();
+                Object userObject = message.getUserObject();
+                if (userObject instanceof Map) {
+                    Map<?, ?> metadata = (Map<?, ?>) userObject;
+                    Object hostValue = metadata.get("target.host");
+                    if (hostValue != null) {
+                        host = hostValue.toString();
+                    }
+                    Object portValue = metadata.get("target.port");
+                    if (portValue != null) {
+                        try {
+                            port = Integer.parseInt(portValue.toString());
+                        } catch (NumberFormatException ignore) {
+                        }
+                    }
+                }
+
+                httpConnector.connect(
+                        request,
+                        requestCtx,
+                        new HttpHost(host, port),
+                        (response, socket) -> {
+                            copyResponse(response, message, responseBodyConsumer);
+                            message.setUserObject(socket);
+                        });
+            } else {
+                clientImpl.execute(
+                        request,
+                        requestCtx,
+                        response -> {
+                            copyResponse(response, message, responseBodyConsumer);
+                            return null;
+                        });
+            }
+        } finally {
+            message.setTimeElapsedMillis(
+                    (int) (System.currentTimeMillis() - message.getTimeSentMillis()));
+        }
+
+        if (!isSet(requestCtx, "zap.initial-cookie-setup")) {
+            requestCtx.setAttribute(
+                    "zap.initial-cookie-origin",
+                    requestCtx.getAttribute(HttpClientContext.COOKIE_ORIGIN));
+            requestCtx.setAttribute(
+                    "zap.initial-cookie-spec",
+                    requestCtx.getAttribute(HttpClientContext.COOKIE_SPEC));
+        }
+
+        updateRequestHeaders(message.getRequestHeader(), requestCtx.getRequest());
+
+        if (user != null) {
+            LegacyUtils.updateHttpState(
+                    user.getCorrespondingHttpState(), requestCtx.getCookieStore());
+        }
+
+        Socket socket = (Socket) requestCtx.getAttribute(ZapHttpRequestExecutor.CONNECTION_SOCKET);
+        if (socket != null) {
+            InputStream inputStream =
+                    (InputStream)
+                            requestCtx.getAttribute(ZapHttpRequestExecutor.CONNECTION_INPUT_STREAM);
+            ZapGetMethod method =
+                    new ZapGetMethod() {
+                        @Override
+                        public InputStream getResponseBodyAsStream() {
+                            return inputStream;
+                        }
+                    };
+            method.setUpgradedSocket(socket);
+            method.setUpgradedInputStream(socket.getInputStream());
+            message.setUserObject(method);
+        }
+    }
+
+    private static void copyResponse(
+            ClassicHttpResponse response,
+            HttpMessage message,
+            ResponseBodyConsumer<HttpEntity> responseBodyConsumer)
+            throws IOException {
+        message.setResponseFromTargetHost(true);
+
+        HttpResponseHeader responseHeader = message.getResponseHeader();
+        try {
+            responseHeader.setMessage(
+                    response + " " + response.getCode() + getReasonPhrase(response));
+        } catch (HttpMalformedHeaderException e) {
+            throw new IOException(e);
+        }
+        copyHeaders(response, responseHeader);
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            responseBodyConsumer.accept(message, entity);
+        }
+    }
+
+    private static boolean isSet(HttpContext context, String attributeName) {
+        return context.getAttribute(attributeName) != null;
+    }
+
+    @Override
+    protected void updateInitialMessage(
+            HttpSenderContextApache ctx, ZapHttpClientContext requestCtx, HttpMessage message) {
+
+        if (requestCtx.getRequestCount() != 1 && requestCtx.hasCookieSetup()) {
+            try {
+                zapRequestAddCookies.process(
+                        requestCtx.getFirstRequest(), null, requestCtx.getCookieContext());
+            } catch (Exception e) {
+                LOGGER.error("An error occurred while updating the request cookies:", e);
+            }
+        }
+    }
+
+    private static void updateRequestHeaders(HttpRequestHeader req, HttpRequest httpRequest) {
+        try {
+            req.setMessage(req.getPrimeHeader());
+            copyHeaders(httpRequest, req);
+        } catch (HttpMalformedHeaderException e) {
+            LOGGER.error("An error occurred while updating the request headers:", e);
+        }
+    }
+
+    private static ClassicHttpRequest createHttpRequest(HttpMessage msg) {
+        String host = null;
+        Object userObject = msg.getUserObject();
+        if (userObject instanceof Map) {
+            Map<?, ?> metadata = (Map<?, ?>) userObject;
+            Object hostValue = metadata.get("host");
+            if (hostValue != null) {
+                host = hostValue.toString();
+            }
+        }
+
+        addHostHeader(msg, host);
+
+        BasicClassicHttpRequest copy =
+                new BasicClassicHttpRequest(
+                        msg.getRequestHeader().getMethod(),
+                        getScheme(
+                                msg.getRequestHeader().getMethod(),
+                                msg.getRequestHeader().getURI()),
+                        new URIAuthority(
+                                msg.getRequestHeader().getURI().getEscapedUserinfo(),
+                                msg.getRequestHeader().getHostName(),
+                                msg.getRequestHeader().getHostPort()),
+                        getPath(msg));
+        copy.setVersion(toHttpVersion(msg.getRequestHeader().getVersion()));
+        boolean skipHostHeader = false;
+        for (HttpHeaderField header : msg.getRequestHeader().getHeaders()) {
+            if (HttpRequestHeader.HOST.equals(header.getName())) {
+                if (skipHostHeader) {
+                    continue;
+                }
+                skipHostHeader = true;
+            }
+            copy.addHeader(header.getName(), header.getValue());
+        }
+
+        copy.setEntity(new ByteArrayEntity(msg.getRequestBody().getBytes(), null));
+
+        return copy;
+    }
+
+    private static String getPath(HttpMessage msg) {
+        if (HttpRequestHeader.CONNECT.equals(msg.getRequestHeader().getMethod())) {
+            return msg.getRequestHeader().getURI().toString();
+        }
+        String path = msg.getRequestHeader().getURI().getEscapedPathQuery();
+        if (path == null) {
+            return "/";
+        }
+        return path;
+    }
+
+    private static String getScheme(String method, URI uri) {
+        String scheme = uri.getScheme();
+        if (scheme != null) {
+            return scheme;
+        }
+        return "http";
+    }
+
+    private static ProtocolVersion toHttpVersion(String version) {
+        String[] data = version.substring(version.indexOf('/') + 1).split("\\.", 2);
+        int major = Integer.parseInt(data[0]);
+        int minor = Integer.parseInt(data[1]);
+        return new HttpVersion(major, minor);
+    }
+
+    private static void addHostHeader(HttpMessage msg, String host) {
+        HttpRequestHeader header = msg.getRequestHeader();
+        String expectedHost = host != null ? host : createExpectedHost(header);
+        String currentHost = header.getHeader(HttpRequestHeader.HOST);
+        if (currentHost == null) {
+            header.addHeader(HttpRequestHeader.HOST, expectedHost);
+            return;
+        }
+        header.setHeader(HttpRequestHeader.HOST, expectedHost);
+    }
+
+    private static String createExpectedHost(HttpRequestHeader header) {
+        char[] rawHost = header.getURI().getRawHost();
+        if (rawHost == null) {
+            return header.getURI().getEscapedAuthority();
+        }
+        StringBuilder host = new StringBuilder();
+        host.append(rawHost);
+        int port = header.getURI().getPort();
+        boolean appendPort = false;
+        if (port != -1) {
+            if (header.isSecure()) {
+                appendPort = port != 443;
+            } else {
+                appendPort = port != 80;
+            }
+
+            if (appendPort) {
+                host.append(':').append(port);
+            }
+        }
+        return host.toString();
+    }
+
+    private static String getReasonPhrase(HttpResponse response) {
+        String reason = response.getReasonPhrase();
+        return reason != null ? " " + reason : "";
+    }
+
+    private static void copyHeaders(MessageHeaders from, HttpHeader to) {
+        for (Iterator<Header> it = from.headerIterator(); it.hasNext(); ) {
+            Header header = it.next();
+            to.addHeader(header.getName(), header.getValue());
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderContextApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderContextApache.java
@@ -1,0 +1,106 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.util.TimeValue;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.internal.client.BaseHttpSenderContext;
+
+/** A {@link BaseHttpSenderContext} for {@link HttpSenderApache}. */
+public class HttpSenderContextApache extends BaseHttpSenderContext {
+
+    enum CookieUsage {
+        IGNORE,
+        GLOBAL,
+        LOCAL
+    }
+
+    private static final TimeValue RETRY_INTERVAL = TimeValue.ofSeconds(0L);
+
+    private HttpRequestRetryStrategy requestRetryStrategy;
+    private CookieUsage cookieUsage;
+    private CookieStore localCookieStore;
+
+    public HttpSenderContextApache(HttpSender parent, int initiator) {
+        super(parent, initiator);
+    }
+
+    @Override
+    public void setMaxRetriesOnIoError(int max) {
+        super.setMaxRetriesOnIoError(max);
+
+        requestRetryStrategy =
+                new DefaultHttpRequestRetryStrategy(max, RETRY_INTERVAL) {
+                    @Override
+                    protected boolean handleAsIdempotent(HttpRequest request) {
+                        return true;
+                    }
+                };
+    }
+
+    @Override
+    public void setUseGlobalState(boolean use) {
+        super.setUseGlobalState(use);
+        checkCookieState();
+    }
+
+    @Override
+    public void setUseCookies(boolean use) {
+        super.setUseCookies(use);
+        checkCookieState();
+    }
+
+    HttpRequestRetryStrategy getRequestRetryStrategy() {
+        return requestRetryStrategy;
+    }
+
+    CookieUsage getCookieUsage() {
+        return cookieUsage;
+    }
+
+    CookieStore getLocalCookieStore() {
+        return localCookieStore;
+    }
+
+    private void checkCookieState() {
+        if (!isUseCookies()) {
+            cookieUsage = CookieUsage.IGNORE;
+            resetLocalCookieStore();
+            return;
+        }
+
+        if (isUseGlobalState()) {
+            cookieUsage = CookieUsage.GLOBAL;
+            return;
+        }
+
+        cookieUsage = CookieUsage.LOCAL;
+        resetLocalCookieStore();
+    }
+
+    private void resetLocalCookieStore() {
+        localCookieStore = new BasicCookieStore();
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpStateCredentialsProvider.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpStateCredentialsProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.NTCredentials;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.core5.http.protocol.HttpContext;
+
+/**
+ * A {@link CredentialsProvider} that provides the credentials contained in a {@link
+ * org.apache.commons.httpclient.HttpState HttpState}.
+ */
+public class HttpStateCredentialsProvider implements CredentialsProvider {
+
+    private final org.apache.commons.httpclient.HttpState state;
+
+    public HttpStateCredentialsProvider(org.apache.commons.httpclient.HttpState state) {
+        this.state = state;
+    }
+
+    @Override
+    public Credentials getCredentials(AuthScope authScope, HttpContext context) {
+        return convertCredentials(authScope, state.getCredentials(convertAuthScope(authScope)));
+    }
+
+    private static org.apache.commons.httpclient.auth.AuthScope convertAuthScope(
+            AuthScope authScope) {
+        return new org.apache.commons.httpclient.auth.AuthScope(
+                authScope.getHost(),
+                authScope.getPort(),
+                authScope.getRealm(),
+                authScope.getSchemeName());
+    }
+
+    private static Credentials convertCredentials(
+            AuthScope authScope, org.apache.commons.httpclient.Credentials credentials) {
+        if ((StandardAuthScheme.BASIC.equals(authScope.getSchemeName())
+                        || StandardAuthScheme.DIGEST.equals(authScope.getSchemeName()))
+                && credentials
+                        instanceof org.apache.commons.httpclient.UsernamePasswordCredentials) {
+            org.apache.commons.httpclient.UsernamePasswordCredentials upCredentials =
+                    (org.apache.commons.httpclient.UsernamePasswordCredentials) credentials;
+            return new UsernamePasswordCredentials(
+                    upCredentials.getUserName(), upCredentials.getPassword().toCharArray());
+        }
+
+        if (credentials instanceof org.apache.commons.httpclient.NTCredentials) {
+            org.apache.commons.httpclient.NTCredentials ntCredentials =
+                    (org.apache.commons.httpclient.NTCredentials) credentials;
+            return new NTCredentials(
+                    ntCredentials.getUserName(),
+                    ntCredentials.getPassword().toCharArray(),
+                    ntCredentials.getHost(),
+                    ntCredentials.getDomain(),
+                    null);
+        }
+
+        if (credentials instanceof org.apache.commons.httpclient.UsernamePasswordCredentials) {
+            org.apache.commons.httpclient.UsernamePasswordCredentials upCredentials =
+                    (org.apache.commons.httpclient.UsernamePasswordCredentials) credentials;
+            return new UsernamePasswordCredentials(
+                    upCredentials.getUserName(), upCredentials.getPassword().toCharArray());
+        }
+        return null;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/LenientMessageParserFactory.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/LenientMessageParserFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.config.Http1Config;
+import org.apache.hc.core5.http.impl.io.DefaultClassicHttpResponseFactory;
+import org.apache.hc.core5.http.impl.io.DefaultHttpResponseParser;
+import org.apache.hc.core5.http.io.HttpMessageParser;
+import org.apache.hc.core5.http.io.HttpMessageParserFactory;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.message.BasicLineParser;
+import org.apache.hc.core5.http.message.LineParser;
+import org.apache.hc.core5.util.CharArrayBuffer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** A {@link HttpMessageParserFactory} that accepts malformed headers. */
+public class LenientMessageParserFactory implements HttpMessageParserFactory<ClassicHttpResponse> {
+
+    private static final Logger LOGGER = LogManager.getLogger(LenientMessageParserFactory.class);
+
+    static final LineParser LINE_PARSER =
+            new BasicLineParser() {
+
+                @Override
+                public Header parseHeader(CharArrayBuffer buffer) {
+                    try {
+                        return super.parseHeader(buffer);
+                    } catch (ParseException ex) {
+                        String line = buffer.toString();
+                        LOGGER.warn("Accepting malformed HTTP header line: {}", line);
+                        return new BasicHeader(line, "");
+                    }
+                }
+            };
+
+    @Override
+    public HttpMessageParser<ClassicHttpResponse> create(Http1Config h1Config) {
+        return new DefaultHttpResponseParser(
+                LINE_PARSER, DefaultClassicHttpResponseFactory.INSTANCE, h1Config);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/OutgoingContentStrategy.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/OutgoingContentStrategy.java
@@ -1,0 +1,40 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.core5.http.ContentLengthStrategy;
+import org.apache.hc.core5.http.HttpEntityContainer;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpMessage;
+import org.apache.hc.core5.http.impl.DefaultContentLengthStrategy;
+
+/**
+ * A {@link ContentLengthStrategy} that always determines the length based on the contained entity.
+ */
+public class OutgoingContentStrategy implements ContentLengthStrategy {
+
+    @Override
+    public long determineLength(HttpMessage message) throws HttpException {
+        if (message instanceof HttpEntityContainer) {
+            return ((HttpEntityContainer) message).getEntity().getContentLength();
+        }
+        return DefaultContentLengthStrategy.INSTANCE.determineLength(message);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyCredentialsProvider.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyCredentialsProvider.java
@@ -1,0 +1,73 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.net.PasswordAuthentication;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.NTCredentials;
+import org.apache.hc.client5.http.auth.StandardAuthScheme;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+
+/** A {@link CredentialsProvider} that provides the credentials for the configured HTTP proxy. */
+public class ProxyCredentialsProvider implements CredentialsProvider {
+
+    private final ConnectionOptions options;
+
+    public ProxyCredentialsProvider(ConnectionOptions options) {
+        this.options = options;
+    }
+
+    @Override
+    public Credentials getCredentials(AuthScope authScope, HttpContext context) {
+        HttpProxy proxy = options.getHttpProxy();
+        if (!options.isHttpProxyEnabled() || !options.isHttpProxyAuthEnabled()) {
+            return null;
+        }
+
+        String realm = proxy.getRealm();
+        int result =
+                authScope.match(
+                        new AuthScope(
+                                null,
+                                proxy.getHost(),
+                                proxy.getPort(),
+                                realm.isEmpty() ? null : realm,
+                                null));
+        if (result <= 0) {
+            return null;
+        }
+
+        PasswordAuthentication credentials = proxy.getPasswordAuthentication();
+
+        if ((StandardAuthScheme.BASIC.equalsIgnoreCase(authScope.getSchemeName())
+                || StandardAuthScheme.DIGEST.equalsIgnoreCase(authScope.getSchemeName()))) {
+            return new UsernamePasswordCredentials(
+                    credentials.getUserName(), credentials.getPassword());
+        }
+
+        return new NTCredentials(
+                credentials.getUserName(), credentials.getPassword(), "", proxy.getRealm());
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlanner.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlanner.java
@@ -1,0 +1,47 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+
+/** A {@link DefaultRoutePlanner} that proxies through the configured HTTP proxy. */
+public class ProxyRoutePlanner extends DefaultRoutePlanner {
+
+    private final ConnectionOptions options;
+
+    public ProxyRoutePlanner(ConnectionOptions options) {
+        super(null);
+
+        this.options = options;
+    }
+
+    @Override
+    protected HttpHost determineProxy(HttpHost target, HttpContext context) {
+        HttpProxy proxy = options.getHttpProxy();
+        if (!options.isUseHttpProxy(target.getHostName())) {
+            return null;
+        }
+        return new HttpHost(target.getSchemeName(), proxy.getHost(), proxy.getPort());
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RemoveAuthHeader.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RemoveAuthHeader.java
@@ -1,0 +1,114 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.hc.client5.http.auth.AuthExchange;
+import org.apache.hc.client5.http.auth.AuthExchange.State;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpRequestInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+
+/**
+ * A {@link HttpRequestInterceptor} that removes the proxy/host authorization headers if required.
+ */
+public class RemoveAuthHeader implements HttpRequestInterceptor {
+
+    private static final Logger LOGGER = LogManager.getLogger(RemoveAuthHeader.class);
+
+    static final String ATTR_NAME = "zap.auth.remove-user-headers";
+    private static final String PROXY_HEADER_PROCESSED = ATTR_NAME + ".proxy.processed";
+    private static final String HOST_HEADER_PROCESSED = ATTR_NAME + ".host.processed";
+
+    private final ConnectionOptions connectionOptions;
+
+    public RemoveAuthHeader(ConnectionOptions connectionOptions) {
+        this.connectionOptions = connectionOptions;
+    }
+
+    @Override
+    public void process(HttpRequest request, EntityDetails entity, HttpContext context)
+            throws HttpException, IOException {
+        if (!isSet(context, ATTR_NAME)) {
+            return;
+        }
+
+        HttpClientContext clientContext = HttpClientContext.adapt(context);
+        Map<HttpHost, AuthExchange> exchanges = clientContext.getAuthExchanges();
+        if (exchanges.isEmpty()) {
+            return;
+        }
+
+        for (Map.Entry<HttpHost, AuthExchange> entry : exchanges.entrySet()) {
+            HttpHost host = entry.getKey();
+            AuthExchange exchange = entry.getValue();
+            if (exchange.getState() == State.CHALLENGED) {
+                if (isProxy(host)) {
+                    process(
+                            clientContext,
+                            PROXY_HEADER_PROCESSED,
+                            request,
+                            HttpHeaders.PROXY_AUTHORIZATION);
+                } else {
+                    process(
+                            clientContext,
+                            HOST_HEADER_PROCESSED,
+                            request,
+                            HttpHeaders.AUTHORIZATION);
+                }
+            }
+        }
+    }
+
+    private static void process(
+            HttpClientContext context,
+            String attributeName,
+            HttpRequest request,
+            String headerName) {
+        if (isSet(context, attributeName)) {
+            return;
+        }
+
+        context.setAttribute(attributeName, Boolean.TRUE);
+        if (request.containsHeader(headerName)) {
+            LOGGER.debug("{} removing existing {} header", context.getExchangeId(), headerName);
+            request.removeHeaders(headerName);
+        }
+    }
+
+    private boolean isProxy(HttpHost host) {
+        HttpProxy proxy = connectionOptions.getHttpProxy();
+        return proxy.getHost().equals(host.getHostName()) && proxy.getPort() == host.getPort();
+    }
+
+    private static boolean isSet(HttpContext context, String attributeName) {
+        return Boolean.TRUE.equals(context.getAttribute(attributeName));
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RemoveTransferEncoding.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RemoveTransferEncoding.java
@@ -1,0 +1,52 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.HttpResponseInterceptor;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A {@link HttpResponseInterceptor} that removes the Transfer-Encoding header, the response body is
+ * read without preserving the chunks.
+ */
+public class RemoveTransferEncoding implements HttpResponseInterceptor {
+
+    private static final Logger LOGGER = LogManager.getLogger(RemoveTransferEncoding.class);
+
+    @Override
+    public void process(HttpResponse response, EntityDetails entity, HttpContext context) {
+        if (response.containsHeader(HttpHeaders.TRANSFER_ENCODING)) {
+            if (LOGGER.isDebugEnabled()) {
+                HttpClientContext clientContext = HttpClientContext.adapt(context);
+                LOGGER.debug(
+                        "{} removing {} header",
+                        clientContext.getExchangeId(),
+                        HttpHeaders.TRANSFER_ENCODING);
+            }
+            response.removeHeaders(HttpHeaders.TRANSFER_ENCODING);
+        }
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RequestRetryStrategy.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RequestRetryStrategy.java
@@ -1,0 +1,67 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.io.IOException;
+import org.apache.hc.client5.http.HttpRequestRetryStrategy;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
+
+/**
+ * A {@link HttpRequestRetryStrategy} that retries with the strategy available in the context,
+ * otherwise with the default strategy.
+ *
+ * @see DefaultHttpRequestRetryStrategy#INSTANCE
+ */
+public class RequestRetryStrategy implements HttpRequestRetryStrategy {
+
+    static final String CUSTOM_RETRY = "zap.request-retry-strategy";
+
+    private static final HttpRequestRetryStrategy DEFAULT_RETRY =
+            DefaultHttpRequestRetryStrategy.INSTANCE;
+
+    @Override
+    public boolean retryRequest(
+            HttpRequest request, IOException exception, int execCount, HttpContext context) {
+        return getRetryStrategy(context).retryRequest(request, exception, execCount, context);
+    }
+
+    private static HttpRequestRetryStrategy getRetryStrategy(HttpContext context) {
+        HttpRequestRetryStrategy retryStrategy =
+                (HttpRequestRetryStrategy) context.getAttribute(CUSTOM_RETRY);
+        if (retryStrategy == null) {
+            return DEFAULT_RETRY;
+        }
+        return retryStrategy;
+    }
+
+    @Override
+    public boolean retryRequest(HttpResponse response, int execCount, HttpContext context) {
+        return getRetryStrategy(context).retryRequest(response, execCount, context);
+    }
+
+    @Override
+    public TimeValue getRetryInterval(HttpResponse response, int execCount, HttpContext context) {
+        return getRetryStrategy(context).getRetryInterval(response, execCount, context);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/SslConnectionSocketFactory.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/SslConnectionSocketFactory.java
@@ -1,0 +1,204 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.security.SecureRandom;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import org.apache.hc.client5.http.socket.LayeredConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.HttpsSupport;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.util.TimeValue;
+import org.apache.hc.core5.util.Timeout;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.zaproxy.addon.network.ClientCertificatesOptions;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.CertificateEntry;
+import org.zaproxy.addon.network.internal.client.KeyStores;
+import org.zaproxy.addon.network.internal.client.LaxTrustManager;
+
+/**
+ * A {@link LayeredConnectionSocketFactory} that allows to trust all certificates, use a client
+ * certificate, or verify all certificates.
+ */
+public class SslConnectionSocketFactory implements LayeredConnectionSocketFactory {
+
+    static final String LAX_ATTR_NAME = "zap.ssl.lax";
+
+    private static final Logger LOGGER = LogManager.getLogger(SslConnectionSocketFactory.class);
+
+    private static final TrustManager[] LAX_TRUST_MANAGER =
+            new TrustManager[] {new LaxTrustManager()};
+    private static final HostnameVerifier ACCEPT_ALL_NAMES = (host, cert) -> true;
+
+    private static final String SSL = "SSL";
+
+    private final ConnectionOptions connectionOptions;
+    private final ClientCertificatesOptions clientCertificatesOptions;
+
+    private final KeyStores keyStores;
+
+    private final SSLConnectionSocketFactory strictSslConnectionSocketFactory;
+    private final SSLConnectionSocketFactory laxSslConnectionSocketFactory;
+
+    private CertificateEntry activeCertificate;
+    private SSLConnectionSocketFactory activeCertificateSslConnectionSocketFactory;
+
+    public SslConnectionSocketFactory(
+            ConnectionOptions connectionOptions,
+            ClientCertificatesOptions clientCertificatesOptions) {
+        this.connectionOptions = connectionOptions;
+        this.clientCertificatesOptions = clientCertificatesOptions;
+
+        keyStores = clientCertificatesOptions.getKeyStores();
+        keyStores.addChangeListener(
+                e -> {
+                    CertificateEntry currentActiveCertificate = keyStores.getActiveCertificate();
+                    if (currentActiveCertificate != activeCertificate) {
+                        activeCertificate = currentActiveCertificate;
+                        applyActiveCertificate();
+                    }
+                });
+        activeCertificate = keyStores.getActiveCertificate();
+        applyActiveCertificate();
+
+        strictSslConnectionSocketFactory =
+                new SSLConnectionSocketFactory(
+                        createSslSocketFactory(null), HttpsSupport.getDefaultHostnameVerifier());
+        laxSslConnectionSocketFactory =
+                createLaxSslSocketFactory(createSslSocketFactory(LAX_TRUST_MANAGER));
+    }
+
+    private void applyActiveCertificate() {
+        activeCertificateSslConnectionSocketFactory =
+                activeCertificate == null
+                        ? null
+                        : createLaxSslSocketFactory(activeCertificate.getSocketFactory());
+    }
+
+    private static SSLSocketFactory createSslSocketFactory(TrustManager[] trustManagers) {
+        try {
+            SSLContext sslContext = SSLContext.getInstance(SSL);
+            SecureRandom random = new SecureRandom();
+            random.setSeed(System.currentTimeMillis());
+            sslContext.init(null, trustManagers, random);
+            return sslContext.getSocketFactory();
+        } catch (Exception e) {
+            LOGGER.error(e.getMessage(), e);
+        }
+        return null;
+    }
+
+    private SSLConnectionSocketFactory createLaxSslSocketFactory(SSLSocketFactory socketFactory) {
+        return new SSLConnectionSocketFactory(socketFactory, ACCEPT_ALL_NAMES) {
+
+            @Override
+            protected void prepareSocket(SSLSocket socket) throws IOException {
+                socket.setEnabledProtocols(
+                        connectionOptions.getTlsProtocols().toArray(new String[0]));
+                socket.setEnabledCipherSuites(socket.getSupportedCipherSuites());
+            }
+        };
+    }
+
+    @Override
+    public Socket createSocket(HttpContext context) throws IOException {
+        return getSslConnectionSocketFactory(context).createSocket(context);
+    }
+
+    private LayeredConnectionSocketFactory getSslConnectionSocketFactory(HttpContext context) {
+        if (!isLax(context)) {
+            return strictSslConnectionSocketFactory;
+        }
+
+        LayeredConnectionSocketFactory clientCertificateSocketFactory =
+                activeCertificateSslConnectionSocketFactory;
+        if (clientCertificateSocketFactory != null
+                && clientCertificatesOptions.isUseCertificate()) {
+            return clientCertificateSocketFactory;
+        }
+        return laxSslConnectionSocketFactory;
+    }
+
+    private static boolean isLax(HttpContext context) {
+        return Boolean.TRUE.equals(context.getAttribute(LAX_ATTR_NAME));
+    }
+
+    @Override
+    public Socket createLayeredSocket(Socket socket, String target, int port, HttpContext context)
+            throws IOException {
+        return createLayeredSocket(socket, target, port, null, context);
+    }
+
+    @Override
+    public Socket createLayeredSocket(
+            Socket socket, String target, int port, Object attachment, HttpContext context)
+            throws IOException {
+        return getSslConnectionSocketFactory(context)
+                .createLayeredSocket(socket, target, port, attachment, context);
+    }
+
+    @Override
+    public Socket connectSocket(
+            TimeValue connectTimeout,
+            Socket socket,
+            HttpHost host,
+            InetSocketAddress remoteAddress,
+            InetSocketAddress localAddress,
+            HttpContext context)
+            throws IOException {
+        Timeout timeout =
+                connectTimeout != null
+                        ? Timeout.of(connectTimeout.getDuration(), connectTimeout.getTimeUnit())
+                        : null;
+        return connectSocket(socket, host, remoteAddress, localAddress, timeout, timeout, context);
+    }
+
+    @Override
+    public Socket connectSocket(
+            final Socket socket,
+            final HttpHost host,
+            final InetSocketAddress remoteAddress,
+            final InetSocketAddress localAddress,
+            final Timeout connectTimeout,
+            final Object attachment,
+            final HttpContext context)
+            throws IOException {
+
+        return getSslConnectionSocketFactory(context)
+                .connectSocket(
+                        socket,
+                        host,
+                        remoteAddress,
+                        localAddress,
+                        connectTimeout,
+                        attachment,
+                        context);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpClientContext.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpClientContext.java
@@ -1,0 +1,80 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.client5.http.RouteInfo;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.cookie.CookieSpecFactory;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.config.Lookup;
+
+/** A {@link HttpClientContext} with enhanced behaviour. */
+public class ZapHttpClientContext extends HttpClientContext {
+
+    private int requestCount;
+
+    private CookieStore cookieStore;
+    private Lookup<CookieSpecFactory> registry;
+    private RouteInfo route;
+    private RequestConfig config;
+    private HttpRequest request;
+
+    ZapHttpClientContext() {}
+
+    void increaseRequestCount() {
+        requestCount++;
+    }
+
+    public int getRequestCount() {
+        return requestCount;
+    }
+
+    boolean hasCookieSetup() {
+        return cookieStore != null;
+    }
+
+    public void setCookieSetup(
+            CookieStore cookieStore,
+            Lookup<CookieSpecFactory> registry,
+            RouteInfo route,
+            RequestConfig config,
+            HttpRequest request) {
+        this.cookieStore = cookieStore;
+        this.registry = registry;
+        this.route = route;
+        this.config = config;
+        this.request = request;
+    }
+
+    HttpRequest getFirstRequest() {
+        return request;
+    }
+
+    HttpClientContext getCookieContext() {
+        HttpClientContext context = new HttpClientContext();
+        context.setCookieStore(cookieStore);
+        context.setCookieSpecRegistry(registry);
+        context.setAttribute(HttpClientContext.HTTP_ROUTE, route);
+        context.setRequestConfig(config);
+        return context;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpRequestExecutor.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapHttpRequestExecutor.java
@@ -1,0 +1,129 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.Locale;
+import org.apache.hc.client5.http.io.ManagedHttpClientConnection;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpException;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.ProtocolException;
+import org.apache.hc.core5.http.impl.io.DefaultClassicHttpResponseFactory;
+import org.apache.hc.core5.http.impl.io.HttpRequestExecutor;
+import org.apache.hc.core5.http.io.HttpClientConnection;
+import org.apache.hc.core5.http.io.HttpResponseInformationCallback;
+import org.apache.hc.core5.http.message.MessageSupport;
+import org.apache.hc.core5.http.message.StatusLine;
+import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.http.protocol.HttpCoreContext;
+import org.apache.hc.core5.io.Closer;
+
+/**
+ * A {@link HttpRequestExecutor} that does not try to read the response if switching protocols or if
+ * the response is an event stream.
+ */
+public class ZapHttpRequestExecutor extends HttpRequestExecutor {
+
+    public static final String CONNECTION_SOCKET = "zap.connection.socket";
+    public static final String CONNECTION_INPUT_STREAM = "zap.connection.inputstream";
+
+    public ZapHttpRequestExecutor() {
+        super(DEFAULT_WAIT_FOR_CONTINUE, null, null);
+    }
+
+    @Override
+    public ClassicHttpResponse execute(
+            ClassicHttpRequest request,
+            HttpClientConnection conn,
+            HttpResponseInformationCallback informationCallback,
+            HttpContext context)
+            throws IOException, HttpException {
+        try {
+            context.setAttribute(HttpCoreContext.SSL_SESSION, conn.getSSLSession());
+            context.setAttribute(HttpCoreContext.CONNECTION_ENDPOINT, conn.getEndpointDetails());
+
+            conn.sendRequestHeader(request);
+            conn.sendRequestEntity(request);
+            conn.flush();
+            ClassicHttpResponse response = null;
+            while (response == null) {
+                response = conn.receiveResponseHeader();
+                int status = response.getCode();
+                if (status < HttpStatus.SC_INFORMATIONAL) {
+                    throw new ProtocolException("Invalid response: " + new StatusLine(response));
+                }
+                if (status < HttpStatus.SC_SUCCESS) {
+                    if (informationCallback != null && status != HttpStatus.SC_CONTINUE) {
+                        informationCallback.execute(response, conn, context);
+                    }
+                    if (status != HttpStatus.SC_SWITCHING_PROTOCOLS) {
+                        response = null;
+                    }
+                }
+            }
+            if (response.getCode() == HttpStatus.SC_SWITCHING_PROTOCOLS
+                    || isEventStream(response)) {
+                if (conn instanceof ManagedHttpClientConnection) {
+                    HttpClientContext clientContext = HttpClientContext.adapt(context);
+                    clientContext.setUserToken("zap.connection.stream");
+
+                    Socket socket = ((ManagedHttpClientConnection) conn).getSocket();
+                    context.setAttribute(CONNECTION_SOCKET, socket);
+
+                    ClassicHttpResponse r =
+                            DefaultClassicHttpResponseFactory.INSTANCE.newHttpResponse(200);
+                    Header transferEncoding = response.getLastHeader(HttpHeaders.TRANSFER_ENCODING);
+                    if (transferEncoding != null) {
+                        r.addHeader(transferEncoding);
+                    }
+                    conn.receiveResponseEntity(r);
+                    context.setAttribute(CONNECTION_INPUT_STREAM, r.getEntity().getContent());
+                } else {
+                    response = null;
+                }
+
+            } else if (MessageSupport.canResponseHaveBody(request.getMethod(), response)) {
+                conn.receiveResponseEntity(response);
+            }
+            return response;
+
+        } catch (final HttpException | IOException | RuntimeException ex) {
+            Closer.closeQuietly(conn);
+            throw ex;
+        }
+    }
+
+    private static boolean isEventStream(ClassicHttpResponse response) {
+        for (Header contentType : response.getHeaders(HttpHeaders.CONTENT_TYPE)) {
+            if (contentType != null
+                    && contentType.getValue() != null
+                    && contentType.getValue().toLowerCase(Locale.ROOT).contains("event-stream")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapPoolingHttpClientConnectionManager.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/ZapPoolingHttpClientConnectionManager.java
@@ -1,0 +1,57 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import org.apache.hc.client5.http.impl.io.ManagedHttpClientConnectionFactory;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.ZapHttpClientConnectionOperator;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.LayeredConnectionSocketFactory;
+import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
+import org.apache.hc.core5.http.URIScheme;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
+import org.apache.hc.core5.pool.PoolReusePolicy;
+
+/** A {@link PoolingHttpClientConnectionManager} with custom configuration. */
+public class ZapPoolingHttpClientConnectionManager extends PoolingHttpClientConnectionManager {
+
+    public ZapPoolingHttpClientConnectionManager(
+            LayeredConnectionSocketFactory sslSocketFactory,
+            ManagedHttpClientConnectionFactory connectionFactory) {
+        super(
+                new ZapHttpClientConnectionOperator(
+                        RegistryBuilder.<ConnectionSocketFactory>create()
+                                .register(
+                                        URIScheme.HTTP.id,
+                                        PlainConnectionSocketFactory.getSocketFactory())
+                                .register(URIScheme.HTTPS.id, sslSocketFactory)
+                                .build(),
+                        null,
+                        null),
+                PoolConcurrencyPolicy.LAX,
+                PoolReusePolicy.LIFO,
+                null,
+                connectionFactory);
+
+        setDefaultMaxPerRoute(100);
+        setMaxTotal(getDefaultMaxPerRoute() * 100);
+    }
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/core/HttpSenderContext.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/core/HttpSenderContext.java
@@ -1,0 +1,42 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.core;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.users.User;
+
+public interface HttpSenderContext {
+
+    void setUseGlobalState(boolean use);
+
+    void setUseCookies(boolean use);
+
+    void setFollowRedirects(boolean followRedirects);
+
+    void setMaxRedirects(int max);
+
+    void setMaxRetriesOnIoError(int max);
+
+    void setRemoveUserDefinedAuthHeaders(boolean remove);
+
+    void setUser(User user);
+
+    User getUser(HttpMessage msg);
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/core/HttpSenderImpl.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/core/HttpSenderImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.core;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.network.HttpSenderListener;
+
+public interface HttpSenderImpl<T extends HttpSenderContext> {
+
+    boolean isGlobalStateEnabled();
+
+    void addListener(HttpSenderListener listener);
+
+    void removeListener(HttpSenderListener listener);
+
+    T createContext(HttpSender parent, int initiator);
+
+    void sendAndReceive(T ctx, HttpRequestConfig config, HttpMessage msg, Path file)
+            throws IOException;
+}

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/CertificatesTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/CertificatesTableModel.java
@@ -19,10 +19,11 @@
  */
 package org.zaproxy.addon.network.internal.ui;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.client.CertificateEntry;
 
 public class CertificatesTableModel extends AbstractTableModel {
 
@@ -35,21 +36,24 @@ public class CertificatesTableModel extends AbstractTableModel {
 
     private static final int COLUMN_COUNT = COLUMN_NAMES.length;
 
-    private final List<String> certificates;
+    private List<CertificateEntry> certificates;
 
     public CertificatesTableModel() {
-        certificates = new ArrayList<>();
+        certificates = Collections.emptyList();
     }
 
-    public void addCertificate(String certificate) {
-        certificates.add(certificate);
-        int index = certificates.size() - 1;
-        fireTableRowsInserted(index, index);
+    public void setCertificates(List<CertificateEntry> certificates) {
+        this.certificates = certificates;
+        fireTableDataChanged();
     }
 
     public void clear() {
-        certificates.clear();
+        certificates = Collections.emptyList();
         fireTableDataChanged();
+    }
+
+    public CertificateEntry getCertificateEntry(int rowIndex) {
+        return certificates.get(rowIndex);
     }
 
     @Override
@@ -74,6 +78,6 @@ public class CertificatesTableModel extends AbstractTableModel {
 
     @Override
     public Object getValueAt(int rowIndex, int columnIndex) {
-        return certificates.get(rowIndex);
+        return certificates.get(rowIndex).getName();
     }
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/KeyStoresTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/KeyStoresTableModel.java
@@ -19,10 +19,10 @@
  */
 package org.zaproxy.addon.network.internal.ui;
 
-import java.util.ArrayList;
-import java.util.List;
+import javax.swing.event.ChangeEvent;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
+import org.zaproxy.addon.network.internal.client.KeyStores;
 
 /** A table model for KeyStores. */
 public class KeyStoresTableModel extends AbstractTableModel {
@@ -36,31 +36,24 @@ public class KeyStoresTableModel extends AbstractTableModel {
 
     private static final int COLUMN_COUNT = COLUMN_NAMES.length;
 
-    private final List<String> keyStores;
+    private KeyStores keyStores;
 
-    public KeyStoresTableModel() {
-        keyStores = new ArrayList<>();
-    }
+    public void setKeyStores(KeyStores keyStores) {
+        if (this.keyStores != null) {
+            this.keyStores.removeChangeListener(this::keyStoresChanged);
+        }
 
-    public void clear() {
-        keyStores.clear();
+        this.keyStores = keyStores;
+
+        if (keyStores != null) {
+            keyStores.addChangeListener(this::keyStoresChanged);
+        }
+
         fireTableDataChanged();
     }
 
-    public void add(String name) {
-        keyStores.add(name);
-        int index = keyStores.size() - 1;
-        fireTableRowsInserted(index, index);
-    }
-
-    public void add(int index, String name) {
-        keyStores.add(index, name);
-        fireTableRowsInserted(index, index);
-    }
-
-    public void remove(int index) {
-        keyStores.remove(index);
-        fireTableRowsDeleted(index, index);
+    private void keyStoresChanged(ChangeEvent e) {
+        fireTableDataChanged();
     }
 
     @Override
@@ -80,11 +73,17 @@ public class KeyStoresTableModel extends AbstractTableModel {
 
     @Override
     public int getRowCount() {
+        if (keyStores == null) {
+            return 0;
+        }
         return keyStores.size();
     }
 
     @Override
-    public String getValueAt(int rowIndex, int columnIndex) {
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        if (keyStores == null) {
+            return null;
+        }
         return keyStores.get(rowIndex);
     }
 }

--- a/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
+++ b/addOns/network/src/main/resources/org/zaproxy/addon/network/resources/Messages.properties
@@ -165,7 +165,6 @@ network.ui.options.clientcertificates.keystore.view = View
 network.ui.options.clientcertificates.error = Error
 network.ui.options.clientcertificates.error.accesskeystore = Error accessing KeyStore:
 network.ui.options.clientcertificates.error.cert.title = Client Certificate
-network.ui.options.clientcertificates.error.fingerprint = Error calculating key fingerprint:
 network.ui.options.clientcertificates.error.pkcs11.pinempty = The PIN was not provided.
 network.ui.options.clientcertificates.error.pkcs11.lib = Try to specify the PKCS#11 library again...
 network.ui.options.clientcertificates.error.pkcs11.notavailable = <html><body><p>The required Sun/IBM PKCS#11 provider is not available.</p><p>For more information visit the pages:</p></body></html>

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
@@ -1,0 +1,1074 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.NettyRuntime;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.io.IOException;
+import java.net.PasswordAuthentication;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.hc.client5.http.cookie.CookieStore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InOrder;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.ClientCertificatesOptions;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.apachev5.HttpSenderApache;
+import org.zaproxy.addon.network.server.Server;
+import org.zaproxy.addon.network.testutils.TestHttpServer;
+import org.zaproxy.addon.network.testutils.TestHttpServer.TestHttpMessageHandler;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.network.HttpSenderListener;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+/** Unit test for {@link HttpSender} implementations. */
+class HttpSenderImplUnitTest {
+
+    private static final int INITIATOR = -1234;
+
+    private static final String PROXY_RESPONSE = "Proxy Response";
+    private static final String SERVER_RESPONSE = "Server Response";
+    private static final String DEFAULT_SERVER_HEADER = "HTTP/1.1 200 OK";
+
+    private static NioEventLoopGroup group;
+    private static EventExecutorGroup mainHandlerExecutor;
+
+    private TestHttpMessageHandler defaultHandler;
+    private TestHttpServer server;
+    private int serverPort;
+
+    private HttpMessage message;
+
+    private CookieStore globalCookieStore;
+    private ConnectionOptions options;
+    private ClientCertificatesOptions clientCertificatesOptions;
+    private KeyStores keyStores;
+
+    private HttpSenderImplWrapper<?> httpSender;
+
+    @BeforeAll
+    static void setupAll() throws Exception {
+        group = new NioEventLoopGroup(new DefaultThreadFactory("ZAP-HttpSenderImplUnitTest"));
+        mainHandlerExecutor =
+                new DefaultEventExecutorGroup(
+                        NettyRuntime.availableProcessors() * 2,
+                        new DefaultThreadFactory("ZAP-HttpSenderImplUnitTest-Events"));
+    }
+
+    @AfterAll
+    static void tearDownAll() throws Exception {
+        if (group != null) {
+            group.shutdownGracefully();
+            group = null;
+        }
+
+        if (mainHandlerExecutor != null) {
+            mainHandlerExecutor.shutdownGracefully();
+            mainHandlerExecutor = null;
+        }
+    }
+
+    @BeforeEach
+    void setup() throws IOException {
+        server = new TestHttpServer(group, mainHandlerExecutor);
+        defaultHandler =
+                (ctx, msg) -> {
+                    msg.setResponseHeader(DEFAULT_SERVER_HEADER);
+                    msg.setResponseBody(SERVER_RESPONSE);
+                    msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                };
+        server.setHttpMessageHandler(defaultHandler);
+        serverPort = server.start(Server.ANY_PORT);
+
+        message = createMessage("GET", "/");
+
+        options = new ConnectionOptions();
+        options.load(new ZapXmlConfiguration());
+        clientCertificatesOptions = mock(ClientCertificatesOptions.class);
+        keyStores = mock(KeyStores.class);
+        given(clientCertificatesOptions.getKeyStores()).willReturn(keyStores);
+
+        httpSender =
+                new HttpSenderImplWrapper<>(
+                        new HttpSenderApache(
+                                () -> globalCookieStore, options, clientCertificatesOptions),
+                        INITIATOR);
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        server.close();
+        httpSender.close();
+    }
+
+    @Test
+    void shouldThrowWhenAddingNullHttpSenderListener() throws Exception {
+        // Given
+        HttpSenderListener listener = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> httpSender.addListener(listener));
+    }
+
+    @Test
+    void shouldThrowWhenRemovingNullHttpSenderListener() throws Exception {
+        // Given
+        HttpSenderListener listener = null;
+        // When / Then
+        assertThrows(NullPointerException.class, () -> httpSender.addListener(listener));
+    }
+
+    static Stream<SenderMethod> sendAndReceiveMethods() {
+        return Stream.of(
+                (httpSender, httpMessage) -> httpSender.sendAndReceive(httpMessage),
+                (httpSender, httpMessage) -> httpSender.sendAndReceive(httpMessage, false),
+                (httpSender, httpMessage) ->
+                        httpSender.sendAndReceive(
+                                httpMessage, HttpRequestConfig.builder().build()));
+    }
+
+    static Stream<Arguments> requestMethodsAndSendAndReceiveMethods() {
+        return Stream.of(
+                        "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE",
+                        "TRACK", "XYZ")
+                .flatMap(method -> sendAndReceiveMethods().map(sm -> arguments(method, sm)));
+    }
+
+    @Nested
+    class Request {
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#requestMethodsAndSendAndReceiveMethods")
+        void shouldBeSentWithBodyForAnyMethod(String requestMethod, SenderMethod method)
+                throws Exception {
+            // Given
+            String requestBody = "Request Body";
+            message.getRequestHeader().setMethod(requestMethod);
+            message.setRequestBody(requestBody);
+            message.getRequestHeader().setContentLength(message.getRequestBody().length());
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            HttpMessage receivedMessage = server.getReceivedMessages().get(0);
+            assertThat(
+                    receivedMessage.getRequestHeader().toString(),
+                    is(
+                            equalTo(
+                                    requestMethod
+                                            + " "
+                                            + getServerUri("/")
+                                            + " HTTP/1.1\r\n"
+                                            + "Content-Length: 12\r\n"
+                                            + "Host: localhost:"
+                                            + serverPort
+                                            + "\r\n"
+                                            + "\r\n")));
+            assertThat(receivedMessage.getRequestBody().toString(), is(equalTo(requestBody)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeSentWithExistingHostHeaderRemainingInPlace(SenderMethod method)
+                throws Exception {
+            // Given
+            message.getRequestHeader().setHeader("Host", "localhost:" + serverPort);
+            message.getRequestHeader().setContentLength(message.getRequestBody().length());
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            HttpMessage receivedMessage = server.getReceivedMessages().get(0);
+            assertThat(
+                    receivedMessage.getRequestHeader().toString(),
+                    is(
+                            equalTo(
+                                    "GET "
+                                            + getServerUri("/")
+                                            + " HTTP/1.1\r\n"
+                                            + "Host: localhost:"
+                                            + serverPort
+                                            + "\r\n"
+                                            + "Content-Length: 0\r\n"
+                                            + "\r\n")));
+            assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeSentWithUpdatedHostHeaderRemainingInPlace(SenderMethod method)
+                throws Exception {
+            // Given
+            message.getRequestHeader().setHeader("Host", "example.org:" + serverPort);
+            message.getRequestHeader().setContentLength(message.getRequestBody().length());
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            HttpMessage receivedMessage = server.getReceivedMessages().get(0);
+            assertThat(
+                    receivedMessage.getRequestHeader().toString(),
+                    is(
+                            equalTo(
+                                    "GET "
+                                            + getServerUri("/")
+                                            + " HTTP/1.1\r\n"
+                                            + "Host: localhost:"
+                                            + serverPort
+                                            + "\r\n"
+                                            + "Content-Length: 0\r\n"
+                                            + "\r\n")));
+            assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeSentWithHostHeaderIfNotAlreadyPresent(SenderMethod method) throws Exception {
+            // Given
+            message.getRequestHeader().setHeader("Host", null);
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            HttpMessage receivedMessage = server.getReceivedMessages().get(0);
+            assertThat(
+                    receivedMessage.getRequestHeader().toString(),
+                    is(
+                            equalTo(
+                                    "GET "
+                                            + getServerUri("/")
+                                            + " HTTP/1.1\r\n"
+                                            + "Host: localhost:"
+                                            + serverPort
+                                            + "\r\n\r\n")));
+            assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeSentWithIncorrectContentLength(SenderMethod method) throws Exception {
+            // Given
+            message.getRequestHeader().setHeader("Host", "localhost:" + serverPort);
+            message.getRequestHeader().setContentLength(42);
+            server.setFixedLengthMessage(61);
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            HttpMessage receivedMessage = server.getReceivedMessages().get(0);
+            assertThat(
+                    receivedMessage.getRequestHeader().toString(),
+                    is(
+                            equalTo(
+                                    "GET "
+                                            + getServerUri("/")
+                                            + " HTTP/1.1\r\n"
+                                            + "Host: localhost:"
+                                            + serverPort
+                                            + "\r\n"
+                                            + "Content-Length: 42\r\n"
+                                            + "\r\n")));
+            assertThat(receivedMessage.getRequestBody().toString(), is(equalTo("")));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#requestMethodsAndSendAndReceiveMethods")
+        void shouldBeSentWithRetriesOnIoError(String requestMethod, SenderMethod method)
+                throws Exception {
+            // Given
+            String requestBody = "Request Body";
+            message.getRequestHeader().setMethod(requestMethod);
+            message.setRequestBody(requestBody);
+            message.getRequestHeader().setContentLength(message.getRequestBody().length());
+            int maxRetries = 5;
+            httpSender.setMaxRetriesOnIOError(maxRetries);
+            MutableInt counter = new MutableInt();
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        if (counter.incrementAndGet() < maxRetries) {
+                            ctx.close();
+                            return;
+                        }
+                        defaultHandler.handleMessage(ctx, msg);
+                    });
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(maxRetries));
+            for (HttpMessage receivedMessage : server.getReceivedMessages()) {
+                assertThat(
+                        receivedMessage.getRequestHeader().toString(),
+                        is(
+                                equalTo(
+                                        requestMethod
+                                                + " "
+                                                + getServerUri("/")
+                                                + " HTTP/1.1\r\n"
+                                                + "Content-Length: 12\r\n"
+                                                + "Host: localhost:"
+                                                + serverPort
+                                                + "\r\n"
+                                                + "\r\n")));
+                assertThat(receivedMessage.getRequestBody().toString(), is(equalTo(requestBody)));
+            }
+        }
+    }
+
+    @Nested
+    class Response {
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldHaveDataReceived(SenderMethod method) throws Exception {
+            // Given
+            String responseHeader =
+                    "HTTP/1.1 500 Reason\r\nHeader1: HeaderValue\r\nX: y\r\nContent-Length: 13\r\n\r\n";
+            String responseBody = "Response Body";
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        msg.setResponseHeader(responseHeader);
+                        msg.setResponseBody(responseBody);
+                    });
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            assertThat(message.getResponseHeader().toString(), is(equalTo(responseHeader)));
+            assertThat(message.getResponseBody().toString(), is(equalTo(responseBody)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldHaveTimingsSet(SenderMethod method) throws Exception {
+            // Given
+            long now = System.currentTimeMillis();
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            assertThat(message.getTimeSentMillis(), is(greaterThanOrEqualTo(now)));
+            assertThat(message.getTimeElapsedMillis(), is(greaterThan(0)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeFromTargetIfRequestSent(SenderMethod method) throws Exception {
+            // Given / When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            assertThat(message.isResponseFromTargetHost(), is(equalTo(true)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldNotBeFromTargetIfRequestNotSent(SenderMethod method) throws Exception {
+            // Given
+            server.setHttpMessageHandler((ctx, msg) -> ctx.close());
+            // When
+            assertThrows(IOException.class, () -> method.sendWith(httpSender, message));
+            // Then
+            assertThat(server.getReceivedMessages(), is(not(empty())));
+            assertThat(message.isResponseFromTargetHost(), is(equalTo(false)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldHaveContentEncodingsSetToBody() throws Exception {
+            // Given
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        msg.setResponseHeader("HTTP/1.1 200 OK\r\nContent-Encoding: gzip");
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+            // When
+            httpSender.sendAndReceive(message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            assertThat(message.getResponseBody().getContentEncodings(), is(not(empty())));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldNotHaveContentEncodingsSetToBodyIfNoneInHeader() throws Exception {
+            // Given / When
+            httpSender.sendAndReceive(message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            assertThat(message.getResponseBody().getContentEncodings(), is(empty()));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethodsWithRedirections")
+        void shouldContainFinalResponseOfFollowedRedirections(SenderMethod method)
+                throws Exception {
+            // Given
+            int expectedMessages = 3;
+            AtomicInteger requestCounter = new AtomicInteger(1);
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        int requestCount = requestCounter.getAndIncrement();
+                        if (requestCount < expectedMessages) {
+                            msg.setResponseHeader("HTTP/1.1 302");
+                            msg.getResponseHeader()
+                                    .setHeader("Location", getServerUri("/redir" + requestCount));
+                        } else {
+                            msg.setResponseHeader("HTTP/1.1 200");
+                            msg.setResponseBody("Final Response");
+                        }
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(expectedMessages));
+            assertThat(
+                    message.getRequestHeader().getURI().toString(), is(equalTo(getServerUri("/"))));
+            assertThat(message.getResponseHeader().getStatusCode(), is(equalTo(200)));
+            assertThat(message.getResponseBody().toString(), is(equalTo("Final Response")));
+        }
+    }
+
+    static Stream<SenderMethod> sendAndReceiveMethodsWithRedirections() {
+        return Stream.of(
+                (httpSender, httpMessage) -> {
+                    httpSender.setFollowRedirect(true);
+                    httpSender.sendAndReceive(httpMessage);
+                },
+                (httpSender, httpMessage) -> httpSender.sendAndReceive(httpMessage, true),
+                (httpSender, httpMessage) ->
+                        httpSender.sendAndReceive(
+                                httpMessage,
+                                HttpRequestConfig.builder().setFollowRedirects(true).build()));
+    }
+
+    @Nested
+    @Timeout(60)
+    class Listeners {
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeNotifiedWhenSendAndReceive(SenderMethod method) throws Exception {
+            // Given
+            HttpSenderListener listener = mock(HttpSenderListener.class);
+            httpSender.addListener(listener);
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            verify(listener).onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            verify(listener).onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethodsWithRedirections")
+        void shouldBeNotifiedOfAllFollowedRedirections(SenderMethod method) throws Exception {
+            // Given
+            int expectedMessages = 4;
+            AtomicInteger requestCounter = new AtomicInteger(1);
+            server.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        int requestCount = requestCounter.getAndIncrement();
+                        if (requestCount < expectedMessages) {
+                            msg.setResponseHeader("HTTP/1.1 302");
+                            msg.getResponseHeader()
+                                    .setHeader("Location", getServerUri("/redir" + requestCount));
+                        } else {
+                            msg.setResponseHeader("HTTP/1.1 200");
+                        }
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+            TestHttpSenderListener listener = new TestHttpSenderListener();
+            httpSender.addListener(listener);
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(expectedMessages));
+            List<HttpMessage> messagesNotified = listener.getMessages();
+            assertThat(messagesNotified, hasSize(expectedMessages));
+            assertThat(
+                    messagesNotified.get(0).getRequestHeader().getURI().toString(),
+                    is(equalTo(getServerUri("/redir1"))));
+            assertThat(
+                    messagesNotified.get(0).getResponseHeader().getStatusCode(), is(equalTo(302)));
+            assertThat(
+                    messagesNotified.get(1).getRequestHeader().getURI().toString(),
+                    is(equalTo(getServerUri("/redir2"))));
+            assertThat(
+                    messagesNotified.get(1).getResponseHeader().getStatusCode(), is(equalTo(302)));
+            assertThat(
+                    messagesNotified.get(2).getRequestHeader().getURI().toString(),
+                    is(equalTo(getServerUri("/redir3"))));
+            assertThat(
+                    messagesNotified.get(2).getResponseHeader().getStatusCode(), is(equalTo(200)));
+            assertThat(
+                    messagesNotified.get(3).getRequestHeader().getURI().toString(),
+                    is(equalTo(getServerUri("/"))));
+            assertThat(
+                    messagesNotified.get(3).getResponseHeader().getStatusCode(), is(equalTo(200)));
+        }
+
+        @Test
+        void shouldNotBeNotifiedWhenNotificationIsDisabled() throws Exception {
+            // Given
+            HttpSenderListener listener = mock(HttpSenderListener.class);
+            httpSender.addListener(listener);
+            HttpRequestConfig requestConfig =
+                    HttpRequestConfig.builder().setNotifyListeners(false).build();
+            // When
+            httpSender.sendAndReceive(message, requestConfig);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            verifyNoInteractions(listener);
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeNotifiedInListenerOrder(SenderMethod method) throws Exception {
+            // Given
+            HttpSenderListener listener1 = mock(HttpSenderListener.class);
+            given(listener1.getListenerOrder()).willReturn(1);
+            httpSender.addListener(listener1);
+            HttpSenderListener listener2 = mock(HttpSenderListener.class);
+            given(listener2.getListenerOrder()).willReturn(2);
+            httpSender.addListener(listener2);
+            HttpSenderListener listener3 = mock(HttpSenderListener.class);
+            given(listener3.getListenerOrder()).willReturn(-1);
+            httpSender.addListener(listener3);
+            HttpSenderListener listener4 = mock(HttpSenderListener.class);
+            given(listener4.getListenerOrder()).willReturn(2);
+            httpSender.addListener(listener4);
+            InOrder inOrder = inOrder(listener1, listener2, listener3, listener4);
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            inOrder.verify(listener3).onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            inOrder.verify(listener1).onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            inOrder.verify(listener2).onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            inOrder.verify(listener4).onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            inOrder.verify(listener3)
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+            inOrder.verify(listener1)
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+            inOrder.verify(listener2)
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+            inOrder.verify(listener4)
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldContinueToBeNotifiedAfterListenerExceptions(SenderMethod method)
+                throws Exception {
+            // Given
+            HttpSenderListener listener = mock(HttpSenderListener.class);
+            doThrow(NullPointerException.class)
+                    .when(listener)
+                    .onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            doThrow(NullPointerException.class)
+                    .when(listener)
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+            httpSender.addListener(listener);
+            // When
+            method.sendWith(httpSender, message);
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(2));
+            verify(listener, times(2))
+                    .onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            verify(listener, times(2))
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldContinueToBeNotifiedAfterOtherListenerExceptions(SenderMethod method)
+                throws Exception {
+            // Given
+            HttpSenderListener listener1 = mock(HttpSenderListener.class);
+            doThrow(NullPointerException.class)
+                    .when(listener1)
+                    .onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            doThrow(NullPointerException.class)
+                    .when(listener1)
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+            given(listener1.getListenerOrder()).willReturn(1);
+            httpSender.addListener(listener1);
+            HttpSenderListener listener2 = mock(HttpSenderListener.class);
+            given(listener2.getListenerOrder()).willReturn(2);
+            httpSender.addListener(listener2);
+            // When
+            method.sendWith(httpSender, message);
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(2));
+            verify(listener2, times(2))
+                    .onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            verify(listener2, times(2))
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeNotifiedConcurrentlyFromSameHttpSender(SenderMethod method) throws Exception {
+            // Given
+            CyclicBarrier barrier = new CyclicBarrier(3);
+            TestHttpSenderListener listener =
+                    new TestHttpSenderListener(
+                            (messages, message, initiator, sender) -> {
+                                messages.add(message);
+                                barrier.await();
+                            });
+            httpSender.addListener(listener);
+            HttpMessage message2 = createMessage("GET", "/");
+            ForkJoinPool pool = new ForkJoinPool(2);
+            // When
+            pool.submit(
+                    () -> {
+                        method.sendWith(httpSender, message);
+                        return null;
+                    });
+            pool.submit(
+                    () -> {
+                        method.sendWith(httpSender, message2);
+                        return null;
+                    });
+            // Then
+            barrier.await();
+            pool.shutdown();
+            assertThat(barrier.isBroken(), is(equalTo(false)));
+            assertThat(server.getReceivedMessages(), hasSize(2));
+            assertThat(
+                    listener.getMessages(),
+                    containsInAnyOrder(sameInstance(message), sameInstance(message2)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldBeNotifiedConcurrentlyFromDifferentHttpSenders(SenderMethod method)
+                throws Exception {
+            // Given
+            CyclicBarrier barrier = new CyclicBarrier(3);
+            TestHttpSenderListener listener =
+                    new TestHttpSenderListener(
+                            (messages, message, initiator, sender) -> {
+                                messages.add(message);
+                                barrier.await();
+                            });
+            httpSender.addListener(listener);
+            HttpSenderImplWrapper<?> httpSender2 =
+                    new HttpSenderImplWrapper<>(
+                            new HttpSenderApache(
+                                    () -> globalCookieStore, options, clientCertificatesOptions),
+                            INITIATOR);
+            httpSender2.addListener(listener);
+            HttpMessage message2 = createMessage("GET", "/");
+            ForkJoinPool pool = new ForkJoinPool(2);
+            // When
+            pool.submit(
+                    () -> {
+                        method.sendWith(httpSender, message);
+                        return null;
+                    });
+            pool.submit(
+                    () -> {
+                        method.sendWith(httpSender2, message2);
+                        return null;
+                    });
+            // Then
+            barrier.await();
+            pool.shutdown();
+            httpSender2.close();
+            assertThat(barrier.isBroken(), is(equalTo(false)));
+            assertThat(server.getReceivedMessages(), hasSize(2));
+            assertThat(
+                    listener.getMessages(),
+                    containsInAnyOrder(sameInstance(message), sameInstance(message2)));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldNotBeNotifiedForMessagesSentFromThemselves(SenderMethod method)
+                throws Exception {
+            // Given
+            TestHttpSenderListener listener =
+                    new TestHttpSenderListener(
+                            (messages, message, initiator, sender) -> {
+                                messages.add(message);
+                                sender.sendAndReceive(message.cloneRequest());
+                            });
+            httpSender.addListener(listener);
+            // When
+            method.sendWith(httpSender, message);
+            // Then
+            assertThat(server.getReceivedMessages(), hasSize(2));
+            assertThat(listener.getMessages(), hasSize(1));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldNotBeAbleToAddOtherListenersWhenNotifiedOfRequest(SenderMethod method)
+                throws Exception {
+            // Given
+            HttpSenderListener listener1 = mock(HttpSenderListener.class);
+            HttpSenderListener listener2 = mock(HttpSenderListener.class);
+            doAnswer(
+                            invocation -> {
+                                httpSender.addListener(listener2);
+                                return null;
+                            })
+                    .when(listener1)
+                    .onHttpRequestSend(message, INITIATOR, httpSender.getParent());
+            httpSender.addListener(listener1);
+            // When / Then
+            assertThrows(
+                    ConcurrentModificationException.class,
+                    () -> method.sendWith(httpSender, message));
+        }
+
+        @ParameterizedTest
+        @MethodSource(
+                "org.zaproxy.addon.network.internal.client.HttpSenderImplUnitTest#sendAndReceiveMethods")
+        void shouldNotBeAbleToAddOtherListenersWhenNotifiedOfResponse(SenderMethod method)
+                throws Exception {
+            // Given
+            HttpSenderListener listener1 = mock(HttpSenderListener.class);
+            HttpSenderListener listener2 = mock(HttpSenderListener.class);
+            doAnswer(
+                            invocation -> {
+                                httpSender.addListener(listener2);
+                                return null;
+                            })
+                    .when(listener1)
+                    .onHttpResponseReceive(message, INITIATOR, httpSender.getParent());
+            httpSender.addListener(listener1);
+            // When / Then
+            assertThrows(
+                    ConcurrentModificationException.class,
+                    () -> method.sendWith(httpSender, message));
+        }
+    }
+
+    @Nested
+    class Proxy {
+
+        private TestHttpServer proxy;
+        private int proxyPort;
+
+        @BeforeEach
+        void setup() throws IOException {
+            proxy = new TestHttpServer(group, mainHandlerExecutor);
+            proxy.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        msg.setResponseHeader(DEFAULT_SERVER_HEADER);
+                        msg.setResponseBody(PROXY_RESPONSE);
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+            proxyPort = proxy.start(Server.ANY_PORT);
+        }
+
+        @AfterEach
+        void teardown() throws IOException {
+            proxy.close();
+        }
+
+        @Test
+        void shouldProxyIfEnabled() throws Exception {
+            // Given
+            configOptionsWithProxy("localhost", proxyPort);
+            // When
+            httpSender.sendAndReceive(message);
+            // Then
+            assertThat(proxy.getReceivedMessages(), hasSize(1));
+            assertThat(
+                    proxy.getReceivedMessages().get(0).getRequestHeader().getHeader("host"),
+                    is(equalTo("localhost:" + serverPort)));
+            assertThat(server.getReceivedMessages(), hasSize(0));
+            assertThat(message.getResponseBody().toString(), is(equalTo(PROXY_RESPONSE)));
+        }
+
+        @Test
+        void shouldNotProxyIfDisabled() throws Exception {
+            // Given
+            configOptionsWithProxy("localhost", proxyPort);
+            options.setHttpProxyEnabled(false);
+            // When
+            httpSender.sendAndReceive(message);
+            // Then
+            assertThat(proxy.getReceivedMessages(), hasSize(0));
+            assertThat(server.getReceivedMessages(), hasSize(1));
+            assertThat(
+                    server.getReceivedMessages().get(0).getRequestHeader().getHeader("host"),
+                    is(equalTo("localhost:" + serverPort)));
+            assertThat(message.getResponseBody().toString(), is(equalTo(SERVER_RESPONSE)));
+        }
+
+        @Test
+        void shouldNotAuthenticateToProxyIfAuthDisabled() throws Exception {
+            // Given
+            proxy.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        msg.setResponseHeader(
+                                "HTTP/1.1 407\r\nProxy-Authenticate: Basic realm=\"\"\r\n");
+                        msg.setResponseBody(PROXY_RESPONSE);
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+            configOptionsWithProxy("localhost", proxyPort);
+            options.setHttpProxyAuthEnabled(false);
+            // When
+            httpSender.sendAndReceive(message);
+            // Then
+            assertThat(proxy.getReceivedMessages(), hasSize(1));
+            assertThat(
+                    proxy.getReceivedMessages()
+                            .get(0)
+                            .getRequestHeader()
+                            .getHeader("Proxy-Authorization"),
+                    is(nullValue()));
+            assertThat(
+                    proxy.getReceivedMessages().get(0).getRequestHeader().getHeader("host"),
+                    is(equalTo("localhost:" + serverPort)));
+            assertThat(server.getReceivedMessages(), hasSize(0));
+            assertThat(message.getResponseBody().toString(), is(equalTo(PROXY_RESPONSE)));
+        }
+
+        @Test
+        void shouldBasicAuthenticateToProxy() throws Exception {
+            // Given
+            String authRealm = "SomeRealm";
+            AtomicBoolean challenged = new AtomicBoolean();
+            proxy.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        if (challenged.compareAndSet(false, true)) {
+                            msg.setResponseHeader(
+                                    "HTTP/1.1 407\r\nProxy-Authenticate: Basic realm=\""
+                                            + authRealm
+                                            + "\"\r\n");
+                            msg.setResponseBody(PROXY_RESPONSE);
+                            msg.getResponseHeader()
+                                    .setContentLength(msg.getResponseBody().length());
+                            return;
+                        }
+
+                        msg.setResponseHeader("HTTP/1.1 200\r\n");
+                        msg.setResponseBody(SERVER_RESPONSE);
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+            configOptionsWithProxy("localhost", proxyPort, authRealm);
+            // When
+            httpSender.sendAndReceive(message);
+            // Then
+
+            assertThat(proxy.getReceivedMessages(), hasSize(2));
+            assertThat(
+                    proxy.getReceivedMessages()
+                            .get(0)
+                            .getRequestHeader()
+                            .getHeader("Proxy-Authorization"),
+                    is(nullValue()));
+            assertThat(
+                    proxy.getReceivedMessages().get(0).getRequestHeader().getHeader("host"),
+                    is(equalTo("localhost:" + serverPort)));
+            assertThat(
+                    proxy.getReceivedMessages()
+                            .get(1)
+                            .getRequestHeader()
+                            .getHeader("Proxy-Authorization"),
+                    is(equalTo("Basic dXNlcm5hbWU6cGFzc3dvcmQ=")));
+            assertThat(
+                    proxy.getReceivedMessages().get(1).getRequestHeader().getHeader("host"),
+                    is(equalTo("localhost:" + serverPort)));
+            assertThat(server.getReceivedMessages(), hasSize(0));
+            assertThat(message.getResponseBody().toString(), is(equalTo(SERVER_RESPONSE)));
+        }
+
+        @Test
+        void shouldNotBasicAuthenticateToProxyIfRealmMismatch() throws Exception {
+            // Given
+            proxy.setHttpMessageHandler(
+                    (ctx, msg) -> {
+                        msg.setResponseHeader(
+                                "HTTP/1.1 407\r\nProxy-Authenticate: Basic realm=\"SomeRealm\"\r\n");
+                        msg.setResponseBody(PROXY_RESPONSE);
+                        msg.getResponseHeader().setContentLength(msg.getResponseBody().length());
+                    });
+            configOptionsWithProxy("localhost", proxyPort, "NotSomeRealm");
+            // When
+            httpSender.sendAndReceive(message);
+            // Then
+            assertThat(proxy.getReceivedMessages(), hasSize(1));
+            assertThat(
+                    proxy.getReceivedMessages()
+                            .get(0)
+                            .getRequestHeader()
+                            .getHeader("Proxy-Authorization"),
+                    is(nullValue()));
+            assertThat(
+                    proxy.getReceivedMessages().get(0).getRequestHeader().getHeader("host"),
+                    is(equalTo("localhost:" + serverPort)));
+            assertThat(server.getReceivedMessages(), hasSize(0));
+            assertThat(message.getResponseBody().toString(), is(equalTo(PROXY_RESPONSE)));
+        }
+
+        private void configOptionsWithProxy(String host, int port) {
+            configOptionsWithProxy(host, port, "");
+        }
+
+        private void configOptionsWithProxy(String host, int port, String realm) {
+            options.setHttpProxy(
+                    new HttpProxy(
+                            host,
+                            port,
+                            realm,
+                            new PasswordAuthentication("username", "password".toCharArray())));
+            options.setHttpProxyEnabled(true);
+            options.setHttpProxyAuthEnabled(true);
+        }
+    }
+
+    private HttpMessage createMessage(String method, String path) {
+        try {
+            URI uri = new URI(getServerUri(path), true);
+            HttpRequestHeader requestHeader =
+                    new HttpRequestHeader(method + " " + uri + " HTTP/1.1");
+            return new HttpMessage(requestHeader);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getServerUri(String path) {
+        return "http://localhost:" + serverPort + path;
+    }
+
+    private static class TestHttpSenderListener implements HttpSenderListener {
+
+        private final List<HttpMessage> messages;
+        private final HttpMessageProcessor messageProcessor;
+
+        TestHttpSenderListener() {
+            this((messages, message, initiator, sender) -> messages.add(message.cloneAll()));
+        }
+
+        TestHttpSenderListener(HttpMessageProcessor messageProcessor) {
+            this.messages = Collections.synchronizedList(new ArrayList<>());
+            this.messageProcessor = messageProcessor;
+        }
+
+        List<HttpMessage> getMessages() {
+            return messages;
+        }
+
+        @Override
+        public int getListenerOrder() {
+            return 0;
+        }
+
+        @Override
+        public void onHttpRequestSend(HttpMessage msg, int initiator, HttpSender sender) {}
+
+        @Override
+        public void onHttpResponseReceive(HttpMessage msg, int initiator, HttpSender sender) {
+            try {
+                messageProcessor.process(messages, msg, initiator, sender);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private interface HttpMessageProcessor {
+        void process(
+                List<HttpMessage> messages, HttpMessage message, int initiator, HttpSender sender)
+                throws Exception;
+    }
+
+    private interface SenderMethod {
+        void sendWith(HttpSenderImplWrapper<?> httpSender, HttpMessage message) throws IOException;
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplWrapper.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplWrapper.java
@@ -1,0 +1,151 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.mockito.invocation.InvocationOnMock;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.addon.network.internal.client.core.HttpSenderContext;
+import org.zaproxy.zap.network.HttpRequestConfig;
+import org.zaproxy.zap.network.HttpSenderListener;
+import org.zaproxy.zap.users.User;
+
+public class HttpSenderImplWrapper<T extends HttpSenderContext> {
+
+    private static final HttpRequestConfig NO_REDIRECTS = HttpRequestConfig.builder().build();
+    private static final HttpRequestConfig FOLLOW_REDIRECTS =
+            HttpRequestConfig.builder().setFollowRedirects(true).build();
+
+    private HttpSender parent;
+
+    private CloseableHttpSenderImpl<T> impl;
+
+    private final T ctx;
+
+    public HttpSenderImplWrapper(CloseableHttpSenderImpl<T> impl, int initiator) {
+        this.impl = impl;
+        parent = mock(HttpSender.class);
+        try {
+            doAnswer(this::send).when(parent).sendAndReceive(any());
+            doAnswer(this::send).when(parent).sendAndReceive(any(), anyBoolean());
+            doAnswer(this::send).when(parent).sendAndReceive(any(), any(HttpRequestConfig.class));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        ctx = impl.createContext(parent, initiator);
+
+        setUseGlobalState(true);
+        setUseCookies(true);
+    }
+
+    private Void send(InvocationOnMock invocation) throws IOException {
+        int argCount = invocation.getArguments().length;
+        HttpMessage msg = invocation.getArgument(0);
+        if (argCount == 1) {
+            sendAndReceive(msg);
+            return null;
+        }
+
+        Object secondArg = invocation.getArgument(1);
+        if (secondArg instanceof Boolean) {
+            sendAndReceive(msg, (Boolean) secondArg);
+            return null;
+        }
+
+        sendAndReceive(msg, (HttpRequestConfig) secondArg);
+        return null;
+    }
+
+    public HttpSender getParent() {
+        return parent;
+    }
+
+    public void addListener(HttpSenderListener listener) {
+        impl.addListener(listener);
+    }
+
+    public void removeListener(HttpSenderListener listener) {
+        impl.removeListener(listener);
+    }
+
+    public void close() {
+        impl.close();
+    }
+
+    public void setUseGlobalState(boolean enableGlobalState) {
+        ctx.setUseGlobalState(enableGlobalState);
+    }
+
+    public boolean isGlobalStateEnabled() {
+        return impl.isGlobalStateEnabled();
+    }
+
+    public void setUseCookies(boolean shouldUseCookies) {
+        ctx.setUseCookies(shouldUseCookies);
+    }
+
+    public void sendAndReceive(HttpMessage message, Path file) throws IOException {
+        impl.sendAndReceive(ctx, null, message, file);
+    }
+
+    public void sendAndReceive(HttpMessage msg) throws IOException {
+        impl.sendAndReceive(ctx, null, msg, null);
+    }
+
+    public void sendAndReceive(HttpMessage msg, boolean isFollowRedirect) throws IOException {
+        impl.sendAndReceive(ctx, isFollowRedirect ? FOLLOW_REDIRECTS : NO_REDIRECTS, msg, null);
+    }
+
+    public User getUser(HttpMessage msg) {
+        return ctx.getUser(msg);
+    }
+
+    public void setFollowRedirect(boolean followRedirect) {
+        ctx.setFollowRedirects(followRedirect);
+    }
+
+    public void setUser(User user) {
+        ctx.setUser(user);
+    }
+
+    public void setRemoveUserDefinedAuthHeaders(boolean removeHeaders) {
+        ctx.setRemoveUserDefinedAuthHeaders(removeHeaders);
+    }
+
+    public void setMaxRetriesOnIOError(int retries) {
+        ctx.setMaxRetriesOnIoError(retries);
+    }
+
+    public void setMaxRedirects(int maxRedirects) {
+        ctx.setMaxRedirects(maxRedirects);
+    }
+
+    public void sendAndReceive(HttpMessage message, HttpRequestConfig requestConfig)
+            throws IOException {
+        impl.sendAndReceive(ctx, requestConfig, message, null);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ConnectRequestInterceptorUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ConnectRequestInterceptorUnitTest.java
@@ -1,0 +1,70 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.zaproxy.addon.network.ConnectionOptions;
+
+/** Unit test of {@link ConnectRequestInterceptor}. */
+class ConnectRequestInterceptorUnitTest {
+
+    private ConnectionOptions connectionOptions;
+    private ConnectRequestInterceptor connectRequestInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        connectionOptions = mock(ConnectionOptions.class);
+        connectRequestInterceptor = new ConnectRequestInterceptor(connectionOptions);
+    }
+
+    @Test
+    void shouldAddUserAgentIfDefined() {
+        // Given
+        String userAgent = "Custom User-Agent";
+        given(connectionOptions.getDefaultUserAgent()).willReturn(userAgent);
+        HttpRequest request = mock(HttpRequest.class);
+        // When
+        connectRequestInterceptor.process(request, null, null);
+        // Then
+        verify(request).addHeader(HttpHeaders.USER_AGENT, userAgent);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldNotAddUserAgentIfNullOrEmpty(String userAgent) {
+        // Given
+        given(connectionOptions.getDefaultUserAgent()).willReturn(userAgent);
+        HttpRequest request = mock(HttpRequest.class);
+        // When
+        connectRequestInterceptor.process(request, null, null);
+        // Then
+        verifyNoInteractions(request);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/HttpConnectorUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/HttpConnectorUnitTest.java
@@ -1,0 +1,70 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.zaproxy.addon.network.ConnectionOptions;
+
+/** Unit test of {@link HttpConnector}. */
+class HttpConnectorUnitTest {
+
+    private ConnectionOptions connectionOptions;
+    private ConnectRequestInterceptor connectRequestInterceptor;
+
+    @BeforeEach
+    void setUp() {
+        connectionOptions = mock(ConnectionOptions.class);
+        connectRequestInterceptor = new ConnectRequestInterceptor(connectionOptions);
+    }
+
+    @Test
+    void shouldAddUserAgentIfDefined() {
+        // Given
+        String userAgent = "Custom User-Agent";
+        given(connectionOptions.getDefaultUserAgent()).willReturn(userAgent);
+        HttpRequest request = mock(HttpRequest.class);
+        // When
+        connectRequestInterceptor.process(request, null, null);
+        // Then
+        verify(request).addHeader(HttpHeaders.USER_AGENT, userAgent);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldNotAddUserAgentIfNullOrEmpty(String userAgent) {
+        // Given
+        given(connectionOptions.getDefaultUserAgent()).willReturn(userAgent);
+        HttpRequest request = mock(HttpRequest.class);
+        // When
+        connectRequestInterceptor.process(request, null, null);
+        // Then
+        verifyNoInteractions(request);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/LenientMessageParserFactoryUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/LenientMessageParserFactoryUnitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.zaproxy.addon.network.internal.client.apachev5.LenientMessageParserFactory.LINE_PARSER;
+
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.config.Http1Config;
+import org.apache.hc.core5.http.io.HttpMessageParser;
+import org.apache.hc.core5.util.CharArrayBuffer;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for  {@link LenientMessageParserFactory}. */
+class LenientMessageParserFactoryUnitTest {
+
+    @Test
+    void shouldParseValidLine() throws Exception {
+        // Given
+        CharArrayBuffer buffer = new CharArrayBuffer(100);
+        String headerContent = "Header: with separator";
+        buffer.append(headerContent);
+        // When
+        Header header = LINE_PARSER.parseHeader(buffer);
+        // Then
+        assertThat(header.getName(), is(equalTo("Header")));
+        assertThat(header.getValue(), is(equalTo("with separator")));
+    }
+
+    @Test
+    void shouldParseLineWithoutNameValuePairSeparator() throws Exception {
+        // Given
+        CharArrayBuffer buffer = new CharArrayBuffer(100);
+        String headerContent = "Header without separator";
+        buffer.append(headerContent);
+        // When
+        Header header = LINE_PARSER.parseHeader(buffer);
+        // Then
+        assertThat(header.getName(), is(equalTo(headerContent)));
+        assertThat(header.getValue(), is(equalTo("")));
+    }
+
+    @Test
+    void shouldCreateMessageParser() {
+        // Given
+        Http1Config h1Config = Http1Config.DEFAULT;
+        LenientMessageParserFactory parserFactory = new LenientMessageParserFactory();
+        // When
+        HttpMessageParser<ClassicHttpResponse> parser = parserFactory.create(h1Config);
+        // Then
+        assertThat(parser, is(notNullValue()));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/OutgoingContentStrategyUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/OutgoingContentStrategyUnitTest.java
@@ -1,0 +1,56 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link OutgoingContentStrategy}. */
+class OutgoingContentStrategyUnitTest {
+
+    private OutgoingContentStrategy outgoingContentStrategy;
+
+    @BeforeEach
+    void setUp() {
+        outgoingContentStrategy = new OutgoingContentStrategy();
+    }
+
+    @Test
+    void shouldDetermineLengthFromEntity() throws Exception {
+        // Given
+        ClassicHttpRequest request = mock(ClassicHttpRequest.class);
+        HttpEntity entity = mock(HttpEntity.class);
+        long length = 1234L;
+        given(entity.getContentLength()).willReturn(length);
+        given(request.getEntity()).willReturn(entity);
+        // When
+        long determinedLength = outgoingContentStrategy.determineLength(request);
+        // Then
+        assertThat(determinedLength, is(equalTo(length)));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyCredentialsProviderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyCredentialsProviderUnitTest.java
@@ -1,0 +1,194 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.net.PasswordAuthentication;
+import java.util.Locale;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.Credentials;
+import org.apache.hc.client5.http.auth.NTCredentials;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+
+/** Unit test for  {@link ProxyCredentialsProvider}. */
+class ProxyCredentialsProviderUnitTest {
+
+    private static final HttpProxy HTTP_PROXY =
+            new HttpProxy(
+                    "proxy.example.org",
+                    443,
+                    "Realm",
+                    new PasswordAuthentication("UserName", "Password".toCharArray()));
+
+    private ConnectionOptions connectionOptions;
+    private ProxyCredentialsProvider proxyCredentialsProvider;
+
+    @BeforeEach
+    void setUp() {
+        connectionOptions = mock(ConnectionOptions.class);
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        given(connectionOptions.isHttpProxyEnabled()).willReturn(true);
+        given(connectionOptions.isHttpProxyAuthEnabled()).willReturn(true);
+        proxyCredentialsProvider = new ProxyCredentialsProvider(connectionOptions);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"basic", "Basic", "digest", "Digest"})
+    void shouldProvideUsernamePasswordCredentialsForBasicAndDigestSchemes(String scheme) {
+        // Given
+        AuthScope authScope = createProxyAuthScope(scheme);
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(instanceOf(UsernamePasswordCredentials.class)));
+        UsernamePasswordCredentials credentials = (UsernamePasswordCredentials) providedCredentials;
+        assertThat(
+                credentials.getUserName(),
+                is(equalTo(HTTP_PROXY.getPasswordAuthentication().getUserName())));
+        assertThat(
+                credentials.getPassword(),
+                is(equalTo(HTTP_PROXY.getPasswordAuthentication().getPassword())));
+    }
+
+    @Test
+    void shouldProvideNtCredentialsForOtherSchemes() {
+        // Given
+        AuthScope authScope = createProxyAuthScope("ntlm");
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(instanceOf(NTCredentials.class)));
+        NTCredentials credentials = (NTCredentials) providedCredentials;
+        assertThat(
+                credentials.getUserName(),
+                is(equalTo(HTTP_PROXY.getPasswordAuthentication().getUserName())));
+        assertThat(
+                credentials.getPassword(),
+                is(equalTo(HTTP_PROXY.getPasswordAuthentication().getPassword())));
+        assertThat(credentials.getWorkstation(), is(equalTo("")));
+        assertThat(
+                credentials.getDomain(),
+                is(equalTo(HTTP_PROXY.getRealm().toUpperCase(Locale.ROOT))));
+    }
+
+    @Test
+    void shouldNotProvideCredentialsIfProxyNotEnabled() {
+        // Given
+        AuthScope authScope = createProxyAuthScope("basic");
+        given(connectionOptions.isHttpProxyEnabled()).willReturn(false);
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(nullValue()));
+    }
+
+    @Test
+    void shouldNotProvideCredentialsIfProxyAuthNotEnabled() {
+        // Given
+        AuthScope authScope = createProxyAuthScope("basic");
+        given(connectionOptions.isHttpProxyAuthEnabled()).willReturn(false);
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(nullValue()));
+    }
+
+    @Test
+    void shouldNotProvideCredentialsIfHostDoesNotMatch() {
+        // Given
+        AuthScope authScope =
+                createAuthScope("basic", "Other Host", HTTP_PROXY.getPort(), HTTP_PROXY.getRealm());
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(nullValue()));
+    }
+
+    @Test
+    void shouldNotProvideCredentialsIfPortDoesNotMatch() {
+        // Given
+        AuthScope authScope =
+                createAuthScope(
+                        "basic",
+                        HTTP_PROXY.getHost(),
+                        HTTP_PROXY.getPort() + 1,
+                        HTTP_PROXY.getRealm());
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(nullValue()));
+    }
+
+    @Test
+    void shouldNotProvideCredentialsIfRealmDoesNotMatch() {
+        // Given
+        AuthScope authScope =
+                createAuthScope("basic", HTTP_PROXY.getHost(), HTTP_PROXY.getPort(), "Other Realm");
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(nullValue()));
+    }
+
+    @Test
+    void shouldProvideCredentialsIfAnyRealmMatch() {
+        // Given
+        HttpProxy httpProxy =
+                new HttpProxy(
+                        "proxy.example.org",
+                        443,
+                        "",
+                        new PasswordAuthentication("UserName", "Password".toCharArray()));
+        given(connectionOptions.getHttpProxy()).willReturn(httpProxy);
+        AuthScope authScope =
+                createAuthScope(
+                        "basic",
+                        httpProxy.getHost(),
+                        httpProxy.getPort(),
+                        "Other Realm But Any Allowed");
+        // When
+        Credentials providedCredentials = proxyCredentialsProvider.getCredentials(authScope, null);
+        // Then
+        assertThat(providedCredentials, is(notNullValue()));
+    }
+
+    private static AuthScope createProxyAuthScope(String scheme) {
+        return createAuthScope(
+                scheme, HTTP_PROXY.getHost(), HTTP_PROXY.getPort(), HTTP_PROXY.getRealm());
+    }
+
+    private static AuthScope createAuthScope(String scheme, String host, int port, String realm) {
+        return new AuthScope(null, host, port, realm, scheme);
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlannerUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/apachev5/ProxyRoutePlannerUnitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.internal.client.apachev5;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.net.PasswordAuthentication;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.zaproxy.addon.network.ConnectionOptions;
+import org.zaproxy.addon.network.internal.client.HttpProxy;
+
+/** Unit test for  {@link ProxyRoutePlanner}. */
+class ProxyRoutePlannerUnitTest {
+
+    private static final HttpProxy HTTP_PROXY =
+            new HttpProxy(
+                    "proxy.example.org",
+                    443,
+                    "Realm",
+                    new PasswordAuthentication("UserName", "Password".toCharArray()));
+
+    private ConnectionOptions connectionOptions;
+    private ProxyRoutePlanner proxyRoutePlanner;
+
+    @BeforeEach
+    void setUp() {
+        connectionOptions = mock(ConnectionOptions.class);
+        given(connectionOptions.getHttpProxy()).willReturn(HTTP_PROXY);
+        proxyRoutePlanner = new ProxyRoutePlanner(connectionOptions);
+    }
+
+    @Test
+    void shouldProxyIfEnabledForHost() {
+        // Given
+        String schemeName = "http";
+        String hostName = "localhost";
+        HttpHost host = new HttpHost(schemeName, hostName, 8080);
+        given(connectionOptions.isUseHttpProxy(hostName)).willReturn(true);
+        // When
+        HttpHost proxy = proxyRoutePlanner.determineProxy(host, null);
+        // Then
+        assertThat(proxy, is(notNullValue()));
+        assertThat(proxy.getSchemeName(), is(equalTo(schemeName)));
+        assertThat(proxy.getHostName(), is(equalTo(HTTP_PROXY.getHost())));
+        assertThat(proxy.getPort(), is(equalTo(HTTP_PROXY.getPort())));
+    }
+
+    @Test
+    void shouldNotProxyIfNotEnabledForHost() {
+        // Given
+        String schemeName = "http";
+        String hostName = "localhost";
+        HttpHost host = new HttpHost(schemeName, hostName, 8080);
+        given(connectionOptions.isUseHttpProxy(hostName)).willReturn(false);
+        // When
+        HttpHost proxy = proxyRoutePlanner.determineProxy(host, null);
+        // Then
+        assertThat(proxy, is(nullValue()));
+    }
+}

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
@@ -1,0 +1,163 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.network.testutils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.FixedLengthFrameDecoder;
+import io.netty.util.concurrent.EventExecutorGroup;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpRequestHeader;
+import org.parosproxy.paros.security.SslCertificateService;
+import org.zaproxy.addon.network.internal.server.http.HttpServer;
+import org.zaproxy.addon.network.internal.server.http.MainServerHandler;
+import org.zaproxy.addon.network.server.HttpMessageHandler;
+import org.zaproxy.addon.network.server.HttpMessageHandlerContext;
+
+/** A HTTP server that allows to receive and send text messages, to help with the tests. */
+public class TestHttpServer extends HttpServer {
+
+    private static final SslCertificateService SSL_CERTIFICATE_SERVICE =
+            TestSslCertificateService.createInstance();
+
+    private final List<HttpMessage> receivedMessages;
+    private HttpMessageHandler handler;
+    private Integer fixedLengthMessage;
+
+    /**
+     * Constructs a {@code TestHttpServer} with the given properties.
+     *
+     * @param group the event loop group.
+     * @param mainHandlerExecutor the event executor for the main handler.
+     */
+    public TestHttpServer(NioEventLoopGroup group, EventExecutorGroup mainHandlerExecutor) {
+        super(group, mainHandlerExecutor, SSL_CERTIFICATE_SERVICE);
+
+        receivedMessages = Collections.synchronizedList(new ArrayList<>());
+        setMainServerHandler(() -> new MainServerHandler(Collections.singletonList(this::handle)));
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) {
+        super.initChannel(ch);
+
+        if (fixedLengthMessage != null) {
+            ch.pipeline()
+                    .replace(
+                            "http.decoder",
+                            "http.decoder",
+                            new FixedLengthFrameDecoder(fixedLengthMessage) {
+                                @Override
+                                protected Object decode(ChannelHandlerContext ctx, ByteBuf in)
+                                        throws Exception {
+                                    ByteBuf decoded = (ByteBuf) super.decode(ctx, in);
+                                    if (decoded == null) {
+                                        return null;
+                                    }
+
+                                    String data = decoded.toString(StandardCharsets.US_ASCII);
+                                    int idx = data.indexOf("\r\n\r\n");
+                                    HttpMessage message =
+                                            new HttpMessage(
+                                                    new HttpRequestHeader(data.substring(0, idx)));
+                                    idx += 4;
+                                    if (idx < data.length()) {
+                                        message.setRequestBody(data.substring(idx));
+                                    }
+                                    return message;
+                                }
+                            });
+        }
+    }
+
+    /**
+     * Sets the size of the message that will be received.
+     *
+     * <p>Allows to read malformed HTTP requests.
+     *
+     * @param fixedLengthMessage the length of the message.
+     */
+    public void setFixedLengthMessage(Integer fixedLengthMessage) {
+        this.fixedLengthMessage = fixedLengthMessage;
+    }
+
+    private void handle(HttpMessageHandlerContext ctx, HttpMessage msg) {
+        if (ctx.isFromClient()) {
+            return;
+        }
+
+        receivedMessages.add(msg);
+
+        if (handler != null) {
+            handler.handleMessage(ctx, msg);
+        }
+    }
+
+    /** Gets the messages received by the server. @return the messages received by the server. */
+    public List<HttpMessage> getReceivedMessages() {
+        return receivedMessages;
+    }
+
+    /**
+     * Sets the handler to provide custom responses.
+     *
+     * @param handler the handler.
+     */
+    public void setHttpMessageHandler(TestHttpMessageHandler handler) {
+        this.handler = new TestHttpMessageHandlerImpl(handler);
+    }
+
+    /** The handler of received messages. */
+    public interface TestHttpMessageHandler {
+
+        /**
+         * Called when a message is received.
+         *
+         * @param ctx the context.
+         * @param msg the message.
+         * @throws Exception if an error occurred.
+         */
+        void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) throws Exception;
+    }
+
+    private static class TestHttpMessageHandlerImpl implements HttpMessageHandler {
+
+        private final TestHttpMessageHandler delegatee;
+
+        private TestHttpMessageHandlerImpl(TestHttpMessageHandler delegatee) {
+            this.delegatee = delegatee;
+        }
+
+        @Override
+        public final void handleMessage(HttpMessageHandlerContext ctx, HttpMessage msg) {
+            try {
+                delegatee.handleMessage(ctx, msg);
+            } catch (Throwable e) {
+                throw new RuntimeException("Test error:", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a `HttpSender` implementation based on Apache HttpComponents and
set it to core, on newer versions.
Fully manage the client certificates as they are now used by the newer
`HttpSender` implementation.