### PR TITLE
replacer: special replacement string processing

### DIFF
--- a/addOns/replacer/CHANGELOG.md
+++ b/addOns/replacer/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+### Added
+- Added special replacement string processing for:
+  - Random Integer
+  - UUID
+  - Epoch Milliseconds
+
 ### Changed
 - Maintenance changes.
 

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplaceRuleAddDialog.java
@@ -48,6 +48,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
     protected static final String REGEX_FIELD = "replacer.label.regex";
     protected static final String REPLACEMENT_FIELD = "replacer.label.replace";
     protected static final String ENABLE_FIELD = "replacer.label.enable";
+    protected static final String ENABLE_TOKEN_PROCESSING = "replacer.label.tokenprocessing";
     protected static final String INIT_TYPE_SUMMARY_FIELD = "replacer.label.initsummary";
 
     protected static final String INIT_TYPE_ALL_FIELD = "replacer.label.init.all";
@@ -105,6 +106,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         this.addTextField(0, REPLACEMENT_FIELD, "");
         this.addReadOnlyField(0, INIT_TYPE_SUMMARY_FIELD, "", false);
         this.addCheckBoxField(0, ENABLE_FIELD, false);
+        this.addCheckBoxField(0, ENABLE_TOKEN_PROCESSING, false);
         this.addPadding(0);
 
         this.addCheckBoxField(1, INIT_TYPE_ALL_FIELD, true);
@@ -192,6 +194,7 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
             this.setFieldValue(REGEX_FIELD, rule.isMatchRegex());
             this.setFieldValue(REPLACEMENT_FIELD, rule.getReplacement());
             this.setFieldValue(ENABLE_FIELD, rule.isEnabled());
+            this.setFieldValue(ENABLE_TOKEN_PROCESSING, rule.isTokenProcessingEnabled());
             if (rule.appliesToAllInitiators()) {
                 this.setFieldValue(INIT_TYPE_ALL_FIELD, true);
             } else {
@@ -287,7 +290,8 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
                         this.getBoolValue(REGEX_FIELD),
                         this.getStringValue(REPLACEMENT_FIELD),
                         initiators,
-                        this.getBoolValue(ENABLE_FIELD));
+                        this.getBoolValue(ENABLE_FIELD),
+                        this.getBoolValue(ENABLE_TOKEN_PROCESSING));
     }
 
     protected String checkIfUnique() {
@@ -320,6 +324,16 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
                 return Constant.messages.getString("replacer.add.warning.badregex");
             }
         }
+        if (Boolean.TRUE.equals(this.getBoolValue(ENABLE_TOKEN_PROCESSING))) {
+            List<String> tokens =
+                    ExtensionReplacer.parseReplacementTokens(
+                            this.getStringValue(REPLACEMENT_FIELD));
+
+            if (tokens.isEmpty()) {
+                return Constant.messages.getString("replacer.add.warning.tokmissing");
+            }
+        }
+
         return checkIfUnique();
     }
 
@@ -480,5 +494,6 @@ public class ReplaceRuleAddDialog extends StandardFieldsDialog {
         this.setFieldValue(MATCH_STR_FIELD, "");
         this.setFieldValue(REPLACEMENT_FIELD, "");
         this.setFieldValue(ENABLE_FIELD, false);
+        this.setFieldValue(ENABLE_TOKEN_PROCESSING, false);
     }
 }

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerAPI.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerAPI.java
@@ -175,7 +175,8 @@ public class ReplacerAPI extends ApiImplementor {
                                     matchRegex,
                                     getParam(params, REPLACEMENT, ""),
                                     initiators,
-                                    enabled));
+                                    enabled,
+                                    false));
 
             try {
                 this.extension.getParams().getConfig().save();

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParam.java
@@ -46,6 +46,7 @@ public class ReplacerParam extends AbstractParam {
     private static final String RULE_REGEX_KEY = "regex";
     private static final String RULE_REPLACEMENT_KEY = "replacement";
     private static final String RULE_INITIATORS_KEY = "initiators";
+    private static final String RULE_EXTRA_PROCESSING_KEY = "extraprocessing";
 
     private static final String CONFIRM_REMOVE_RULE_KEY = REPLACER_BASE_KEY + ".confirmRemoveToken";
     private static final String FALSE_STRING = "false";
@@ -120,6 +121,7 @@ public class ReplacerParam extends AbstractParam {
                 if (!"".equals(desc) && !tempTokensNames.contains(desc)) {
                     boolean enabled = sub.getBoolean(RULE_ENABLED_KEY, true);
                     boolean regex = sub.getBoolean(RULE_REGEX_KEY, true);
+                    boolean extraProcessing = sub.getBoolean(RULE_EXTRA_PROCESSING_KEY, false);
                     String matchStr = sub.getString(RULE_MATCH_STRING_KEY, "");
                     MatchType matchType =
                             MatchType.valueOf(
@@ -154,7 +156,8 @@ public class ReplacerParam extends AbstractParam {
                                     regex,
                                     replace,
                                     initList,
-                                    enabled));
+                                    enabled,
+                                    extraProcessing));
                     tempTokensNames.add(desc);
                 }
             }
@@ -202,6 +205,11 @@ public class ReplacerParam extends AbstractParam {
                     .setProperty(
                             elementBaseKey + RULE_REGEX_KEY, Boolean.valueOf(rule.isMatchRegex()));
             getConfig().setProperty(elementBaseKey + RULE_REPLACEMENT_KEY, rule.getReplacement());
+            getConfig()
+                    .setProperty(
+                            elementBaseKey + RULE_EXTRA_PROCESSING_KEY,
+                            Boolean.valueOf(rule.isTokenProcessingEnabled()));
+
             List<Integer> initiators = rule.getInitiators();
             if (initiators == null || initiators.isEmpty()) {
                 getConfig().setProperty(elementBaseKey + RULE_INITIATORS_KEY, "");

--- a/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
+++ b/addOns/replacer/src/main/java/org/zaproxy/zap/extension/replacer/ReplacerParamRule.java
@@ -44,6 +44,7 @@ public class ReplacerParamRule extends Enableable {
     private MatchType matchType;
     private boolean matchRegex;
     private List<Integer> initiators;
+    private boolean tokenProcessingEnabled;
 
     public ReplacerParamRule() {
         this("", MatchType.RESP_BODY_STR, "");
@@ -77,7 +78,16 @@ public class ReplacerParamRule extends Enableable {
             String replacement,
             List<Integer> initiators,
             boolean enabled) {
-        this(description, "", matchType, matchString, matchRegex, replacement, initiators, enabled);
+        this(
+                description,
+                "",
+                matchType,
+                matchString,
+                matchRegex,
+                replacement,
+                initiators,
+                enabled,
+                false);
     }
 
     /**
@@ -92,6 +102,7 @@ public class ReplacerParamRule extends Enableable {
      * @param initiators a list of initiators as defined in {@link
      *     org.parosproxy.paros.network.HttpSender}
      * @param enabled true if the rule is enabled
+     * @param tokenProcessingEnabled true if token processing is enabled
      */
     public ReplacerParamRule(
             String description,
@@ -101,7 +112,8 @@ public class ReplacerParamRule extends Enableable {
             boolean matchRegex,
             String replacement,
             List<Integer> initiators,
-            boolean enabled) {
+            boolean enabled,
+            boolean tokenProcessingEnabled) {
         super(enabled);
 
         setUrl(url);
@@ -112,6 +124,7 @@ public class ReplacerParamRule extends Enableable {
         this.escapedReplacement = HexString.compile(replacement);
         this.replacement = replacement;
         this.initiators = initiators;
+        this.tokenProcessingEnabled = tokenProcessingEnabled;
     }
 
     public ReplacerParamRule(ReplacerParamRule token) {
@@ -123,7 +136,8 @@ public class ReplacerParamRule extends Enableable {
                 token.matchRegex,
                 token.replacement,
                 token.initiators,
-                token.isEnabled());
+                token.isEnabled(),
+                token.isTokenProcessingEnabled());
     }
 
     public String getDescription() {
@@ -211,6 +225,10 @@ public class ReplacerParamRule extends Enableable {
         return initiators == null || initiators.isEmpty();
     }
 
+    public boolean isTokenProcessingEnabled() {
+        return tokenProcessingEnabled;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -254,6 +272,8 @@ public class ReplacerParamRule extends Enableable {
         if (replacement == null) {
             if (other.replacement != null) return false;
         } else if (!replacement.equals(other.replacement)) return false;
+        if (tokenProcessingEnabled != other.tokenProcessingEnabled) return false;
+
         return true;
     }
 }

--- a/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
+++ b/addOns/replacer/src/main/javahelp/org/zaproxy/zap/extension/replacer/resources/help/contents/replacer.html
@@ -61,12 +61,41 @@ This option is disabled when matching actual headers.
 Hexadecimal bytes are represented with "\x00 - \xFF" (for example "abc\x01\x02\x03def").
 
 <h3>Replacement String</h3>
+<p>
 The new string that will replace the specified selection.
 Hexadecimal bytes are represented with "\x00 - \xFF".
 The literal string "\x00" can be kept with "\\x00".
+</p>
 
 <h3>Enable</h3>
 If not set then the rule will not apply.
+
+<h3>Token Processing</h3>
+<p>
+When enabled, the Replacement String may contain a single token which is replaced with a dynamic value:
+</p>
+<table>
+	<tr>
+		<th>Token</th>
+		<th>Description</th>
+	</tr>
+	<tr>
+		<td>{{RINT|MIN|MAX}}</td>
+		<td>
+			<p>Random Integer. <code>MIN</code> and <code>MAX</code> are each optional.</p> 
+			<p><code>MIN</code> defaults to <code>0</code></p>
+			<p><code>MAX</code> defaults to <a href="https://docs.oracle.com/javase/8/docs/api/constant-values.html#java.lang.Integer.MAX_VALUE">Integer.maxValue</a></p>
+		</td>
+	</tr>
+	<tr>
+		<td>{{UUID}}</td>
+		<td>Random UUID generated using <a href="https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html#randomUUID--">java.util.UUID.randomUUID()</a></td>
+	</tr>
+	<tr>
+		<td>{{TICKS}}</td>
+		<td>Unix epoch milliseconds using <a href="https://docs.oracle.com/javase/8/docs/api/java/lang/System.html#currentTimeMillis--">System.currentTimeMillis()</a></td>
+	</tr>
+</table> 
 
 <h3>Initiators tab</h3>
 Allows you to specify which 'initiators' the rule should apply to.

--- a/addOns/replacer/src/main/resources/org/zaproxy/zap/extension/replacer/resources/Messages.properties
+++ b/addOns/replacer/src/main/resources/org/zaproxy/zap/extension/replacer/resources/Messages.properties
@@ -7,6 +7,7 @@ replacer.add.warning.nodesc		= You must supply a description
 replacer.add.warning.nomatch	= You must supply a Match String
 replacer.add.warning.badregex	= The Match String is not a valid regex pattern
 replacer.add.warning.badregexurl = The URL is not a valid regex pattern.
+replacer.add.warning.tokmissing = Token processing is enabled but no valid token replacements were found in the replacement string
 
 replacer.api.action.addRule 	= Adds a replacer rule. For the parameters: desc is a user friendly description, \
 enabled is true or false, matchType is one of [REQ_HEADER, REQ_HEADER_STR, REQ_BODY_STR, RESP_HEADER, RESP_HEADER_STR, RESP_BODY_STR], \
@@ -31,6 +32,7 @@ replacer.label.enable			= Enable:
 replacer.label.initsummary		= Initiators:
 replacer.label.initsummary.all  = Applies to all initiators
 replacer.label.initsummary.tab  = See Initiators tab
+replacer.label.tokenprocessing	= Token Processing:
 
 replacer.label.init.all			= Apply to all HTTP(S) messages:
 replacer.label.init.proxy		= Proxy messages:


### PR DESCRIPTION
Adding replacement string processing for the Replacer add-on to permit
users to embed `{{RINT}}`, `{{UUID}}`, and `{{TICKS}}` as values within
their replacement strings which will be converted to the relevant random
type at the time the replacement is performed.

An example use-case is in attempting to determine the source of stored
XSS payloads. By embedding a random integer or uuid into an XSS 
payload, it becomes much quicker to identify the original source requests
for stored XSS.

Example replacement strings:
`<script>alert({{RINT}})</script>` becomes
`<script>alert(1657335)</script>` where 1657335 is a randomly-generated
Integer between `0` and `Integer.maxValue`.

The `RINT` value has optional MIN and MAX value settings. See docs for
details.