### PR TITLE
exim: Import URLs is now more informative about failures

### DIFF
--- a/addOns/exim/CHANGELOG.md
+++ b/addOns/exim/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Changed
 - Maintenance changes.
+- When importing a file of URLs the output tab and log will now be more informative about failures.
 
 ## [0.2.0] - 2022-07-20
 ### Fixed

--- a/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
+++ b/addOns/exim/src/main/resources/org/zaproxy/addon/exim/resources/Messages.properties
@@ -25,6 +25,7 @@ exim.api.action.importurls = Imports URLs (one per line) from the file with the 
 
 exim.importurls.topmenu.import = Import a File Containing URLs
 exim.importurls.topmenu.import.tooltip = The file must be plain text with one URL per line.\nBlank lines and lines starting with a # are ignored.
+exim.importurls.warn.scheme = \"{0}\" does not have a scheme.
 
 exim.api.action.importzaplogs = Imports previously exported ZAP messages from the file with the given file system path.
 exim.api.action.importmodsec2logs = Imports ModSecurity2 logs from the file with the given file system path.


### PR DESCRIPTION
Related to: https://groups.google.com/g/zaproxy-users/c/hCQAsOIOuSY

Example output:
```console
GET	fed.com/test	"fed.com/test" does not seem to have a scheme.
GET	fred.com/bleh	"fred.com/bleh" does not seem to have a scheme.
GET	https://scanme.nmap.org	Connect to https://scanme.nmap.org:443 [scanme.nmap.org/45.33.32.156] failed: Connection refused: connect
```

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>