### PR TITLE
Spider help tweaks

### DIFF
--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/automation.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/automation.html
@@ -11,7 +11,7 @@ Spider Automation Framework Support
 This add-on supports the Automation Framework.
 
 <H2>Job: spider</H2>
-The spider job runs the traditional spider. This is fast but does not handle modern applications as effectively.
+The Spider job runs the Traditional Spider. This is fast but does not handle modern applications as effectively.
 <p>
 By default this job will spider the first context defined in the environment and so none of the parameters are mandatory.
 

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/dialog.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/dialog.html
@@ -9,20 +9,20 @@ Spider dialog
 <BODY>
 <H1>Spider dialog</H1>
 <p>
-This dialog launches the <a href="spider.html">spider</a>.<br>
-  
+This dialog launches the <a href="spider.html">Spider</a>.<br>
+
 <H2>Scope</H2>
 The first tab allows you to select or change the starting point.<br>
 If the starting point is in one or more Contexts then you will be able to choose one of them.<br>
-If that context has any Users  defined then you will be able to select one of them.<br>
+If that context has any Users defined then you will be able to select one of them.<br>
 If you select one of the users then the spider will be performed as that user, with ZAP (re)authenticating as that user whenever necessary.
 <br><br>
-If you select 'Recurse' then all of the nodes underneath the one selected will also be used to seed the spider.
+If you select 'Recurse' then all of the nodes underneath the one selected will also be used to seed the Spider.
 <br><br>
-If you select 'Spider Subtree Only' the spider will only access resources that are under the starting point (URI).
-When evaluating if a resource is found within the specified subtree, the spider considers only the scheme, host, port, and path components of the URI.
+If you select 'Spider Subtree Only' the Spider will only access resources that are under the starting point (URI).
+When evaluating if a resource is found within the specified subtree, the Spider considers only the scheme, host, port, and path components of the URI.
 <br><br>
-If you select 'Show Advanced Options' then the following tab will be shown which provide fine grain control over the spider process.
+If you select 'Show Advanced Options' then the following tab will be shown which provides fine grain control over the spider process.
 <br><br>
 Clicking on the 'Reset' button will reset all of the options to their default values. 
 

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/options.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/options.html
@@ -8,7 +8,7 @@
 	<h1>Options Spider screen</h1>
 	<p>
 		This screen allows you to configure the <a
-			href="spider.html">spider</a> options.</p> 
+			href="spider.html">Spider</a> options.</p> 
 	<p>It should be noted that modifying most of these options also affects
 	the running Spider.
 	</p>
@@ -27,13 +27,13 @@
 	</p>
 
 	<h3>Number of threads used</h3>
-	The spider is multi-threaded and this is the number that defines the
+	The Spider is multi-threaded and this is the number that defines the
 	maximum number of worker threads used in the crawling process. Changing this
-	parameter does not have any effect on any crawling is in progress. 
+	parameter does not have any effect on any crawling that is in progress. 
 
 	<h3>Maximum duration</h3>
-	The maximum length of time that the spider should run for, measured in minutes.
-	Zero (the default) means that the spider will run until it has found all of the links that it is able to. 
+	The maximum length of time that the Spider should run for, measured in minutes.
+	Zero (the default) means that the Spider will run until it has found all of the links that it is able to. 
 
 	<h3>Maximum children to crawl</h3>
 	This parameter limits the number of children that will be crawled at every node in the tree.<br>
@@ -43,11 +43,11 @@
 
 	<h3>Maximum parse size</h3>
 	Defines the maximum size, in bytes, that a response might have to be parsed. This allows
-	the spider to skip big responses/files.
+	the Spider to skip big responses/files.
 
 	<h3>Domains Always in Scope</h3>
 	Allows to manage the domains, string literals or regular expressions, that are in the
-	spider's scope. The normal behavior of the spider is to only follow links to resources
+	Spider's scope. The normal behavior of the Spider is to only follow links to resources
 	found on the same domain as the page where the scan started. However,
 	this option allows you to define additional domains that are considered
 	"in scope" during the crawling process. Pages on these domains are
@@ -70,15 +70,15 @@
 	</ul>
 
 	<h3>Send "Referer" header</h3>
-	If the spider requests should be sent with the "Referer" header.
+	If the Spider requests should be sent with the "Referer" header.
 
 	<h3>Accept Cookies</h3>
-	If the spider scans should accept cookies while spidering. If enabled the Spider will
+	If the Spider scans should accept cookies while Spidering. If enabled the Spider will
 	properly handle any cookies received from the server and will send them back accordingly.
 	If the option is disabled, the Spider will not send any cookies in its requests. For
 	example, this might control whether or not the Spider uses the same session throughout a
 	spidering scan.
-	<br>When accepting cookies the cookies are not shared between spider scans, each scan has
+	<br>When accepting cookies the cookies are not shared between Spider scans, each scan has
 	its own cookie jar.
 	<br>This option has low priority, the Spider will respect other (global) options related
 	to the HTTP state. This option is ignored if, for example, the option Use Global HTTP
@@ -86,7 +86,7 @@
 	or when a HTTP Session is active.
 
 	<h3>Process forms</h3>
-	During the crawling process, the behaviour of the spider when it
+	During the crawling process, the behaviour of the Spider when it
 	encounters HTML forms is defined by this option. If disabled, the HTML
 	forms will not be processed at all. If enabled, the HTML forms with the
 	method defined as HTTP GET will be submitted with some generated
@@ -95,23 +95,35 @@
 
 	<h3>POST forms</h3>
 	As briefly described in the previous paragraph (Process Forms), this
-	option configures the behaviour of the spider when
+	option configures the behaviour of the Spider when
 	<i>Process Forms</i> is enabled and when encountering HTML forms that
 	have to be POSTed.
 
 	<h3>Parse HTML Comments</h3>
-	This option defines whether the spider should also spider the HTML
-	comments searching for links to resources. Only the resources found in
+	This option defines whether the Spider should also consider HTML
+	comments when searching for links to resources. Only the resources found in
 	commented valid HTML tags will be processed.
 
 	<h3>Parse 'robots.txt' files</h3>
-	This option defines whether the spider should also spider the
+	This option defines whether the Spider should also spider the
 	robots.txt files found on websites, searching for links to resources.
-	This option does not define whether the spider should follow the rules
+	This option does not define whether the Spider should follow the rules
 	imposed by the robots.txt file.
 
+	<h3>Parse 'sitemap.xml' files</h3>
+	This option controls whether the Spider should also consider 
+	'sitemap.xml' file and try to identify new resources.
+	
+	<h3>Parse SVN metadata files</h3>
+	This option controls whether the Spider should also parse 
+	SVN metadata files and try to identify new resources.
+	
+	<h3>Parse Git metadata files</h3>
+	This option controls whether the Spider should also parse 
+	Git metadata files and try to identify new resources.
+	
 	<h3>Handle OData-specific parameters</h3>
-	This options defines whether the spider should try to detect OData-specific
+	This options defines whether the Spider should try to detect OData-specific
 	parameters (i.e. resources identifiers) in order to properly process them 
 	according to the rule defined by the "Query parameters handling" option.
 

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/spider.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/spider.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 	<h1>Spider</h1>
-	<p>The spider is a tool that is used to automatically discover new
+	<p>The Spider is a tool that is used to automatically discover new
 		resources (URLs) on a particular Site. It begins with a list of URLs
 		to visit, called the seeds, which depends on how the Spider is
 		started. The Spider then visits these URLs, it identifies all the
@@ -57,20 +57,35 @@
 	the Spider does not follow the rules specified in the 'Robots.txt'
 	file.
 
-	<h4>SVG Files</H4>
-	SVG image files are parsed to identify HREF attributes and extract/resolve any contained links.
+	<h4>sitemap.xml file</h4>
+	If set in the <a href="options.html">Options Spider screen</a>, 
+	the Spider also analyzes the 'sitemap.xml' file and tries to identify
+	new resources.
 
-	<h4>OData Atom format</h4>
+	<h4>SVN metadata files</h4>
+	If set in the <a href="options.html">Options Spider screen</a>,
+	the Spider should also parse SVN metadata files and tries to 
+	identify new resources.
+	
+	<h4>Git metadata files</h4>
+	If set in the <a href="options.html">Options Spider screen</a>,
+	the Spider should also parse Git metadata files and tries to 
+	identify new resources.
+
+	<h4>OData Atom Format</h4>
 	OData content using the Atom format is currently supported. All included links 
 	(relative or absolute) are processed.
+
+	<h4>SVG Files</H4>
+	SVG image files are parsed to identify HREF attributes and extract/resolve any contained links.
 
 	<h4>Non-HTML Text Response</h4>
 	Text responses are parsed scanning for the URL pattern
 
-	<h4>Non-Text response</h4>
+	<h4>Non-Text Response</h4>
 	Currently, the Spider does not process this type of resources.
 
-	<h2>Other aspects</h2>
+	<h2>Other Aspects</h2>
 	<ul>
 	<li> When checking if an URL was already visited, the behaviour regarding how
 	parameters are handled can be configured on the Spider Options screen.
@@ -78,7 +93,7 @@
 	<li> When checking if an URL was already visited, there are a few common parameters
 	which are ignored: jsessionid, phpsessid, aspsessionid, utm_*
 	</li>
-	<li> The Spider's behaviour regarding cookies depends on how the spider is started and which options are enabled. For more
+	<li> The Spider's behaviour regarding cookies depends on how the Spider is started and which options are enabled. For more
 	details refer to the Spider Options screen.
 	</li>
 	</ul>

--- a/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/tab.html
+++ b/addOns/spider/src/main/javahelp/org/zaproxy/addon/spider/resources/help/contents/tab.html
@@ -25,16 +25,16 @@ to specify exactly what should be scanned.<br>
 	<ul>
 		<li><img align="bottom" alt="pause button" src="images/pause.png">
 			Pause (and <img alt="resume button" src="images/play.png"> resume) the
-			selected spider scan;</li>
+			selected Spider scan;</li>
 		<li><img align="bottom" alt="stop button" src="images/stop.png"> Stop
-			the selected spider scan;</li>
+			the selected Spider scan;</li>
 		<li><img align="bottom" alt="clean scans button" src="images/broom.png">
 			Clean completed scans;</li>
-		<li><img align="bottom" alt="spider options button" src="images/gear.png">
+		<li><img align="bottom" alt="Spider options button" src="images/gear.png">
 			Open the <a href="options.html">Spider Options screen</a>.</li>
 	</ul>
-	The progress bar shows how far the selected spider scan has progressed. It is also shown
-	the number of active spider scans and the number of URIs found for the selected scan.
+	The progress bar shows how far the selected Spider scan has progressed. It is also shown
+	the number of active Spider scans and the number of URIs found for the selected scan.
 	<p>For each URI found you can see:
 	<ul>
 		<li>Processed - Whether the URI was processed by the Spider or
@@ -47,7 +47,7 @@ to specify exactly what should be scanned.<br>
 			why was it not processed)</li>
 	</ul>
 
-	<p>For each spider message, shown under the Messages tab, you can see details of the request sent and response
+	<p>For each Spider message, shown under the Messages tab, you can see details of the request sent and response
 		received. The <code>Processed</code> column, indicates whether:
 	<ul>
 		<li><img align="bottom" alt="successful parse" src="images/green_dot.png">Successfully
@@ -66,7 +66,7 @@ to specify exactly what should be scanned.<br>
 		<li><img align="bottom" alt="no parse" src="images/red_dot.png">Not
 			Text - the response was not parsed because it's not text, for example, an image</li>
 		<li><img align="bottom" alt="no parse" src="images/red_dot.png">Spider
-			Stopped - the response was not fetched or parsed because the spider was already stopped</li>
+			Stopped - the response was not fetched or parsed because the Spider was already stopped</li>
 	</ul>
 
 	<h2>See also</h2>


### PR DESCRIPTION
- Ensure sitemap.xml, SVN metadata, and Git metadata are covered.
- Use capitals on Traditional and Spider where it is used as a name.
- Other minor grammar tweaks.

Related to zaproxy/zaproxy#3113

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>