### PR TITLE
graphql: update dependency

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 ### Changed
+- Update graphql-java dependency, with important bugfixes.
 - Maintenance changes.
 - Update dependency, which reduces add-on file size (Issue 7322).
 

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -41,7 +41,7 @@ crowdin {
 dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
     implementation("com.google.code.gson:gson:2.8.8")
-    implementation("com.graphql-java:graphql-java:18.2")
+    implementation("com.graphql-java:graphql-java:19.0")
 
     testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(project(":testutils"))


### PR DESCRIPTION
Update GraphQL Java to latest version (19.0), with important bugfixes.