### PR TITLE
alertFilters: include ID when listing scan rules

### DIFF
--- a/addOns/alertFilters/CHANGELOG.md
+++ b/addOns/alertFilters/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - When the automation Job is edited via UI Dialog then the status will be set to Not started
 - Maintenance changes.
 
+### Fixed
+- Include the ID when listing scan rules, to allow to differentiate scan rules with the same name (Issue 5699).
+
 ## [13] - 2021-10-06
 ### Added
 - Stats for alerts changed

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/DialogAddAlertFilter.java
@@ -36,6 +36,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
+import org.zaproxy.zap.extension.alertFilters.internal.ui.ScanRulesInfoComboBoxModel;
 import org.zaproxy.zap.model.Context;
 import org.zaproxy.zap.utils.ZapTextField;
 import org.zaproxy.zap.view.AbstractFormDialog;
@@ -63,7 +65,7 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
     private JPanel fieldsPanel;
     private Insets insets = new Insets(4, 8, 2, 4);
     private JCheckBox enabledCheckBox;
-    private JComboBox<String> alertCombo;
+    private JComboBox<ScanRulesInfo.Entry> alertCombo;
     private JComboBox<String> newLevelCombo;
     private ZapTextField urlTextField;
     private JCheckBox urlRegexCheckBox;
@@ -138,7 +140,8 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
             log.debug("Initializing add alertFilter dialog for: {}", oldAlertFilter);
             getAlertCombo()
                     .setSelectedItem(
-                            ExtensionAlertFilters.getRuleNameForId(oldAlertFilter.getRuleId()));
+                            ExtensionAlertFilters.getScanRulesInfo()
+                                    .getById(oldAlertFilter.getRuleId()));
             getNewLevelCombo()
                     .setSelectedItem(AlertFilter.getNameForRisk(oldAlertFilter.getNewRisk()));
             getUrlTextField().setText(oldAlertFilter.getUrl());
@@ -220,14 +223,14 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
     }
 
     private AlertFilter fieldsToFilter() {
-        String alertName = (String) getAlertCombo().getSelectedItem();
+        ScanRulesInfo.Entry scanRuleInfo = (ScanRulesInfo.Entry) getAlertCombo().getSelectedItem();
         if (canChangeContext) {
             workingContext = this.getChosenContext();
         }
 
         return new AlertFilter(
                 workingContext != null ? workingContext.getId() : -1,
-                ExtensionAlertFilters.getIdForRuleName(alertName),
+                scanRuleInfo.getId(),
                 getNewLevel(),
                 getUrlTextField().getText(),
                 getUrlRegexCheckBox().isSelected(),
@@ -517,12 +520,12 @@ public class DialogAddAlertFilter extends AbstractFormDialog {
         return evidenceRegexCheckBox;
     }
 
-    protected JComboBox<String> getAlertCombo() {
+    protected JComboBox<ScanRulesInfo.Entry> getAlertCombo() {
         if (alertCombo == null) {
-            alertCombo = new JComboBox<>();
-            for (String name : ExtensionAlertFilters.getAllRuleNames()) {
-                alertCombo.addItem(name);
-            }
+            alertCombo =
+                    new JComboBox<>(
+                            new ScanRulesInfoComboBoxModel(
+                                    ExtensionAlertFilters.getScanRulesInfo()));
         }
         return alertCombo;
     }

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/ExtensionAlertFilters.java
@@ -54,6 +54,7 @@ import org.zaproxy.zap.eventBus.EventConsumer;
 import org.zaproxy.zap.extension.alert.AlertEventPublisher;
 import org.zaproxy.zap.extension.alert.ExtensionAlert;
 import org.zaproxy.zap.extension.alert.PopupMenuItemAlert;
+import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
 import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
 import org.zaproxy.zap.extension.ascan.PolicyManager;
 import org.zaproxy.zap.extension.ascan.ScanPolicy;
@@ -99,6 +100,7 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
     private AlertFilterAPI api = null;
     private int lastAlert = -1;
 
+    private static ScanRulesInfo scanRulesInfo;
     private static Map<String, Integer> nameToId = new HashMap<>();
     private static Map<Integer, String> idToName = new HashMap<>();
     private static List<String> allRuleNames;
@@ -138,6 +140,17 @@ public class ExtensionAlertFilters extends ExtensionAdaptor
                                     .getExtension(ExtensionActiveScan.NAME);
         }
         return extAscan;
+    }
+
+    public static ScanRulesInfo getScanRulesInfo() {
+        if (scanRulesInfo == null) {
+            scanRulesInfo =
+                    new ScanRulesInfo(
+                            getExtAscan(),
+                            CoreFunctionality.getBuiltInPassiveScanRules(),
+                            ExtensionFactory.getAddOnLoader().getPassiveScanRules());
+        }
+        return scanRulesInfo;
     }
 
     public static List<String> getAllRuleNames() {

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AddAlertFilterDialog.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/automation/AddAlertFilterDialog.java
@@ -29,6 +29,8 @@ import org.parosproxy.paros.view.View;
 import org.zaproxy.addon.automation.jobs.JobUtils;
 import org.zaproxy.zap.extension.alertFilters.ExtensionAlertFilters;
 import org.zaproxy.zap.extension.alertFilters.automation.AlertFilterJob.Risk;
+import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
+import org.zaproxy.zap.extension.alertFilters.internal.ui.ScanRulesInfoComboBoxModel;
 import org.zaproxy.zap.utils.DisplayUtils;
 import org.zaproxy.zap.view.StandardFieldsDialog;
 
@@ -60,6 +62,7 @@ public class AddAlertFilterDialog extends StandardFieldsDialog {
     private int tableIndex;
     private AlertFilterJob job;
     private AlertFilterTableModel model;
+    private ScanRulesInfoComboBoxModel scanRulesInfoComboBoxModel;
 
     public AddAlertFilterDialog(AlertFilterJob job, AlertFilterTableModel model) {
         this(job, model, null, -1);
@@ -80,10 +83,10 @@ public class AddAlertFilterDialog extends StandardFieldsDialog {
         this.model = model;
         this.tableIndex = tableIndex;
 
-        this.addComboField(
-                RULE_PARAM,
-                ExtensionAlertFilters.getAllRuleNames(),
-                ExtensionAlertFilters.getRuleNameForId(rule.getRuleId()));
+        ScanRulesInfo scanRulesInfo = ExtensionAlertFilters.getScanRulesInfo();
+        scanRulesInfoComboBoxModel = new ScanRulesInfoComboBoxModel(scanRulesInfo);
+        scanRulesInfoComboBoxModel.setSelectedItem(scanRulesInfo.getById(rule.getRuleId()));
+        this.addComboField(RULE_PARAM, scanRulesInfoComboBoxModel);
 
         List<String> contextNames = this.job.getEnv().getContextNames();
         // Add blank option
@@ -115,9 +118,9 @@ public class AddAlertFilterDialog extends StandardFieldsDialog {
 
     @Override
     public void save() {
-        String ruleName = this.getStringValue(RULE_PARAM);
-        rule.setRuleId(ExtensionAlertFilters.getIdForRuleName(ruleName));
-        rule.setRuleName(ruleName);
+        ScanRulesInfo.Entry scanRule = scanRulesInfoComboBoxModel.getSelectedItem();
+        rule.setRuleId(scanRule.getId());
+        rule.setRuleName(scanRule.getName());
         rule.setContext(this.getStringValue(CONTEXT_PARAM));
         rule.setNewRisk(Risk.getRiskFromI18n(this.getStringValue(NEW_RISK_PARAM)).toString());
         rule.setParameter(this.getStringValue(PARAM_PARAM));

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ScanRulesInfo.java
@@ -1,0 +1,145 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.alertFilters.internal;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.parosproxy.paros.core.scanner.Plugin;
+import org.zaproxy.zap.extension.ascan.ExtensionActiveScan;
+import org.zaproxy.zap.extension.ascan.ScanPolicy;
+import org.zaproxy.zap.extension.pscan.PluginPassiveScanner;
+
+public class ScanRulesInfo extends AbstractList<ScanRulesInfo.Entry> {
+
+    private List<Entry> entries;
+    private Map<Integer, Entry> entriesById;
+
+    public ScanRulesInfo(
+            ExtensionActiveScan extensionActiveScan,
+            List<PluginPassiveScanner> builtInPassiveScanRules,
+            List<PluginPassiveScanner> passiveScanRules) {
+        entries = new ArrayList<>();
+        entriesById = new HashMap<>();
+        ScanPolicy sp = extensionActiveScan.getPolicyManager().getDefaultScanPolicy();
+        for (Plugin scanRule : sp.getPluginFactory().getAllPlugin()) {
+            addEntry(scanRule.getId(), scanRule.getName());
+        }
+        for (PluginPassiveScanner scanRule : builtInPassiveScanRules) {
+            addEntry(scanRule.getPluginId(), scanRule.getName());
+        }
+        for (PluginPassiveScanner scanRule : passiveScanRules) {
+            addEntry(scanRule.getPluginId(), scanRule.getName());
+        }
+        Collections.sort(entries);
+    }
+
+    private void addEntry(int id, String name) {
+        if (id == -1) {
+            return;
+        }
+
+        Entry entry = new Entry(id, name);
+        entriesById.put(id, entry);
+        entries.add(entry);
+    }
+
+    public Entry getById(int id) {
+        return entriesById.get(id);
+    }
+
+    @Override
+    public Entry get(int index) {
+        return entries.get(index);
+    }
+
+    @Override
+    public int size() {
+        return entries.size();
+    }
+
+    @Override
+    public int hashCode() {
+        return entries.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return entries.equals(o);
+    }
+
+    public static class Entry implements Comparable<Entry> {
+
+        private final int id;
+        private final String name;
+
+        Entry(int id, String name) {
+            this.id = id;
+            this.name =
+                    name == null || name.isEmpty() ? String.valueOf(id) : name + " (" + id + ")";
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public int compareTo(Entry o) {
+            if (o == null) {
+                return 1;
+            }
+            int result = name.compareTo(o.name);
+            if (result != 0) {
+                return result;
+            }
+            return Integer.compare(id, o.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof Entry)) {
+                return false;
+            }
+            Entry other = (Entry) obj;
+            return id == other.id;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}

--- a/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ui/ScanRulesInfoComboBoxModel.java
+++ b/addOns/alertFilters/src/main/java/org/zaproxy/zap/extension/alertFilters/internal/ui/ScanRulesInfoComboBoxModel.java
@@ -1,0 +1,98 @@
+/*
+ * Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2022 The ZAP Development Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zaproxy.zap.extension.alertFilters.internal.ui;
+
+import javax.swing.AbstractListModel;
+import javax.swing.ComboBoxModel;
+import javax.swing.event.EventListenerList;
+import javax.swing.event.ListDataEvent;
+import javax.swing.event.ListDataListener;
+import org.zaproxy.zap.extension.alertFilters.internal.ScanRulesInfo;
+
+@SuppressWarnings("serial")
+public class ScanRulesInfoComboBoxModel extends AbstractListModel<ScanRulesInfo.Entry>
+        implements ComboBoxModel<ScanRulesInfo.Entry> {
+
+    private final EventListenerList listenerList;
+    private final ScanRulesInfo scanRulesInfo;
+    private ScanRulesInfo.Entry selectedScanRuleInfo;
+
+    public ScanRulesInfoComboBoxModel(ScanRulesInfo scanRulesInfo) {
+        listenerList = new EventListenerList();
+        this.scanRulesInfo = scanRulesInfo;
+        selectedScanRuleInfo = scanRulesInfo.isEmpty() ? null : scanRulesInfo.get(0);
+    }
+
+    @Override
+    public void addListDataListener(ListDataListener l) {
+        listenerList.add(ListDataListener.class, l);
+    }
+
+    @Override
+    public void removeListDataListener(ListDataListener l) {
+        listenerList.remove(ListDataListener.class, l);
+    }
+
+    @Override
+    public int getSize() {
+        return scanRulesInfo.size();
+    }
+
+    @Override
+    public ScanRulesInfo.Entry getElementAt(int index) {
+        return scanRulesInfo.get(index);
+    }
+
+    @Override
+    public void setSelectedItem(Object anItem) {
+        if (anItem == null) {
+            if (selectedScanRuleInfo != null) {
+                selectedScanRuleInfo = null;
+                notifySelectedItemChanged();
+            }
+            return;
+        }
+
+        if (!(anItem instanceof ScanRulesInfo.Entry) || selectedScanRuleInfo == anItem) {
+            return;
+        }
+
+        selectedScanRuleInfo = (ScanRulesInfo.Entry) anItem;
+        notifySelectedItemChanged();
+    }
+
+    private void notifySelectedItemChanged() {
+        ListDataEvent event = null;
+        Object[] listeners = listenerList.getListenerList();
+        for (int i = listeners.length - 2; i >= 0; i -= 2) {
+            if (listeners[i] == ListDataListener.class) {
+                if (event == null) {
+                    event = new ListDataEvent(this, ListDataEvent.CONTENTS_CHANGED, -1, -1);
+                }
+                ((ListDataListener) listeners[i + 1]).contentsChanged(event);
+            }
+        }
+    }
+
+    @Override
+    public ScanRulesInfo.Entry getSelectedItem() {
+        return selectedScanRuleInfo;
+    }
+}


### PR DESCRIPTION
Change the dialogues to show the ID of the scan rules along the name.
Use a specific class to hold the scan rule info to avoid mappings between the names and the IDs.

Fix zaproxy/zaproxy#5699.