### PR TITLE
automation: use latest script wrapper added

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 
+### Fixed
+- Correct loading of custom scripts (e.g. Zest).
+
 ## [0.16.0] - 2022-06-22
 ### Changed
 - Maintenance changes.

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/jobs/JobUtils.java
@@ -46,6 +46,7 @@ import org.zaproxy.addon.automation.AutomationJob;
 import org.zaproxy.addon.automation.AutomationProgress;
 import org.zaproxy.zap.extension.script.ExtensionScript;
 import org.zaproxy.zap.extension.script.ScriptEngineWrapper;
+import org.zaproxy.zap.extension.script.ScriptNode;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 
@@ -571,7 +572,8 @@ public class JobUtils {
                                                 scriptType,
                                                 true,
                                                 file));
-                        extScript.addScript(wrapper, false);
+                        ScriptNode scriptNode = extScript.addScript(wrapper, false);
+                        wrapper = (ScriptWrapper) scriptNode.getUserObject();
                     } catch (IOException e) {
                         progress.error(
                                 Constant.messages.getString(


### PR DESCRIPTION
Use the script wrapper that was added to the node rather than the one
being added as they might be different and the former is the correct
one (e.g. Zest injects its own script wrapper).

---
Issue reported in the OWASP ZAP User Group: https://groups.google.com/g/zaproxy-users/c/a1spgsKb-Qs/m/hd6SFDJmAwAJ