### PR TITLE
pscanrules: fix tests in newer Java versions

### DIFF
--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieHttpOnlyScanRuleUnitTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.withSettings;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.model.Model;
@@ -299,6 +300,7 @@ class CookieHttpOnlyScanRuleUnitTest extends PassiveScannerTest<CookieHttpOnlySc
 
         DateTimeFormatter df =
                 DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz")
+                        .withLocale(Locale.US)
                         .withZone(ZoneOffset.UTC);
         LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
         String expiry = dateTime.format(df);

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/CookieSecureFlagScanRuleUnitTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.withSettings;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.parosproxy.paros.model.Model;
@@ -298,6 +299,7 @@ class CookieSecureFlagScanRuleUnitTest extends PassiveScannerTest<CookieSecureFl
 
         DateTimeFormatter df =
                 DateTimeFormatter.ofPattern("EEE, dd-MMM-yyyy HH:mm:ss zzz")
+                        .withLocale(Locale.US)
                         .withZone(ZoneOffset.UTC);
         LocalDateTime dateTime = LocalDateTime.now().plusYears(1);
         String expiry = dateTime.format(df);


### PR DESCRIPTION
Specify correct locale when producing dates for the tests.
The month abbreviation for September in GB locale has changed in latest
Java versions (16+, now "Sept" instead of the wanted 3 letters "Sep")
which was causing the incorrect dates to be created.