### PR TITLE
graphql: use Spider add-on

### DIFF
--- a/addOns/graphql/CHANGELOG.md
+++ b/addOns/graphql/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Maintenance changes.
 - Update dependency, which reduces add-on file size (Issue 7322).
+- Use Spider add-on (Issue 3113).
 
 ## [0.9.0] - 2022-04-05
 ### Changed

--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -20,6 +20,19 @@ zapAddOn {
                     }
                 }
             }
+
+            register("org.zaproxy.addon.graphql.spider.ExtensionGraphQlSpider") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.addon.graphql.spider"))
+                }
+                dependencies {
+                    addOns {
+                        register("spider") {
+                            version.set(">=0.1.0")
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -40,9 +53,11 @@ crowdin {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
+    compileOnly(parent!!.childProjects.get("spider")!!)
     implementation("com.google.code.gson:gson:2.8.8")
     implementation("com.graphql-java:graphql-java:18.2")
 
     testImplementation(parent!!.childProjects.get("automation")!!)
+    testImplementation(parent!!.childProjects.get("spider")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlSpiderHelper.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlSpiderHelper.java
@@ -1,0 +1,63 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql;
+
+import org.apache.commons.httpclient.URI;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+
+public final class GraphQlSpiderHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger(GraphQlSpiderHelper.class);
+
+    private GraphQlSpiderHelper() {}
+
+    public static boolean parseMessage(HttpMessage message) {
+        try {
+            GraphQlParser parser =
+                    new GraphQlParser(
+                            message.getRequestHeader().getURI(),
+                            HttpSender.SPIDER_INITIATOR,
+                            false);
+            parser.addRequesterListener(new HistoryPersister());
+            parser.introspect();
+        } catch (Exception e) {
+            LOGGER.debug(e.getMessage(), e);
+            return false;
+        }
+        return true;
+    }
+
+    public static boolean canParseMessage(HttpMessage message) {
+        URI uri = message.getRequestHeader().getURI();
+        switch (MessageValidator.validate(message)) {
+            case VALID_ENDPOINT:
+                LOGGER.debug("Found GraphQL endpoint at: {}", uri);
+                return true;
+            case VALID_SCHEMA:
+                LOGGER.debug("Found GraphQL schema at: {}", uri);
+                break;
+            default:
+        }
+        return false;
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/ExtensionGraphQlSpider.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/ExtensionGraphQlSpider.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql.spider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.addon.graphql.ExtensionGraphQl;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.addon.spider.parser.SpiderParser;
+
+public class ExtensionGraphQlSpider extends ExtensionAdaptor {
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionSpider2.class, ExtensionGraphQl.class));
+
+    private SpiderParser spiderParser;
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("graphql.spider.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("graphql.spider.desc");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        spiderParser = new GraphQlSpider();
+        getExtension(ExtensionSpider2.class).addCustomParser(spiderParser);
+    }
+
+    private static <T extends Extension> T getExtension(Class<T> clazz) {
+        return Control.getSingleton().getExtensionLoader().getExtension(clazz);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        getExtension(ExtensionSpider2.class).removeCustomParser(spiderParser);
+    }
+}

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/GraphQlSpider.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/GraphQlSpider.java
@@ -3,7 +3,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2020 The ZAP Development Team
+ * Copyright 2022 The ZAP Development Team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.addon.graphql;
+package org.zaproxy.addon.graphql.spider;
 
 import net.htmlparser.jericho.Source;
 import org.parosproxy.paros.network.HttpMessage;
-import org.zaproxy.zap.spider.parser.SpiderParser;
+import org.zaproxy.addon.graphql.GraphQlSpiderHelper;
+import org.zaproxy.addon.spider.parser.SpiderParser;
 
 public class GraphQlSpider extends SpiderParser {
 

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -106,3 +106,7 @@ graphql.options.value.split.postGraphql = POST (with GraphQL body)
 graphql.options.value.split.get = GET
 
 graphql.script.description = Input Vectors Script for injecting inline arguments in GraphQL queries proxied through ZAP.
+
+graphql.spider.desc = GraphQL Spider Integration
+graphql.spider.name = GraphQL Spider
+


### PR DESCRIPTION
Add extension that depends on the spider add-on and adds a custom
spider parser.
Extract common spider parser code into helper class and update existing
parser accordingly.

Part of zaproxy/zaproxy#3113.