### PR TITLE
requester: allow to regenerate anti-csrf token

### DIFF
--- a/addOns/requester/CHANGELOG.md
+++ b/addOns/requester/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 ### Added
 - Add a context menu to open the Manual Request Editor, on ZAP versions newer than 2.11.
+- Add button to allow to regenerate Anti-CSRF tokens (Issue 111).
 
 ### Changed
 - Maintenance changes.

--- a/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/HttpPanelSender.java
+++ b/addOns/requester/src/main/java/org/zaproxy/zap/extension/requester/HttpPanelSender.java
@@ -45,6 +45,7 @@ import org.parosproxy.paros.network.HttpSender;
 import org.parosproxy.paros.view.View;
 import org.zaproxy.zap.PersistentConnectionListener;
 import org.zaproxy.zap.ZapGetMethod;
+import org.zaproxy.zap.extension.anticsrf.ExtensionAntiCSRF;
 import org.zaproxy.zap.extension.httppanel.HttpPanel;
 import org.zaproxy.zap.extension.httppanel.HttpPanelRequest;
 import org.zaproxy.zap.extension.httppanel.HttpPanelResponse;
@@ -61,6 +62,7 @@ public class HttpPanelSender implements MessageSender {
 
     private final HttpPanelResponse responsePanel;
     private ExtensionHistory extension;
+    private ExtensionAntiCSRF extAntiCSRF;
 
     private HttpSender delegate;
 
@@ -68,11 +70,15 @@ public class HttpPanelSender implements MessageSender {
     private JToggleButton followRedirect = null;
     private JToggleButton useTrackingSessionState = null;
     private JToggleButton useCookies = null;
+    private JToggleButton useCsrf = null;
 
     private List<PersistentConnectionListener> persistentConnectionListener = new ArrayList<>();
 
     public HttpPanelSender(HttpPanelRequest requestPanel, HttpPanelResponse responsePanel) {
         this.responsePanel = responsePanel;
+
+        extAntiCSRF =
+                Control.getSingleton().getExtensionLoader().getExtension(ExtensionAntiCSRF.class);
 
         requestPanel.addOptions(
                 getButtonUseTrackingSessionState(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
@@ -81,6 +87,9 @@ public class HttpPanelSender implements MessageSender {
                 getButtonFollowRedirects(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
         requestPanel.addOptions(
                 getButtonFixContentLength(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
+        if (extAntiCSRF != null) {
+            requestPanel.addOptions(getButtonUseCsrf(), HttpPanel.OptionsLocation.AFTER_COMPONENTS);
+        }
 
         final boolean isSessionTrackingEnabled =
                 Model.getSingleton().getOptionsParam().getConnectionParam().isHttpStateEnabled();
@@ -99,6 +108,10 @@ public class HttpPanelSender implements MessageSender {
         try {
             final ModeRedirectionValidator redirectionValidator = new ModeRedirectionValidator();
             boolean followRedirects = getButtonFollowRedirects().isSelected();
+
+            if (extAntiCSRF != null && getButtonUseCsrf().isSelected()) {
+                extAntiCSRF.regenerateAntiCsrfToken(httpMessage, getDelegate()::sendAndReceive);
+            }
 
             if (followRedirects) {
                 getDelegate()
@@ -292,6 +305,18 @@ public class HttpPanelSender implements MessageSender {
                     e -> setUseCookies(e.getStateChange() == ItemEvent.SELECTED));
         }
         return useCookies;
+    }
+
+    private JToggleButton getButtonUseCsrf() {
+        if (useCsrf == null) {
+            useCsrf =
+                    new JToggleButton(
+                            new ImageIcon(
+                                    HttpPanelSender.class.getResource(
+                                            "/resource/icon/csrf-button.png")));
+            useCsrf.setToolTipText(Constant.messages.getString("manReq.checkBox.useCSRF"));
+        }
+        return useCsrf;
     }
 
     private JToggleButton getButtonFixContentLength() {


### PR DESCRIPTION
Add button to enable the regeneration of the anti-csrf token, migration
of core change zaproxy/zaproxy#5828.