### PR TITLE
graaljs: declare engine single threaded

### DIFF
--- a/addOns/graaljs/CHANGELOG.md
+++ b/addOns/graaljs/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Update minimum ZAP version to 2.11.1.
 
+### Fixed
+- Declare the engine is single threaded (Issue 6992).
+
 ## [0.2.0] - 2021-10-06
 ### Added
 - encode-decode Default and rot13 templates.

--- a/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/GraalJsEngineWrapper.java
+++ b/addOns/graaljs/src/main/java/org/zaproxy/zap/extension/graaljs/GraalJsEngineWrapper.java
@@ -44,6 +44,10 @@ public class GraalJsEngineWrapper extends DefaultEngineWrapper {
         this.icon = icon;
     }
 
+    public boolean isSingleThreaded() {
+        return true;
+    }
+
     @Override
     public ImageIcon getIcon() {
         return icon;


### PR DESCRIPTION
Declare the engine is single threaded, to have the cached scripts
accessed by a single thread at a time.

Fix zaproxy/zaproxy#6992.

---
Depends on zaproxy/zaproxy#7446.