### PR TITLE
Address warns with Java 18

### DIFF
--- a/addOns/accessControl/CHANGELOG.md
+++ b/addOns/accessControl/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [7] - 2021-10-07

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlResultsTableModel.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlResultsTableModel.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
  * The table model for access control testing results. This table is used in the status panel of the
  * Access Control extension.
  */
+@SuppressWarnings("serial")
 public class AccessControlResultsTableModel
         extends AbstractCustomColumnHistoryReferencesTableModel<AccessControlResultsTableEntry> {
 

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlScanOptionsDialog.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlScanOptionsDialog.java
@@ -44,6 +44,7 @@ import org.zaproxy.zap.view.widgets.UsersMultiSelectTable;
  * <p>If the un-authenticated user was selected, it is returned in the {@link ScanStartOptions} as
  * <code>null</code>.
  */
+@SuppressWarnings("serial")
 public class AccessControlScanOptionsDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = -4540976404891062951L;

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/AccessControlStatusPanel.java
@@ -70,6 +70,7 @@ import org.zaproxy.zap.view.widgets.WritableFileChooser;
  * The status panel used for the Access Control extension. It allows ZAP users to control and
  * configure the scans, generate a report and see the scan results.
  */
+@SuppressWarnings("serial")
 public class AccessControlStatusPanel extends AbstractScanToolbarStatusPanel
         implements AccessControlScanListener {
 

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextAccessControlPanel.java
@@ -66,6 +66,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.widgets.ContextPanelUsersSelectComboBox;
 
 /** The context configuration panel used for specifying the Access Control rules. */
+@SuppressWarnings("serial")
 public class ContextAccessControlPanel extends AbstractContextPropertiesPanel {
 
     private static final Logger log = LogManager.getLogger(ContextAccessControlPanel.class);

--- a/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextUserAccessRulesModel.java
+++ b/addOns/accessControl/src/main/java/org/zaproxy/zap/extension/accessControl/view/ContextUserAccessRulesModel.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.extension.accessControl.widgets.SiteTreeNode;
  * The model used in the {@link ContextAccessControlPanel} for each user, in order to specify the
  * access rules for each Context node.
  */
+@SuppressWarnings("serial")
 public class ContextUserAccessRulesModel extends DefaultTreeModel implements TreeTableModel {
 
     private static final long serialVersionUID = -1876199137051156699L;

--- a/addOns/addOns.gradle.kts
+++ b/addOns/addOns.gradle.kts
@@ -33,6 +33,11 @@ val parentProjects = listOf(
     "webdrivers"
 )
 
+val jacocoToolVersion = "0.8.8"
+jacoco {
+    toolVersion = jacocoToolVersion
+}
+
 val ghReleaseDataProvider = provider {
     subprojects.first().zapAddOn.gitHubRelease
 }
@@ -102,6 +107,10 @@ subprojects {
             sourceCompatibility = JavaVersion.VERSION_1_8
             targetCompatibility = JavaVersion.VERSION_1_8
         }
+    }
+
+    jacoco {
+        toolVersion = jacocoToolVersion
     }
 
     tasks.named<JacocoReport>("jacocoTestReport") {

--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - When the automation Job is edited via UI Dialog then the status will be set to Not started
+- Maintenance changes.
 
 ## [13] - 2021-10-06
 ### Added

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilterTableModel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFilterTableModel.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
 /** A table model for holding a set of AlertFilter, for a {@link Context}. */
+@SuppressWarnings("serial")
 public class AlertFilterTableModel extends AbstractMultipleOptionsTableModel<AlertFilter> {
 
     /** The Constant defining the table column names. */

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFiltersMultipleOptionsPanel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/AlertFiltersMultipleOptionsPanel.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
+@SuppressWarnings("serial")
 public class AlertFiltersMultipleOptionsPanel
         extends AbstractMultipleOptionsTablePanel<AlertFilter> {
 

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterPanel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ContextAlertFilterPanel.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.AbstractContextPropertiesPanel;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class ContextAlertFilterPanel extends AbstractContextPropertiesPanel {
 
     private AlertFiltersMultipleOptionsPanel alertFilterOptionsPanel;

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
@@ -42,6 +42,7 @@ import org.zaproxy.zap.view.AbstractFormDialog;
 import org.zaproxy.zap.view.LayoutHelper;
 
 /** The Dialog for adding and configuring a new {@link AlertFilter}. */
+@SuppressWarnings("serial")
 public class DialogAddAlertFilter extends AbstractFormDialog {
 
     /** The Constant serialVersionUID. */

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AddAlertFilterDialog.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AddAlertFilterDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.extension.alertFilters.automation.AlertFilterJob.Risk;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AddAlertFilterDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJobDialog.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterJobDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AlertFilterJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterTableModel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AlertFilterTableModel.java
@@ -25,6 +25,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.alertFilters.automation.AlertFilterJob.AlertFilterData;
 
+@SuppressWarnings("serial")
 public class AlertFilterTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/allinonenotes/CHANGELOG.md
+++ b/addOns/allinonenotes/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Update minimum ZAP version to 2.11.1.
+- Maintenance changes.
 
 ## [2] - 2021-10-07
 ### Added

--- a/addOns/allinonenotes/src/main/java/org/zaproxy/zap/extension/allinonenotes/NotesTableModel.java
+++ b/addOns/allinonenotes/src/main/java/org/zaproxy/zap/extension/allinonenotes/NotesTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class NotesTableModel extends AbstractTableModel {
 
     private static final String PREFIX = "allinonenotes";

--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add Save As button that allows user to save the automation plan to a different file (Issue 7178).
 
+### Changed
+- Maintenance changes.
+
 ## [0.16.0] - 2022-06-22
 ### Changed
 - Maintenance changes.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ActiveScanJobDialog.java
@@ -39,6 +39,7 @@ import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ActiveScanJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddAscanRuleDialog.java
@@ -37,6 +37,7 @@ import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AddAscanRuleDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddJobDialog.java
@@ -34,6 +34,7 @@ import org.zaproxy.addon.automation.ExtensionAutomation;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AddJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnJobDialog.java
@@ -30,6 +30,7 @@ import org.zaproxy.addon.automation.jobs.AddOnJob;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AddOnJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnsTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddOnsTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class AddOnsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddPscanRuleDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddPscanRuleDialog.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AddPscanRuleDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddRequestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddRequestDialog.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AddRequestDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AddTestDialog.java
@@ -34,6 +34,7 @@ import org.zaproxy.addon.automation.tests.UrlPresenceTest;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AddTestDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AlertTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AlertTestDialog.java
@@ -29,6 +29,7 @@ import org.zaproxy.addon.automation.tests.AutomationAlertTest;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AlertTestDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AscanRulesTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AscanRulesTableModel.java
@@ -31,6 +31,7 @@ import org.zaproxy.addon.automation.jobs.ActiveScanJob.Rule;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 
+@SuppressWarnings("serial")
 public class AscanRulesTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/AutomationPanel.java
@@ -64,6 +64,7 @@ import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class AutomationPanel extends AbstractPanel implements EventConsumer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextDialog.java
@@ -30,6 +30,7 @@ import org.zaproxy.addon.automation.ContextWrapper;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ContextDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextsTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/ContextsTableModel.java
@@ -25,6 +25,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.automation.ContextWrapper;
 
+@SuppressWarnings("serial")
 public class ContextsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/DelayJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/DelayJobDialog.java
@@ -27,6 +27,7 @@ import org.zaproxy.addon.automation.jobs.DelayJob;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class DelayJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarDialog.java
@@ -23,6 +23,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class EnvVarDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvVarTableModel.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class EnvVarTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/EnvironmentDialog.java
@@ -34,6 +34,7 @@ import org.zaproxy.addon.automation.ContextWrapper.Data;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class EnvironmentDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/NewPlanDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/NewPlanDialog.java
@@ -47,6 +47,7 @@ import org.zaproxy.addon.automation.jobs.SpiderJob;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class NewPlanDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanConfigJobDialog.java
@@ -33,6 +33,7 @@ import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class PassiveScanConfigJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanWaitJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PassiveScanWaitJobDialog.java
@@ -25,6 +25,7 @@ import org.zaproxy.addon.automation.jobs.PassiveScanWaitJob;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class PassiveScanWaitJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PlanTreeTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PlanTreeTableModel.java
@@ -34,6 +34,7 @@ import org.zaproxy.addon.automation.AutomationPlan;
 import org.zaproxy.addon.automation.AutomationProgress.JobResults;
 import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
 
+@SuppressWarnings("serial")
 public class PlanTreeTableModel extends DefaultTreeModel implements TreeTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PscanRulesTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/PscanRulesTableModel.java
@@ -30,6 +30,7 @@ import org.zaproxy.addon.automation.jobs.PassiveScanConfigJob.Rule;
 import org.zaproxy.zap.extension.pscan.ExtensionPassiveScan;
 import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
 
+@SuppressWarnings("serial")
 public class PscanRulesTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestorJobDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.addon.automation.jobs.RequestorJob;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class RequestorJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestsTableModel.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/RequestsTableModel.java
@@ -25,6 +25,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.automation.jobs.RequestorJob;
 
+@SuppressWarnings("serial")
 public class RequestsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/SpiderJobDialog.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.spider.SpiderParam.HandleParametersOption;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class SpiderJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/StatisticTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/StatisticTestDialog.java
@@ -27,6 +27,7 @@ import org.zaproxy.addon.automation.tests.AutomationStatisticTest.Operator;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class StatisticTestDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/UrlPresenceTestDialog.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/gui/UrlPresenceTestDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.addon.automation.tests.UrlPresenceTest.Operator;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class UrlPresenceTestDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/beanshell/CHANGELOG.md
+++ b/addOns/beanshell/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 - Dependency updates.
 

--- a/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
+++ b/addOns/beanshell/src/main/java/org/zaproxy/zap/extension/beanshell/BeanShellConsoleFrame.java
@@ -45,6 +45,7 @@ import org.parosproxy.paros.view.AbstractFrame;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class BeanShellConsoleFrame extends AbstractFrame {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/BrowserPanel.java
+++ b/addOns/browserView/src/main/java/org/zaproxy/zap/extension/browserView/BrowserPanel.java
@@ -38,6 +38,7 @@ import javax.swing.SwingUtilities;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+@SuppressWarnings("serial")
 public class BrowserPanel extends JPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/BruteForcePanel.java
@@ -58,6 +58,7 @@ import org.zaproxy.zap.view.ScanStatus;
 import org.zaproxy.zap.view.ZapToggleButton;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
+@SuppressWarnings("serial")
 public class BruteForcePanel extends AbstractPanel implements BruteForceListenner {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/OptionsBruteForcePanel.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/OptionsBruteForcePanel.java
@@ -42,6 +42,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.PositiveValuesSlider;
 
+@SuppressWarnings("serial")
 public class OptionsBruteForcePanel extends AbstractParamPanel {
 
     private static final String MESSAGE_PREFIX = "bruteforce.options.";

--- a/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/PopupMenuBruteForceSite.java
+++ b/addOns/bruteforce/src/main/java/org/zaproxy/zap/extension/bruteforce/PopupMenuBruteForceSite.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuBruteForceSite extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/callgraph/CHANGELOG.md
+++ b/addOns/callgraph/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [5] - 2021-10-07

--- a/addOns/callgraph/src/main/java/org/zaproxy/zap/extension/callgraph/CallGraphFrame.java
+++ b/addOns/callgraph/src/main/java/org/zaproxy/zap/extension/callgraph/CallGraphFrame.java
@@ -62,6 +62,7 @@ import org.parosproxy.paros.view.AbstractFrame;
  *
  * @author 70pointer@gmail.com
  */
+@SuppressWarnings("serial")
 public class CallGraphFrame extends AbstractFrame {
 
     private static final long serialVersionUID = 6666666666666666666L;

--- a/addOns/callhome/CHANGELOG.md
+++ b/addOns/callhome/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.4.0] - 2022-07-18
 ### Changed

--- a/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/OptionsCallHomePanel.java
+++ b/addOns/callhome/src/main/java/org/zaproxy/addon/callhome/OptionsCallHomePanel.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class OptionsCallHomePanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = -7541236934312940852L;

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPanel.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/ui/ProgressPanel.java
@@ -51,6 +51,7 @@ import org.zaproxy.zap.utils.FontUtils;
  *
  * @since 1.8.0
  */
+@SuppressWarnings("serial")
 public class ProgressPanel extends AbstractPanel {
 
     private enum DisplayStatus {

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [0.11.0] - 2021-10-07

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnDialog.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnDialog.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AbstractColumnDialog<T> extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractColumnTableModel.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.custompayloads;
 import java.util.List;
 import javax.swing.table.AbstractTableModel;
 
+@SuppressWarnings("serial")
 public class AbstractColumnTableModel<T> extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractMultipleOptionsColumnTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractMultipleOptionsColumnTableModel.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.zaproxy.zap.utils.EnableableInterface;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class AbstractMultipleOptionsColumnTableModel<T extends EnableableInterface>
         extends AbstractMultipleOptionsTableModel<T> {
 

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractTableModelAsAbstractColumnTableModelWrapper.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/AbstractTableModelAsAbstractColumnTableModelWrapper.java
@@ -26,6 +26,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 
+@SuppressWarnings("serial")
 public class AbstractTableModelAsAbstractColumnTableModelWrapper<T> {
 
     private final AbstractTableModel abstractTableModel;

--- a/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
+++ b/addOns/custompayloads/src/main/java/org/zaproxy/zap/extension/custompayloads/CustomPayloadMultipleOptionsTableModel.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+@SuppressWarnings("serial")
 public class CustomPayloadMultipleOptionsTableModel
         extends AbstractMultipleOptionsColumnTableModel<CustomPayload> {
 

--- a/addOns/diff/CHANGELOG.md
+++ b/addOns/diff/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [11] - 2021-10-06

--- a/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/PopupMenuDiff.java
+++ b/addOns/diff/src/main/java/org/zaproxy/zap/extension/diff/PopupMenuDiff.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuDiff extends PopupMenuItemHistoryReferenceContainer {
 
     private static final Logger LOGGER = LogManager.getLogger(PopupMenuDiff.class);

--- a/addOns/encoder/CHANGELOG.md
+++ b/addOns/encoder/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [0.6.0] - 2021-10-06

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/AddEncodeDecodeOutputPanelDialog.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/AddEncodeDecodeOutputPanelDialog.java
@@ -31,6 +31,7 @@ import org.zaproxy.addon.encoder.processors.EncodeDecodeProcessors;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class AddEncodeDecodeOutputPanelDialog extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeDialog.java
+++ b/addOns/encoder/src/main/java/org/zaproxy/addon/encoder/EncodeDecodeDialog.java
@@ -62,6 +62,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapTextArea;
 
+@SuppressWarnings("serial")
 public class EncodeDecodeDialog extends AbstractFrame implements OptionsChangedListener {
 
     public static final String ENCODE_DECODE_FIELD = "EncodeDecodeInputField";

--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.2.0] - 2022-07-20
 ### Fixed

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/AbstractPopupMenuSaveMessage.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 abstract class AbstractPopupMenuSaveMessage extends PopupMenuHttpMessageContainer {
 
     private static final long serialVersionUID = 8080417865825721164L;

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportMessages.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportMessages.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class PopupMenuExportMessages extends JMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportUrls.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/PopupMenuExportUrls.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.utils.Stats;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class PopupMenuExportUrls extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ImportJobDialog.java
+++ b/addOns/exim/src/main/java/org/zaproxy/addon/exim/automation/ImportJobDialog.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ImportJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [5] - 2022-07-20
 ### Changed

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/DialogAddField.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/DialogAddField.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddField extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/OptionsFormHandlerTableModel.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/OptionsFormHandlerTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsFormHandlerTableModel
         extends AbstractMultipleOptionsTableModel<FormHandlerParamField> {
 

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/PopupDialogAddField.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/PopupDialogAddField.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.swing.JComboBox;
 import org.parosproxy.paros.control.Control;
 
+@SuppressWarnings("serial")
 class PopupDialogAddField extends DialogAddField {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update dependency, which reduces add-on file size (Issue 7322).
 
 ## [0.9.0] - 2022-04-05

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportFromAbstractDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ImportFromAbstractDialog.java
@@ -34,6 +34,7 @@ import org.parosproxy.paros.extension.AbstractDialog;
 import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 
+@SuppressWarnings("serial")
 abstract class ImportFromAbstractDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/automation/GraphQlJobDialog.java
@@ -39,6 +39,7 @@ import org.zaproxy.addon.graphql.automation.GraphQlJob.Parameters;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class GraphQlJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/highlighter/CHANGELOG.md
+++ b/addOns/highlighter/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [8] - 2021-10-07

--- a/addOns/highlighter/src/main/java/org/zaproxy/zap/extension/highlighter/HighlightEntryLineUi.java
+++ b/addOns/highlighter/src/main/java/org/zaproxy/zap/extension/highlighter/HighlightEntryLineUi.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.view.HighlightSearchEntry;
  * A panel which specifies all values of an HighlightEntry in a JPanel,
  * with UI elements to input and output of its content.
  */
+@SuppressWarnings("serial")
 public class HighlightEntryLineUi extends AbstractPanel implements ActionListener {
     private static final long serialVersionUID = 1L;
 

--- a/addOns/highlighter/src/main/java/org/zaproxy/zap/extension/highlighter/HighlighterPanel.java
+++ b/addOns/highlighter/src/main/java/org/zaproxy/zap/extension/highlighter/HighlighterPanel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.view.HighlighterManager;
 /*
  * The main highlighter tab, used to configure highlights in the HighlightManager
  */
+@SuppressWarnings("serial")
 public class HighlighterPanel extends AbstractPanel implements ActionListener {
     private static final long serialVersionUID = -1085991554138327045L;
     private JPanel mainPanel;

--- a/addOns/invoke/CHANGELOG.md
+++ b/addOns/invoke/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [11] - 2021-10-06

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/DialogAddApp.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/DialogAddApp.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddApp extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4629430215148620470L;

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/OptionsInvokePanel.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/OptionsInvokePanel.java
@@ -31,6 +31,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
+@SuppressWarnings("serial")
 public class OptionsInvokePanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/OptionsInvokeTableModel.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/OptionsInvokeTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsInvokeTableModel extends AbstractMultipleOptionsTableModel<InvokableApp> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/PopupMenuItemInvoke.java
+++ b/addOns/invoke/src/main/java/org/zaproxy/zap/extension/invoke/PopupMenuItemInvoke.java
@@ -35,7 +35,7 @@ public class PopupMenuItemInvoke extends PopupMenuItemHttpMessageContainer {
     private boolean captureOutput = true;
     private boolean outputNote = false;
 
-    private Logger logger = LogManager.getLogger(PopupMenuItemInvoke.class);
+    private static final Logger LOGGER = LogManager.getLogger(PopupMenuItemInvoke.class);
 
     /** @param label */
     public PopupMenuItemInvoke(String label) {
@@ -93,7 +93,7 @@ public class PopupMenuItemInvoke extends PopupMenuItemHttpMessageContainer {
             }
         } catch (Exception e1) {
             View.getSingleton().showWarningDialog(e1.getMessage());
-            logger.error(e1.getMessage(), e1);
+            LOGGER.error(e1.getMessage(), e1);
         }
     }
 }

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ClientCertificatesOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ClientCertificatesOptionsPanel.java
@@ -65,6 +65,7 @@ import org.zaproxy.addon.network.internal.ui.Pkcs11DriversDialog;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.ZapTable;
 
+@SuppressWarnings("serial")
 class ClientCertificatesOptionsPanel extends AbstractParamPanel {
 
     private static final Logger LOGGER = LogManager.getLogger(ClientCertificatesOptionsPanel.class);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ConnectionOptionsPanel.java
@@ -52,6 +52,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapPortNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextField;
 
+@SuppressWarnings("serial")
 class ConnectionOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/LocalServersOptionsPanel.java
@@ -48,6 +48,7 @@ import org.zaproxy.addon.network.internal.ui.PassThroughTablePanel;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapLabel;
 
+@SuppressWarnings("serial")
 class LocalServersOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/ServerCertificatesOptionsPanel.java
@@ -55,6 +55,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapXmlConfiguration;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 class ServerCertificatesOptionsPanel extends AbstractParamPanel {
 
     private static final Logger LOGGER = LogManager.getLogger(ServerCertificatesOptionsPanel.class);

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddAliasDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddAliasDialog.java
@@ -31,6 +31,7 @@ import org.zaproxy.addon.network.internal.server.http.Alias;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 public class AddAliasDialog extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddHttpProxyExclusionDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddHttpProxyExclusionDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 public class AddHttpProxyExclusionDialog extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddLocalServerDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddLocalServerDialog.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.utils.NetworkUtils;
 import org.zaproxy.zap.utils.ZapPortNumberSpinner;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 public class AddLocalServerDialog extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddPassThroughDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddPassThroughDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.addon.network.internal.server.http.PassThrough;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 public class AddPassThroughDialog extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddPkcs11DriverDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AddPkcs11DriverDialog.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 public class AddPkcs11DriverDialog extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AliasTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/AliasTableModel.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.network.internal.server.http.Alias;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class AliasTableModel extends AbstractMultipleOptionsTableModel<Alias> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/CertificatesTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/CertificatesTableModel.java
@@ -25,6 +25,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.network.internal.client.CertificateEntry;
 
+@SuppressWarnings("serial")
 public class CertificatesTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/DriversComboBoxModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/DriversComboBoxModel.java
@@ -26,6 +26,7 @@ import org.zaproxy.addon.network.internal.client.Pkcs11Driver;
 import org.zaproxy.addon.network.internal.client.Pkcs11Drivers;
 
 /** A {@link ComboBoxModel} of {@link Pkcs11Driver}s. */
+@SuppressWarnings("serial")
 public class DriversComboBoxModel extends AbstractListModel<Pkcs11Driver>
         implements ComboBoxModel<Pkcs11Driver> {
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/HttpProxyExclusionTableModel.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.network.internal.client.HttpProxyExclusion;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class HttpProxyExclusionTableModel
         extends AbstractMultipleOptionsTableModel<HttpProxyExclusion> {
 

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/KeyStoresTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/KeyStoresTableModel.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.network.internal.client.KeyStores;
 
 /** A table model for KeyStores. */
+@SuppressWarnings("serial")
 public class KeyStoresTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServerPropertiesDialogue.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServerPropertiesDialogue.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.network.internal.server.http.LocalServerConfig;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 public class LocalServerPropertiesDialogue extends AbstractFormDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServerPropertiesPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServerPropertiesPanel.java
@@ -34,6 +34,7 @@ import org.zaproxy.addon.network.internal.TlsUtils;
 import org.zaproxy.addon.network.internal.server.http.LocalServerConfig;
 import org.zaproxy.addon.network.internal.server.http.LocalServerConfig.ServerMode;
 
+@SuppressWarnings("serial")
 public class LocalServerPropertiesPanel extends JPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServersTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServersTableModel.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.network.internal.server.http.LocalServerConfig;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class LocalServersTableModel extends AbstractMultipleOptionsTableModel<LocalServerConfig> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServersTablePanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/LocalServersTablePanel.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.network.internal.server.http.LocalServerConfig;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
+@SuppressWarnings("serial")
 public class LocalServersTablePanel extends AbstractMultipleOptionsTablePanel<LocalServerConfig> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PassThroughTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/PassThroughTableModel.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.addon.network.internal.server.http.PassThrough;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class PassThroughTableModel extends AbstractMultipleOptionsTableModel<PassThrough> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/Pkcs11DriverTableModel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/Pkcs11DriverTableModel.java
@@ -25,6 +25,7 @@ import org.zaproxy.addon.network.internal.client.Pkcs11Driver;
 import org.zaproxy.addon.network.internal.client.Pkcs11Drivers;
 import org.zaproxy.zap.view.AbstractMultipleOptionsBaseTableModel;
 
+@SuppressWarnings("serial")
 public class Pkcs11DriverTableModel extends AbstractMultipleOptionsBaseTableModel<Pkcs11Driver> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/Pkcs11DriversDialog.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/Pkcs11DriversDialog.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
 import org.zaproxy.addon.network.internal.client.Pkcs11Drivers;
 
+@SuppressWarnings("serial")
 public class Pkcs11DriversDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/SecurityProtocolsPanel.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/ui/SecurityProtocolsPanel.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.utils.FontUtils;
  *
  * @see TlsUtils
  */
+@SuppressWarnings("serial")
 public class SecurityProtocolsPanel extends JPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastOptionsPanelTab.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/boast/BoastOptionsPanelTab.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class BoastOptionsPanelTab extends OastOptionsPanelTab {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackOptionsPanelTab.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/callback/CallbackOptionsPanelTab.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.utils.ZapPortNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class CallbackOptionsPanelTab extends OastOptionsPanelTab {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/services/interactsh/InteractshOptionsPanelTab.java
@@ -43,6 +43,7 @@ import org.zaproxy.zap.utils.ZapNumberSpinner;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class InteractshOptionsPanelTab extends OastOptionsPanelTab {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/DefaultCustomColumnHistoryReferencesTableModel.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/DefaultCustomColumnHistoryReferencesTableModel.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableModel;
 
+@SuppressWarnings("serial")
 public class DefaultCustomColumnHistoryReferencesTableModel<
                 T extends DefaultHistoryReferencesTableEntry>
         extends DefaultHistoryReferencesTableModel {

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/OastOptionsPanel.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/OastOptionsPanel.java
@@ -30,6 +30,7 @@ import org.parosproxy.paros.model.OptionsParam;
 import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class OastOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/OastPanel.java
+++ b/addOns/oast/src/main/java/org/zaproxy/addon/oast/ui/OastPanel.java
@@ -46,6 +46,7 @@ import org.zaproxy.addon.oast.OastState;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 
+@SuppressWarnings("serial")
 public class OastPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromAbstractDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ImportFromAbstractDialog.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.extension.AbstractDialog;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.openapi.converter.swagger.UriBuilder;
 
+@SuppressWarnings("serial")
 abstract class ImportFromAbstractDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/automation/OpenApiJobDialog.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class OpenApiJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/ParamGuessResultEvent.java
+++ b/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/ParamGuessResultEvent.java
@@ -21,6 +21,7 @@ package org.zaproxy.addon.paramminer;
 
 import java.util.EventObject;
 
+@SuppressWarnings("serial")
 public class ParamGuessResultEvent extends EventObject {
     private static final long serialVersionUID = 1L;
     private final ParamGuessResult result;

--- a/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/ParamMinerDialog.java
+++ b/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/ParamMinerDialog.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.NodeSelectDialog;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ParamMinerDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/ParamMinerPanel.java
+++ b/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/ParamMinerPanel.java
@@ -41,6 +41,7 @@ import org.zaproxy.addon.paramminer.ParamMinerOptions;
 import org.zaproxy.addon.paramminer.ParamMinerResultEventListener;
 import org.zaproxy.zap.view.ScanPanel2;
 
+@SuppressWarnings("serial")
 public class ParamMinerPanel extends ScanPanel2<GuesserScan, ParamGuesserScanController> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/ParamMinerResultsTable.java
+++ b/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/ParamMinerResultsTable.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.extension.history.ExtensionHistory;
 import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
+@SuppressWarnings("serial")
 public class ParamMinerResultsTable extends HistoryReferencesTable {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/PopupMenuParamMiner.java
+++ b/addOns/paramminer/src/main/java/org/zaproxy/addon/paramminer/gui/PopupMenuParamMiner.java
@@ -23,6 +23,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.addon.paramminer.ExtensionParamMiner;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuParamMiner extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/CHANGELOG.md
+++ b/addOns/plugnhack/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 - Use Network add-on to obtain main proxy address/port.
 

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientConfigDialog.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientConfigDialog.java
@@ -23,6 +23,7 @@ import java.awt.Dimension;
 import java.awt.Frame;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ClientConfigDialog extends StandardFieldsDialog {
 
     private static final String FIELD_HEARTBEAT = "plugnhack.dialog.clientconf.heartbeat";

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/ClientsPanel.java
@@ -54,6 +54,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.ZapTable;
 import org.zaproxy.zap.view.ZapToggleButton;
 
+@SuppressWarnings("serial")
 public class ClientsPanel extends AbstractPanel implements MonitoredPageListener {
 
     public static final String CLIENTS_PANEL_NAME = "pnhClientsAlert";

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/MessageListTableModel.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/MessageListTableModel.java
@@ -28,6 +28,7 @@ import javax.swing.ImageIcon;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class MessageListTableModel extends AbstractTableModel {
 
     private static final SimpleDateFormat SDF = new SimpleDateFormat("HH:mm:ss.SSS");

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuConfigureClient.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuConfigureClient.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 
+@SuppressWarnings("serial")
 public class PopupMenuConfigureClient extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuMonitorScope.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuMonitorScope.java
@@ -23,6 +23,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuMonitorScope extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuMonitorSubtree.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuMonitorSubtree.java
@@ -23,6 +23,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuMonitorSubtree extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuOpenAndMonitorUrl.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuOpenAndMonitorUrl.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.utils.DesktopUtils;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuOpenAndMonitorUrl extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuResend.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/PopupMenuResend.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.plugnhack.manualsend.ManualClientMessageSendEditorDialog;
 
+@SuppressWarnings("serial")
 public class PopupMenuResend extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/SessionMonitoredClientsPanel.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/SessionMonitoredClientsPanel.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.SingleColumnTableModel;
 
+@SuppressWarnings("serial")
 public class SessionMonitoredClientsPanel extends AbstractParamPanel {
 
     public static final String PANEL_NAME = Constant.messages.getString("plugnhack.session.title");

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialog.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialog.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.extension.plugnhack.ExtensionPlugNHack;
 import org.zaproxy.zap.extension.plugnhack.MonitoredPagesManager;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public abstract class ClientBreakDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogAdd.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogAdd.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.plugnhack.ClientMessage;
 import org.zaproxy.zap.extension.plugnhack.ExtensionPlugNHack;
 
+@SuppressWarnings("serial")
 public class ClientBreakDialogAdd extends ClientBreakDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogEdit.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/ClientBreakDialogEdit.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.plugnhack.ExtensionPlugNHack;
 
+@SuppressWarnings("serial")
 public class ClientBreakDialogEdit extends ClientBreakDialog {
     private static final long serialVersionUID = 1L;
 

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuAddBreakClient.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuAddBreakClient.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.extension.brk.ExtensionBreak;
 import org.zaproxy.zap.extension.plugnhack.ClientsPanel;
 import org.zaproxy.zap.extension.plugnhack.MessageListTableModel;
 
+@SuppressWarnings("serial")
 public class PopupMenuAddBreakClient extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuEditBreak.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/brk/PopupMenuEditBreak.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.brk.BreakpointsPanel;
 import org.zaproxy.zap.extension.brk.ExtensionBreak;
 
+@SuppressWarnings("serial")
 public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/httppanel/views/ClientSyntaxHighlightTextView.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/httppanel/views/ClientSyntaxHighlightTextView.java
@@ -24,10 +24,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
 import org.parosproxy.paros.Constant;
-import org.parosproxy.paros.control.Control;
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextArea;
 import org.zaproxy.zap.extension.httppanel.view.syntaxhighlight.HttpPanelSyntaxHighlightTextView;
-import org.zaproxy.zap.extension.plugnhack.ExtensionPlugNHack;
 import org.zaproxy.zap.extension.plugnhack.httppanel.models.StringClientPanelViewModel;
 import org.zaproxy.zap.extension.search.SearchMatch;
 
@@ -59,20 +57,12 @@ public class ClientSyntaxHighlightTextView extends HttpPanelSyntaxHighlightTextV
 
         private static ClientTokenMakerFactory tokenMakerFactory = null;
 
-        private final ExtensionPlugNHack extension;
-
         public ClientSyntaxHighlightTextArea() {
             addSyntaxStyle(CSS, SyntaxConstants.SYNTAX_STYLE_CSS);
             addSyntaxStyle(HTML, SyntaxConstants.SYNTAX_STYLE_HTML);
             addSyntaxStyle(JAVASCRIPT, SyntaxConstants.SYNTAX_STYLE_JAVASCRIPT);
             addSyntaxStyle(JSON, SyntaxConstants.SYNTAX_STYLE_JSON);
             addSyntaxStyle(XML, SyntaxConstants.SYNTAX_STYLE_XML);
-
-            this.extension =
-                    (ExtensionPlugNHack)
-                            Control.getSingleton()
-                                    .getExtensionLoader()
-                                    .getExtension(ExtensionPlugNHack.NAME);
         }
 
         @Override

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/manualsend/ClientMessagePanelSender.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/manualsend/ClientMessagePanelSender.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.extension.plugnhack.ClientMessage;
 import org.zaproxy.zap.extension.plugnhack.ExtensionPlugNHack;
 
 /** Knows how to send {@link HttpMessage} objects. Contains a list of valid WebSocket channels. */
+@SuppressWarnings("serial")
 public class ClientMessagePanelSender implements MessageSender {
 
     private ExtensionPlugNHack extension = null;

--- a/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/manualsend/ManualClientMessageSendEditorDialog.java
+++ b/addOns/plugnhack/src/main/java/org/zaproxy/zap/extension/plugnhack/manualsend/ManualClientMessageSendEditorDialog.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.plugnhack.ClientMessage;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 /** Send custom crafted WebSocket messages. */
+@SuppressWarnings("serial")
 public class ManualClientMessageSendEditorDialog extends ManualRequestEditorDialog {
 
     private static final long serialVersionUID = -5830450800029295419L;

--- a/addOns/portscan/CHANGELOG.md
+++ b/addOns/portscan/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [9] - 2021-10-07

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PopupMenuPortCopy.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PopupMenuPortCopy.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 
+@SuppressWarnings("serial")
 public class PopupMenuPortCopy extends ExtensionPopupMenuItem implements ClipboardOwner {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PopupMenuPortScan.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PopupMenuPortScan.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuPortScan extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PortScanResultsTableModel.java
+++ b/addOns/portscan/src/main/java/org/zaproxy/zap/extension/portscan/PortScanResultsTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class PortScanResultsTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = -5470998501458271203L;

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -44,6 +44,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.NodeSelectDialog;
 
+@SuppressWarnings("serial")
 public class AttackPanel extends QuickStartSubPanel {
     private static final long serialVersionUID = 1L;
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/DefaultExplorePanel.java
@@ -41,6 +41,7 @@ import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class DefaultExplorePanel extends QuickStartSubPanel {
     private static final long serialVersionUID = 1L;
     private static final String OWASP_ZAP_ROOT_CA_NAME = "owasp_zap_root_ca";

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -50,6 +50,7 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.FontUtils.Size;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class QuickStartPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartSubPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartSubPanel.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.FontUtils.Size;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public abstract class QuickStartSubPanel extends QuickStartBackgroundPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/launch/LaunchPanel.java
@@ -55,6 +55,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.NodeSelectDialog;
 
+@SuppressWarnings("serial")
 public class LaunchPanel extends QuickStartSubPanel implements EventConsumer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/regextester/CHANGELOG.md
+++ b/addOns/regextester/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [2] - 2021-10-07

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegExTesterPopupMenuItem.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/RegExTesterPopupMenuItem.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class RegExTesterPopupMenuItem extends PopupMenuHttpMessageContainer {
     private static final long serialVersionUID = 1L;
 

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/MatchPanel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/MatchPanel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.regextester.RegexTestResult;
 import org.zaproxy.zap.extension.regextester.RegexTester;
 import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
 
+@SuppressWarnings("serial")
 public class MatchPanel extends JPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/RegexPanel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/RegexPanel.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
 import org.zaproxy.zap.extension.regextester.ui.util.SimpleDocumentListener;
 
+@SuppressWarnings("serial")
 public class RegexPanel extends JPanel {
     private static final long serialVersionUID = 1L;
 

--- a/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/TestValuePanel.java
+++ b/addOns/regextester/src/main/java/org/zaproxy/zap/extension/regextester/ui/TestValuePanel.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.regextester.ui.model.RegexModel;
 import org.zaproxy.zap.extension.regextester.ui.util.SimpleDocumentListener;
 
+@SuppressWarnings("serial")
 public class TestValuePanel extends JPanel {
     private static final long serialVersionUID = 1L;
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerPanel.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerPanel.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.view.AbstractParamPanel;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTablePanel;
 
+@SuppressWarnings("serial")
 public class OptionsReplacerPanel extends AbstractParamPanel {
 
     public static final String PANEL_NAME = Constant.messages.getString("replacer.options.title");

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerTableModel.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/OptionsReplacerTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsReplacerTableModel
         extends AbstractMultipleOptionsTableModel<ReplacerParamRule> {
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.extension.replacer.ReplacerParamRule.MatchType;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ReplaceRuleAddDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/reports/CHANGELOG.md
+++ b/addOns/reports/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [0.15.0] - 2022-07-20
 

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/ReportDialog.java
@@ -54,6 +54,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ReportDialog extends StandardFieldsDialog {
 
     private static final Logger LOGGER = LogManager.getLogger(ReportDialog.class);

--- a/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
+++ b/addOns/reports/src/main/java/org/zaproxy/addon/reports/automation/ReportJobDialog.java
@@ -50,6 +50,7 @@ import org.zaproxy.addon.reports.automation.ReportJob.Parameters;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ReportJobDialog extends StandardFieldsDialog {
 
     private static final String FIELD_NAME = "reports.automation.dialog.field.name";

--- a/addOns/requester/src/main/java/org/zaproxy/addon/requester/PopupMenuResendMessage.java
+++ b/addOns/requester/src/main/java/org/zaproxy/addon/requester/PopupMenuResendMessage.java
@@ -25,6 +25,7 @@ import javax.swing.Icon;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuResendMessage extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ManualHttpRequestEditorPanel.java
@@ -56,6 +56,7 @@ import org.zaproxy.zap.extension.httppanel.Message;
 import org.zaproxy.zap.view.HttpPanelManager;
 import org.zaproxy.zap.view.ZapMenuItem;
 
+@SuppressWarnings("serial")
 public class ManualHttpRequestEditorPanel extends ManualRequestEditorPanel {
 
     private static final long serialVersionUID = -5830450800029295419L;

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/RightClickMsgMenuRequester.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/RightClickMsgMenuRequester.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class RightClickMsgMenuRequester extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ToolsMenuItemRequester.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/ToolsMenuItemRequester.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.ZapMenuItem;
 
+@SuppressWarnings("serial")
 public class ToolsMenuItemRequester extends ZapMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/EditAlertDialog.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/EditAlertDialog.java
@@ -29,6 +29,7 @@ import javax.swing.JPanel;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
 
+@SuppressWarnings("serial")
 public class EditAlertDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/EditAlertPanel.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/EditAlertPanel.java
@@ -50,6 +50,7 @@ import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class EditAlertPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/PlanTableModel.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/PlanTableModel.java
@@ -25,6 +25,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 
+@SuppressWarnings("serial")
 public class PlanTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestDialog.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestDialog.java
@@ -65,6 +65,7 @@ import org.zaproxy.zap.extension.alert.AlertTreeCellRenderer;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.help.ExtensionHelp;
 
+@SuppressWarnings("serial")
 public class RetestDialog extends AbstractDialog implements EventConsumer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestMenu.java
+++ b/addOns/retest/src/main/java/org/zaproxy/addon/retest/RetestMenu.java
@@ -23,6 +23,7 @@ import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.zaproxy.zap.extension.alert.PopupMenuItemAlert;
 
+@SuppressWarnings("serial")
 public class RetestMenu extends PopupMenuItemAlert {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/revisit/CHANGELOG.md
+++ b/addOns/revisit/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [4] - 2021-10-07

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RevisitDialog.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RevisitDialog.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class RevisitDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RightClickRevisitMenu.java
+++ b/addOns/revisit/src/main/java/org/zaproxy/zap/extension/revisit/RightClickRevisitMenu.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
  *
  * This class is defines the popup menu item.
  */
+@SuppressWarnings("serial")
 public class RightClickRevisitMenu extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/ui/AddAttributeUI.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/ui/AddAttributeUI.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.saml.Attribute;
 import org.zaproxy.zap.extension.saml.AttributeListener;
 import org.zaproxy.zap.extension.saml.SamlI18n;
 
+@SuppressWarnings("serial")
 public class AddAttributeUI extends JFrame {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/ui/SamlExtentionSettingsUI.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/ui/SamlExtentionSettingsUI.java
@@ -46,6 +46,7 @@ import org.zaproxy.zap.extension.saml.SAMLConfiguration;
 import org.zaproxy.zap.extension.saml.SAMLException;
 import org.zaproxy.zap.extension.saml.SamlI18n;
 
+@SuppressWarnings("serial")
 public class SamlExtentionSettingsUI extends JFrame
         implements PassiveAttributeChangeListener, AttributeListener {
 

--- a/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/ui/SamlManualEditor.java
+++ b/addOns/saml/src/main/java/org/zaproxy/zap/extension/saml/ui/SamlManualEditor.java
@@ -43,6 +43,7 @@ import org.zaproxy.zap.extension.saml.SAMLMessage;
 import org.zaproxy.zap.extension.saml.SAMLResender;
 import org.zaproxy.zap.extension.saml.SamlI18n;
 
+@SuppressWarnings("serial")
 public class SamlManualEditor extends JFrame {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/CommandPanel.java
@@ -33,6 +33,7 @@ import org.parosproxy.paros.extension.AbstractPanel;
 import org.zaproxy.zap.extension.scripts.autocomplete.ScriptAutoCompleteKeyListener;
 import org.zaproxy.zap.utils.FontUtils;
 
+@SuppressWarnings("serial")
 public class CommandPanel extends AbstractPanel {
 
     private static final long serialVersionUID = -947074835463140074L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ConsolePanel.java
@@ -49,6 +49,7 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.ZapToggleButton;
 
+@SuppressWarnings("serial")
 public class ConsolePanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;
@@ -601,7 +602,7 @@ public class ConsolePanel extends AbstractPanel {
             }
         }
 
-        @SuppressWarnings("deprecation")
+        @SuppressWarnings({"deprecation", "removal"})
         public void terminate() {
             if (isAlive()) {
                 interrupt();

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessageMenu.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessageMenu.java
@@ -28,6 +28,7 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class InvokeScriptWithHttpMessageMenu extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessagePopupMenu.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/InvokeScriptWithHttpMessagePopupMenu.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class InvokeScriptWithHttpMessagePopupMenu extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/OutputPanel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.view.ZapToggleButton;
 
+@SuppressWarnings("serial")
 public class OutputPanel extends AbstractPanel {
 
     private static final long serialVersionUID = -947074835463140074L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupDuplicateScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupDuplicateScript.java
@@ -26,7 +26,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class PopupDuplicateScript extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupEnableDisableScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupEnableDisableScript.java
@@ -29,7 +29,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class PopupEnableDisableScript extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupInstantiateTemplate.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupInstantiateTemplate.java
@@ -26,7 +26,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class PopupInstantiateTemplate extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupMenuItemSaveScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupMenuItemSaveScript.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 /**
  * An {@link ExtensionPopupMenuItem} that allows to save the script selected in the Scripts tree.
  */
+@SuppressWarnings("serial")
 public class PopupMenuItemSaveScript extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupNewScriptFromType.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupNewScriptFromType.java
@@ -26,7 +26,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptType;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class PopupNewScriptFromType extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupRemoveScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupRemoveScript.java
@@ -28,7 +28,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class PopupRemoveScript extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupUseScriptAsAuthenticationScript.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/PopupUseScriptAsAuthenticationScript.java
@@ -46,6 +46,7 @@ import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
  * The Popup that allows users to set, for a Context, the authentication method to Script-Based
  * Authentication and directly load the Authentication script.
  */
+@SuppressWarnings("serial")
 public class PopupUseScriptAsAuthenticationScript extends ExtensionPopupMenuItem {
 
     private static final Logger log =

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptTreeTransferHandler.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptTreeTransferHandler.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.zaproxy.zap.extension.script.ScriptNode;
 
+@SuppressWarnings("serial")
 public class ScriptTreeTransferHandler extends TransferHandler {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsListPanel.java
@@ -79,6 +79,7 @@ import org.zaproxy.zap.view.LayoutHelper;
 import org.zaproxy.zap.view.ScanPanel2;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class ScriptsListPanel extends AbstractPanel {
 
     public static final String TREE = "ScriptListTree";

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsTreeCellRenderer.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/ScriptsTreeCellRenderer.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.view.OverlayIcon;
  * tooltips you have to enable them via: <code>
  * ToolTipManager.sharedInstance().registerComponent(tree);</code>
  */
+@SuppressWarnings("serial")
 public class ScriptsTreeCellRenderer extends DefaultTreeCellRenderer {
 
     private static final String RESOURCE_ROOT =

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxMenu.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/SyntaxMenu.java
@@ -35,6 +35,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.ExtensionPopupMenu;
 import org.zaproxy.zap.extension.scripts.SyntaxHighlightTextArea.SyntaxStyle;
 
+@SuppressWarnings("serial")
 public class SyntaxMenu extends ExtensionPopupMenu {
 
     private static final long serialVersionUID = 8472491919281117716L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/autocomplete/ScriptAutoCompleteMenu.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/autocomplete/ScriptAutoCompleteMenu.java
@@ -27,6 +27,7 @@ import javax.swing.JMenuItem;
 import javax.swing.MenuElement;
 import javax.swing.MenuSelectionManager;
 
+@SuppressWarnings("serial")
 public class ScriptAutoCompleteMenu extends JScrollPopupMenu {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ui/ScriptJobDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/automation/ui/ScriptJobDialog.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.scripts.automation.actions.ScriptAction;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ScriptJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/CopyScriptDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/CopyScriptDialog.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class CopyScriptDialog extends StandardFieldsDialog {
 
     private static final String FIELD_NAME = "scripts.dialog.script.label.name";

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/EditScriptDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/EditScriptDialog.java
@@ -28,6 +28,7 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class EditScriptDialog extends StandardFieldsDialog {
 
     private static final String FIELD_NAME = "scripts.dialog.script.label.name";

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/LoadScriptDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class LoadScriptDialog extends StandardFieldsDialog {
 
     private static final String FIELD_FILE = "scripts.dialog.script.label.file";

--- a/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
+++ b/addOns/scripts/src/main/java/org/zaproxy/zap/extension/scripts/dialogs/NewScriptDialog.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.scripts.ExtensionScriptsUI;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class NewScriptDialog extends StandardFieldsDialog {
 
     private static final String FIELD_NAME = "scripts.dialog.script.label.name";

--- a/addOns/selenium/CHANGELOG.md
+++ b/addOns/selenium/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [15.9.0] - 2022-05-06
 ### Changed

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/BrowsersComboBoxModel.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/BrowsersComboBoxModel.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.Validate;
  *
  * @see BrowserUI
  */
+@SuppressWarnings("serial")
 public class BrowsersComboBoxModel extends AbstractListModel<BrowserUI>
         implements ComboBoxModel<BrowserUI> {
 

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/OptionsBrowserExtensionsTableModel.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/OptionsBrowserExtensionsTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsBrowserExtensionsTableModel
         extends AbstractMultipleOptionsTableModel<BrowserExtension> {
 

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuItemOpenInBrowser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuItemOpenInBrowser.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuItemOpenInBrowser extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuOpenInBrowser.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/PopupMenuOpenInBrowser.java
@@ -23,6 +23,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.messagecontainer.MessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuOpenInBrowser extends PopupMenuHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ProvidedBrowsersComboBoxModel.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/ProvidedBrowsersComboBoxModel.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.Validate;
  *
  * @since 1.1.0
  */
+@SuppressWarnings("serial")
 public class ProvidedBrowsersComboBoxModel extends AbstractListModel<ProvidedBrowserUI>
         implements ComboBoxModel<ProvidedBrowserUI> {
 

--- a/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
+++ b/addOns/selenium/src/main/java/org/zaproxy/zap/extension/selenium/SeleniumOptionsPanel.java
@@ -56,6 +56,7 @@ import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
  *
  * @see SeleniumOptions
  */
+@SuppressWarnings("serial")
 class SeleniumOptionsPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = -4918932139321106800L;

--- a/addOns/sequence/CHANGELOG.md
+++ b/addOns/sequence/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [6] - 2021-10-07

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequencePanel.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequencePanel.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.utils.DisplayUtils;
 
+@SuppressWarnings("serial")
 public class SequencePanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequencePopupMenuItem.java
+++ b/addOns/sequence/src/main/java/org/zaproxy/zap/extension/sequence/SequencePopupMenuItem.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.script.SequenceScript;
 
+@SuppressWarnings("serial")
 public class SequencePopupMenuItem extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/simpleexample/src/main/java/org/zaproxy/addon/simpleexample/RightClickMsgMenu.java
+++ b/addOns/simpleexample/src/main/java/org/zaproxy/addon/simpleexample/RightClickMsgMenu.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
  *
  * @see HttpMessageContainer
  */
+@SuppressWarnings("serial")
 public class RightClickMsgMenu extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ImportFromUrlDialog.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/ImportFromUrlDialog.java
@@ -39,6 +39,7 @@ import javax.swing.JTextField;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.extension.AbstractDialog;
 
+@SuppressWarnings("serial")
 public class ImportFromUrlDialog extends AbstractDialog implements ActionListener {
 
     private static final long serialVersionUID = -7074394202143400215L;

--- a/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
+++ b/addOns/soap/src/main/java/org/zaproxy/zap/extension/soap/automation/SoapJobDialog.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class SoapJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/DialogAddDomainAlwaysInScope.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/DialogAddDomainAlwaysInScope.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddDomainAlwaysInScope extends AbstractFormDialog {
 
     private static final long serialVersionUID = -7356390753317082681L;

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/DomainsAlwaysInScopeTableModel.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/DomainsAlwaysInScopeTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 class DomainsAlwaysInScopeTableModel
         extends AbstractMultipleOptionsTableModel<DomainAlwaysInScopeMatcher> {
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/PopupMenuItemSpiderDialog.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/PopupMenuItemSpiderDialog.java
@@ -28,8 +28,9 @@ import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
  * A {@code PopupMenuItemSiteNodeContainer} that allows to show the Spider dialogue, for a selected
  * {@link SiteNode}.
  *
- * @see org.zaproxy.zap.extension.spider.ExtensionSpider2#showSpiderDialog(SiteNode)
+ * @see org.zaproxy.addon.spider.ExtensionSpider2#showSpiderDialog(SiteNode)
  */
+@SuppressWarnings("serial")
 public class PopupMenuItemSpiderDialog extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderDialog.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderDialog.java
@@ -43,6 +43,7 @@ import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class SpiderDialog extends StandardFieldsDialog {
 
     private static final String FIELD_START = "spider.custom.label.start";

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderMessagesTable.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderMessagesTable.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.model.HistoryReference;
 import org.zaproxy.addon.spider.SpiderMessagesTableModel.ProcessedCellItem;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
+@SuppressWarnings("serial")
 class SpiderMessagesTable extends HistoryReferencesTable {
 
     private static final long serialVersionUID = -1910120966638329368L;

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderMessagesTableModel.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderMessagesTableModel.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.view.table.AbstractCustomColumnHistoryReferencesTableMode
 import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 
+@SuppressWarnings("serial")
 class SpiderMessagesTableModel
         extends AbstractCustomColumnHistoryReferencesTableModel<
                 SpiderMessagesTableModel.SpiderTableEntry> {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanel.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanel.java
@@ -60,6 +60,7 @@ import org.zaproxy.zap.view.table.decorator.AbstractTableCellItemIconHighlighter
  * The Class SpiderPanel implements the Panel that is shown to the users when selecting the Spider
  * Scan Tab.
  */
+@SuppressWarnings("serial")
 public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderScan>>
         implements ScanListenner2 {
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanelTableModel.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanelTableModel.java
@@ -25,6 +25,7 @@ import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
 /** The Class HttpSessionsTableModel that is used as a TableModel for the Http Sessions Panel. */
+@SuppressWarnings("serial")
 public class SpiderPanelTableModel extends AbstractTableModel {
 
     /** The Constant serialVersionUID. */

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderDialog.java
@@ -43,6 +43,7 @@ import org.zaproxy.zap.model.Target;
 import org.zaproxy.zap.users.User;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AjaxSpiderDialog extends StandardFieldsDialog {
 
     protected static final String[] LABELS = {

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTable.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTable.java
@@ -40,6 +40,7 @@ import org.zaproxy.zap.extension.spiderAjax.AjaxSpiderResultsTableModel.Processe
 import org.zaproxy.zap.extension.spiderAjax.SpiderListener.ResourceState;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
+@SuppressWarnings("serial")
 public class AjaxSpiderResultsTable extends HistoryReferencesTable {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AjaxSpiderResultsTableModel.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.view.table.AbstractCustomColumnHistoryReferencesTableMode
 import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 
+@SuppressWarnings("serial")
 public class AjaxSpiderResultsTableModel
         extends AbstractCustomColumnHistoryReferencesTableModel<
                 AjaxSpiderResultsTableModel.AjaxSpiderTableEntry> {

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AllowedResourcesTableModel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/AllowedResourcesTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class AllowedResourcesTableModel extends AbstractMultipleOptionsTableModel<AllowedResource> {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/DialogAddAllowedResource.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/DialogAddAllowedResource.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddAllowedResource extends AbstractFormDialog {
 
     private static final long serialVersionUID = -5209887319253495735L;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/DialogAddElem.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/DialogAddElem.java
@@ -32,6 +32,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
 
+@SuppressWarnings("serial")
 class DialogAddElem extends AbstractFormDialog {
 
     private static final long serialVersionUID = 4460797449668634319L;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/OptionsAjaxSpider.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/OptionsAjaxSpider.java
@@ -38,6 +38,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.selenium.ProvidedBrowsersComboBoxModel;
 import org.zaproxy.zap.utils.ZapNumberSpinner;
 
+@SuppressWarnings("serial")
 public class OptionsAjaxSpider extends AbstractParamPanel {
 
     private static final long serialVersionUID = -1350537974139536669L;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/OptionsAjaxSpiderTableModel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/OptionsAjaxSpiderTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.view.AbstractMultipleOptionsTableModel;
 
+@SuppressWarnings("serial")
 public class OptionsAjaxSpiderTableModel
         extends AbstractMultipleOptionsTableModel<AjaxSpiderParamElem> {
 

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/PopupMenuAjaxSite.java
@@ -26,6 +26,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.view.messagecontainer.http.HttpMessageContainer;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class PopupMenuAjaxSite extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/SpiderPanel.java
@@ -49,6 +49,7 @@ import org.zaproxy.zap.view.table.HistoryReferencesTable;
  * This class creates the Spider AJAX Panel where the found URLs are displayed It has a button to
  * stop the crawler and another one to open the options.
  */
+@SuppressWarnings("serial")
 public class SpiderPanel extends AbstractPanel implements SpiderListener {
     private static final long serialVersionUID = 1L;
     private static final Logger logger = LogManager.getLogger(SpiderPanel.class);

--- a/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobDialog.java
+++ b/addOns/spiderAjax/src/main/java/org/zaproxy/zap/extension/spiderAjax/automation/AjaxSpiderJobDialog.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.extension.spiderAjax.automation.AjaxSpiderJob.Parameters;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class AjaxSpiderJobDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/sse/CHANGELOG.md
+++ b/addOns/sse/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ### Fixed

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ui/EventStreamPanel.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ui/EventStreamPanel.java
@@ -65,6 +65,7 @@ import org.zaproxy.zap.view.ZapToggleButton;
  * Represents the Server-Sent Events tab. It listens to all Event Streams and displays events
  * accordingly.
  */
+@SuppressWarnings("serial")
 public class EventStreamPanel extends AbstractPanel implements EventStreamObserver {
 
     private static final long serialVersionUID = -4518225363808518571L;

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ui/EventStreamViewModel.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ui/EventStreamViewModel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.utils.PagingTableModel;
  * This model uses a database table to load only needed entries from database. Moreover it shows
  * only those entries that are not deny listed by the given filter.
  */
+@SuppressWarnings("serial")
 public class EventStreamViewModel extends PagingTableModel<ServerSentEvent> {
 
     private static final long serialVersionUID = -5047686640383236512L;

--- a/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ui/filter/EventStreamViewFilterDialog.java
+++ b/addOns/sse/src/main/java/org/zaproxy/zap/extension/sse/ui/filter/EventStreamViewFilterDialog.java
@@ -37,6 +37,7 @@ import org.parosproxy.paros.extension.AbstractDialog;
 import org.zaproxy.zap.extension.sse.ui.EventStreamUiHelper;
 
 /** Filter Server-Sent Events in EventStream-Panel. Show only specific ones. */
+@SuppressWarnings("serial")
 public class EventStreamViewFilterDialog extends AbstractDialog {
     private static final long serialVersionUID = 4750602961870366348L;
 

--- a/addOns/tips/src/main/java/org/zaproxy/zap/extension/tips/TipsAndTricksDialog.java
+++ b/addOns/tips/src/main/java/org/zaproxy/zap/extension/tips/TipsAndTricksDialog.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.extension.help.ExtensionHelp;
 import org.zaproxy.zap.utils.ZapTextArea;
 import org.zaproxy.zap.view.LayoutHelper;
 
+@SuppressWarnings("serial")
 public class TipsAndTricksDialog extends AbstractDialog {
 
     private static final long serialVersionUID = -1L;

--- a/addOns/tokengen/CHANGELOG.md
+++ b/addOns/tokengen/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
 
 ## [15] - 2021-10-07

--- a/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/AnalyseTokensDialog.java
+++ b/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/AnalyseTokensDialog.java
@@ -44,6 +44,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class AnalyseTokensDialog extends AbstractDialog implements TokenAnalyserListenner {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/GenerateTokensDialog.java
+++ b/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/GenerateTokensDialog.java
@@ -42,6 +42,7 @@ import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.params.HtmlParameterStats;
 
+@SuppressWarnings("serial")
 public class GenerateTokensDialog extends AbstractDialog {
 
     private static String[] PARAM_TYPES = {

--- a/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/TokenGenPopupMenu.java
+++ b/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/TokenGenPopupMenu.java
@@ -23,6 +23,7 @@ import javax.swing.ImageIcon;
 import org.parosproxy.paros.network.HttpMessage;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class TokenGenPopupMenu extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/TokenPanel.java
+++ b/addOns/tokengen/src/main/java/org/zaproxy/zap/extension/tokengen/TokenPanel.java
@@ -48,6 +48,7 @@ import org.zaproxy.zap.view.ScanStatus;
 import org.zaproxy.zap.view.ZapToggleButton;
 import org.zaproxy.zap.view.widgets.WritableFileChooser;
 
+@SuppressWarnings("serial")
 public class TokenPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/wappalyzer/CHANGELOG.md
+++ b/addOns/wappalyzer/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+- Maintenance changes.
 - Updated with upstream Wappalyzer icon and pattern changes.
 
 

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/PopupMenuEvidence.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.extension.ExtensionPopupMenu;
 import org.zaproxy.zap.extension.search.ExtensionSearch;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 
+@SuppressWarnings("serial")
 public class PopupMenuEvidence extends ExtensionPopupMenu {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechPanel.java
@@ -48,6 +48,7 @@ import org.zaproxy.zap.utils.SortedComboBoxModel;
 import org.zaproxy.zap.utils.TableExportButton;
 import org.zaproxy.zap.view.ZapToggleButton;
 
+@SuppressWarnings("serial")
 public class TechPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechTableModel.java
+++ b/addOns/wappalyzer/src/main/java/org/zaproxy/zap/extension/wappalyzer/TechTableModel.java
@@ -26,6 +26,7 @@ import java.util.Vector;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class TechTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/websocket/CHANGELOG.md
+++ b/addOns/websocket/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Maintenance changes.
 
 ## [26] - 2022-05-20
 ### Changed

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/PopupMenuAddBreakWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/PopupMenuAddBreakWebSocket.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.extension.brk.ExtensionBreak;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
 import org.zaproxy.zap.extension.websocket.ui.WebSocketMessagesViewModel;
 
+@SuppressWarnings("serial")
 public class PopupMenuAddBreakWebSocket extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/PopupMenuEditBreak.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/PopupMenuEditBreak.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.brk.BreakpointsPanel;
 import org.zaproxy.zap.extension.brk.ExtensionBreak;
 
+@SuppressWarnings("serial")
 public class PopupMenuEditBreak extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialog.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialog.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.websocket.WebSocketMessage.Direction;
 import org.zaproxy.zap.extension.websocket.ui.ChannelSortedListModel;
 import org.zaproxy.zap.extension.websocket.ui.WebSocketUiHelper;
 
+@SuppressWarnings("serial")
 public abstract class WebSocketBreakDialog extends AbstractDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogAdd.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogAdd.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
 import org.zaproxy.zap.extension.websocket.ui.ChannelSortedListModel;
 
+@SuppressWarnings("serial")
 public class WebSocketBreakDialogAdd extends WebSocketBreakDialog {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogEdit.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/brk/WebSocketBreakDialogEdit.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.extension.websocket.WebSocketMessage.Direction;
 import org.zaproxy.zap.extension.websocket.ui.ChannelSortedListModel;
 
+@SuppressWarnings("serial")
 public class WebSocketBreakDialogEdit extends WebSocketBreakDialog {
     private static final long serialVersionUID = 1L;
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzAttackPopupMenuItem.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzAttackPopupMenuItem.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.view.messagecontainer.MessageContainer;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuItemMessageContainer;
 
+@SuppressWarnings("serial")
 public class WebSocketFuzzAttackPopupMenuItem extends ExtensionPopupMenuItemMessageContainer {
 
     private static final long serialVersionUID = 3515657836446348454L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzMessagesViewModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzMessagesViewModel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.extension.websocket.ui.WebSocketMessagesViewModel;
  * This {@link TableModel} is also backed by the database, but has got some additional columns.
  * Moreover, erroneous entries are stored into an extra {@link List}.
  */
+@SuppressWarnings("serial")
 public class WebSocketFuzzMessagesViewModel extends WebSocketMessagesViewModel {
     private static final long serialVersionUID = 5435325545219552543L;
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzResultsContentPanel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/fuzz/ui/WebSocketFuzzResultsContentPanel.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.extension.websocket.fuzz.WebSocketFuzzer;
 import org.zaproxy.zap.extension.websocket.fuzz.WebSocketFuzzerListener;
 import org.zaproxy.zap.utils.StickyScrollbarAdjustmentListener;
 
+@SuppressWarnings("serial")
 public class WebSocketFuzzResultsContentPanel extends JPanel
         implements FuzzResultsContentPanel<WebSocketMessageDTO, WebSocketFuzzer> {
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/ManualWebSocketSendEditorDialog.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/manualsend/ManualWebSocketSendEditorDialog.java
@@ -51,6 +51,7 @@ import org.zaproxy.zap.extension.websocket.ui.WebSocketUiHelper;
 import org.zaproxy.zap.view.ZapMenuItem;
 
 /** Send custom crafted WebSocket messages. */
+@SuppressWarnings("serial")
 public class ManualWebSocketSendEditorDialog extends ManualRequestEditorDialog {
 
     private static final long serialVersionUID = -5830450800029295419L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ChannelSortedListModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ChannelSortedListModel.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.websocket.WebSocketChannelDTO;
 import org.zaproxy.zap.utils.SortedListModel;
 
+@SuppressWarnings("serial")
 public class ChannelSortedListModel extends SortedListModel<WebSocketChannelDTO> {
 
     private static final long serialVersionUID = 83057590716441165L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ExcludeFromWebSocketsMenuItem.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/ExcludeFromWebSocketsMenuItem.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
  * Menu Item for Popup. Used in WebSockets tab, when you click on some message with right mouse
  * button.
  */
+@SuppressWarnings("serial")
 public class ExcludeFromWebSocketsMenuItem extends WebSocketMessagesPopupMenuItem {
     private static final long serialVersionUID = 2208451830578743381L;
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/OptionsWebSocketPanel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/OptionsWebSocketPanel.java
@@ -46,6 +46,7 @@ import org.zaproxy.zap.utils.FontUtils;
  *       example, compression).
  * </ul>
  */
+@SuppressWarnings("serial")
 public class OptionsWebSocketPanel extends AbstractParamPanel {
 
     private static final long serialVersionUID = -7541236934312940852L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketFromContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupExcludeWebSocketFromContextMenu.java
@@ -34,6 +34,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.ContextExcludePanel;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 
+@SuppressWarnings("serial")
 public class PopupExcludeWebSocketFromContextMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = -2345060529128495874L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/PopupIncludeWebSocketInContextMenu.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.view.ContextIncludePanel;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 
+@SuppressWarnings("serial")
 public class PopupIncludeWebSocketInContextMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = -2345060529128495874L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/SessionExcludeFromWebSocket.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/SessionExcludeFromWebSocket.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.extension.websocket.ExtensionWebSocket;
 import org.zaproxy.zap.extension.websocket.WebSocketException;
 import org.zaproxy.zap.view.MultipleRegexesOptionsPanel;
 
+@SuppressWarnings("serial")
 public class SessionExcludeFromWebSocket extends AbstractParamPanel {
     public static final String PANEL_NAME =
             Constant.messages.getString("websocket.session.exclude.title");

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesPopupMenuItem.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesPopupMenuItem.java
@@ -27,6 +27,7 @@ import org.parosproxy.paros.extension.ExtensionPopupMenuItem;
 import org.zaproxy.zap.extension.websocket.WebSocketMessageDTO;
 
 /** Menu Item for a right click menu on the {@link WebSocketMessagesView}. */
+@SuppressWarnings("serial")
 public abstract class WebSocketMessagesPopupMenuItem extends ExtensionPopupMenuItem {
     private static final long serialVersionUID = 4774753835401981588L;
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewFilterDialog.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewFilterDialog.java
@@ -39,6 +39,7 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.utils.DisplayUtils;
 
 /** Filter WebSocket messages in {@link WebSocketPanel}. Show only specific ones. */
+@SuppressWarnings("serial")
 public class WebSocketMessagesViewFilterDialog extends AbstractDialog {
     private static final long serialVersionUID = 4750602961870366348L;
 

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewModel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketMessagesViewModel.java
@@ -39,6 +39,7 @@ import org.zaproxy.zap.utils.PagingTableModel;
  * Moreover it shows only those entries that are not deny listed by given {@link
  * WebSocketMessagesViewFilter}.
  */
+@SuppressWarnings("serial")
 public class WebSocketMessagesViewModel extends PagingTableModel<WebSocketMessageDTO> {
 
     private static final long serialVersionUID = -5047686640383236512L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/WebSocketPanel.java
@@ -69,6 +69,7 @@ import org.zaproxy.zap.view.ZapToggleButton;
  * Represents the WebSockets tab. It listens to all WebSocket channels and displays messages
  * accordingly.
  */
+@SuppressWarnings("serial")
 public class WebSocketPanel extends AbstractPanel implements WebSocketObserver {
 
     private static final long serialVersionUID = -2853099315338427006L;

--- a/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/views/WebSocketSyntaxHighlightTextView.java
+++ b/addOns/websocket/src/main/java/org/zaproxy/zap/extension/websocket/ui/httppanel/views/WebSocketSyntaxHighlightTextView.java
@@ -48,6 +48,7 @@ import org.zaproxy.zap.view.messagelocation.MessageLocationProducerFocusListener
 import org.zaproxy.zap.view.messagelocation.TextMessageLocationHighlight;
 import org.zaproxy.zap.view.messagelocation.TextMessageLocationHighlightsManager;
 
+@SuppressWarnings("serial")
 public class WebSocketSyntaxHighlightTextView extends HttpPanelSyntaxHighlightTextView
         implements SelectableContentWebSocketMessageContainer {
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/OptionsZestIgnoreHeadersTableModel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/OptionsZestIgnoreHeadersTableModel.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class OptionsZestIgnoreHeadersTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestResultsPanel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.utils.FontUtils;
 import org.zaproxy.zap.view.table.HistoryReferencesTable;
 
+@SuppressWarnings("serial")
 public class ZestResultsPanel extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestResultsTableModel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestResultsTableModel.java
@@ -37,6 +37,7 @@ import org.zaproxy.zap.view.table.AbstractCustomColumnHistoryReferencesTableMode
 import org.zaproxy.zap.view.table.AbstractHistoryReferencesTableEntry;
 import org.zaproxy.zap.view.table.DefaultHistoryReferencesTableEntry;
 
+@SuppressWarnings("serial")
 public class ZestResultsTableModel
         extends AbstractCustomColumnHistoryReferencesTableModel<
                 ZestResultsTableModel.ZestResultsTableEntry> {

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/ZestTreeTransferHandler.java
@@ -35,6 +35,7 @@ import org.zaproxy.zest.core.v1.ZestContainer;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestTreeTransferHandler extends TransferHandler {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/CookiesTableModel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/CookiesTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class CookiesTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ScriptTokensTableModel.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ScriptTokensTableModel.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.swing.table.AbstractTableModel;
 import org.parosproxy.paros.Constant;
 
+@SuppressWarnings("serial")
 public class ScriptTokensTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestActionDialog.java
@@ -47,6 +47,7 @@ import org.zaproxy.zest.core.v1.ZestActionSleep;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestActionDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_MESSAGE = "zest.dialog.action.label.message";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssertionsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssertionsDialog.java
@@ -39,6 +39,7 @@ import org.zaproxy.zest.core.v1.ZestExpressionRegex;
 import org.zaproxy.zest.core.v1.ZestExpressionStatusCode;
 import org.zaproxy.zest.core.v1.ZestRequest;
 
+@SuppressWarnings("serial")
 public class ZestAssertionsDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_VARIABLE = "zest.dialog.assert.label.variable";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestAssignmentDialog.java
@@ -45,6 +45,7 @@ import org.zaproxy.zest.core.v1.ZestFieldDefinition;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestAssignmentDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_VARIABLE = "zest.dialog.assign.label.variable";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientAssignCookieDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientAssignCookieDialog.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientAssignCookie;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestClientAssignCookieDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_VARIABLE = "zest.dialog.assign.label.variable";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientElementDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientElement;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public abstract class ZestClientElementDialog extends StandardFieldsDialog implements ZestDialog {
 
     protected static final String FIELD_WINDOW_HANDLE = "zest.dialog.client.label.windowHandle";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientLaunchDialog.java
@@ -38,6 +38,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientLaunch;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestClientLaunchDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_WINDOW_HANDLE = "zest.dialog.client.label.windowHandle";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientScreenshotDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientScreenshotDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientScreenshot;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestClientScreenshotDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_WINDOW_HANDLE = "zest.dialog.client.label.windowHandle";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientSwitchToFrameDialog.java
@@ -36,6 +36,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientSwitchToFrame;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestClientSwitchToFrameDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_WINDOW_HANDLE = "zest.dialog.client.label.windowHandle";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowCloseDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowCloseDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientWindowClose;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestClientWindowCloseDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_WINDOW_HANDLE = "zest.dialog.client.label.windowHandle";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowHandleDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowHandleDialog.java
@@ -30,6 +30,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientWindowHandle;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestClientWindowHandleDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_WINDOW_HANDLE = "zest.dialog.client.label.windowHandle";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowOpenUrlDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestClientWindowOpenUrlDialog.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestClientWindowOpenUrl;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestClientWindowOpenUrlDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_WINDOW_HANDLE = "zest.dialog.client.label.windowHandle";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestCommentDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestCommentDialog.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestComment;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestCommentDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_COMMENT = "zest.dialog.comment.label.comment";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestControlDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestControlDialog.java
@@ -31,6 +31,7 @@ import org.zaproxy.zest.core.v1.ZestControlReturn;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestControlDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_VALUE = "zest.dialog.return.label.value";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestCookieDialog.java
@@ -25,6 +25,7 @@ import org.parosproxy.paros.Constant;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ZestCookieDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_PARAM_DOMAIN = "zest.dialog.cookies.label.domain";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestDialogManager.java
@@ -71,6 +71,7 @@ import org.zaproxy.zest.core.v1.ZestStatement;
 import org.zaproxy.zest.core.v1.ZestStructuredExpression;
 import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 
+@SuppressWarnings("serial")
 public class ZestDialogManager extends AbstractPanel {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestExpressionDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestExpressionDialog.java
@@ -44,6 +44,7 @@ import org.zaproxy.zest.core.v1.ZestExpressionStatusCode;
 import org.zaproxy.zest.core.v1.ZestExpressionURL;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestExpressionDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_REGEX = "zest.dialog.condition.label.regex";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestLoopDialog.java
@@ -48,6 +48,7 @@ import org.zaproxy.zest.core.v1.ZestLoopTokenStringSet;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestLoopDialog extends StandardFieldsDialog implements ZestDialog {
     private static final long serialVersionUID = 3720969585202318312L;
 

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestParameterDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestParameterDialog.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ZestParameterDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_PARAM_NAME = "zest.dialog.param.label.name";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestParameterizeDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestParameterizeDialog.java
@@ -29,6 +29,7 @@ import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestRequest;
 
+@SuppressWarnings("serial")
 public class ZestParameterizeDialog extends StandardFieldsDialog {
 
     private static final String FIELD_REPLACE_STRING = "zest.dialog.parameterize.label.repstring";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRecordScriptDialog.java
@@ -44,6 +44,7 @@ import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.impl.ZestScriptEngineFactory;
 
+@SuppressWarnings("serial")
 public class ZestRecordScriptDialog extends StandardFieldsDialog {
 
     private static final String FIELD_TITLE = "zest.dialog.script.label.title";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRedactDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRedactDialog.java
@@ -26,6 +26,7 @@ import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
+@SuppressWarnings("serial")
 public class ZestRedactDialog extends StandardFieldsDialog {
 
     private static final String FIELD_REPLACE_STRING = "zest.dialog.redact.label.repstring";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRequestDialog.java
@@ -42,6 +42,7 @@ import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestResponse;
 import org.zaproxy.zest.core.v1.ZestVariables;
 
+@SuppressWarnings("serial")
 public class ZestRequestDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_URL = "zest.dialog.request.label.url";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRunScriptWithParamsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestRunScriptWithParamsDialog.java
@@ -35,6 +35,7 @@ import org.zaproxy.zap.extension.zest.ZestZapRunner;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 import org.zaproxy.zest.core.v1.ZestScript;
 
+@SuppressWarnings("serial")
 public class ZestRunScriptWithParamsDialog extends StandardFieldsDialog implements ZestDialog {
 
     private static final String FIELD_PARAMS = "zest.dialog.run.label.params";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/dialogs/ZestScriptsDialog.java
@@ -52,6 +52,7 @@ import org.zaproxy.zest.core.v1.ZestHttpAuthentication;
 import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestScript;
 
+@SuppressWarnings("serial")
 public class ZestScriptsDialog extends StandardFieldsDialog {
 
     private static final String FIELD_TITLE = "zest.dialog.script.label.title";

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddActionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddActionPopupMenu.java
@@ -47,6 +47,7 @@ import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestAddActionPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssertionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssertionPopupMenu.java
@@ -36,6 +36,7 @@ import org.zaproxy.zest.core.v1.ZestExpressionStatusCode;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestVariables;
 
+@SuppressWarnings("serial")
 public class ZestAddAssertionPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssignPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddAssignPopupMenu.java
@@ -43,6 +43,7 @@ import org.zaproxy.zest.core.v1.ZestElement;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestAddAssignPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddClientPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddClientPopupMenu.java
@@ -29,7 +29,7 @@ import org.zaproxy.zest.core.v1.ZestElement;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public abstract class ZestAddClientPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddCommentPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddCommentPopupMenu.java
@@ -29,7 +29,7 @@ import org.zaproxy.zest.core.v1.ZestContainer;
 import org.zaproxy.zest.core.v1.ZestElement;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class ZestAddCommentPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddConditionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddConditionPopupMenu.java
@@ -53,6 +53,7 @@ import org.zaproxy.zest.core.v1.ZestVariables;
 // import org.zaproxy.zest.core.v1.ZestExpressionOr;
 // import org.zaproxy.zest.core.v1.ZestExpressionLength;
 
+@SuppressWarnings("serial")
 public class ZestAddConditionPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddControlPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddControlPopupMenu.java
@@ -36,6 +36,7 @@ import org.zaproxy.zest.core.v1.ZestLoop;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestScript;
 
+@SuppressWarnings("serial")
 public class ZestAddControlPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddExpressionPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddExpressionPopupMenu.java
@@ -46,6 +46,7 @@ import org.zaproxy.zest.core.v1.ZestStatement;
 import org.zaproxy.zest.core.v1.ZestStructuredExpression;
 import org.zaproxy.zest.core.v1.ZestVariables;
 
+@SuppressWarnings("serial")
 public class ZestAddExpressionPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = -2858088231126854392L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddLoopPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddLoopPopupMenu.java
@@ -42,6 +42,7 @@ import org.zaproxy.zest.core.v1.ZestLoopRegex;
 import org.zaproxy.zest.core.v1.ZestLoopString;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestAddLoopPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = -8433923894855139684L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddRequestPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddRequestPopupMenu.java
@@ -29,7 +29,7 @@ import org.zaproxy.zest.core.v1.ZestElement;
 import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestScript;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class ZestAddRequestPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptMenu.java
@@ -28,6 +28,7 @@ import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 import org.zaproxy.zap.view.popup.PopupMenuItemHttpMessageContainer;
 
+@SuppressWarnings("serial")
 public class ZestAddToScriptMenu extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestAddToScriptPopupMenu.java
@@ -33,6 +33,7 @@ import org.zaproxy.zap.view.popup.PopupMenuItemHistoryReferenceContainer;
 import org.zaproxy.zest.core.v1.ZestConditional;
 import org.zaproxy.zest.core.v1.ZestElement;
 
+@SuppressWarnings("serial")
 public class ZestAddToScriptPopupMenu extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestCompareReqRespPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestCompareReqRespPopupMenu.java
@@ -37,6 +37,7 @@ import org.zaproxy.zest.core.v1.ZestRequest;
 import org.zaproxy.zest.core.v1.ZestResponse;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
+@SuppressWarnings("serial")
 public class ZestCompareReqRespPopupMenu extends PopupMenuItemHistoryReferenceContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestGenerateScriptFromAlertMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestGenerateScriptFromAlertMenu.java
@@ -44,6 +44,7 @@ import org.zaproxy.zest.core.v1.ZestJSON;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestVariables;
 
+@SuppressWarnings("serial")
 public class ZestGenerateScriptFromAlertMenu extends PopupMenuItemHttpMessageContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestParameterizePopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestParameterizePopupMenu.java
@@ -28,6 +28,7 @@ import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zest.core.v1.ZestRequest;
 
+@SuppressWarnings("serial")
 public class ZestParameterizePopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPasteVariableMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPasteVariableMenu.java
@@ -28,6 +28,7 @@ import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.view.popup.ExtensionPopupMenuComponent;
 import org.zaproxy.zest.core.v1.ZestVariables;
 
+@SuppressWarnings("serial")
 public class ZestPasteVariableMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPasteVariablePopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPasteVariablePopupMenu.java
@@ -32,6 +32,7 @@ import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 import org.zaproxy.zap.extension.zest.dialogs.ZestDialog;
 
+@SuppressWarnings("serial")
 public class ZestPasteVariablePopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupCommentOnOff.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupCommentOnOff.java
@@ -31,7 +31,7 @@ import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class ZestPopupCommentOnOff extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodeCopyOrCut.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodeCopyOrCut.java
@@ -32,7 +32,7 @@ import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class ZestPopupNodeCopyOrCut extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodePaste.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupNodePaste.java
@@ -32,7 +32,7 @@ import org.zaproxy.zest.core.v1.ZestContainer;
 import org.zaproxy.zest.core.v1.ZestElement;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class ZestPopupNodePaste extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestDelete.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestDelete.java
@@ -30,7 +30,7 @@ import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zest.core.v1.ZestScript;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class ZestPopupZestDelete extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestMove.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestPopupZestMove.java
@@ -32,7 +32,7 @@ import org.zaproxy.zest.core.v1.ZestControl;
 import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 
-/** ZAP: New Popup Menu Alert Delete */
+@SuppressWarnings("serial")
 public class ZestPopupZestMove extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordFromNodePopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordFromNodePopupMenu.java
@@ -24,6 +24,7 @@ import org.parosproxy.paros.model.SiteNode;
 import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.view.popup.PopupMenuItemSiteNodeContainer;
 
+@SuppressWarnings("serial")
 public class ZestRecordFromNodePopupMenu extends PopupMenuItemSiteNodeContainer {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRecordOnOffPopupMenu.java
@@ -31,6 +31,7 @@ import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestScriptWrapper;
 
 /** Popup for turning on and off recording for Zest standalone scripts */
+@SuppressWarnings("serial")
 public class ZestRecordOnOffPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 1L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRedactPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestRedactPopupMenu.java
@@ -27,6 +27,7 @@ import org.zaproxy.zap.extension.zest.ExtensionZest;
 import org.zaproxy.zap.extension.zest.ZestZapUtils;
 import org.zaproxy.zest.core.v1.ZestRequest;
 
+@SuppressWarnings("serial")
 public class ZestRedactPopupMenu extends ExtensionPopupMenuItem {
 
     private static final long serialVersionUID = 2282358266003940700L;

--- a/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestSurroundWithPopupMenu.java
+++ b/addOns/zest/src/main/java/org/zaproxy/zap/extension/zest/menu/ZestSurroundWithPopupMenu.java
@@ -48,6 +48,7 @@ import org.zaproxy.zest.core.v1.ZestScript;
 import org.zaproxy.zest.core.v1.ZestStatement;
 import org.zaproxy.zest.core.v1.ZestStructuredExpression;
 
+@SuppressWarnings("serial")
 public class ZestSurroundWithPopupMenu extends ExtensionPopupMenuItem {
     private static final long serialVersionUID = -5847208243296422433L;
     private static final Logger LOGGER = LogManager.getLogger(ZestSurroundWithPopupMenu.class);


### PR DESCRIPTION
Suppress the serialisation warnings in UI related classes, they are not
expected to be serialised.
Address warnings in other classes.
Update JaCoCo to latest version which fully supports Java 18.
Update changelogs where needed.

Part of zaproxy/zaproxy#7389.