### PR TITLE
Ajax Spider: Missing 'user' param in the AF job help

### DIFF
--- a/addOns/spiderAjax/CHANGELOG.md
+++ b/addOns/spiderAjax/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Missing 'user' param in the Automation Framework help
+
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 - Use Network add-on to proxy Crawljax/browser requests.

--- a/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/automation.html
+++ b/addOns/spiderAjax/src/main/javahelp/org/zaproxy/zap/extension/spiderAjax/resources/help/contents/automation.html
@@ -16,6 +16,7 @@ The spiderAjax job allows you to run the Ajax Spider - it is slower than the tra
   - type: spiderAjax                   # The ajax spider - slower than the spider but handles modern apps well
     parameters:
       context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
       url:                             # String: Url to start spidering from, default: first context URL
       maxDuration:                     # Int: The max time in minutes the ajax spider will be allowed to run for, default: 0 unlimited
       maxCrawlDepth:                   # Int: The max depth that the crawler can reach, default: 10, 0 is unlimited


### PR DESCRIPTION
Signed-off-by: Simon Bennetts <psiinon@gmail.com>