### PR TITLE
Add and leverage "CUSTOM_PAYLOADS" CommonAlertTag

### DIFF
--- a/addOns/ascanrulesBeta/CHANGELOG.md
+++ b/addOns/ascanrulesBeta/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Improved description, solution, and references for the Integer Overflow scan rule.
+- Added new Custom Payloads alert tag to the example alerts of the Hidden File Finder and User Agent scan rules.
 
 ### Added
 - New User Agent strings to the User Agent fuzz scan rule.

--- a/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
+++ b/addOns/ascanrulesBeta/ascanrulesBeta.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.7.0 & < 2.0.0")
+                    version.set(">= 1.10.0 & < 2.0.0")
                 }
                 register("network") {
                     version.set(">= 0.1.0")

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRule.java
@@ -42,6 +42,7 @@ import org.parosproxy.paros.core.scanner.AbstractHostPlugin;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpHeader;
+import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.parosproxy.paros.network.HttpStatusCode;
@@ -194,15 +195,42 @@ public class HiddenFilesScanRule extends AbstractHostPlugin {
     }
 
     private void raiseAlert(HttpMessage msg, int confidence, int risk, HiddenFile file) {
-        newAlert()
+        buildAlert(msg, confidence, risk, file).raise();
+    }
+
+    private AlertBuilder buildAlert(HttpMessage msg, int confidence, int risk, HiddenFile file) {
+        return newAlert()
                 .setRisk(risk)
                 .setConfidence(confidence)
                 .setName(getAlertName())
                 .setOtherInfo(getOtherInfo(file.getType()))
                 .setEvidence(msg.getResponseHeader().getPrimeHeader())
                 .setReference(getReferences(file))
-                .setMessage(msg)
-                .raise();
+                .setMessage(msg);
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<>();
+        String testPath = "CVS/root";
+        List<String> contents = Arrays.asList(":");
+        List<String> notContents = Arrays.asList("<");
+        List<String> links = Collections.emptyList();
+        HiddenFile hiddenFile =
+                new HiddenFile(testPath, contents, notContents, "", links, "cvs_dir", false);
+        HttpMessage msg;
+        try {
+            msg = new HttpMessage(new URI("https://example.com/" + testPath, false));
+        } catch (URIException | HttpMalformedHeaderException | NullPointerException e) {
+            LOG.warn("The HttpMessage for Example Alerts could not be created for some reason.", e);
+            return Collections.emptyList();
+        }
+        msg.getResponseHeader().setStatusCode(HttpStatusCode.OK);
+        Alert example = buildAlert(msg, Alert.CONFIDENCE_LOW, getRisk(), hiddenFile).build();
+        example.setTags(
+                CommonAlertTag.mergeTags(example.getTags(), CommonAlertTag.CUSTOM_PAYLOADS));
+        alerts.add(example);
+        return alerts;
     }
 
     @Override

--- a/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java
+++ b/addOns/ascanrulesBeta/src/main/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRule.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
@@ -34,6 +35,7 @@ import org.parosproxy.paros.core.scanner.Category;
 import org.parosproxy.paros.network.HttpHeader;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 /** @author kniepdennis@gmail.com */
 public class UserAgentScanRule extends AbstractAppPlugin {
@@ -196,11 +198,24 @@ public class UserAgentScanRule extends AbstractAppPlugin {
     }
 
     private void createAlert(HttpMessage newMsg, String userAgent) {
-        newAlert()
+        buildAlert(newMsg, userAgent).raise();
+    }
+
+    private AlertBuilder buildAlert(HttpMessage msg, String userAgent) {
+        return newAlert()
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setParam(USER_AGENT_PARAM_NAME)
                 .setAttack(userAgent)
-                .setMessage(newMsg)
-                .raise();
+                .setMessage(msg);
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<>();
+        Alert example = buildAlert(null, "ExampleBot 1.1").build();
+        example.setTags(
+                CommonAlertTag.mergeTags(example.getTags(), CommonAlertTag.CUSTOM_PAYLOADS));
+        alerts.add(example);
+        return alerts;
     }
 }

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/HiddenFilesScanRuleUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -695,6 +696,23 @@ class HiddenFilesScanRuleUnitTest extends ActiveScannerTest<HiddenFilesScanRule>
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        Alert alert = alerts.get(0);
+        Map<String, String> tags = alert.getTags();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
     }
 
     private static class ForbiddenResponseWithReqPath extends NanoServerHandler {

--- a/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRuleUnitTest.java
+++ b/addOns/ascanrulesBeta/src/test/java/org/zaproxy/zap/extension/ascanrulesBeta/UserAgentScanRuleUnitTest.java
@@ -21,10 +21,14 @@ package org.zaproxy.zap.extension.ascanrulesBeta;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.core.scanner.Alert;
+import org.parosproxy.paros.network.HttpHeader;
+import org.zaproxy.addon.commonlib.CommonAlertTag;
 
 /** Unit test for {@link UserAgentScanRule}. */
 class UserAgentScanRuleUnitTest extends ActiveScannerTest<UserAgentScanRule> {
@@ -45,5 +49,20 @@ class UserAgentScanRuleUnitTest extends ActiveScannerTest<UserAgentScanRule> {
         int risk = rule.getRisk();
         // Then
         assertThat(risk, is(equalTo(Alert.RISK_INFO)));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        Alert alert = alerts.get(0);
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        assertThat(alert.getTags().size(), is(equalTo(1)));
+        assertThat(alert.getTags(), hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
+        assertThat(alert.getParam(), is(equalTo("Header " + HttpHeader.USER_AGENT)));
+        assertThat(alert.getAttack(), is(equalTo("ExampleBot 1.1")));
     }
 }

--- a/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
+++ b/addOns/commonlib/src/main/java/org/zaproxy/addon/commonlib/CommonAlertTag.java
@@ -373,7 +373,14 @@ public enum CommonAlertTag {
             "https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/11-Client-side_Testing/13-Testing_for_Cross_Site_Script_Inclusion"),
     WSTG_V42_APIT_01_GRAPHQL(
             "WSTG-v42-APIT-01",
-            "https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL");
+            "https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/12-API_Testing/01-Testing_GraphQL"),
+    /**
+     * This Alert Tag is used to indicate (Ex: via Example Alerts) alerts (rules) which support user
+     * defined payloads via Custom Payloads.
+     *
+     * @since 1.10.0
+     */
+    CUSTOM_PAYLOADS("CUSTOM_PAYLOADS", "");
 
     private String tag;
     private String value;
@@ -397,5 +404,23 @@ public enum CommonAlertTag {
             map.put(tag.getTag(), tag.getValue());
         }
         return Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Merges a {@code Map<String, String>} of {@code CommonAlertTag} with any number of other {@code CommonAlertTag}s.
+     *
+     * @param tagMap the {@code Map<String, String>} of {@code CommonAlertTag}s to be merged with.
+     * @param alertTags the {@code CommonAlertTag}s to be added.
+     * @return a {@code Map<String, String> of the unified collection of CommonAlertTags
+     * @since 1.10.0
+     */
+    public static Map<String, String> mergeTags(
+            Map<String, String> tagMap, CommonAlertTag... alertTags) {
+        Map<String, String> map = new HashMap<>();
+        map.putAll(tagMap);
+        for (CommonAlertTag tag : alertTags) {
+            map.put(tag.getTag(), tag.getValue());
+        }
+        return map;
     }
 }

--- a/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CommonAlertTagsUnitTest.java
+++ b/addOns/commonlib/src/test/java/org/zaproxy/addon/commonlib/CommonAlertTagsUnitTest.java
@@ -1,0 +1,71 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.commonlib;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CommonAlertTagsUnitTest {
+
+    private static final Map<String, String> BASE_TAGS =
+            CommonAlertTag.toMap(
+                    CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG,
+                    CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG,
+                    CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE);
+
+    @Test
+    void shouldAddAlertTagToMap() {
+        // Given / When
+        Map<String, String> allTags =
+                CommonAlertTag.mergeTags(BASE_TAGS, CommonAlertTag.CUSTOM_PAYLOADS);
+        // Then
+        assertThat(allTags.size(), is(equalTo(4)));
+        assertTrue(allTags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+        assertTrue(allTags.containsKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+        assertTrue(
+                allTags.containsKey(
+                        CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getTag()));
+        assertTrue(allTags.containsKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+    }
+
+    @Test
+    void shouldAddMultipleAlertTagsToMap() {
+        // Given / When
+        Map<String, String> allTags =
+                CommonAlertTag.mergeTags(
+                        BASE_TAGS,
+                        CommonAlertTag.CUSTOM_PAYLOADS,
+                        CommonAlertTag.WSTG_V42_SESS_09_SESS_HIJACK);
+        // Then
+        assertThat(allTags.size(), is(equalTo(5)));
+        assertTrue(allTags.containsKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+        assertTrue(allTags.containsKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+        assertTrue(
+                allTags.containsKey(
+                        CommonAlertTag.WSTG_V42_CONF_05_ENUMERATE_INFRASTRUCTURE.getTag()));
+        assertTrue(allTags.containsKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+        assertTrue(allTags.containsKey(CommonAlertTag.WSTG_V42_SESS_09_SESS_HIJACK.getTag()));
+    }
+}

--- a/addOns/custompayloads/CHANGELOG.md
+++ b/addOns/custompayloads/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Maintenance changes.
 - Update minimum ZAP version to 2.11.1.
+- Add help content linking to the Scan Rules which support Custom Payloads.
 
 ## [0.11.0] - 2021-10-07
 ### Changed

--- a/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/contents/custompayloads.html
+++ b/addOns/custompayloads/src/main/javahelp/org/zaproxy/zap/extension/custompayloads/resources/help/contents/custompayloads.html
@@ -13,5 +13,6 @@ which support custom payloads (accessible via the Tools menu Options menu item).
 <p>
 The option panel interface also facilitates addition of multiple payloads from a file.
 </p>
+You can see the Scan Rules which support Custom Payloads <a href="https://www.zaproxy.org/alerttags/custom_payloads/">here</a>.
 </BODY>
 </HTML>

--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Changed
+
 - Reduce Cache Control scan rule confidence to Low, and add new reference (Issue 6446).
+- Added new Custom Payloads alert tag to the example alerts of the Username IDOR and Application Error scan rules.
 
 ## [42] - 2022-07-15
 ### Changed

--- a/addOns/pscanrules/pscanrules.gradle.kts
+++ b/addOns/pscanrules/pscanrules.gradle.kts
@@ -14,7 +14,7 @@ zapAddOn {
         dependencies {
             addOns {
                 register("commonlib") {
-                    version.set(">= 1.7.0 & < 2.0.0")
+                    version.set(">= 1.10.0 & < 2.0.0")
                 }
             }
         }

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRule.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -188,7 +189,11 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
 
     // Internal service method for alert management
     private void raiseAlert(HttpMessage msg, int id, String evidence, int risk) {
-        newAlert() // has PluginId, msg, URI, name
+        buildAlert(msg, id, evidence, risk).raise();
+    }
+
+    private AlertBuilder buildAlert(HttpMessage msg, int id, String evidence, int risk) {
+        return newAlert()
                 .setRisk(risk)
                 .setConfidence(Alert.CONFIDENCE_MEDIUM)
                 .setDescription(getDescription())
@@ -196,8 +201,18 @@ public class ApplicationErrorScanRule extends PluginPassiveScanner {
                 .setReference(getReference())
                 .setEvidence(evidence)
                 .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setWascId(getWascId());
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<>();
+        Alert example =
+                buildAlert(null, 0, "ERROR: parser: parse error at or near", getRisk()).build();
+        example.setTags(
+                CommonAlertTag.mergeTags(example.getTags(), CommonAlertTag.CUSTOM_PAYLOADS));
+        alerts.add(example);
+        return alerts;
     }
 
     static Supplier<Iterable<String>> getCustomPayloads() {

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRule.java
@@ -109,7 +109,12 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
 
     private void raiseAlert(
             String username, String evidence, String hashType, int id, HttpMessage msg) {
-        newAlert()
+        buildAlert(username, evidence, hashType, id, msg).raise();
+    }
+
+    private AlertBuilder buildAlert(
+            String username, String evidence, String hashType, int id, HttpMessage msg) {
+        return newAlert()
                 .setRisk(getRisk())
                 .setConfidence(Alert.CONFIDENCE_HIGH)
                 .setDescription(getDescription(username))
@@ -118,8 +123,19 @@ public class UsernameIdorScanRule extends PluginPassiveScanner {
                 .setReference(getReference())
                 .setEvidence(evidence)
                 .setCweId(getCweId())
-                .setWascId(getWascId())
-                .raise();
+                .setWascId(getWascId());
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<>();
+        Alert example =
+                buildAlert(ADMIN_2, "d033e22ae348aeb5660fc2140aec35850c4da997", "SHA1", 0, null)
+                        .build();
+        example.setTags(
+                CommonAlertTag.mergeTags(example.getTags(), CommonAlertTag.CUSTOM_PAYLOADS));
+        alerts.add(example);
+        return alerts;
     }
 
     @Override

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ApplicationErrorScanRuleUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.pscanrules;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -34,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.Constant;
@@ -104,6 +106,24 @@ class ApplicationErrorScanRuleUnitTest extends PassiveScannerTest<ApplicationErr
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_ERRH_02_STACK.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_ERRH_02_STACK.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        Alert alert = alerts.get(0);
+        Map<String, String> tags = alert.getTags();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        assertThat(alert.getTags().size(), is(equalTo(5)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A05_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A06_SEC_MISCONFIG.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_ERRH_01_ERR.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_ERRH_02_STACK.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_MEDIUM)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_MEDIUM)));
     }
 
     @Test

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/UsernameIdorScanRuleUnitTest.java
@@ -21,6 +21,7 @@ package org.zaproxy.zap.extension.pscanrules;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -32,6 +33,7 @@ import org.apache.commons.httpclient.URI;
 import org.apache.commons.httpclient.URIException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
 import org.zaproxy.addon.commonlib.CommonAlertTag;
@@ -95,6 +97,22 @@ class UsernameIdorScanRuleUnitTest extends PassiveScannerTest<UsernameIdorScanRu
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_ATHZ_04_IDOR.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_ATHZ_04_IDOR.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        Alert alert = alerts.get(0);
+        Map<String, String> tags = alert.getTags();
+        // Then
+        assertThat(tags.size(), is(equalTo(4)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A01_BROKEN_AC.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2017_A05_BROKEN_AC.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_ATHZ_04_IDOR.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_INFO)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_HIGH)));
     }
 
     @Test

--- a/addOns/pscanrulesAlpha/CHANGELOG.md
+++ b/addOns/pscanrulesAlpha/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Maintenance changes.
 - Sub Resource Integrity Attribute Missing scan rule now supports Trusted Domains.
 - The Base64 Disclosure scan rule will now ignore headers which are known to contain irrelevant Base64 like strings or are covered by other rules (ETag, Authorization, X-ChromeLogger-Data, X-ChromePhp-Data) (Issue 6619).
+- Added new Custom Payloads alert tag to the example alerts of the Dangerous JS Function scan rule.
 
 ### Fixed
 - False positive condition from Sub Resource Integrity Attribute Missing scan rule when rel=canonical is used (Issue 7040).

--- a/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
+++ b/addOns/pscanrulesAlpha/src/main/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRule.java
@@ -142,15 +142,28 @@ public class JsFunctionScanRule extends PluginPassiveScanner {
     }
 
     private void raiseAlert(String evidence) {
-        newAlert()
+        buildAlert(evidence).raise();
+    }
+
+    private AlertBuilder buildAlert(String evidence) {
+        return newAlert()
                 .setRisk(Alert.RISK_LOW)
                 .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(getDescription())
                 .setSolution(getSolution())
                 .setReference(getReference())
                 .setEvidence(evidence)
-                .setCweId(749) // CWE-749: Exposed Dangerous Method or Function
-                .raise();
+                .setCweId(749); // CWE-749: Exposed Dangerous Method or Function
+    }
+
+    @Override
+    public List<Alert> getExampleAlerts() {
+        List<Alert> alerts = new ArrayList<>();
+        Alert example = buildAlert("eval").build();
+        example.setTags(
+                CommonAlertTag.mergeTags(example.getTags(), CommonAlertTag.CUSTOM_PAYLOADS));
+        alerts.add(example);
+        return alerts;
     }
 
     private void loadPayload() {

--- a/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
+++ b/addOns/pscanrulesAlpha/src/test/java/org/zaproxy/zap/extension/pscanrulesAlpha/JsFunctionScanRuleUnitTest.java
@@ -22,6 +22,7 @@ package org.zaproxy.zap.extension.pscanrulesAlpha;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.Constant;
+import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.network.HttpMalformedHeaderException;
 import org.parosproxy.paros.network.HttpMessage;
 import org.parosproxy.paros.network.HttpRequestHeader;
@@ -233,6 +235,22 @@ class JsFunctionScanRuleUnitTest extends PassiveScannerTest<JsFunctionScanRule> 
         assertThat(
                 tags.get(CommonAlertTag.WSTG_V42_CLNT_02_JS_EXEC.getTag()),
                 is(equalTo(CommonAlertTag.WSTG_V42_CLNT_02_JS_EXEC.getValue())));
+    }
+
+    @Test
+    void shouldReturnExpectedExampleAlert() {
+        // Given / When
+        List<Alert> alerts = rule.getExampleAlerts();
+        Alert alert = alerts.get(0);
+        Map<String, String> tags = alert.getTags();
+        // Then
+        assertThat(alerts.size(), is(equalTo(1)));
+        assertThat(tags.size(), is(equalTo(3)));
+        assertThat(tags, hasKey(CommonAlertTag.OWASP_2021_A04_INSECURE_DESIGN.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.WSTG_V42_CLNT_02_JS_EXEC.getTag()));
+        assertThat(tags, hasKey(CommonAlertTag.CUSTOM_PAYLOADS.getTag()));
+        assertThat(alert.getRisk(), is(equalTo(Alert.RISK_LOW)));
+        assertThat(alert.getConfidence(), is(equalTo(Alert.CONFIDENCE_LOW)));
     }
 
     private HttpMessage createHttpMessageWithRespBody(String responseBody, String contentType)


### PR DESCRIPTION
- commonlib > Add new CommonAlertTag "CUSTOM_PAYLOADS". Added convenience method for merging Maps of CommonAlertTags with vargs of CommonAlertTags. CHANGELOG already has a maintenance changes entry.
- custompayloads > Update help to point to the supported scan rules, CHANGELOG add change note.
- ascanrulesBeta > Leverage new alert tag in Hidden File Finder and User Agent scan rules example alerts. Update unit tests as needed. Tweak commonlib dependency in build file. CHANGELOG add change note.
- pscanrules > Leverage new alert tag in Application Error and Username IDOR scan rules example alerts. Update unit tests as needed. Tweak commonlib dependency in build file. CHANGELOG add change note.
- pscanrulesAlpha > Leverage new alert tag in Dangerous JS Function scan rule example alerts. Update unit test as needed. CHANGELOG add change note.

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>