### PR TITLE
spider: do not destroy if core spider enabled

### DIFF
--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
@@ -414,6 +414,10 @@ public class ExtensionSpider2 extends ExtensionAdaptor
 
     @Override
     public void destroy() {
+        if (!coreSpiderDisabled) {
+            return;
+        }
+
         // Shut all of the scans down
         this.stopAllScans();
         if (hasView()) {


### PR DESCRIPTION
Only destroy if the core spider is disabled, otherwise as side effect
it would initialise the scan panel and add the scan status to the
footer.