### PR TITLE
openapi: Reduce logging when core spider not available

### DIFF
--- a/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
+++ b/addOns/openapi/src/main/java/org/zaproxy/zap/extension/openapi/ExtensionOpenApi.java
@@ -111,7 +111,7 @@ public class ExtensionOpenApi extends ExtensionAdaptor implements CommandLineLis
             spider.addCustomParser(customSpider);
             LOG.debug("Added custom Open API spider.");
         } else {
-            LOG.warn("Custom Open API spider could not be added.");
+            LOG.debug("Custom Open API spider could not be added.");
         }
 
         if (getView() != null) {


### PR DESCRIPTION
When the core spider isn't available don't WARN on failure to add custom spider, just DEBUG.

Related to zaproxy/zaproxy#3113

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>