### PR TITLE
ascanrules: CMDi: Decode HTML Entities in Responses

### DIFF
--- a/addOns/ascanrules/CHANGELOG.md
+++ b/addOns/ascanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Command Injection Scan Rule: Decode HTML entities in HTML responses before attempting to search for attack validation patterns.
 
 ## [47] - 2022-08-16
 ### Added

--- a/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
+++ b/addOns/ascanrules/src/main/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRule.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.configuration.ConversionException;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
@@ -540,6 +541,11 @@ public class CommandInjectionScanRule extends AbstractAppParamPlugin {
 
                 // Check if the injected content has been evaluated and printed
                 String content = msg.getResponseBody().toString();
+
+                if (msg.getResponseHeader().hasContentType("html")) {
+                    content = StringEscapeUtils.unescapeHtml4(content);
+                }
+
                 Matcher matcher = osPayloads.get(payload).matcher(content);
                 if (matcher.find()) {
                     // We Found IT!

--- a/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRuleUnitTest.java
+++ b/addOns/ascanrules/src/test/java/org/zaproxy/zap/extension/ascanrules/CommandInjectionScanRuleUnitTest.java
@@ -253,6 +253,39 @@ class CommandInjectionScanRuleUnitTest extends ActiveScannerTest<CommandInjectio
         assertThat(alertsRaised, hasSize(1));
     }
 
+    @Test
+    void shouldRaiseAlertIfResponseHasEscapedHtmlControlPattern()
+            throws HttpMalformedHeaderException {
+        // Given
+        nano.addHandler(
+                new NanoServerHandler("/") {
+                    @Override
+                    protected Response serve(IHTTPSession session) {
+                        String value = getFirstParamValue(session, "p");
+                        if (value == null || !value.contains("/etc/passwd")) {
+                            String regularContent =
+                                    "<!DOCTYPE html><html><body>Nothing to see here.</body></html>";
+                            return newFixedLengthResponse(regularContent);
+                        }
+                        String content =
+                                "<!DOCTYPE html>\n"
+                                        + "<html><body>"
+                                        + "root&#x3a;x&#x3a;0&#x3a;0&#x3a;root&#x3a;&#x2f;root&#x3a;&#x2f;bin&#x2f;bash<br>"
+                                        + "daemon&#x3a;x&#x3a;1&#x3a;1&#x3a;daemon&#x3a;&#x2f;usr&#x2f;sbin&#x3a;&#x2f;usr&#x2f;sbin&#x2f;nologin<br>"
+                                        + "bin&#x3a;x&#x3a;2&#x3a;2&#x3a;bin&#x3a;&#x2f;bin&#x3a;&#x2f;usr&#x2f;sbin&#x2f;nologin<br>"
+                                        + "sys&#x3a;x&#x3a;3&#x3a;3&#x3a;sys&#x3a;&#x2f;dev&#x3a;&#x2f;usr&#x2f;sbin&#x2f;nologin<br>"
+                                        + "sync&#x3a;x&#x3a;4&#x3a;65534&#x3a;sync&#x3a;&#x2f;bin&#x3a;&#x2f;bin&#x2f;sync<br>"
+                                        + "</body></html>";
+                        return newFixedLengthResponse(content);
+                    }
+                });
+        rule.init(getHttpMessage("/?p=a"), parent);
+        // When
+        rule.scan();
+        // Then
+        assertThat(alertsRaised, hasSize(1));
+    }
+
     private static Stream<Arguments> shouldReturnRelevantTechs() {
         return Stream.of(
                 Arguments.of(Tech.Windows), Arguments.of(Tech.Linux), Arguments.of(Tech.MacOS));


### PR DESCRIPTION
ZAP reported 22 more CMDi vulnerabilities in OWASP Benchmark with this change :).