### PR TITLE
scripts: prevent curl from adding User-Agent

### DIFF
--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
+- 'Copy as curl command menu.js' added change that prevents curl from adding User-Agent when no user Agent should be present
 - Automation ScriptJob - Enable or Disable any script and run a targeted script (Issue 7025).
 
 ### Changed

--- a/addOns/scripts/CHANGELOG.md
+++ b/addOns/scripts/CHANGELOG.md
@@ -5,10 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 ### Added
-- 'Copy as curl command menu.js' added change that prevents curl from adding User-Agent when no user Agent should be present
 - Automation ScriptJob - Enable or Disable any script and run a targeted script (Issue 7025).
 
 ### Changed
+- 'Copy as curl command menu.js' added change that prevents curl from adding User-Agent when no User-Agent should be present.
 - Maintenance changes.
 
 ## [30] - 2022-02-25

--- a/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
+++ b/addOns/scripts/src/main/zapHomeFiles/scripts/templates/extender/Copy as curl command menu.js
@@ -56,6 +56,9 @@ function invokeWith(msg) {
 		if(keyval[0].trim() != "Host")
 			string += " -H '"+header[i].trim()+"' ";
 	}
+	// if no User-Agent present ensures that curl request doesn't add one
+	if(string.indexOf("User-Agent") < 0)
+		string += " -A '' ";
 	string += " \\\n";
 	body = msg.getRequestBody().toString();
 	if(body.length() != 0){


### PR DESCRIPTION
When investigating and reproducing errors found in zap i found that errors caused by an empty user agent were not reproduce able with this extension due to curl adding the user agent 'User-Agent: curl/version' to any requests without a specified user agent. To fix this I have specified an empty user agent in this case.  