### PR TITLE
pscanrules: CSP Missing add check for META definition

### DIFF
--- a/addOns/pscanrules/CHANGELOG.md
+++ b/addOns/pscanrules/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added new Custom Payloads alert tag to the example alerts of the Username IDOR and Application Error scan rules.
 - Maintenance changes.
 - The Timestamp Disclosure scan rule is now scoped to a 10 year range with a cap at the Y2038 rollover point (Issue 6741).
+- THe Content Security Policy Header Set scan rule will no longer alert if CSP is specified via META tag (Issue 7303).
 
 ## [42] - 2022-07-15
 ### Changed

--- a/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
+++ b/addOns/pscanrules/src/main/javahelp/org/zaproxy/zap/extension/pscanrules/resources/help/contents/pscanrules.html
@@ -70,13 +70,15 @@ Further reference:<br>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/CharsetMismatchScanRule.java">CharsetMismatchScanRule.java</a>
 
 <H2>Content Security Policy (CSP) Header Not Set</H2>
-This checks HTML response headers for the presence of a Content Security Policy header.<br>
+This checks HTML response headers for the presence of a Content Security Policy header, or the response body for CSP specified via META tag.<br>
 By default this rule checks for the presence of the "Content-Security-Policy" header, 
 and at the Low threshold also checks for the "X-Content-Security-Policy" and "X-WebKit-CSP" headers.<br>
-Redirects and non HTML responses are ignored except at the Low threshold.
+Redirects and non-HTML responses are ignored except at the Low threshold.
 <p>
 If a "Content-Security-Policy-Report-Only" header is found on a response an INFO alert is raised. This may represent an enforcement effort 
 that is actively being refined or developed, or one which is only partially implemented.
+<p>
+Note: This rule does not perform any actual analysis of the specified policy, for that please ensure the CSP scan rule is enabled.
 <p>
 Latest code: <a href="https://github.com/zaproxy/zap-extensions/blob/main/addOns/pscanrules/src/main/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRule.java">ContentSecurityPolicyMissingScanRule.java</a>
 

--- a/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRuleUnitTest.java
+++ b/addOns/pscanrules/src/test/java/org/zaproxy/zap/extension/pscanrules/ContentSecurityPolicyMissingScanRuleUnitTest.java
@@ -26,6 +26,8 @@ import static org.hamcrest.Matchers.is;
 import java.util.Map;
 import org.apache.commons.httpclient.URI;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.parosproxy.paros.Constant;
 import org.parosproxy.paros.core.scanner.Alert;
 import org.parosproxy.paros.core.scanner.Plugin;
@@ -57,6 +59,26 @@ class ContentSecurityPolicyMissingScanRuleUnitTest
 
         // Then
         assertContentSecurityPolicyAlertRaised();
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "Content-Security-Policy",
+                "CONTENT-SECURITY-POLICY",
+                "content-security-policy"
+            })
+    void givenMissingCspHeaderWithMetaThenAlertNotRaised(String name) throws Exception {
+        // Given
+        HttpMessage msg = createHttpMessageWithHeaders(HEADER_HTML);
+        msg.setResponseBody(
+                "<html><head><meta http-equiv=\""
+                        + name
+                        + "\" content=\"default-src 'self'\"></head><H1>Test</H1></html>");
+        // When
+        scanHttpResponseReceive(msg);
+        // Then
+        assertThat(alertsRaised.size(), is(0));
     }
 
     @Test


### PR DESCRIPTION
- CHANGELOG.md > Add change note.
- ContentSecurityPolicyMissingScanRule > Add functionality to validate if CSP is specified via META. Remove unnecessary block comment for functionality now covered by 10055. Remove unnecessary block comment for functionality now covered by 10055.
- ContentSecurityPolicyMissingScanRuleUnitTest > Add a new unit test to assert the new behavior.
- pscanrules.html > Update help entry.

Related to zaproxy/zaproxy#7303

Signed-off-by: kingthorin <kingthorin@users.noreply.github.com>