### PR TITLE
spider: hide session changed listener

### DIFF
--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/ExtensionSpider2UnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/ExtensionSpider2UnitTest.java
@@ -1,0 +1,76 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.addon.spider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.parosproxy.paros.extension.ExtensionHook;
+import org.parosproxy.paros.extension.SessionChangedListener;
+
+/** Unit test for {@link ExtensionSpider2}. */
+class ExtensionSpider2UnitTest {
+
+    private ExtensionSpider2 extension;
+
+    @BeforeEach
+    void setUp() {
+        coreSpiderDeprecated(false);
+
+        extension = new ExtensionSpider2();
+    }
+
+    private static void coreSpiderDeprecated(boolean deprecated) {
+        ExtensionSpider2.coreSpiderDisabled = deprecated;
+    }
+
+    @Test
+    void shouldNotAddSessionChangedListenerOnHookIfCoreSpiderNotDeprecated() {
+        // Given
+        coreSpiderDeprecated(false);
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        // When
+        extension.hook(extensionHook);
+        // Then
+        verify(extensionHook, times(0)).addSessionListener(any());
+    }
+
+    @Test
+    void shouldAddSessionChangedListenerOnHookIfCoreSpiderDeprecated() {
+        // Given
+        coreSpiderDeprecated(true);
+        ExtensionHook extensionHook = mock(ExtensionHook.class);
+        // When
+        extension.hook(extensionHook);
+        // Then
+        ArgumentCaptor<SessionChangedListener> argument =
+                ArgumentCaptor.forClass(SessionChangedListener.class);
+        verify(extensionHook).addSessionListener(argument.capture());
+        assertThat(argument.getValue(), is(notNullValue()));
+    }
+}


### PR DESCRIPTION
Do not expose the `SessionChangedListener` through the extension it's
used to manage internal state and not meant for client code to call
directly.