### PR TITLE
quickstart: use Spider add-on

### DIFF
--- a/addOns/quickstart/CHANGELOG.md
+++ b/addOns/quickstart/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Spider checkboxes in Automated Scan will be disabled when scan is running. (Issue 7072)
 - Use Network add-on to obtain main proxy address/port.
 - Maintenance changes.
+- Use Spider add-on (Issue 3113).
 
 ### Fixed
 - Accept any 2xx result code instead of just 200.

--- a/addOns/quickstart/quickstart.gradle.kts
+++ b/addOns/quickstart/quickstart.gradle.kts
@@ -51,6 +51,18 @@ zapAddOn {
                     }
                 }
             }
+            register("org.zaproxy.zap.extension.quickstart.spider.ExtensionQuickStartSpider") {
+                classnames {
+                    allowed.set(listOf("org.zaproxy.zap.extension.quickstart.spider"))
+                }
+                dependencies {
+                    addOns {
+                        register("spider") {
+                            version.set(">=0.1.0")
+                        }
+                    }
+                }
+            }
         }
         dependencies {
             addOns {
@@ -73,5 +85,6 @@ dependencies {
     compileOnly(parent!!.childProjects.get("network")!!)
     compileOnly(parent!!.childProjects.get("reports")!!)
     compileOnly(parent!!.childProjects.get("selenium")!!)
+    compileOnly(parent!!.childProjects.get("spider")!!)
     compileOnly(parent!!.childProjects.get("spiderAjax")!!)
 }

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/AttackPanel.java
@@ -26,7 +26,6 @@ import javax.swing.Box;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -50,7 +49,6 @@ public class AttackPanel extends QuickStartSubPanel {
 
     private static final String DEFAULT_VALUE_URL_FIELD = "http://";
 
-    private JCheckBox spiderCheckBox;
     private JButton attackButton;
     private JButton stopButton;
     private JComboBox<String> urlField;
@@ -60,6 +58,10 @@ public class AttackPanel extends QuickStartSubPanel {
     private JPanel contentPanel;
     private JLabel lowerPadding;
     private int paddingY;
+
+    private TraditionalSpider traditionalSpider;
+    private JLabel traditionalSpiderLabel;
+    private int traditionalSpiderY;
 
     /** Optional class that adds the ajax spider - may be added after init or not at all */
     private PlugableSpider plugableSpider;
@@ -147,15 +149,7 @@ public class AttackPanel extends QuickStartSubPanel {
             urlSelectPanel.add(selectButton, LayoutHelper.getGBC(1, 0, 1, 0.0D));
             contentPanel.add(urlSelectPanel, LayoutHelper.getGBC(2, formPanelY, 3, 0.25D));
 
-            contentPanel.add(
-                    new JLabel(Constant.messages.getString("quickstart.label.tradspider")),
-                    LayoutHelper.getGBC(
-                            1, ++formPanelY, 1, 0.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));
-            contentPanel.add(
-                    getSpiderCheckBox(),
-                    LayoutHelper.getGBC(
-                            2, formPanelY, 1, 0.0D, DisplayUtils.getScaledInsets(5, 5, 5, 5)));
-
+            traditionalSpiderY = ++formPanelY;
             plugableSpiderY = ++formPanelY;
 
             JPanel buttonPanel = QuickStartHelper.getHorizontalPanel();
@@ -189,18 +183,35 @@ public class AttackPanel extends QuickStartSubPanel {
         return progressLabel;
     }
 
-    private JCheckBox getSpiderCheckBox() {
-        if (spiderCheckBox == null) {
-            spiderCheckBox = new JCheckBox();
-            spiderCheckBox.setSelected(
-                    getExtensionQuickStart().getQuickStartParam().isTradSpiderEnabled());
-            spiderCheckBox.addActionListener(
-                    e ->
-                            getExtensionQuickStart()
-                                    .getQuickStartParam()
-                                    .setTradSpiderEnabled(spiderCheckBox.isSelected()));
+    public void setTraditionalSpider(TraditionalSpider traditionalSpider) {
+        if (traditionalSpider == null) {
+            contentPanel.remove(traditionalSpiderLabel);
+            traditionalSpiderLabel = null;
+            contentPanel.remove(this.traditionalSpider.getComponent());
+        } else {
+            traditionalSpiderLabel = new JLabel(traditionalSpider.getLabel());
+            contentPanel.add(
+                    traditionalSpiderLabel,
+                    LayoutHelper.getGBC(
+                            1,
+                            traditionalSpiderY,
+                            1,
+                            0.0D,
+                            DisplayUtils.getScaledInsets(5, 5, 5, 5)));
+            contentPanel.add(
+                    traditionalSpider.getComponent(),
+                    LayoutHelper.getGBC(
+                            2,
+                            traditionalSpiderY,
+                            1,
+                            0.0D,
+                            DisplayUtils.getScaledInsets(5, 5, 5, 5)));
         }
-        return spiderCheckBox;
+
+        this.traditionalSpider = traditionalSpider;
+
+        validate();
+        repaint();
     }
 
     public void addPlugableSpider(PlugableSpider plugableSpider) {
@@ -319,7 +330,7 @@ public class AttackPanel extends QuickStartSubPanel {
 
             attackButton.addActionListener(
                     e -> {
-                        if (!spiderCheckBox.isSelected()
+                        if ((traditionalSpider == null || !traditionalSpider.isSelected())
                                 && (plugableSpider == null || !plugableSpider.isSelected())) {
                             getExtensionQuickStart()
                                     .getView()
@@ -381,7 +392,8 @@ public class AttackPanel extends QuickStartSubPanel {
         getAttackButton().setEnabled(false);
         getStopButton().setEnabled(true);
 
-        getExtensionQuickStart().attack(url, spiderCheckBox.isSelected());
+        getExtensionQuickStart()
+                .attack(url, traditionalSpider != null && traditionalSpider.isSelected());
         setSpiderButtonsEnabled(false);
         return true;
     }
@@ -397,7 +409,9 @@ public class AttackPanel extends QuickStartSubPanel {
     }
 
     private void setSpiderButtonsEnabled(boolean enabled) {
-        getSpiderCheckBox().setEnabled(enabled);
+        if (traditionalSpider != null) {
+            traditionalSpider.setEnabled(enabled);
+        }
         if (plugableSpider != null) {
             plugableSpider.setEnabled(enabled);
         }
@@ -437,7 +451,6 @@ public class AttackPanel extends QuickStartSubPanel {
     }
 
     public void optionsLoaded(QuickStartParam quickStartParam) {
-        this.getSpiderCheckBox().setSelected(quickStartParam.isTradSpiderEnabled());
         setRecentUrls();
     }
 

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/QuickStartPanel.java
@@ -259,6 +259,12 @@ public class QuickStartPanel extends AbstractPanel {
         this.explorePanel = panel;
     }
 
+    public void setTraditionalSpider(TraditionalSpider traditionalSpider) {
+        if (this.attackPanel != null) {
+            this.attackPanel.setTraditionalSpider(traditionalSpider);
+        }
+    }
+
     public void addPlugableSpider(PlugableSpider pe) {
         if (this.attackPanel != null) {
             this.attackPanel.addPlugableSpider(pe);

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/TraditionalSpider.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/TraditionalSpider.java
@@ -1,0 +1,45 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.quickstart;
+
+import javax.swing.JComponent;
+import org.zaproxy.zap.model.Target;
+
+public interface TraditionalSpider {
+
+    String getLabel();
+
+    JComponent getComponent();
+
+    boolean isSelected();
+
+    void setEnabled(boolean enabled);
+
+    Scan startScan(String displayName, Target target);
+
+    public interface Scan {
+
+        boolean isStopped();
+
+        void stopScan();
+
+        int getProgress();
+    }
+}

--- a/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/spider/ExtensionQuickStartSpider.java
+++ b/addOns/quickstart/src/main/java/org/zaproxy/zap/extension/quickstart/spider/ExtensionQuickStartSpider.java
@@ -1,0 +1,154 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.quickstart.spider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JCheckBox;
+import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.control.Control;
+import org.parosproxy.paros.extension.Extension;
+import org.parosproxy.paros.extension.ExtensionAdaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.zaproxy.addon.spider.ExtensionSpider2;
+import org.zaproxy.addon.spider.SpiderScan;
+import org.zaproxy.zap.extension.quickstart.ExtensionQuickStart;
+import org.zaproxy.zap.extension.quickstart.QuickStartParam;
+import org.zaproxy.zap.extension.quickstart.TraditionalSpider;
+import org.zaproxy.zap.extension.spider.ExtensionSpider;
+import org.zaproxy.zap.model.Target;
+
+public class ExtensionQuickStartSpider extends ExtensionAdaptor {
+
+    private static final List<Class<? extends Extension>> DEPENDENCIES =
+            Collections.unmodifiableList(
+                    Arrays.asList(ExtensionQuickStart.class, ExtensionSpider2.class));
+
+    private TraditionalSpiderImpl traditionalSpider;
+
+    @Override
+    public String getUIName() {
+        return Constant.messages.getString("quickstart.spider.name");
+    }
+
+    @Override
+    public String getDescription() {
+        return Constant.messages.getString("quickstart.spider.desc");
+    }
+
+    @Override
+    public List<Class<? extends Extension>> getDependencies() {
+        return DEPENDENCIES;
+    }
+
+    @Override
+    public void hook(ExtensionHook extensionHook) {
+        if (ExtensionSpider.class.getAnnotation(Deprecated.class) == null) {
+            return;
+        }
+
+        traditionalSpider = new TraditionalSpiderImpl();
+        getExtension(ExtensionQuickStart.class).setTraditionalSpider(traditionalSpider);
+    }
+
+    private static <T extends Extension> T getExtension(Class<T> clazz) {
+        return Control.getSingleton().getExtensionLoader().getExtension(clazz);
+    }
+
+    @Override
+    public boolean canUnload() {
+        return true;
+    }
+
+    @Override
+    public void unload() {
+        if (ExtensionSpider.class.getAnnotation(Deprecated.class) == null) {
+            return;
+        }
+
+        getExtension(ExtensionQuickStart.class).setTraditionalSpider(null);
+    }
+
+    private static class TraditionalSpiderImpl implements TraditionalSpider {
+
+        private JCheckBox spiderCheckBox;
+
+        @Override
+        public String getLabel() {
+            return Constant.messages.getString("quickstart.label.tradspider");
+        }
+
+        @Override
+        public JCheckBox getComponent() {
+            if (spiderCheckBox == null) {
+                QuickStartParam param =
+                        getExtension(ExtensionQuickStart.class).getQuickStartParam();
+                spiderCheckBox = new JCheckBox();
+                spiderCheckBox.setSelected(param.isTradSpiderEnabled());
+                spiderCheckBox.addActionListener(
+                        e -> param.setTradSpiderEnabled(spiderCheckBox.isSelected()));
+            }
+            return spiderCheckBox;
+        }
+
+        @Override
+        public boolean isSelected() {
+            return getComponent().isSelected();
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            getComponent().setEnabled(enabled);
+        }
+
+        @Override
+        public Scan startScan(String displayName, Target target) {
+            ExtensionSpider2 extension = getExtension(ExtensionSpider2.class);
+
+            int scanId = extension.startScan(displayName, target, null, null);
+            return new ScanImpl(extension.getScan(scanId));
+        }
+    }
+
+    private static class ScanImpl implements TraditionalSpider.Scan {
+
+        private SpiderScan scan;
+
+        public ScanImpl(SpiderScan scan) {
+            this.scan = scan;
+        }
+
+        @Override
+        public boolean isStopped() {
+            return scan.isStopped();
+        }
+
+        @Override
+        public void stopScan() {
+            scan.stopScan();
+        }
+
+        @Override
+        public int getProgress() {
+            return scan.getProgress();
+        }
+    }
+}

--- a/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
+++ b/addOns/quickstart/src/main/resources/org/zaproxy/zap/extension/quickstart/resources/Messages.properties
@@ -116,6 +116,10 @@ quickstart.progress.spider				= Using traditional spider to discover the content
 quickstart.progress.started 			= Accessing URL
 quickstart.progress.stopped				= Manually stopped
 quickstart.start.remove					= Remove the Quick Start tab?\nYou can add it back by enabling the\nextension: ExtensionQuickStart 
+
+quickstart.spider.desc = Adds the option to use the traditional Spider in the Quick Start scan.
+quickstart.spider.name = Quick Start Spider Integration
+
 quickstart.url.warning.invalid			= You need to enter a valid URL.
 quickstart.url.warning.nospider			= You need to select one of the spiders.
 


### PR DESCRIPTION
Add extension that depends on the spider add-on and adds it to the
attack panel and the attack thread.

Part of zaproxy/zaproxy#3113.