### PR TITLE
openapi: Use the Spider add-on when available

### DIFF
--- a/addOns/openapi/CHANGELOG.md
+++ b/addOns/openapi/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Use Spider add-on (Issue 3113).
+- Use Form Handler add-on directly.
 
 ## [27] - 2022-03-29
 ### Added

--- a/addOns/openapi/openapi.gradle.kts
+++ b/addOns/openapi/openapi.gradle.kts
@@ -23,6 +23,30 @@ zapAddOn {
                     }
                 }
             }
+            register("org.zaproxy.zap.extension.openapi.spider.ExtensionOpenApiSpider") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.zap.extension.openapi.spider"))
+                }
+                dependencies {
+                    addOns {
+                        register("spider") {
+                            version.set(">=0.1.0")
+                        }
+                    }
+                }
+            }
+            register("org.zaproxy.zap.extension.openapi.formhandler.ExtensionOpenApiFormHandler") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.zap.extension.openapi.formhandler"))
+                }
+                dependencies {
+                    addOns {
+                        register("formhandler") {
+                            version.set(">=6.0.0 & < 7.0.0")
+                        }
+                    }
+                }
+            }
         }
         dependencies {
             addOns {
@@ -50,6 +74,8 @@ configurations {
 dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
     compileOnly(parent!!.childProjects.get("commonlib")!!)
+    compileOnly(parent!!.childProjects.get("formhandler")!!)
+    compileOnly(parent!!.childProjects.get("spider")!!)
 
     implementation("io.swagger.parser.v3:swagger-parser:2.0.28")
     implementation("io.swagger:swagger-compat-spec-parser:1.0.56") {
@@ -66,5 +92,7 @@ dependencies {
     testImplementation(parent!!.childProjects.get("commonlib")!!.sourceSets.test.get().output)
     testImplementation("org.apache.logging.log4j:log4j-core:2.17.2")
     testImplementation(parent!!.childProjects.get("automation")!!)
+    testImplementation(parent!!.childProjects.get("formhandler")!!)
+    testImplementation(parent!!.childProjects.get("spider")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -52,6 +52,7 @@ import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerConverter;
 import org.zaproxy.zap.extension.openapi.network.RequestModel;
 import org.zaproxy.zap.extension.openapi.network.Requestor;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.model.DefaultValueGenerator;
 import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -73,6 +74,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
     private ImportFromUrlDialog currentUrlDialog = null;
     private int threadId = 1;
     private SpiderParser customSpider;
+    private ValueGenerator valueGenerator;
 
     private CommandLineArgument[] arguments = new CommandLineArgument[3];
     private static final int ARG_IMPORT_FILE_IDX = 0;
@@ -83,6 +85,15 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
 
     public ExtensionOpenApi() {
         super(NAME);
+        setValueGenerator(null);
+    }
+
+    public void setValueGenerator(ValueGenerator valueGenerator) {
+        this.valueGenerator = valueGenerator == null ? new DefaultValueGenerator() : valueGenerator;
+    }
+
+    public ValueGenerator getValueGenerator() {
+        return valueGenerator;
     }
 
     @Override
@@ -95,8 +106,8 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                         Control.getSingleton()
                                 .getExtensionLoader()
                                 .getExtension(ExtensionSpider.NAME);
-        customSpider = new OpenApiSpider();
         if (spider != null) {
+            customSpider = new OpenApiSpider(this::getValueGenerator);
             spider.addCustomParser(customSpider);
             LOG.debug("Added custom Open API spider.");
         } else {
@@ -445,16 +456,6 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
                 LOG.debug(e.getMessage(), e);
             }
             return errors;
-        }
-        return null;
-    }
-
-    private ValueGenerator getValueGenerator() {
-        // Always get the latest ValueGenerator as it could have changed
-        ExtensionSpider spider =
-                Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider.class);
-        if (spider != null) {
-            return spider.getValueGenerator();
         }
         return null;
     }

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/formhandler/ExtensionOpenApiFormHandler.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/formhandler/ExtensionOpenApiFormHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.formhandler;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.zap.extension.formhandler.ExtensionFormHandler;
+import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+import org.zaproxy.zap.model.ValueGenerator;
+
+public class ExtensionOpenApiFormHandler extends ExtensionAdaptor {
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionFormHandler.class, ExtensionOpenApi.class));
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("openapi.formhandler.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("openapi.formhandler.desc");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        ValueGenerator valueGenerator =
+                getExtension(ExtensionFormHandler.class).getValueGenerator();
+        getExtension(ExtensionOpenApi.class).setValueGenerator(valueGenerator);
+    }
+
+    private static <T extends Extension> T getExtension(Class<T> clazz) {
+        return Control.getSingleton().getExtensionLoader().getExtension(clazz);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        getExtension(ExtensionOpenApi.class).setValueGenerator(null);
+    }
+}

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/ExtensionOpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/ExtensionOpenApiSpider.java
@@ -1,0 +1,89 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.spider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.addon.spider.parser.SpiderParser;
+import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+
+public class ExtensionOpenApiSpider extends ExtensionAdaptor {
+
+    public static final String NAME = "ExtensionOpenApiSpider";
+    private static final Logger LOGGER = LogManager.getLogger(ExtensionOpenApiSpider.class);
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionSpider2.class, ExtensionOpenApi.class));
+
+    private SpiderParser customSpider;
+
+    public ExtensionOpenApiSpider() {
+        super(NAME);
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        ExtensionSpider2 spider =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider2.class);
+        ExtensionOpenApi extOpenApi =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionOpenApi.class);
+        customSpider = new OpenApiSpider(extOpenApi::getValueGenerator);
+        spider.addCustomParser(customSpider);
+        LOGGER.debug("Added custom Open API spider.");
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        super.unload();
+        ExtensionSpider2 spider =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionSpider2.class);
+        spider.removeCustomParser(customSpider);
+        LOGGER.debug("Removed custom Open API spider.");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("openapi.spider.desc");
+    }
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("openapi.spider.name");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+}

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpider.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2017 The ZAP Development Team
+ * Copyright 2022 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.zap.extension.openapi;
+package org.zaproxy.zap.extension.openapi.spider;
 
 import java.util.function.Supplier;
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.extension.openapi.spider.OpenApiSpiderFunctionality;
+import org.zaproxy.addon.spider.parser.SpiderParser;
 import org.zaproxy.zap.model.ValueGenerator;
-import org.zaproxy.zap.spider.parser.SpiderParser;
 
 public class OpenApiSpider extends SpiderParser {
 
-    private OpenApiSpiderFunctionality func = null;
+    private OpenApiSpiderFunctionality func;
 
     public OpenApiSpider(Supplier<ValueGenerator> valueGeneratorSupplier) {
         func = new OpenApiSpiderFunctionality(valueGeneratorSupplier);

--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpiderFunctionality.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpiderFunctionality.java
@@ -1,0 +1,88 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.spider;
+
+import java.util.Locale;
+import java.util.function.Supplier;
+import net.htmlparser.jericho.Source;
+import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.zaproxy.zap.extension.openapi.HistoryPersister;
+import org.zaproxy.zap.extension.openapi.converter.Converter;
+import org.zaproxy.zap.extension.openapi.converter.swagger.SwaggerConverter;
+import org.zaproxy.zap.extension.openapi.network.Requestor;
+import org.zaproxy.zap.model.ValueGenerator;
+
+public class OpenApiSpiderFunctionality {
+
+    private static final Logger LOGGER = LogManager.getLogger(OpenApiSpiderFunctionality.class);
+    private Requestor requestor;
+    private Supplier<ValueGenerator> valGenSupplier;
+
+    public OpenApiSpiderFunctionality(Supplier<ValueGenerator> valueGeneratorSupplier) {
+        valGenSupplier = valueGeneratorSupplier;
+        requestor = new Requestor(HttpSender.SPIDER_INITIATOR);
+        requestor.addListener(new HistoryPersister());
+    }
+
+    public boolean parseResource(HttpMessage message, Source source, int depth) {
+        try {
+            Converter converter =
+                    new SwaggerConverter(
+                            null,
+                            message.getRequestHeader().getURI().toString(),
+                            message.getResponseBody().toString(),
+                            valGenSupplier.get());
+            requestor.run(converter.getRequestModels());
+        } catch (Exception e) {
+            LOGGER.debug(e.getMessage(), e);
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean canParseResource(HttpMessage message, String path, boolean wasAlreadyConsumed) {
+        try {
+            String contentType =
+                    message.getResponseHeader()
+                            .getHeader(HttpHeader.CONTENT_TYPE)
+                            .toLowerCase(Locale.ROOT);
+            String responseBodyStart =
+                    StringUtils.left(message.getResponseBody().toString(), 250)
+                            .toLowerCase(Locale.ROOT);
+            if (contentType.startsWith("application/vnd.oai.openapi")
+                    || (contentType.contains("json")
+                            || contentType.contains("yaml")
+                                    && (responseBodyStart.contains("swagger")
+                                            || responseBodyStart.contains("openapi")))) {
+                return true;
+            }
+        } catch (Exception e) {
+            return false;
+        }
+        LOGGER.debug("Can't parse {}", message.getRequestHeader().getURI());
+        return false;
+    }
+}

--- a/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
+++ b/addOns/openapi/src/main/resources/org/zaproxy/zap/extension/openapi/resources/Messages.properties
@@ -24,6 +24,9 @@ openapi.cmdline.file.help = Imports an OpenAPI definition from the specified fil
 openapi.cmdline.url.help = Imports an OpenAPI definition from the specified URL
 openapi.cmdline.targeturl.help = The Target URL, to override the server URL present in the OpenAPI definition. Refer to the help for supported format.
 
+openapi.formhandler.desc = OpenAPI Form Handler Integration
+openapi.formhandler.name = OpenAPI Form Handler
+
 openapi.desc = Allows you to spider and import OpenAPI (Swagger) definitions 
 openapi.name = OpenAPI Import
 openapi.topmenu.import.importopenapi = Import an OpenAPI definition from the local file system
@@ -55,6 +58,9 @@ openapi.parse.trailer = Further details may be available in the Output tab.
 openapi.progress.importpane.currentimport = Importing: {0}
 
 openapi.import.error = Failed to access URL: {0} : {1} : {2}
+
+openapi.spider.desc = OpenAPI Spider Integration
+openapi.spider.name = OpenAPI Spider
 
 openapi.swaggerconverter.parse.defn.exception = Failed to parse swagger defn {0}
 

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/formhandler/ExtensionOpenApiFormHandlerUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/formhandler/ExtensionOpenApiFormHandlerUnitTest.java
@@ -1,0 +1,50 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.formhandler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class ExtensionOpenApiFormHandlerUnitTest extends TestUtils {
+
+    private ExtensionLoader extensionLoader;
+    private ExtensionOpenApiFormHandler extension;
+
+    @BeforeEach
+    void setUp() {
+        extension = new ExtensionOpenApiFormHandler();
+        extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+    }
+
+    @Test
+    void shouldBeUnloadable() {
+        assertThat(extension.canUnload(), is(true));
+    }
+}

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/spider/ExtensionOpenApiSpiderUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/spider/ExtensionOpenApiSpiderUnitTest.java
@@ -1,0 +1,79 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.spider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.zap.extension.openapi.ExtensionOpenApi;
+import org.zaproxy.zap.testutils.TestUtils;
+
+class ExtensionOpenApiSpiderUnitTest extends TestUtils {
+
+    private ExtensionLoader extensionLoader;
+    private ExtensionOpenApiSpider extension;
+
+    @BeforeEach
+    void setUp() {
+        extension = new ExtensionOpenApiSpider();
+        extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+    }
+
+    @Test
+    void shouldAddCustomParserOnHook() {
+        // Given
+        ExtensionSpider2 extensionSpider = mock(ExtensionSpider2.class);
+        given(extensionLoader.getExtension(ExtensionSpider2.class)).willReturn(extensionSpider);
+        ExtensionOpenApi extensionOpenApi = mock(ExtensionOpenApi.class);
+        given(extensionLoader.getExtension(ExtensionOpenApi.class)).willReturn(extensionOpenApi);
+        // When
+        extension.hook(null);
+        // Then
+        verify(extensionSpider).addCustomParser(any());
+    }
+
+    @Test
+    void shouldBeUnloadable() {
+        assertThat(extension.canUnload(), is(true));
+    }
+
+    @Test
+    void shouldRemoveCustomParserOnUnload() {
+        // Given
+        ExtensionSpider2 extensionSpider = mock(ExtensionSpider2.class);
+        given(extensionLoader.getExtension(ExtensionSpider2.class)).willReturn(extensionSpider);
+        // When
+        extension.unload();
+        // Then
+        verify(extensionSpider).removeCustomParser(any());
+    }
+}

--- a/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpiderFunctionalityUnitTest.java
+++ b/addOns/openapi/src/test/java/org/zaproxy/zap/extension/openapi/spider/OpenApiSpiderFunctionalityUnitTest.java
@@ -1,0 +1,81 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.openapi.spider;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.mock;
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.zap.extension.openapi.AbstractServerTest;
+import org.zaproxy.zap.model.ValueGenerator;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+
+/** Unit test for {@link OpenApiSpiderFunctionality}. */
+class OpenApiSpiderFunctionalityUnitTest extends AbstractServerTest {
+
+    private ValueGenerator valueGenerator;
+    private OpenApiSpiderFunctionality spider;
+
+    @BeforeEach
+    void setupSpider() {
+        valueGenerator = mock(ValueGenerator.class);
+        spider = new OpenApiSpiderFunctionality(() -> valueGenerator);
+    }
+
+    @Test
+    void shouldParseResource() throws Exception {
+        // Given
+        List<String> accessedUris = new ArrayList<>();
+        this.nano.addHandler(
+                new NanoServerHandler("") {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        accessedUris.add(session.getUri());
+                        return newFixedLengthResponse("");
+                    }
+                });
+        HttpMessage message = getHttpMessage("");
+        message.setResponseBody(
+                "openapi: 3.0.0\n"
+                        + "servers:\n"
+                        + "  - url: http://localhost:"
+                        + nano.getListeningPort()
+                        + "\n"
+                        + "paths:\n"
+                        + "  /path:\n"
+                        + "    get:\n"
+                        + "      responses:\n"
+                        + "        200:\n"
+                        + "          content:\n"
+                        + "            application/json: {}");
+        // When
+        spider.parseResource(message, null, 0);
+        // Then
+        assertThat(accessedUris, contains("/path"));
+    }
+}


### PR DESCRIPTION
- CHANGELOG > Added change notes.
- Build file > Included spider extension and updated dependencies.
- Separated spider functionality into a static class which is now used by both spider parser implementations (core & add-on).

Part of zaproxy/zaproxy#3113

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>