### PR TITLE
network: set content-length to response

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -565,5 +565,14 @@ public class HttpSenderApache
             Header header = it.next();
             to.addHeader(header.getName(), header.getValue());
         }
+
+        String contentLength = to.getHeader(HttpHeader.CONTENT_LENGTH);
+        if (contentLength != null) {
+            try {
+                to.setContentLength(Integer.parseInt(contentLength));
+            } catch (NumberFormatException e) {
+                LOGGER.debug("Invalid content-length value: {}", contentLength);
+            }
+        }
     }
 }


### PR DESCRIPTION
Set the content-length to the response as it is not set when the
corresponding header field is simply added to the header.
This was breaking the download of add-ons bigger than 16MiB.