### PR TITLE
ascanrules: correct tag search in HtmlContextAnalyser

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).
 - False positive where Cross Site Scripting payloads are safely rendered in a textarea tag.
+- Unescaped tag end causing Cross Site Scripting rule to crash.
 
 ## [46] - 2022-03-21
 ### Changed

--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - The Remote File Inclusion scan rule no longer follows redirects before checking the response for content indicating a vulnerability (Issue 5887).
 - False positive where Cross Site Scripting payloads are safely rendered in a textarea tag.
-- Unescaped tag end causing Cross Site Scripting rule to crash.
+- Unescaped tag end causing Cross Site Scripting rule to throw an exception.
 
 ## [46] - 2022-03-21
 ### Changed

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
@@ -169,6 +169,9 @@ public class HtmlContextAnalyser {
             if (tagEnd == -1) {
                 break;
             }
+            if (tagStart + 1 > tagEnd) {
+                break;
+            }
             tagString = StringUtils.strip(input.substring(tagStart + 1, tagEnd));
             /** Check if tag string is comment or not. If it is a comment then don't parse it. */
             if (tagString.startsWith("!--")) {

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
@@ -165,8 +165,8 @@ public class HtmlContextAnalyser {
             if (tagStart == -1) {
                 break;
             }
-            tagEnd = input.indexOf('>');
-            if (tagEnd == -1 || tagStart + 1 > tagEnd) {
+            tagEnd = input.indexOf('>', tagStart);
+            if (tagEnd == -1) {
                 break;
             }
             tagString = StringUtils.strip(input.substring(tagStart + 1, tagEnd));

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyser.java
@@ -166,10 +166,7 @@ public class HtmlContextAnalyser {
                 break;
             }
             tagEnd = input.indexOf('>');
-            if (tagEnd == -1) {
-                break;
-            }
-            if (tagStart + 1 > tagEnd) {
+            if (tagEnd == -1 || tagStart + 1 > tagEnd) {
                 break;
             }
             tagString = StringUtils.strip(input.substring(tagStart + 1, tagEnd));

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
@@ -166,12 +166,13 @@ public class HtmlContextAnalyserUnitTest extends TestUtils {
     }
 
     @Test
-    void shouldNotRaiseStringIndexOutOfBoundsException() {
-        String tag = "<html> <body> <span>></span> </body> </html>";
+    void shouldParseWithUnescapedTagEndChar() {
+        String tag = "<html> <body> <span>></span> <a></a> </body> </html>";
         Map<String, Map<String, String>> tagMap = HtmlContextAnalyser.parseTag(tag);
-        assertThat(tagMap.size(), is(equalTo(3)));
+        assertThat(tagMap.size(), is(equalTo(4)));
         assertThat(tagMap.get("html").size(), is(equalTo(0)));
         assertThat(tagMap.get("body").size(), is(equalTo(0)));
         assertThat(tagMap.get("span").size(), is(equalTo(0)));
+        assertThat(tagMap.get("a").size(), is(equalTo(0)));
     }
 }

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/httputils/HtmlContextAnalyserUnitTest.java
@@ -164,4 +164,14 @@ public class HtmlContextAnalyserUnitTest extends TestUtils {
         tagMap = HtmlContextAnalyser.parseTag(tag);
         assertThat(tagMap.size(), is(equalTo(3)));
     }
+
+    @Test
+    void shouldNotRaiseStringIndexOutOfBoundsException() {
+        String tag = "<html> <body> <span>></span> </body> </html>";
+        Map<String, Map<String, String>> tagMap = HtmlContextAnalyser.parseTag(tag);
+        assertThat(tagMap.size(), is(equalTo(3)));
+        assertThat(tagMap.get("html").size(), is(equalTo(0)));
+        assertThat(tagMap.get("body").size(), is(equalTo(0)));
+        assertThat(tagMap.get("span").size(), is(equalTo(0)));
+    }
 }


### PR DESCRIPTION
Was seeing this stacktrace in the most recent update to the XSS rule that was causing the rule to crash and not find the reflected injection.

```
java.lang.StringIndexOutOfBoundsException: begin 3, end 1, length 28
	at java.lang.String.checkBoundsBeginEnd(String.java:4604) ~[?:?]
	at java.lang.String.substring(String.java:2707) ~[?:?]
	at org.zaproxy.zap.extension.ascanrules.httputils.HtmlContextAnalyser.parseTag(HtmlContextAnalyser.java:172) ~[?:?]
	at org.zaproxy.zap.extension.ascanrules.httputils.HtmlContextAnalyser.getHtmlContexts(HtmlContextAnalyser.java:308) ~[?:?]
	at org.zaproxy.zap.extension.ascanrules.CrossSiteScriptingScanRule.performAttack(CrossSiteScriptingScanRule.java:240) ~[?:?]
	at org.zaproxy.zap.extension.ascanrules.CrossSiteScriptingScanRule.performAttack(CrossSiteScriptingScanRule.java:177) ~[?:?]
	at org.zaproxy.zap.extension.ascanrules.CrossSiteScriptingScanRule.performAttack(CrossSiteScriptingScanRule.java:154) ~[?:?]
	at org.zaproxy.zap.extension.ascanrules.CrossSiteScriptingScanRule.performTagAttack(CrossSiteScriptingScanRule.java:364) ~[?:?]
	at org.zaproxy.zap.extension.ascanrules.CrossSiteScriptingScanRule.scan(CrossSiteScriptingScanRule.java:812) ~[?:?]
	at org.parosproxy.paros.core.scanner.AbstractAppParamPlugin.scan(AbstractAppParamPlugin.java:201) ~[zap-2.12.0-h0.0.41-SNAPSHOT.jar:2.12.0-h0.0.41-SNAPSHOT]
	at org.zaproxy.zap.extension.ascanrules.CrossSiteScriptingScanRule.scan(CrossSiteScriptingScanRule.java:145) ~[?:?]
	at org.parosproxy.paros.core.scanner.AbstractAppParamPlugin.scan(AbstractAppParamPlugin.java:126) ~[zap-2.12.0-h0.0.41-SNAPSHOT.jar:2.12.0-h0.0.41-SNAPSHOT]
	at org.parosproxy.paros.core.scanner.AbstractAppParamPlugin.scan(AbstractAppParamPlugin.java:87) ~[zap-2.12.0-h0.0.41-SNAPSHOT.jar:2.12.0-h0.0.41-SNAPSHOT]
	at org.parosproxy.paros.core.scanner.AbstractPlugin.run(AbstractPlugin.java:330) ~[zap-2.12.0-h0.0.41-SNAPSHOT.jar:2.12.0-h0.0.41-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

Signed-off-by: KC Berg <kc.berg@stackhawk.com>