### PR TITLE
ascanrulesBeta: Add more source control paths to Hidden File Finder

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - New User Agent strings to the User Agent fuzz scan rule.
+- Additional source control paths for the Hidden Files finder scan rule.
 
 ## [41] - 2022-06-08
 ### Changed

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +72,14 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
                     CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE);
     static final String PAYLOADS_FILE_PATH = "json/hidden_files.json";
 
-    private static final List<String> HIDDEN_FILES = new ArrayList<>();
+    private static final List<String> HIDDEN_FILES =
+            Arrays.asList(
+                    // Source Control paths to look for, per:
+                    // https://twitter.com/intigriti/status/1533050946212839424
+                    ".hg", // Mercurial
+                    ".bzr", // Bazaar
+                    "._darcs", // Darcs
+                    "BitKeeper");
     private static final Supplier<Iterable<String>> DEFAULT_PAYLOAD_PROVIDER = () -> HIDDEN_FILES;
     public static final String HIDDEN_FILE_PAYLOAD_CATEGORY = "Hidden-File";
     private static Supplier<Iterable<String>> payloadProvider = DEFAULT_PAYLOAD_PROVIDER;

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -125,7 +126,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // When
         rule.scan();
         // Then
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(HttpRequestHeader.GET, httpMessagesSent.get(0).getRequestHeader().getMethod());
         assertNull(httpMessagesSent.get(0).getRequestHeader().getHeader(HttpHeader.CONTENT_TYPE));
         assertEquals(0, httpMessagesSent.get(0).getRequestBody().length());
@@ -160,7 +161,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
         assertEquals(hiddenFile.getType(), alert.getOtherInfo());
@@ -256,7 +257,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_INFO, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
         assertEquals(hiddenFile.getType(), alert.getOtherInfo());
@@ -286,7 +287,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         rule.scan();
         // Then
         assertThat(alertsRaised, hasSize(0));
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
     }
 
     @Test
@@ -316,7 +317,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
         assertEquals(hiddenFile.getType(), alert.getOtherInfo());
@@ -378,7 +379,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
         assertEquals(hiddenFile.getType(), alert.getOtherInfo());
@@ -441,7 +442,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         rule.scan();
         // Then
         assertThat(alertsRaised, hasSize(0));
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
     }
 
     @Test
@@ -473,7 +474,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
         assertEquals(rule.getReference(), alert.getReference());
@@ -510,7 +511,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
         assertEquals(rule.getReference(), alert.getReference());
@@ -581,7 +582,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_HIGH, alertsRaised.get(0).getConfidence());
         assertEquals(rule.getReference(), alert.getReference());
@@ -623,7 +624,7 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         // Then
         assertThat(alertsRaised, hasSize(1));
         Alert alert = alertsRaised.get(0);
-        assertEquals(1, httpMessagesSent.size());
+        assertThat(httpMessagesSent, hasSize(greaterThanOrEqualTo(1)));
         assertEquals(Alert.RISK_MEDIUM, alertsRaised.get(0).getRisk());
         assertEquals(Alert.CONFIDENCE_LOW, alertsRaised.get(0).getConfidence());
         assertEquals(rule.getReference(), alert.getReference());


### PR DESCRIPTION
- CHANGELOG > Add, added note.
- HiddenFilesScanRule > Added default payloads for source control paths not already covered by ZAP.
- HiddenFilesScanRule > Updated to account for default payloads in messages sent counts.

Note: 
1. UnitTest wise these are covered by:
`shouldRaiseAlertWithLowConfidenceIfTestedUrlRespondsOkToCustomPayload`
2. These have been added as Custom Payloads as I do not currently have content checks to supplement them.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>