### PR TITLE
reports: check that the passive scan data exists

### DIFF
--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Exceptions when generating some reports without the Automation add-on being installed.
+
 ## [0.13.0] - 2022-04-05
 ### Changed
 - Dependency updates.

--- a/addOns/reports/src/main/zapHomeFiles/reports/modern/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/modern/report.html
@@ -241,17 +241,20 @@
 								</th:block>
 							</th:block>
 							<th:block
-								th:each="pscan : ${reportData.reportObjects.get('passiveScanData').allRuleData}">
-								<tr th:if="${alertCountsByRule.get(pscan.id) == null}">
-									<td><a
-										th:href="${'https://www.zaproxy.org/docs/alerts/' + pscan.id + '/'}"
-										th:if="${pscan.id &gt;= 0}" th:text="${pscan.name}">Alert
-											Name</a></td>
-									<td th:text="#{report.template.pass.type.passive}"
-										align="center">Passive</td>
-									<td align="center" th:text="${pscan.threshold}">Threshold</td>
-									<td align="center">-</td>
-								</tr>
+								th:if="${reportData.reportObjects.get('passiveScanData') != null}">
+								<th:block
+									th:each="pscan : ${reportData.reportObjects.get('passiveScanData').allRuleData}">
+									<tr th:if="${alertCountsByRule.get(pscan.id) == null}">
+										<td><a
+											th:href="${'https://www.zaproxy.org/docs/alerts/' + pscan.id + '/'}"
+											th:if="${pscan.id &gt;= 0}" th:text="${pscan.name}">Alert
+												Name</a></td>
+										<td th:text="#{report.template.pass.type.passive}"
+											align="center">Passive</td>
+										<td align="center" th:text="${pscan.threshold}">Threshold</td>
+										<td align="center">-</td>
+									</tr>
+								</th:block>
 							</th:block>
 						</table>
 					</div>

--- a/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
+++ b/addOns/reports/src/main/zapHomeFiles/reports/traditional-html-plus/report.html
@@ -164,15 +164,19 @@
 				</th:block>
 			</th:block>
 			<th:block
-				th:each="pscan : ${reportData.reportObjects.get('passiveScanData').allRuleData}">
-				<tr th:if="${alertCountsByRule.get(pscan.id) == null}">
-					<td><a
-						th:href="${'https://www.zaproxy.org/docs/alerts/' + pscan.id + '/'}"
-						th:if="${pscan.id &gt;= 0}" th:text="${pscan.name}">Alert Name</a></td>
-					<td th:text="#{report.template.pass.type.passive}" align="center">Passive</td>
-					<td align="center" th:text="${pscan.threshold}">Threshold</td>
-					<td align="center">-</td>
-				</tr>
+				th:if="${reportData.reportObjects.get('passiveScanData') != null}">
+				<th:block
+					th:each="pscan : ${reportData.reportObjects.get('passiveScanData').allRuleData}">
+					<tr th:if="${alertCountsByRule.get(pscan.id) == null}">
+						<td><a
+							th:href="${'https://www.zaproxy.org/docs/alerts/' + pscan.id + '/'}"
+							th:if="${pscan.id &gt;= 0}" th:text="${pscan.name}">Alert
+								Name</a></td>
+						<td th:text="#{report.template.pass.type.passive}" align="center">Passive</td>
+						<td align="center" th:text="${pscan.threshold}">Threshold</td>
+						<td align="center">-</td>
+					</tr>
+				</th:block>
 			</th:block>
 		</table>
 		<div class="spacer-lg"></div>


### PR DESCRIPTION
Check in the report templates that the `passiveScanData` exists before
using it, it's no available if the automation add-on is not installed.

---
Reported in the OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/PErQlsAl-T8/m/Cd1xsZMcAAAJ