### PR TITLE
spider: Extend SVG handling (crawl maze)

### DIFF
--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/spider.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/spider.html
@@ -32,6 +32,7 @@
 		<li>Img - 'longdesc', 'lowsrc', 'dynsrc', 'srcset' attributes</li>
 		<li>Isindex - 'action' attribute</li>
 		<li>Object - 'codebase', 'data' attributes</li>
+		<li>Svg - 'href' and 'xlink:href' attributes of 'image' and 'script' elements</li>
 		<li>Table - 'background' attribute</li>
 		<li>Video - 'poster' attribute</li>
 		<li>Form - proper handling of Forms with both GET and POST

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SvgHrefParserUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SvgHrefParserUnitTest.java
@@ -226,6 +226,75 @@ class SvgHrefParserUnitTest extends SpiderParserTestUtils {
                 is(equalTo("http://example.org/use_element/upload.php")));
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"href", "HREF", "xlink:href", "XLINK:HREF"})
+    void shouldParseValidResourceWithSvgTagWithImageTag(String attributeName) {
+        // Given
+        HttpMessage msg = createMessage("test.html");
+        msg.setResponseBody(
+                "<!DOCTYPE html>\n"
+                        + "<h1>SVG Tag Test</h1>\n"
+                        + "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n"
+                        + "  <image "
+                        + attributeName
+                        + "=\"/test/html/file.svg\"/>\n"
+                        + "</svg>\n"
+                        + "<p>\n"
+                        + "  The attribute points at a URL for the image file.\n"
+                        + "</p>");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        boolean parse = parser.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertTrue(parse);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"href", "HREF", "xlink:href", "XLINK:HREF"})
+    void shouldParseValidResourceWithSvgTagWithScriptTag(String attributeName) {
+        // Given
+        HttpMessage msg = createMessage("test.html");
+        msg.setResponseBody(
+                "<!DOCTYPE html>\n"
+                        + "<h1>SVG Tag Test</h1>\n"
+                        + "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n"
+                        + "  <script "
+                        + attributeName
+                        + "=\"/test/html/getImage\"/>\n"
+                        + "</svg>\n"
+                        + "<p>\n"
+                        + "  The attribute points at a URL for the script file.\n"
+                        + "</p>");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        boolean parse = parser.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertTrue(parse);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"href", "HREF", "xlink:href", "XLINK:HREF"})
+    void shouldNotParseResourceWithSvgTagWithOtherTag(String attributeName) {
+        // Given
+        HttpMessage msg = createMessage("test.html");
+        msg.setResponseBody(
+                "<!DOCTYPE html>\n"
+                        + "<h1>SVG Tag Test</h1>\n"
+                        + "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n"
+                        + "  <other "
+                        + attributeName
+                        + "=\"/test/html/getImage\"/>\n"
+                        + "</svg>\n"
+                        + "<p>\n"
+                        + "  The attribute in \"other\" tag.\n"
+                        + "</p>");
+        msg.getResponseHeader().addHeader(HttpHeader.CONTENT_TYPE, "text/html");
+        // When
+        boolean parse = parser.parseResource(msg, new Source(msg.getResponseBody().toString()), 0);
+        // Then
+        assertFalse(parse);
+    }
+
     private HttpMessage createMessage(String path) {
         HttpMessage msg = new HttpMessage();
         try {


### PR DESCRIPTION
[/test/html/body/svg/image/xlink.found](https://security-crawl-maze.app/test/html/body/svg/image/xlink.found) and [/test/html/body/svg/script/xlink.found](https://security-crawl-maze.app/test/html/body/svg/script/xlink.found) are now handled by the SvgHrefParser.

![image](https://user-images.githubusercontent.com/7570458/185024621-0a6e336c-0d70-4e85-996e-5050f0ad5399.png)

Related to zaproxy/zaproxy#7152

It looks like a lot of change but it really isn't, it's just that the original SVG file handling was indented another level within a conditional.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>