### PR TITLE
formhandler: properly handle unidentified fields

### DIFF
--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update minimum ZAP version to 2.11.1.
 - Maintenance changes.
 
+### Fixed
+- Fix an exception when generating values for unidentified fields (Issue 7386).
+
 ## [4] - 2021-10-06
 ### Changed
 - Maintenance changes.

--- a/addOns/formhandler/formhandler.gradle.kts
+++ b/addOns/formhandler/formhandler.gradle.kts
@@ -12,3 +12,7 @@ zapAddOn {
         url.set("https://www.zaproxy.org/docs/desktop/addons/form-handler/")
     }
 }
+
+dependencies {
+    testImplementation(project(":testutils"))
+}

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerValueGenerator.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/FormHandlerValueGenerator.java
@@ -45,6 +45,10 @@ public class FormHandlerValueGenerator implements ValueGenerator {
             Map<String, String> envAttributes,
             Map<String, String> fieldAttributes) {
 
+        if (fieldId == null || fieldId.isEmpty()) {
+            return defaultValue != null ? defaultValue : "";
+        }
+
         // Check to see if there is an enabled field for the current field being processed, based on
         // field attribute 'name'
         String value = param.getEnabledFieldValue(fieldId.toLowerCase());

--- a/addOns/formhandler/src/test/java/org/zaproxy/zap/extension/formhandler/FormHandlerValueGeneratorUnitTest.java
+++ b/addOns/formhandler/src/test/java/org/zaproxy/zap/extension/formhandler/FormHandlerValueGeneratorUnitTest.java
@@ -1,0 +1,64 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.formhandler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+/** Unit test for {@link FormHandlerValueGenerator}. */
+class FormHandlerValueGeneratorUnitTest {
+
+    private FormHandlerParam param;
+    private FormHandlerValueGenerator valueGenerator;
+
+    @BeforeEach
+    void setUp() {
+        param = mock(FormHandlerParam.class);
+        valueGenerator = new FormHandlerValueGenerator(param);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldReturnEmptyStringForUnidentifiedFields(String fieldId) {
+        // Given / When
+        String generatedvalue =
+                valueGenerator.getValue(null, null, fieldId, null, null, null, null);
+        // Then
+        assertThat(generatedvalue, is(equalTo("")));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldUseDefaultValueWhenAvailableForUnidentifiedFields(String fieldId) {
+        // Given
+        String defaultValue = "DefaultValue";
+        // When
+        String generatedvalue =
+                valueGenerator.getValue(null, null, fieldId, defaultValue, null, null, null);
+        // Then
+        assertThat(generatedvalue, is(equalTo(defaultValue)));
+    }
+}


### PR DESCRIPTION
Check if the provided field ID is invalid (null/empty) and return an
appropriate value, preventing the exception when normalising the ID.

Fix zaproxy/zaproxy#7386.