### PR TITLE
graphql: use Form Handler and add parse filter

### DIFF
--- a/addOns/graphql/graphql.gradle.kts
+++ b/addOns/graphql/graphql.gradle.kts
@@ -21,6 +21,19 @@ zapAddOn {
                 }
             }
 
+            register("org.zaproxy.addon.graphql.formhandler.ExtensionGraphQlFormHandler") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.addon.graphql.formhandler"))
+                }
+                dependencies {
+                    addOns {
+                        register("formhandler") {
+                            version.set(">=6.0.0 & < 7.0.0")
+                        }
+                    }
+                }
+            }
+
             register("org.zaproxy.addon.graphql.spider.ExtensionGraphQlSpider") {
                 classnames {
                     allowed.set(listOf("org.zaproxy.addon.graphql.spider"))
@@ -53,11 +66,13 @@ crowdin {
 
 dependencies {
     compileOnly(parent!!.childProjects.get("automation")!!)
+    compileOnly(parent!!.childProjects.get("formhandler")!!)
     compileOnly(parent!!.childProjects.get("spider")!!)
     implementation("com.google.code.gson:gson:2.8.8")
     implementation("com.graphql-java:graphql-java:18.2")
 
     testImplementation(parent!!.childProjects.get("automation")!!)
+    testImplementation(parent!!.childProjects.get("formhandler")!!)
     testImplementation(parent!!.childProjects.get("spider")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/ExtensionGraphQl.java
@@ -47,6 +47,8 @@ import org.zaproxy.zap.extension.script.ScriptEngineWrapper;
 import org.zaproxy.zap.extension.script.ScriptType;
 import org.zaproxy.zap.extension.script.ScriptWrapper;
 import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.model.DefaultValueGenerator;
+import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.spider.filters.ParseFilter;
 import org.zaproxy.zap.spider.parser.SpiderParser;
 import org.zaproxy.zap.view.ZapMenuItem;
@@ -69,8 +71,20 @@ public class ExtensionGraphQl extends ExtensionAdaptor
     private static final int ARG_IMPORT_URL_IDX = 1;
     private static final int ARG_END_URL_IDX = 2;
 
+    private ValueGenerator valueGenerator;
+
     public ExtensionGraphQl() {
         super(NAME);
+
+        setValueGenerator(null);
+    }
+
+    public void setValueGenerator(ValueGenerator valueGenerator) {
+        this.valueGenerator = valueGenerator == null ? new DefaultValueGenerator() : valueGenerator;
+    }
+
+    ValueGenerator getValueGenerator() {
+        return valueGenerator;
     }
 
     @Override

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/GraphQlParser.java
@@ -151,7 +151,9 @@ public class GraphQlParser {
 
     private void generate(String schema) {
         try {
-            GraphQlGenerator generator = new GraphQlGenerator(schema, requestor, param);
+            GraphQlGenerator generator =
+                    new GraphQlGenerator(
+                            extensionGraphQl.getValueGenerator(), schema, requestor, param);
             generator.checkServiceMethods();
             generator.generateAndSend();
         } catch (Exception e) {

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/MessageValidator.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/MessageValidator.java
@@ -26,15 +26,15 @@ import org.parosproxy.paros.network.HttpMessage;
 
 public final class MessageValidator {
 
-    protected enum Result {
+    public enum Result {
         INVALID,
         VALID_SCHEMA,
         VALID_ENDPOINT
-    };
+    }
 
     private MessageValidator() {}
 
-    protected static Result validate(HttpMessage message) {
+    public static Result validate(HttpMessage message) {
         String uri = message.getRequestHeader().getURI().toString();
         if (message.getResponseHeader().getHeader(HttpHeader.CONTENT_TYPE) == null) {
             return Result.INVALID;

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/formhandler/ExtensionGraphQlFormHandler.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/formhandler/ExtensionGraphQlFormHandler.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.zaproxy.addon.graphql.spider;
+package org.zaproxy.addon.graphql.formhandler;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -28,27 +28,23 @@ import org.parosproxy.paros.extension.Extension;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
 import org.zaproxy.addon.graphql.ExtensionGraphQl;
-import org.zaproxy.addon.spider.ExtensionSpider2;
-import org.zaproxy.addon.spider.filters.ParseFilter;
-import org.zaproxy.addon.spider.parser.SpiderParser;
+import org.zaproxy.zap.extension.formhandler.ExtensionFormHandler;
+import org.zaproxy.zap.model.ValueGenerator;
 
-public class ExtensionGraphQlSpider extends ExtensionAdaptor {
+public class ExtensionGraphQlFormHandler extends ExtensionAdaptor {
 
     private static final List<Class<? extends Extension>> DEPENDENCIES =
             Collections.unmodifiableList(
-                    Arrays.asList(ExtensionSpider2.class, ExtensionGraphQl.class));
-
-    private SpiderParser spiderParser;
-    private ParseFilter parseFilter;
+                    Arrays.asList(ExtensionFormHandler.class, ExtensionGraphQl.class));
 
     @Override
     public String getUIName() {
-        return Constant.messages.getString("graphql.spider.name");
+        return Constant.messages.getString("graphql.formhandler.name");
     }
 
     @Override
     public String getDescription() {
-        return Constant.messages.getString("graphql.spider.desc");
+        return Constant.messages.getString("graphql.formhandler.desc");
     }
 
     @Override
@@ -58,11 +54,9 @@ public class ExtensionGraphQlSpider extends ExtensionAdaptor {
 
     @Override
     public void hook(ExtensionHook extensionHook) {
-        spiderParser = new GraphQlSpider();
-        ExtensionSpider2 spider = getExtension(ExtensionSpider2.class);
-        spider.addCustomParser(spiderParser);
-        parseFilter = new GraphQlParseFilter();
-        spider.addCustomParseFilter(parseFilter);
+        ValueGenerator valueGenerator =
+                getExtension(ExtensionFormHandler.class).getValueGenerator();
+        getExtension(ExtensionGraphQl.class).setValueGenerator(valueGenerator);
     }
 
     private static <T extends Extension> T getExtension(Class<T> clazz) {
@@ -76,8 +70,6 @@ public class ExtensionGraphQlSpider extends ExtensionAdaptor {
 
     @Override
     public void unload() {
-        ExtensionSpider2 spider = getExtension(ExtensionSpider2.class);
-        spider.removeCustomParser(spiderParser);
-        spider.removeCustomParseFilter(parseFilter);
+        getExtension(ExtensionGraphQl.class).setValueGenerator(null);
     }
 }

--- a/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/GraphQlParseFilter.java
+++ b/addOns/graphql/src/main/java/org/zaproxy/addon/graphql/spider/GraphQlParseFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.graphql.spider;
+
+import org.parosproxy.paros.network.HttpMessage;
+import org.zaproxy.addon.graphql.MessageValidator;
+import org.zaproxy.addon.spider.filters.ParseFilter;
+
+public class GraphQlParseFilter extends ParseFilter {
+
+    @Override
+    public FilterResult filtered(HttpMessage message) {
+        if (MessageValidator.validate(message) != MessageValidator.Result.INVALID) {
+            return FilterResult.WANTED;
+        }
+        return FilterResult.NOT_FILTERED;
+    }
+}

--- a/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
+++ b/addOns/graphql/src/main/resources/org/zaproxy/addon/graphql/resources/Messages.properties
@@ -65,6 +65,9 @@ graphql.topmenu.import.importgraphql.tooltip = The file must be a formally descr
 graphql.topmenu.import.importremotegraphql = Import a GraphQL Schema from a URL
 graphql.topmenu.import.importremotegraphql.tooltip = The URL that locates a GraphQL schema. If it is not specified, Introspection will be used.
 
+graphql.formhandler.desc = GraphQL Form Handler Integration
+graphql.formhandler.name = GraphQL Form Handler
+
 graphql.importfromdialog.message = TO DO: Import and Parse Schema
 graphql.importfromdialog.importbutton = Import
 graphql.importfromdialog.pasteaction = Paste

--- a/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
+++ b/addOns/graphql/src/test/java/org/zaproxy/addon/graphql/GraphQlGeneratorUnitTest.java
@@ -20,24 +20,32 @@
 package org.zaproxy.addon.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.zaproxy.zap.model.ValueGenerator;
 import org.zaproxy.zap.testutils.TestUtils;
 
 class GraphQlGeneratorUnitTest extends TestUtils {
     GraphQlGenerator generator;
     GraphQlParam param;
+    private ValueGenerator valueGenerator;
 
     @BeforeEach
     void setup() throws Exception {
         setUpZap();
         param = new GraphQlParam(5, true, 5, 5, true, null, null, null);
+        valueGenerator = mock(ValueGenerator.class);
+    }
+
+    private GraphQlGenerator createGraphQlGenerator(String sdl) {
+        return new GraphQlGenerator(valueGenerator, sdl, null, param);
     }
 
     @Test
     void scalarFieldsOnly() throws Exception {
-        generator = new GraphQlGenerator(getHtml("scalarFieldsOnly.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("scalarFieldsOnly.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { name id age height human } ";
         assertEquals(query, expectedQuery);
@@ -45,7 +53,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void zeroDepthObjects() throws Exception {
-        generator = new GraphQlGenerator(getHtml("zeroDepthObjects.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("zeroDepthObjects.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { gymName dumbbell { fixedWeight weight } treadmill { maxSpeed manufacturer } } ";
@@ -54,7 +62,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void nestedObjects() throws Exception {
-        generator = new GraphQlGenerator(getHtml("nestedObjects.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("nestedObjects.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { book { id name pageCount author { id firstName lastName } } } ";
@@ -63,7 +71,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void circularRelationship() throws Exception {
-        generator = new GraphQlGenerator(getHtml("circularRelationship.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("circularRelationship.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { thread { id message { text thread { id message { text thread { id } } } } } } ";
@@ -72,7 +80,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void scalarArguments() throws Exception {
-        generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("scalarArguments.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { polygon (sides: 1, regular: true) { perimeter area } } ";
         assertEquals(query, expectedQuery);
@@ -80,8 +88,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void nonNullableScalarArguments() throws Exception {
-        generator =
-                new GraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { getLyrics (song: \"ZAP\", artist: \"ZAP\") } ";
         assertEquals(query, expectedQuery);
@@ -89,7 +96,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void enumArgument() throws Exception {
-        generator = new GraphQlGenerator(getHtml("enumArgument.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("enumArgument.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { location (direction: NORTH) } ";
         assertEquals(query, expectedQuery);
@@ -97,7 +104,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void listAsArgument() throws Exception {
-        generator = new GraphQlGenerator(getHtml("listAsArgument.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("listAsArgument.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { sum (numbers: [3.14, 3.14, 3.14]) concat (words: [\"ZAP\", \"ZAP\", \"ZAP\"]) "
@@ -107,7 +114,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void inputObjectArgument() throws Exception {
-        generator = new GraphQlGenerator(getHtml("inputObjectArgument.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("inputObjectArgument.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { plot (point: { x: 3.14, y: 3.14 }) } ";
         assertEquals(query, expectedQuery);
@@ -115,7 +122,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void listsAndNonNull() throws Exception {
-        generator = new GraphQlGenerator(getHtml("listsAndNonNull.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("listsAndNonNull.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { jellyBean { count } marshmallow { count } nougat { count } pie { count } } ";
@@ -124,7 +131,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void nonNullableFields() throws Exception {
-        generator = new GraphQlGenerator(getHtml("nonNullableFields.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("nonNullableFields.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { name phone child { id name school } } ";
         assertEquals(query, expectedQuery);
@@ -132,7 +139,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void objectsImplementInterface() throws Exception {
-        generator = new GraphQlGenerator(getHtml("objectsImplementInterface.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("objectsImplementInterface.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { character { ... on Hero { id name superPower weakness } ... on Villain { id name grudge origin } } } ";
@@ -141,8 +148,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void implementMultipleInterfaces() throws Exception {
-        generator =
-                new GraphQlGenerator(getHtml("implementMultipleInterfaces.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("implementMultipleInterfaces.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { someAnimal { ... on Swallow { wingspan speed } } someBird { ... on Swallow { wingspan speed } } } ";
@@ -151,8 +157,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void interfaceImplementsInterface() throws Exception {
-        generator =
-                new GraphQlGenerator(getHtml("interfaceImplementsInterface.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("interfaceImplementsInterface.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { picture { ... on Photo { id url thumbnail filter } } } ";
         assertEquals(query, expectedQuery);
@@ -160,7 +165,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void unionType() throws Exception {
-        generator = new GraphQlGenerator(getHtml("unionType.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("unionType.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { firstSearchResult { ... on Photo { height width } ... on Person { name age } } } ";
@@ -169,7 +174,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void enumType() throws Exception {
-        generator = new GraphQlGenerator(getHtml("enumType.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("enumType.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { direction } ";
         assertEquals(query, expectedQuery);
@@ -177,7 +182,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void mutation() throws Exception {
-        generator = new GraphQlGenerator(getHtml("mutation.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("mutation.graphql"));
         String mutation = generator.generate(GraphQlGenerator.RequestType.MUTATION);
         String expectedMutation =
                 "mutation { createStudent (id: 1, name: \"ZAP\") { id name college { name location } } } ";
@@ -186,7 +191,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void subscription() throws Exception {
-        generator = new GraphQlGenerator(getHtml("subscription.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("subscription.graphql"));
         String subscription = generator.generate(GraphQlGenerator.RequestType.SUBSCRIPTION);
         String expectedSubscription = "subscription { newMessage (roomId: 1) { sender text } } ";
         assertEquals(subscription, expectedSubscription);
@@ -196,7 +201,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void separatedScalarArguments() throws Exception {
-        generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("scalarArguments.graphql"));
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query ($polygon_regular: Boolean, $polygon_sides: Int) "
@@ -208,8 +213,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void separatedNonNullableScalarArguments() throws Exception {
-        generator =
-                new GraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("nonNullableScalarArguments.graphql"));
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query ($getLyrics_artist: String!, $getLyrics_song: String!) "
@@ -221,7 +225,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void separatedEnumArgumentVariable() throws Exception {
-        generator = new GraphQlGenerator(getHtml("enumArgument.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("enumArgument.graphql"));
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query ($location_direction: Direction) { location (direction: $location_direction) } ";
@@ -232,7 +236,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void separatedListAsArgument() throws Exception {
-        generator = new GraphQlGenerator(getHtml("listAsArgument.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("listAsArgument.graphql"));
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query ($compare_objects: [Object], $concat_words: [String!]!, $sum_numbers: [Float]) "
@@ -247,7 +251,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void separatedInputObjectArgument() throws Exception {
-        generator = new GraphQlGenerator(getHtml("inputObjectArgument.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("inputObjectArgument.graphql"));
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query ($plot_point: Point2D) { plot (point: $plot_point) } ";
         String expectedVariables = "{\"plot_point\": { \"x\": 3.14, \"y\": 3.14 }}";
@@ -257,7 +261,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
 
     @Test
     void variableNamesClash() throws Exception {
-        generator = new GraphQlGenerator(getHtml("variableNamesClash.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("variableNamesClash.graphql"));
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query ($field2_name_id: ID, $field1_name_id: ID) { field1 { name (id: $field1_name_id) } field2 { name (id: $field2_name_id) } } ";
@@ -271,7 +275,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void lenientDepthDeepNestedLeaf() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("deepNestedLeaf.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("deepNestedLeaf.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query { user (id: 1) { follower { favouriteIceCream { flavour } } } } ";
@@ -281,7 +285,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void strictDepthScalarArguments() throws Exception {
         param = new GraphQlParam(1, false, 5, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("scalarArguments.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { polygon (sides: 1, regular: true) } ";
         assertEquals(expectedQuery, query);
@@ -290,7 +294,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void lenientDepthScalarArguments() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("scalarArguments.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { polygon (sides: 1, regular: true) { perimeter } } ";
         assertEquals(expectedQuery, query);
@@ -299,7 +303,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void lenientDepthObjectsImplementInterface() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("objectsImplementInterface.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("objectsImplementInterface.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { character { ... on Hero { id } } } ";
         assertEquals(expectedQuery, query);
@@ -308,7 +312,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void lenientDepthUnionType() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("unionType.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("unionType.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { firstSearchResult { ... on Photo { height } } } ";
         assertEquals(expectedQuery, query);
@@ -317,7 +321,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void lenientDepthEnumType() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("enumType.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("enumType.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query { direction } ";
         assertEquals(expectedQuery, query);
@@ -326,7 +330,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void lenientDepthScalarArgumentsVariables() throws Exception {
         param = new GraphQlParam(0, true, 5, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("scalarArguments.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("scalarArguments.graphql"));
         String[] request = generator.generateWithVariables(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery =
                 "query ($polygon_regular: Boolean, $polygon_sides: Int) "
@@ -339,7 +343,7 @@ class GraphQlGeneratorUnitTest extends TestUtils {
     @Test
     void lenientDepthExceeded() throws Exception {
         param = new GraphQlParam(0, true, 3, 5, true, null, null, null);
-        generator = new GraphQlGenerator(getHtml("deepNestedLeaf.graphql"), null, param);
+        generator = createGraphQlGenerator(getHtml("deepNestedLeaf.graphql"));
         String query = generator.generate(GraphQlGenerator.RequestType.QUERY);
         String expectedQuery = "query ";
         assertEquals(expectedQuery, query);


### PR DESCRIPTION
Add extension that depends on the Form Handler add-on to use its value
generator.
Add the parse filter to the spider add-on.

Part of zaproxy/zaproxy#3113.