### PR TITLE
spider: use Form Handler add-on

### DIFF
--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -10,10 +10,28 @@ zapAddOn {
     manifest {
         author.set("ZAP Dev Team")
         url.set("https://www.zaproxy.org/docs/desktop/addons/spider/")
+
+        extensions {
+            register("org.zaproxy.addon.spider.formhandler.ExtensionSpiderFormHandler") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.addon.spider.formhandler"))
+                }
+                dependencies {
+                    addOns {
+                        register("formhandler") {
+                            version.set(">=6.0.0 & < 7.0.0")
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("formhandler")!!)
+
+    testImplementation(parent!!.childProjects.get("formhandler")!!)
     testImplementation(project(":testutils"))
 }
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
@@ -133,13 +133,10 @@ public class ExtensionSpider2 extends ExtensionAdaptor
     }
 
     public void setValueGenerator(ValueGenerator generator) {
-        if (generator == null) {
-            throw new IllegalArgumentException("Parameter generator must not be null.");
-        }
-        this.generator = generator;
+        this.generator = generator == null ? new DefaultValueGenerator() : generator;
     }
 
-    public ValueGenerator getValueGenerator() {
+    ValueGenerator getValueGenerator() {
         return generator;
     }
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/formhandler/ExtensionSpiderFormHandler.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/formhandler/ExtensionSpiderFormHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider.formhandler;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.zap.extension.formhandler.ExtensionFormHandler;
+import org.zaproxy.zap.model.ValueGenerator;
+
+public class ExtensionSpiderFormHandler extends ExtensionAdaptor {
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionFormHandler.class, ExtensionSpider2.class));
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("spider.formhandler.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("spider.formhandler.desc");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        ValueGenerator valueGenerator =
+                getExtension(ExtensionFormHandler.class).getValueGenerator();
+        getExtension(ExtensionSpider2.class).setValueGenerator(valueGenerator);
+    }
+
+    private static <T extends Extension> T getExtension(Class<T> clazz) {
+        return Control.getSingleton().getExtensionLoader().getExtension(clazz);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        getExtension(ExtensionSpider2.class).setValueGenerator(null);
+    }
+}

--- a/addOns/spider/src/main/resources/org/zaproxy/addon/spider/Messages.properties
+++ b/addOns/spider/src/main/resources/org/zaproxy/addon/spider/Messages.properties
@@ -157,6 +157,9 @@ spider.custom.nostart.error	= You must select a valid starting point\nincluding 
 spider.custom.noStartSubtreeOnly.error = A site node must be selected or a URL manually introduced, to spider a site's subtree.
 spider.custom.targetNotInScope.error = The following target is not allowed in 'Protected' mode:\n{0}
 
+spider.formhandler.desc = Spider Form Handler Integration
+spider.formhandler.name = Spider Form Handler
+
 spider.label.inScope            = URI found during crawl:
 spider.label.outOfScope         = URI found but out of crawl scope:
 spider.name = Spider Extension

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/formhandler/ExtensionSpiderFormHandlerUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/formhandler/ExtensionSpiderFormHandlerUnitTest.java
@@ -1,0 +1,123 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider.formhandler;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.zap.extension.formhandler.ExtensionFormHandler;
+import org.zaproxy.zap.model.ValueGenerator;
+import org.zaproxy.zap.testutils.TestUtils;
+
+/** Unit test for {@link ExtensionSpiderFormHandler}. */
+class ExtensionSpiderFormHandlerUnitTest extends TestUtils {
+
+    private ExtensionSpider2 extensionSpider;
+    private ExtensionFormHandler extensionFormHandler;
+    private ExtensionLoader extensionLoader;
+    private ExtensionSpiderFormHandler extension;
+
+    @BeforeEach
+    void setUp() {
+        extension = new ExtensionSpiderFormHandler();
+        mockMessages("org.zaproxy.addon.spider." + Constant.MESSAGES_PREFIX, "spider");
+
+        Model model = mock(Model.class, withSettings().lenient());
+        Model.setSingletonForTesting(model);
+
+        extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        Control.initSingletonForTesting(model, extensionLoader);
+
+        extensionSpider = mockLoadedExtension(ExtensionSpider2.class);
+        extensionFormHandler = mockLoadedExtension(ExtensionFormHandler.class);
+    }
+
+    private <T extends Extension> T mockLoadedExtension(Class<T> clazz) {
+        T extension = mock(clazz);
+        given(extensionLoader.getExtension(clazz)).willReturn(extension);
+        return extension;
+    }
+
+    @Test
+    void shouldHaveName() {
+        assertThat(
+                extension.getName(),
+                is(equalTo("org.zaproxy.addon.spider.formhandler.ExtensionSpiderFormHandler")));
+    }
+
+    @Test
+    void shouldHaveUiName() {
+        assertThat(extension.getUIName(), is(not(emptyString())));
+    }
+
+    @Test
+    void shouldHaveDescription() {
+        assertThat(extension.getDescription(), is(not(emptyString())));
+    }
+
+    @Test
+    void shouldHaveExpectedDependencies() {
+        assertThat(
+                extension.getDependencies(),
+                containsInAnyOrder(ExtensionFormHandler.class, ExtensionSpider2.class));
+    }
+
+    @Test
+    void shouldSetValueGeneratorOnHook() {
+        // Given
+        ValueGenerator valueGenerator = mock(ValueGenerator.class);
+        given(extensionFormHandler.getValueGenerator()).willReturn(valueGenerator);
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        // When
+        extension.hook(extensionHook);
+        // Then
+        verify(extensionSpider).setValueGenerator(valueGenerator);
+    }
+
+    @Test
+    void shouldBeUnloadable() {
+        assertThat(extension.canUnload(), is(true));
+    }
+
+    @Test
+    void shouldUnload() {
+        // Given / When
+        extension.unload();
+        // Then
+        verify(extensionSpider).setValueGenerator(null);
+    }
+}


### PR DESCRIPTION
Add extension that depends on the Form Handler add-on to use its value
generator.

Part of zaproxy/zaproxy#3113.