### PR TITLE
network: use UTF-8 for the HTTP headers

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -22,6 +22,8 @@ package org.zaproxy.addon.network.internal.client.apachev5;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -58,6 +60,7 @@ import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.HttpVersion;
 import org.apache.hc.core5.http.MessageHeaders;
 import org.apache.hc.core5.http.ProtocolVersion;
+import org.apache.hc.core5.http.config.CharCodingConfig;
 import org.apache.hc.core5.http.config.Lookup;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
@@ -144,6 +147,12 @@ public class HttpSenderApache
 
         managedHttpClientConnectionFactory =
                 ManagedHttpClientConnectionFactory.builder()
+                        .charCodingConfig(
+                                CharCodingConfig.custom()
+                                        .setCharset(StandardCharsets.UTF_8)
+                                        .setMalformedInputAction(CodingErrorAction.REPLACE)
+                                        .setUnmappableInputAction(CodingErrorAction.REPLACE)
+                                        .build())
                         .outgoingContentLengthStrategy(outgoingContentStrategy)
                         .responseParserFactory(new LenientMessageParserFactory())
                         .build();

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoder.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoder.java
@@ -24,6 +24,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 import org.parosproxy.paros.network.HttpBody;
@@ -35,6 +36,8 @@ import org.parosproxy.paros.network.HttpMessage;
 abstract class HttpMessageEncoder extends MessageToByteEncoder<HttpMessage> {
 
     private static final int CRLF = '\r' << 8 | '\n';
+
+    private static final Charset HEADER_CHARSET = StandardCharsets.UTF_8;
 
     private final Function<HttpMessage, HttpHeader> headerProvider;
     private final Function<HttpMessage, HttpBody> bodyProvider;
@@ -56,10 +59,10 @@ abstract class HttpMessageEncoder extends MessageToByteEncoder<HttpMessage> {
     protected void encode(ChannelHandlerContext ctx, HttpMessage msg, ByteBuf out) {
         HttpHeader header = headerProvider.apply(msg);
 
-        out.writeCharSequence(header.getPrimeHeader(), StandardCharsets.US_ASCII);
+        out.writeCharSequence(header.getPrimeHeader(), HEADER_CHARSET);
         ByteBufUtil.writeShortBE(out, CRLF);
 
-        out.writeCharSequence(header.getHeadersAsString(), StandardCharsets.US_ASCII);
+        out.writeCharSequence(header.getHeadersAsString(), HEADER_CHARSET);
         ByteBufUtil.writeShortBE(out, CRLF);
 
         HttpBody body = bodyProvider.apply(msg);

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoderUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/codec/HttpMessageEncoderUnitTest.java
@@ -86,6 +86,25 @@ class HttpMessageEncoderUnitTest {
     }
 
     @Test
+    void shouldEncodeNonAsciiHeaderInHttpMessage() throws Exception {
+        // Given
+        HttpMessage httpMessage = new HttpMessage();
+        given(header.getPrimeHeader()).willReturn("Prime J/ψ:  → VP Header");
+        given(header.getHeadersAsString()).willReturn("Headers J/ψ:  → VP");
+        // When
+        boolean written = channel.writeOutbound(httpMessage);
+        // Then
+        assertThat(written, is(equalTo(true)));
+        ByteBuf encoded = channel.readOutbound();
+        assertNotNull(encoded);
+        assertThat(
+                encoded.toString(StandardCharsets.UTF_8),
+                is(equalTo("Prime J/ψ:  → VP Header\r\nHeaders J/ψ:  → VP\r\n")));
+        encoded.release();
+        assertChannelStateEnd();
+    }
+
+    @Test
     void shouldNotGetBodyBytesIfBodyEmpty() throws Exception {
         // Given
         HttpMessage httpMessage = new HttpMessage();

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/testutils/TestHttpServer.java
@@ -80,7 +80,7 @@ public class TestHttpServer extends HttpServer {
                                         return null;
                                     }
 
-                                    String data = decoded.toString(StandardCharsets.US_ASCII);
+                                    String data = decoded.toString(StandardCharsets.UTF_8);
                                     int idx = data.indexOf("\r\n\r\n");
                                     HttpMessage message =
                                             new HttpMessage(


### PR DESCRIPTION
Encode and send with UTF-8 instead of ASCII to attempt to preserve the
most data possible.