### PR TITLE
automation: skip removed alerts for scan result

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show each context URL in its own line when editing in the GUI (Issue 7241).
 - Correct error messages.
 - Wrong API end point reference in help
+- Fix exception when alerts found during active scan no longer exist when creating the data for the report.
 
 ## [0.15.0] - 2022-04-25
 ### Added

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJobResultData.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/ActiveScanJobResultData.java
@@ -29,6 +29,7 @@ import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.HostProcess;
 import org.parosproxy.paros.core.scanner.Plugin;
 import org.parosproxy.paros.db.DatabaseException;
+import org.parosproxy.paros.db.RecordAlert;
 import org.parosproxy.paros.model.Model;
 import org.zaproxy.addon.automation.JobResultData;
 import org.zaproxy.zap.extension.ascan.ActiveScan;
@@ -60,8 +61,10 @@ public class ActiveScanJobResultData extends JobResultData {
         List<Integer> alertIds = activeScan.getAlertsIds();
         for (int id : alertIds) {
             try {
-                alertDataMap.put(
-                        id, new Alert(Model.getSingleton().getDb().getTableAlert().read(id)));
+                RecordAlert recordAlert = Model.getSingleton().getDb().getTableAlert().read(id);
+                if (recordAlert != null) {
+                    alertDataMap.put(id, new Alert(recordAlert));
+                }
             } catch (DatabaseException e) {
                 LOG.error("Could not read alert with id {} from the database : {}", id, e);
             }

--- a/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobResultDataUnitTest.java
+++ b/addOns/automation/src/test/java/org/zaproxy/addon/automation/jobs/ActiveScanJobResultDataUnitTest.java
@@ -1,0 +1,93 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.automation.jobs;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.HostProcess;
+import org.parosproxy.paros.db.Database;
+import org.parosproxy.paros.db.RecordAlert;
+import org.parosproxy.paros.db.TableAlert;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.ascan.ActiveScan;
+
+/** Unit test for {@link ActiveScanJobResultData}. */
+class ActiveScanJobResultDataUnitTest {
+
+    private static final String JOB_NAME = "Job Name";
+
+    private List<HostProcess> hostProcesses;
+    private List<Integer> alertIds;
+    private TableAlert tableAlert;
+
+    private ActiveScan activeScan;
+
+    @BeforeEach
+    void setUp() {
+        activeScan = mock(ActiveScan.class);
+        hostProcesses = new ArrayList<>();
+        given(activeScan.getHostProcesses()).willReturn(hostProcesses);
+        alertIds = new ArrayList<>();
+        given(activeScan.getAlertsIds()).willReturn(alertIds);
+
+        Database db = mock(Database.class);
+        tableAlert = mock(TableAlert.class);
+        given(db.getTableAlert()).willReturn(tableAlert);
+
+        Model model = mock(Model.class);
+        given(model.getDb()).willReturn(db);
+        Model.setSingletonForTesting(model);
+    }
+
+    @Test
+    void shouldReadAllAlerts() throws Exception {
+        // Given
+        mockPersistedAlert(1);
+        mockPersistedAlert(2);
+        // When
+        ActiveScanJobResultData data = new ActiveScanJobResultData(JOB_NAME, activeScan);
+        // Then
+        assertThat(data.getAllAlertData(), hasSize(2));
+    }
+
+    @Test
+    void shouldNotFailIfAlertNoLongerExists() throws Exception {
+        // Given
+        mockPersistedAlert(1);
+        mockPersistedAlert(2);
+        given(tableAlert.read(1)).willReturn(null);
+        // When
+        ActiveScanJobResultData data = new ActiveScanJobResultData(JOB_NAME, activeScan);
+        // Then
+        assertThat(data.getAllAlertData(), hasSize(1));
+    }
+
+    private void mockPersistedAlert(int id) throws Exception {
+        given(tableAlert.read(id)).willReturn(mock(RecordAlert.class));
+        alertIds.add(id);
+    }
+}


### PR DESCRIPTION
Skip the alerts that might have been removed when building the scan
result.

---
Reported in the OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/PErQlsAl-T8/m/1STkYjQUAAAJ