### PR TITLE
formhandler: expose value generator

### DIFF
--- a/addOns/formhandler/CHANGELOG.md
+++ b/addOns/formhandler/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- Expose value generator for other add-ons (Related to Issue 3113).
 
 ## [5] - 2022-07-20
 ### Changed

--- a/addOns/formhandler/gradle.properties
+++ b/addOns/formhandler/gradle.properties
@@ -1,2 +1,2 @@
-version=6
+version=6.0.0
 release=false

--- a/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/ExtensionFormHandler.java
+++ b/addOns/formhandler/src/main/java/org/zaproxy/zap/extension/formhandler/ExtensionFormHandler.java
@@ -28,6 +28,7 @@ import org.parosproxy.paros.extension.ExtensionLoader;
 import org.zaproxy.zap.extension.params.ExtensionParams;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
 import org.zaproxy.zap.model.DefaultValueGenerator;
+import org.zaproxy.zap.model.ValueGenerator;
 
 public class ExtensionFormHandler extends ExtensionAdaptor {
 
@@ -36,6 +37,7 @@ public class ExtensionFormHandler extends ExtensionAdaptor {
     protected static final String PREFIX = "formhandler";
 
     private FormHandlerParam param;
+    private ValueGenerator valueGenerator;
 
     private OptionsFormHandlerPanel optionsFormHandlerPanel;
     private PopupMenuAddFormhandlerParam popupMenuAddFormhandlerParam;
@@ -44,15 +46,31 @@ public class ExtensionFormHandler extends ExtensionAdaptor {
         super(NAME);
     }
 
+    /**
+     * Gets the value generator, with user provided values.
+     *
+     * @return the value generator.
+     * @since 6.0.0
+     */
+    public ValueGenerator getValueGenerator() {
+        return valueGenerator;
+    }
+
+    @Override
+    public void init() {
+        valueGenerator = new FormHandlerValueGenerator(getParam());
+    }
+
     @Override
     public void hook(ExtensionHook extensionHook) {
         super.hook(extensionHook);
 
         extensionHook.addOptionsParamSet(getParam());
         ExtensionLoader extLoader = Control.getSingleton().getExtensionLoader();
+        // TODO Remove once other add-ons no longer use the core spider to get the generator.
         ExtensionSpider extension = extLoader.getExtension(ExtensionSpider.class);
         if (extension != null) {
-            extension.setValueGenerator(new FormHandlerValueGenerator(getParam()));
+            extension.setValueGenerator(valueGenerator);
         }
 
         if (getView() != null) {

--- a/addOns/formhandler/src/main/resources/org/zaproxy/zap/extension/formhandler/resources/Messages.properties
+++ b/addOns/formhandler/src/main/resources/org/zaproxy/zap/extension/formhandler/resources/Messages.properties
@@ -1,5 +1,5 @@
 formhandler.options.title = Form Handler
-formhandler.options.desc = This extension allows a user to change the default values used by ZAP Spiders.
+formhandler.options.desc = This extension allows a user to change the default values used for generated content (e.g. spiders, importers).
 formhandler.options.label.description = <html> <body> This Form Handler extension allows for the custom configuration of values used in forms based on field names. Newly created field names must match the field name in the form being processed. The field name inputed is not case sensitive, however the values are and will be reflected in the POST form. If only a field name is provided then an empty string will be used as a value. If a form's field does not match any defined in the extension then it will be passed to the Default Value Generator, which may not provide proper values. </body> </html>
 formhandler.options.table.column.enabled = Enabled
 formhandler.options.table.column.field = Field Name


### PR DESCRIPTION
Allow other add-ons to use the custom value generator without going
through the spider (e.g. importers don't need the spider).
Tweak the description of the extension which was referring just to
spider usage.
Change the add-on version to SemVer.

Related to zaproxy/zaproxy#3113.