### PR TITLE
ascanrules: Merge XSS detection logic of CrossSiteScriptingScanRule and PersistentXssScanRule

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Use XSS detection logic from CrossSiteScriptingScanRule on PersistentXssScanRule
 
 ### Fixed
 - The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -751,10 +751,10 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             // Inject the 'safe' eyecatcher and see where it appears
             boolean attackWorked = false;
             boolean appendedValue = false;
-            HttpMessage msg2 = getNewMsg();
-            setParameter(msg2, param, Constant.getEyeCatcher());
+            HttpMessage eyeCatcherMsg = getNewMsg();
+            setParameter(eyeCatcherMsg, param, Constant.getEyeCatcher());
             try {
-                sendAndReceive(msg2);
+                sendAndReceive(eyeCatcherMsg);
             } catch (URIException e) {
                 log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
                 return;
@@ -768,7 +768,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 return;
             }
 
-            HtmlContextAnalyser hca = new HtmlContextAnalyser(msg2);
+            HtmlContextAnalyser hca = new HtmlContextAnalyser(eyeCatcherMsg);
             List<HtmlContext> contexts = hca.getHtmlContexts(Constant.getEyeCatcher(), null, 0);
             if (contexts.isEmpty()) {
                 // Lower case?
@@ -781,11 +781,11 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             if (contexts.isEmpty()) {
                 // No luck - try again, appending the eyecatcher to the original
                 // value
-                msg2 = getNewMsg();
-                setParameter(msg2, param, value + Constant.getEyeCatcher());
+                eyeCatcherMsg = getNewMsg();
+                setParameter(eyeCatcherMsg, param, value + Constant.getEyeCatcher());
                 appendedValue = true;
                 try {
-                    sendAndReceive(msg2);
+                    sendAndReceive(eyeCatcherMsg);
                 } catch (URIException e) {
                     log.debug("Failed to send HTTP message, cause: {}", e.getMessage());
                     return;
@@ -794,7 +794,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                     // continue
                     return;
                 }
-                hca = new HtmlContextAnalyser(msg2);
+                hca = new HtmlContextAnalyser(eyeCatcherMsg);
                 contexts = hca.getHtmlContexts(value + Constant.getEyeCatcher(), null, 0);
             }
             if (contexts.isEmpty()) {
@@ -851,7 +851,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             }
             // Always attack the header if the eyecatcher is reflected in it - this will be
             // different to any alert raised above
-            if (msg2.getResponseHeader().toString().contains(Constant.getEyeCatcher())) {
+            if (eyeCatcherMsg.getResponseHeader().toString().contains(Constant.getEyeCatcher())) {
                 attackHeader(msg, param, appendedValue ? value : "");
             }
 

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CrossSiteScriptingScanRule.java
@@ -147,26 +147,30 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
     private List<HtmlContext> performAttack(
             HttpMessage msg,
+            HttpMessage sinkMsg,
             String param,
             String attack,
             HtmlContext targetContext,
             int ignoreFlags) {
-        return performAttack(msg, param, attack, targetContext, ignoreFlags, false, false, false);
+        return performAttack(
+                msg, sinkMsg, param, attack, targetContext, ignoreFlags, false, false, false);
     }
 
     private List<HtmlContext> performAttack(
             HttpMessage msg,
+            HttpMessage sinkMsg,
             String param,
             String attack,
             HtmlContext targetContext,
             int ignoreFlags,
             boolean findDecoded) {
         return performAttack(
-                msg, param, attack, targetContext, ignoreFlags, findDecoded, false, false);
+                msg, sinkMsg, param, attack, targetContext, ignoreFlags, findDecoded, false, false);
     }
 
     private List<HtmlContext> performAttack(
             HttpMessage msg,
+            HttpMessage sinkMsg,
             String param,
             String attack,
             HtmlContext targetContext,
@@ -176,6 +180,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             boolean ignoreSafeParents) {
         return this.performAttack(
                 msg,
+                sinkMsg,
                 param,
                 attack,
                 targetContext,
@@ -188,6 +193,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
 
     private List<HtmlContext> performAttack(
             HttpMessage msg,
+            HttpMessage sinkMsg,
             String param,
             String attack,
             HtmlContext targetContext,
@@ -228,7 +234,19 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             attack = attack.replaceFirst(NULL_BYTE_CHARACTER, "");
             evidence = attack;
         }
-        HtmlContextAnalyser hca = new HtmlContextAnalyser(msg2);
+        HtmlContextAnalyser hca;
+        if (sinkMsg != null) {
+            HttpMessage sinkUpdated = sinkMsg.cloneRequest();
+            try {
+                sendAndReceive(sinkUpdated);
+            } catch (Exception e) {
+                log.warn(e.getMessage(), e);
+                return null;
+            }
+            hca = new HtmlContextAnalyser(sinkUpdated);
+        } else {
+            hca = new HtmlContextAnalyser(msg2);
+        }
         if (Plugin.AlertThreshold.HIGH.equals(this.getAlertThreshold())) {
             // High level, so check all results are in the expected context
             return hca.getHtmlContexts(
@@ -248,13 +266,14 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 .setAttack(ctx.getTarget())
                 .setEvidence(ctx.getTarget())
                 .setMessage(ctx.getMsg())
-                .setOtherInfo(otherInfo)
+                .setOtherInfo(adaptOtherInfo(otherInfo))
                 .raise();
     }
 
     private boolean performDirectAttack(HttpMessage msg, String param, String value) {
         for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
-            List<HtmlContext> contexts2 = performAttack(msg, param, "'\"" + scriptAlert, null, 0);
+            List<HtmlContext> contexts2 =
+                    performAttack(msg, null, param, "'\"" + scriptAlert, null, 0);
             if (contexts2 == null) {
                 continue;
             }
@@ -266,6 +285,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(contexts2.get(0).getTarget())
                         .setEvidence(contexts2.get(0).getTarget())
                         .setMessage(contexts2.get(0).getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return true;
             }
@@ -278,12 +298,13 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
     }
 
     private boolean performTagAttack(
-            HtmlContext context, HttpMessage msg, String param, String value) {
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param, String value) {
 
         if (context.isInScriptAttribute()) {
             // Good chance this will be vulnerable
             // Try a simple alert attack
-            List<HtmlContext> contexts2 = performAttack(msg, param, ";alert(1)", context, 0);
+            List<HtmlContext> contexts2 =
+                    performAttack(msg, sinkMsg, param, ";alert(1)", context, 0);
             if (contexts2 == null) {
                 return false;
             }
@@ -297,6 +318,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                             .setAttack(context2.getTarget())
                             .setEvidence(context2.getTarget())
                             .setMessage(context2.getMsg())
+                            .setOtherInfo(adaptOtherInfo(""))
                             .raise();
                     return true;
                 }
@@ -308,7 +330,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         } else if (context.isInUrlAttribute()) {
             // Its a url attribute
             List<HtmlContext> contexts2 =
-                    performAttack(msg, param, "javascript:alert(1);", context, 0);
+                    performAttack(msg, sinkMsg, param, "javascript:alert(1);", context, 0);
             if (contexts2 == null) {
                 return false;
             }
@@ -322,6 +344,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                             .setAttack(ctx.getTarget())
                             .setEvidence(ctx.getTarget())
                             .setMessage(ctx.getMsg())
+                            .setOtherInfo(adaptOtherInfo(""))
                             .raise();
                     return true;
                 }
@@ -335,6 +358,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             List<HtmlContext> contexts2 =
                     performAttack(
                             msg,
+                            sinkMsg,
                             param,
                             context.getSurroundingQuote() + " src=http://badsite.com",
                             context,
@@ -350,6 +374,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(contexts2.get(0).getTarget())
                         .setEvidence(contexts2.get(0).getTarget())
                         .setMessage(contexts2.get(0).getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return true;
             }
@@ -363,6 +388,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             List<HtmlContext> contexts2 =
                     performAttack(
                             msg,
+                            sinkMsg,
                             param,
                             context.getSurroundingQuote() + ">" + scriptAlert,
                             context,
@@ -378,6 +404,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(contexts2.get(0).getTarget())
                         .setEvidence(contexts2.get(0).getTarget())
                         .setMessage(contexts2.get(0).getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return true;
             }
@@ -392,6 +419,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         List<HtmlContext> contexts2 =
                 performAttack(
                         msg,
+                        sinkMsg,
                         param,
                         context.getSurroundingQuote()
                                 + " onMouseOver="
@@ -410,6 +438,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                     .setAttack(contexts2.get(0).getTarget())
                     .setEvidence(contexts2.get(0).getTarget())
                     .setMessage(contexts2.get(0).getMsg())
+                    .setOtherInfo(adaptOtherInfo(""))
                     .raise();
             return true;
         }
@@ -419,11 +448,13 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         return false;
     }
 
-    private boolean performCommentAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performCommentAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
             List<HtmlContext> contexts2 =
                     performAttack(
                             msg,
+                            sinkMsg,
                             param,
                             "-->" + scriptAlert + "<!--",
                             context,
@@ -439,6 +470,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(contexts2.get(0).getTarget())
                         .setEvidence(contexts2.get(0).getTarget())
                         .setMessage(contexts2.get(0).getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return true;
             }
@@ -451,6 +483,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         List<HtmlContext> contexts2 =
                 performAttack(
                         msg,
+                        sinkMsg,
                         param,
                         "-->" + B_MOUSE_ALERT + "<!--",
                         context,
@@ -466,17 +499,20 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                     .setAttack(contexts2.get(0).getTarget())
                     .setEvidence(contexts2.get(0).getTarget())
                     .setMessage(contexts2.get(0).getMsg())
+                    .setOtherInfo(adaptOtherInfo(""))
                     .raise();
             return true;
         }
         return false;
     }
 
-    private boolean performBodyAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performBodyAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         // Try a simple alert attack
         for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
             List<HtmlContext> contexts2 =
-                    performAttack(msg, param, scriptAlert, null, HtmlContext.IGNORE_PARENT);
+                    performAttack(
+                            msg, sinkMsg, param, scriptAlert, null, HtmlContext.IGNORE_PARENT);
             if (contexts2 == null) {
                 continue;
             }
@@ -488,6 +524,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(contexts2.get(0).getTarget())
                         .setEvidence(contexts2.get(0).getTarget())
                         .setMessage(contexts2.get(0).getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return true;
             }
@@ -497,7 +534,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         }
         // Maybe they're blocking script tags
         List<HtmlContext> contexts2 =
-                performAttack(msg, param, B_MOUSE_ALERT, context, HtmlContext.IGNORE_PARENT);
+                performAttack(
+                        msg, sinkMsg, param, B_MOUSE_ALERT, context, HtmlContext.IGNORE_PARENT);
         if (contexts2 != null) {
             for (HtmlContext context2 : contexts2) {
                 if ("body".equalsIgnoreCase(context2.getParentTag())
@@ -509,6 +547,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                             .setAttack(contexts2.get(0).getTarget())
                             .setEvidence(contexts2.get(0).getTarget())
                             .setMessage(contexts2.get(0).getMsg())
+                            .setOtherInfo(adaptOtherInfo(""))
                             .raise();
                     return true;
                 }
@@ -517,7 +556,8 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         if (GET_POST_TYPES.contains(currentParamType)) {
             // Try double encoded
             List<HtmlContext> contexts3 =
-                    performAttack(msg, param, getURLEncode(GENERIC_SCRIPT_ALERT), null, 0, true);
+                    performAttack(
+                            msg, sinkMsg, param, getURLEncode(GENERIC_SCRIPT_ALERT), null, 0, true);
             if (contexts3 != null && !contexts3.isEmpty()) {
                 newAlert()
                         .setConfidence(Alert.CONFIDENCE_MEDIUM)
@@ -525,6 +565,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(getURLEncode(getURLEncode(contexts3.get(0).getTarget())))
                         .setEvidence(GENERIC_SCRIPT_ALERT)
                         .setMessage(contexts3.get(0).getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return true;
             }
@@ -532,11 +573,13 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         return false;
     }
 
-    private boolean performCloseTagAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performCloseTagAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
             List<HtmlContext> contexts2 =
                     performAttack(
                             msg,
+                            sinkMsg,
                             param,
                             "</"
                                     + context.getParentTag()
@@ -559,6 +602,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                             .setAttack(ctx.getTarget())
                             .setEvidence(ctx.getTarget())
                             .setMessage(ctx.getMsg())
+                            .setOtherInfo(adaptOtherInfo(""))
                             .raise();
                     return true;
                 }
@@ -570,10 +614,12 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         return false;
     }
 
-    private boolean performScriptAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performScriptAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         List<HtmlContext> contexts2 =
                 performAttack(
                         msg,
+                        sinkMsg,
                         param,
                         context.getSurroundingQuote()
                                 + ";alert(1);"
@@ -592,6 +638,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(ctx.getTarget())
                         .setEvidence(ctx.getTarget())
                         .setMessage(ctx.getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return true;
             }
@@ -599,11 +646,12 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         return false;
     }
 
-    private boolean performOutsideTagsAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performOutsideTagsAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         for (String scriptAlert : OUTSIDE_OF_TAGS_PAYLOADS) {
             if (context.getMsg().getResponseBody().toString().contains(context.getTarget())) {
                 List<HtmlContext> contexts2 =
-                        performAttack(msg, param, scriptAlert, null, 0, false, true, true);
+                        performAttack(msg, sinkMsg, param, scriptAlert, null, 0, false, true, true);
                 if (contexts2 == null) {
                     continue;
                 }
@@ -617,6 +665,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                                     .setAttack(ctx.getTarget())
                                     .setEvidence(ctx.getTarget())
                                     .setMessage(contexts2.get(0).getMsg())
+                                    .setOtherInfo(adaptOtherInfo(""))
                                     .raise();
                         } else {
                             HttpMessage ctx2Message = contexts2.get(0).getMsg();
@@ -637,8 +686,10 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                                         .setParam(param)
                                         .setAttack(scriptAlert)
                                         .setOtherInfo(
-                                                Constant.messages.getString(
-                                                        MESSAGE_PREFIX + "otherinfo.nothtml"))
+                                                adaptOtherInfo(
+                                                        Constant.messages.getString(
+                                                                MESSAGE_PREFIX
+                                                                        + "otherinfo.nothtml")))
                                         .setMessage(ctx2Message)
                                         .raise();
                             } else {
@@ -647,8 +698,10 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                                         .setParam(param)
                                         .setAttack(ctx.getTarget())
                                         .setOtherInfo(
-                                                Constant.messages.getString(
-                                                        MESSAGE_PREFIX + "otherinfo.nothtml"))
+                                                adaptOtherInfo(
+                                                        Constant.messages.getString(
+                                                                MESSAGE_PREFIX
+                                                                        + "otherinfo.nothtml")))
                                         .setEvidence(ctx.getTarget())
                                         .setMessage(ctx2Message)
                                         .raise();
@@ -665,10 +718,12 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         return false;
     }
 
-    private boolean performImageTagAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performImageTagAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         List<HtmlContext> contextsA =
                 performAttack(
                         msg,
+                        sinkMsg,
                         param,
                         GENERIC_ONERROR_ALERT,
                         context,
@@ -683,6 +738,7 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                     .setAttack(contextsA.get(0).getTarget())
                     .setEvidence(contextsA.get(0).getTarget())
                     .setMessage(contextsA.get(0).getMsg())
+                    .setOtherInfo(adaptOtherInfo(""))
                     .raise();
             return true;
         }
@@ -697,9 +753,10 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 Constant.messages.getString(MESSAGE_PREFIX + "otherinfo.accesskey"));
     }
 
-    private boolean performAttributeAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performAttributeAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         List<HtmlContext> context2 =
-                performAttack(msg, param, ACCESSKEY_ATTRIBUTE_ALERT, context, 0);
+                performAttack(msg, sinkMsg, param, ACCESSKEY_ATTRIBUTE_ALERT, context, 0);
         if (context2 == null) {
             return false;
         }
@@ -713,11 +770,12 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
         return false;
     }
 
-    private boolean performElementAttack(HtmlContext context, HttpMessage msg, String param) {
+    private boolean performElementAttack(
+            HtmlContext context, HttpMessage msg, HttpMessage sinkMsg, String param) {
         String attackString1 = "tag " + ACCESSKEY_ATTRIBUTE_ALERT;
-        List<HtmlContext> context2 = performAttack(msg, param, attackString1, context, 0);
+        List<HtmlContext> context2 = performAttack(msg, sinkMsg, param, attackString1, context, 0);
         if (context2 == null) {
-            context2 = performAttack(msg, param, TAG_ONCLICK_ALERT, context, 0);
+            context2 = performAttack(msg, sinkMsg, param, TAG_ONCLICK_ALERT, context, 0);
             if (context2 == null) {
                 return false;
             }
@@ -804,17 +862,18 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                 return;
             }
 
-            testContexts(contexts, msg, eyeCatcherMsg, appendedValue, param, value);
+            testContexts(contexts, msg, eyeCatcherMsg, null, appendedValue, param, value);
 
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
     }
 
-    private void testContexts(
+    protected void testContexts(
             List<HtmlContext> contexts,
             HttpMessage msg,
             HttpMessage eyeCatcherMsg,
+            HttpMessage sinkMsg,
             boolean appendedValue,
             String param,
             String value) {
@@ -829,60 +888,61 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
             }
             if (context.getTagAttribute() != null) {
                 // its in a tag attribute - lots of attack vectors possible
-                attackWorked = performTagAttack(context, msg, param, value);
+                attackWorked = performTagAttack(context, msg, sinkMsg, param, value);
 
             } else if (context.isInAttributeName()) {
 
-                attackWorked = performAttributeAttack(context, msg, param);
+                attackWorked = performAttributeAttack(context, msg, sinkMsg, param);
 
             } else if (context.isHtmlComment()) {
                 // Try breaking out of the comment
-                attackWorked = performCommentAttack(context, msg, param);
+                attackWorked = performCommentAttack(context, msg, sinkMsg, param);
             } else {
                 // its not in a tag attribute
                 if ("body".equalsIgnoreCase(context.getParentTag())) {
                     // Immediately under a body tag
-                    attackWorked = performBodyAttack(context, msg, param);
+                    attackWorked = performBodyAttack(context, msg, sinkMsg, param);
 
                 } else if (context.getParentTag() != null) {
                     // Its not immediately under a body tag, try to close
                     // the tag
-                    attackWorked = performCloseTagAttack(context, msg, param);
+                    attackWorked = performCloseTagAttack(context, msg, sinkMsg, param);
 
                     if (attackWorked) {
                         break;
                     } else if ("script".equalsIgnoreCase(context.getParentTag())) {
                         // its in a script tag...
-                        attackWorked = performScriptAttack(context, msg, param);
+                        attackWorked = performScriptAttack(context, msg, sinkMsg, param);
                     } else {
                         // Try an img tag
-                        attackWorked = performImageTagAttack(context, msg, param);
+                        attackWorked = performImageTagAttack(context, msg, sinkMsg, param);
                     }
                 } else {
                     // Last chance - is the payload reflected outside of any
                     // tags
-                    attackWorked = performOutsideTagsAttack(context, msg, param);
+                    attackWorked = performOutsideTagsAttack(context, msg, sinkMsg, param);
                 }
             }
             if (context.isInElementName()) {
 
-                attackWorked = performElementAttack(context, msg, param);
+                attackWorked = performElementAttack(context, msg, sinkMsg, param);
             }
         }
         // Always attack the header if the eyecatcher is reflected in it - this will be
         // different to any alert raised above
         if (eyeCatcherMsg.getResponseHeader().toString().contains(Constant.getEyeCatcher())) {
-            attackHeader(msg, param, appendedValue ? value : "");
+            attackHeader(msg, sinkMsg, param, appendedValue ? value : "");
         }
     }
 
-    private void attackHeader(HttpMessage msg, String param, String value) {
+    private void attackHeader(HttpMessage msg, HttpMessage sinkMsg, String param, String value) {
         // We know the eyecatcher was reflected in the header, lets try some header splitting
         // attacks
         for (String scriptAlert : GENERIC_SCRIPT_ALERT_LIST) {
             String attack = value + HEADER_SPLITTING + scriptAlert;
             List<HtmlContext> contexts2 =
-                    performAttack(msg, param, attack, null, scriptAlert, 0, false, false, true);
+                    performAttack(
+                            msg, sinkMsg, param, attack, null, scriptAlert, 0, false, false, true);
             if (contexts2 != null && !contexts2.isEmpty()) {
                 // Yep, its vulnerable
                 newAlert()
@@ -891,10 +951,15 @@ public class CrossSiteScriptingScanRule extends AbstractAppParamPlugin {
                         .setAttack(attack)
                         .setEvidence(contexts2.get(0).getTarget())
                         .setMessage(contexts2.get(0).getMsg())
+                        .setOtherInfo(adaptOtherInfo(""))
                         .raise();
                 return;
             }
         }
+    }
+
+    public String adaptOtherInfo(String text) {
+        return text;
     }
 
     @Override

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/PersistentXssScanRule.java
@@ -19,30 +19,20 @@
  */
 package org.zaproxy.zap.extension.ascanrules;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.core.scanner.AbstractAppParamPlugin;
-import org.parosproxy.paros.core.scanner.Alert;
-import org.parosproxy.paros.core.scanner.Category;
-import org.parosproxy.paros.core.scanner.NameValuePair;
-import org.parosproxy.paros.core.scanner.Plugin;
-import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
 import org.zaproxy.addon.commonlib.SourceSinkUtils;
 import org.zaproxy.zap.extension.ascanrules.httputils.HtmlContext;
 import org.zaproxy.zap.extension.ascanrules.httputils.HtmlContextAnalyser;
-import org.zaproxy.zap.model.Vulnerabilities;
-import org.zaproxy.zap.model.Vulnerability;
 
-public class PersistentXssScanRule extends AbstractAppParamPlugin {
+public class PersistentXssScanRule extends CrossSiteScriptingScanRule {
 
     /** Prefix for internationalised messages used by this rule */
     private static final String MESSAGE_PREFIX = "ascanrules.persistentxssattack.";
@@ -53,13 +43,7 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                     CommonAlertTag.OWASP_2017_A07_XSS,
                     CommonAlertTag.WSTG_V42_INPV_02_STORED_XSS);
 
-    private static final String GENERIC_SCRIPT_ALERT = "<script>alert(1);</script>";
-    private static final List<Integer> GET_POST_TYPES =
-            Arrays.asList(NameValuePair.TYPE_QUERY_STRING, NameValuePair.TYPE_POST_DATA);
-
-    private static Vulnerability vuln = Vulnerabilities.getVulnerability("wasc_8");
     private static Logger log = LogManager.getLogger(PersistentXssScanRule.class);
-    private int currentParamType;
 
     @Override
     public int getId() {
@@ -77,119 +61,11 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
     }
 
     @Override
-    public String getDescription() {
-        if (vuln != null) {
-            return vuln.getDescription();
-        }
-        return "Failed to load vulnerability description from file";
-    }
-
-    @Override
-    public int getCategory() {
-        return Category.INJECTION;
-    }
-
-    @Override
-    public String getSolution() {
-        if (vuln != null) {
-            return vuln.getSolution();
-        }
-        return "Failed to load vulnerability solution from file";
-    }
-
-    @Override
-    public String getReference() {
-        if (vuln != null) {
-            StringBuilder sb = new StringBuilder();
-            for (String ref : vuln.getReferences()) {
-                if (sb.length() > 0) {
-                    sb.append('\n');
-                }
-                sb.append(ref);
-            }
-            return sb.toString();
-        }
-        return "Failed to load vulnerability reference from file";
-    }
-
-    @Override
-    public void scan(HttpMessage msg, NameValuePair originalParam) {
-        currentParamType = originalParam.getType();
-        super.scan(msg, originalParam);
-    }
-
-    private List<HtmlContext> performAttack(
-            HttpMessage sourceMsg,
-            String param,
-            String attack,
-            HttpMessage sinkMsg,
-            HtmlContext targetContext,
-            int ignoreFlags) {
-        return performAttack(
-                sourceMsg, param, attack, sinkMsg, targetContext, ignoreFlags, false, false);
-    }
-
-    private List<HtmlContext> performAttack(
-            HttpMessage sourceMsg,
-            String param,
-            String attack,
-            HttpMessage sinkMsg,
-            HtmlContext targetContext,
-            int ignoreFlags,
-            boolean findDecoded,
-            boolean ignoreSafeParents) {
-        if (isStop()) {
-            return null;
-        }
-
-        HttpMessage sourceMsg2 = sourceMsg.cloneRequest();
-        setParameter(sourceMsg2, param, attack);
-        try {
-            sendAndReceive(sourceMsg2);
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-        }
-
-        if (isStop()) {
-            return null;
-        }
-
-        HttpMessage sinkMsg2 = sinkMsg.cloneRequest();
-        try {
-            sendAndReceive(sinkMsg2);
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-        }
-
-        if (isStop()) {
-            return null;
-        }
-
-        HtmlContextAnalyser hca = new HtmlContextAnalyser(sinkMsg2);
-        if (Plugin.AlertThreshold.HIGH.equals(this.getAlertThreshold())) {
-            // High level, so check all results are in the expected context
-            return hca.getHtmlContexts(
-                    findDecoded ? getURLDecode(attack) : attack,
-                    targetContext,
-                    ignoreFlags,
-                    ignoreSafeParents);
-        }
-
-        return hca.getHtmlContexts(
-                findDecoded ? getURLDecode(attack) : attack, null, 0, ignoreSafeParents);
-    }
-
-    @Override
     public void scan(HttpMessage sourceMsg, String param, String value) {
         if (!AlertThreshold.LOW.equals(getAlertThreshold())
                 && HttpRequestHeader.PUT.equals(sourceMsg.getRequestHeader().getMethod())) {
             return;
         }
-
-        String otherInfo =
-                Constant.messages.getString(
-                        MESSAGE_PREFIX + "otherinfo",
-                        sourceMsg.getRequestHeader().getURI().toString());
 
         try {
             Set<Integer> sinks = SourceSinkUtils.getSinksIdsForSource(sourceMsg, param);
@@ -198,7 +74,6 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                 // Loop through each one
 
                 // Inject the 'safe' eyecatcher
-                boolean attackWorked = false;
                 setParameter(sourceMsg, param, Constant.getEyeCatcher());
                 sendAndReceive(sourceMsg);
 
@@ -219,473 +94,8 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
                     HtmlContextAnalyser hca = new HtmlContextAnalyser(sinkMsg);
                     List<HtmlContext> contexts =
                             hca.getHtmlContexts(Constant.getEyeCatcher(), null, 0);
-
-                    for (HtmlContext context : contexts) {
-                        // Loop through the returned contexts and lauch targetted attacks
-                        if (attackWorked || isStop()) {
-                            break;
-                        }
-                        if (context.getTagAttribute() != null) {
-                            // its in a tag attribute - lots of attack vectors possible
-
-                            if (context.isInScriptAttribute()) {
-                                // Good chance this will be vulnerable
-                                // Try a simple alert attack
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                sourceMsg, param, ";alert(1)", sinkMsg, context, 0);
-                                if (contexts2 == null) {
-                                    break;
-                                }
-
-                                for (HtmlContext context2 : contexts2) {
-                                    if (context2.getTagAttribute() != null
-                                            && context2.isInScriptAttribute()) {
-                                        // Yep, its vulnerable
-                                        newAlert()
-                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                .setParam(param)
-                                                .setAttack(context2.getTarget())
-                                                .setOtherInfo(otherInfo)
-                                                .setMessage(context2.getMsg())
-                                                .raise();
-                                        attackWorked = true;
-                                        break;
-                                    }
-                                }
-                                if (!attackWorked) {
-                                    log.debug(
-                                            "Failed to find vuln in script attribute on {}",
-                                            sourceMsg.getRequestHeader().getURI());
-                                }
-
-                            } else if (context.isInUrlAttribute()) {
-                                // Its a url attribute
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                sourceMsg,
-                                                param,
-                                                "javascript:alert(1);",
-                                                sinkMsg,
-                                                context,
-                                                0);
-                                if (contexts2 == null) {
-                                    break;
-                                }
-
-                                for (HtmlContext ctx : contexts2) {
-                                    if (ctx.isInUrlAttribute()) {
-                                        // Yep, its vulnerable
-                                        newAlert()
-                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                .setParam(param)
-                                                .setAttack(ctx.getTarget())
-                                                .setEvidence(ctx.getTarget())
-                                                .setMessage(ctx.getMsg())
-                                                .raise();
-                                        attackWorked = true;
-                                        break;
-                                    }
-                                }
-                                if (!attackWorked) {
-                                    log.debug(
-                                            "Failed to find vuln in url attribute on {}",
-                                            sourceMsg.getRequestHeader().getURI());
-                                }
-                            }
-                            if (!attackWorked && context.isInTagWithSrc()) {
-                                // Its in an attribute in a tag which supports src attributes
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                sourceMsg,
-                                                param,
-                                                context.getSurroundingQuote()
-                                                        + " src=http://badsite.com",
-                                                sinkMsg,
-                                                context,
-                                                HtmlContext.IGNORE_TAG);
-                                if (contexts2 == null) {
-                                    break;
-                                }
-
-                                if (!contexts2.isEmpty()) {
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(contexts2.get(0).getTarget())
-                                            .setOtherInfo(otherInfo)
-                                            .setMessage(contexts2.get(0).getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                }
-                                if (!attackWorked) {
-                                    log.debug(
-                                            "Failed to find vuln in tag with src attribute on {}",
-                                            sourceMsg.getRequestHeader().getURI());
-                                }
-                            }
-
-                            if (!attackWorked) {
-                                // Try a simple alert attack
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                sourceMsg,
-                                                param,
-                                                context.getSurroundingQuote()
-                                                        + ">"
-                                                        + GENERIC_SCRIPT_ALERT,
-                                                sinkMsg,
-                                                context,
-                                                HtmlContext.IGNORE_TAG);
-                                if (contexts2 == null) {
-                                    break;
-                                }
-
-                                if (!contexts2.isEmpty()) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(contexts2.get(0).getTarget())
-                                            .setOtherInfo(otherInfo)
-                                            .setMessage(contexts2.get(0).getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                }
-                                if (!attackWorked) {
-                                    log.debug(
-                                            "Failed to find vuln with simple script attack {}",
-                                            sourceMsg.getRequestHeader().getURI());
-                                }
-                            }
-                            if (!attackWorked) {
-                                // Try adding an onMouseOver
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                sourceMsg,
-                                                param,
-                                                context.getSurroundingQuote()
-                                                        + " onMouseOver="
-                                                        + context.getSurroundingQuote()
-                                                        + "alert(1);",
-                                                sinkMsg,
-                                                context,
-                                                HtmlContext.IGNORE_TAG);
-                                if (contexts2 == null) {
-                                    break;
-                                }
-
-                                if (!contexts2.isEmpty()) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(contexts2.get(0).getTarget())
-                                            .setOtherInfo(otherInfo)
-                                            .setMessage(contexts2.get(0).getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                }
-                                if (!attackWorked) {
-                                    log.debug(
-                                            "Failed to find vuln in with simple onmounseover {}",
-                                            sourceMsg.getRequestHeader().getURI());
-                                }
-                            }
-                        } else if (context.isHtmlComment()) {
-                            // Try breaking out of the comment
-                            List<HtmlContext> contexts2 =
-                                    performAttack(
-                                            sourceMsg,
-                                            param,
-                                            "-->" + GENERIC_SCRIPT_ALERT + "<!--",
-                                            sinkMsg,
-                                            context,
-                                            HtmlContext.IGNORE_HTML_COMMENT);
-                            if (contexts2 == null) {
-                                break;
-                            }
-
-                            if (!contexts2.isEmpty()) {
-                                // Yep, its vulnerable
-                                newAlert()
-                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                        .setParam(param)
-                                        .setAttack(contexts2.get(0).getTarget())
-                                        .setOtherInfo(otherInfo)
-                                        .setMessage(contexts2.get(0).getMsg())
-                                        .raise();
-                                attackWorked = true;
-                            } else {
-                                // Maybe they're blocking script tags
-                                contexts2 =
-                                        performAttack(
-                                                sourceMsg,
-                                                param,
-                                                "--><b onMouseOver=alert(1);>test</b><!--",
-                                                sinkMsg,
-                                                context,
-                                                HtmlContext.IGNORE_HTML_COMMENT);
-                                if (contexts2 != null && !contexts2.isEmpty()) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(contexts2.get(0).getTarget())
-                                            .setOtherInfo(otherInfo)
-                                            .setMessage(contexts2.get(0).getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                }
-                            }
-                        } else {
-                            // its not in a tag attribute
-                            if ("body".equalsIgnoreCase(context.getParentTag())) {
-                                // Immediately under a body tag
-                                // Try a simple alert attack
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                sourceMsg,
-                                                param,
-                                                GENERIC_SCRIPT_ALERT,
-                                                sinkMsg,
-                                                null,
-                                                HtmlContext.IGNORE_PARENT);
-                                if (contexts2 == null) {
-                                    break;
-                                }
-
-                                if (!contexts2.isEmpty()) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(contexts2.get(0).getTarget())
-                                            .setOtherInfo(otherInfo)
-                                            .setMessage(contexts2.get(0).getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                } else {
-                                    // Maybe they're blocking script tags
-                                    contexts2 =
-                                            performAttack(
-                                                    sourceMsg,
-                                                    param,
-                                                    "<b onMouseOver=alert(1);>test</b>",
-                                                    sinkMsg,
-                                                    context,
-                                                    HtmlContext.IGNORE_PARENT);
-                                    if (contexts2 != null) {
-                                        for (HtmlContext context2 : contexts2) {
-                                            if ("body".equalsIgnoreCase(context2.getParentTag())
-                                                    || "b".equalsIgnoreCase(context2.getParentTag())
-                                                    || "script"
-                                                            .equalsIgnoreCase(
-                                                                    context2.getParentTag())) {
-                                                // Yep, its vulnerable
-                                                newAlert()
-                                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                        .setParam(param)
-                                                        .setAttack(contexts2.get(0).getTarget())
-                                                        .setEvidence(contexts2.get(0).getTarget())
-                                                        .setMessage(contexts2.get(0).getMsg())
-                                                        .raise();
-                                                attackWorked = true;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                    if (!attackWorked) {
-                                        if (GET_POST_TYPES.contains(currentParamType)) {
-                                            // Try double encoded
-                                            List<HtmlContext> contexts3 =
-                                                    performAttack(
-                                                            sourceMsg,
-                                                            param,
-                                                            getURLEncode(GENERIC_SCRIPT_ALERT),
-                                                            sinkMsg,
-                                                            null,
-                                                            0,
-                                                            true,
-                                                            false);
-                                            if (contexts3 != null && !contexts3.isEmpty()) {
-                                                attackWorked = true;
-                                                newAlert()
-                                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                        .setParam(param)
-                                                        .setAttack(
-                                                                getURLEncode(
-                                                                        getURLEncode(
-                                                                                contexts3
-                                                                                        .get(0)
-                                                                                        .getTarget())))
-                                                        .setEvidence(GENERIC_SCRIPT_ALERT)
-                                                        .setMessage(contexts3.get(0).getMsg())
-                                                        .raise();
-                                            }
-                                            break;
-                                        }
-                                    }
-                                }
-                            } else if (context.getParentTag() != null) {
-                                // Its not immediately under a body tag, try to close the tag
-                                List<HtmlContext> contexts2 =
-                                        performAttack(
-                                                sourceMsg,
-                                                param,
-                                                "</"
-                                                        + context.getParentTag()
-                                                        + ">"
-                                                        + GENERIC_SCRIPT_ALERT
-                                                        + "<"
-                                                        + context.getParentTag()
-                                                        + ">",
-                                                sinkMsg,
-                                                context,
-                                                HtmlContext.IGNORE_IN_SCRIPT);
-                                if (contexts2 == null) {
-                                    break;
-                                }
-
-                                if (!contexts2.isEmpty()) {
-                                    // Yep, its vulnerable
-                                    newAlert()
-                                            .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                            .setParam(param)
-                                            .setAttack(contexts2.get(0).getTarget())
-                                            .setOtherInfo(otherInfo)
-                                            .setMessage(contexts2.get(0).getMsg())
-                                            .raise();
-                                    attackWorked = true;
-                                } else if ("script".equalsIgnoreCase(context.getParentTag())) {
-                                    // its in a script tag...
-                                    contexts2 =
-                                            performAttack(
-                                                    sourceMsg,
-                                                    param,
-                                                    context.getSurroundingQuote()
-                                                            + ";alert(1);"
-                                                            + context.getSurroundingQuote(),
-                                                    sinkMsg,
-                                                    context,
-                                                    0);
-                                    if (contexts2 == null) {
-                                        break;
-                                    }
-                                    if (!contexts2.isEmpty()) {
-                                        // Yep, its vulnerable
-                                        newAlert()
-                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                .setParam(param)
-                                                .setAttack(contexts2.get(0).getTarget())
-                                                .setOtherInfo(otherInfo)
-                                                .setMessage(contexts2.get(0).getMsg())
-                                                .raise();
-                                        attackWorked = true;
-                                    }
-                                } else {
-                                    // Try an img tag
-                                    List<HtmlContext> contextsA =
-                                            performAttack(
-                                                    sourceMsg,
-                                                    param,
-                                                    "<img src=x onerror=alert(1);>",
-                                                    sinkMsg,
-                                                    context,
-                                                    0,
-                                                    false,
-                                                    true);
-                                    if (contextsA != null && !contextsA.isEmpty()) {
-                                        newAlert()
-                                                .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                .setParam(param)
-                                                .setAttack(contextsA.get(0).getTarget())
-                                                .setEvidence(contextsA.get(0).getTarget())
-                                                .setMessage(contextsA.get(0).getMsg())
-                                                .raise();
-                                        attackWorked = true;
-                                        break;
-                                    }
-                                }
-                            } else {
-                                // Last chance - is the payload outside of any tags
-                                if (context.getMsg()
-                                        .getResponseBody()
-                                        .toString()
-                                        .contains(context.getTarget())) {
-                                    List<HtmlContext> contexts2 =
-                                            performAttack(
-                                                    sourceMsg,
-                                                    param,
-                                                    GENERIC_SCRIPT_ALERT,
-                                                    sinkMsg,
-                                                    null,
-                                                    0,
-                                                    false,
-                                                    true);
-                                    if (contexts2 == null) {
-                                        break;
-                                    }
-                                    for (HtmlContext ctx : contexts2) {
-                                        if (ctx.getParentTag() != null) {
-                                            // Yep, its vulnerable
-                                            if (ctx.getMsg().getResponseHeader().isHtml()) {
-                                                newAlert()
-                                                        .setConfidence(Alert.CONFIDENCE_MEDIUM)
-                                                        .setParam(param)
-                                                        .setAttack(ctx.getTarget())
-                                                        .setEvidence(ctx.getTarget())
-                                                        .setMessage(contexts2.get(0).getMsg())
-                                                        .raise();
-                                            } else {
-                                                HttpMessage ctx2Message = contexts2.get(0).getMsg();
-                                                if (StringUtils.containsIgnoreCase(
-                                                        ctx.getMsg()
-                                                                .getResponseHeader()
-                                                                .getHeader(HttpHeader.CONTENT_TYPE),
-                                                        "json")) {
-                                                    newAlert()
-                                                            .setRisk(Alert.RISK_LOW)
-                                                            .setConfidence(Alert.CONFIDENCE_LOW)
-                                                            .setName(
-                                                                    Constant.messages.getString(
-                                                                            MESSAGE_PREFIX
-                                                                                    + "json.name"))
-                                                            .setDescription(
-                                                                    Constant.messages.getString(
-                                                                            MESSAGE_PREFIX
-                                                                                    + "json.desc"))
-                                                            .setParam(param)
-                                                            .setAttack(GENERIC_SCRIPT_ALERT)
-                                                            .setOtherInfo(
-                                                                    Constant.messages.getString(
-                                                                            MESSAGE_PREFIX
-                                                                                    + "otherinfo.nothtml"))
-                                                            .setSolution(getSolution())
-                                                            .setMessage(ctx2Message)
-                                                            .raise();
-                                                } else {
-                                                    newAlert()
-                                                            .setConfidence(Alert.CONFIDENCE_LOW)
-                                                            .setParam(param)
-                                                            .setAttack(ctx.getTarget())
-                                                            .setOtherInfo(
-                                                                    Constant.messages.getString(
-                                                                            MESSAGE_PREFIX
-                                                                                    + "otherinfo.nothtml"))
-                                                            .setEvidence(ctx.getTarget())
-                                                            .setMessage(ctx2Message)
-                                                            .raise();
-                                                }
-                                            }
-                                            attackWorked = true;
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    boolean appendValue = false; // Check if somehow we can get this value on stored
+                    testContexts(contexts, sourceMsg, sinkMsg, sinkMsg, appendValue, param, value);
                 }
             }
         } catch (Exception e) {
@@ -694,22 +104,16 @@ public class PersistentXssScanRule extends AbstractAppParamPlugin {
     }
 
     @Override
-    public int getRisk() {
-        return Alert.RISK_HIGH;
+    public String adaptOtherInfo(String text) {
+        return Constant.messages.getString(
+                        MESSAGE_PREFIX + "otherinfo",
+                        getBaseMsg().getRequestHeader().getURI().toString())
+                + "\n"
+                + text;
     }
 
     @Override
     public Map<String, String> getAlertTags() {
         return ALERT_TAGS;
-    }
-
-    @Override
-    public int getCweId() {
-        return 79;
-    }
-
-    @Override
-    public int getWascId() {
-        return 8;
     }
 }


### PR DESCRIPTION
Both CrossSiteScriptingScanRule and PersistentXssScanRule need the same logic to detect the existence of an XSS only differing on the the HTTP request where the reflection is checked. At the moment stored XSS rule is not receiving all the upgrades and fixes the reflected XSS rule is receiving, this solves the problem and removes duplicated code.
Once [Fix stored xss scanner](https://github.com/zaproxy/zap-extensions/pull/2443) is used the FPs on stored XSS start to appear. 