### PR TITLE
graphql: update dependency

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Update dependency, which reduces add-on file size (Issue 7322).
 
 ## [0.9.0] - 2022-04-05
 ### Changed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -41,7 +41,7 @@ crowdin {
 dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
     implementation("com.google.code.gson:gson:2.8.8")
-    implementation("com.graphql-java:graphql-java:17.3")
+    implementation("com.graphql-java:graphql-java:18.2")
 
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))


### PR DESCRIPTION
Update GraphQL Java to latest version (18.2), which reduces the size of
the add-on (the number of transitive dependencies is lower).

Fix zaproxy/zaproxy#7322.