### PR TITLE
network: correct HTTP version conversion

### DIFF
--- a/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
+++ b/addOns/network/src/main/java/org/zaproxy/addon/network/internal/client/apachev5/HttpSenderApache.java
@@ -530,7 +530,7 @@ public class HttpSenderApache
     private static ProtocolVersion toHttpVersion(String version) {
         String[] data = version.substring(version.indexOf('/') + 1).split("\\.", 2);
         int major = Integer.parseInt(data[0]);
-        int minor = Integer.parseInt(data[1]);
+        int minor = data.length > 1 ? Integer.parseInt(data[1]) : 0;
         return new HttpVersion(major, minor);
     }
 


### PR DESCRIPTION
Check that the minor HTTP version is present when converting it, in case the message is being sent with just the major version.

Related to zaproxy/zaproxy#7456.