### PR TITLE
openapi: Improve Support for DDNs

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Imported specs are now persisted to the session database. They are used by the new variant to mark path parameters as
+  Data Driven Nodes.
+
 ### Fixed
 - JSON body examples specified under `schema` were being enclosed in quotes.
 - Error message when `apiFile` field is not accessible was outputting the `targetUrl` and not the incorrect filename (Issue 7370).
@@ -12,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Use Spider add-on (Issue 3113).
 - Use Form Handler add-on directly.
+- DDNs added as Structural Modifiers have been superseded by a custom variant. The variant supports nested DDNs and leaf
+  DDNs, prevents non-parameter URL paths from being merged with DDNs, and treats paths with different HTTP methods
+  uniquely. DDNs are named with the parameter name from the spec.
 
 ## [27] - 2022-03-29
 ### Added

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -22,12 +22,16 @@ package org.zaproxy.zap.extension.openapi;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import java.awt.EventQueue;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 import org.apache.commons.httpclient.URI;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -35,6 +39,10 @@ import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.control.Control.Mode;
+import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.db.Database;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.db.DatabaseUnsupportedException;
 import org.parosproxy.paros.extension.CommandLineArgument;
 import org.parosproxy.paros.extension.CommandLineListener;
 import org.parosproxy.paros.extension.Extension;
@@ -42,17 +50,25 @@ import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.parosproxy.paros.extension.SessionChangedListener;
 import org.parosproxy.paros.model.Session;
+import org.parosproxy.paros.model.SiteMap;
+import org.parosproxy.paros.model.SiteNode;
+import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.commonlib.ExtensionCommonlib;
 import org.zaproxy.addon.commonlib.ui.ProgressPane;
 import org.zaproxy.addon.commonlib.ui.ProgressPanel;
+import org.zaproxy.zap.extension.openapi.TableOpenApi.TableOpenApiReadResult;
+import org.zaproxy.zap.extension.openapi.VariantOpenApi.VariantOpenApiChecks;
 import org.zaproxy.zap.extension.openapi.converter.swagger.InvalidUrlException;
+import org.zaproxy.zap.extension.openapi.converter.swagger.OperationModel;
 import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerConverter;
 import org.zaproxy.zap.extension.openapi.network.RequestModel;
 import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.model.DefaultValueGenerator;
+import org.zaproxy.zap.model.SessionStructure;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -75,6 +91,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     private int threadId = 1;
     private SpiderParser customSpider;
     private ValueGenerator valueGenerator;
+    private final Map<Integer, VariantOpenApiChecks> variantChecksMap = new HashMap<>();
+    private TableOpenApi table = new TableOpenApi();
 
     private CommandLineArgument[] arguments = new CommandLineArgument[3];
     private static final int ARG_IMPORT_FILE_IDX = 0;
@@ -123,6 +141,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
         extensionHook.addApiImplementor(new OpenApiAPI(this));
         extensionHook.addCommandLine(getCommandLineArguments());
+        extensionHook.addVariant(VariantOpenApi.class);
+        getModel().getSession().addOnContextsChangedListener(new ContextsChangedListenerImpl());
     }
 
     @Override
@@ -139,9 +159,32 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
         }
         if (currentFileDialog != null) {
             currentFileDialog.dispose();
+            currentFileDialog.unload();
         }
         if (currentUrlDialog != null) {
             currentUrlDialog.dispose();
+            currentUrlDialog.unload();
+        }
+    }
+
+    @Override
+    public void databaseOpen(Database db) throws DatabaseException, DatabaseUnsupportedException {
+        db.addDatabaseListener(table);
+        table.databaseOpen(db.getDatabaseServer());
+    }
+
+    private void importStoredOpenApiDefinitions(int contextId) {
+        try {
+            List<TableOpenApiReadResult> openApiSpecs =
+                    table.getOpenApiDefinitionsForContext(contextId);
+            if (openApiSpecs != null && !openApiSpecs.isEmpty()) {
+                for (TableOpenApiReadResult spec : openApiSpecs) {
+                    importOpenApiDefinition(
+                            spec.definition, spec.target, null, false, null, contextId, true);
+                }
+            }
+        } catch (DatabaseException e) {
+            LOG.error(e.getMessage(), e);
         }
     }
 
@@ -267,7 +310,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                             uri.getScheme() + "://" + uri.getAuthority() + path,
                             initViaUi,
                             requestor,
-                            contextId));
+                            contextId,
+                            false));
             return results;
         } catch (IOException e) {
             if (initViaUi) {
@@ -355,7 +399,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                                 null,
                                 initViaUi,
                                 requestor,
-                                contextId);
+                                contextId,
+                                false);
             }
             results.setErrors(errors);
             return results;
@@ -375,7 +420,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             final String definitionUrl,
             boolean initViaUi,
             final Requestor requestor,
-            int contextId) {
+            int contextId,
+            boolean existsInDb) {
         final List<String> errors = new ArrayList<>();
         SwaggerConverter converter =
                 new SwaggerConverter(targetUrl, definitionUrl, defn, getValueGenerator());
@@ -387,8 +433,19 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                         ProgressPane currentImportPane = null;
                         try {
                             List<RequestModel> requestModels = converter.getRequestModels();
-                            converter.setStructuralNodeModifiers(contextId);
-
+                            if (contextId != -1) {
+                                Context context = getModel().getSession().getContext(contextId);
+                                if (context != null) {
+                                    converter.updateVariantChecks(
+                                            context,
+                                            targetUrl,
+                                            variantChecksMap.computeIfAbsent(
+                                                    contextId, VariantOpenApiChecks::new));
+                                }
+                            }
+                            if (requestor == null) {
+                                return;
+                            }
                             if (initViaUi) {
                                 currentImportPane = new ProgressPane();
                                 requestor.addListener(new ProgressListener(currentImportPane));
@@ -414,6 +471,13 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                                                     Constant.messages.getString(
                                                             "openapi.parse.ok"));
                                 }
+                            }
+                            if (!existsInDb && contextId != -1) {
+                                table.insertOpenApiSpec(
+                                        defn,
+                                        targetUrl,
+                                        getModel().getSession().getSessionId(),
+                                        contextId);
                             }
                         } catch (Exception e) {
                             if (initViaUi) {
@@ -460,6 +524,96 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
         return null;
     }
 
+    List<String> getTreePath(HttpMessage msg) {
+        try {
+            String path = msg.getRequestHeader().getURI().getPath();
+            if (path == null || path.isEmpty()) {
+                return Collections.emptyList();
+            }
+            if ("/".equals(path) || path.startsWith("/?")) {
+                return Collections.singletonList("/");
+            }
+            String uri = msg.getRequestHeader().getURI().toString().replaceAll("/?\\?.*", "");
+            List<Context> contexts = getModel().getSession().getContextsForUrl(uri);
+            for (Context c : contexts) {
+                if (!variantChecksMap.containsKey(c.getId())) {
+                    continue;
+                }
+                VariantOpenApiChecks checks = variantChecksMap.get(c.getId());
+                for (OperationModel operation : checks.pathsWithNoParams) {
+                    if (operation.getPath().equals(uri)
+                            && operation
+                                    .getRequestMethod()
+                                    .name()
+                                    .equalsIgnoreCase(msg.getRequestHeader().getMethod())) {
+                        return extractTreePathFromUri(uri);
+                    }
+                }
+                for (Map.Entry<OperationModel, Pattern> entry :
+                        checks.pathsWithParamsRegex.entrySet()) {
+                    if (entry.getValue().matcher(uri).matches()
+                            && entry.getKey()
+                                    .getRequestMethod()
+                                    .name()
+                                    .equalsIgnoreCase(msg.getRequestHeader().getMethod())) {
+                        return extractTreePathFromUri(
+                                entry.getKey()
+                                        .getPath()
+                                        .replace("{", SessionStructure.DATA_DRIVEN_NODE_PREFIX)
+                                        .replace("}", SessionStructure.DATA_DRIVEN_NODE_POSTFIX));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.debug("Error getting tree path for message: {}", msg, e);
+        }
+        return null;
+    }
+
+    private static List<String> extractTreePathFromUri(String uri) {
+        try {
+            URI target = new URI(uri, false);
+            String path = target.getPath();
+            return Arrays.asList(path.split("/"));
+        } catch (Exception e) {
+            LOG.warn("Error extracting tree path from uri: {}", uri, e);
+        }
+        return null;
+    }
+
+    private void updateSitesTreeDDNs(Context context) {
+        try {
+            VariantOpenApiChecks checks = variantChecksMap.get(context.getId());
+            if (checks == null) {
+                return;
+            }
+            SiteMap sitesTree = getModel().getSession().getSiteTree();
+            List<SiteNode> nodes = getModel().getSession().getNodesInContextFromSiteTree(context);
+            for (SiteNode node : nodes) {
+                for (Map.Entry<OperationModel, Pattern> entry :
+                        checks.pathsWithParamsRegex.entrySet()) {
+                    if (entry.getValue()
+                                    .matcher(node.getHistoryReference().getURI().toString())
+                                    .matches()
+                            && entry.getKey()
+                                    .getRequestMethod()
+                                    .name()
+                                    .equalsIgnoreCase(node.getHistoryReference().getMethod())) {
+                        List<Alert> alerts = node.getAlerts();
+                        node.deleteAlerts(alerts);
+                        sitesTree.removeNodeFromParent(node);
+                        sitesTree.removeHistoryReference(node.getHistoryReference().getHistoryId());
+                        SiteNode node2 = sitesTree.addPath(node.getHistoryReference());
+                        alerts.forEach(node2::addAlert);
+                    }
+                }
+                node.setIncludedInScope(true, false);
+            }
+        } catch (Exception e) {
+            LOG.warn("Could not update OpenAPI DDNs in the sites tree: {}.", e.getMessage(), e);
+        }
+    }
+
     private void logErrors(List<String> errors, boolean initViaUi) {
         if (errors != null) {
             for (String error : errors) {
@@ -472,9 +626,19 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
         }
     }
 
+    // Convenience method for tests
+    void setTable(TableOpenApi table) {
+        this.table = table;
+    }
+
     @Override
     public boolean canUnload() {
         return true;
+    }
+
+    @Override
+    public boolean supportsDb(String type) {
+        return Database.DB_TYPE_HSQLDB.equals(type);
     }
 
     @Override
@@ -584,9 +748,21 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     }
 
     private class SessionChangedListenerImpl implements SessionChangedListener {
-
         @Override
-        public void sessionChanged(Session session) {}
+        public void sessionChanged(Session session) {
+            if (currentFileDialog != null) {
+                currentFileDialog.refreshContextsComboBox();
+            }
+            if (currentUrlDialog != null) {
+                currentUrlDialog.refreshContextsComboBox();
+            }
+            if (session != null) {
+                for (Context context : session.getContexts()) {
+                    importStoredOpenApiDefinitions(context.getId());
+                    EventQueue.invokeLater(() -> updateSitesTreeDDNs(context));
+                }
+            }
+        }
 
         @Override
         public void sessionAboutToChange(Session session) {
@@ -596,6 +772,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             if (currentUrlDialog != null) {
                 currentUrlDialog.clear();
             }
+            variantChecksMap.clear();
         }
 
         @Override
@@ -603,5 +780,25 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
         @Override
         public void sessionModeChanged(Mode mode) {}
+    }
+
+    private class ContextsChangedListenerImpl implements Session.OnContextsChangedListener {
+        @Override
+        public void contextAdded(Context context) {}
+
+        @Override
+        public void contextDeleted(Context context) {
+            try {
+                int contextId = context.getId();
+                variantChecksMap.remove(contextId);
+                table.deleteOpenApiSpecForContext(contextId);
+            } catch (Exception e) {
+                LOG.debug(
+                        "Could not delete OpenAPI definition for context {}.", context.getId(), e);
+            }
+        }
+
+        @Override
+        public void contextsChanged() {}
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromAbstractDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromAbstractDialog.java
@@ -23,6 +23,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import javax.swing.JButton;
+import javax.swing.JComboBox;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
@@ -30,8 +31,10 @@ import javax.swing.JPopupMenu;
 import javax.swing.JTextField;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
+import org.parosproxy.paros.model.Session;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.openapi.converter.swagger.UriBuilder;
+import org.zaproxy.zap.model.Context;
 
 @SuppressWarnings("serial")
 abstract class ImportFromAbstractDialog extends AbstractDialog {
@@ -41,7 +44,9 @@ abstract class ImportFromAbstractDialog extends AbstractDialog {
 
     private final JTextField fieldFrom = new JTextField(35);
     private final JTextField fieldTarget = new JTextField(35);
-
+    private final JComboBox<String> contextsComboBox = new JComboBox<>();
+    private final ContextsChangedListenerImpl contextsChangedListener =
+            new ContextsChangedListenerImpl();
     protected final ExtensionOpenApi caller;
 
     public ImportFromAbstractDialog(
@@ -95,9 +100,23 @@ abstract class ImportFromAbstractDialog extends AbstractDialog {
         constraints.gridwidth = 3;
         add(fieldTarget, constraints);
 
+        constraints.weightx = 0;
+        constraints.gridwidth = 1;
+        constraints.gridx = 0;
+        constraints.gridy = 2;
+        add(new JLabel(Constant.messages.getString(MESSAGE_PREFIX + "labelcontext")), constraints);
+
+        constraints.gridx = 1;
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.weightx = 1.0;
+        constraints.gridwidth = 3;
+        refreshContextsComboBox();
+        add(contextsComboBox, constraints);
+        caller.getModel().getSession().addOnContextsChangedListener(contextsChangedListener);
+
         constraints.gridwidth = 1;
         constraints.gridx = 2;
-        constraints.gridy = 2;
+        constraints.gridy = 3;
         constraints.anchor = GridBagConstraints.CENTER;
         add(buttonCancel, constraints);
         constraints.gridx = 3;
@@ -131,6 +150,21 @@ abstract class ImportFromAbstractDialog extends AbstractDialog {
         return fieldTarget;
     }
 
+    protected int getSelectedContextId() {
+        if (contextsComboBox.getSelectedItem() == null) {
+            return -1;
+        }
+        String selectedContextName = contextsComboBox.getSelectedItem().toString();
+        if ("".equals(selectedContextName)) {
+            return -1;
+        }
+        Context selectedContext = caller.getModel().getSession().getContext(selectedContextName);
+        if (selectedContext == null) {
+            return -1;
+        }
+        return selectedContext.getId();
+    }
+
     protected void addFromFields(GridBagConstraints constraints) {
         add(fieldFrom, constraints);
     }
@@ -150,6 +184,10 @@ abstract class ImportFromAbstractDialog extends AbstractDialog {
         getTargetField().setText("");
     }
 
+    public void unload() {
+        caller.getModel().getSession().removeOnContextsChangedListener(contextsChangedListener);
+    }
+
     private static void setContextMenu(JTextField field) {
         JMenuItem paste =
                 new JMenuItem(Constant.messages.getString(MESSAGE_PREFIX + "pasteaction"));
@@ -158,5 +196,33 @@ abstract class ImportFromAbstractDialog extends AbstractDialog {
         JPopupMenu jPopupMenu = new JPopupMenu();
         jPopupMenu.add(paste);
         field.setComponentPopupMenu(jPopupMenu);
+    }
+
+    void refreshContextsComboBox() {
+        contextsComboBox.removeAllItems();
+        contextsComboBox.addItem("");
+        caller.getModel().getSession().getContexts().stream()
+                .map(Context::getName)
+                .forEach(contextsComboBox::addItem);
+        if (contextsComboBox.getItemCount() > 1) {
+            contextsComboBox.setSelectedIndex(1);
+        }
+    }
+
+    private class ContextsChangedListenerImpl implements Session.OnContextsChangedListener {
+        @Override
+        public void contextAdded(Context context) {
+            contextsComboBox.addItem(context.getName());
+        }
+
+        @Override
+        public void contextDeleted(Context context) {
+            contextsComboBox.removeItem(context.getName());
+        }
+
+        @Override
+        public void contextsChanged() {
+            refreshContextsComboBox();
+        }
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromFileDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromFileDialog.java
@@ -92,7 +92,8 @@ public class ImportFromFileDialog extends ImportFromAbstractDialog {
         }
 
         try {
-            caller.importOpenApiDefinition(file, getTargetField().getText(), true);
+            caller.importOpenApiDefinition(
+                    file, getTargetField().getText(), true, getSelectedContextId());
         } catch (InvalidUrlException e) {
             showWarningInvalidUrl(e.getUrl());
             return false;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromUrlDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromUrlDialog.java
@@ -65,7 +65,8 @@ public class ImportFromUrlDialog extends ImportFromAbstractDialog {
         }
 
         try {
-            caller.importOpenApiDefinition(uri, getTargetField().getText(), true);
+            caller.importOpenApiDefinition(
+                    uri, getTargetField().getText(), true, getSelectedContextId());
         } catch (InvalidUrlException e) {
             showWarningInvalidUrl(e.getUrl());
             return false;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/TableOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/TableOpenApi.java
@@ -1,0 +1,139 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hsqldb.jdbc.JDBCClob;
+import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.db.DbUtils;
+import org.parosproxy.paros.db.paros.ParosAbstractTable;
+
+public class TableOpenApi extends ParosAbstractTable {
+
+    private static final Logger LOGGER = LogManager.getLogger(TableOpenApi.class);
+
+    private PreparedStatement psInsertOpenApiSpec;
+    private PreparedStatement psSelectOpenApiSpecsForContext;
+    private PreparedStatement psDeleteOpenApiSpecForContext;
+
+    @Override
+    protected void reconnect(Connection conn) throws DatabaseException {
+        try {
+            if (!DbUtils.hasTable(conn, "OPENAPI_SPECS")) {
+                DbUtils.execute(
+                        conn,
+                        "CREATE CACHED TABLE openapi_specs ("
+                                + "id INT NOT NULL IDENTITY, "
+                                + "definition CLOB(16M) NOT NULL, "
+                                + "target NVARCHAR(2048), "
+                                + "session_id BIGINT NOT NULL, "
+                                + "context_id INT NOT NULL, "
+                                + "PRIMARY KEY (id))");
+            }
+            psInsertOpenApiSpec =
+                    conn.prepareStatement(
+                            "INSERT INTO openapi_specs (definition, target, session_id, context_id) VALUES (?, ?, ?, ?)");
+            psSelectOpenApiSpecsForContext =
+                    conn.prepareStatement(
+                            "SELECT definition, target, session_id, context_id "
+                                    + "FROM openapi_specs WHERE context_id = ?");
+            psDeleteOpenApiSpecForContext =
+                    conn.prepareStatement("DELETE FROM openapi_specs WHERE context_id = ?");
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+
+    public synchronized void insertOpenApiSpec(
+            String definition, String targetUrl, long sessionId, int contextId)
+            throws DatabaseException {
+        try {
+            if (getConnection().isClosed()) {
+                LOGGER.debug(
+                        "Database connection is closed, skipping persisting the OpenAPI definition.");
+                return;
+            }
+            psInsertOpenApiSpec.setClob(1, new JDBCClob(definition));
+            psInsertOpenApiSpec.setString(2, targetUrl);
+            psInsertOpenApiSpec.setLong(3, sessionId);
+            psInsertOpenApiSpec.setInt(4, contextId);
+            psInsertOpenApiSpec.execute();
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+
+    public synchronized List<TableOpenApiReadResult> getOpenApiDefinitionsForContext(int contextId)
+            throws DatabaseException {
+        try {
+            psSelectOpenApiSpecsForContext.setInt(1, contextId);
+            psSelectOpenApiSpecsForContext.execute();
+            ResultSet rs = psSelectOpenApiSpecsForContext.getResultSet();
+            List<TableOpenApiReadResult> results = new ArrayList<>();
+            while (rs.next()) {
+                results.add(
+                        new TableOpenApiReadResult(
+                                rs.getString("definition"),
+                                rs.getString("target"),
+                                rs.getLong("session_id"),
+                                rs.getInt("context_id")));
+            }
+            return results;
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+
+    public synchronized void deleteOpenApiSpecForContext(int contextId) throws DatabaseException {
+        try {
+            if (getConnection().isClosed()) {
+                LOGGER.debug(
+                        "Database connection is closed, skipping deleting the OpenAPI definition.");
+                return;
+            }
+            psDeleteOpenApiSpecForContext.setInt(1, contextId);
+            psDeleteOpenApiSpecForContext.execute();
+        } catch (SQLException e) {
+            throw new DatabaseException(e);
+        }
+    }
+
+    static class TableOpenApiReadResult {
+        public final String definition;
+        public final String target;
+        public final long sessionId;
+        public final int contextId;
+
+        public TableOpenApiReadResult(
+                String definition, String target, long sessionId, int contextId) {
+            this.definition = definition;
+            this.target = target;
+            this.sessionId = sessionId;
+            this.contextId = contextId;
+        }
+    }
+}

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/VariantOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/VariantOpenApi.java
@@ -1,0 +1,80 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.core.scanner.NameValuePair;
+import org.parosproxy.paros.core.scanner.Variant;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.openapi.converter.swagger.OperationModel;
+
+public class VariantOpenApi implements Variant {
+    private final ExtensionOpenApi extensionOpenApi;
+
+    public VariantOpenApi() {
+        this(Control.getSingleton().getExtensionLoader().getExtension(ExtensionOpenApi.class));
+    }
+
+    public VariantOpenApi(ExtensionOpenApi extensionOpenApi) {
+        this.extensionOpenApi = extensionOpenApi;
+    }
+
+    @Override
+    public void setMessage(HttpMessage msg) {}
+
+    @Override
+    public List<NameValuePair> getParamList() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String setParameter(
+            HttpMessage msg, NameValuePair originalPair, String param, String value) {
+        return null;
+    }
+
+    @Override
+    public String setEscapedParameter(
+            HttpMessage msg, NameValuePair originalPair, String param, String value) {
+        return null;
+    }
+
+    @Override
+    public List<String> getTreePath(HttpMessage msg) {
+        return extensionOpenApi.getTreePath(msg);
+    }
+
+    public static class VariantOpenApiChecks {
+
+        public final int contextId;
+        public final List<OperationModel> pathsWithNoParams = new ArrayList<>();
+        public final Map<OperationModel, Pattern> pathsWithParamsRegex = new HashMap<>();
+
+        public VariantOpenApiChecks(int contextId) {
+            this.contextId = contextId;
+        }
+    }
+}

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.parosproxy.paros.CommandLine;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.automation.AutomationData;
 import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
@@ -48,6 +49,7 @@ public class OpenApiJob extends AutomationJob {
     private static final String PARAM_API_URL = "apiUrl";
     private static final String PARAM_API_FILE = "apiFile";
     private static final String PARAM_TARGET_URL = "targetUrl";
+    private static final String PARAM_CONTEXT = "context";
 
     private ExtensionOpenApi extOpenApi;
 
@@ -93,6 +95,7 @@ public class OpenApiJob extends AutomationJob {
         map.put(PARAM_API_URL, "");
         map.put(PARAM_API_FILE, "");
         map.put(PARAM_TARGET_URL, "");
+        map.put(PARAM_CONTEXT, "");
         return map;
     }
 
@@ -106,12 +109,18 @@ public class OpenApiJob extends AutomationJob {
         if (!StringUtils.isEmpty(targetStr)) {
             targetUrl = env.replaceVars(targetStr);
         }
+        String context = this.getParameters().getContext();
+        int contextId =
+                context != null
+                        ? Model.getSingleton().getSession().getContext(context).getId()
+                        : -1;
 
         if (!StringUtils.isEmpty(apiFile)) {
             File file = new File(apiFile);
             if (file.exists() && file.canRead()) {
                 OpenApiResults results =
-                        getExtOpenApi().importOpenApiDefinitionV2(file, targetUrl, false);
+                        getExtOpenApi()
+                                .importOpenApiDefinitionV2(file, targetUrl, false, contextId);
                 List<String> errors = results.getErrors();
                 if (errors != null && errors.size() > 0) {
                     for (String error : errors) {
@@ -139,7 +148,7 @@ public class OpenApiJob extends AutomationJob {
             try {
                 URI uri = new URI(apiUrl, true);
                 OpenApiResults results =
-                        getExtOpenApi().importOpenApiDefinitionV2(uri, targetUrl, false);
+                        getExtOpenApi().importOpenApiDefinitionV2(uri, targetUrl, false, contextId);
                 List<String> errors = results.getErrors();
                 if (errors != null && errors.size() > 0) {
                     for (String error : errors) {
@@ -251,6 +260,7 @@ public class OpenApiJob extends AutomationJob {
         private String apiFile;
         private String apiUrl;
         private String targetUrl;
+        private String context;
 
         public String getApiFile() {
             return apiFile;
@@ -274,6 +284,14 @@ public class OpenApiJob extends AutomationJob {
 
         public void setTargetUrl(String targetUrl) {
             this.targetUrl = targetUrl;
+        }
+
+        public String getContext() {
+            return context;
+        }
+
+        public void setContext(String context) {
+            this.context = context;
         }
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
@@ -23,7 +23,9 @@ import java.awt.Component;
 import java.io.File;
 import javax.swing.JFileChooser;
 import javax.swing.JTextField;
+import org.parosproxy.paros.model.Model;
 import org.parosproxy.paros.view.View;
+import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
@@ -37,11 +39,12 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
     private static final String API_FILE_PARAM = "openapi.automation.dialog.apifile";
     private static final String API_URL_PARAM = "openapi.automation.dialog.apiurl";
     private static final String TARGET_URL_PARAM = "openapi.automation.dialog.targeturl";
+    private static final String CONTEXT_PARAM = "openapi.automation.dialog.context";
 
     private OpenApiJob job;
 
     public OpenApiJobDialog(OpenApiJob job) {
-        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 200));
+        super(View.getSingleton().getMainFrame(), TITLE, DisplayUtils.getScaledDimension(500, 250));
         this.job = job;
 
         this.addTextField(NAME_PARAM, this.job.getData().getName());
@@ -63,6 +66,11 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
         if (targetUrlField instanceof JTextField) {
             ((JTextField) targetUrlField).setText(this.job.getParameters().getTargetUrl());
         }
+        this.addContextSelectField(
+                CONTEXT_PARAM,
+                Model.getSingleton()
+                        .getSession()
+                        .getContext(this.job.getParameters().getContext()));
         this.addPadding();
     }
 
@@ -72,6 +80,8 @@ public class OpenApiJobDialog extends StandardFieldsDialog {
         this.job.getParameters().setApiFile(this.getStringValue(API_FILE_PARAM));
         this.job.getParameters().setApiUrl(this.getStringValue(API_URL_PARAM));
         this.job.getParameters().setTargetUrl(this.getStringValue(TARGET_URL_PARAM));
+        Context context = this.getContextValue(CONTEXT_PARAM);
+        this.job.getParameters().setContext(context != null ? context.getName() : null);
         this.job.resetAndSetChanged();
     }
 

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/OperationModel.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/OperationModel.java
@@ -24,9 +24,9 @@ import org.zaproxy.zap.extension.openapi.network.RequestMethod;
 
 public class OperationModel {
 
-    private String path;
-    private Operation operation;
-    private RequestMethod requestMethod;
+    private final String path;
+    private final Operation operation;
+    private final RequestMethod requestMethod;
 
     public OperationModel(String path, Operation operation, RequestMethod requestMethod) {
         this.path = path;
@@ -38,23 +38,11 @@ public class OperationModel {
         return path;
     }
 
-    public void setPath(String path) {
-        this.path = path;
-    }
-
     public Operation getOperation() {
         return operation;
     }
 
-    public void setOperation(Operation operation) {
-        this.operation = operation;
-    }
-
     public RequestMethod getRequestMethod() {
         return requestMethod;
-    }
-
-    public void setRequestMethod(RequestMethod requestMethod) {
-        this.requestMethod = requestMethod;
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/converter/swagger/SwaggerConverter.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -50,17 +49,18 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.httpclient.URIException;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.openapi.VariantOpenApi;
 import org.zaproxy.zap.extension.openapi.converter.Converter;
 import org.zaproxy.zap.extension.openapi.generators.Generators;
 import org.zaproxy.zap.extension.openapi.network.RequestMethod;
 import org.zaproxy.zap.extension.openapi.network.RequestModel;
 import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.model.StructuralNodeModifier;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.utils.Pair;
 
@@ -83,7 +83,7 @@ public class SwaggerConverter implements Converter {
     private static final String BASE_KEY_I18N = "openapi.swaggerconverter.";
 
     private static final Logger LOG = LogManager.getLogger(SwaggerConverter.class);
-    private static final Pattern PATH_PART_PATTERN = Pattern.compile("\\{.*}");
+    private static final Pattern PATH_PART_PATTERN = Pattern.compile("\\{.*?}");
     private final UriBuilder targetUriBuilder;
     private final UriBuilder definitionUriBuilder;
     private String defn;
@@ -92,6 +92,7 @@ public class SwaggerConverter implements Converter {
     private List<String> errors = new ArrayList<>();
     private Set<String> apiUrls;
     private OpenAPI openAPI;
+    private List<OperationModel> operationModels;
 
     public SwaggerConverter(String defn, ValueGenerator valGen) {
         this(null, null, defn, valGen);
@@ -180,10 +181,16 @@ public class SwaggerConverter implements Converter {
                 || "https".equalsIgnoreCase(scheme);
     }
 
+    public List<OperationModel> getOperationModels() throws SwaggerException {
+        if (operationModels == null) {
+            operationModels = readOpenAPISpec();
+        }
+        return operationModels;
+    }
+
     @Override
     public List<RequestModel> getRequestModels() throws SwaggerException {
-        List<OperationModel> operations = readOpenAPISpec();
-        return convertToRequest(operations);
+        return convertToRequest(getOperationModels());
     }
 
     private List<RequestModel> convertToRequest(List<OperationModel> operations) {
@@ -471,103 +478,40 @@ public class SwaggerConverter implements Converter {
         return swaggerParseResult;
     }
 
-    private List<StructuralNodeModifier> getStructuralNodeModifiers() {
-        if (openAPI == null) {
-            throw new IllegalStateException("The OpenAPI was not yet imported.");
+    public void updateVariantChecks(
+            Context context, String targetUrl, VariantOpenApi.VariantOpenApiChecks variantChecks)
+            throws SwaggerException {
+        if (targetUrl != null && !targetUrl.isEmpty()) {
+            includeInContext(context, targetUrl);
         }
-
-        String targetUrl = apiUrls.stream().findFirst().get();
-
-        Set<String> ddnRegexStrings = new HashSet<>();
-        // check for DDN on each key (path) in the spec
-        for (Map.Entry<String, PathItem> entry : openAPI.getPaths().entrySet()) {
-            String key = entry.getKey();
-            try {
-                List<String> params = getPathParameters(key);
-                String ddnPattern = createStructuralNodeRegexString(params, targetUrl, key);
-                if (ddnPattern != null) {
-                    ddnRegexStrings.add(ddnPattern);
-                }
-            } catch (Exception e) {
-                LOG.error("error evaluating DDN for key: {}", key, e);
+        for (OperationModel operation : getOperationModels()) {
+            String uri = operation.getPath();
+            if (targetUrl == null || targetUrl.isEmpty()) {
+                includeInContext(context, uri);
+            }
+            if (PATH_PART_PATTERN.matcher(uri).find()) {
+                String regex = uri.replaceAll(PATH_PART_PATTERN.pattern(), "[^/?]+");
+                variantChecks.pathsWithParamsRegex.put(operation, Pattern.compile(regex));
+            } else {
+                variantChecks.pathsWithNoParams.add(operation);
             }
         }
-
-        List<StructuralNodeModifier> structuralNodeModifiers = new ArrayList<>();
-        int ddnCnt = 0;
-        for (String regexString : ddnRegexStrings) {
-            try {
-                Pattern pattern = Pattern.compile(regexString);
-                StructuralNodeModifier structuralNodeModifier =
-                        createStructuralNode(pattern, "DDN" + ddnCnt++);
-                structuralNodeModifiers.add(structuralNodeModifier);
-            } catch (Exception e) {
-                LOG.error("error adding structural node", e);
-            }
-        }
-
-        return structuralNodeModifiers;
     }
 
-    public void setStructuralNodeModifiers(int contextId) {
-        if (contextId == -1) {
-            return;
-        }
-
+    private static void includeInContext(Context context, String url) {
         try {
-            List<StructuralNodeModifier> structuralNodeModifiers = getStructuralNodeModifiers();
-            Context ctx = Model.getSingleton().getSession().getContext(contextId);
-            ctx.setDataDrivenNodes(structuralNodeModifiers);
-        } catch (Exception e) {
-            LOG.error("Error setting data driven nodes from spec for contextId: {}", contextId, e);
-            errors.add(e.getMessage());
-        }
-    }
-
-    private static StructuralNodeModifier createStructuralNode(Pattern pattern, String ddnName) {
-        return new StructuralNodeModifier(
-                StructuralNodeModifier.Type.DataDrivenNode, pattern, ddnName);
-    }
-
-    private static String createStructuralNodeRegexString(
-            List<String> params, String finalTargetUrl, String key) {
-        if (params.isEmpty()) {
-            return null;
-        }
-        // get last param as the DDN for the key
-        String lastParam = params.get(params.size() - 1);
-
-        StringBuilder sb = new StringBuilder();
-        if (finalTargetUrl != null) {
-            sb.append(finalTargetUrl);
-        }
-
-        sb.append('(');
-        String pathTill = key.split(lastParam)[0].replace("{", "");
-        // replace other params with .+? regex in the first path grouping
-        for (String param : params) {
-            if (!param.equals(lastParam)) {
-                pathTill = pathTill.replace(param, ".+?");
+            if (context.isInContext(url)) {
+                return;
             }
+            URI uri = new URI(url, true);
+            String scheme = uri.getScheme();
+            String authority = uri.getAuthority();
+            String regex = scheme != null ? scheme + "://" : "";
+            regex += authority != null ? authority : "";
+            regex += ".*";
+            context.addIncludeInContextRegex(regex);
+        } catch (URIException e) {
+            LOG.debug("Could not add openapi target to context.", e);
         }
-        sb.append(pathTill);
-        // add trailing matcher for this DDN
-        sb.append(")(.+?)(/.*)");
-        return removeBrackets(sb.toString());
-    }
-
-    private static List<String> getPathParameters(String key) {
-        String[] pathParts = key.split("/");
-        List<String> params = new ArrayList<>();
-        for (String part : pathParts) {
-            if (PATH_PART_PATTERN.matcher(part).matches()) {
-                params.add(removeBrackets(part));
-            }
-        }
-        return params;
-    }
-
-    private static String removeBrackets(String str) {
-        return str.replace("{", "").replace("}", "");
     }
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/PathGenerator.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/generators/PathGenerator.java
@@ -31,8 +31,9 @@ public class PathGenerator {
     }
 
     public String generateFullPath(OperationModel operationModel) {
-        String queryString = "?";
-        if (operationModel.getOperation().getParameters() != null)
+        StringBuilder queryString = new StringBuilder("?");
+        String newPath = operationModel.getPath();
+        if (operationModel.getOperation().getParameters() != null) {
             for (Parameter parameter : operationModel.getOperation().getParameters()) {
                 if (parameter == null) {
                     continue;
@@ -40,16 +41,13 @@ public class PathGenerator {
                 String parameterType = parameter.getIn();
                 if ("query".equals(parameterType)) {
                     String value = dataGenerator.generate(parameter.getName(), parameter);
-                    queryString += parameter.getName() + "=" + value + "&";
+                    queryString.append(parameter.getName()).append('=').append(value).append('&');
                 } else if ("path".equals(parameterType)) {
                     String value = dataGenerator.generate(parameter.getName(), parameter);
-                    String newPath =
-                            operationModel
-                                    .getPath()
-                                    .replace("{" + parameter.getName() + "}", value);
-                    operationModel.setPath(newPath);
+                    newPath = newPath.replace("{" + parameter.getName() + "}", value);
                 }
             }
-        return operationModel.getPath() + queryString.substring(0, queryString.length() - 1);
+        }
+        return newPath + queryString.substring(0, queryString.length() - 1);
     }
 }

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/automation.html
@@ -21,7 +21,8 @@ The openapi job allows you to import OpenAPI definitions via a URL or file.
     parameters:
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden
+      context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden
 </pre>
 
 </BODY>

--- a/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
+++ b/addOns/openapi/src/main/javahelp/org/zaproxy/zap/extension/openapi/resources/help/contents/openapi.html
@@ -25,6 +25,14 @@ It also supports the <a href="automation.html">Automation Framework</a>.
 Both dialogues allow to override the server URL present in the OpenAPI definition (or specify one if not present) through the Target URL field.
 The import progress is shown in the progress tab.
 
+<H3>Context for Adding DDNs</H3>
+The dialogues also allow selecting a Context, optionally. If a context is selected,
+<ul>
+    <li>the target URL used for importing is added to the context</li>
+    <li>the imported spec is saved to the session database</li>
+    <li>data driven nodes are generated for endpoints with path parameters</li>
+</ul>
+
 <h3>Target URL Format</h3>
 The Target URL has the following format:<br>
 <code>scheme://authority/path</code><br>
@@ -40,46 +48,53 @@ Following some examples, overriding:
 <H2>API</H2>
 The following operations are added to the API:
 <ul>
-<li>ACTION importFile (file, target)</li>
-<li>ACTION importUrl (url, hostOverride)</li>
+<li>ACTION importFile (file, target, contextId)</li>
+<li>ACTION importUrl (url, hostOverride, contextId)</li>
 </ul>
 Both <code>target</code> and <code>hostOverride</code> support the <code>Target URL</code> format explained earlier.
 
 The definitions will be imported synchronously and any warnings will be returned.
 
-<H3>Data Driven Nodes</H3>
-<span style="white-space: pre;">
-When the OpenAPI schema contains path params the plugin will automatically generate data driven nodes in either the default context or for the context from the provided <code>contextId</code>.
+<H2>Data Driven Nodes</H2>
+When the OpenAPI definition contains path parameters, and a context is specified during importing, the add-on will
+automatically generate data driven nodes. If no context is specified, no data driven nodes are generated.
 
 For example, the following OpenAPI definition will result in at least one data driven node.
 
-<strong>openapi.yml</strong>
-<code >
+<pre>
     ...
     /users/v1/{username}/email:
       ...
       parameters:
         - name: username
-        in: path
-        description: username to update email
-        required: true
-        schema:
-          type: string
+          in: path
+          description: username to update email
+          required: true
+          schema:
+            type: string
     ...
-</code>
+</pre>
 
-<strong>Default Context > Structure > Structural Modifiers</strong>
-<code>
-    DDN0: (/)(.+?)(/.*)
-    DDN1: (/users/v1/)(.+?)(/.*)
-</code>
-</span>
+The following nodes are added to the Sites Tree for the above endpoint:
+<pre>
+Sites
+└── http://example.com
+    └── users
+        └── v1
+            └── «username»
+                └── email
+</pre>
+
+The imported OpenAPI definition is persisted to the session database. When the session is reloaded, the definition is
+used to generate the data driven nodes and mark them for future requests.
+
 <H2>Command Line</H2>
 The following Command Line options are added:
 <ul>
 <li>-openapifile &lt;filename&gt;  : Imports an OpenAPI definition from the specified file name</li>
 <li>-openapiurl &lt;url&gt;  : Imports an OpenAPI definition from the specified URL</li>
 <li>-openapitargeturl &lt;url&gt;  : The Target URL, to override the server URL present in the OpenAPI definition</li>
+<li>-openapicontextid &lt;id&gt; : The Context ID used to associate data driven nodes generated from path parameters in the OpenAPI definition</li>
 </ul>
 
 The definitions will be imported synchronously and any warnings will be displayed on the command line.

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -19,10 +19,12 @@ openapi.automation.dialog.name = Job Name:
 openapi.automation.dialog.apifile = API File:
 openapi.automation.dialog.apiurl = API URL:
 openapi.automation.dialog.targeturl = Target URL:
+openapi.automation.dialog.context = Context:
 
 openapi.cmdline.file.help = Imports an OpenAPI definition from the specified file name
 openapi.cmdline.url.help = Imports an OpenAPI definition from the specified URL
 openapi.cmdline.targeturl.help = The Target URL, to override the server URL present in the OpenAPI definition. Refer to the help for supported format.
+openapi.cmdline.contextid.help = The Context ID used to associate data driven nodes generated from path parameters in the OpenAPI definition
 
 openapi.formhandler.desc = OpenAPI Form Handler Integration
 openapi.formhandler.name = OpenAPI Form Handler
@@ -34,6 +36,7 @@ openapi.topmenu.import.importopenapi.tooltip = The file must be a formal describ
 openapi.topmenu.import.importremoteopenapi = Import an OpenAPI definition from a URL
 openapi.topmenu.import.importremoteopenapi.tooltip = The contents must be a formal described OpenAPI definition.
 
+openapi.importfromdialog.labelcontext = Context For Adding DDNs:
 openapi.importfromdialog.labeltarget = Target URL:
 openapi.importfromdialog.importbutton = Import
 openapi.importfromdialog.pasteaction = Paste

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-max.yaml
@@ -2,4 +2,5 @@
     parameters:
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden
+      context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-min.yaml
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/openapi-min.yaml
@@ -2,4 +2,5 @@
     parameters:
       apiFile:                         # String: Local file containing the OpenAPI definition, default: null, no definition will be imported
       apiUrl:                          # String: URL containing the OpenAPI definition, default: null, no definition will be imported
-      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overriden
+      context:                         # String: Context to use when importing the OpenAPI definition, default: null, no context will be used
+      targetUrl:                       # String: URL which overrides the target defined in the definition, default: null, the target will not be overridden

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApiTest.java
@@ -39,22 +39,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.control.Control;
 import org.parosproxy.paros.db.RecordHistory;
@@ -65,8 +55,6 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.zap.extension.ascan.VariantFactory;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
-import org.zaproxy.zap.model.Context;
-import org.zaproxy.zap.model.StructuralNodeModifier;
 import org.zaproxy.zap.testutils.NanoServerHandler;
 import org.zaproxy.zap.utils.I18N;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
@@ -193,46 +181,6 @@ class ExtensionOpenApiTest extends AbstractServerTest {
         assertThat(results.getHistoryReferences(), hasSize(1));
     }
 
-    @ParameterizedTest
-    @NullAndEmptySource
-    void shouldGenerateDataDrivenNodesOnContext(String target) throws IOException {
-        // Given
-        File file = createLocalDefinition("v3/PetStore_defn.json").toFile();
-        Context ctx = createContext();
-        String serverUrl = "http://localhost:" + nano.getListeningPort();
-        String targetUrl = target != null ? serverUrl + "/v1" : null;
-        String expectedUrl = target != null ? targetUrl : serverUrl + "/PetStore";
-
-        // When
-        extensionOpenApi.importOpenApiDefinition(file, targetUrl, false, ctx.getId());
-
-        // Then
-        assertThat(
-                ctx.getDataDrivenNodes(),
-                contains(
-                        expectedUrl + "(/pet/)(.+?)(/.*)",
-                        expectedUrl + "(/store/order/)(.+?)(/.*)",
-                        expectedUrl + "(/user/)(.+?)(/.*)"));
-    }
-
-    @Test
-    void shouldGenerateDataDrivenNodesOnContextForMultiVarPath() throws IOException {
-        // Given
-        File file = createLocalDefinition("v3/MultiVarPath_defn.yaml").toFile();
-        Context ctx = createContext();
-        String serverUrl = "http://localhost:" + nano.getListeningPort();
-
-        // When
-        extensionOpenApi.importOpenApiDefinition(file, null, false, ctx.getId());
-
-        // Then
-        assertThat(
-                ctx.getDataDrivenNodes(),
-                contains(
-                        serverUrl + "(/api/stuff/.+?/subthing/)(.+?)(/.*)",
-                        serverUrl + "(/api/stuff/)(.+?)(/.*)"));
-    }
-
     private Path createLocalDefinition(String path) throws IOException {
         Path directory = Files.createTempDirectory("local-defn");
         Path localDefinition = directory.resolve(path.substring(path.lastIndexOf("/") + 1));
@@ -257,10 +205,6 @@ class ExtensionOpenApiTest extends AbstractServerTest {
         return localDefinition.toFile();
     }
 
-    private static Context createContext() {
-        return Model.getSingleton().getSession().getNewContext("Test Context");
-    }
-
     private static class EmptyServerHandler extends NanoServerHandler {
 
         EmptyServerHandler() {
@@ -271,56 +215,5 @@ class ExtensionOpenApiTest extends AbstractServerTest {
         protected NanoHTTPD.Response serve(NanoHTTPD.IHTTPSession session) {
             return newFixedLengthResponse("");
         }
-    }
-
-    private static Matcher<List<StructuralNodeModifier>> contains(String... regexes) {
-        List<String> expectedValues = new ArrayList<>();
-        expectedValues.addAll(Arrays.asList(regexes));
-        Collections.sort(expectedValues);
-
-        return new BaseMatcher<List<StructuralNodeModifier>>() {
-
-            @Override
-            public boolean matches(Object actualValue) {
-                @SuppressWarnings("unchecked")
-                List<StructuralNodeModifier> values = (List<StructuralNodeModifier>) actualValue;
-                if (values.isEmpty()) {
-                    return false;
-                }
-
-                List<String> matched = new ArrayList<>(expectedValues);
-                for (StructuralNodeModifier value : values) {
-                    if (!matched.remove(value.getPattern().pattern())) {
-                        return false;
-                    }
-                }
-                return matched.isEmpty();
-            }
-
-            @Override
-            public void describeTo(Description description) {
-                description
-                        .appendText("the DDN regular expressions to be ")
-                        .appendValue(expectedValues);
-            }
-
-            @Override
-            public void describeMismatch(Object item, Description description) {
-                @SuppressWarnings("unchecked")
-                List<StructuralNodeModifier> values = (List<StructuralNodeModifier>) item;
-                if (values.isEmpty()) {
-                    description.appendText("had no DDNs");
-                } else {
-                    description
-                            .appendText("were ")
-                            .appendValue(
-                                    values.stream()
-                                            .map(StructuralNodeModifier::getPattern)
-                                            .map(Pattern::pattern)
-                                            .sorted()
-                                            .collect(Collectors.toList()));
-                }
-            }
-        };
     }
 }

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/VariantOpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/VariantOpenApiUnitTest.java
@@ -1,0 +1,171 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.model.Context;
+
+class VariantOpenApiUnitTest extends AbstractServerTest {
+
+    ExtensionOpenApi extensionOpenApi;
+
+    VariantOpenApi variantOpenApi;
+
+    @BeforeEach
+    void setUp() {
+        extensionOpenApi = new ExtensionOpenApi();
+        extensionOpenApi.initModel(Model.getSingleton());
+        Model.getSingleton().closeSession();
+        Context context = new Context(Model.getSingleton().getSession(), 0);
+        Model.getSingleton().getSession().addContext(context);
+        variantOpenApi = new VariantOpenApi(extensionOpenApi);
+    }
+
+    @Test
+    void shouldGetTreePathWithDdn() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/PetStore_defn.json").toFile();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        String targetUrl = serverUrl + "/v1";
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, targetUrl, false, 0);
+        // Then
+        assertThat(getTreePathAsString("GET", targetUrl + "/pet/1"), is("/v1/pet/«petId»"));
+        assertThat(
+                getTreePathAsString("GET", targetUrl + "/store/order/2"),
+                is("/v1/store/order/«orderId»"));
+        assertThat(
+                getTreePathAsString("GET", targetUrl + "/user/example"), is("/v1/user/«username»"));
+    }
+
+    @Test
+    void shouldGetTreePathWithNestedDdns() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/MultiVarPath_defn.yaml").toFile();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, serverUrl, false, 0);
+        // Then
+        assertThat(
+                getTreePathAsString("GET", serverUrl + "/api/stuff/42/subthing/54"),
+                is("/api/stuff/«thingid»/subthing/«thingid2»"));
+    }
+
+    @Test
+    void shouldNotCreateDdnForUrlWithoutPathParamInSpec() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/MultiVarPath_defn.yaml").toFile();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, serverUrl, false, 0);
+        // Then
+        assertThat(
+                getTreePathAsString("GET", serverUrl + "/api/stuff/static"),
+                is("/api/stuff/static"));
+        assertThat(
+                getTreePathAsString("GET", serverUrl + "/api/stuff/dynamic"),
+                is("/api/stuff/«thingid»"));
+    }
+
+    @Test
+    void shouldCreateDdnsForSpecifiedMethodInSpec() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/MultiVarPath_defn.yaml").toFile();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, serverUrl, false, 0);
+        // Then
+        assertThat(
+                getTreePathAsString("GET", serverUrl + "/api/stuff/42"),
+                is("/api/stuff/«thingid»"));
+        assertThat(getTreePathAsString("POST", serverUrl + "/api/stuff/42"), is(nullValue()));
+    }
+
+    @Test
+    void shouldGetTreePathForUriWithQueryParams() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/MultiVarPath_defn.yaml").toFile();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, serverUrl, false, 0);
+        // Then
+        assertThat(
+                getTreePathAsString("GET", serverUrl + "/api/stuff/42/subthing/54?a=b&c=d"),
+                is("/api/stuff/«thingid»/subthing/«thingid2»"));
+        assertThat(
+                getTreePathAsString("GET", serverUrl + "/api/stuff/42/subthing/54/?a=b&c=d"),
+                is("/api/stuff/«thingid»/subthing/«thingid2»"));
+    }
+
+    @Test
+    void shouldCreateSlashNode() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/openapi_slash_node.yaml").toFile();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, serverUrl, false, 0);
+        // Then
+        assertThat(getTreePathAsString("GET", serverUrl + "/"), is("/"));
+        assertThat(getTreePathAsString("GET", serverUrl + "/?a=b&c=d"), is("/"));
+    }
+
+    @Test
+    void shouldCreateSlashNodeWithQueryParams() throws IOException {
+        // Given
+        File file = createLocalDefinition("v3/openapi_slash_node.yaml").toFile();
+        String serverUrl = "http://localhost:" + nano.getListeningPort();
+        // When
+        extensionOpenApi.importOpenApiDefinition(file, serverUrl, false, 0);
+        // Then
+        assertThat(getTreePathAsString("GET", serverUrl), is(""));
+        assertThat(getTreePathAsString("GET", serverUrl + "?a=b&c=d"), is(""));
+    }
+
+    private Path createLocalDefinition(String path) throws IOException {
+        Path directory = Files.createTempDirectory("local-defn");
+        Path localDefinition = directory.resolve(path.substring(path.lastIndexOf("/") + 1));
+        String fileContents =
+                getHtml(
+                        path,
+                        new String[][] {{"PORT", String.valueOf(this.nano.getListeningPort())}});
+        Files.write(localDefinition, fileContents.getBytes(StandardCharsets.UTF_8));
+        return localDefinition;
+    }
+
+    private String getTreePathAsString(String method, String url) throws IOException {
+        HttpMessage msg = new HttpMessage();
+        msg.setRequestHeader(method + " " + url + " HTTP/1.1\r\n");
+        List<String> treePath = variantOpenApi.getTreePath(msg);
+        return treePath != null ? String.join("/", treePath) : null;
+    }
+}

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -84,10 +84,11 @@ class OpenApiJobUnitTest extends TestUtils {
         Map<String, String> params = job.getCustomConfigParameters();
 
         // Then
-        assertThat(params.size(), is(equalTo(3)));
+        assertThat(params.size(), is(equalTo(4)));
         assertThat(params.get("apiFile"), is(equalTo("")));
         assertThat(params.get("apiUrl"), is(equalTo("")));
         assertThat(params.get("targetUrl"), is(equalTo("")));
+        assertThat(params.get("context"), is(equalTo("")));
     }
 
     @Test
@@ -97,6 +98,7 @@ class OpenApiJobUnitTest extends TestUtils {
         String apiFile = "C:\\Users\\ZAPBot\\Documents\\test file.json";
         String apiUrl = "https://example.com/test%20file.json";
         String targetUrl = "https://example.com/endpoint/";
+        String context = "My Context";
         String yamlStr =
                 "parameters:\n"
                         + "  apiUrl: "
@@ -106,7 +108,10 @@ class OpenApiJobUnitTest extends TestUtils {
                         + apiFile
                         + "\n"
                         + "  targetUrl: "
-                        + targetUrl;
+                        + targetUrl
+                        + "\n"
+                        + "  context: "
+                        + context;
         Yaml yaml = new Yaml();
         Object data = yaml.load(yamlStr);
 
@@ -121,6 +126,7 @@ class OpenApiJobUnitTest extends TestUtils {
         assertThat(job.getParameters().getApiFile(), is(equalTo(apiFile)));
         assertThat(job.getParameters().getApiUrl(), is(equalTo(apiUrl)));
         assertThat(job.getParameters().getTargetUrl(), is(equalTo(targetUrl)));
+        assertThat(job.getParameters().getContext(), is(equalTo(context)));
         assertThat(progress.hasErrors(), is(equalTo(false)));
         assertThat(progress.hasWarnings(), is(equalTo(false)));
     }

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_slash_node.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/openapi_slash_node.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: OpenAPI definition with Slash Node
+  version: "0"
+servers:
+  - url: http://localhost:@@@PORT@@@/
+paths:
+  /:
+    get:
+      tags:
+        - home
+      summary: home
+      operationId: api_views.main.basic
+      responses:
+        '200':
+          description: Home - Help
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  Help:
+                    type: string


### PR DESCRIPTION
Added
- Imported specs are now persisted to the session database. They are used by the new variant to mark path parameters as
  Data Driven Nodes.

Changed
- DDNs added as Structural Modifiers have been superseded by a custom variant. The variant supports nested DDNs and leaf
  DDNs, prevents non-parameter URL paths from being merged with DDNs, and treats paths with different HTTP methods
  uniquely. DDNs are named with the parameter name from the spec.