### PR TITLE
ascanrules: External Redirect scan rule accuracy updates

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -6,9 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Cross Site Scripting header splitting attacks.
+- The External Redirect scan rule now includes alert references on Alerts, and has example alert functionality for documentation generation purposes.
 
 ### Changed
 - Maintenance changes.
+- Updated the External Redirect scan rule to be more accurate.
 
 ### Fixed
 - The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).


### PR DESCRIPTION
Related to: https://groups.google.com/g/zaproxy-users/c/n-l-8qj9ggk

- CHANGELOG > Added change note.
- ExternalRedirectScanRule > Updated to be hopefully more accurate.
- ExternalRedirectScanRuleUnitTest > Updated to more fully test functionality.

Tested against wavsep docker, 60 alerts before, 60 after.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>