### PR TITLE
spider: tidy up

### DIFF
--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/ExtensionSpider2.java
@@ -76,19 +76,19 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
     private ValueGenerator generator = new DefaultValueGenerator();
 
     /** The spider panel. */
-    private SpiderPanel spiderPanel = null;
+    private SpiderPanel spiderPanel;
 
-    SpiderDialog spiderDialog = null;
+    SpiderDialog spiderDialog;
 
     private PopupMenuItemSpiderDialog popupMenuItemSpiderDialog;
 
     private PopupMenuItemSpiderDialogWithContext popupMenuItemSpiderDialogWithContext;
 
     /** The options spider panel. */
-    private OptionsSpiderPanel optionsSpiderPanel = null;
+    private OptionsSpiderPanel optionsSpiderPanel;
 
     /** The params for the spider. */
-    private SpiderParam params = null;
+    private SpiderParam params;
 
     private List<SpiderParser> customParsers;
     private List<FetchFilter> customFetchFilters;
@@ -96,7 +96,7 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
 
     private SpiderAPI spiderApi;
 
-    private SpiderScanController scanController = null;
+    private SpiderScanController scanController;
 
     private Icon icon;
 
@@ -108,15 +108,11 @@ public class ExtensionSpider2 extends ExtensionAdaptor implements ScanController
      */
     private List<String> excludeList = Collections.emptyList();
 
-    private ZapMenuItem menuItemCustomScan = null;
+    private ZapMenuItem menuItemCustomScan;
 
     public ExtensionSpider2() {
         super(NAME);
-        initialize();
-    }
 
-    /** This method initializes this extension. */
-    private void initialize() {
         this.customParsers = new LinkedList<>();
         this.customFetchFilters = new LinkedList<>();
         this.customParseFilters = new LinkedList<>();

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/OptionsSpiderPanel.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/OptionsSpiderPanel.java
@@ -61,37 +61,33 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
     private static final long serialVersionUID = -5623691753271231473L;
 
     /** The full panel for the spider options. */
-    private JPanel panelSpider = null;
+    private JPanel panelSpider;
 
     // The controls for the options:
-    private JSlider sliderMaxDepth = null;
-    private JSlider sliderThreads = null;
-    private ZapNumberSpinner durationNumberSpinner = null;
+    private JSlider sliderMaxDepth;
+    private JSlider sliderThreads;
+    private ZapNumberSpinner durationNumberSpinner;
     private ZapNumberSpinner maxChildrenNumberSpinner;
     private ZapNumberSpinner maxParseSizeBytesNumberSpinner;
-    private JCheckBox chkPostForm = null;
-    private JCheckBox chkProcessForm = null;
-    private JCheckBox parseComments = null;
-    private JCheckBox parseRobotsTxt = null;
-    private JCheckBox parseSitemapXml = null;
-    private JCheckBox parseSVNEntries = null;
-    private JCheckBox parseGit = null;
-    private JCheckBox handleODataSpecificParameters = null;
+    private JCheckBox chkPostForm;
+    private JCheckBox chkProcessForm;
+    private JCheckBox parseComments;
+    private JCheckBox parseRobotsTxt;
+    private JCheckBox parseSitemapXml;
+    private JCheckBox parseSVNEntries;
+    private JCheckBox parseGit;
+    private JCheckBox handleODataSpecificParameters;
     private JCheckBox chkSendRefererHeader;
     private JCheckBox chkAcceptCookies;
     private DomainsAlwaysInScopeMultipleOptionsPanel domainsAlwaysInScopePanel;
     private DomainsAlwaysInScopeTableModel domainsAlwaysInScopeTableModel;
 
-    private JComboBox<HandleParametersOption> handleParameters = null;
+    private JComboBox<HandleParametersOption> handleParameters;
 
     /** Instantiates a new options spider panel. */
     public OptionsSpiderPanel() {
         super();
-        initialize();
-    }
 
-    /** This method initializes this options Panel. */
-    private void initialize() {
         this.setLayout(new CardLayout());
         this.setName(Constant.messages.getString("spider.options.title"));
         if (Model.getSingleton().getOptionsParam().getViewParam().getWmUiHandlingOption() == 0) {
@@ -529,8 +525,8 @@ public class OptionsSpiderPanel extends AbstractParamPanel {
                 Constant.messages.getString(
                         "spider.options.domains.in.scope.dialog.remove.checkbox.label");
 
-        private DialogAddDomainAlwaysInScope addDialog = null;
-        private DialogModifyDomainAlwaysInScope modifyDialog = null;
+        private DialogAddDomainAlwaysInScope addDialog;
+        private DialogModifyDomainAlwaysInScope modifyDialog;
 
         public DomainsAlwaysInScopeMultipleOptionsPanel(DomainsAlwaysInScopeTableModel model) {
             super(model);

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/Spider.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/Spider.java
@@ -127,13 +127,13 @@ public class Spider {
      * we do not want to recurse into an SVN folder, or a subfolder of an SVN folder, if one was
      * created from a previous Spider run
      */
-    private static final Pattern svnUrlPattern = Pattern.compile("\\.svn/"); // case sensitive
+    private static final Pattern SVN_URL_PATTERN = Pattern.compile("\\.svn/"); // case sensitive
 
     /**
      * we do not want to recurse into a Git folder, or a subfolder of a Git folder, if one was
      * created from a previous Spider run
      */
-    private static final Pattern gitUrlPattern = Pattern.compile("\\.git/"); // case sensitive
+    private static final Pattern GIT_URL_PATTERN = Pattern.compile("\\.git/"); // case sensitive
 
     private final String id;
 
@@ -236,13 +236,13 @@ public class Spider {
         }
         // And add '.svn/entries' as a seed, for SVN based spidering
         if (getSpiderParam().isParseSVNEntries()) {
-            addFileSeed(uri, ".svn/entries", svnUrlPattern);
-            addFileSeed(uri, ".svn/wc.db", svnUrlPattern);
+            addFileSeed(uri, ".svn/entries", SVN_URL_PATTERN);
+            addFileSeed(uri, ".svn/wc.db", SVN_URL_PATTERN);
         }
 
         // And add '.git/index' as a seed, for Git based spidering
         if (getSpiderParam().isParseGit()) {
-            addFileSeed(uri, ".git/index", gitUrlPattern);
+            addFileSeed(uri, ".git/index", GIT_URL_PATTERN);
         }
     }
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderController.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderController.java
@@ -266,7 +266,7 @@ public class SpiderController implements SpiderParserListener {
             throws URIException {
         StringBuilder identifierBuilder = new StringBuilder(50);
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri,
                         spider.getSpiderParam().getHandleParameters(),
                         spider.getSpiderParam().isHandleODataParametersVisited());

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderDialog.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderDialog.java
@@ -72,10 +72,10 @@ public class SpiderDialog extends StandardFieldsDialog {
 
     private static final long serialVersionUID = 1L;
 
-    private JButton[] extraButtons = null;
+    private JButton[] extraButtons;
 
-    private ExtensionSpider2 extension = null;
-    private SpiderParam spiderParam = null;
+    private ExtensionSpider2 extension;
+    private SpiderParam spiderParam;
 
     /**
      * Flag that holds the previous checked state of the "Subtree Only" checkbox.
@@ -89,7 +89,7 @@ public class SpiderDialog extends StandardFieldsDialog {
     private ExtensionUserManagement extUserMgmt =
             Control.getSingleton().getExtensionLoader().getExtension(ExtensionUserManagement.class);
 
-    private Target target = null;
+    private Target target;
 
     public SpiderDialog(ExtensionSpider2 ext, Frame owner, Dimension dim) {
         super(

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderEventPublisher.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderEventPublisher.java
@@ -26,7 +26,7 @@ import org.zaproxy.zap.users.User;
 
 public class SpiderEventPublisher extends ScanEventPublisher {
 
-    private static SpiderEventPublisher publisher = null;
+    private static SpiderEventPublisher publisher;
 
     @Override
     public String getPublisherName() {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderMessagesTable.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderMessagesTable.java
@@ -24,6 +24,7 @@ import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.SortOrder;
+import javax.swing.SwingConstants;
 import javax.swing.table.TableModel;
 import org.jdesktop.swingx.decorator.AbstractHighlighter;
 import org.jdesktop.swingx.decorator.ComponentAdapter;
@@ -57,7 +58,7 @@ class SpiderMessagesTable extends HistoryReferencesTable {
                 .setCellRenderer(
                         new DefaultTableRenderer(
                                 new MappedValue(StringValues.EMPTY, IconValues.NONE),
-                                JLabel.CENTER));
+                                SwingConstants.CENTER));
         getColumnExt(0).setHighlighters(new ProcessedCellItemIconHighlighter(0));
 
         getColumnExt(Constant.messages.getString("view.href.table.header.hrefid"))

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanel.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderPanel.java
@@ -24,6 +24,7 @@ import java.awt.Component;
 import java.awt.EventQueue;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.Icon;
@@ -36,6 +37,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
 import javax.swing.JToolBar;
 import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.apache.logging.log4j.LogManager;
@@ -104,7 +106,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
     /** The {@code JTabbedPane} used to show the tabs for URLs found and HTTP messages sent. */
     private JTabbedPane tabbedPane;
 
-    private JButton scanButton = null;
+    private JButton scanButton;
 
     /**
      * The table with URLs found.
@@ -180,7 +182,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
 
     private TableExportButton<JXTable> exportButton;
 
-    private ExtensionSpider2 extension = null;
+    private ExtensionSpider2 extension;
 
     /**
      * Instantiates a new spider panel.
@@ -213,7 +215,8 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
         this.setDefaultAccelerator(
                 extension
                         .getView()
-                        .getMenuShortcutKeyStroke(KeyEvent.VK_D, KeyEvent.SHIFT_DOWN_MASK, false));
+                        .getMenuShortcutKeyStroke(
+                                KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK, false));
         this.setMnemonic(Constant.messages.getChar("spider.panel.mnemonic"));
     }
 
@@ -281,7 +284,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
                     .setCellRenderer(
                             new DefaultTableRenderer(
                                     new MappedValue(StringValues.EMPTY, IconValues.NONE),
-                                    JLabel.CENTER));
+                                    SwingConstants.CENTER));
             urlsTable.getColumnExt(0).setHighlighters(new ProcessedCellItemIconHighlighter(0));
 
             urlsTable.getColumnModel().getColumn(0).setMinWidth(80);
@@ -327,7 +330,7 @@ public class SpiderPanel extends ScanPanel2<SpiderScan, ScanController<SpiderSca
                     .setCellRenderer(
                             new DefaultTableRenderer(
                                     new MappedValue(StringValues.EMPTY, IconValues.NONE),
-                                    JLabel.CENTER));
+                                    SwingConstants.CENTER));
             addedNodesTable
                     .getColumnExt(0)
                     .setHighlighters(new ProcessedCellItemIconHighlighter(0));

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderParam.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderParam.java
@@ -175,9 +175,9 @@ public class SpiderParam extends VersionedAbstractParam {
     /** Whether sitemap.xml file should be parsed for URIs. */
     private boolean parseSitemapXml = true;
     /** Whether SVN entries files should be parsed for URIs. */
-    private boolean parseSVNentries = false;
+    private boolean parseSVNentries;
     /** Whether Git files should be parsed for URIs. */
-    private boolean parseGit = false;
+    private boolean parseGit;
     /** Whether the forms are processed and submitted at all. */
     private boolean processForm = true;
     /**
@@ -190,18 +190,18 @@ public class SpiderParam extends VersionedAbstractParam {
     /** Which urls are skipped. */
     private String skipURL = "";
     /** The pattern for skip url. */
-    private Pattern patternSkipURL = null;
+    private Pattern patternSkipURL;
     /** The user agent string, if different than the default one. */
-    private String userAgent = null;
+    private String userAgent;
     /** The handle parameters visited. */
     private HandleParametersOption handleParametersVisited = HandleParametersOption.USE_ALL;
     /**
      * Defines if we take care of OData specific parameters during the visit in order to identify
      * known URL *
      */
-    private boolean handleODataParametersVisited = false;
+    private boolean handleODataParametersVisited;
     /** The maximum duration in minutes that the spider is allowed to run for, 0 meaning no limit */
-    private int maxDuration = 0;
+    private int maxDuration;
 
     /** The maximum number of child nodes (per node) that can be crawled, 0 means no limit. */
     private int maxChildren;
@@ -210,7 +210,7 @@ public class SpiderParam extends VersionedAbstractParam {
     private List<DomainAlwaysInScopeMatcher> domainsAlwaysInScopeEnabled = new ArrayList<>(0);
     private boolean confirmRemoveDomainAlwaysInScope;
     private int maxScansInUI = 5;
-    private boolean showAdvancedDialog = false; // TODO load/save
+    private boolean showAdvancedDialog; // TODO load/save
 
     /** The log. */
     private static final Logger log = LogManager.getLogger(SpiderParam.class);

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderScan.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderScan.java
@@ -96,13 +96,13 @@ public class SpiderScan implements ScanListenner, SpiderListener, GenericScanner
 
     private Set<String> foundURIsOutOfScope;
 
-    private SpiderThread spiderThread = null;
+    private SpiderThread spiderThread;
 
     private State state;
 
     private int progress;
 
-    private ScanListenner2 listener = null;
+    private ScanListenner2 listener;
 
     private volatile boolean cleared;
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderTask.java
@@ -71,7 +71,7 @@ public class SpiderTask implements Runnable {
     /** The spider resource found. */
     private SpiderResourceFound resourceFound;
 
-    private ExtensionHistory extHistory = null;
+    private ExtensionHistory extHistory;
 
     /** The Constant log. */
     private static final Logger log = LogManager.getLogger(SpiderTask.class);

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderThread.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/SpiderThread.java
@@ -58,25 +58,25 @@ import org.zaproxy.zap.users.User;
 public class SpiderThread extends ScanThread implements SpiderListener {
 
     /** Whether the scanning process has stopped (either completed, either by user request). */
-    private boolean stopScan = false;
+    private boolean stopScan;
 
     /** Whether the scanning process is paused. */
-    private boolean isPaused = false;
+    private boolean isPaused;
 
     /** Whether the scanning process is running. */
-    private boolean isAlive = false;
+    private boolean isAlive;
 
     /** The related extension. */
     private ExtensionSpider2 extension;
 
     /** The spider. */
-    private Spider spider = null;
+    private Spider spider;
 
     /** The pending spider listeners which will be added to the Spider as soon at is initialized. */
     private List<SpiderListener> pendingSpiderListeners;
 
     /** The spider done. */
-    private int spiderDone = 0;
+    private int spiderDone;
 
     /** The spider todo. It will be updated by the "spiderProgress()" method. */
     private int spiderTodo = 1;
@@ -85,16 +85,16 @@ public class SpiderThread extends ScanThread implements SpiderListener {
     private static final Logger log = LogManager.getLogger(SpiderThread.class);
 
     /** The just scan in scope. */
-    private boolean justScanInScope = false;
+    private boolean justScanInScope;
 
     /** The scan children. */
-    private boolean scanChildren = false;
+    private boolean scanChildren;
 
     /** The scan context. */
-    private Context scanContext = null;
+    private Context scanContext;
 
     /** The scan user. */
-    private User scanUser = null;
+    private User scanUser;
 
     /** The results model. */
     private SpiderPanelTableModel resultsModel;
@@ -103,15 +103,15 @@ public class SpiderThread extends ScanThread implements SpiderListener {
     private SpiderPanelTableModel addedNodesModel;
 
     /** The start uri. */
-    private URI startURI = null;
+    private URI startURI;
 
     private SpiderParam spiderParams;
 
-    private List<SpiderParser> customSpiderParsers = null;
+    private List<SpiderParser> customSpiderParsers;
 
-    private List<FetchFilter> customFetchFilters = null;
+    private List<FetchFilter> customFetchFilters;
 
-    private List<ParseFilter> customParseFilters = null;
+    private List<ParseFilter> customParseFilters;
 
     private final String id;
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/UrlCanonicalizer.java
@@ -70,15 +70,15 @@ public final class UrlCanonicalizer {
      * OData support Extract the ID of a resource including the surrounding quote First group is the
      * resource_name Second group is the ID (quote will be taken as part of the value)
      */
-    private static final Pattern patternResourceIdentifierUnquoted =
+    private static final Pattern PATTERN_RESOURCE_IDENTIFIER_UNQUOTED =
             Pattern.compile("/([\\w%]*)\\(([\\w']*)\\)");
 
     /** OData support Detect a section containing a composite IDs */
-    private static final Pattern patternResourceMultipleIdentifier =
+    private static final Pattern PATTERN_RESOURCE_MULTIPLE_IDENTIFIER =
             Pattern.compile("/[\\w%]*\\((.*)\\)");
 
     /** OData support Extract the detail of the multiples IDs */
-    private static final Pattern patternResourceMultipleIdentifierDetail =
+    private static final Pattern PATTERN_RESOURCE_MULTIPLE_IDENTIFIER_DETAIL =
             Pattern.compile("([\\w%]*)=([\\w']*)");
 
     /** Private constructor to avoid initialization of object. */
@@ -90,8 +90,8 @@ public final class UrlCanonicalizer {
      * @param url the url
      * @return the canonical url
      */
-    public static String getCanonicalURL(String url) {
-        return getCanonicalURL(url, null);
+    public static String getCanonicalUrl(String url) {
+        return getCanonicalUrl(url, null);
     }
 
     /**
@@ -102,7 +102,7 @@ public final class UrlCanonicalizer {
      * @param baseURL the context in which this url was found
      * @return the canonical url
      */
-    public static String getCanonicalURL(String url, String baseURL) {
+    public static String getCanonicalUrl(String url, String baseURL) {
         if ("javascript:".equals(url)) {
             return null;
         }
@@ -219,7 +219,7 @@ public final class UrlCanonicalizer {
      * Builds a String representation of the URI with cleaned parameters, that can be used when
      * checking if an URI was already visited. The URI provided as a parameter should be already
      * cleaned and canonicalized, so it should be build with a result from {@link
-     * #getCanonicalURL(String)}.
+     * #getCanonicalUrl(String)}.
      *
      * <p>When building the URI representation, the same format should be used for all the cases, as
      * it may affect the number of times the pages are visited and reported if the option
@@ -231,7 +231,7 @@ public final class UrlCanonicalizer {
      * @return the string representation of the URI
      * @throws URIException the URI exception
      */
-    public static String buildCleanedParametersURIRepresentation(
+    public static String buildCleanedParametersUriRepresentation(
             org.apache.commons.httpclient.URI uri,
             SpiderParam.HandleParametersOption handleParameters,
             boolean handleODataParametersVisited)
@@ -354,7 +354,7 @@ public final class UrlCanonicalizer {
         } else {
 
             // check for single ID (unnamed)
-            Matcher matcher = patternResourceIdentifierUnquoted.matcher(path);
+            Matcher matcher = PATTERN_RESOURCE_IDENTIFIER_UNQUOTED.matcher(path);
             if (matcher.find()) {
                 String resourceName = matcher.group(1);
                 String resourceID = matcher.group(2);
@@ -376,7 +376,7 @@ public final class UrlCanonicalizer {
 
             } else {
 
-                matcher = patternResourceMultipleIdentifier.matcher(path);
+                matcher = PATTERN_RESOURCE_MULTIPLE_IDENTIFIER.matcher(path);
                 if (matcher.find()) {
                     // We've found a composite identifier. i.e: /Resource(field1=a,field2=3)
 
@@ -394,7 +394,7 @@ public final class UrlCanonicalizer {
                         StringBuilder sb = new StringBuilder(beforeSubstring);
 
                         matcher =
-                                patternResourceMultipleIdentifierDetail.matcher(
+                                PATTERN_RESOURCE_MULTIPLE_IDENTIFIER_DETAIL.matcher(
                                         multipleIdentifierSection);
                         int i = 1;
                         while (matcher.find()) {

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/filters/DefaultFetchFilter.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/filters/DefaultFetchFilter.java
@@ -46,7 +46,7 @@ public class DefaultFetchFilter extends FetchFilter {
     private List<DomainAlwaysInScopeMatcher> domainsAlwaysInScope = Collections.emptyList();
 
     /** The exclude list. */
-    private List<String> excludeList = null;
+    private List<String> excludeList;
 
     private Context scanContext;
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderGitParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderGitParser.java
@@ -40,12 +40,12 @@ public class SpiderGitParser extends SpiderParser {
     private SpiderParam params;
 
     /** a pattern to match the file name of the Git index file */
-    private static final Pattern gitIndexFilenamePattern = Pattern.compile("/.git/index$");
+    private static final Pattern GIT_INDEX_FILENAME_PATTERN = Pattern.compile("/.git/index$");
 
     /** a pattern to match the content of the Git index file */
-    private static final Pattern gitIndexContentPattern = Pattern.compile("^DIRC");
+    private static final Pattern GIT_INDEX_CONTENT_PATTERN = Pattern.compile("^DIRC");
 
-    private Pattern GIT_FILE_PATTERN = Pattern.compile("/\\.git/index$");
+    private static final Pattern GIT_FILE_PATTERN = Pattern.compile("/\\.git/index$");
 
     /**
      * Instantiates a new spider Git Index parser.
@@ -78,7 +78,7 @@ public class SpiderGitParser extends SpiderParser {
             getLogger().debug("The full path is [{}]", fullpath);
 
             // make sure the file name is as expected
-            Matcher gitIndexFilenameMatcher = gitIndexFilenamePattern.matcher(fullpath);
+            Matcher gitIndexFilenameMatcher = GIT_INDEX_FILENAME_PATTERN.matcher(fullpath);
             if (!gitIndexFilenameMatcher.find()) {
                 getLogger().warn("This path cannot be handled by the Git parser: {}", fullpath);
                 return false;
@@ -86,7 +86,7 @@ public class SpiderGitParser extends SpiderParser {
 
             // dealing with the Git Index file
 
-            Matcher gitIndexContentMatcher = gitIndexContentPattern.matcher(new String(data));
+            Matcher gitIndexContentMatcher = GIT_INDEX_CONTENT_PATTERN.matcher(new String(data));
             if (!gitIndexContentMatcher.find()) {
                 getLogger()
                         .debug(
@@ -303,7 +303,7 @@ public class SpiderGitParser extends SpiderParser {
                             .info(
                                     "Found file/symbolic link/gitlink {} in the Git entries file",
                                     indexEntryName);
-                    processURL(message, depth, "../" + indexEntryName, baseURL);
+                    processUrl(message, depth, "../" + indexEntryName, baseURL);
                 }
             }
             // all good, we're outta here.

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlFormParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlFormParser.java
@@ -119,7 +119,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
             getLogger().debug("Base tag was found in HTML: {}", base.getDebugInfo());
             String href = base.getAttributeValue("href");
             if (href != null && !href.isEmpty()) {
-                baseURL = UrlCanonicalizer.getCanonicalURL(href, baseURL);
+                baseURL = UrlCanonicalizer.getCanonicalUrl(href, baseURL);
             }
         }
 
@@ -158,13 +158,13 @@ public class SpiderHtmlFormParser extends SpiderParser {
                     action = action.substring(0, fs);
                 }
 
-                url = UrlCanonicalizer.getCanonicalURL(action, baseURL);
+                url = UrlCanonicalizer.getCanonicalUrl(action, baseURL);
                 FormData formData = prepareFormDataSet(source, form);
 
                 // Process the case of a POST method
                 if (method != null && method.trim().equalsIgnoreCase(METHOD_POST)) {
                     // Build the absolute canonical URL
-                    String fullURL = UrlCanonicalizer.getCanonicalURL(action, baseURL);
+                    String fullURL = UrlCanonicalizer.getCanonicalUrl(action, baseURL);
                     if (fullURL == null) {
                         return false;
                     }
@@ -331,7 +331,7 @@ public class SpiderHtmlFormParser extends SpiderParser {
                     .debug(
                             "Submitting form with GET method and query with form parameters: {}",
                             submitData);
-            processURL(message, depth, action + submitData, baseURL);
+            processUrl(message, depth, action + submitData, baseURL);
         }
     }
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHtmlParser.java
@@ -118,7 +118,7 @@ public class SpiderHtmlParser extends SpiderParser {
             getLogger().debug("Base tag was found in HTML: {}", base.getDebugInfo());
             String href = base.getAttributeValue("href");
             if (href != null && !href.isEmpty()) {
-                baseURL = UrlCanonicalizer.getCanonicalURL(href, baseURL);
+                baseURL = UrlCanonicalizer.getCanonicalUrl(href, baseURL);
                 baseTagSet = true;
             }
         }
@@ -134,7 +134,7 @@ public class SpiderHtmlParser extends SpiderParser {
                 if (!parseSource(message, s, depth, baseURL)) {
                     Matcher matcher = PLAIN_COMMENTS_URL_PATTERN.matcher(s.toString());
                     while (matcher.find()) {
-                        processURL(message, depth, matcher.group(), baseURL);
+                        processUrl(message, depth, matcher.group(), baseURL);
                     }
                 }
             }
@@ -145,7 +145,7 @@ public class SpiderHtmlParser extends SpiderParser {
         for (StartTag doctype : doctypes) {
             for (String str : doctype.getTagContent().toString().split(" ")) {
                 if (str.startsWith("\"") && str.endsWith("\"")) {
-                    processURL(message, depth, str.substring(1, str.length() - 1), baseURL);
+                    processUrl(message, depth, str.substring(1, str.length() - 1), baseURL);
                 }
             }
         }
@@ -163,7 +163,7 @@ public class SpiderHtmlParser extends SpiderParser {
         Matcher results = SRCSET_PATTERN.matcher(localURL);
         while (results.find()) {
             if (!results.group().isEmpty()) {
-                processURL(message, depth, results.group(), baseURL);
+                processUrl(message, depth, results.group(), baseURL);
             }
         }
     }
@@ -318,7 +318,7 @@ public class SpiderHtmlParser extends SpiderParser {
                             foundMatch = foundMatch.substring(1);
                         }
                     }
-                    processURL(message, depth, foundMatch, baseUrlForText);
+                    processUrl(message, depth, foundMatch, baseUrlForText);
                     resourcesfound = true;
                 }
             }
@@ -342,7 +342,7 @@ public class SpiderHtmlParser extends SpiderParser {
                     Matcher matcher = URL_PATTERN.matcher(content);
                     if (matcher.find()) {
                         String url = matcher.group(1);
-                        processURL(message, depth, url, baseURL);
+                        processUrl(message, depth, url, baseURL);
                         resourcesfound = true;
                     }
                 }
@@ -350,7 +350,7 @@ public class SpiderHtmlParser extends SpiderParser {
                     && content != null
                     && !content.equals("")
                     && !content.equalsIgnoreCase("none")) {
-                processURL(message, depth, content, baseURL);
+                processUrl(message, depth, content, baseURL);
                 resourcesfound = true;
             }
         }
@@ -414,11 +414,11 @@ public class SpiderHtmlParser extends SpiderParser {
         if (customUrlProcessor != null) {
             customUrlProcessor.process(message, depth, localURL, baseURL);
         } else if (!attributeName.equalsIgnoreCase("ping")) {
-            processURL(message, depth, localURL, baseURL);
+            processUrl(message, depth, localURL, baseURL);
         } else {
             for (String pingURL : localURL.split("\\s")) {
                 if (!pingURL.isEmpty()) {
-                    processURL(message, depth, pingURL, baseURL);
+                    processUrl(message, depth, pingURL, baseURL);
                 }
             }
         }

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHttpHeaderParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderHttpHeaderParser.java
@@ -38,7 +38,7 @@ public class SpiderHttpHeaderParser extends SpiderParser {
         // TODO replace when next core version available HttpHeader.CONTENT_LOCATION
         String location = message.getResponseHeader().getHeader("Content-Location");
         if (location != null && !location.isEmpty()) {
-            processURL(message, depth, location, baseURL);
+            processUrl(message, depth, location, baseURL);
         }
         // Refresh header
         // TODO replace when next core version available HttpHeader.REFRESH
@@ -47,7 +47,7 @@ public class SpiderHttpHeaderParser extends SpiderParser {
             Matcher matcher = SpiderHtmlParser.URL_PATTERN.matcher(refresh);
             if (matcher.find()) {
                 String url = matcher.group(1);
-                processURL(message, depth, url, baseURL);
+                processUrl(message, depth, url, baseURL);
             }
         }
 
@@ -65,7 +65,7 @@ public class SpiderHttpHeaderParser extends SpiderParser {
                 if (j < 0) {
                     break;
                 }
-                processURL(message, depth, link.substring(i + 1, j), baseURL);
+                processUrl(message, depth, link.substring(i + 1, j), baseURL);
                 offset = j;
             }
         }

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderODataAtomParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderODataAtomParser.java
@@ -34,10 +34,10 @@ import org.parosproxy.paros.network.HttpMessage;
 public class SpiderODataAtomParser extends SpiderParser {
 
     /** The Constant urlPattern defining the pattern for an url. */
-    private static final Pattern patternURL = Pattern.compile("href=\\\"([\\w();&'/,=\\-]*)\\\"");
+    private static final Pattern PATTERN_URL = Pattern.compile("href=\\\"([\\w();&'/,=\\-]*)\\\"");
 
     /** the Constant patternBase defines the pattern for a base url */
-    private static final Pattern patternBase =
+    private static final Pattern PATTERN_BASE =
             Pattern.compile("base=\"(http(s?)://[^\\x00-\\x1f\"'\\s<>#]+)\"");
 
     @Override
@@ -54,19 +54,19 @@ public class SpiderODataAtomParser extends SpiderParser {
         // Handle base tag if any
         // xml:base="http://myserver:8001/remoting/myapp.svc/"
 
-        Matcher matcher = patternBase.matcher(bodyAsStr);
+        Matcher matcher = PATTERN_BASE.matcher(bodyAsStr);
         if (matcher.find()) {
             baseURL = matcher.group(1);
             baseURL = StringEscapeUtils.unescapeXml(baseURL);
         }
 
         boolean foundAtLeastOneResult = false;
-        matcher = patternURL.matcher(bodyAsStr);
+        matcher = PATTERN_URL.matcher(bodyAsStr);
         while (matcher.find()) {
             String s = matcher.group(1);
             s = StringEscapeUtils.unescapeXml(s);
 
-            processURL(message, depth, s, baseURL);
+            processUrl(message, depth, s, baseURL);
             foundAtLeastOneResult = true;
         }
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderParser.java
@@ -85,9 +85,9 @@ public abstract class SpiderParser {
      * @param localURL the local url
      * @param baseURL the base url
      */
-    protected void processURL(HttpMessage message, int depth, String localURL, String baseURL) {
+    protected void processUrl(HttpMessage message, int depth, String localURL, String baseURL) {
         // Build the absolute canonical URL
-        String fullURL = UrlCanonicalizer.getCanonicalURL(localURL, baseURL);
+        String fullURL = UrlCanonicalizer.getCanonicalUrl(localURL, baseURL);
         if (fullURL == null) {
             return;
         }
@@ -105,7 +105,7 @@ public abstract class SpiderParser {
      * Parses the resource. The HTTP message containing the request and the response is given. Also,
      * if possible, a Jericho source with the Response Body is provided.
      *
-     * <p>When a link is encountered, implementations can use {@link #processURL(HttpMessage, int,
+     * <p>When a link is encountered, implementations can use {@link #processUrl(HttpMessage, int,
      * String, String)} and {@link #notifyListenersResourceFound(SpiderResourceFound)} to announce
      * the found URIs.
      *

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderRedirectParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderRedirectParser.java
@@ -36,7 +36,7 @@ public class SpiderRedirectParser extends SpiderParser {
             // Include the base url as well as some applications send relative URLs instead of
             // absolute ones
             String baseURL = message.getRequestHeader().getURI().toString();
-            processURL(message, depth, location, baseURL);
+            processUrl(message, depth, location, baseURL);
         }
         // We consider the message fully parsed
         return true;

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderResourceFound.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderResourceFound.java
@@ -215,12 +215,9 @@ public class SpiderResourceFound {
         private List<HttpHeaderField> headers;
 
         private Builder() {
-            this.message = null;
-            this.depth = 0;
             this.method = HttpRequestHeader.GET;
             this.uri = "";
             this.body = "";
-            this.shouldIgnore = false;
             this.headers = Collections.emptyList();
         }
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderRobotstxtParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderRobotstxtParser.java
@@ -96,7 +96,7 @@ public class SpiderRobotstxtParser extends SpiderParser {
         }
 
         if (!processedPath.isEmpty()) {
-            processURL(message, depth, processedPath, baseURL);
+            processUrl(message, depth, processedPath, baseURL);
         }
     }
 

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderSitemapXmlParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderSitemapXmlParser.java
@@ -48,10 +48,10 @@ import org.zaproxy.zap.utils.XmlUtils;
 public class SpiderSitemapXmlParser extends SpiderParser {
 
     /** a pattern to match the sitemap.xml file name */
-    private Pattern SITEMAP_XML_FILENAME_PATTERN = Pattern.compile("/sitemap\\.xml$");
+    private static final Pattern SITEMAP_XML_FILENAME_PATTERN = Pattern.compile("/sitemap\\.xml$");
 
     /** a pattern to match the sitemap.xml file.. hint: It's XML */
-    private static final Pattern xmlPattern =
+    private static final Pattern XML_PATTERN =
             Pattern.compile(
                     "^<\\?xml\\s+version\\s*=\\s*\"[0-9.]+\"\\s+encoding\\s*=\\s*\"[^\"]+\"\\s*\\?>");
 
@@ -105,7 +105,7 @@ public class SpiderSitemapXmlParser extends SpiderParser {
         // Get the response content
         byte[] response = message.getResponseBody().getBytes();
         String baseURL = message.getRequestHeader().getURI().toString();
-        Matcher xmlFormatMatcher = xmlPattern.matcher(new String(response));
+        Matcher xmlFormatMatcher = XML_PATTERN.matcher(new String(response));
         if (xmlFormatMatcher.find()) {
 
             getLogger().debug("The format matches XML");
@@ -116,7 +116,7 @@ public class SpiderSitemapXmlParser extends SpiderParser {
                 NodeList locationNodes =
                         (NodeList) xpathLocationExpression.evaluate(xmldoc, XPathConstants.NODESET);
                 for (int i = 0; i < locationNodes.getLength(); i++) {
-                    processURL(message, depth, locationNodes.item(i).getNodeValue(), baseURL);
+                    processUrl(message, depth, locationNodes.item(i).getNodeValue(), baseURL);
                 }
             } catch (Exception e) {
                 getLogger().error("An error occurred trying to parse sitemap.xml", e);

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderTextParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SpiderTextParser.java
@@ -32,7 +32,7 @@ import org.parosproxy.paros.network.HttpMessage;
 public class SpiderTextParser extends SpiderParser {
 
     /** The Constant urlPattern defining the pattern for an url. */
-    private static final Pattern patternURL =
+    private static final Pattern PATTERN_URL =
             Pattern.compile(
                     "\\W(http(s?)://[^\\x00-\\x1f\"'\\s<>#()\\[\\]{}]+)", Pattern.CASE_INSENSITIVE);
 
@@ -43,10 +43,10 @@ public class SpiderTextParser extends SpiderParser {
         String baseURL = message.getRequestHeader().getURI().toString();
 
         // Use a simple pattern matcher to find urls
-        Matcher matcher = patternURL.matcher(message.getResponseBody().toString());
+        Matcher matcher = PATTERN_URL.matcher(message.getResponseBody().toString());
         while (matcher.find()) {
             String s = matcher.group(1);
-            processURL(message, depth, s, baseURL);
+            processUrl(message, depth, s, baseURL);
         }
 
         return false;

--- a/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SvgHrefParser.java
+++ b/addOns/spider/src/main/java/org/zaproxy/addon/spider/parser/SvgHrefParser.java
@@ -133,7 +133,7 @@ public class SvgHrefParser extends SpiderParser {
             getLogger().debug("Base tag was found in HTML: {}", base.getDebugInfo());
             String href = base.getAttributeValue("href");
             if (href != null && !href.isEmpty()) {
-                baseUrl = UrlCanonicalizer.getCanonicalURL(href, baseUrl);
+                baseUrl = UrlCanonicalizer.getCanonicalUrl(href, baseUrl);
             }
         }
         return processSvgTags(message, depth, baseUrl, svgElements, IMAGE_TAG)
@@ -152,7 +152,7 @@ public class SvgHrefParser extends SpiderParser {
                 for (String attribute : ATTRIBUTE_NAMES) {
                     String hrefCandidate = imageTag.getAttributeValue(attribute);
                     if (hrefCandidate != null && !hrefCandidate.isEmpty()) {
-                        processURL(message, depth, hrefCandidate, baseUrl);
+                        processUrl(message, depth, hrefCandidate, baseUrl);
                         found = true;
                         break;
                     }
@@ -183,7 +183,7 @@ public class SvgHrefParser extends SpiderParser {
                 }
                 getLogger().debug("Resolved URL: {} from: {}", newUri, baseUrl);
                 if (newUri != null && newUri.isAbsolute()) {
-                    processURL(message, depth, extractedUrl, baseUrl);
+                    processUrl(message, depth, extractedUrl, baseUrl);
                 }
             }
         }

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/UrlCanonicalizerUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/UrlCanonicalizerUnitTest.java
@@ -44,7 +44,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = "http://example.com:80/";
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("http://example.com/")));
     }
@@ -54,7 +54,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = "http://example.com:443/";
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("http://example.com:443/")));
     }
@@ -64,7 +64,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = "https://example.com:443/";
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("https://example.com/")));
     }
@@ -74,7 +74,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = "https://example.com:80/";
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("https://example.com:80/")));
     }
@@ -84,7 +84,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = "http://example.com";
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("http://example.com/")));
     }
@@ -95,7 +95,7 @@ class UrlCanonicalizerUnitTest {
         String[] uris = {"http://example.com/", "https://example.com/", "ftp://example.com/"};
         for (String uri : uris) {
             // When
-            String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+            String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
             // Then
             assertThat(canonicalizedUri, canonicalizedUri, is(equalTo(uri)));
         }
@@ -115,7 +115,7 @@ class UrlCanonicalizerUnitTest {
         };
         for (int i = 0; i < relativeURIs.length; i++) {
             // When
-            String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(relativeURIs[i], baseURI);
+            String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(relativeURIs[i], baseURI);
             // Then
             assertThat(canonicalizedUri, canonicalizedUri, is(equalTo(expectedCanonicalURIs[i])));
         }
@@ -138,7 +138,7 @@ class UrlCanonicalizerUnitTest {
         };
         for (int i = 0; i < uris.length; i++) {
             // When
-            String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uris[i]);
+            String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uris[i]);
             // Then
             assertThat(canonicalizedUri, canonicalizedUri, is(equalTo(expectedCanonicalURIs[i])));
         }
@@ -154,7 +154,7 @@ class UrlCanonicalizerUnitTest {
             })
     void shouldIgnoreURIsWithNoAuthority(String uri) {
         // Given / When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, canonicalizedUri, is(equalTo(null)));
     }
@@ -164,7 +164,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = new URI("http://example.com/path/%C3%A1/", true).toString();
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("http://example.com/path/%C3%A1/")));
     }
@@ -174,7 +174,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = new URI("http://example.com/path/?par%C3%A2m=v%C3%A3lue", true).toString();
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("http://example.com/path/?par%C3%A2m=v%C3%A3lue")));
     }
@@ -185,7 +185,7 @@ class UrlCanonicalizerUnitTest {
         // Given
         String uri = new URI("http://example.com/?par%26am%3D1=val%26u%3De1", true).toString();
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(canonicalizedUri, is(equalTo("http://example.com/?par%26am%3D1=val%26u%3De1")));
     }
@@ -199,7 +199,7 @@ class UrlCanonicalizerUnitTest {
                                 true)
                         .toString();
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(
                 canonicalizedUri,
@@ -217,7 +217,7 @@ class UrlCanonicalizerUnitTest {
                                 true)
                         .toString();
         // When
-        String canonicalizedUri = UrlCanonicalizer.getCanonicalURL(uri);
+        String canonicalizedUri = UrlCanonicalizer.getCanonicalUrl(uri);
         // Then
         assertThat(
                 canonicalizedUri,
@@ -232,7 +232,7 @@ class UrlCanonicalizerUnitTest {
         URI uri = new URI("http://example.com/path/%C3%A1/?par%C3%A2m=v%C3%A3lue", true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.USE_ALL, false);
         // Then
         assertThat(
@@ -246,7 +246,7 @@ class UrlCanonicalizerUnitTest {
         URI uri = new URI("http://example.com/path/%C3%A1/?par%C3%A2m=v%C3%A3lue1", true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.IGNORE_VALUE, false);
         // Then
         assertThat(cleanedUri, is(equalTo("http://example.com/path/%C3%A1/?par%C3%A2m")));
@@ -259,7 +259,7 @@ class UrlCanonicalizerUnitTest {
         URI uri = new URI("http://example.com/path/%C3%A1/?par%C3%A2m=v%C3%A3lue", true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.IGNORE_COMPLETELY, false);
         // Then
         assertThat(cleanedUri, is(equalTo("http://example.com/path/%C3%A1/")));
@@ -273,7 +273,7 @@ class UrlCanonicalizerUnitTest {
         URI uri = new URI("http://example.com/path/?par%3Dam1=val%26ue1&par%26am2=val%3Due2", true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.USE_ALL, false);
         // Then
         assertThat(
@@ -289,7 +289,7 @@ class UrlCanonicalizerUnitTest {
         URI uri = new URI("http://example.com/path/?par%3Dam1=val%26ue1&par%26am2=val%3Due2", true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.IGNORE_VALUE, false);
         // Then
         assertThat(cleanedUri, is(equalTo("http://example.com/path/?par%26am2&par%3Dam1")));
@@ -303,7 +303,7 @@ class UrlCanonicalizerUnitTest {
         URI uri = new URI("http://example.com/path/?par%3Dam1=val%26ue1&par%26am2=val%3Due2", true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.IGNORE_COMPLETELY, false);
         // Then
         assertThat(cleanedUri, is(equalTo("http://example.com/path/")));
@@ -319,7 +319,7 @@ class UrlCanonicalizerUnitTest {
                         true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.USE_ALL, false);
         // Then
         assertThat(
@@ -339,7 +339,7 @@ class UrlCanonicalizerUnitTest {
                         true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.IGNORE_VALUE, false);
         // Then
         assertThat(cleanedUri, is(equalTo("http://example.com/path/?param1&param2")));
@@ -355,7 +355,7 @@ class UrlCanonicalizerUnitTest {
                         true);
         // When
         String cleanedUri =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, HandleParametersOption.IGNORE_COMPLETELY, false);
         // Then
         assertThat(cleanedUri, is(equalTo("http://example.com/path/")));
@@ -367,7 +367,7 @@ class UrlCanonicalizerUnitTest {
     void shouldCanonicalizeNormalURLWithoutParametersIn_USE_ALL_mode() throws URIException {
         URI uri = new URI("http", null, "host", 9001, "/myservlet");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri,
                         HandleParametersOption.USE_ALL,
                         false /* handleODataParametersVisited */);
@@ -379,7 +379,7 @@ class UrlCanonicalizerUnitTest {
             throws URIException {
         URI uri = new URI("http", null, "host", 9001, "/myservlet");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri,
                         HandleParametersOption.IGNORE_COMPLETELY,
                         false /* handleODataParametersVisited */);
@@ -390,7 +390,7 @@ class UrlCanonicalizerUnitTest {
     void shouldCanonicalizeNormalURLWithoutParametersIn_IGNORE_VALUE_mode() throws URIException {
         URI uri = new URI("http", null, "host", 9001, "/myservlet");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri,
                         HandleParametersOption.IGNORE_VALUE,
                         false /* handleODataParametersVisited */);
@@ -402,7 +402,7 @@ class UrlCanonicalizerUnitTest {
 
         URI uri = new URI("http", null, "host", 9001, "/myservlet", "p1=2&p2=myparam");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri,
                         HandleParametersOption.USE_ALL,
                         false /* handleODataParametersVisited */);
@@ -413,7 +413,7 @@ class UrlCanonicalizerUnitTest {
     void shouldCanonicalizeNormalURLWithParametersIn_IGNORE_COMPLETELY_mode() throws URIException {
         URI uri = new URI("http", null, "host", 9001, "/myservlet", "p1=2&p2=myparam");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri,
                         HandleParametersOption.IGNORE_COMPLETELY,
                         false /* handleODataParametersVisited */);
@@ -424,7 +424,7 @@ class UrlCanonicalizerUnitTest {
     void shouldCanonicalizeNormalURLWithParametersIn_IGNORE_VALUE_mode() throws URIException {
         URI uri = new URI("http", null, "host", 9001, "/myservlet", "p1=2&p2=myparam");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri,
                         HandleParametersOption.IGNORE_VALUE,
                         false /* handleODataParametersVisited */);
@@ -439,13 +439,13 @@ class UrlCanonicalizerUnitTest {
 
         URI uri = new URI("http", null, "host", 9001, "/app.svc/Book(1)");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book(1)"));
 
         uri = new URI("http", null, "host", 9001, "/app.svc/Book(1)/Author");
         visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book(1)/Author"));
     }
@@ -456,13 +456,13 @@ class UrlCanonicalizerUnitTest {
 
         URI uri = new URI("http", null, "host", 9001, "/app.svc/Book(1)");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book()"));
 
         uri = new URI("http", null, "host", 9001, "/app.svc/Book(1)/Author");
         visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book()/Author"));
     }
@@ -473,13 +473,13 @@ class UrlCanonicalizerUnitTest {
 
         URI uri = new URI("http", null, "host", 9001, "/app.svc/Book(1)");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book()"));
 
         uri = new URI("http", null, "host", 9001, "/app.svc/Book(1)/Author");
         visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book()/Author"));
     }
@@ -490,13 +490,13 @@ class UrlCanonicalizerUnitTest {
 
         URI uri = new URI("http", null, "host", 9001, "/app.svc/Book(title='dummy',year=2012)");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book(title='dummy',year=2012)"));
 
         uri = new URI("http", null, "host", 9001, "/app.svc/Book(title='dummy',year=2012)/Author");
         visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book(title='dummy',year=2012)/Author"));
     }
@@ -507,13 +507,13 @@ class UrlCanonicalizerUnitTest {
 
         URI uri = new URI("http", null, "host", 9001, "/app.svc/Book(title='dummy',year=2012)");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book()"));
 
         uri = new URI("http", null, "host", 9001, "/app.svc/Book(title='dummy',year=2012)/Author");
         visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book()/Author"));
     }
@@ -524,13 +524,13 @@ class UrlCanonicalizerUnitTest {
 
         URI uri = new URI("http", null, "host", 9001, "/app.svc/Book(title='dummy',year=2012)");
         String visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book(title,year)"));
 
         uri = new URI("http", null, "host", 9001, "/app.svc/Book(title='dummy',year=2012)/Author");
         visitedURI =
-                UrlCanonicalizer.buildCleanedParametersURIRepresentation(
+                UrlCanonicalizer.buildCleanedParametersUriRepresentation(
                         uri, spiderOption, true /* handleODataParametersVisited */);
         assertThat(visitedURI, is("http://host:9001/app.svc/Book(title,year)/Author"));
     }

--- a/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderParserUnitTest.java
+++ b/addOns/spider/src/test/java/org/zaproxy/addon/spider/parser/SpiderParserUnitTest.java
@@ -91,7 +91,7 @@ class SpiderParserUnitTest extends SpiderParserTestUtils {
         String localUrl = "/path/";
         String expectedUri = "https://example.com/path/";
         // When
-        testSpiderParser.processURL(message, depth, localUrl, baseUrl);
+        testSpiderParser.processUrl(message, depth, localUrl, baseUrl);
         // Then
         assertThat(
                 listener.getResourcesFound(),
@@ -109,7 +109,7 @@ class SpiderParserUnitTest extends SpiderParserTestUtils {
         String baseUrl = "/";
         String localUrl = "/";
         // When
-        testSpiderParser.processURL(message, depth, localUrl, baseUrl);
+        testSpiderParser.processUrl(message, depth, localUrl, baseUrl);
         // Then
         assertThat(listener.getResourcesFound(), is(empty()));
     }


### PR DESCRIPTION
Remove redundant initialisations.
Remove "init" methods.
Use expected case for constants.
Set constants static and final.
Rename some methods to normalise the case of acronyms.