### PR TITLE
openapi: test definition with component recursion

### DIFF
--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/v3/OpenApiUnitTest.java
@@ -319,6 +319,40 @@ class OpenApiUnitTest extends AbstractServerTest {
     }
 
     @Test
+    void shouldFailToParseDefinitionWithSchemaComponentRecursion() throws Exception {
+        // Given
+        String test = "/";
+        String defnName = "defn.yaml";
+
+        this.nano.addHandler(
+                new DefnServerHandler(test, defnName, "schema_component_recursion.yaml"));
+
+        Requestor requestor = new Requestor(HttpSender.MANUAL_REQUEST_INITIATOR);
+        HttpMessage defnMsg = this.getHttpMessage(test + defnName);
+        SwaggerConverter converter =
+                new SwaggerConverter(
+                        requestor.getResponseBody(defnMsg.getRequestHeader().getURI()), null);
+
+        final Map<String, String> accessedUrls = new HashMap<>();
+        RequesterListener listener =
+                new RequesterListener() {
+
+                    @Override
+                    public void handleMessage(HttpMessage message, int initiator) {
+                        accessedUrls.put(
+                                message.getRequestHeader().getMethod()
+                                        + " "
+                                        + message.getRequestHeader().getURI().toString(),
+                                message.getRequestBody().toString());
+                    }
+                };
+        requestor.addListener(listener);
+
+        // When / Then
+        assertThrows(StackOverflowError.class, () -> converter.getRequestModels());
+    }
+
+    @Test
     void shouldUseValueGenerator() throws NullPointerException, IOException, SwaggerException {
         String test = "/PetStoreJson/";
         String defnName = "defn.json";

--- a/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/schema_component_recursion.yaml
+++ b/addOns/openapi/src/test/resources/org/zaproxy/zap/extension/openapi/v3/schema_component_recursion.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+servers:
+  - url: http://localhost:@@@PORT@@@/
+paths:
+  /first:
+    get:
+      parameters:
+      - "$ref": "#/components/parameters/p_one"
+      - "$ref": "#/components/parameters/p_one"
+      - "$ref": "#/components/parameters/p_one"
+      responses:
+        200:
+          description: ok
+components:
+  parameters:
+    p_one:
+      in: query
+      schema:
+        "$ref": "#/components/schemas/NestedObject"
+      style: deepObject
+  schemas:
+    NestedObject:
+      additionalProperties:
+        oneOf:
+        - "$ref": "#/components/schemas/NestedObject"
+        - not:
+            type: object
+      type: object


### PR DESCRIPTION
Add test with definition that has component recursion to verify the fix
once the Swagger library is updated.
Adapted example definition provided in the issue.

Part of zaproxy/zaproxy#7346.