### PR TITLE
pscanrules: CSP Scan Rule adjust confidence add example alerts

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- The Content Security Policy scan rule will now raise alerts at High confidence, all alerts now include the appropriate header as the "parameter" value, and has functionality to generate example alerts for documentation purposes.
 
 ## [41] - 2022-06-24
 ### Changed

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyScanRuleUnitTest.java
@@ -77,6 +77,24 @@ class ContentSecurityPolicyScanRuleUnitTest
     }
 
     @Test
+    void shouldReturnExpectedExampleAlerts() {
+        // Given / When
+        int count = rule.getExampleAlerts().size();
+        long countLows =
+                rule.getExampleAlerts().stream()
+                        .filter(alert -> Alert.RISK_LOW == alert.getRisk())
+                        .count();
+        long countMediums =
+                rule.getExampleAlerts().stream()
+                        .filter(alert -> Alert.RISK_MEDIUM == alert.getRisk())
+                        .count();
+        // Then
+        assertThat(count, is(equalTo(8)));
+        assertThat(countLows, is(equalTo(3L)));
+        assertThat(countMediums, is(equalTo(5L)));
+    }
+
+    @Test
     void shouldNotRaiseAlertOnNonHtmlAtMediumThreshold() {
         // Given
         HttpMessage msg = createHttpMessage("report-uri /__cspreport__");
@@ -118,7 +136,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                 alertsRaised.get(0).getEvidence(),
                 equalTo("default-src: 'none'; report_uri /__cspreport__"));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
 
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: Wildcard Directive"));
         assertThat(
@@ -134,7 +152,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                 alertsRaised.get(1).getEvidence(),
                 equalTo("default-src: 'none'; report_uri /__cspreport__"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-4"));
     }
 
@@ -154,7 +172,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                 alertsRaised.get(1).getEvidence(),
                 equalTo("default-src: 'none'; report_uri /__cspreport__; frame-ancestors 'none'"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-4"));
     }
 
@@ -177,7 +195,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                 alertsRaised.get(0).getEvidence(),
                 equalTo("default-src none; report-to csp-endpoint"));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-3"));
     }
 
@@ -203,7 +221,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                 alertsRaised.get(0).getEvidence(),
                 equalTo("frame-ancestors *; default-src 'self'; form-action 'none'"));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-4"));
     }
 
@@ -229,7 +247,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                 equalTo(
                         "connect-src *; default-src 'self'; form-action 'none'; frame-ancestors 'self'"));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-4"));
     }
 
@@ -270,7 +288,7 @@ class ContentSecurityPolicyScanRuleUnitTest
                         "Warnings:\nThis host name is unusual, and likely meant to be a keyword that is missing the required quotes: 'none'.\n"));
         assertThat(alertsRaised.get(0).getEvidence(), equalTo(policy));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-3"));
     }
 
@@ -285,7 +303,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         assertThat(alertsRaised.size(), equalTo(1));
         assertThat(alertsRaised.get(0).getName(), equalTo("CSP: " + input));
         assertThat(alertsRaised.get(0).getRisk(), equalTo(Alert.RISK_LOW));
-        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(0).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(0).getAlertRef(), equalTo("10055-" + alertRef));
     }
 
@@ -300,7 +318,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // Verify the specific alerts
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
 
         assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
@@ -317,7 +335,7 @@ class ContentSecurityPolicyScanRuleUnitTest
         // Verify the specific alerts
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
 
         assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
@@ -339,13 +357,13 @@ class ContentSecurityPolicyScanRuleUnitTest
 
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getEvidence(), equalTo("style-src 'unsafe-inline'"));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
 
         assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
         assertThat(alertsRaised.get(2).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(2).getEvidence(), equalTo("style-src 'unsafe-inline'"));
         assertThat(alertsRaised.get(2).getAlertRef(), equalTo("10055-6"));
     }
@@ -366,13 +384,13 @@ class ContentSecurityPolicyScanRuleUnitTest
 
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-inline"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getEvidence(), equalTo("default-src 'unsafe-inline'"));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-5"));
 
         assertThat(alertsRaised.get(2).getName(), equalTo("CSP: style-src unsafe-inline"));
         assertThat(alertsRaised.get(2).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(2).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(2).getEvidence(), equalTo("default-src 'unsafe-inline'"));
         assertThat(alertsRaised.get(2).getAlertRef(), equalTo("10055-6"));
     }
@@ -394,7 +412,7 @@ class ContentSecurityPolicyScanRuleUnitTest
 
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: script-src unsafe-hashes"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getEvidence(), equalTo(policy));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-7"));
     }
@@ -416,7 +434,7 @@ class ContentSecurityPolicyScanRuleUnitTest
 
         assertThat(alertsRaised.get(1).getName(), equalTo("CSP: style-src unsafe-hashes"));
         assertThat(alertsRaised.get(1).getRisk(), equalTo(Alert.RISK_MEDIUM));
-        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_MEDIUM));
+        assertThat(alertsRaised.get(1).getConfidence(), equalTo(Alert.CONFIDENCE_HIGH));
         assertThat(alertsRaised.get(1).getEvidence(), equalTo(policy));
         assertThat(alertsRaised.get(1).getAlertRef(), equalTo("10055-8"));
     }


### PR DESCRIPTION
- CHANGELOG > Added change note.
- ContentSecurityPolicyScanRule > Added example alerts functionality, tweaked alert param details, and bumped confidence up to high.
- ContentSecurityPolicyScanRuleUnitTest > Added a test to assert the expected example alerts.

Related to https://github.com/zaproxy/zaproxy/issues/7100

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>