### PR TITLE
pscanrules: CSP rule now raises alerts on non-ASCII policies

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - The Content Security Policy scan rule will now raise alerts at High confidence, all alerts now include the appropriate header as the "parameter" value, and has functionality to generate example alerts for documentation purposes.
+- The Content Security Policy scan rule will now raise an alert when the assessed policy contains non-ASCII characters (Issue 7379).
 
 ## [41] - 2022-06-24
 ### Changed

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -215,6 +215,8 @@ pscanrules.csp.xcsp.name=X-Content-Security-Policy
 pscanrules.csp.xcsp.otherinfo=The header X-Content-Security-Policy was found on this response. While it is a good sign that CSP is implemented to some degree the policy specified in this header has not been analyzed by ZAP. To ensure full support by modern browsers ensure that the Content-Security-Policy header is defined and attached to responses.
 pscanrules.csp.xwkcsp.name=X-WebKit-CSP
 pscanrules.csp.xwkcsp.otherinfo=The header X-WebKit-CSP was found on this response. While it is a good sign that CSP is implemented to some degree the policy specified in this header has not been analyzed by ZAP. To ensure full support by modern browsers ensure that the Content-Security-Policy header is defined and attached to responses.
+pscanrules.csp.malformed.name=Malformed Policy (Non-ASCII)
+pscanrules.csp.malformed.otherinfo=A non-ASCII character was encountered while attempting to parse the policy, thus rendering it invalid (no further evaluation occurred). The following invalid characters were collected: {0}
 
 pscanrules.mixedcontent.name = Secure Pages Include Mixed Content
 pscanrules.mixedcontent.name.inclscripts = Secure Pages Include Mixed Content (Including Scripts)


### PR DESCRIPTION
This is based on https://github.com/zaproxy/zap-extensions/pull/3877, so that one will need to be merged first, then this one rebased.

- CHANGELOG > Added Change note.
- ContentSecurityPolicyScanRule > Updated with new functionality.
- ContentSecurityPolicyScanRuleUnitTest > Added a new test to assert the new behavior.
- Messages.properties > Added supporting key/value pairs.

Fixes zaproxy/zaproxy#7379

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>