### PR TITLE
spider: add automation job

### DIFF
--- a/addOns/automation/CHANGELOG.md
+++ b/addOns/automation/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Maintenance changes.
+- Rely on spider add-on (Issue 3113).
 
 ### Fixed
 - Correct loading of custom scripts (e.g. Zest).

--- a/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
+++ b/addOns/automation/src/main/java/org/zaproxy/addon/automation/ExtensionAutomation.java
@@ -59,6 +59,7 @@ import org.zaproxy.addon.automation.jobs.SpiderJob;
 import org.zaproxy.zap.ZAP;
 import org.zaproxy.zap.ZAP.ProcessType;
 import org.zaproxy.zap.eventBus.Event;
+import org.zaproxy.zap.extension.spider.ExtensionSpider;
 import org.zaproxy.zap.utils.Stats;
 
 public class ExtensionAutomation extends ExtensionAdaptor implements CommandLineListener {
@@ -113,7 +114,9 @@ public class ExtensionAutomation extends ExtensionAdaptor implements CommandLine
         registerAutomationJob(new PassiveScanConfigJob());
         registerAutomationJob(new RequestorJob());
         registerAutomationJob(new PassiveScanWaitJob());
-        registerAutomationJob(new SpiderJob());
+        if (ExtensionSpider.class.getAnnotation(Deprecated.class) == null) {
+            registerAutomationJob(new SpiderJob());
+        }
         registerAutomationJob(new DelayJob());
         registerAutomationJob(new ActiveScanJob());
         registerAutomationJob(new ParamsJob());

--- a/addOns/spider/spider.gradle.kts
+++ b/addOns/spider/spider.gradle.kts
@@ -12,6 +12,19 @@ zapAddOn {
         url.set("https://www.zaproxy.org/docs/desktop/addons/spider/")
 
         extensions {
+            register("org.zaproxy.addon.spider.automation.ExtensionSpiderAutomation") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.addon.spider.automation"))
+                }
+                dependencies {
+                    addOns {
+                        register("automation") {
+                            version.set(">=0.17.0")
+                        }
+                    }
+                }
+            }
+
             register("org.zaproxy.addon.spider.formhandler.ExtensionSpiderFormHandler") {
                 classnames {
                     allowed.set(listOf("org.zaproxy.addon.spider.formhandler"))
@@ -29,8 +42,10 @@ zapAddOn {
 }
 
 dependencies {
+    compileOnly(parent!!.childProjects.get("automation")!!)
     compileOnly(parent!!.childProjects.get("formhandler")!!)
 
+    testImplementation(parent!!.childProjects.get("automation")!!)
     testImplementation(parent!!.childProjects.get("formhandler")!!)
     testImplementation(project(":testutils"))
 }

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/ExtensionSpiderAutomation.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/ExtensionSpiderAutomation.java
@@ -1,0 +1,84 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider.automation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.addon.automation.ExtensionAutomation;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.zap.extension.spider.ExtensionSpider;
+
+public class ExtensionSpiderAutomation extends ExtensionAdaptor {
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionSpider2.class, ExtensionAutomation.class));
+
+    private SpiderJob job;
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("spider.automation.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("spider.automation.desc");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        if (ExtensionSpider.class.getAnnotation(Deprecated.class) == null) {
+            return;
+        }
+
+        job = new SpiderJob();
+        getExtension(ExtensionAutomation.class).registerAutomationJob(job);
+    }
+
+    private static <T extends Extension> T getExtension(Class<T> clazz) {
+        return Control.getSingleton().getExtensionLoader().getExtension(clazz);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        if (job == null) {
+            return;
+        }
+
+        getExtension(ExtensionAutomation.class).unregisterAutomationJob(job);
+    }
+}

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJob.java
@@ -1,0 +1,640 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider.automation;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.commons.httpclient.URI;
+import org.apache.commons.lang.StringUtils;
+import org.parosproxy.paros.CommandLine;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.HistoryReference;
+import org.parosproxy.paros.model.Model;
+import org.parosproxy.paros.network.ConnectionParam;
+import org.parosproxy.paros.network.HttpMessage;
+import org.parosproxy.paros.network.HttpSender;
+import org.parosproxy.paros.network.HttpStatusCode;
+import org.zaproxy.addon.automation.AutomationData;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
+import org.zaproxy.addon.automation.jobs.JobData;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.automation.tests.AbstractAutomationTest;
+import org.zaproxy.addon.automation.tests.AutomationStatisticTest;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.addon.spider.SpiderScan;
+import org.zaproxy.zap.model.Target;
+import org.zaproxy.zap.users.User;
+import org.zaproxy.zap.utils.Stats;
+import org.zaproxy.zap.utils.ThreadUtils;
+
+public class SpiderJob extends AutomationJob {
+
+    public static final String JOB_NAME = "spider";
+    private static final String OPTIONS_METHOD_NAME = "getSpiderParam";
+
+    private static final String PARAM_CONTEXT = "context";
+    private static final String PARAM_URL = "url";
+    private static final String PARAM_FAIL_IF_LESS_URLS = "failIfFoundUrlsLessThan";
+    private static final String PARAM_WARN_IF_LESS_URLS = "warnIfFoundUrlsLessThan";
+
+    private ExtensionSpider2 extSpider;
+
+    private Data data;
+    private Parameters parameters = new Parameters();
+
+    private UrlRequester urlRequester = new UrlRequester(this.getName());
+
+    public SpiderJob() {
+        this.data = new Data(this, parameters);
+    }
+
+    @Override
+    public String getTemplateDataMin() {
+        return getResourceAsString(getType() + "-min.yaml");
+    }
+
+    private static String getResourceAsString(String fileName) {
+        try (InputStream in = SpiderJob.class.getResourceAsStream(fileName)) {
+            return new BufferedReader(new InputStreamReader(in))
+                            .lines()
+                            .collect(Collectors.joining("\n"))
+                    + "\n";
+        } catch (Exception e) {
+            CommandLine.error(
+                    Constant.messages.getString("spider.automation.error.nofile", fileName));
+        }
+        return "";
+    }
+
+    @Override
+    public String getTemplateDataMax() {
+        return getResourceAsString(getType() + "-max.yaml");
+    }
+
+    private ExtensionSpider2 getExtSpider() {
+        if (extSpider == null) {
+            extSpider =
+                    Control.getSingleton()
+                            .getExtensionLoader()
+                            .getExtension(ExtensionSpider2.class);
+        }
+        return extSpider;
+    }
+
+    @Override
+    public void verifyParameters(AutomationProgress progress) {
+        Map<?, ?> jobData = this.getJobData();
+        if (jobData == null) {
+            return;
+        }
+        JobUtils.applyParamsToObject(
+                (LinkedHashMap<?, ?>) jobData.get("parameters"),
+                this.parameters,
+                this.getName(),
+                null,
+                progress);
+
+        this.verifyUser(this.getParameters().getUser(), progress);
+
+        if (this.getParameters().getWarnIfFoundUrlsLessThan() != null
+                || this.getParameters().getFailIfFoundUrlsLessThan() != null) {
+            progress.warn(
+                    Constant.messages.getString(
+                            "spider.automation.error.failIfUrlsLessThan.deprecated",
+                            getName(),
+                            "spider.automation.urls.added"));
+        }
+    }
+
+    @Override
+    public void applyParameters(AutomationProgress progress) {
+        JobUtils.applyObjectToObject(
+                this.parameters,
+                JobUtils.getJobOptions(this, progress),
+                this.getName(),
+                new String[] {
+                    PARAM_CONTEXT, PARAM_URL, PARAM_FAIL_IF_LESS_URLS, PARAM_WARN_IF_LESS_URLS
+                },
+                progress,
+                this.getPlan().getEnv());
+    }
+
+    @Override
+    public Map<String, String> getCustomConfigParameters() {
+        Map<String, String> map = super.getCustomConfigParameters();
+        map.put(PARAM_CONTEXT, "");
+        map.put(PARAM_URL, "");
+        return map;
+    }
+
+    @Override
+    public void runJob(AutomationEnvironment env, AutomationProgress progress) {
+
+        ContextWrapper context;
+        if (parameters.getContext() != null) {
+            context = env.getContextWrapper(parameters.getContext());
+            if (context == null) {
+                progress.error(
+                        Constant.messages.getString(
+                                "automation.error.context.unknown", parameters.getContext()));
+                return;
+            }
+        } else {
+            context = env.getDefaultContextWrapper();
+        }
+        URI uri = null;
+        String urlStr = parameters.getUrl();
+        try {
+            if (urlStr != null) {
+                urlStr = env.replaceVars(urlStr);
+                uri = new URI(urlStr, true);
+            }
+        } catch (Exception e1) {
+            progress.error(Constant.messages.getString("automation.error.context.badurl", urlStr));
+            return;
+        }
+        User user = this.getUser(this.getParameters().getUser(), progress);
+
+        // Request all specified URLs
+        for (String u : context.getUrls()) {
+            urlStr = env.replaceVars(u);
+            progress.info(
+                    Constant.messages.getString("automation.info.requrl", this.getName(), urlStr));
+            this.urlRequester.requestUrl(urlStr, user, progress);
+        }
+
+        if (env.isTimeToQuit()) {
+            // Failed to access one of the URLs
+            return;
+        }
+
+        Target target = new Target(context.getContext());
+        target.setRecurse(true);
+        List<Object> contextSpecificObjects = new ArrayList<>();
+        if (uri != null) {
+            contextSpecificObjects.add(uri);
+        }
+
+        int scanId = this.getExtSpider().startScan(target, user, contextSpecificObjects.toArray());
+
+        long endTime = Long.MAX_VALUE;
+        if (parameters.getMaxDuration() != null && parameters.getMaxDuration() > 0) {
+            // The spider should stop, if it doesnt we will stop it (after a few seconds leeway)
+            endTime =
+                    System.currentTimeMillis()
+                            + TimeUnit.MINUTES.toMillis(parameters.getMaxDuration())
+                            + TimeUnit.SECONDS.toMillis(5);
+        }
+
+        // Wait for the spider to finish
+        SpiderScan scan;
+
+        while (true) {
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+            scan = this.getExtSpider().getScan(scanId);
+            if (scan.isStopped()) {
+                break;
+            }
+            if (System.currentTimeMillis() > endTime) {
+                // It should have stopped but didn't (happens occasionally)
+                this.getExtSpider().stopScan(scanId);
+                break;
+            }
+        }
+
+        int numUrlsFound = scan.getNumberOfURIsFound();
+        progress.info(
+                Constant.messages.getString(
+                        "automation.info.urlsfound", this.getName(), numUrlsFound));
+        Stats.incCounter("spider.automation.urls.added", numUrlsFound);
+    }
+
+    /**
+     * Only for use by unit tests
+     *
+     * @param urlRequester the UrlRequester to use
+     */
+    protected void setUrlRequester(UrlRequester urlRequester) {
+        this.urlRequester = urlRequester;
+    }
+
+    @Override
+    public boolean isExcludeParam(String param) {
+        switch (param) {
+            case "confirmRemoveDomainAlwaysInScope":
+            case "maxScansInUI":
+            case "showAdvancedDialog":
+            case "skipURLString":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public Parameters getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public void showDialog() {
+        new SpiderJobDialog(this).setVisible(true);
+    }
+
+    @Override
+    public String getSummary() {
+        String context = this.getParameters().getContext();
+        if (StringUtils.isEmpty(context)) {
+            context = Constant.messages.getString("automation.dialog.default");
+        }
+        return Constant.messages.getString(
+                "spider.automation.dialog.summary",
+                context,
+                JobUtils.unBox(this.getParameters().getUrl(), "''"));
+    }
+
+    @Override
+    public String getType() {
+        return JOB_NAME;
+    }
+
+    @Override
+    public Order getOrder() {
+        return Order.LAST_EXPLORE;
+    }
+
+    @Override
+    public Object getParamMethodObject() {
+        return this.getExtSpider();
+    }
+
+    @Override
+    public String getParamMethodName() {
+        return OPTIONS_METHOD_NAME;
+    }
+
+    @Override
+    public int addDefaultTests(AutomationProgress progress) {
+        AutomationStatisticTest test =
+                new AutomationStatisticTest(
+                        "spider.automation.urls.added",
+                        Constant.messages.getString(
+                                "spider.automation.dialog.tests.stats.defaultname", 100),
+                        AutomationStatisticTest.Operator.GREATER_OR_EQUAL.getSymbol(),
+                        100,
+                        AbstractAutomationTest.OnFail.INFO.name(),
+                        this,
+                        progress);
+        this.addTest(test);
+        return 1;
+    }
+
+    public static class UrlRequester {
+
+        private final HttpSender httpSender;
+        private final String requester;
+
+        public UrlRequester(String requester) {
+            this.requester = requester;
+            httpSender =
+                    new HttpSender(
+                            Model.getSingleton().getOptionsParam().getConnectionParam(),
+                            true,
+                            HttpSender.SPIDER_INITIATOR);
+        }
+
+        public void requestUrl(String url, User user, AutomationProgress progress) {
+            // Request the URL
+            try {
+                final HttpMessage msg = new HttpMessage(new URI(url, true));
+
+                if (user != null) {
+                    msg.setRequestingUser(user);
+                }
+
+                httpSender.sendAndReceive(msg, true);
+
+                if (msg.getResponseHeader().getStatusCode() != HttpStatusCode.OK) {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "spider.automation.error.url.notok",
+                                    requester,
+                                    url,
+                                    msg.getResponseHeader().getStatusCode()));
+                    return;
+                }
+
+                ExtensionHistory extHistory =
+                        Control.getSingleton()
+                                .getExtensionLoader()
+                                .getExtension(ExtensionHistory.class);
+                extHistory.addHistory(msg, HistoryReference.TYPE_SPIDER);
+
+                ThreadUtils.invokeAndWait(
+                        () ->
+                                // Needs to be done on the EDT
+                                Model.getSingleton()
+                                        .getSession()
+                                        .getSiteTree()
+                                        .addPath(msg.getHistoryRef()));
+            } catch (UnknownHostException e1) {
+                ConnectionParam connectionParam =
+                        Model.getSingleton().getOptionsParam().getConnectionParam();
+                if (connectionParam.isUseProxyChain()
+                        && connectionParam.getProxyChainName().equalsIgnoreCase(e1.getMessage())) {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "spider.automation.error.url.badhost.proxychain",
+                                    requester,
+                                    url,
+                                    e1.getMessage()));
+                } else {
+                    progress.error(
+                            Constant.messages.getString(
+                                    "spider.automation.error.url.badhost",
+                                    requester,
+                                    url,
+                                    e1.getMessage()));
+                }
+            } catch (Exception e1) {
+                progress.error(
+                        Constant.messages.getString(
+                                "spider.automation.error.url.failed",
+                                requester,
+                                url,
+                                e1.getMessage()));
+            }
+        }
+    }
+
+    @Override
+    public Data getData() {
+        return data;
+    }
+
+    public static class Data extends JobData {
+        private Parameters parameters;
+
+        public Data(AutomationJob job, Parameters parameters) {
+            super(job);
+            this.parameters = parameters;
+        }
+
+        public Parameters getParameters() {
+            return parameters;
+        }
+    }
+
+    public static class Parameters extends AutomationData {
+        private String context;
+        private String user;
+        private String url;
+        private Integer maxDuration;
+        private Integer maxDepth;
+        private Integer maxChildren;
+        private Boolean acceptCookies;
+        private Boolean handleODataParametersVisited;
+        private String handleParameters;
+        private Integer maxParseSizeBytes;
+        private Boolean parseComments;
+        private Boolean parseGit;
+        private Boolean parseRobotsTxt;
+        private Boolean parseSitemapXml;
+        private Boolean parseSVNEntries;
+        private Boolean postForm;
+        private Boolean processForm;
+        private Integer requestWaitTime;
+        private Boolean sendRefererHeader;
+        private Integer threadCount;
+        private String userAgent;
+        // These 2 fields are deprecated
+        private Boolean failIfFoundUrlsLessThan;
+        private Boolean warnIfFoundUrlsLessThan;
+
+        public Parameters() {
+            super();
+        }
+
+        public void setMaxDuration(int maxDuration) {
+            this.maxDuration = maxDuration;
+        }
+
+        public Integer getMaxDuration() {
+            return maxDuration;
+        }
+
+        public String getContext() {
+            return context;
+        }
+
+        public void setContext(String context) {
+            this.context = context;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public void setUser(String user) {
+            this.user = user;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public Integer getMaxDepth() {
+            return maxDepth;
+        }
+
+        public void setMaxDepth(Integer maxDepth) {
+            this.maxDepth = maxDepth;
+        }
+
+        public Integer getMaxChildren() {
+            return maxChildren;
+        }
+
+        public void setMaxChildren(Integer maxChildren) {
+            this.maxChildren = maxChildren;
+        }
+
+        public Boolean getAcceptCookies() {
+            return acceptCookies;
+        }
+
+        public void setAcceptCookies(Boolean acceptCookies) {
+            this.acceptCookies = acceptCookies;
+        }
+
+        public Boolean getHandleODataParametersVisited() {
+            return handleODataParametersVisited;
+        }
+
+        public void setHandleODataParametersVisited(Boolean handleODataParametersVisited) {
+            this.handleODataParametersVisited = handleODataParametersVisited;
+        }
+
+        public void setMaxDuration(Integer maxDuration) {
+            this.maxDuration = maxDuration;
+        }
+
+        public String getHandleParameters() {
+            return handleParameters;
+        }
+
+        public void setHandleParameters(String handleParameters) {
+            this.handleParameters = handleParameters;
+        }
+
+        public Integer getMaxParseSizeBytes() {
+            return maxParseSizeBytes;
+        }
+
+        public void setMaxParseSizeBytes(Integer maxParseSizeBytes) {
+            this.maxParseSizeBytes = maxParseSizeBytes;
+        }
+
+        public Boolean getParseComments() {
+            return parseComments;
+        }
+
+        public void setParseComments(Boolean parseComments) {
+            this.parseComments = parseComments;
+        }
+
+        public Boolean getParseGit() {
+            return parseGit;
+        }
+
+        public void setParseGit(Boolean parseGit) {
+            this.parseGit = parseGit;
+        }
+
+        public Boolean getParseRobotsTxt() {
+            return parseRobotsTxt;
+        }
+
+        public void setParseRobotsTxt(Boolean parseRobotsTxt) {
+            this.parseRobotsTxt = parseRobotsTxt;
+        }
+
+        public Boolean getParseSitemapXml() {
+            return parseSitemapXml;
+        }
+
+        public void setParseSitemapXml(Boolean parseSitemapXml) {
+            this.parseSitemapXml = parseSitemapXml;
+        }
+
+        public Boolean getParseSVNEntries() {
+            return parseSVNEntries;
+        }
+
+        public void setParseSVNEntries(Boolean parseSVNEntries) {
+            this.parseSVNEntries = parseSVNEntries;
+        }
+
+        public Boolean getPostForm() {
+            return postForm;
+        }
+
+        public void setPostForm(Boolean postForm) {
+            this.postForm = postForm;
+        }
+
+        public Boolean getProcessForm() {
+            return processForm;
+        }
+
+        public void setProcessForm(Boolean processForm) {
+            this.processForm = processForm;
+        }
+
+        public Integer getRequestWaitTime() {
+            return requestWaitTime;
+        }
+
+        public void setRequestWaitTime(Integer requestWaitTime) {
+            this.requestWaitTime = requestWaitTime;
+        }
+
+        public Boolean getSendRefererHeader() {
+            return sendRefererHeader;
+        }
+
+        public void setSendRefererHeader(Boolean sendRefererHeader) {
+            this.sendRefererHeader = sendRefererHeader;
+        }
+
+        public Integer getThreadCount() {
+            return threadCount;
+        }
+
+        public void setThreadCount(Integer threadCount) {
+            this.threadCount = threadCount;
+        }
+
+        public String getUserAgent() {
+            return userAgent;
+        }
+
+        public void setUserAgent(String userAgent) {
+            this.userAgent = userAgent;
+        }
+
+        public Boolean getFailIfFoundUrlsLessThan() {
+            return failIfFoundUrlsLessThan;
+        }
+
+        public void setFailIfFoundUrlsLessThan(Boolean failIfFoundUrlsLessThan) {
+            this.failIfFoundUrlsLessThan = failIfFoundUrlsLessThan;
+        }
+
+        public Boolean getWarnIfFoundUrlsLessThan() {
+            return warnIfFoundUrlsLessThan;
+        }
+
+        public void setWarnIfFoundUrlsLessThan(Boolean warnIfFoundUrlsLessThan) {
+            this.warnIfFoundUrlsLessThan = warnIfFoundUrlsLessThan;
+        }
+    }
+}

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJobDialog.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/automation/SpiderJobDialog.java
@@ -1,0 +1,313 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider.automation;
+
+import java.awt.Component;
+import java.util.Arrays;
+import java.util.List;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JTextField;
+import org.parosproxy.paros.view.View;
+import org.zaproxy.addon.automation.jobs.JobUtils;
+import org.zaproxy.addon.spider.SpiderParam;
+import org.zaproxy.addon.spider.SpiderParam.HandleParametersOption;
+import org.zaproxy.zap.utils.DisplayUtils;
+import org.zaproxy.zap.view.StandardFieldsDialog;
+
+@SuppressWarnings("serial")
+public class SpiderJobDialog extends StandardFieldsDialog {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String[] TAB_LABELS = {
+        "automation.dialog.tab.params",
+        "spider.automation.dialog.tab.parse",
+        "spider.automation.dialog.tab.adv"
+    };
+
+    private static final String TITLE = "spider.automation.dialog.title";
+    private static final String NAME_PARAM = "automation.dialog.all.name";
+    private static final String CONTEXT_PARAM = "spider.automation.dialog.context";
+    private static final String USER_PARAM = "automation.dialog.all.user";
+    private static final String URL_PARAM = "spider.automation.dialog.url";
+    private static final String MAX_DURATION_PARAM = "spider.automation.dialog.maxduration";
+    private static final String MAX_DEPTH_PARAM = "spider.automation.dialog.maxdepth";
+    private static final String MAX_CHILDREN_PARAM = "spider.automation.dialog.maxchildren";
+    private static final String FIELD_ADVANCED = "spider.automation.dialog.advanced";
+
+    private static final String ACCEPT_COOKIES_PARAM = "spider.automation.dialog.acceptcookies";
+    private static final String HANDLE_ODATA_PARAM = "spider.automation.dialog.handleodata";
+    private static final String HANDLE_PARAMS_PARAM = "spider.automation.dialog.handleparams";
+    private static final String MAX_PARSE_PARAM = "spider.automation.dialog.maxparse";
+    private static final String PARSE_COMMENTS_PARAM = "spider.automation.dialog.parsecomments";
+    private static final String PARSE_GIT_PARAM = "spider.automation.dialog.parsegit";
+    private static final String PARSE_ROBOTS_PARAM = "spider.automation.dialog.parserobots";
+    private static final String PARSE_SITEMAP_PARAM = "spider.automation.dialog.parsesitemap";
+    private static final String PARSE_SVN_PARAM = "spider.automation.dialog.parsessvn";
+    private static final String POST_FORM_PARAM = "spider.automation.dialog.postform";
+    private static final String PROCESS_FORM_PARAM = "spider.automation.dialog.processform";
+    private static final String REQ_WAIT_TIME_PARAM = "spider.automation.dialog.reqwaittime";
+    private static final String SEND_REFERER_PARAM = "spider.automation.dialog.sendreferer";
+    private static final String THREAD_COUNT_PARAM = "spider.automation.dialog.threadcount";
+    private static final String USER_AGENT_PARAM = "spider.automation.dialog.useragent";
+
+    private SpiderJob job;
+    private DefaultComboBoxModel<SpiderParam.HandleParametersOption> handleParamsModel;
+
+    public SpiderJobDialog(SpiderJob job) {
+        super(
+                View.getSingleton().getMainFrame(),
+                TITLE,
+                DisplayUtils.getScaledDimension(500, 400),
+                TAB_LABELS);
+        this.job = job;
+
+        this.addTextField(0, NAME_PARAM, this.job.getData().getName());
+        List<String> contextNames = this.job.getEnv().getContextNames();
+        // Add blank option
+        contextNames.add(0, "");
+        this.addComboField(0, CONTEXT_PARAM, contextNames, this.job.getParameters().getContext());
+
+        List<String> users = job.getEnv().getAllUserNames();
+        // Add blank option
+        users.add(0, "");
+        this.addComboField(0, USER_PARAM, users, this.job.getData().getParameters().getUser());
+
+        // Cannot select the node as it might not be present in the Sites tree
+        this.addNodeSelectField(0, URL_PARAM, null, true, false);
+        Component urlField = this.getField(URL_PARAM);
+        if (urlField instanceof JTextField) {
+            ((JTextField) urlField).setText(this.job.getParameters().getUrl());
+        }
+        this.addNumberField(
+                0,
+                MAX_DURATION_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxDuration()));
+        this.addNumberField(
+                0,
+                MAX_DEPTH_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxDepth()));
+        this.addNumberField(
+                0,
+                MAX_CHILDREN_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxChildren()));
+        this.addCheckBoxField(0, FIELD_ADVANCED, advOptionsSet());
+
+        this.addFieldListener(FIELD_ADVANCED, e -> setAdvancedTabs(getBoolValue(FIELD_ADVANCED)));
+
+        this.addPadding(0);
+
+        this.addCheckBoxField(
+                1,
+                PARSE_COMMENTS_PARAM,
+                JobUtils.unBox(this.job.getParameters().getParseComments()));
+        this.addCheckBoxField(
+                1, PARSE_GIT_PARAM, JobUtils.unBox(this.job.getParameters().getParseGit()));
+        this.addCheckBoxField(
+                1,
+                PARSE_ROBOTS_PARAM,
+                JobUtils.unBox(this.job.getParameters().getParseRobotsTxt()));
+        this.addCheckBoxField(
+                1,
+                PARSE_SITEMAP_PARAM,
+                JobUtils.unBox(this.job.getParameters().getParseSitemapXml()));
+        this.addCheckBoxField(
+                1, PARSE_SVN_PARAM, JobUtils.unBox(this.job.getParameters().getParseSVNEntries()));
+
+        this.addPadding(1);
+
+        this.addNumberField(
+                2,
+                MAX_PARSE_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getMaxParseSizeBytes()));
+        this.addNumberField(
+                2,
+                REQ_WAIT_TIME_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getRequestWaitTime()));
+        this.addNumberField(
+                2,
+                THREAD_COUNT_PARAM,
+                0,
+                Integer.MAX_VALUE,
+                JobUtils.unBox(this.job.getParameters().getThreadCount()));
+
+        handleParamsModel = new DefaultComboBoxModel<>();
+        Arrays.stream(SpiderParam.HandleParametersOption.values())
+                .forEach(v -> handleParamsModel.addElement(v));
+        DefaultListCellRenderer renderer =
+                new DefaultListCellRenderer() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Component getListCellRendererComponent(
+                            JList<?> list,
+                            Object value,
+                            int index,
+                            boolean isSelected,
+                            boolean cellHasFocus) {
+                        JLabel label =
+                                (JLabel)
+                                        super.getListCellRendererComponent(
+                                                list, value, index, isSelected, cellHasFocus);
+                        if (value instanceof HandleParametersOption) {
+                            // The name is i18n'ed
+                            label.setText(((HandleParametersOption) value).getName());
+                        }
+                        return label;
+                    }
+                };
+
+        SpiderParam.HandleParametersOption hpo = null;
+        if (this.job.getParameters().getHandleParameters() != null) {
+            hpo =
+                    SpiderParam.HandleParametersOption.valueOf(
+                            this.job.getParameters().getHandleParameters());
+            handleParamsModel.setSelectedItem(hpo);
+        }
+        this.addComboField(2, HANDLE_PARAMS_PARAM, handleParamsModel);
+        Component acField = this.getField(HANDLE_PARAMS_PARAM);
+        if (acField instanceof JComboBox) {
+            ((JComboBox<?>) acField).setRenderer(renderer);
+        }
+
+        this.addCheckBoxField(
+                2,
+                ACCEPT_COOKIES_PARAM,
+                JobUtils.unBox(this.job.getParameters().getAcceptCookies()));
+        this.addCheckBoxField(
+                2,
+                HANDLE_ODATA_PARAM,
+                JobUtils.unBox(this.job.getParameters().getHandleODataParametersVisited()));
+
+        this.addCheckBoxField(
+                2, POST_FORM_PARAM, JobUtils.unBox(this.job.getParameters().getPostForm()));
+        this.addCheckBoxField(
+                2, PROCESS_FORM_PARAM, JobUtils.unBox(this.job.getParameters().getProcessForm()));
+        this.addCheckBoxField(
+                2,
+                SEND_REFERER_PARAM,
+                JobUtils.unBox(this.job.getParameters().getSendRefererHeader()));
+        this.addTextField(2, USER_AGENT_PARAM, this.job.getParameters().getUserAgent());
+
+        this.addPadding(2);
+
+        setAdvancedTabs(getBoolValue(FIELD_ADVANCED));
+    }
+
+    private boolean advOptionsSet() {
+        SpiderJob.Parameters params = this.job.getParameters();
+        return params.getAcceptCookies() != null
+                || params.getHandleODataParametersVisited() != null
+                || params.getMaxParseSizeBytes() != null
+                || params.getParseComments() != null
+                || params.getParseGit() != null
+                || params.getParseRobotsTxt() != null
+                || params.getParseSitemapXml() != null
+                || params.getParseSVNEntries() != null
+                || params.getPostForm() != null
+                || params.getProcessForm() != null
+                || params.getRequestWaitTime() != null
+                || params.getSendRefererHeader() != null
+                || params.getThreadCount() != null
+                || params.getUserAgent() != null;
+    }
+
+    private void setAdvancedTabs(boolean visible) {
+        // Show/hide all except from the first tab
+        this.setTabsVisible(
+                new String[] {
+                    "spider.automation.dialog.tab.parse", "spider.automation.dialog.tab.adv"
+                },
+                visible);
+    }
+
+    @Override
+    public void save() {
+        this.job.getData().setName(this.getStringValue(NAME_PARAM));
+        this.job.getParameters().setContext(this.getStringValue(CONTEXT_PARAM));
+        this.job.getParameters().setUser(this.getStringValue(USER_PARAM));
+        this.job.getParameters().setUrl(this.getStringValue(URL_PARAM));
+        this.job.getParameters().setMaxDuration(this.getIntValue(MAX_DURATION_PARAM));
+        this.job.getParameters().setMaxDepth(this.getIntValue(MAX_DEPTH_PARAM));
+        this.job.getParameters().setMaxChildren(this.getIntValue(MAX_CHILDREN_PARAM));
+
+        if (JobUtils.unBox(this.getBoolValue(FIELD_ADVANCED))) {
+            this.job.getParameters().setAcceptCookies(this.getBoolValue(ACCEPT_COOKIES_PARAM));
+            this.job
+                    .getParameters()
+                    .setHandleODataParametersVisited(this.getBoolValue(HANDLE_ODATA_PARAM));
+            this.job.getParameters().setMaxParseSizeBytes(this.getIntValue(MAX_PARSE_PARAM));
+            this.job.getParameters().setParseComments(this.getBoolValue(PARSE_COMMENTS_PARAM));
+            this.job.getParameters().setParseGit(this.getBoolValue(PARSE_GIT_PARAM));
+            this.job.getParameters().setParseRobotsTxt(this.getBoolValue(PARSE_ROBOTS_PARAM));
+            this.job.getParameters().setParseSitemapXml(this.getBoolValue(PARSE_SITEMAP_PARAM));
+            this.job.getParameters().setParseSVNEntries(this.getBoolValue(PARSE_SVN_PARAM));
+            this.job.getParameters().setPostForm(this.getBoolValue(POST_FORM_PARAM));
+            this.job.getParameters().setProcessForm(this.getBoolValue(PROCESS_FORM_PARAM));
+            this.job.getParameters().setRequestWaitTime(this.getIntValue(REQ_WAIT_TIME_PARAM));
+            this.job.getParameters().setSendRefererHeader(this.getBoolValue(SEND_REFERER_PARAM));
+            this.job.getParameters().setUserAgent(this.getStringValue(USER_AGENT_PARAM));
+
+            Object hpoObj = handleParamsModel.getSelectedItem();
+            if (hpoObj instanceof SpiderParam.HandleParametersOption) {
+                SpiderParam.HandleParametersOption hpo =
+                        (SpiderParam.HandleParametersOption) hpoObj;
+                this.job.getParameters().setHandleParameters(hpo.name());
+            }
+
+        } else {
+            this.job.getParameters().setAcceptCookies(null);
+            this.job.getParameters().setHandleODataParametersVisited(null);
+            this.job.getParameters().setMaxParseSizeBytes(null);
+            this.job.getParameters().setParseComments(null);
+            this.job.getParameters().setParseGit(null);
+            this.job.getParameters().setParseRobotsTxt(null);
+            this.job.getParameters().setParseSitemapXml(null);
+            this.job.getParameters().setParseSVNEntries(null);
+            this.job.getParameters().setPostForm(null);
+            this.job.getParameters().setProcessForm(null);
+            this.job.getParameters().setRequestWaitTime(null);
+            this.job.getParameters().setSendRefererHeader(null);
+            this.job.getParameters().setUserAgent(null);
+            this.job.getParameters().setHandleParameters(null);
+        }
+        this.job.resetAndSetChanged();
+    }
+
+    @Override
+    public String validateFields() {
+        // Nothing to do TODO validate url - coping with envvars :O
+        return null;
+    }
+}

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/automation.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/automation.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8">
+<TITLE>
+Spider Automation Framework Support
+</TITLE>
+</HEAD>
+<BODY>
+<H1>Spider Automation Framework Support</H1>
+This add-on supports the Automation Framework.
+
+<H2>Job: spider</H2>
+The spider job runs the traditional spider. This is fast but does not handle modern applications as effectively.
+<p>
+By default this job will spider the first context defined in the environment and so none of the parameters are mandatory.
+
+<H2>YAML</H2>
+
+<pre>
+  - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
+    parameters:
+      context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
+      url:                             # String: Url to start spidering from, default: first context URL
+      maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
+      maxDepth:                        # Int: The maximum tree depth to explore, default 5
+      maxChildren:                     # Int: The maximum number of children to add to each node in the tree
+      acceptCookies:                   # Bool: Whether the spider will accept cookies, default: true
+      handleODataParametersVisited:    # Bool: Whether the spider will handle OData responses, default: false
+      handleParameters:                # Enum [ignore_completely, ignore_value, use_all]: How query string parameters are used when checking if a URI has already been visited, default: use_all
+      maxParseSizeBytes:               # Int: The max size of a response that will be parsed, default: 2621440 - 2.5 Mb
+      parseComments:                   # Bool: Whether the spider will parse HTML comments in order to find URLs, default: true
+      parseGit:                        # Bool: Whether the spider will parse Git metadata in order to find URLs, default: false
+      parseRobotsTxt:                  # Bool: Whether the spider will parse 'robots.txt' files in order to find URLs, default: true
+      parseSitemapXml:                 # Bool: Whether the spider will parse 'sitemap.xml' files in order to find URLs, default: true
+      parseSVNEntries:                 # Bool: Whether the spider will parse SVN metadata in order to find URLs, default: false
+      postForm:                        # Bool: Whether the spider will submit POST forms, default: true
+      processForm:                     # Bool: Whether the spider will process forms, default: true
+      requestWaitTime:                 # Int: The time between the requests sent to a server in milliseconds, default: 200
+      sendRefererHeader:               # Bool: Whether the spider will send the referer header, default: true
+      threadCount:                     # Int: The number of spider threads, default: 2
+      userAgent:                       # String: The user agent to use in requests, default: '' - use the default ZAP one 
+    tests:
+      - name: 'At least 100 URLs found'                 # String: Name of the test, default: statistic + operator + value
+        type: 'stats'                                   # String: Type of test, only 'stats' is supported for now
+        statistic: 'automation.spider.urls.added'       # String: Name of an integer / long statistic, currently supported: 'automation.spider.urls.added'
+        operator: '>='                                  # String ['==', '!=', '>=', '>', '<', '<=']: Operator used for testing
+        value: 100                                      # Int: Change this to the number of URLs you expect to find
+        onFail: 'info'                                  # String: One of 'warn', 'error', 'info', mandatory
+</pre>
+
+</BODY>
+</HTML>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/index.xml
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/index.xml
@@ -5,6 +5,7 @@
 
 <index version="2.0">
     <indexitem text="Spider" target="addon.spider"/>
+	<indexitem text="spider automation" target="addon.spider.automation" />
     <indexitem text="Spider dialog" target="addon.spider.dialog"/>
     <indexitem text="Spider tab" target="addon.spider.tab"/>
     <indexitem text="Spider options" target="addon.spider.options"/>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/map.jhm
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/map.jhm
@@ -7,6 +7,7 @@
 	<mapID target="addon.spider.icon" url="contents/images/spider.png"/>
 
     <mapID target="addon.spider" url="contents/spider.html"/>
+    <mapID target="addon.spider.automation" url="contents/automation.html"/>
     <mapID target="addon.spider.dialog" url="contents/dialog.html"/>
     <mapID target="addon.spider.tab" url="contents/tab.html"/>
     <mapID target="addon.spider.options" url="contents/options.html"/>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/toc.xml
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/toc.xml
@@ -7,6 +7,7 @@
     <tocitem text="ZAP User Guide" tocid="toplevelitem">
         <tocitem text="Add Ons" tocid="addons">
             <tocitem text="Spider" image="addon.spider.icon" target="addon.spider">
+                <tocitem text="Automation" target="addon.spider.automation"/>
                 <tocitem text="Dialog" target="addon.spider.dialog"/>
                 <tocitem text="Tab" target="addon.spider.tab"/>
                 <tocitem text="Options" target="addon.spider.options"/>

--- a/addOns/spider/src/main/resources/org/zaproxy/addon/spider/Messages.properties
+++ b/addOns/spider/src/main/resources/org/zaproxy/addon/spider/Messages.properties
@@ -125,6 +125,46 @@ spider.api.view.results.param.scanId =
 spider.api.view.scans = 
 spider.api.view.status = 
 spider.api.view.status.param.scanId = 
+
+spider.automation.desc = Spider Automation Integration
+spider.automation.name = Spider Automation
+
+spider.automation.dialog.advanced = Show Advanced Options:
+spider.automation.dialog.summary = Context: {0}, URL: {1}
+spider.automation.dialog.title = Spider Job
+spider.automation.dialog.context = Context:
+spider.automation.dialog.url = URL:
+spider.automation.dialog.maxduration = Max Duration:
+spider.automation.dialog.maxdepth = Max Depth:
+spider.automation.dialog.maxchildren = Max Children:
+spider.automation.dialog.tab.adv = Advanced
+spider.automation.dialog.tab.parse = Parsing
+spider.automation.dialog.tests.stats.defaultname = At least {0} URLs found
+
+spider.automation.dialog.acceptcookies = Accept Cookies:
+spider.automation.dialog.handleodata = Handle OData:
+spider.automation.dialog.handleparams = Handle Parameters:
+spider.automation.dialog.maxparse = Max Size to Parse in Bytes:
+spider.automation.dialog.parsecomments = Parse Comments:
+spider.automation.dialog.parsegit = Parse GIT:
+spider.automation.dialog.parserobots = Parse Robots.txt:
+spider.automation.dialog.parsesitemap = Parse Sitemap:
+spider.automation.dialog.parsessvn = Parse SVN:
+
+spider.automation.dialog.postform = Post Forms:
+spider.automation.dialog.processform = Process Forms:
+spider.automation.dialog.reqwaittime = Request Wait Time
+spider.automation.dialog.sendreferer = Send "Referer" Header:
+spider.automation.dialog.threadcount = Number of Threads:
+spider.automation.dialog.useragent = User Agent:
+
+spider.automation.error.nofile = Cannot access file: {0}
+spider.automation.error.url.notok = Job {0} failed to access URL {1} status code returned : {2} expected 200
+spider.automation.error.url.badhost.proxychain = Job {0} failed to access URL {1} your proxy chain may be wrong : {2}
+spider.automation.error.url.badhost = Job {0} failed to access URL {1} check that it is valid : {2}
+spider.automation.error.url.failed = Job {0} failed to access URL {1} : {2}
+spider.automation.error.failIfUrlsLessThan.deprecated = Job {0} the fields 'failIfFoundUrlsLessThan' and 'warnIfFoundUrlsLessThan' have been replaced with the {1} stats test.
+
 spider.custom.button.reset	= Reset
 spider.custom.button.scan	= Start Scan
 spider.custom.label.adv		= Show Advanced Options

--- a/addOns/spider/src/main/resources/org/zaproxy/addon/spider/automation/spider-max.yaml
+++ b/addOns/spider/src/main/resources/org/zaproxy/addon/spider/automation/spider-max.yaml
@@ -1,0 +1,30 @@
+  - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
+    parameters:
+      context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
+      url:                             # String: Url to start spidering from, default: first context URL
+      maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
+      maxDepth:                        # Int: The maximum tree depth to explore, default 5
+      maxChildren:                     # Int: The maximum number of children to add to each node in the tree
+      acceptCookies:                   # Bool: Whether the spider will accept cookies, default: true
+      handleODataParametersVisited:    # Bool: Whether the spider will handle OData responses, default: false
+      handleParameters:                # Enum [ignore_completely, ignore_value, use_all]: How query string parameters are used when checking if a URI has already been visited, default: use_all
+      maxParseSizeBytes:               # Int: The max size of a response that will be parsed, default: 2621440 - 2.5 Mb
+      parseComments:                   # Bool: Whether the spider will parse HTML comments in order to find URLs, default: true
+      parseGit:                        # Bool: Whether the spider will parse Git metadata in order to find URLs, default: false
+      parseRobotsTxt:                  # Bool: Whether the spider will parse 'robots.txt' files in order to find URLs, default: true
+      parseSitemapXml:                 # Bool: Whether the spider will parse 'sitemap.xml' files in order to find URLs, default: true
+      parseSVNEntries:                 # Bool: Whether the spider will parse SVN metadata in order to find URLs, default: false
+      postForm:                        # Bool: Whether the spider will submit POST forms, default: true
+      processForm:                     # Bool: Whether the spider will process forms, default: true
+      requestWaitTime:                 # Int: The time between the requests sent to a server in milliseconds, default: 200
+      sendRefererHeader:               # Bool: Whether the spider will send the referer header, default: true
+      threadCount:                     # Int: The number of spider threads, default: 2
+      userAgent:                       # String: The user agent to use in requests, default: '' - use the default ZAP one
+    tests:
+      - name: 'At least X URLs found'                   # String: Name of the test, default: statistic + operator + value
+        type: 'stats'                                   # String: Type of test, only 'stats' is supported for now
+        statistic: 'automation.spider.urls.added'       # String: Name of an integer / long statistic, currently supported: 'automation.spider.urls.added'
+        operator: '>='                                  # String ['==', '!=', '>=', '>', '<', '<=']: Operator used for testing
+        value: 100                                      # Int: Change this to the number of URLs you expect to find
+        onFail: 'info'                                  # String: One of 'warn', 'error', 'info', mandatory

--- a/addOns/spider/src/main/resources/org/zaproxy/addon/spider/automation/spider-min.yaml
+++ b/addOns/spider/src/main/resources/org/zaproxy/addon/spider/automation/spider-min.yaml
@@ -1,0 +1,15 @@
+  - type: spider                       # The traditional spider - fast but doesnt handle modern apps so well
+    parameters:
+      context:                         # String: Name of the context to spider, default: first context
+      user:                            # String: An optional user to use for authentication, must be defined in the env
+      url:                             # String: Url to start spidering from, default: first context URL
+      maxDuration:                     # Int: The max time in minutes the spider will be allowed to run for, default: 0 unlimited
+      maxDepth:                        # Int: The maximum tree depth to explore
+      maxChildren:                     # Int: The maximum number of children to add to each node in the tree
+    tests:
+      - name: 'At least X URLs found'                   # String: Name of the test, default: statistic + operator + value
+        type: 'stats'                                   # String: Type of test, only 'stats' is supported for now
+        statistic: 'automation.spider.urls.added'       # String: Name of an integer / long statistic, currently supported: 'automation.spider.urls.added'
+        operator: '>='                                  # String ['==', '!=', '>=', '>', '<', '<=']: Operator used for testing
+        value: 100                                      # Int: Change this to the number of URLs you expect to find
+        onFail: 'info'                                  # String: One of 'warn', 'error', 'info', mandatory

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/automation/SpiderJobUnitTest.java
@@ -1,0 +1,716 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2021 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider.automation;
+
+import static fi.iki.elonen.NanoHTTPD.newFixedLengthResponse;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import fi.iki.elonen.NanoHTTPD;
+import fi.iki.elonen.NanoHTTPD.IHTTPSession;
+import fi.iki.elonen.NanoHTTPD.Response;
+import fi.iki.elonen.NanoHTTPD.Response.Status;
+import java.net.MalformedURLException;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.parosproxy.paros.CommandLine;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.ExtensionLoader;
+import org.parosproxy.paros.extension.history.ExtensionHistory;
+import org.parosproxy.paros.model.Model;
+import org.yaml.snakeyaml.Yaml;
+import org.zaproxy.addon.automation.AutomationEnvironment;
+import org.zaproxy.addon.automation.AutomationJob.Order;
+import org.zaproxy.addon.automation.AutomationProgress;
+import org.zaproxy.addon.automation.ContextWrapper;
+import org.zaproxy.addon.automation.tests.AutomationStatisticTest;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.addon.spider.SpiderParam;
+import org.zaproxy.addon.spider.SpiderScan;
+import org.zaproxy.addon.spider.automation.SpiderJob.UrlRequester;
+import org.zaproxy.zap.extension.stats.ExtensionStats;
+import org.zaproxy.zap.extension.stats.InMemoryStats;
+import org.zaproxy.zap.model.Context;
+import org.zaproxy.zap.model.Target;
+import org.zaproxy.zap.testutils.NanoServerHandler;
+import org.zaproxy.zap.testutils.TestUtils;
+import org.zaproxy.zap.utils.I18N;
+import org.zaproxy.zap.utils.ZapXmlConfiguration;
+
+class SpiderJobUnitTest extends TestUtils {
+
+    private static MockedStatic<CommandLine> mockedCmdLine;
+    private ExtensionSpider2 extSpider;
+    private ExtensionLoader extensionLoader;
+
+    private static UrlRequester urlRequester = mock(UrlRequester.class);
+
+    @BeforeAll
+    static void init() {
+        mockedCmdLine = Mockito.mockStatic(CommandLine.class);
+    }
+
+    @AfterAll
+    static void close() {
+        mockedCmdLine.close();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Constant.messages = new I18N(Locale.ENGLISH);
+
+        Model model = mock(Model.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        Model.setSingletonForTesting(model);
+        extensionLoader = mock(ExtensionLoader.class, withSettings().lenient());
+        extSpider = mock(ExtensionSpider2.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionSpider2.class)).willReturn(extSpider);
+
+        ExtensionStats extStats = mock(ExtensionStats.class);
+        given(extensionLoader.getExtension(ExtensionStats.class)).willReturn(extStats);
+        Mockito.lenient().when(extStats.getInMemoryStats()).thenReturn(mock(InMemoryStats.class));
+
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        Model.getSingleton().getOptionsParam().load(new ZapXmlConfiguration());
+    }
+
+    @Test
+    void shouldReturnDefaultFields() {
+        // Given
+
+        // When
+        SpiderJob job = new SpiderJob();
+
+        // Then
+        assertThat(job.getType(), is(equalTo("spider")));
+        assertThat(job.getName(), is(equalTo("spider")));
+        assertThat(job.getOrder(), is(equalTo(Order.LAST_EXPLORE)));
+        assertThat(job.getParamMethodObject(), is(extSpider));
+        assertThat(job.getParamMethodName(), is("getSpiderParam"));
+    }
+
+    @Test
+    void shouldReturnCustomConfigParams() {
+        // Given
+        SpiderJob job = new SpiderJob();
+
+        // When
+        Map<String, String> params = job.getCustomConfigParameters();
+
+        // Then
+        assertThat(params.size(), is(equalTo(2)));
+        assertThat(params.get("context"), is(equalTo("")));
+        assertThat(params.get("url"), is(equalTo("")));
+    }
+
+    @Test
+    void shouldReturnConfigParams() throws MalformedURLException {
+        // Given
+        SpiderJob job = new SpiderJob();
+
+        // When
+        Map<String, String> params =
+                job.getConfigParameters(new SpiderParamWrapper(), job.getParamMethodName());
+
+        // Then
+        assertThat(params.size(), is(equalTo(18)));
+        assertThat(params.containsKey("maxDuration"), is(equalTo(true)));
+        assertThat(params.containsKey("maxDepth"), is(equalTo(true)));
+        assertThat(params.containsKey("maxChildren"), is(equalTo(true)));
+        assertThat(params.containsKey("acceptCookies"), is(equalTo(true)));
+        assertThat(params.containsKey("handleODataParametersVisited"), is(equalTo(true)));
+        assertThat(params.containsKey("handleParameters"), is(equalTo(true)));
+        assertThat(params.containsKey("maxParseSizeBytes"), is(equalTo(true)));
+        assertThat(params.containsKey("parseComments"), is(equalTo(true)));
+        assertThat(params.containsKey("parseGit"), is(equalTo(true)));
+        assertThat(params.containsKey("parseRobotsTxt"), is(equalTo(true)));
+        assertThat(params.containsKey("parseSitemapXml"), is(equalTo(true)));
+        assertThat(params.containsKey("parseSVNEntries"), is(equalTo(true)));
+        assertThat(params.containsKey("postForm"), is(equalTo(true)));
+        assertThat(params.containsKey("processForm"), is(equalTo(true)));
+        assertThat(params.containsKey("requestWaitTime"), is(equalTo(true)));
+        assertThat(params.containsKey("sendRefererHeader"), is(equalTo(true)));
+        assertThat(params.containsKey("threadCount"), is(equalTo(true)));
+        assertThat(params.containsKey("userAgent"), is(equalTo(true)));
+    }
+
+    private static class SpiderParamWrapper {
+        @SuppressWarnings("unused")
+        public SpiderParam getSpiderParam() {
+            return new SpiderParam();
+        }
+    }
+
+    @Test
+    void shouldRunValidJob() throws MalformedURLException {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        contextWrapper.addUrl("https://www.example.com");
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+
+        // When
+        SpiderJob job = new SpiderJob();
+        job.setUrlRequester(urlRequester);
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(job.getType(), is(equalTo("spider")));
+        assertThat(job.getOrder(), is(equalTo(Order.LAST_EXPLORE)));
+        assertThat(job.getParamMethodObject(), is(extSpider));
+        assertThat(job.getParamMethodName(), is("getSpiderParam"));
+
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldFailIfInvalidUrl() throws MalformedURLException {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+
+        // When
+        SpiderJob job = new SpiderJob();
+        job.getParameters().setUrl("Not a url");
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!automation.error.context.badurl!")));
+    }
+
+    @Test
+    void shouldFailIfUnknownContext() throws MalformedURLException {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = new AutomationEnvironment(progress);
+
+        // When
+        SpiderJob job = new SpiderJob();
+        job.getParameters().setContext("Unknown");
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!automation.error.context.unknown!")));
+    }
+
+    @Test
+    void shouldUseSpecifiedContext() throws MalformedURLException {
+        // Given
+        Constant.messages = new I18N(Locale.ENGLISH);
+        Context context1 = mock(Context.class);
+        Context context2 = mock(Context.class);
+        Target target1 = new Target(context1);
+        Target target2 = new Target(context2);
+        ContextWrapper contextWrapper1 = new ContextWrapper(context1);
+        ContextWrapper contextWrapper2 = new ContextWrapper(context2);
+        contextWrapper1.addUrl("https://www.example.com");
+        contextWrapper2.addUrl("https://www.example.com");
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getContextWrapper("context2")).willReturn(contextWrapper2);
+
+        // When
+        SpiderJob job = new SpiderJob();
+        job.setUrlRequester(urlRequester);
+        job.getParameters().setContext("context2");
+        job.runJob(env, progress);
+
+        // Then
+        verify(extSpider, times(0))
+                .startScan(argThat(new TargetContextMatcher(target1)), any(), any());
+        verify(extSpider, times(1))
+                .startScan(argThat(new TargetContextMatcher(target2)), any(), any());
+
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    private static class TargetContextMatcher implements ArgumentMatcher<Target> {
+
+        private Target left;
+
+        public TargetContextMatcher(Target target) {
+            left = target;
+        }
+
+        @Override
+        public boolean matches(Target right) {
+            return (Objects.equals(left.getContext(), right.getContext()));
+        }
+    }
+
+    @Test
+    void shouldUseSpecifiedUrl() throws MalformedURLException {
+        Constant.messages = new I18N(Locale.ENGLISH);
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        String url = "https://www.example.com";
+        contextWrapper.addUrl(url);
+
+        String specifiedUrl = "https://www.example.com/url";
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
+        given(env.replaceVars(specifiedUrl)).willReturn(specifiedUrl);
+
+        // When
+        SpiderJob job = new SpiderJob();
+        job.setUrlRequester(urlRequester);
+        job.getParameters().setUrl(specifiedUrl);
+        job.runJob(env, progress);
+
+        // Then
+        // Note that this isnt actually testing that specifiedUrl is used - couldnt get that to
+        // work using aryEq or matchers :( However later tests _do_ check the exact URLs
+        verify(extSpider, times(1)).startScan(any(), any(), refEq(new Object[] {specifiedUrl}));
+
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldExitIfSpiderTakesTooLong() throws MalformedURLException {
+        // Given
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        contextWrapper.addUrl("https://www.example.com");
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(false);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+
+        SpiderJob job = new SpiderJob();
+        job.setUrlRequester(urlRequester);
+
+        // When
+        job.getParameters().setMaxDuration(1);
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(job.getType(), is(equalTo("spider")));
+        assertThat(job.getOrder(), is(equalTo(Order.LAST_EXPLORE)));
+        assertThat(job.getParamMethodObject(), is(extSpider));
+        assertThat(job.getParamMethodName(), is("getSpiderParam"));
+
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+    }
+
+    @Test
+    void shouldTestAddedUrlsStatistic() {
+        // Given
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        contextWrapper.addUrl("https://www.example.com");
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+        AutomationProgress progress = new AutomationProgress();
+        SpiderJob job = new SpiderJob();
+        job.setEnv(new AutomationEnvironment(progress));
+        job.setUrlRequester(urlRequester);
+
+        // When
+        job.addTest(
+                new AutomationStatisticTest(
+                        "automation.spider.urls.added", null, ">", 1, "error", job, progress));
+        job.logTestsToProgress(progress);
+
+        // Then
+        assertThat(job.getType(), is(equalTo("spider")));
+        assertThat(job.getOrder(), is(equalTo(Order.LAST_EXPLORE)));
+        assertThat(job.getParamMethodObject(), is(extSpider));
+        assertThat(job.getParamMethodName(), is("getSpiderParam"));
+
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(1));
+        assertThat(progress.getErrors().get(0), is("!automation.tests.fail!"));
+    }
+
+    @Test
+    void shouldRequestContextUrl() throws Exception {
+        ExtensionHistory extHistory = mock(ExtensionHistory.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionHistory.class)).willReturn(extHistory);
+
+        startServer();
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        String url = "http://localhost:" + nano.getListeningPort() + "/top";
+        contextWrapper.addUrl(url);
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
+
+        SpiderJob job = new SpiderJob();
+
+        TestServerHandler testHandler = new TestServerHandler("/");
+
+        nano.addHandler(testHandler);
+
+        // When
+        job.runJob(env, progress);
+
+        stopServer();
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(testHandler.wasCalled(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldRequestContextUrls() throws Exception {
+        ExtensionHistory extHistory = mock(ExtensionHistory.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionHistory.class)).willReturn(extHistory);
+
+        startServer();
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        String url1 = "http://localhost:" + nano.getListeningPort() + "/1";
+        String url2 = "http://localhost:" + nano.getListeningPort() + "/2";
+        String url3 = "http://localhost:" + nano.getListeningPort() + "/3";
+        contextWrapper.addUrl(url1);
+        contextWrapper.addUrl(url2);
+        contextWrapper.addUrl(url3);
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url1)).willReturn(url1);
+        given(env.replaceVars(url2)).willReturn(url2);
+        given(env.replaceVars(url3)).willReturn(url3);
+
+        SpiderJob job = new SpiderJob();
+
+        TestServerHandler testHandler1 = new TestServerHandler("/1");
+        TestServerHandler testHandler2 = new TestServerHandler("/2");
+        TestServerHandler testHandler3 = new TestServerHandler("/3");
+
+        nano.addHandler(testHandler1);
+        nano.addHandler(testHandler2);
+        nano.addHandler(testHandler3);
+
+        // When
+        job.runJob(env, progress);
+
+        stopServer();
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(testHandler1.wasCalled(), is(equalTo(true)));
+        assertThat(testHandler2.wasCalled(), is(equalTo(true)));
+        assertThat(testHandler3.wasCalled(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldFailIfInvalidHost() throws Exception {
+        ExtensionHistory extHistory = mock(ExtensionHistory.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionHistory.class)).willReturn(extHistory);
+
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        String url = "http://null.example.com/";
+        contextWrapper.addUrl(url);
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
+
+        SpiderJob job = new SpiderJob();
+
+        // When
+        job.runJob(env, progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(
+                progress.getErrors().get(0), is(equalTo("!spider.automation.error.url.badhost!")));
+    }
+
+    @Test
+    void shouldFailIfForbiddenResponse() throws Exception {
+        ExtensionHistory extHistory = mock(ExtensionHistory.class, withSettings().lenient());
+        given(extensionLoader.getExtension(ExtensionHistory.class)).willReturn(extHistory);
+
+        startServer();
+        Context context = mock(Context.class);
+        ContextWrapper contextWrapper = new ContextWrapper(context);
+        String url = "http://localhost:" + nano.getListeningPort() + "/top";
+        contextWrapper.addUrl(url);
+
+        given(extSpider.startScan(any(), any(), any())).willReturn(1);
+
+        SpiderScan spiderScan = mock(SpiderScan.class);
+        given(spiderScan.isStopped()).willReturn(true);
+        given(extSpider.getScan(1)).willReturn(spiderScan);
+
+        AutomationProgress progress = new AutomationProgress();
+
+        AutomationEnvironment env = mock(AutomationEnvironment.class);
+        given(env.getDefaultContextWrapper()).willReturn(contextWrapper);
+        given(env.replaceVars(url)).willReturn(url);
+
+        Control.initSingletonForTesting(Model.getSingleton(), extensionLoader);
+        SpiderJob job = new SpiderJob();
+
+        TestServerHandler testHandler = new TestServerHandler("/", Response.Status.FORBIDDEN);
+
+        nano.addHandler(testHandler);
+
+        // When
+
+        job.runJob(env, progress);
+
+        stopServer();
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(testHandler.wasCalled(), is(equalTo(true)));
+        assertThat(progress.getErrors().size(), is(equalTo(1)));
+        assertThat(progress.getErrors().get(0), is(equalTo("!spider.automation.error.url.notok!")));
+    }
+
+    @Test
+    void shouldVerifyAllOfTheParameters() {
+        String yamlStr =
+                "parameters:\n"
+                        + "  context: context1\n"
+                        + "  url: url1\n"
+                        + "  maxDuration: 2\n"
+                        + "  maxDepth: 2\n"
+                        + "  maxChildren: 2\n"
+                        + "  acceptCookies: true\n"
+                        + "  handleODataParametersVisited: true\n"
+                        + "  handleParameters: ignore_completely\n"
+                        + "  maxParseSizeBytes: 2\n"
+                        + "  parseComments: true\n"
+                        + "  parseGit: true\n"
+                        + "  parseRobotsTxt: true\n"
+                        + "  parseSitemapXml: true\n"
+                        + "  parseSVNEntries: true\n"
+                        + "  postForm: true\n"
+                        + "  processForm: true\n"
+                        + "  requestWaitTime: 2\n"
+                        + "  sendRefererHeader: true\n"
+                        + "  threadCount: 2\n"
+                        + "  userAgent: ua2";
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        SpiderJob job = new SpiderJob();
+
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasWarnings(), is(equalTo(false)));
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(job.getParameters().getContext(), is(equalTo("context1")));
+        assertThat(job.getParameters().getUrl(), is(equalTo("url1")));
+        assertThat(job.getParameters().getMaxDuration(), is(equalTo(2)));
+        assertThat(job.getParameters().getMaxDepth(), is(equalTo(2)));
+        assertThat(job.getParameters().getMaxChildren(), is(equalTo(2)));
+        assertThat(job.getParameters().getAcceptCookies(), is(equalTo(true)));
+        assertThat(job.getParameters().getHandleODataParametersVisited(), is(equalTo(true)));
+        assertThat(job.getParameters().getHandleParameters(), is(equalTo("ignore_completely")));
+        assertThat(job.getParameters().getMaxParseSizeBytes(), is(equalTo(2)));
+        assertThat(job.getParameters().getParseComments(), is(equalTo(true)));
+        assertThat(job.getParameters().getParseGit(), is(equalTo(true)));
+        assertThat(job.getParameters().getParseRobotsTxt(), is(equalTo(true)));
+        assertThat(job.getParameters().getParseSitemapXml(), is(equalTo(true)));
+        assertThat(job.getParameters().getParseSVNEntries(), is(equalTo(true)));
+        assertThat(job.getParameters().getPostForm(), is(equalTo(true)));
+        assertThat(job.getParameters().getProcessForm(), is(equalTo(true)));
+        assertThat(job.getParameters().getRequestWaitTime(), is(equalTo(2)));
+        assertThat(job.getParameters().getSendRefererHeader(), is(equalTo(true)));
+        assertThat(job.getParameters().getThreadCount(), is(equalTo(2)));
+        assertThat(job.getParameters().getUserAgent(), is(equalTo("ua2")));
+    }
+
+    @Test
+    void shouldWarnOnDeprecatedFields() {
+        String yamlStr =
+                "parameters:\n"
+                        + "  context: context1\n"
+                        + "  failIfFoundUrlsLessThan: true\n"
+                        + "  warnIfFoundUrlsLessThan: true";
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        SpiderJob job = new SpiderJob();
+
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(progress.getWarnings().size(), is(equalTo(1)));
+        assertThat(
+                progress.getWarnings().get(0),
+                is(equalTo("!spider.automation.error.failIfUrlsLessThan.deprecated!")));
+        assertThat(job.getParameters().getFailIfFoundUrlsLessThan(), is(equalTo(true)));
+        assertThat(job.getParameters().getWarnIfFoundUrlsLessThan(), is(equalTo(true)));
+    }
+
+    @Test
+    void shouldWarnOnUnknownFields() {
+        String yamlStr = "parameters:\n" + "  context: context1\n" + "  unknown: true\n";
+        AutomationProgress progress = new AutomationProgress();
+        Yaml yaml = new Yaml();
+        Object data = yaml.load(yamlStr);
+
+        SpiderJob job = new SpiderJob();
+
+        job.setJobData(((LinkedHashMap<?, ?>) data));
+
+        // When
+        job.verifyParameters(progress);
+
+        // Then
+        assertThat(progress.hasErrors(), is(equalTo(false)));
+        assertThat(progress.hasWarnings(), is(equalTo(true)));
+        assertThat(progress.getWarnings().size(), is(equalTo(1)));
+        assertThat(
+                progress.getWarnings().get(0), is(equalTo("!automation.error.options.unknown!")));
+    }
+
+    private static class TestServerHandler extends NanoServerHandler {
+
+        private boolean called = false;
+        private Status status = Response.Status.OK;
+
+        public TestServerHandler(String name) {
+            super(name);
+        }
+
+        public TestServerHandler(String name, Status status) {
+            super(name);
+            this.status = status;
+        }
+
+        @Override
+        protected Response serve(IHTTPSession session) {
+            called = true;
+            return newFixedLengthResponse(status, NanoHTTPD.MIME_HTML, "<html></html>");
+        }
+
+        public boolean wasCalled() {
+            return called;
+        }
+    }
+}


### PR DESCRIPTION
Copy the spider automation job from the automation add-on into the
spider add-on, doing the required changes to work with the add-on
instead of core.
Only add the spider job in the automation add-on if the core spider
extension is not yet deprecated.

Part of zaproxy/zaproxy#3113.