### PR TITLE
pscanrules: Adjust Cache Control scan rule confidence and references

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-
+### Changed
+- Reduce Cache Control scan rule confidence to Low, and add new reference (Issue 6446).
 
 ## [42] - 2022-07-15
 ### Changed

--- a/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
+++ b/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CacheControlScanRule.java
@@ -80,7 +80,7 @@ public class CacheControlScanRule extends PluginPassiveScanner {
         }
         newAlert()
                 .setRisk(getRisk())
-                .setConfidence(Alert.CONFIDENCE_MEDIUM)
+                .setConfidence(Alert.CONFIDENCE_LOW)
                 .setDescription(getDescription())
                 .setParam(header)
                 .setSolution(getSolution())

--- a/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
+++ b/addOns/pscanrules/src/main/resources/org/zaproxy/zap/extension/pscanrules/resources/Messages.properties
@@ -168,7 +168,7 @@ pscanrules.applicationerrors.soln = Review the source code of this page. Impleme
 pscanrules.cachecontrol.name = Re-examine Cache-control Directives
 pscanrules.cachecontrol.desc = The cache-control header has not been set properly or is missing, allowing the browser and proxies to cache content. For static assets like css, js, or image files this might be intended, however, the resources should be reviewed to ensure that no sensitive content will be cached.
 pscanrules.cachecontrol.soln = For secure content, ensure the cache-control HTTP header is set with "no-cache, no-store, must-revalidate". If an asset should be cached consider setting the directives "public, max-age, immutable".
-pscanrules.cachecontrol.refs = https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#web-content-caching\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+pscanrules.cachecontrol.refs = https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#web-content-caching\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control\nhttps://grayduck.mn/2021/09/13/cache-control-recommendations/
 
 pscanrules.contenttypemissing.name = Content-Type Header Missing
 pscanrules.contenttypemissing.name.empty = Content-Type Header Empty


### PR DESCRIPTION
- CacheControlScanRule > Adjust confidence to Low.
- CacheControlScanRuleUnitTest > Assested the new confidence, updated  test method names to be more specific.
- CHANGELOG > Add change note.
- Messages.properties > Add new reference.

Fixes zaproxy/zaproxy#6446

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>