### PR TITLE
callhome: set order to the extension

### DIFF
--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/ExtensionCallHome.java
@@ -134,6 +134,8 @@ public class ExtensionCallHome extends ExtensionAdaptor
     public ExtensionCallHome() {
         super(NAME);
         setI18nPrefix(PREFIX);
+        // Just before the Network extension.
+        setOrder(Integer.MAX_VALUE - 1);
     }
 
     @Override


### PR DESCRIPTION
Ensure the callhome extension is destroyed before the network extension
otherwise it would not be able to send the HTTP requests as the network
extension would be already destroyed.