### PR TITLE
spider: unload the scan panel

### DIFF
--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
@@ -186,6 +186,10 @@ public class ExtensionSpider2 extends ExtensionAdaptor
     public void unload() {
         if (coreSpiderDisabled) {
             SpiderEventPublisher.unload();
+
+            if (hasView()) {
+                getSpiderPanel().unload();
+            }
         } else if (extensionSpider != null) {
             extensionSpider.removeCustomParser(new AddOnToCoreSpiderParser(svgHrefParser));
         }

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanel.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanel.java
@@ -524,6 +524,12 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
         return extension.getSpiderParam().getMaxScansInUI();
     }
 
+    // Overridden to expose the method to the extension
+    @Override
+    protected void unload() {
+        super.unload();
+    }
+
     /**
      * A {@link org.jdesktop.swingx.decorator.Highlighter Highlighter} for a column that indicates,
      * using icons, whether or not an entry was processed, that is, is or not in scope.


### PR DESCRIPTION
Unload the scan panel to remove the scan status from the footer.