### PR TITLE
network: set content-length for chunked response

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -392,6 +392,10 @@ public class HttpSenderApache
 
         updateRequestHeaders(message.getRequestHeader(), requestCtx.getRequest());
 
+        if (isSet(requestCtx, RemoveTransferEncoding.ATTR_NAME)) {
+            message.getResponseHeader().setContentLength(message.getResponseBody().length());
+        }
+
         if (user != null) {
             LegacyUtils.updateHttpState(
                     user.getCorrespondingHttpState(), requestCtx.getCookieStore());

--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RemoveTransferEncoding.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/RemoveTransferEncoding.java
@@ -34,11 +34,14 @@ import org.apache.logging.log4j.Logger;
  */
 public class RemoveTransferEncoding implements HttpResponseInterceptor {
 
+    static final String ATTR_NAME = "zap.transfer-encoding.removed";
+
     private static final Logger LOGGER = LogManager.getLogger(RemoveTransferEncoding.class);
 
     @Override
     public void process(HttpResponse response, EntityDetails entity, HttpContext context) {
-        if (response.containsHeader(HttpHeaders.TRANSFER_ENCODING)) {
+        if (response.removeHeaders(HttpHeaders.TRANSFER_ENCODING)) {
+            context.setAttribute(ATTR_NAME, Boolean.TRUE);
             if (LOGGER.isDebugEnabled()) {
                 HttpClientContext clientContext = HttpClientContext.adapt(context);
                 LOGGER.debug(
@@ -46,7 +49,6 @@ public class RemoveTransferEncoding implements HttpResponseInterceptor {
                         clientContext.getExchangeId(),
                         HttpHeaders.TRANSFER_ENCODING);
             }
-            response.removeHeaders(HttpHeaders.TRANSFER_ENCODING);
         }
     }
 }

--- a/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
+++ b/addOns/network/src/test/java/org/zaproxy/addon/network/internal/client/HttpSenderImplUnitTest.java
@@ -613,6 +613,7 @@ class HttpSenderImplUnitTest {
                         message.getResponseHeader().getHeader("Transfer-Encoding"),
                         is(nullValue()));
                 assertThat(message.getResponseBody().toString(), is(equalTo(RESPONSE_BODY)));
+                assertThat(message.getResponseHeader().getContentLength(), is(equalTo(249)));
             }
 
             @ParameterizedTest


### PR DESCRIPTION
Set the Content-Length if the response was chunked, ZAP removes the
Transfer-Encoding header and the chunks, for the client to properly
know the boundary of the response we should set the Content-Length.

Fix zaproxy/zaproxy#5815.