### PR TITLE
ascanrulesBeta: add constraint for new HttpSender

### DIFF
--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/CloudMetadataScanRule.java
@@ -43,6 +43,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpMethodHelper;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
+import org.parosproxy.paros.network.SSLConnector;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.ZapGetMethod;
 import org.zaproxy.zap.users.User;
@@ -73,7 +74,7 @@ public class CloudMetadataScanRule extends AbstractHostPlugin {
     static {
         try {
             Class.forName("org.zaproxy.addon.network.internal.client.BaseHttpSender");
-            useHttpSender = true;
+            useHttpSender = SSLConnector.class.getAnnotation(Deprecated.class) != null;
         } catch (Exception e) {
             useHttpSender = false;
         }

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/InsecureHttpMethodScanRule.java
@@ -54,6 +54,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpResponseHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
+import org.parosproxy.paros.network.SSLConnector;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.zap.model.Vulnerabilities;
 import org.zaproxy.zap.model.Vulnerability;
@@ -106,7 +107,7 @@ public class InsecureHttpMethodScanRule extends AbstractAppPlugin {
     static {
         try {
             Class.forName("org.zaproxy.addon.network.internal.client.BaseHttpSender");
-            useHttpSender = true;
+            useHttpSender = SSLConnector.class.getAnnotation(Deprecated.class) != null;
         } catch (Exception e) {
             useHttpSender = false;
         }


### PR DESCRIPTION
Only rely on the newer `HttpSender` implementation if the core one is
deprecated, otherwise it would fail in the tests since it is still
using the older implementation, even if the newer is available in the
classpath.