### PR TITLE
openapi: correct job error message on incorrect apiFile

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Fixed
 - JSON body examples specified under `schema` were being enclosed in quotes.
+- Error message when `apiFile` field is not accessible was outputting the `targetUrl` and not the incorrect filename (Issue 7370).
 
 ### Changed
 - Maintenance changes.

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJob.java
@@ -131,10 +131,7 @@ public class OpenApiJob extends AutomationJob {
             } else {
                 progress.error(
                         Constant.messages.getString(
-                                "openapi.automation.error.file",
-                                this.getName(),
-                                targetUrl,
-                                apiFile));
+                                "openapi.automation.error.file", this.getName(), apiFile));
             }
         }
         if (!StringUtils.isEmpty(apiStr)) {

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobUnitTest.java
@@ -42,9 +42,10 @@ import org.zaproxy.addon.automation.AutomationEnvironment;
 import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+import org.zaproxy.zap.testutils.TestUtils;
 import org.zaproxy.zap.utils.I18N;
 
-class OpenApiJobUnitTest {
+class OpenApiJobUnitTest extends TestUtils {
 
     private ExtensionOpenApi extOpenApi;
 
@@ -150,7 +151,7 @@ class OpenApiJobUnitTest {
     @Test
     void shouldFailIfInvalidFile() {
         // Given
-        Constant.messages = new I18N(Locale.ENGLISH);
+        mockMessages(new ExtensionOpenApi());
         AutomationProgress progress = new AutomationProgress();
         AutomationEnvironment env = mock(AutomationEnvironment.class);
         String yamlStr = "parameters:\n" + "  apiFile: 'Invalid file path'";
@@ -167,6 +168,8 @@ class OpenApiJobUnitTest {
         // Then
         assertThat(progress.hasWarnings(), is(equalTo(false)));
         assertThat(progress.hasErrors(), is(equalTo(true)));
-        assertThat(progress.getErrors().get(0), is(equalTo("!openapi.automation.error.file!")));
+        assertThat(
+                progress.getErrors().get(0),
+                is(equalTo("Job openapi cannot read file: Invalid file path")));
     }
 }


### PR DESCRIPTION
…ed the extraneous URL argument now the offending filename is displayed in the error output

Fixes zaproxy/zaproxy#7370

Signed-off-by: Wil Hadden <wilhadden@gmail.com>