### PR TITLE
exim: correct import of HAR response

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Tweaked import functionality to mark import progress components completed when an exception occurs during import (thus allowing them to be cleared properly).
 - HAR imports will now use an indeterminate progress bar if the count of entries cannot be determined.
+- Correct import of HAR responses to allow them to be passively scanned.
 
 ### Added
 - Copy URLs, Export Context URLs, Export Selected URLs, Export Messages, and Export Responses functionality similar to what was previously offered via core functionality.

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/har/HarImporter.java
@@ -112,6 +112,7 @@ public class HarImporter {
 
         HarContent harContent = harResponse.getContent();
         message.setResponseHeader(new HttpResponseHeader(strBuilderResHeader.toString()));
+        message.setResponseFromTargetHost(true);
         if (harContent != null) {
             message.setResponseBody(new HttpResponseBody(harContent.getText()));
         }


### PR DESCRIPTION
Set that the imported response, when valid, is from the target server
to allow them to be passively scanned.

---
Reported in IRC :)